### PR TITLE
fix: web 앱 ESLint 에러 23개 수정

### DIFF
--- a/apps/web/src/lib/components/admin/settings/oauth-settings.svelte
+++ b/apps/web/src/lib/components/admin/settings/oauth-settings.svelte
@@ -94,6 +94,7 @@
                                 placeholder={field.placeholder}
                                 value={(config[field.key as keyof typeof config] as string) ?? ''}
                                 oninput={(e) => {
+                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                                     (adminSettingsStore.settings.oauth[meta.id] as any)[field.key] =
                                         e.currentTarget.value;
                                 }}

--- a/apps/web/src/lib/components/admin/widgets/widget-list-table.svelte
+++ b/apps/web/src/lib/components/admin/widgets/widget-list-table.svelte
@@ -46,6 +46,7 @@
     const selectedWidgetId = $derived(widgetStore.selectedWidgetId);
     const selectedZone = $derived(widgetStore.selectedZone);
 
+    // eslint-disable-next-line svelte/prefer-writable-derived -- items are mutated by dnd-action during drag
     let items = $state(widgets.map((w) => ({ ...w })));
 
     $effect(() => {

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -19,6 +19,7 @@
         processBracketImages
     } from '$lib/plugins/auto-embed/index.js';
     import { getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
     interface Props {
         comments: FreeComment[];
@@ -47,13 +48,13 @@
     }: Props = $props();
 
     // 댓글별 좋아요 상태 관리
-    let likedComments = $state<Set<string>>(new Set());
-    let commentLikes = $state<Map<string, number>>(new Map());
+    let likedComments = new SvelteSet<string>();
+    let commentLikes = new SvelteMap<string, number>();
     let likingComment = $state<string | null>(null);
 
     // 댓글별 비추천 상태 관리
-    let dislikedComments = $state<Set<string>>(new Set());
-    let commentDislikes = $state<Map<string, number>>(new Map());
+    let dislikedComments = new SvelteSet<string>();
+    let commentDislikes = new SvelteMap<string, number>();
     let dislikingComment = $state<string | null>(null);
 
     // 수정 상태 관리
@@ -84,7 +85,7 @@
         }
 
         // parent_id 기반 트리 구조 (새 API용)
-        const map = new Map<string | number, FreeComment[]>();
+        const map = new SvelteMap<string | number, FreeComment[]>();
         const roots: FreeComment[] = [];
 
         // 댓글이 루트인지 확인 (parent_id가 없거나, 0이거나, postId와 같으면 루트)
@@ -242,9 +243,7 @@
             } else {
                 likedComments.delete(commentId);
             }
-            likedComments = new Set(likedComments); // 반응성 트리거
             commentLikes.set(commentId, response.likes);
-            commentLikes = new Map(commentLikes); // 반응성 트리거
         } catch (err) {
             console.error('Failed to like comment:', err);
         } finally {
@@ -275,9 +274,7 @@
             } else {
                 dislikedComments.delete(commentId);
             }
-            dislikedComments = new Set(dislikedComments); // 반응성 트리거
             commentDislikes.set(commentId, response.dislikes);
-            commentDislikes = new Map(commentDislikes); // 반응성 트리거
         } catch (err) {
             console.error('Failed to dislike comment:', err);
         } finally {
@@ -542,6 +539,7 @@
                         </div>
                     {:else}
                         <div class="text-foreground whitespace-pre-wrap {isReply ? 'text-sm' : ''}">
+                            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                             {@html renderCommentContent(comment.content)}
                         </div>
                     {/if}

--- a/apps/web/src/lib/components/features/board/draft-list.svelte
+++ b/apps/web/src/lib/components/features/board/draft-list.svelte
@@ -96,7 +96,7 @@
 
     // 내용 미리보기 (50자)
     function getPreview(content: string): string {
-        const plain = content.replace(/[#*`>\-\[\]()]/g, '').trim();
+        const plain = content.replace(/[#*`>\-[\]()]/g, '').trim();
         return plain.length > 50 ? plain.slice(0, 50) + '...' : plain;
     }
 

--- a/apps/web/src/lib/components/features/widget-editor/edit-mode-toggle.svelte
+++ b/apps/web/src/lib/components/features/widget-editor/edit-mode-toggle.svelte
@@ -11,8 +11,7 @@
 
     // 사용자 정보
     const user = $derived(getUser());
-    // TODO: 테스트 후 원복 필요
-    const isAdmin = $derived(true || (user?.mb_level ?? 0) >= 10);
+    const isAdmin = $derived((user?.mb_level ?? 0) >= 10);
 
     // 스토어 상태
     const isEditMode = $derived(widgetLayoutStore.isEditMode);

--- a/apps/web/src/lib/components/layout/sidebar-board-groups.svelte
+++ b/apps/web/src/lib/components/layout/sidebar-board-groups.svelte
@@ -4,6 +4,7 @@
      * 게시판을 그룹별로 묶어 표시
      */
     import type { BoardGroup } from '$lib/api/types.js';
+    import { SvelteSet } from 'svelte/reactivity';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
     import FolderOpen from '@lucide/svelte/icons/folder-open';
@@ -16,16 +17,14 @@
     let { groups, currentBoardId }: Props = $props();
 
     // 그룹별 열림/닫힘 상태
-    let expandedGroups = $state<Set<string>>(new Set(groups.map((g) => g.id)));
+    let expandedGroups = new SvelteSet<string>(groups.map((g) => g.id));
 
     function toggleGroup(groupId: string) {
-        const next = new Set(expandedGroups);
-        if (next.has(groupId)) {
-            next.delete(groupId);
+        if (expandedGroups.has(groupId)) {
+            expandedGroups.delete(groupId);
         } else {
-            next.add(groupId);
+            expandedGroups.add(groupId);
         }
-        expandedGroups = next;
     }
 
     const visibleGroups = $derived(groups.filter((g) => g.is_visible));

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -107,6 +107,7 @@
 
 {#if isBrowser}
     <div class="prose prose-neutral dark:prose-invert max-w-none {className}">
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         {@html renderedHtml}
     </div>
 {:else}

--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -10,6 +10,7 @@
     import { widgetLayoutStore, type WidgetConfig } from '$lib/stores/widget-layout.svelte';
     import { loadWidgetComponent } from '$lib/utils/widget-component-loader';
     import type { Component } from 'svelte';
+    import { SvelteMap } from 'svelte/reactivity';
     import WidgetWrapper from './widget-wrapper.svelte';
 
     interface Props {
@@ -54,8 +55,8 @@
     }
 
     // 위젯 컴포넌트 캐시
-    const componentCache = new Map<string, Component | null>();
-    let loadedComponents = $state<Map<string, Component | null>>(new Map());
+    const componentCache = new SvelteMap<string, Component | null>();
+    let loadedComponents = new SvelteMap<string, Component | null>();
 
     // 위젯 타입이 변경될 때마다 컴포넌트 로드
     $effect(() => {
@@ -64,8 +65,8 @@
             if (!componentCache.has(type)) {
                 loadWidgetComponent(type).then((component) => {
                     componentCache.set(type, component);
-                    // 반응성 트리거를 위해 새 Map 생성
-                    loadedComponents = new Map(componentCache);
+                    // SvelteMap is reactive, just copy entries to trigger updates
+                    loadedComponents.set(type, component);
                 });
             }
         }

--- a/apps/web/src/lib/plugins/auto-embed/components/embed-container.svelte
+++ b/apps/web/src/lib/plugins/auto-embed/components/embed-container.svelte
@@ -69,6 +69,7 @@
         data-platform={embedInfo.platform}
         style={containerStyle}
     >
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
         {@html embedHtml}
     </div>
 {:else if url}

--- a/apps/web/src/lib/plugins/auto-embed/index.ts
+++ b/apps/web/src/lib/plugins/auto-embed/index.ts
@@ -51,7 +51,7 @@ export {
 } from './platforms/bracket-image.js';
 
 // 컴포넌트 내보내기
-export { default as EmbedContainer } from './components/EmbedContainer.svelte';
+export { default as EmbedContainer } from './components/embed-container.svelte';
 
 /**
  * CSS 스타일 (전역에서 import 필요)

--- a/apps/web/src/lib/seo/seo-head.svelte
+++ b/apps/web/src/lib/seo/seo-head.svelte
@@ -48,6 +48,7 @@
 
     <!-- JSON-LD 구조화 데이터 -->
     {#if jsonLdScript}
-        {@html `<script type="application/ld+json">${jsonLdScript}</script>`}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html '<script type="application/ld+json">' + jsonLdScript + '</' + 'script>'}
     {/if}
 </svelte:head>

--- a/apps/web/src/lib/stores/gam.svelte.ts
+++ b/apps/web/src/lib/stores/gam.svelte.ts
@@ -45,6 +45,7 @@ const state = $state<GAMState>({
 });
 
 // 슬롯 렌더 이벤트 콜백 저장
+// eslint-disable-next-line svelte/prefer-svelte-reactivity -- non-reactive callback storage
 const slotCallbacks = new Map<string, (isEmpty: boolean) => void>();
 
 /**
@@ -175,6 +176,7 @@ export function defineResponsiveSlot(
 
         // 모든 사이즈 수집
         const allSizes = sizeMapping.flatMap((m) => m.sizes);
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- deduplication only, not reactive
         const uniqueSizes = Array.from(new Set(allSizes.map((s) => JSON.stringify(s)))).map(
             (s) => JSON.parse(s) as number[]
         );

--- a/apps/web/src/lib/utils/widget-component-loader.ts
+++ b/apps/web/src/lib/utils/widget-component-loader.ts
@@ -186,7 +186,18 @@ export function getWidgetRegistry(): Record<
     }
 > {
     const widgets = getScannedWidgets();
-    const registry: Record<string, any> = {};
+    const registry: Record<
+        string,
+        {
+            name: string;
+            icon: string;
+            description: string;
+            category: string;
+            allowMultiple: boolean;
+            defaultSettings?: Record<string, unknown>;
+            slots: string[];
+        }
+    > = {};
 
     for (const [type, w] of widgets) {
         const defaultSettings: Record<string, unknown> = {};

--- a/apps/web/src/routes/api/widgets/post-list/data/+server.ts
+++ b/apps/web/src/routes/api/widgets/post-list/data/+server.ts
@@ -25,7 +25,8 @@ export const GET: RequestHandler = async ({ url }) => {
             return json({ posts: [], board, sort, count });
         }
 
-        let posts: unknown[] = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic widget data from various board types
+        let posts: any[] = [];
 
         switch (board) {
             case 'notice':
@@ -50,7 +51,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
         // 정렬
         if (sort !== 'date') {
-            posts = [...posts].sort((a: any, b: any) => {
+            posts = [...posts].sort((a, b) => {
                 switch (sort) {
                     case 'recommend':
                         return (b.recommend_count ?? 0) - (a.recommend_count ?? 0);
@@ -66,9 +67,9 @@ export const GET: RequestHandler = async ({ url }) => {
 
         // 필터
         if (filter === 'recommended') {
-            posts = posts.filter((p: any) => (p.recommend_count ?? 0) > 0);
+            posts = posts.filter((p) => (p.recommend_count ?? 0) > 0);
         } else if (filter === 'has-image') {
-            posts = posts.filter((p: any) => p.thumbnail_url);
+            posts = posts.filter((p) => p.thumbnail_url);
         }
 
         // 개수 제한


### PR DESCRIPTION
## Summary
- Map/Set → SvelteMap/SvelteSet 마이그레이션 (comment-list, sidebar-board-groups, widget-renderer)
- $state 불필요 래핑 제거 (SvelteMap/SvelteSet은 자체 반응성)
- @html eslint-disable 주석 추가 (markdown, seo-head, comment-list)
- EmbedContainer.svelte → embed-container.svelte 파일명 컨벤션 수정
- no-explicit-any, no-constant-binary-expression, no-useless-escape, prefer-writable-derived 수정
- gam.svelte.ts 비반응성 Map/Set eslint-disable 주석 추가

## 변경 파일 (14개)
- `comment-list.svelte` - Map/Set → SvelteMap/SvelteSet, @html 주석
- `sidebar-board-groups.svelte` - Set → SvelteSet
- `widget-renderer.svelte` - Map → SvelteMap
- `markdown.svelte` - @html eslint-disable
- `seo-head.svelte` - 템플릿 리터럴 파싱 에러 수정 + @html 주석
- `embed-container.svelte` - 파일명 kebab-case로 변경
- `auto-embed/index.ts` - import 경로 업데이트
- `oauth-settings.svelte` - no-explicit-any 주석
- `widget-list-table.svelte` - prefer-writable-derived 주석
- `edit-mode-toggle.svelte` - 디버그용 `true ||` 제거
- `draft-list.svelte` - 불필요 이스케이프 제거
- `gam.svelte.ts` - 비반응성 Map/Set eslint-disable 주석
- `widget-component-loader.ts` - any → 명시적 타입
- `+server.ts` - any 타입 정리