### PR TITLE
fix: Docker 빌드 시 pnpm workspace 의존성 해결

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -41,12 +41,22 @@ WORKDIR /app
 # Copy workspace configuration files
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 
+# Copy workspace packages (workspace:* dependencies)
+COPY packages ./packages
+
 # Copy application source
 COPY apps/web ./apps/web
 
 # Install dependencies and build
-RUN pnpm install --frozen-lockfile --filter web
+RUN pnpm install --frozen-lockfile --filter web...
 RUN pnpm --filter web run build
+
+# Deploy as standalone package (resolves workspace:* dependencies)
+# --legacy: pnpm v10에서 inject-workspace-packages 없이 deploy 허용
+RUN pnpm --filter web deploy /app/deploy --prod --legacy
+
+# Copy build output to deploy directory
+RUN cp -r /app/apps/web/build /app/deploy/build
 
 # -----------------------------
 # Production stage (SSR Node.js)
@@ -58,12 +68,8 @@ RUN adduser -D -u 1001 -s /bin/sh nodeuser
 
 WORKDIR /app
 
-# Copy built application from builder
-COPY --from=builder --chown=nodeuser:nodeuser /app/apps/web/build ./build
-COPY --from=builder --chown=nodeuser:nodeuser /app/apps/web/package.json ./package.json
-
-# Install production dependencies only
-RUN pnpm install --prod --frozen-lockfile
+# Copy deployed standalone package from builder
+COPY --from=builder --chown=nodeuser:nodeuser /app/deploy ./
 
 # Switch to non-root user
 USER nodeuser


### PR DESCRIPTION
- pnpm deploy --legacy를 사용하여 standalone 패키지 생성
- workspace:* 의존성(@angple/*)을 자동으로 해결
- pnpm-lock.yaml 미복사로 인한 --frozen-lockfile 오류 해결
- packages 디렉터리 복사 추가
