### PR TITLE
fix: googletag TypeScript 타입 에러 및 Prettier 포맷 수정

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
         "@tailwindcss/vite": "^4.0.0",
         "@types/adm-zip": "^0.5.7",
         "@types/dompurify": "^3.2.0",
+        "@types/google-publisher-tag": "^1.20260202.0",
         "@types/node": "^25.0.3",
         "@types/tar": "^6.1.13",
         "@vitest/browser": "^3.2.3",

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -26,6 +26,8 @@ declare global {
     interface Window {
         DamoangAds?: DamoangAdsInterface;
         adsbygoogle?: object[];
+        googletag?: typeof googletag;
+        [key: string]: unknown;
     }
 }
 

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -9,12 +9,7 @@
         sizes?: Array<[number, number]> | 'fluid';
     }
 
-    let {
-        position,
-        height = '90px',
-        class: className = '',
-        sizes
-    }: Props = $props();
+    let { position, height = '90px', class: className = '', sizes }: Props = $props();
 
     // GAM 설정 (www/theme/damoang/layout/basic/config/gam-slots.php 와 동일)
     const GAM_NETWORK_CODE = '23338387889';
@@ -30,11 +25,11 @@
     // GPT 서비스 초기화 플래그 (전역)
     const GPT_INITIALIZED_KEY = '__gpt_services_initialized__';
     function isGptInitialized(): boolean {
-        return browser && (window as Record<string, unknown>)[GPT_INITIALIZED_KEY] === true;
+        return browser && window[GPT_INITIALIZED_KEY] === true;
     }
     function markGptInitialized(): void {
         if (browser) {
-            (window as Record<string, unknown>)[GPT_INITIALIZED_KEY] = true;
+            window[GPT_INITIALIZED_KEY] = true;
         }
     }
 
@@ -57,44 +52,104 @@
         // 메인 콘텐츠 영역 배너 (큰 배너) → main
         'banner-horizontal': {
             unit: AD_UNIT_PATHS.main,
-            sizes: [[970, 250], [970, 90], [728, 90], [320, 100], [300, 250]],
+            sizes: [
+                [970, 250],
+                [970, 90],
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
             responsive: [
-                [970, [[970, 250], [970, 90], [728, 90]]],
+                [
+                    970,
+                    [
+                        [970, 250],
+                        [970, 90],
+                        [728, 90]
+                    ]
+                ],
                 [728, [[728, 90]]],
-                [0, [[320, 100], [300, 250]]]
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
             ]
         },
         'banner-large': {
             unit: AD_UNIT_PATHS.main,
-            sizes: [[970, 250], [970, 90], [728, 90], [320, 100], [300, 250]],
+            sizes: [
+                [970, 250],
+                [970, 90],
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
             responsive: [
-                [970, [[970, 250], [970, 90]]],
+                [
+                    970,
+                    [
+                        [970, 250],
+                        [970, 90]
+                    ]
+                ],
                 [728, [[728, 90]]],
-                [0, [[320, 100], [300, 250]]]
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
             ]
         },
         // 게시글 본문 영역 → article
         'banner-view-content': {
             unit: AD_UNIT_PATHS.article,
-            sizes: [[728, 90], [320, 100], [300, 250]],
+            sizes: [
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
             responsive: [
                 [728, [[728, 90]]],
-                [0, [[320, 100], [300, 250]]]
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
             ]
         },
         // 반응형 배너 → sub
         'banner-responsive': {
             unit: AD_UNIT_PATHS.sub,
-            sizes: [[728, 90], [320, 100], [300, 250]],
+            sizes: [
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
             responsive: [
                 [728, [[728, 90]]],
-                [0, [[320, 100], [300, 250]]]
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
             ]
         },
         // 소형 배너 → sub
         'banner-small': {
             unit: AD_UNIT_PATHS.sub,
-            sizes: [[728, 90], [320, 100]],
+            sizes: [
+                [728, 90],
+                [320, 100]
+            ],
             responsive: [
                 [728, [[728, 90]]],
                 [0, [[320, 100]]]
@@ -102,7 +157,10 @@
         },
         'banner-compact': {
             unit: AD_UNIT_PATHS.sub,
-            sizes: [[728, 90], [320, 100]],
+            sizes: [
+                [728, 90],
+                [320, 100]
+            ],
             responsive: [
                 [728, [[728, 90]]],
                 [0, [[320, 100]]]
@@ -117,16 +175,29 @@
         // 사이드바 수직형 → sub
         'banner-halfpage': {
             unit: AD_UNIT_PATHS.sub,
-            sizes: [[300, 600], [300, 250]],
+            sizes: [
+                [300, 600],
+                [300, 250]
+            ],
             responsive: null
         },
         // 인피드 (목록 사이) → curation
-        'infeed': {
+        infeed: {
             unit: AD_UNIT_PATHS.curation,
-            sizes: [[728, 90], [320, 100], [300, 250]],
+            sizes: [
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
             responsive: [
                 [728, [[728, 90]]],
-                [0, [[320, 100], [300, 250]]]
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
             ]
         }
     };
@@ -150,29 +221,94 @@
         'comment-infeed': 'infeed',
         'comment-top': 'banner-compact',
         'sidebar-sticky': 'banner-halfpage',
-        'sidebar': 'banner-square'
+        sidebar: 'banner-square'
     };
 
     // 위치별 기본 사이즈 매핑 (fallback)
     const DEFAULT_SIZES: Record<string, Array<[number, number]> | 'fluid'> = {
-        'header-after': [[728, 90], [970, 90], [320, 100]],
-        'index-head': [[728, 90], [320, 100]],
-        'index-top': [[728, 90], [320, 100], [300, 250]],
-        'index-news-economy': [[728, 90], [320, 100], [300, 250]],
-        'index-middle-1': [[728, 90], [970, 90], [320, 100]],
-        'index-middle-2': [[728, 90], [970, 90], [320, 100]],
-        'index-middle-3': [[728, 90], [970, 90], [320, 100]],
-        'index-bottom': [[728, 90], [970, 90], [320, 100]],
-        'board-head': [[728, 90], [970, 90], [320, 100]],
-        'board-list-head': [[728, 90], [320, 100], [300, 250]],
-        'board-list-bottom': [[728, 90], [970, 90], [320, 100]],
-        'board-content': [[728, 90], [300, 250], [320, 100]],
-        'board-content-bottom': [[728, 90], [970, 90], [320, 100]],
-        'board-footer': [[728, 90], [970, 90], [320, 100]],
-        'comment-infeed': [[728, 90], [300, 250], [320, 100]],
-        'comment-top': [[728, 90], [320, 100]],
-        'sidebar-sticky': [[300, 250], [300, 600]],
-        'sidebar': [[300, 250]]
+        'header-after': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'index-head': [
+            [728, 90],
+            [320, 100]
+        ],
+        'index-top': [
+            [728, 90],
+            [320, 100],
+            [300, 250]
+        ],
+        'index-news-economy': [
+            [728, 90],
+            [320, 100],
+            [300, 250]
+        ],
+        'index-middle-1': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'index-middle-2': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'index-middle-3': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'index-bottom': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'board-head': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'board-list-head': [
+            [728, 90],
+            [320, 100],
+            [300, 250]
+        ],
+        'board-list-bottom': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'board-content': [
+            [728, 90],
+            [300, 250],
+            [320, 100]
+        ],
+        'board-content-bottom': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'board-footer': [
+            [728, 90],
+            [970, 90],
+            [320, 100]
+        ],
+        'comment-infeed': [
+            [728, 90],
+            [300, 250],
+            [320, 100]
+        ],
+        'comment-top': [
+            [728, 90],
+            [320, 100]
+        ],
+        'sidebar-sticky': [
+            [300, 250],
+            [300, 600]
+        ],
+        sidebar: [[300, 250]]
     };
 
     // 위치별 라벨 매핑
@@ -207,7 +343,9 @@
                 return;
             }
 
-            const existingScript = document.querySelector('script[src*="securepubads.g.doubleclick.net"]');
+            const existingScript = document.querySelector(
+                'script[src*="securepubads.g.doubleclick.net"]'
+            );
             if (existingScript) {
                 // 스크립트가 있지만 아직 로드 안됨
                 const checkReady = setInterval(() => {
@@ -235,7 +373,11 @@
     }
 
     // 광고 설정 가져오기
-    function getAdConfig(): { unit: string; sizes: Array<[number, number]>; responsive: Array<[number, Array<[number, number]>]> | null } {
+    function getAdConfig(): {
+        unit: string;
+        sizes: Array<[number, number]>;
+        responsive: Array<[number, Array<[number, number]>]> | null;
+    } {
         const configKey = POSITION_MAP[position];
         if (configKey && AD_CONFIGS[configKey]) {
             return AD_CONFIGS[configKey];
@@ -243,7 +385,11 @@
         // Fallback: 기본 설정
         return {
             unit: AD_UNIT_PATHS.sub,
-            sizes: (sizes as Array<[number, number]>) || DEFAULT_SIZES[position] as Array<[number, number]> || [[728, 90], [320, 100]],
+            sizes: (sizes as Array<[number, number]>) ||
+                (DEFAULT_SIZES[position] as Array<[number, number]>) || [
+                    [728, 90],
+                    [320, 100]
+                ],
             responsive: [
                 [728, [[728, 90]]],
                 [0, [[320, 100]]]
@@ -290,21 +436,26 @@
                 slot.addService(googletag.pubads());
 
                 // 빈 광고 이벤트 처리
-                googletag.pubads().addEventListener('slotRenderEnded', (event: googletag.events.SlotRenderEndedEvent) => {
-                    if (event.slot === slot) {
-                        isLoaded = true;
-                        hasAd = !event.isEmpty;
+                googletag
+                    .pubads()
+                    .addEventListener(
+                        'slotRenderEnded',
+                        (event: googletag.events.SlotRenderEndedEvent) => {
+                            if (event.slot === slot) {
+                                isLoaded = true;
+                                hasAd = !event.isEmpty;
 
-                        // 빈 광고면 재시도
-                        if (event.isEmpty) {
-                            setTimeout(() => {
-                                if (slot) {
-                                    googletag.pubads().refresh([slot]);
+                                // 빈 광고면 재시도
+                                if (event.isEmpty) {
+                                    setTimeout(() => {
+                                        if (slot) {
+                                            googletag.pubads().refresh([slot]);
+                                        }
+                                    }, GAM_AD_EMPTY_RETRY_DELAY * 1000);
                                 }
-                            }, GAM_AD_EMPTY_RETRY_DELAY * 1000);
+                            }
                         }
-                    }
-                });
+                    );
 
                 // GPT 서비스 초기화 (한 번만 실행)
                 if (!isGptInitialized()) {
@@ -362,20 +513,24 @@
 
     {#if !isLoaded}
         <!-- 로딩 중 플레이스홀더 -->
-        <div class="absolute inset-0 flex items-center justify-center rounded-lg border-2 border-dashed border-slate-300 bg-slate-50/50 dark:border-slate-600 dark:bg-slate-800/50">
+        <div
+            class="absolute inset-0 flex items-center justify-center rounded-lg border-2 border-dashed border-slate-300 bg-slate-50/50 dark:border-slate-600 dark:bg-slate-800/50"
+        >
             <div class="flex flex-col items-center gap-1.5 text-center">
-                <span class="text-slate-500 dark:text-slate-400 text-xs font-semibold">AD</span>
-                <span class="text-slate-400 dark:text-slate-500 text-[10px]">
+                <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">AD</span>
+                <span class="text-[10px] text-slate-400 dark:text-slate-500">
                     {positionLabels[position] || position}
                 </span>
             </div>
         </div>
     {:else if !hasAd}
         <!-- 광고 없음 플레이스홀더 -->
-        <div class="absolute inset-0 flex items-center justify-center rounded-lg border-2 border-dashed border-amber-300 bg-amber-50/50 dark:border-amber-600 dark:bg-amber-900/20">
+        <div
+            class="absolute inset-0 flex items-center justify-center rounded-lg border-2 border-dashed border-amber-300 bg-amber-50/50 dark:border-amber-600 dark:bg-amber-900/20"
+        >
             <div class="flex flex-col items-center gap-1.5 text-center">
-                <span class="text-amber-600 dark:text-amber-400 text-xs font-semibold">AD</span>
-                <span class="text-amber-500 dark:text-amber-500 text-[10px]">
+                <span class="text-xs font-semibold text-amber-600 dark:text-amber-400">AD</span>
+                <span class="text-[10px] text-amber-500 dark:text-amber-500">
                     {positionLabels[position] || position}
                 </span>
             </div>

--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -5,7 +5,7 @@
 
     interface Props {
         position: 'index' | 'board-list' | 'board-view';
-        showCelebration?: boolean;  // 축하메시지 표시 여부 (메인만 true)
+        showCelebration?: boolean; // 축하메시지 표시 여부 (메인만 true)
         height?: string;
         class?: string;
     }
@@ -48,14 +48,14 @@
 
     // position → 다모앙 광고 서버 position 매핑
     const ADS_POSITION_MAP: Record<string, string> = {
-        'index': 'main-top',
+        index: 'main-top',
         'board-list': 'board-list-head',
         'board-view': 'board-view-top'
     };
 
     // position → GAM 슬롯 위치 매핑
     const GAM_POSITION_MAP: Record<string, string> = {
-        'index': 'index-head',
+        index: 'index-head',
         'board-list': 'board-list-head',
         'board-view': 'board-content'
     };
@@ -99,7 +99,7 @@
                 `${DAMOANG_API_BASE}/api/plugins/advertising/banners/today`,
                 {
                     method: 'GET',
-                    headers: { 'Accept': 'application/json' }
+                    headers: { Accept: 'application/json' }
                 }
             );
 
@@ -155,8 +155,8 @@
             style:min-height={height}
         >
             <div class="flex flex-col items-center gap-1.5 text-center">
-                <span class="text-slate-500 dark:text-slate-400 text-xs font-semibold">AD</span>
-                <span class="text-slate-400 dark:text-slate-500 text-[10px]">로딩 중...</span>
+                <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">AD</span>
+                <span class="text-[10px] text-slate-400 dark:text-slate-500">로딩 중...</span>
             </div>
         </div>
     {:else if celebrationBanner}

--- a/docs/phase-16-plan.md
+++ b/docs/phase-16-plan.md
@@ -32,12 +32,12 @@ export interface FreeComment {
 
 ### 1.2 백엔드 API 스펙
 
-| Method | Endpoint | 설명 | 권한 |
-|--------|----------|------|------|
-| `PATCH` | `/api/v2/boards/{boardId}/posts/{postId}/soft-delete` | 소프트 삭제 | 작성자, 관리자 |
-| `POST` | `/api/v2/boards/{boardId}/posts/{postId}/restore` | 복구 | 관리자 |
-| `DELETE` | `/api/v2/boards/{boardId}/posts/{postId}/permanent` | 영구 삭제 | 관리자 |
-| `GET` | `/api/v2/admin/posts/deleted` | 삭제된 게시물 목록 | 관리자 |
+| Method   | Endpoint                                              | 설명               | 권한           |
+| -------- | ----------------------------------------------------- | ------------------ | -------------- |
+| `PATCH`  | `/api/v2/boards/{boardId}/posts/{postId}/soft-delete` | 소프트 삭제        | 작성자, 관리자 |
+| `POST`   | `/api/v2/boards/{boardId}/posts/{postId}/restore`     | 복구               | 관리자         |
+| `DELETE` | `/api/v2/boards/{boardId}/posts/{postId}/permanent`   | 영구 삭제          | 관리자         |
+| `GET`    | `/api/v2/admin/posts/deleted`                         | 삭제된 게시물 목록 | 관리자         |
 
 **백엔드 DB 마이그레이션** (Go/Fiber):
 
@@ -63,10 +63,10 @@ async getDeletedPosts(page?: number, limit?: number): Promise<PaginatedResponse<
 
 #### 컴포넌트
 
-| 파일 | 위치 | 설명 |
-|------|------|------|
-| `deleted-post-banner.svelte` | `apps/web/src/lib/components/post/` | 삭제된 게시물 안내 배너 + 복구 버튼 |
-| `deleted-posts-list.svelte` | `apps/admin/src/routes/posts/deleted/` | Admin 삭제 게시물 관리 |
+| 파일                         | 위치                                   | 설명                                |
+| ---------------------------- | -------------------------------------- | ----------------------------------- |
+| `deleted-post-banner.svelte` | `apps/web/src/lib/components/post/`    | 삭제된 게시물 안내 배너 + 복구 버튼 |
+| `deleted-posts-list.svelte`  | `apps/admin/src/routes/posts/deleted/` | Admin 삭제 게시물 관리              |
 
 #### 동작 흐름
 
@@ -105,11 +105,11 @@ export interface RevisionDiff {
 
 ### 2.2 백엔드 API 스펙
 
-| Method | Endpoint | 설명 | 권한 |
-|--------|----------|------|------|
-| `GET` | `/api/v2/boards/{boardId}/posts/{postId}/revisions` | 수정 이력 목록 | 작성자, 관리자 |
-| `GET` | `/api/v2/boards/{boardId}/posts/{postId}/revisions/{version}` | 특정 버전 조회 | 작성자, 관리자 |
-| `POST` | `/api/v2/boards/{boardId}/posts/{postId}/revisions/{version}/restore` | 버전 복원 | 작성자, 관리자 |
+| Method | Endpoint                                                              | 설명           | 권한           |
+| ------ | --------------------------------------------------------------------- | -------------- | -------------- |
+| `GET`  | `/api/v2/boards/{boardId}/posts/{postId}/revisions`                   | 수정 이력 목록 | 작성자, 관리자 |
+| `GET`  | `/api/v2/boards/{boardId}/posts/{postId}/revisions/{version}`         | 특정 버전 조회 | 작성자, 관리자 |
+| `POST` | `/api/v2/boards/{boardId}/posts/{postId}/revisions/{version}/restore` | 버전 복원      | 작성자, 관리자 |
 
 **백엔드 DB 마이그레이션**:
 
@@ -142,11 +142,11 @@ async restoreRevision(boardId: string, postId: string, version: number): Promise
 
 #### 컴포넌트
 
-| 파일 | 위치 | 설명 |
-|------|------|------|
-| `revision-history.svelte` | `apps/web/src/lib/components/post/` | 수정 이력 타임라인 + diff 뷰 |
-| `revision-diff.svelte` | `apps/web/src/lib/components/post/` | 두 버전 간 차이 비교 |
-| `revision-restore-dialog.svelte` | `apps/web/src/lib/components/post/` | 버전 복원 확인 다이얼로그 |
+| 파일                             | 위치                                | 설명                         |
+| -------------------------------- | ----------------------------------- | ---------------------------- |
+| `revision-history.svelte`        | `apps/web/src/lib/components/post/` | 수정 이력 타임라인 + diff 뷰 |
+| `revision-diff.svelte`           | `apps/web/src/lib/components/post/` | 두 버전 간 차이 비교         |
+| `revision-restore-dialog.svelte` | `apps/web/src/lib/components/post/` | 버전 복원 확인 다이얼로그    |
 
 #### 동작 흐름
 
@@ -169,18 +169,18 @@ export interface Scrap {
     user_id: string;
     memo?: string;
     created_at: string;
-    post?: FreePost;  // 조회 시 포함
+    post?: FreePost; // 조회 시 포함
 }
 ```
 
 ### 3.2 백엔드 API 스펙
 
-| Method | Endpoint | 설명 | 권한 |
-|--------|----------|------|------|
-| `POST` | `/api/v2/posts/{postId}/scrap` | 스크랩 추가 | 로그인 |
-| `DELETE` | `/api/v2/posts/{postId}/scrap` | 스크랩 해제 | 로그인 |
-| `GET` | `/api/v2/my/scraps` | 내 스크랩 목록 | 로그인 |
-| `GET` | `/api/v2/posts/{postId}/scrap/status` | 스크랩 여부 | 로그인 |
+| Method   | Endpoint                              | 설명           | 권한   |
+| -------- | ------------------------------------- | -------------- | ------ |
+| `POST`   | `/api/v2/posts/{postId}/scrap`        | 스크랩 추가    | 로그인 |
+| `DELETE` | `/api/v2/posts/{postId}/scrap`        | 스크랩 해제    | 로그인 |
+| `GET`    | `/api/v2/my/scraps`                   | 내 스크랩 목록 | 로그인 |
+| `GET`    | `/api/v2/posts/{postId}/scrap/status` | 스크랩 여부    | 로그인 |
 
 **백엔드 DB 마이그레이션**:
 
@@ -212,10 +212,10 @@ async getScrapStatus(postId: string): Promise<{ scrapped: boolean }>
 
 #### 컴포넌트
 
-| 파일 | 위치 | 설명 |
-|------|------|------|
+| 파일                  | 위치                                | 설명                               |
+| --------------------- | ----------------------------------- | ---------------------------------- |
 | `scrap-button.svelte` | `apps/web/src/lib/components/post/` | 스크랩 토글 버튼 (Bookmark 아이콘) |
-| `+page.svelte` | `apps/web/src/routes/my/scraps/` | 내 스크랩 목록 페이지 |
+| `+page.svelte`        | `apps/web/src/routes/my/scraps/`    | 내 스크랩 목록 페이지              |
 
 #### 동작 흐름
 
@@ -242,14 +242,14 @@ export interface BoardGroup {
 
 ### 4.2 백엔드 API 스펙
 
-| Method | Endpoint | 설명 | 권한 |
-|--------|----------|------|------|
-| `GET` | `/api/v2/board-groups` | 그룹 목록 (게시판 포함) | 공개 |
-| `POST` | `/api/v2/admin/board-groups` | 그룹 생성 | 관리자 |
-| `PUT` | `/api/v2/admin/board-groups/{groupId}` | 그룹 수정 | 관리자 |
-| `DELETE` | `/api/v2/admin/board-groups/{groupId}` | 그룹 삭제 | 관리자 |
-| `PATCH` | `/api/v2/admin/board-groups/reorder` | 그룹 순서 변경 | 관리자 |
-| `PATCH` | `/api/v2/admin/boards/{boardId}/group` | 게시판 그룹 변경 | 관리자 |
+| Method   | Endpoint                               | 설명                    | 권한   |
+| -------- | -------------------------------------- | ----------------------- | ------ |
+| `GET`    | `/api/v2/board-groups`                 | 그룹 목록 (게시판 포함) | 공개   |
+| `POST`   | `/api/v2/admin/board-groups`           | 그룹 생성               | 관리자 |
+| `PUT`    | `/api/v2/admin/board-groups/{groupId}` | 그룹 수정               | 관리자 |
+| `DELETE` | `/api/v2/admin/board-groups/{groupId}` | 그룹 삭제               | 관리자 |
+| `PATCH`  | `/api/v2/admin/board-groups/reorder`   | 그룹 순서 변경          | 관리자 |
+| `PATCH`  | `/api/v2/admin/boards/{boardId}/group` | 게시판 그룹 변경        | 관리자 |
 
 **백엔드 DB 마이그레이션**:
 
@@ -273,11 +273,11 @@ ALTER TABLE boards ADD FOREIGN KEY (group_id) REFERENCES board_groups(id);
 
 #### 컴포넌트
 
-| 파일 | 위치 | 설명 |
-|------|------|------|
-| `+page.svelte` | `apps/admin/src/routes/board-groups/` | Admin 게시판 그룹 CRUD |
-| `board-group-form.svelte` | `apps/admin/src/lib/components/board/` | 그룹 생성/수정 폼 |
-| `sidebar-board-groups.svelte` | `apps/web/src/lib/components/layout/` | 사이드바 그룹별 게시판 표시 |
+| 파일                          | 위치                                   | 설명                        |
+| ----------------------------- | -------------------------------------- | --------------------------- |
+| `+page.svelte`                | `apps/admin/src/routes/board-groups/`  | Admin 게시판 그룹 CRUD      |
+| `board-group-form.svelte`     | `apps/admin/src/lib/components/board/` | 그룹 생성/수정 폼           |
+| `sidebar-board-groups.svelte` | `apps/web/src/lib/components/layout/`  | 사이드바 그룹별 게시판 표시 |
 
 #### 동작 흐름
 
@@ -334,15 +334,15 @@ Phase 16 코어 기능 완성 후, `extensions/plugin-content-history/`는:
 
 ## 7. QA 이슈 반영 (Phase 11-15에서 발견)
 
-| 이슈 | 해결 방안 | 적용 시점 |
-|------|-----------|-----------|
-| PluginSlot handleError 미연결 | ErrorBoundary 래퍼 추가 | Phase 16과 별도 |
-| ALLOWED_EXTENSIONS 미적용 | validateZipEntries에서 검증 추가 | Phase 16과 별도 |
-| Web 설정페이지 코드 중복 | PluginSettingsForm 공유 컴포넌트 사용 | Phase 16과 별도 |
-| 마켓플레이스 GitHub 미연동 | 하드코딩 → API 연동 | Phase 17 이후 |
-| 다크모드 미지원 (plugin-slot 등) | dark: 클래스 추가 | Phase 16 구현 시 반영 |
-| 접근성 미지원 (history-viewer 등) | role/aria 속성 추가 | Phase 16 구현 시 반영 |
-| history-track 인메모리 저장 | 코어 DB 연동으로 해결 | task-49 |
+| 이슈                              | 해결 방안                             | 적용 시점             |
+| --------------------------------- | ------------------------------------- | --------------------- |
+| PluginSlot handleError 미연결     | ErrorBoundary 래퍼 추가               | Phase 16과 별도       |
+| ALLOWED_EXTENSIONS 미적용         | validateZipEntries에서 검증 추가      | Phase 16과 별도       |
+| Web 설정페이지 코드 중복          | PluginSettingsForm 공유 컴포넌트 사용 | Phase 16과 별도       |
+| 마켓플레이스 GitHub 미연동        | 하드코딩 → API 연동                   | Phase 17 이후         |
+| 다크모드 미지원 (plugin-slot 등)  | dark: 클래스 추가                     | Phase 16 구현 시 반영 |
+| 접근성 미지원 (history-viewer 등) | role/aria 속성 추가                   | Phase 16 구현 시 반영 |
+| history-track 인메모리 저장       | 코어 DB 연동으로 해결                 | task-49               |
 
 ---
 

--- a/extensions/plugin-content-history/plugin.json
+++ b/extensions/plugin-content-history/plugin.json
@@ -13,12 +13,7 @@
     "tags": ["history", "soft-delete", "restore", "diff", "admin"],
     "angpleVersion": ">=1.0.0",
     "main": "./src/index.js",
-    "permissions": [
-        "posts:read",
-        "posts:write",
-        "posts:delete",
-        "settings:read"
-    ],
+    "permissions": ["posts:read", "posts:write", "posts:delete", "settings:read"],
     "hooks": [
         {
             "name": "before_post_delete",

--- a/extensions/plugin-content-history/src/hooks/history-track.ts
+++ b/extensions/plugin-content-history/src/hooks/history-track.ts
@@ -28,37 +28,41 @@ export function setupHistoryTrack(
     maxVersions: number,
     logger: PluginLogger
 ): void {
-    hooks.addAction('after_post_update', (context: {
-        postId: string | number;
-        previousTitle: string;
-        previousContent: string;
-        newTitle: string;
-        newContent: string;
-        userId: string;
-        changeType?: 'create' | 'update' | 'soft_delete' | 'restore';
-    }) => {
-        const postKey = String(context.postId);
-        const entries = historyStore.get(postKey) ?? [];
+    hooks.addAction(
+        'after_post_update',
+        (context: {
+            postId: string | number;
+            previousTitle: string;
+            previousContent: string;
+            newTitle: string;
+            newContent: string;
+            userId: string;
+            changeType?: 'create' | 'update' | 'soft_delete' | 'restore';
+        }) => {
+            const postKey = String(context.postId);
+            const entries = historyStore.get(postKey) ?? [];
 
-        const newEntry: HistoryEntry = {
-            version: entries.length + 1,
-            title: context.previousTitle,
-            content: context.previousContent,
-            editedBy: context.userId,
-            editedAt: new Date().toISOString(),
-            changeType: context.changeType ?? 'update'
-        };
+            const newEntry: HistoryEntry = {
+                version: entries.length + 1,
+                title: context.previousTitle,
+                content: context.previousContent,
+                editedBy: context.userId,
+                editedAt: new Date().toISOString(),
+                changeType: context.changeType ?? 'update'
+            };
 
-        entries.push(newEntry);
+            entries.push(newEntry);
 
-        // 최대 버전 수 초과 시 오래된 것 제거
-        while (entries.length > maxVersions) {
-            entries.shift();
-        }
+            // 최대 버전 수 초과 시 오래된 것 제거
+            while (entries.length > maxVersions) {
+                entries.shift();
+            }
 
-        historyStore.set(postKey, entries);
-        logger.info(`이력 저장: postId=${postKey}, version=${newEntry.version}`);
-    }, 10);
+            historyStore.set(postKey, entries);
+            logger.info(`이력 저장: postId=${postKey}, version=${newEntry.version}`);
+        },
+        10
+    );
 }
 
 /**

--- a/extensions/plugin-content-history/src/hooks/soft-delete.ts
+++ b/extensions/plugin-content-history/src/hooks/soft-delete.ts
@@ -22,14 +22,18 @@ interface DeleteContext {
  * 소프트 삭제 훅 설정
  */
 export function setupSoftDelete(hooks: HookManager, logger: PluginLogger): void {
-    hooks.addFilter('before_post_delete', (context: DeleteContext): DeleteContext => {
-        logger.info(`소프트 삭제 처리: postId=${context.postId}`);
+    hooks.addFilter(
+        'before_post_delete',
+        (context: DeleteContext): DeleteContext => {
+            logger.info(`소프트 삭제 처리: postId=${context.postId}`);
 
-        // 실제 삭제를 중단하고 소프트 삭제로 표시
-        return {
-            ...context,
-            softDeleted: true,
-            proceed: false // 실제 삭제 중단
-        };
-    }, 1); // 최우선 실행
+            // 실제 삭제를 중단하고 소프트 삭제로 표시
+            return {
+                ...context,
+                softDeleted: true,
+                proceed: false // 실제 삭제 중단
+            };
+        },
+        1
+    ); // 최우선 실행
 }

--- a/extensions/plugin-content-history/src/ui/deleted-banner.svelte
+++ b/extensions/plugin-content-history/src/ui/deleted-banner.svelte
@@ -41,7 +41,9 @@
 </script>
 
 {#if deletedAt}
-    <div class="mb-4 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30">
+    <div
+        class="mb-4 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950/30"
+    >
         <div class="flex items-center gap-3">
             <AlertTriangle class="h-5 w-5 flex-shrink-0 text-red-500" />
             <div>

--- a/extensions/plugin-content-history/src/ui/history-viewer.svelte
+++ b/extensions/plugin-content-history/src/ui/history-viewer.svelte
@@ -6,7 +6,15 @@
      * 버전 간 diff를 확인할 수 있습니다.
      */
 
-    import { Clock, ChevronDown, ChevronUp, FileText, Trash2, RotateCcw, Edit } from '@lucide/svelte';
+    import {
+        Clock,
+        ChevronDown,
+        ChevronUp,
+        FileText,
+        Trash2,
+        RotateCcw,
+        Edit
+    } from '@lucide/svelte';
 
     interface HistoryEntry {
         version: number;
@@ -31,33 +39,48 @@
     /** 변경 타입 라벨 */
     function getChangeLabel(type: string): string {
         switch (type) {
-            case 'create': return '최초 작성';
-            case 'update': return '수정';
-            case 'soft_delete': return '삭제';
-            case 'restore': return '복구';
-            default: return type;
+            case 'create':
+                return '최초 작성';
+            case 'update':
+                return '수정';
+            case 'soft_delete':
+                return '삭제';
+            case 'restore':
+                return '복구';
+            default:
+                return type;
         }
     }
 
     /** 변경 타입 아이콘 */
     function getChangeIcon(type: string) {
         switch (type) {
-            case 'create': return FileText;
-            case 'update': return Edit;
-            case 'soft_delete': return Trash2;
-            case 'restore': return RotateCcw;
-            default: return FileText;
+            case 'create':
+                return FileText;
+            case 'update':
+                return Edit;
+            case 'soft_delete':
+                return Trash2;
+            case 'restore':
+                return RotateCcw;
+            default:
+                return FileText;
         }
     }
 
     /** 변경 타입 색상 */
     function getChangeColor(type: string): string {
         switch (type) {
-            case 'create': return 'text-green-600';
-            case 'update': return 'text-blue-600';
-            case 'soft_delete': return 'text-red-600';
-            case 'restore': return 'text-orange-600';
-            default: return 'text-muted-foreground';
+            case 'create':
+                return 'text-green-600';
+            case 'update':
+                return 'text-blue-600';
+            case 'soft_delete':
+                return 'text-red-600';
+            case 'restore':
+                return 'text-orange-600';
+            default:
+                return 'text-muted-foreground';
         }
     }
 
@@ -70,19 +93,20 @@
     }
 
     /** 간단한 텍스트 diff (줄 단위) */
-    function getSimpleDiff(oldText: string, newText: string): { added: string[]; removed: string[] } {
+    function getSimpleDiff(
+        oldText: string,
+        newText: string
+    ): { added: string[]; removed: string[] } {
         const oldLines = oldText.split('\n');
         const newLines = newText.split('\n');
 
-        const removed = oldLines.filter(line => !newLines.includes(line));
-        const added = newLines.filter(line => !oldLines.includes(line));
+        const removed = oldLines.filter((line) => !newLines.includes(line));
+        const added = newLines.filter((line) => !oldLines.includes(line));
 
         return { added, removed };
     }
 
-    const sortedHistory = $derived(
-        [...history].sort((a, b) => b.version - a.version)
-    );
+    const sortedHistory = $derived([...history].sort((a, b) => b.version - a.version));
 </script>
 
 {#if history.length > 0}
@@ -135,13 +159,16 @@
                             <button
                                 class="text-primary mt-1 text-xs hover:underline"
                                 onclick={() =>
-                                    (selectedVersion = selectedVersion === entry.version ? null : entry.version)}
+                                    (selectedVersion =
+                                        selectedVersion === entry.version ? null : entry.version)}
                             >
                                 {selectedVersion === entry.version ? '접기' : '내용 보기'}
                             </button>
 
                             {#if selectedVersion === entry.version}
-                                <div class="bg-muted/50 mt-2 max-h-60 overflow-y-auto rounded p-3 text-sm">
+                                <div
+                                    class="bg-muted/50 mt-2 max-h-60 overflow-y-auto rounded p-3 text-sm"
+                                >
                                     {entry.content || '(내용 없음)'}
                                 </div>
                             {/if}

--- a/plugins/emoticon/components/emoticon-image.svelte
+++ b/plugins/emoticon/components/emoticon-image.svelte
@@ -17,19 +17,8 @@
     let src = $derived(getImageUrl(filename));
 </script>
 
-<button
-    type="button"
-    class="emoticon-image-btn"
-    {onclick}
-    title={filename}
->
-    <img
-        {src}
-        {width}
-        class="emoticon"
-        loading="lazy"
-        alt={filename}
-    />
+<button type="button" class="emoticon-image-btn" {onclick} title={filename}>
+    <img {src} {width} class="emoticon" loading="lazy" alt={filename} />
 </button>
 
 <style>
@@ -42,7 +31,9 @@
         border-radius: 4px;
         background: none;
         cursor: pointer;
-        transition: border-color 0.15s, background-color 0.15s;
+        transition:
+            border-color 0.15s,
+            background-color 0.15s;
     }
 
     .emoticon-image-btn:hover {

--- a/plugins/emoticon/components/emoticon-picker.svelte
+++ b/plugins/emoticon/components/emoticon-picker.svelte
@@ -186,7 +186,9 @@
         font-size: 13px;
         color: var(--text-muted, #64748b);
         white-space: nowrap;
-        transition: color 0.15s, border-color 0.15s;
+        transition:
+            color 0.15s,
+            border-color 0.15s;
     }
 
     .emoticon-tab:hover {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
+      '@types/google-publisher-tag':
+        specifier: ^1.20260202.0
+        version: 1.20260202.0
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.10
@@ -1563,6 +1566,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/google-publisher-tag@1.20260202.0':
+    resolution: {integrity: sha512-+ZPJu9l47RomvjEg8X58n0kfpO1zofJX0COv7SD5/x0ewuPt421VcTt8IIS4J8Xp79izhfaNzGtLBdZaHFj9ww==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -5266,6 +5272,8 @@ snapshots:
       dompurify: 3.3.1
 
   '@types/estree@1.0.8': {}
+
+  '@types/google-publisher-tag@1.20260202.0': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/qa-phase11-15.md
+++ b/qa-phase11-15.md
@@ -6,209 +6,234 @@
 
 ## 환경 정보
 
-| 항목 | 값 |
-|------|------|
-| Web App | `http://localhost:5173` |
+| 항목      | 값                                                           |
+| --------- | ------------------------------------------------------------ |
+| Web App   | `http://localhost:5173`                                      |
 | Admin App | `http://localhost:5174` (또는 `http://localhost:5173/admin`) |
-| 동접 규모 | 상시 1만, 피크 2만 |
+| 동접 규모 | 상시 1만, 피크 2만                                           |
 
 ---
 
 ## Phase 11: Plugin Engine 패키지
 
 ### QA-11-1: 패키지 빌드 검증
-- [ ] `cd packages/plugin-engine && pnpm build` 성공 확인
-- [ ] `dist/` 폴더에 `.js` + `.d.ts` 파일 생성 확인
-- [ ] 다른 패키지에서 `@angple/plugin-engine` import 가능 확인
+
+-   [ ] `cd packages/plugin-engine && pnpm build` 성공 확인
+-   [ ] `dist/` 폴더에 `.js` + `.d.ts` 파일 생성 확인
+-   [ ] 다른 패키지에서 `@angple/plugin-engine` import 가능 확인
 
 ### QA-11-2: PluginRegistry 기능 검증
-- [ ] `register()` → 플러그인 등록 확인
-- [ ] `activate()` → ExtensionContext 반환 확인
-- [ ] `deactivate()` → 권한 회수 + 슬롯 제거 확인
-- [ ] 중복 등록 시 경고 로그 출력 확인
+
+-   [ ] `register()` → 플러그인 등록 확인
+-   [ ] `activate()` → ExtensionContext 반환 확인
+-   [ ] `deactivate()` → 권한 회수 + 슬롯 제거 확인
+-   [ ] 중복 등록 시 경고 로그 출력 확인
 
 ### QA-11-3: ExtensionContext 기능 검증
-- [ ] `context.hooks.addAction()` → 전역 HookManager에 등록 확인
-- [ ] `context.settings.get()` → 기본값 폴백 확인
-- [ ] `context.settings.set()` → 변경 콜백 호출 확인
-- [ ] `context.permissions.check()` → 미부여 권한 false 확인
-- [ ] `context.ui.registerSlot()` → 슬롯 레지스트리에 등록 확인
-- [ ] `context.logger.info/warn/error()` → 플러그인 prefix 로그 확인
+
+-   [ ] `context.hooks.addAction()` → 전역 HookManager에 등록 확인
+-   [ ] `context.settings.get()` → 기본값 폴백 확인
+-   [ ] `context.settings.set()` → 변경 콜백 호출 확인
+-   [ ] `context.permissions.check()` → 미부여 권한 false 확인
+-   [ ] `context.ui.registerSlot()` → 슬롯 레지스트리에 등록 확인
+-   [ ] `context.logger.info/warn/error()` → 플러그인 prefix 로그 확인
 
 ### QA-11-4: PermissionManager 검증
-- [ ] `grant()` → 권한 부여 후 `check()` true 확인
-- [ ] `revoke()` → 권한 회수 후 `check()` false 확인
-- [ ] 미등록 플러그인 `check()` → false 확인
+
+-   [ ] `grant()` → 권한 부여 후 `check()` true 확인
+-   [ ] `revoke()` → 권한 회수 후 `check()` false 확인
+-   [ ] 미등록 플러그인 `check()` → false 확인
 
 ---
 
 ## Phase 12: PluginSlot + ZIP 업로드
 
 ### QA-12-1: PluginSlot 컴포넌트 검증 (Web App)
-- [ ] `<PluginSlot name="header-after" />` 렌더링 확인 (빈 슬롯 = DOM 없음)
-- [ ] 슬롯에 컴포넌트 등록 시 렌더링 확인
-- [ ] 컴포넌트 에러 시 다른 컴포넌트에 영향 없음 확인 (에러 격리)
-- [ ] DEV 모드에서 에러 메시지 표시 확인
-- [ ] 슬롯 name 변경 시 컴포넌트 목록 갱신 확인
+
+-   [ ] `<PluginSlot name="header-after" />` 렌더링 확인 (빈 슬롯 = DOM 없음)
+-   [ ] 슬롯에 컴포넌트 등록 시 렌더링 확인
+-   [ ] 컴포넌트 에러 시 다른 컴포넌트에 영향 없음 확인 (에러 격리)
+-   [ ] DEV 모드에서 에러 메시지 표시 확인
+-   [ ] 슬롯 name 변경 시 컴포넌트 목록 갱신 확인
 
 ### QA-12-2: ZIP 업로드 API 검증
-- [ ] `POST /api/plugins/upload` - 정상 ZIP 업로드 → 성공 응답 확인
-- [ ] 파일 없는 요청 → 400 에러 확인
-- [ ] 20MB 초과 파일 → 400 에러 확인
-- [ ] ZIP 아닌 파일 → 400 에러 (MIME 검증)
-- [ ] plugin.json/extension.json 없는 ZIP → 400 에러
-- [ ] 매니페스트 검증 실패 → 400 에러 + details
-- [ ] 폴더명과 ID 불일치 → 400 에러
-- [ ] 중복 설치 → 409 에러
-- [ ] Zip Slip 공격 시도 → 400 에러
-- [ ] 업로드 후 `custom-plugins/`에 디렉터리 생성 확인
-- [ ] 업로드 후 `scanPlugins()` 재스캔 확인
+
+-   [ ] `POST /api/plugins/upload` - 정상 ZIP 업로드 → 성공 응답 확인
+-   [ ] 파일 없는 요청 → 400 에러 확인
+-   [ ] 20MB 초과 파일 → 400 에러 확인
+-   [ ] ZIP 아닌 파일 → 400 에러 (MIME 검증)
+-   [ ] plugin.json/extension.json 없는 ZIP → 400 에러
+-   [ ] 매니페스트 검증 실패 → 400 에러 + details
+-   [ ] 폴더명과 ID 불일치 → 400 에러
+-   [ ] 중복 설치 → 409 에러
+-   [ ] Zip Slip 공격 시도 → 400 에러
+-   [ ] 업로드 후 `custom-plugins/`에 디렉터리 생성 확인
+-   [ ] 업로드 후 `scanPlugins()` 재스캔 확인
 
 ### QA-12-3: ZIP 업로더 UI 검증 (Admin)
-- [ ] Admin > 플러그인 > 프론트엔드 탭 → "플러그인 업로드" 버튼 표시 확인 (disabled 아님)
-- [ ] 버튼 클릭 → 다이얼로그 열림 확인
-- [ ] 파일 선택 영역 클릭 → 파일 선택기 열림
-- [ ] ZIP 파일 선택 → 업로드 진행 상태 (스피너) 표시
-- [ ] 업로드 성공 → 성공 메시지 + 플러그인 목록 갱신
-- [ ] 업로드 실패 → 에러 메시지 표시 + "다시 시도" 버튼
+
+-   [ ] Admin > 플러그인 > 프론트엔드 탭 → "플러그인 업로드" 버튼 표시 확인 (disabled 아님)
+-   [ ] 버튼 클릭 → 다이얼로그 열림 확인
+-   [ ] 파일 선택 영역 클릭 → 파일 선택기 열림
+-   [ ] ZIP 파일 선택 → 업로드 진행 상태 (스피너) 표시
+-   [ ] 업로드 성공 → 성공 메시지 + 플러그인 목록 갱신
+-   [ ] 업로드 실패 → 에러 메시지 표시 + "다시 시도" 버튼
 
 ### QA-12-4: 마켓플레이스 버튼 활성화 검증
-- [ ] "마켓플레이스" 버튼 클릭 → `/plugins/marketplace` 이동 확인
+
+-   [ ] "마켓플레이스" 버튼 클릭 → `/plugins/marketplace` 이동 확인
 
 ---
 
 ## Phase 13: Plugin Settings 자동 UI + 마켓플레이스
 
 ### QA-13-1: 자동 설정 폼 렌더링 검증
-- [ ] `boolean` 필드 → Switch 컴포넌트 렌더링 확인
-- [ ] `number` 필드 → Input[number] 렌더링 + min/max 적용 확인
-- [ ] `select` 필드 → Select 드롭다운 렌더링 + 옵션 목록 확인
-- [ ] `textarea` 필드 → textarea 렌더링 확인
-- [ ] `color` 필드 → 컬러 피커 + 텍스트 입력 렌더링 확인
-- [ ] `string`/`text`/`url` 필드 → Input[text/url] 렌더링 확인
-- [ ] 설정값 변경 → values 객체 업데이트 확인
-- [ ] 기본값 표시 확인 (settings에 값 없을 때 default 사용)
-- [ ] description 필드 → 설명 텍스트 표시 확인
+
+-   [ ] `boolean` 필드 → Switch 컴포넌트 렌더링 확인
+-   [ ] `number` 필드 → Input[number] 렌더링 + min/max 적용 확인
+-   [ ] `select` 필드 → Select 드롭다운 렌더링 + 옵션 목록 확인
+-   [ ] `textarea` 필드 → textarea 렌더링 확인
+-   [ ] `color` 필드 → 컬러 피커 + 텍스트 입력 렌더링 확인
+-   [ ] `string`/`text`/`url` 필드 → Input[text/url] 렌더링 확인
+-   [ ] 설정값 변경 → values 객체 업데이트 확인
+-   [ ] 기본값 표시 확인 (settings에 값 없을 때 default 사용)
+-   [ ] description 필드 → 설명 텍스트 표시 확인
 
 ### QA-13-2: 플러그인 설정 페이지 통합 검증
-- [ ] `/plugins/[id]/settings` → PluginSettingsForm 렌더링 확인
-- [ ] "저장" 클릭 → API 호출 + 성공 토스트
-- [ ] "기본값 복원" 클릭 → 모든 필드 기본값으로 리셋
+
+-   [ ] `/plugins/[id]/settings` → PluginSettingsForm 렌더링 확인
+-   [ ] "저장" 클릭 → API 호출 + 성공 토스트
+-   [ ] "기본값 복원" 클릭 → 모든 필드 기본값으로 리셋
 
 ### QA-13-3: 마켓플레이스 페이지 검증
-- [ ] `/plugins/marketplace` 페이지 로딩 확인
-- [ ] 뒤로가기 버튼 → `/plugins`로 이동
-- [ ] 검색창 입력 → 플러그인 필터링 확인
-- [ ] 카테고리 버튼 클릭 → 해당 카테고리만 표시
-- [ ] "전체" 카테고리 → 모든 플러그인 표시
-- [ ] 플러그인 카드에 이름/설명/버전/작성자/태그 표시
-- [ ] "무료" 배지 표시 (price === 0)
-- [ ] 검색 결과 없음 → "플러그인을 찾을 수 없습니다" 표시
+
+-   [ ] `/plugins/marketplace` 페이지 로딩 확인
+-   [ ] 뒤로가기 버튼 → `/plugins`로 이동
+-   [ ] 검색창 입력 → 플러그인 필터링 확인
+-   [ ] 카테고리 버튼 클릭 → 해당 카테고리만 표시
+-   [ ] "전체" 카테고리 → 모든 플러그인 표시
+-   [ ] 플러그인 카드에 이름/설명/버전/작성자/태그 표시
+-   [ ] "무료" 배지 표시 (price === 0)
+-   [ ] 검색 결과 없음 → "플러그인을 찾을 수 없습니다" 표시
 
 ---
 
 ## Phase 14: 게시판 뷰 시스템
 
 ### QA-14-1: BoardViewStore 검증
-- [ ] `getViewMode('test-board')` → 기본값 'list' 반환
-- [ ] `setViewMode('test-board', 'card')` → localStorage 저장 확인
-- [ ] 페이지 새로고침 → 저장된 뷰 모드 복원 확인
-- [ ] `resetViewMode('test-board')` → localStorage에서 제거 확인
-- [ ] 서버 기본값 설정 → 사용자 선호 없을 때 서버 기본값 사용 확인
-- [ ] 우선순위: 사용자 선호 > 서버 기본값 > 전역 기본값('list')
+
+-   [ ] `getViewMode('test-board')` → 기본값 'list' 반환
+-   [ ] `setViewMode('test-board', 'card')` → localStorage 저장 확인
+-   [ ] 페이지 새로고침 → 저장된 뷰 모드 복원 확인
+-   [ ] `resetViewMode('test-board')` → localStorage에서 제거 확인
+-   [ ] 서버 기본값 설정 → 사용자 선호 없을 때 서버 기본값 사용 확인
+-   [ ] 우선순위: 사용자 선호 > 서버 기본값 > 전역 기본값('list')
 
 ### QA-14-2: BoardViewSwitcher 컴포넌트 검증
-- [ ] 5가지 뷰 모드 아이콘 버튼 렌더링 확인
-- [ ] 현재 모드 하이라이트 (bg-primary) 확인
-- [ ] 버튼 클릭 → 뷰 모드 변경 + 즉시 반영
-- [ ] `allowedModes` prop → 제한된 모드만 표시 확인
-- [ ] aria-label, role="radiogroup" 접근성 확인
+
+-   [ ] 5가지 뷰 모드 아이콘 버튼 렌더링 확인
+-   [ ] 현재 모드 하이라이트 (bg-primary) 확인
+-   [ ] 버튼 클릭 → 뷰 모드 변경 + 즉시 반영
+-   [ ] `allowedModes` prop → 제한된 모드만 표시 확인
+-   [ ] aria-label, role="radiogroup" 접근성 확인
 
 ### QA-14-3: 뷰 컴포넌트별 렌더링 검증
-- [ ] **ListView**: 제목 + 작성자 + 날짜 + 조회/좋아요 수 표시
-- [ ] **CardView**: 썸네일 + 제목 + 발췌 + 태그 + 메타 표시
-- [ ] **GalleryView**: 이미지 그리드 + 호버 오버레이 표시
-- [ ] **CompactView**: 밀집 텍스트 행 (제목 + 댓글수 + 작성자 + 날짜 + 조회)
-- [ ] **TimelineView**: 타임라인 도트 + 시간 + 카드 형태 표시
-- [ ] 모든 뷰: 게시물 0개 → "게시물이 없습니다." 표시
-- [ ] 모든 뷰: 고정글 아이콘 표시 (isPinned)
+
+-   [ ] **ListView**: 제목 + 작성자 + 날짜 + 조회/좋아요 수 표시
+-   [ ] **CardView**: 썸네일 + 제목 + 발췌 + 태그 + 메타 표시
+-   [ ] **GalleryView**: 이미지 그리드 + 호버 오버레이 표시
+-   [ ] **CompactView**: 밀집 텍스트 행 (제목 + 댓글수 + 작성자 + 날짜 + 조회)
+-   [ ] **TimelineView**: 타임라인 도트 + 시간 + 카드 형태 표시
+-   [ ] 모든 뷰: 게시물 0개 → "게시물이 없습니다." 표시
+-   [ ] 모든 뷰: 고정글 아이콘 표시 (isPinned)
 
 ### QA-14-4: Admin 게시판 뷰 설정 검증
-- [ ] `/boards/[boardId]/view-settings` 페이지 로딩 확인
-- [ ] 기본 뷰 모드 Select → 5개 옵션 표시
-- [ ] 허용 뷰 모드 Switch → 온/오프 토글 확인
-- [ ] 모든 뷰 비활성화 시도 → 최소 1개 유지 (마지막은 끌 수 없음)
-- [ ] 기본 뷰가 비활성화 모드면 → 자동으로 첫 번째 허용 뷰로 변경
-- [ ] "저장" 버튼 클릭 → 토스트 메시지 표시
+
+-   [ ] `/boards/[boardId]/view-settings` 페이지 로딩 확인
+-   [ ] 기본 뷰 모드 Select → 5개 옵션 표시
+-   [ ] 허용 뷰 모드 Switch → 온/오프 토글 확인
+-   [ ] 모든 뷰 비활성화 시도 → 최소 1개 유지 (마지막은 끌 수 없음)
+-   [ ] 기본 뷰가 비활성화 모드면 → 자동으로 첫 번째 허용 뷰로 변경
+-   [ ] "저장" 버튼 클릭 → 토스트 메시지 표시
 
 ---
 
 ## Phase 15: Content History Plugin
 
 ### QA-15-1: plugin.json 매니페스트 검증
-- [ ] `extensions/plugin-content-history/plugin.json` 파싱 성공
-- [ ] Zod 스키마 검증 통과 확인
-- [ ] settings 3개 필드 존재: enable_soft_delete(boolean), history_visibility(select), max_versions(number)
-- [ ] hooks 3개 정의: before_post_delete, post_content, after_post_update
-- [ ] components 2개 정의: history-viewer, deleted-banner
+
+-   [ ] `extensions/plugin-content-history/plugin.json` 파싱 성공
+-   [ ] Zod 스키마 검증 통과 확인
+-   [ ] settings 3개 필드 존재: enable_soft_delete(boolean), history_visibility(select), max_versions(number)
+-   [ ] hooks 3개 정의: before_post_delete, post_content, after_post_update
+-   [ ] components 2개 정의: history-viewer, deleted-banner
 
 ### QA-15-2: 소프트 삭제 훅 검증
-- [ ] enable_soft_delete=true → before_post_delete 필터에서 proceed=false 반환
-- [ ] 삭제 요청 시 softDeleted=true 플래그 설정 확인
+
+-   [ ] enable_soft_delete=true → before_post_delete 필터에서 proceed=false 반환
+-   [ ] 삭제 요청 시 softDeleted=true 플래그 설정 확인
 
 ### QA-15-3: 콘텐츠 필터 훅 검증
-- [ ] 삭제되지 않은 게시물 → 원본 콘텐츠 그대로 반환
-- [ ] 삭제된 게시물 + 관리자 → "[삭제됨] 제목" 표시 + 원본 콘텐츠 유지
-- [ ] 삭제된 게시물 + 일반 사용자 → "[삭제된 게시물입니다]" 표시
-- [ ] history_visibility=author_admins + 작성자 → "[삭제됨] 제목" 표시
+
+-   [ ] 삭제되지 않은 게시물 → 원본 콘텐츠 그대로 반환
+-   [ ] 삭제된 게시물 + 관리자 → "[삭제됨] 제목" 표시 + 원본 콘텐츠 유지
+-   [ ] 삭제된 게시물 + 일반 사용자 → "[삭제된 게시물입니다]" 표시
+-   [ ] history_visibility=author_admins + 작성자 → "[삭제됨] 제목" 표시
 
 ### QA-15-4: 수정 이력 추적 훅 검증
-- [ ] 게시물 수정 시 이전 버전 저장 확인
-- [ ] version 번호 순차 증가 확인
-- [ ] max_versions 초과 시 오래된 버전 제거 확인
-- [ ] changeType 올바르게 기록 (create/update/soft_delete/restore)
+
+-   [ ] 게시물 수정 시 이전 버전 저장 확인
+-   [ ] version 번호 순차 증가 확인
+-   [ ] max_versions 초과 시 오래된 버전 제거 확인
+-   [ ] changeType 올바르게 기록 (create/update/soft_delete/restore)
 
 ### QA-15-5: deleted-banner.svelte UI 검증
-- [ ] deletedAt 없음 → 배너 미표시
-- [ ] deletedAt 있음 → 빨간 배너 표시 + 삭제 일시 표시
-- [ ] isAdmin=true → "복구" 버튼 표시
-- [ ] "복구" 클릭 → onRestore 콜백 호출 확인
-- [ ] 다크/라이트 모드 대응 확인
+
+-   [ ] deletedAt 없음 → 배너 미표시
+-   [ ] deletedAt 있음 → 빨간 배너 표시 + 삭제 일시 표시
+-   [ ] isAdmin=true → "복구" 버튼 표시
+-   [ ] "복구" 클릭 → onRestore 콜백 호출 확인
+-   [ ] 다크/라이트 모드 대응 확인
 
 ### QA-15-6: history-viewer.svelte UI 검증
-- [ ] 이력 0개 → 컴포넌트 미표시
-- [ ] 이력 있음 → "수정 이력 (N개 버전)" 헤더 표시
-- [ ] 클릭으로 펼침/접기 토글
-- [ ] 버전 역순 정렬 (최신 먼저)
-- [ ] 변경 타입별 아이콘/색상 구분 (create=초록, update=파랑, delete=빨강, restore=주황)
-- [ ] isAdmin=true → "내용 보기" 링크 표시
-- [ ] "내용 보기" 클릭 → 해당 버전 내용 표시
+
+-   [ ] 이력 0개 → 컴포넌트 미표시
+-   [ ] 이력 있음 → "수정 이력 (N개 버전)" 헤더 표시
+-   [ ] 클릭으로 펼침/접기 토글
+-   [ ] 버전 역순 정렬 (최신 먼저)
+-   [ ] 변경 타입별 아이콘/색상 구분 (create=초록, update=파랑, delete=빨강, restore=주황)
+-   [ ] isAdmin=true → "내용 보기" 링크 표시
+-   [ ] "내용 보기" 클릭 → 해당 버전 내용 표시
 
 ---
 
 ## 크로스 커팅 QA
 
 ### 성능 (동접 1~2만 대응)
-- [ ] PluginSlot 빈 슬롯 → DOM 요소 생성 안 함 확인
-- [ ] 뷰 스토어 localStorage 접근 → browser 체크로 SSR 안전 확인
-- [ ] plugin-engine 메모리 누수 없음 (deactivate 시 정리)
-- [ ] 마켓플레이스 페이지 초기 로딩 시 불필요한 API 호출 없음
+
+-   [ ] PluginSlot 빈 슬롯 → DOM 요소 생성 안 함 확인
+-   [ ] 뷰 스토어 localStorage 접근 → browser 체크로 SSR 안전 확인
+-   [ ] plugin-engine 메모리 누수 없음 (deactivate 시 정리)
+-   [ ] 마켓플레이스 페이지 초기 로딩 시 불필요한 API 호출 없음
 
 ### 다크/라이트 모드
-- [ ] deleted-banner: 다크 모드 색상 대응 확인
-- [ ] 뷰 스위처: 다크 모드에서 아이콘 가시성 확인
-- [ ] 마켓플레이스: 카드 그림자/배경 다크 모드 대응
+
+-   [ ] deleted-banner: 다크 모드 색상 대응 확인
+-   [ ] 뷰 스위처: 다크 모드에서 아이콘 가시성 확인
+-   [ ] 마켓플레이스: 카드 그림자/배경 다크 모드 대응
 
 ### 접근성
-- [ ] 뷰 스위처: role="radiogroup", aria-checked, aria-label 확인
-- [ ] ZIP 업로더: 키보드(Enter) 트리거 확인
-- [ ] 이력 뷰어: 펼침/접기 키보드 접근 가능
+
+-   [ ] 뷰 스위처: role="radiogroup", aria-checked, aria-label 확인
+-   [ ] ZIP 업로더: 키보드(Enter) 트리거 확인
+-   [ ] 이력 뷰어: 펼침/접기 키보드 접근 가능
 
 ### 보안
-- [ ] ZIP 업로드 Zip Slip 방어 확인
-- [ ] ZIP 업로드 Symlink 방어 확인
-- [ ] ZIP 업로드 파일 크기 제한 확인 (개별 20MB, 전체 50MB)
-- [ ] sanitizePath로 경로 탐색 공격 방지 확인
+
+-   [ ] ZIP 업로드 Zip Slip 방어 확인
+-   [ ] ZIP 업로드 Symlink 방어 확인
+-   [ ] ZIP 업로드 파일 크기 제한 확인 (개별 20MB, 전체 50MB)
+-   [ ] sanitizePath로 경로 탐색 공격 방지 확인
 
 ---
 
@@ -216,9 +241,9 @@
 
 1. **빌드 확인**: web + admin 빌드 성공 (사용자 제공)
 2. **Admin 플러그인 페이지** 접속 → 프론트엔드 탭 확인
-   - ZIP 업로드 버튼 활성 상태
-   - 마켓플레이스 버튼 활성 상태
-   - 기존 플러그인 카드 렌더링
+    - ZIP 업로드 버튼 활성 상태
+    - 마켓플레이스 버튼 활성 상태
+    - 기존 플러그인 카드 렌더링
 3. **ZIP 업로드 다이얼로그** 열기 → UI 확인
 4. **마켓플레이스 페이지** 이동 → 카테고리/검색 테스트
 5. **플러그인 설정 페이지** → 자동 폼 렌더링 확인

--- a/widgets/celebration-card/index.svelte
+++ b/widgets/celebration-card/index.svelte
@@ -61,12 +61,14 @@
 </script>
 
 {#if loading}
-    <div class="animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700 h-24"></div>
+    <div class="h-24 animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700"></div>
 {:else if banner}
     <div class="celeb-card grad-{gradientNum}">
         <div class="celeb-header">
             <span class="icon">🎈</span>
-            <span class="celeb-nick">{banner.target_member_nick || banner.title || '축하합니다'}</span>
+            <span class="celeb-nick"
+                >{banner.target_member_nick || banner.title || '축하합니다'}</span
+            >
             {#if banner.external_link || banner.link_url}
                 <a
                     href={banner.external_link || banner.link_url}
@@ -189,7 +191,8 @@
         border: 3px solid transparent;
         background:
             linear-gradient(white, white) padding-box,
-            conic-gradient(from 0deg, red, orange, yellow, green, cyan, blue, violet, red) border-box;
+            conic-gradient(from 0deg, red, orange, yellow, green, cyan, blue, violet, red)
+                border-box;
         animation: rainbow-rotate 3s linear infinite;
         object-fit: cover;
     }


### PR DESCRIPTION
## Summary
- `@types/google-publisher-tag` 타입 패키지 추가하여 googletag 관련 TypeScript 에러 27건 해결
- `Window` 인터페이스에 `googletag` 프로퍼티 선언 추가
- `window as Record<string, unknown>` 캐스트를 인덱스 시그니처로 대체
- Prettier 포맷 적용

## Test plan
- [x] `pnpm check` (svelte-check) 0 errors 확인
- [x] `pnpm format` 적용 완료