### PR TITLE
feat: 게시판 권한 체크 UI 구현

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -395,6 +395,17 @@ export interface BoardDisplaySettings {
     show_thumbnail: boolean;
 }
 
+// 게시판 권한 정보 (사용자 레벨 기반)
+export interface BoardPermissions {
+    can_list: boolean;
+    can_read: boolean;
+    can_write: boolean;
+    can_reply: boolean;
+    can_comment: boolean;
+    can_upload: boolean;
+    can_download: boolean;
+}
+
 // 게시판 타입
 export interface Board {
     board_id: string;
@@ -420,6 +431,7 @@ export interface Board {
     count_comment: number;
     insert_time: string;
     display_settings: BoardDisplaySettings;
+    permissions?: BoardPermissions; // 사용자별 권한 정보 (서버에서 계산, 인증 시에만 포함)
 }
 
 // 파일 업로드 관련 타입

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -491,7 +491,12 @@
 
             <!-- 댓글 작성 폼 -->
             <div class="border-border border-t pt-6">
-                <CommentForm onSubmit={handleCreateComment} isLoading={isCreatingComment} />
+                <CommentForm
+                    onSubmit={handleCreateComment}
+                    isLoading={isCreatingComment}
+                    permissions={data.board?.permissions}
+                    requiredCommentLevel={data.board?.comment_level ?? 1}
+                />
             </div>
         </CardHeader>
     </Card>


### PR DESCRIPTION
## Summary
- BoardPermissions 타입 추가
- 글쓰기 버튼 권한 체크 (canWrite)
- 댓글 작성 폼 권한 체크 (canComment)
- 권한 부족 시 잠금 아이콘과 안내 메시지 표시

## Related PR
- Backend: https://github.com/damoang/angple-backend/pull/108

## Test plan
- [ ] 권한 있는 사용자: 글쓰기 버튼 활성화
- [ ] 권한 없는 사용자: 글쓰기 버튼 비활성화 + 잠금 아이콘
- [ ] 권한 있는 사용자: 댓글 폼 표시
- [ ] 권한 없는 사용자: 댓글 권한 없음 메시지 표시