### PR TITLE
fix: SvelteSet/SvelteMap 불필요한 $state 래핑 제거

### DIFF
--- a/apps/admin/src/lib/stores/widget-store.svelte.ts
+++ b/apps/admin/src/lib/stores/widget-store.svelte.ts
@@ -56,7 +56,7 @@ class WidgetStore {
     private _selectedZone = $state<WidgetZone>('main');
 
     // 매니페스트 캐시 (위젯 타입 → 매니페스트)
-    private _manifests = $state<SvelteMap<string, WidgetManifestInfo>>(new SvelteMap());
+    private _manifests = new SvelteMap<string, WidgetManifestInfo>();
 
     // Getters - 메인 위젯
     get widgets() {
@@ -166,12 +166,11 @@ class WidgetStore {
     async loadManifests() {
         try {
             const data = await widgetsApi.getInstalledWidgets();
-            const map = new SvelteMap<string, WidgetManifestInfo>();
+            this._manifests.clear();
             for (const w of data.widgets) {
-                map.set(w.id, w as WidgetManifestInfo);
+                this._manifests.set(w.id, w as WidgetManifestInfo);
             }
-            this._manifests = map;
-            console.log(`✅ 매니페스트 로드됨: ${map.size}개`);
+            console.log(`✅ 매니페스트 로드됨: ${this._manifests.size}개`);
         } catch (error) {
             console.warn('⚠️ 매니페스트 로드 실패 (WIDGET_REGISTRY 폴백 사용):', error);
         }

--- a/apps/admin/src/routes/boards/[boardId]/view-settings/+page.svelte
+++ b/apps/admin/src/routes/boards/[boardId]/view-settings/+page.svelte
@@ -51,26 +51,22 @@
     ];
 
     let defaultView = $state<ViewMode>('list');
-    let allowedViews = $state<SvelteSet<ViewMode>>(
-        new SvelteSet(['list', 'card', 'gallery', 'compact', 'timeline'])
-    );
+    let allowedViews = new SvelteSet<ViewMode>(['list', 'card', 'gallery', 'compact', 'timeline']);
     let isLoading = $state(false);
 
     function toggleView(viewId: ViewMode) {
-        const next = new SvelteSet(allowedViews);
-        if (next.has(viewId)) {
+        if (allowedViews.has(viewId)) {
             // 최소 1개는 남겨야 함
-            if (next.size > 1) {
-                next.delete(viewId);
+            if (allowedViews.size > 1) {
+                allowedViews.delete(viewId);
                 // 기본 뷰가 비활성화되면 첫 번째 허용 뷰로 변경
                 if (defaultView === viewId) {
-                    defaultView = Array.from(next)[0];
+                    defaultView = Array.from(allowedViews)[0];
                 }
             }
         } else {
-            next.add(viewId);
+            allowedViews.add(viewId);
         }
-        allowedViews = next;
     }
 
     async function saveSettings() {


### PR DESCRIPTION
## Summary
- `SvelteSet`/`SvelteMap`은 자체 반응성을 가지므로 `$state` 래핑 불필요
- `view-settings/+page.svelte`: `$state<SvelteSet>` → `SvelteSet` 직접 사용, 직접 변경 방식으로 전환
- `widget-store.svelte.ts`: `$state<SvelteMap>` → `SvelteMap` 직접 사용, `clear()`+`set()` 패턴으로 전환
- `svelte/no-unnecessary-state-wrap` ESLint 오류 해결

## Test plan
- [ ] CI / Lint (admin) 통과 확인