### PR TITLE
fix: 유저 위젯 개선 - 등급명, 경험치, 나리야 레벨

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -278,6 +278,8 @@ export interface DamoangUser {
     mb_point?: number; // 보유 포인트
     mb_exp?: number; // 경험치
     mb_image?: string; // 프로필 이미지 URL
+    as_level?: number; // 나리야 경험치 레벨
+    as_max?: number; // 현재 레벨 최대 경험치
 }
 
 // 회원 프로필 타입 (공개 정보)


### PR DESCRIPTION
## Summary
- 닉네임 옆 등급명 표시 (mb_level 기반 앙님💔 등)
- 포인트+경험치 한 줄 배치 (grid-cols-2)
- 나리야 레벨(as_level) 게이지로 변경, getExpSummary API 호출 제거
- DamoangUser 타입에 as_level, as_max 추가