### PR TITLE
fix: 운영 환경 Mock 모드 오류 수정

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -59,16 +59,21 @@ class ApiClient {
             const mockSetting = localStorage.getItem('damoang_use_mock');
 
             // 로컬 개발 환경(localhost)에서는 기본값 true
+            // 운영 환경(damoang.dev, damoang.net)에서는 기본값 false
             const isLocalDev =
                 window.location.hostname === 'localhost' ||
                 window.location.hostname === '127.0.0.1';
 
-            if (mockSetting === null) {
-                // localStorage에 설정이 없으면: 로컬은 true, 운영은 false
-                this.useMock = isLocalDev;
-                localStorage.setItem('damoang_use_mock', isLocalDev.toString());
+            const isProduction =
+                window.location.hostname.includes('damoang.dev') ||
+                window.location.hostname.includes('damoang.net');
+
+            if (mockSetting === null || isProduction) {
+                // localStorage에 설정이 없거나 운영 환경이면: 로컬은 true, 운영은 false
+                this.useMock = isLocalDev && !isProduction;
+                localStorage.setItem('damoang_use_mock', this.useMock.toString());
             } else {
-                // localStorage 설정 우선
+                // localStorage 설정 우선 (개발 환경에서만)
                 this.useMock = mockSetting !== 'false';
             }
         }
@@ -280,7 +285,8 @@ class ApiClient {
                 '48h': '48hours'
             };
             const fileName = periodMap[period] || period;
-            const response = await fetch(`/api/v2/recommended/${fileName}`);
+            // static/data/cache/recommended/ai_1hour.json 형식으로 저장됨
+            const response = await fetch(`/data/cache/recommended/ai_${fileName}.json`);
             if (!response.ok) {
                 throw new Error(`AI 추천 글 데이터 로드 실패: ${period}`);
             }


### PR DESCRIPTION
운영 환경에서 발생한 "Cannot GET" JSON 파싱 오류 수정

변경사항:
- 운영 환경(damoang.dev, damoang.net)에서 Mock 모드 강제 비활성화
- Mock 데이터 파일 경로 수정 (/api/v2/recommended/* → /data/cache/recommended/ai_*.json)
- localStorage 설정보다 운영 환경 감지를 우선 처리

문제:
운영 환경에서 Mock 모드가 활성화되어 존재하지 않는 경로로
요청하면서 404 HTML 페이지를 JSON으로 파싱하려다 실패

해결:
- 호스트명으로 운영 환경 자동 감지
- 운영 환경에서는 무조건 실제 API 호출
- Mock 데이터 경로를 실제 static 파일 구조와 일치시킴