### PR TITLE
chore: Phase 20 레거시 인증 코드 정리

### DIFF
--- a/apps/web/src/lib/api/admin-themes.ts
+++ b/apps/web/src/lib/api/admin-themes.ts
@@ -56,8 +56,6 @@ export async function setActiveTheme(themeId: string): Promise<void> {
         if (!response.ok) {
             throw new Error(`HTTP ${response.status}`);
         }
-
-        console.log('테마 활성화 성공:', { themeId });
     } catch (error) {
         console.error('테마 활성화 실패:', { error });
         throw error;
@@ -100,8 +98,6 @@ export async function setThemeSettings(
         if (!response.ok) {
             throw new Error(`HTTP ${response.status}`);
         }
-
-        console.log('테마 설정 저장 성공:', { themeId });
     } catch (error) {
         console.error('테마 설정 저장 실패:', { themeId, error });
         throw error;
@@ -120,8 +116,6 @@ export async function deleteTheme(themeId: string): Promise<void> {
         if (!response.ok) {
             throw new Error(`HTTP ${response.status}`);
         }
-
-        console.log('테마 삭제 성공:', { themeId });
     } catch (error) {
         console.error('테마 삭제 실패:', { themeId, error });
         throw error;

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -375,8 +375,6 @@ class ApiClient {
 
         const response = await this.request<BackendBoardResponse>(`/boards/${boardId}`);
 
-        console.log('[API] Board detail raw response:', response);
-
         const backendData = response as unknown as BackendBoardResponse;
 
         return backendData.data;
@@ -432,7 +430,6 @@ class ApiClient {
                 mb_email: '' // profile API는 email을 반환하지 않음
             };
         } catch {
-            console.log('User not logged in');
             return null;
         }
     }

--- a/apps/web/src/routes/admin/+page.svelte
+++ b/apps/web/src/routes/admin/+page.svelte
@@ -1,27 +1,16 @@
 <script lang="ts">
     import AdminLoginForm from '$lib/components/admin/auth/login-form.svelte';
-    import { onMount } from 'svelte';
     import { browser } from '$app/environment';
 
     let { data } = $props();
 
     let checking = $state(true);
 
-    onMount(() => {
+    $effect(() => {
         if (!browser) return;
 
-        // 이미 관리자 인증 완료 → 대시보드로 이동
         if (data.isAdmin) {
             window.location.href = '/admin/dashboard';
-            return;
-        }
-
-        // localStorage 토큰이 있으면 쿠키 동기화 후 새로고침
-        const token = localStorage.getItem('access_token');
-        const hasCookie = document.cookie.split('; ').some((c) => c.startsWith('access_token='));
-        if (token && !hasCookie) {
-            document.cookie = `access_token=${token}; path=/; max-age=${60 * 60 * 24 * 7}; SameSite=Lax`;
-            window.location.reload();
             return;
         }
 

--- a/apps/web/src/routes/api-test/+page.svelte
+++ b/apps/web/src/routes/api-test/+page.svelte
@@ -55,9 +55,8 @@
 
     async function testMockMode() {
         addResult(`ℹ️ Mock 모드: OFF (실제 API 호출)`);
-        // Access Token은 localStorage에 저장됨
-        const hasToken = !!localStorage.getItem('access_token');
-        addResult(`ℹ️ Access Token: ${hasToken ? '있음' : '없음'}`);
+        const hasToken = !!apiClient.getAccessToken();
+        addResult(`ℹ️ Access Token: ${hasToken ? '있음 (메모리)' : '없음'}`);
     }
 
     function clearResults() {

--- a/apps/web/src/routes/my/+page.ts
+++ b/apps/web/src/routes/my/+page.ts
@@ -1,22 +1,11 @@
-import { redirect } from '@sveltejs/kit';
-import { browser } from '$app/environment';
 import { apiClient } from '$lib/api/index.js';
 import type { PageLoad } from './$types.js';
 
 export const load: PageLoad = async ({ url }) => {
-    // 클라이언트에서만 인증 체크
-    if (browser) {
-        const accessToken = localStorage.getItem('access_token');
-        if (!accessToken) {
-            throw redirect(302, '/login?redirect=/my');
-        }
-    }
-
     const tab = url.searchParams.get('tab') || 'posts';
     const page = Number(url.searchParams.get('page')) || 1;
 
     try {
-        // 탭에 따라 다른 데이터 로드
         let posts = null;
         let comments = null;
         let likedPosts = null;

--- a/apps/web/src/routes/my/blocked/+page.ts
+++ b/apps/web/src/routes/my/blocked/+page.ts
@@ -1,17 +1,7 @@
-import { redirect } from '@sveltejs/kit';
-import { browser } from '$app/environment';
 import { apiClient } from '$lib/api/index.js';
 import type { PageLoad } from './$types.js';
 
 export const load: PageLoad = async () => {
-    // 클라이언트에서만 인증 체크
-    if (browser) {
-        const accessToken = localStorage.getItem('access_token');
-        if (!accessToken) {
-            throw redirect(302, '/login?redirect=/my/blocked');
-        }
-    }
-
     try {
         const blockedMembers = await apiClient.getBlockedMembers();
 


### PR DESCRIPTION
## Summary
- localStorage.getItem('access_token') 참조 전면 제거
- admin/+page.svelte: 레거시 쿠키 동기화 코드 제거 (SSR 인증으로 대체)
- my/+page.ts, my/blocked/+page.ts: localStorage 인증 체크 제거 (+layout.server.ts에서 보호)
- api-test 페이지: apiClient.getAccessToken() 사용으로 변경
- admin-themes.ts, client.ts: 불필요한 console.log 제거

## 변경 파일 (6개)
- `src/lib/api/admin-themes.ts` — console.log 3건 제거
- `src/lib/api/client.ts` — console.log 2건 제거
- `src/routes/admin/+page.svelte` — localStorage 쿠키 동기화 제거
- `src/routes/api-test/+page.svelte` — 메모리 기반 토큰 체크로 변경
- `src/routes/my/+page.ts` — localStorage 인증 체크 제거
- `src/routes/my/blocked/+page.ts` — localStorage 인증 체크 제거

## Test plan
- [ ] /admin 접근 시 정상 동작
- [ ] /my 미인증 접근 시 /login 리다이렉트
- [ ] /api-test 페이지 정상 동작