### PR TITLE
chore: SESSION_NOTES.md를 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ apps/backend/
 # Docker Compose local override
 compose.override.yml
 docker-compose.override.yml
+
+# Session notes (local only)
+SESSION_NOTES.md
+**/session-notes/
+**/SESSION_NOTES.*


### PR DESCRIPTION
- 세션 노트는 로컬에서만 사용
- Git 추적에서 제외