### PR TITLE
fix: admin Dockerfile 워크스페이스 빌드 수정

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -53,11 +53,9 @@ COPY apps/admin ./apps/admin
 RUN pnpm install --frozen-lockfile --filter admin...
 
 WORKDIR /app
-# 워크스페이스 패키지 먼저 빌드 (의존성 순서대로)
+# 워크스페이스 패키지 먼저 빌드 (admin이 의존하는 패키지만)
 RUN pnpm --filter @angple/types run build
 RUN pnpm --filter @angple/i18n run build
-RUN pnpm --filter @angple/hook-system run build
-RUN pnpm --filter @angple/theme-engine run build
 
 WORKDIR /app/apps/admin
 RUN pnpm run build


### PR DESCRIPTION
## Summary
- admin Dockerfile에서 admin이 의존하지 않는 `@angple/hook-system`, `@angple/theme-engine` 빌드 제거
- admin은 `@angple/types`와 `@angple/i18n`만 의존하므로 해당 패키지만 빌드

PR #112에서 admin Dockerfile에 모든 워크스페이스 패키지 빌드를 추가했으나, `pnpm install --filter admin...`은 admin 의존성만 설치하므로 hook-system/theme-engine 빌드 시 모듈 해석 실패

## Test plan
- [ ] Docker Build & Publish (admin) 통과 확인