### PR TITLE
ci: deploy to dev server on main branch push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,12 +83,12 @@ jobs:
       - name: Image digest
         run: echo "Image pushed with digest ${{ steps.docker_build.outputs.digest }}"
 
-  # 개발서버 배포 (develop 브랜치) - SSH 방식
+  # 개발서버 배포 (main 브랜치) - SSH 방식
   deploy-dev:
     name: Deploy to Dev Server
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev')
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'dev')
 
     steps:
       - name: Deploy via SSH
@@ -102,8 +102,8 @@ jobs:
 
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            docker pull ghcr.io/${{ github.repository_owner }}/angple-web:develop
-            docker pull ghcr.io/${{ github.repository_owner }}/angple-admin:develop
+            docker pull ghcr.io/${{ github.repository_owner }}/angple-web:latest
+            docker pull ghcr.io/${{ github.repository_owner }}/angple-admin:latest
 
             docker compose -f compose.prod.yml up -d
             docker image prune -f


### PR DESCRIPTION
- Change deploy-dev trigger from develop to main branch
- Pull latest tag instead of develop tag

아직 규모가 develop 브랜치까지는 필요없어서???

main 으로 분리를 했고 , 다모앙 서버에 실제 배포가 될 때 분기하더닞 하겠습니다.