### PR TITLE
deploy: use compose.prod.yml for ghcr.io images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,8 +105,7 @@ jobs:
             docker pull ghcr.io/${{ github.repository_owner }}/angple-web:develop
             docker pull ghcr.io/${{ github.repository_owner }}/angple-admin:develop
 
-            docker compose pull
-            docker compose up -d
+            docker compose -f compose.prod.yml up -d
             docker image prune -f
 
             echo "Dev deployed at $(date)"
@@ -136,8 +135,7 @@ jobs:
               "echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin",
               "docker pull ghcr.io/${{ github.repository_owner }}/angple-web:staging",
               "docker pull ghcr.io/${{ github.repository_owner }}/angple-admin:staging",
-              "docker compose pull",
-              "docker compose up -d",
+              "docker compose -f compose.prod.yml up -d",
               "docker image prune -f",
               "echo Staging deployed at $(date)"
             ]' \
@@ -169,8 +167,7 @@ jobs:
               "echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin",
               "docker pull ghcr.io/${{ github.repository_owner }}/angple-web:main",
               "docker pull ghcr.io/${{ github.repository_owner }}/angple-admin:main",
-              "docker compose pull",
-              "docker compose up -d",
+              "docker compose -f compose.prod.yml up -d",
               "docker image prune -f",
               "echo Prod deployed at $(date)"
             ]' \


### PR DESCRIPTION
- Add workflow_dispatch for manual trigger from GitHub web
- Change deploy job to use compose.prod.yml instead of compose.yml

개발 서버를 분리했고 , ghcr.io 에서 하려고 합니다.