### PR TITLE
feat(web): httpOnly 쿠키 기반 인증 및 그누보드 SSO 연동

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -69,8 +69,11 @@ COPY apps/web ./apps/web
 
 # Install dependencies and build
 RUN pnpm install --frozen-lockfile --filter web...
-# 워크스페이스 패키지 먼저 빌드 (@angple/types 등)
+# 워크스페이스 패키지 먼저 빌드 (의존성 순서대로)
 RUN pnpm --filter @angple/types run build
+RUN pnpm --filter @angple/i18n run build
+RUN pnpm --filter @angple/hook-system run build
+RUN pnpm --filter @angple/theme-engine run build
 RUN pnpm --filter web run build
 
 # Deploy as standalone package (resolves workspace:* dependencies)


### PR DESCRIPTION
- Dockerfile: 워크스페이스 패키지 빌드 순서 추가 (@angple/types, i18n, hook-system, theme-engine)
- client.ts: damoang_jwt 쿠키 기반 인증 지원 (/auth/me 엔드포인트)
- client.ts: 그누보드 SSO 쿠키 존재 시 JWT refresh 스킵
