### PR TITLE
feat(widgets): 공지사항 위젯 API 연동 및 축하메시지 위젯 추가

### DIFF
--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -74,23 +74,24 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
 /** 기본 사이드바 위젯 레이아웃 */
 export const DEFAULT_SIDEBAR_WIDGETS: WidgetConfig[] = [
     { id: 'notice', type: 'notice', position: 0, enabled: true },
-    { id: 'podcast', type: 'podcast', position: 1, enabled: true },
+    { id: 'celebration-card', type: 'celebration-card', position: 1, enabled: true },
+    { id: 'podcast', type: 'podcast', position: 2, enabled: true },
     {
         id: 'sidebar-ad-1',
         type: 'ad',
-        position: 2,
+        position: 3,
         enabled: true,
         settings: { position: 'sidebar-1', type: 'image', format: 'square' }
     },
     {
         id: 'sidebar-ad-2',
         type: 'ad',
-        position: 3,
+        position: 4,
         enabled: true,
         settings: { position: 'sidebar-2', type: 'image-text', format: 'grid' }
     },
-    { id: 'sharing-board', type: 'sharing-board', position: 4, enabled: true },
-    { id: 'sticky-ads', type: 'sticky-ads', position: 5, enabled: true }
+    { id: 'sharing-board', type: 'sharing-board', position: 5, enabled: true },
+    { id: 'sticky-ads', type: 'sticky-ads', position: 6, enabled: true }
 ];
 
 /**

--- a/widgets/celebration-card/index.svelte
+++ b/widgets/celebration-card/index.svelte
@@ -1,0 +1,314 @@
+<script lang="ts">
+    /**
+     * 축하메시지 위젯
+     * 오늘의 축하메시지 카드 1개를 PHP 원본 스타일로 표시합니다.
+     */
+    import type { WidgetProps } from '$lib/types/widget-props';
+    import { onMount } from 'svelte';
+
+    let { config, slot, isEditMode = false }: WidgetProps = $props();
+
+    interface CelebrationBanner {
+        id: number;
+        title: string;
+        content: string;
+        image_url: string;
+        link_url: string;
+        display_date: string;
+        is_active: boolean;
+        target_member_id?: string;
+        target_member_nick?: string;
+        target_member_photo?: string;
+        external_link?: string;
+    }
+
+    let banner = $state<CelebrationBanner | null>(null);
+    let gradientNum = $state(1);
+    let loading = $state(true);
+
+    function simpleHash(str: string): number {
+        let hash = 0;
+        for (let i = 0; i < str.length; i++) {
+            const char = str.charCodeAt(i);
+            hash = (hash << 5) - hash + char;
+            hash = hash & hash;
+        }
+        return Math.abs(hash);
+    }
+
+    onMount(async () => {
+        try {
+            const res = await fetch('/api/plugins/advertising/banners/today');
+            if (res.ok) {
+                const data = await res.json();
+                const banners: CelebrationBanner[] = data.data ?? [];
+                if (banners.length > 0) {
+                    banner = banners[Math.floor(Math.random() * banners.length)];
+                    const hashSource = banner.target_member_id || String(banner.id);
+                    gradientNum = (simpleHash(hashSource) % 5) + 1;
+                }
+            }
+        } catch (e) {
+            // 조용히 실패
+        } finally {
+            loading = false;
+        }
+    });
+
+    function stripHtml(html: string): string {
+        return html.replace(/<[^>]*>/g, '').trim();
+    }
+</script>
+
+{#if loading}
+    <div class="animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700 h-24"></div>
+{:else if banner}
+    <div class="celeb-card grad-{gradientNum}">
+        <div class="celeb-header">
+            <span class="icon">🎈</span>
+            <span class="celeb-nick">{banner.target_member_nick || banner.title || '축하합니다'}</span>
+            {#if banner.external_link || banner.link_url}
+                <a
+                    href={banner.external_link || banner.link_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="header-link"
+                >
+                    바로가기 →
+                </a>
+            {/if}
+        </div>
+
+        <div class="celeb-body">
+            <div class="celeb-profile">
+                {#if banner.target_member_photo}
+                    <img
+                        src={banner.target_member_photo}
+                        class="celeb-avatar"
+                        alt=""
+                        loading="lazy"
+                    />
+                {:else}
+                    <div class="celeb-avatar-placeholder">👤</div>
+                {/if}
+            </div>
+
+            {#if banner.image_url}
+                <a
+                    href={banner.link_url || '#'}
+                    class="celeb-banner-wrap"
+                    target={banner.link_url?.startsWith('http') ? '_blank' : undefined}
+                    rel={banner.link_url?.startsWith('http') ? 'noopener noreferrer' : undefined}
+                >
+                    <img src={banner.image_url} class="celeb-banner" alt="" loading="lazy" />
+                    {#if banner.content}
+                        <div class="celeb-overlay">
+                            <div class="celeb-message">{stripHtml(banner.content)}</div>
+                        </div>
+                    {/if}
+                </a>
+            {:else}
+                <div class="celeb-no-banner">
+                    {#if banner.link_url}
+                        <a href={banner.link_url} class="celeb-message-link">
+                            {stripHtml(banner.content || banner.title)}
+                        </a>
+                    {:else}
+                        <div class="celeb-message-text">
+                            {stripHtml(banner.content || banner.title)}
+                        </div>
+                    {/if}
+                </div>
+            {/if}
+        </div>
+    </div>
+{/if}
+
+<style>
+    .celeb-card {
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        background: white;
+    }
+
+    .celeb-header {
+        padding: 8px 12px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        color: white;
+        font-weight: 600;
+        font-size: 0.8rem;
+    }
+
+    .celeb-nick {
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .icon {
+        flex-shrink: 0;
+    }
+
+    .grad-1 .celeb-header {
+        background: linear-gradient(135deg, #667eea, #764ba2);
+    }
+    .grad-2 .celeb-header {
+        background: linear-gradient(135deg, #f093fb, #f5576c);
+    }
+    .grad-3 .celeb-header {
+        background: linear-gradient(135deg, #4facfe, #00f2fe);
+    }
+    .grad-4 .celeb-header {
+        background: linear-gradient(135deg, #43e97b, #38f9d7);
+    }
+    .grad-5 .celeb-header {
+        background: linear-gradient(135deg, #fa709a, #fee140);
+    }
+
+    .celeb-body {
+        position: relative;
+        min-height: 60px;
+    }
+
+    .celeb-profile {
+        position: absolute;
+        left: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        z-index: 10;
+    }
+
+    .celeb-avatar {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        border: 3px solid transparent;
+        background:
+            linear-gradient(white, white) padding-box,
+            conic-gradient(from 0deg, red, orange, yellow, green, cyan, blue, violet, red) border-box;
+        animation: rainbow-rotate 3s linear infinite;
+        object-fit: cover;
+    }
+
+    @keyframes rainbow-rotate {
+        to {
+            filter: hue-rotate(360deg);
+        }
+    }
+
+    .celeb-avatar-placeholder {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, #667eea, #764ba2);
+        color: white;
+        font-size: 1.2rem;
+    }
+
+    .celeb-banner-wrap {
+        display: block;
+        width: 100%;
+        min-height: 70px;
+        position: relative;
+    }
+
+    .celeb-banner {
+        width: 100%;
+        height: 100%;
+        min-height: 70px;
+        max-height: 120px;
+        object-fit: cover;
+    }
+
+    .celeb-overlay {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 8px 12px 8px 70px;
+        background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));
+    }
+
+    .celeb-message {
+        color: white;
+        font-size: 0.75rem;
+        font-weight: 500;
+        line-height: 1.4;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    .celeb-no-banner {
+        padding: 16px 16px 16px 70px;
+        background: #f8f9fa;
+        min-height: 60px;
+        display: flex;
+        align-items: center;
+    }
+
+    .celeb-message-link {
+        color: #333;
+        font-size: 0.8rem;
+        font-weight: 500;
+        line-height: 1.4;
+        text-decoration: none;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    .celeb-message-link:hover {
+        color: #667eea;
+        text-decoration: underline;
+    }
+
+    .celeb-message-text {
+        color: #333;
+        font-size: 0.8rem;
+        font-weight: 500;
+        line-height: 1.4;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    :global(.dark) .celeb-card {
+        background: #2d2d2d;
+    }
+    :global(.dark) .celeb-no-banner {
+        background: #3d3d3d;
+    }
+    :global(.dark) .celeb-message-link,
+    :global(.dark) .celeb-message-text {
+        color: #eee;
+    }
+    :global(.dark) .celeb-message-link:hover {
+        color: #a5b4fc;
+    }
+
+    .header-link {
+        flex-shrink: 0;
+        font-size: 0.7rem;
+        color: rgba(255, 255, 255, 0.85);
+        padding: 3px 8px;
+        background: rgba(255, 255, 255, 0.15);
+        border-radius: 10px;
+        text-decoration: none;
+        transition: background 0.2s;
+    }
+
+    .header-link:hover {
+        background: rgba(255, 255, 255, 0.25);
+    }
+</style>

--- a/widgets/celebration-card/widget.json
+++ b/widgets/celebration-card/widget.json
@@ -1,0 +1,12 @@
+{
+    "id": "celebration-card",
+    "name": "축하메시지",
+    "version": "1.0.0",
+    "description": "오늘의 축하메시지 카드 1개 표시",
+    "author": { "name": "Angple" },
+    "category": "sidebar",
+    "slots": ["sidebar"],
+    "icon": "PartyPopper",
+    "allowMultiple": false,
+    "main": "index.svelte"
+}

--- a/widgets/notice/index.svelte
+++ b/widgets/notice/index.svelte
@@ -1,10 +1,49 @@
 <script lang="ts">
     /**
      * 공지사항 위젯
+     * 실제 notice 게시판 데이터를 표시합니다.
      */
     import type { WidgetProps } from '$lib/types/widget-props';
+    import { onMount } from 'svelte';
 
-    let { config, slot, isEditMode = false }: WidgetProps = $props();
+    let { config, slot, isEditMode = false, prefetchData }: WidgetProps = $props();
+
+    interface Notice {
+        id: number;
+        title: string;
+        url: string;
+    }
+
+    let notices = $state<Notice[]>([]);
+    let loading = $state(true);
+    let error = $state(false);
+
+    onMount(async () => {
+        if (prefetchData) {
+            notices = prefetchData as Notice[];
+            loading = false;
+            return;
+        }
+
+        try {
+            const res = await fetch('/api/v1/boards/notice/posts?per_page=5');
+            if (res.ok) {
+                const data = await res.json();
+                const list = data.data?.list ?? data.data ?? [];
+                notices = list.map((p: { wr_id: number; wr_subject: string }) => ({
+                    id: p.wr_id,
+                    title: p.wr_subject,
+                    url: `/notice/${p.wr_id}`
+                }));
+            } else {
+                error = true;
+            }
+        } catch (e) {
+            error = true;
+        } finally {
+            loading = false;
+        }
+    });
 </script>
 
 <div
@@ -21,9 +60,27 @@
         </svg>
         공지사항
     </h3>
-    <ul class="space-y-2 text-xs text-slate-600 dark:text-slate-400">
-        <li class="truncate">• 서비스 점검 안내</li>
-        <li class="truncate">• 새로운 기능 업데이트</li>
-        <li class="truncate">• 커뮤니티 가이드라인</li>
-    </ul>
+
+    {#if loading}
+        <ul class="space-y-2">
+            {#each Array(3) as _}
+                <li class="h-4 animate-pulse rounded bg-slate-200 dark:bg-slate-700"></li>
+            {/each}
+        </ul>
+    {:else if error || notices.length === 0}
+        <p class="text-xs text-slate-400 dark:text-slate-500">공지사항이 없습니다.</p>
+    {:else}
+        <ul class="space-y-2 text-xs text-slate-600 dark:text-slate-400">
+            {#each notices as notice (notice.id)}
+                <li class="truncate">
+                    <a
+                        href={notice.url}
+                        class="hover:text-blue-600 hover:underline dark:hover:text-blue-400"
+                    >
+                        • {notice.title}
+                    </a>
+                </li>
+            {/each}
+        </ul>
+    {/if}
 </div>


### PR DESCRIPTION
## Summary
- 공지사항 위젯: placeholder 텍스트 → 실제 notice 게시판 API 데이터 표시
- 축하메시지 위젯: 오늘의 축하배너 카드 1개 표시 (PHP 원본 스타일 포팅)
- 기본 사이드바 레이아웃에 축하메시지 위젯 추가

## Changes
- `widgets/notice/index.svelte` - API 연동, 로딩/에러 상태 처리
- `widgets/celebration-card/` - 새 위젯 (widget.json + index.svelte)
- `apps/web/src/lib/constants/default-widgets.ts` - 기본 레이아웃 업데이트

## Test plan
- [ ] 공지사항 위젯에서 실제 공지글 목록 표시 확인
- [ ] 축하 배너 있을 때 축하메시지 위젯 표시 확인
- [ ] 축하 배너 없을 때 위젯 숨김 확인