### PR TITLE
fix(web): Vite 개발 서버에 /api/v1 프록시 설정 추가

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -34,6 +34,17 @@ export default defineConfig(({ mode }) => {
                 allow: ['.', '../..']
             },
             proxy: {
+                '/api/v1': {
+                    target: apiProxyTarget,
+                    changeOrigin: true,
+                    secure: false,
+                    configure: (proxy) => {
+                        proxy.on('proxyReq', (proxyReq, req) => {
+                            proxyReq.setHeader('Origin', apiProxyTarget);
+                            console.log('[Proxy]', req.method, req.url);
+                        });
+                    }
+                },
                 '/api/v2': {
                     target: apiProxyTarget,
                     changeOrigin: true,


### PR DESCRIPTION
## Summary
- Vite 개발 서버에 `/api/v1` 프록시 설정이 누락되어 클라이언트 사이드 API 호출 시 404 에러 발생하는 문제 수정
- `/api/v2`와 동일한 방식으로 `apiProxyTarget` (기본값 `http://localhost:8081`)으로 프록시 설정 추가

## 원인
- `hooks.server.ts`의 SSR 요청은 `BACKEND_URL`로 직접 호출하여 정상 동작
- 클라이언트 사이드 (`$lib/api/client.ts`)는 상대 경로 `/api/v1`을 사용하므로 Vite 프록시 설정이 필요
- `/api/v2` 프록시만 존재하고 `/api/v1` 프록시가 빠져있었음

## Test plan
- [x] 로컬 개발 서버 실행 후 클라이언트 사이드 `/api/v1` 요청이 백엔드로 정상 프록시되는지 확인
- [x] 기존 `/api/v2` 프록시 동작에 영향 없음 확인