### PR TITLE
upgrade: Update Docker images from Node.js 20 to Node.js 24 LTS

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -1,5 +1,5 @@
 # Admin SvelteKit Application Dockerfile
-FROM node:20-alpine AS development
+FROM node:24-alpine AS development
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ EXPOSE 5173
 CMD ["pnpm", "dev", "--host", "0.0.0.0", "--port", "5173"]
 
 # Production build stage
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ COPY . .
 RUN pnpm build
 
 # Production stage
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 
 WORKDIR /app
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Web SvelteKit Application Dockerfile
-FROM node:20-alpine AS development
+FROM node:24-alpine AS development
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ EXPOSE 5174
 CMD ["pnpm", "dev", "--host", "0.0.0.0", "--port", "5174"]
 
 # Production build stage
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ COPY . .
 RUN pnpm build
 
 # Production stage
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
- Update apps/web/Dockerfile to use node:24-alpine
- Update apps/admin/Dockerfile to use node:24-alpine
- Node.js 20 security support ends April 2025
- Node.js 24 LTS supported until April 2027

🤖 Generated with [Claude Code](https://claude.ai/code)