### PR TITLE
feat: 컨텐츠 변환 플러그인 시스템 구축

### DIFF
--- a/apps/web/data/plugin-settings.json
+++ b/apps/web/data/plugin-settings.json
@@ -1,5 +1,5 @@
 {
-    "activePlugins": ["ad-widget", "emoticon"],
+    "activePlugins": ["ad-widget", "emoticon", "bracket-image", "auto-embed"],
     "plugins": {
         "ad-widget": {
             "settings": {
@@ -10,6 +10,14 @@
         "emoticon": {
             "settings": {},
             "activatedAt": "2026-02-04T14:51:20.087Z"
+        },
+        "bracket-image": {
+            "settings": {},
+            "activatedAt": "2026-02-07T12:00:00.000Z"
+        },
+        "auto-embed": {
+            "settings": {},
+            "activatedAt": "2026-02-07T12:00:00.000Z"
         }
     },
     "version": "1.0.0"

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -107,42 +107,8 @@ export const handle: Handle = async ({ event, resolve }) => {
         });
     }
 
-    // /api/plugins/* 요청을 백엔드로 프록시 (SvelteKit에서 처리하는 라우트 제외)
-    const svelteKitApiRoutes = ['/api/plugins/advertising/banners/today'];
-    const shouldProxy =
-        event.url.pathname.startsWith('/api/plugins/') &&
-        !svelteKitApiRoutes.some((route) => event.url.pathname === route);
-
-    if (shouldProxy) {
-        try {
-            const backendUrl = `${BACKEND_URL}${event.url.pathname}${event.url.search}`;
-            const proxyRes = await fetch(backendUrl, {
-                method: event.request.method,
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...(event.locals.accessToken && {
-                        Authorization: `Bearer ${event.locals.accessToken}`
-                    })
-                },
-                body: event.request.method !== 'GET' ? await event.request.text() : undefined
-            });
-
-            const data = await proxyRes.text();
-            return new Response(data, {
-                status: proxyRes.status,
-                headers: {
-                    'Content-Type': proxyRes.headers.get('Content-Type') || 'application/json',
-                    'Access-Control-Allow-Origin': '*'
-                }
-            });
-        } catch (error) {
-            console.error('[Proxy Error]', error);
-            return new Response(JSON.stringify({ error: 'Proxy error' }), {
-                status: 502,
-                headers: { 'Content-Type': 'application/json' }
-            });
-        }
-    }
+    // /api/plugins/* 프록시는 더 이상 사용하지 않음
+    // 모든 /api/plugins/* 요청은 SvelteKit API 라우트에서 처리
 
     const response = await resolve(event);
 

--- a/apps/web/src/lib/hooks/hook-state.svelte.ts
+++ b/apps/web/src/lib/hooks/hook-state.svelte.ts
@@ -1,0 +1,24 @@
+/**
+ * Hook 등록 상태 추적 (Svelte 5 reactive)
+ *
+ * Hook이 동적으로 로드되므로, 컴포넌트가 hook 등록 완료를 감지하여
+ * 필터를 재실행할 수 있도록 reactive 카운터를 제공합니다.
+ */
+
+let hookVersion = $state(0);
+
+/**
+ * Hook 등록 시 호출하여 버전을 증가시킵니다.
+ * 이를 구독하는 컴포넌트의 $effect가 재실행됩니다.
+ */
+export function incrementHookVersion(): void {
+    hookVersion++;
+}
+
+/**
+ * 현재 hook 버전을 반환합니다.
+ * $effect 안에서 호출하면 hook 등록 시 자동으로 재실행됩니다.
+ */
+export function getHookVersion(): number {
+    return hookVersion;
+}

--- a/apps/web/src/lib/hooks/registry.ts
+++ b/apps/web/src/lib/hooks/registry.ts
@@ -4,6 +4,8 @@
  * 테마가 코어 기능을 확장할 수 있도록 이벤트 기반 아키텍처를 제공합니다.
  */
 
+import { incrementHookVersion } from './hook-state.svelte';
+
 /**
  * Hook 타입 정의
  */
@@ -82,6 +84,9 @@ class HookRegistry {
 
         // Priority 순서로 정렬 (낮은 숫자가 먼저)
         hookList.sort((a, b) => a.priority - b.priority);
+
+        // Reactive 버전 증가 (구독 중인 컴포넌트의 $effect 재실행)
+        incrementHookVersion();
 
         console.log(
             `🪝 [Hook] Registered ${type} hook: ${name} (priority: ${priority}${source ? `, source: ${source}` : ''})`

--- a/plugins/auto-embed/hooks/comment-filter.ts
+++ b/plugins/auto-embed/hooks/comment-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * URL 자동 임베딩 댓글 본문 필터
+ * comment_content 필터에 등록하여 bare URL을 임베드로 변환
+ */
+
+import { processContent } from '../lib/embed-engine';
+
+/**
+ * 댓글 본문에서 URL을 임베드로 변환하는 필터 콜백
+ *
+ * @param content - 댓글 본문 HTML
+ * @returns URL이 임베드된 HTML
+ */
+export default function autoEmbedCommentFilter(content: string): string {
+    if (!content) return content;
+    return processContent(content);
+}

--- a/plugins/auto-embed/hooks/content-filter.ts
+++ b/plugins/auto-embed/hooks/content-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * URL 자동 임베딩 게시글 본문 필터
+ * post_content 필터에 등록하여 bare URL을 임베드로 변환
+ */
+
+import { processContent } from '../lib/embed-engine';
+
+/**
+ * 게시글 본문에서 URL을 임베드로 변환하는 필터 콜백
+ *
+ * @param content - 게시글 본문 HTML
+ * @returns URL이 임베드된 HTML
+ */
+export default function autoEmbedContentFilter(content: string): string {
+    if (!content) return content;
+    return processContent(content);
+}

--- a/plugins/auto-embed/lib/embed-engine.ts
+++ b/plugins/auto-embed/lib/embed-engine.ts
@@ -1,0 +1,124 @@
+/**
+ * URL 자동 임베딩 핵심 로직
+ */
+
+import type { EmbedInfo, EmbedResult } from './types';
+import { platforms } from './platforms/index';
+
+/**
+ * URL에서 임베드 정보 추출
+ */
+export function getEmbedInfo(url: string): EmbedInfo | null {
+    for (const platform of platforms) {
+        const info = platform.extract(url);
+        if (info) {
+            return info;
+        }
+    }
+    return null;
+}
+
+/**
+ * URL을 임베드 HTML로 변환
+ */
+export function getEmbed(url: string): EmbedResult {
+    for (const platform of platforms) {
+        const info = platform.extract(url);
+        if (info) {
+            const html = platform.render(info);
+            return {
+                success: true,
+                info,
+                html
+            };
+        }
+    }
+    return { success: false };
+}
+
+/**
+ * 임베드 정보를 컨테이너 HTML로 래핑
+ */
+export function wrapEmbedHtml(info: EmbedInfo, innerHtml: string): string {
+    const aspectRatio = info.aspectRatio || 56.25;
+    const maxWidth = info.maxWidth ? `${info.maxWidth}px` : '100%';
+    const platform = info.platform;
+
+    return `<div class="embed-container" data-platform="${platform}" style="--aspect-ratio: ${aspectRatio}%; --max-width: ${maxWidth};">${innerHtml}</div>`;
+}
+
+/**
+ * 단일 URL을 임베드로 변환 (컨테이너 포함)
+ */
+export function embedUrl(url: string): string | null {
+    const result = getEmbed(url);
+    if (result.success && result.info && result.html) {
+        return wrapEmbedHtml(result.info, result.html);
+    }
+    return null;
+}
+
+/**
+ * HTML 콘텐츠 내 URL을 임베드로 변환
+ *
+ * 변환 규칙:
+ * 1. 줄 단독으로 있는 bare URL → 임베드로 변환
+ * 2. marked autolink로 <a> 태그가 된 URL도 단독 라인이면 변환
+ * 3. 문장 중간의 URL은 변환하지 않음
+ */
+export function processContent(html: string): string {
+    let result = html;
+
+    // 1) bare URL (marked autolink 안 된 경우 — 댓글 등)
+    const bareUrlPattern =
+        /(?:^|\n|<br\s*\/?>|<p>)\s*(https?:\/\/[^\s<>"]+)\s*(?:\n|<br\s*\/?>|<\/p>|$)/gi;
+
+    result = result.replace(bareUrlPattern, (match, url) => {
+        const embedded = embedUrl(url.trim());
+        if (embedded) {
+            const prefix =
+                match.startsWith('\n') || match.startsWith('<br') || match.startsWith('<p>')
+                    ? match.match(/^[^\w]*/)?.[0] || ''
+                    : '';
+            const suffix =
+                match.endsWith('\n') || match.endsWith('<br>') || match.endsWith('</p>')
+                    ? match.match(/[^\w]*$/)?.[0] || ''
+                    : '';
+            return prefix + embedded + suffix;
+        }
+        return match;
+    });
+
+    // 2) autolinked URL: <p><a href="URL">URL</a></p> (marked가 자동 링크한 경우)
+    const linkedUrlPattern =
+        /(<p>)\s*<a[^>]+href="(https?:\/\/[^"]+)"[^>]*>[^<]*<\/a>\s*(<\/p>)/gi;
+
+    result = result.replace(linkedUrlPattern, (match, pOpen, url, pClose) => {
+        const embedded = embedUrl(url.trim());
+        if (embedded) {
+            return pOpen + embedded + pClose;
+        }
+        return match;
+    });
+
+    // 3) autolinked URL after <br>: <br><a href="URL">URL</a><br> 또는 끝
+    const linkedBrPattern =
+        /(<br\s*\/?>)\s*<a[^>]+href="(https?:\/\/[^"]+)"[^>]*>[^<]*<\/a>\s*(?=<br|<\/p>|$)/gi;
+
+    result = result.replace(linkedBrPattern, (match, brTag, url) => {
+        const embedded = embedUrl(url.trim());
+        if (embedded) {
+            return brTag + embedded;
+        }
+        return match;
+    });
+
+    return result;
+}
+
+/**
+ * URL이 임베딩 가능한지 확인
+ */
+export function isEmbeddable(url: string): boolean {
+    return getEmbedInfo(url) !== null;
+}

--- a/plugins/auto-embed/lib/platforms/bluesky.ts
+++ b/plugins/auto-embed/lib/platforms/bluesky.ts
@@ -1,0 +1,30 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Bluesky 임베딩 플랫폼
+ */
+export const bluesky: EmbedPlatform = {
+    name: 'bluesky',
+    patterns: [/bsky\.app\/profile\/([^/]+)\/post\/(\w+)/],
+
+    extract(url: string): EmbedInfo | null {
+        const match = url.match(/bsky\.app\/profile\/([^/]+)\/post\/(\w+)/);
+        if (match) {
+            return {
+                platform: 'bluesky',
+                id: match[2],
+                url,
+                params: {
+                    handle: match[1]
+                }
+            };
+        }
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        const postUrl = `https://bsky.app/profile/${info.params?.handle}/post/${info.id}`;
+
+        return `<blockquote class="bluesky-embed" data-bluesky-uri="at://${info.params?.handle}/app.bsky.feed.post/${info.id}"><a href="${postUrl}">Bluesky 게시글</a></blockquote>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/dailymotion.ts
+++ b/plugins/auto-embed/lib/platforms/dailymotion.ts
@@ -1,0 +1,26 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Dailymotion 임베딩 플랫폼
+ */
+export const dailymotion: EmbedPlatform = {
+    name: 'dailymotion',
+    patterns: [/(?:www\.)?dailymotion\.com\/video\/([a-zA-Z0-9]+)/],
+
+    extract(url: string): EmbedInfo | null {
+        const match = url.match(/(?:www\.)?dailymotion\.com\/video\/([a-zA-Z0-9]+)/);
+        if (match) {
+            return {
+                platform: 'dailymotion',
+                id: match[1],
+                url,
+                aspectRatio: 56.25
+            };
+        }
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        return `<iframe src="https://www.dailymotion.com/embed/video/${info.id}" title="Dailymotion video player" frameborder="0" allow="autoplay" allowfullscreen></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/index.ts
+++ b/plugins/auto-embed/lib/platforms/index.ts
@@ -1,0 +1,55 @@
+/**
+ * 플랫폼 레지스트리
+ * 지원하는 모든 임베딩 플랫폼을 등록
+ */
+
+import type { EmbedPlatform } from '../types';
+import { youtube } from './youtube';
+import { vimeo } from './vimeo';
+import { instagram } from './instagram';
+import { twitter } from './twitter';
+import { twitch } from './twitch';
+import { tiktok } from './tiktok';
+import { reddit } from './reddit';
+import { bluesky } from './bluesky';
+import { dailymotion } from './dailymotion';
+import { kakaoTv } from './kakao-tv';
+
+/**
+ * 등록된 플랫폼 목록 (순서대로 매칭)
+ */
+export const platforms: EmbedPlatform[] = [
+    youtube,
+    vimeo,
+    instagram,
+    twitter,
+    twitch,
+    tiktok,
+    reddit,
+    bluesky,
+    dailymotion,
+    kakaoTv
+];
+
+/**
+ * 플랫폼 이름으로 조회
+ */
+export function getPlatform(name: string): EmbedPlatform | undefined {
+    return platforms.find((p) => p.name === name);
+}
+
+/**
+ * URL에 매칭되는 플랫폼 찾기
+ */
+export function findPlatform(url: string): EmbedPlatform | undefined {
+    for (const platform of platforms) {
+        for (const pattern of platform.patterns) {
+            if (pattern.test(url)) {
+                return platform;
+            }
+        }
+    }
+    return undefined;
+}
+
+export { youtube, vimeo, instagram, twitter, twitch, tiktok, reddit, bluesky, dailymotion, kakaoTv };

--- a/plugins/auto-embed/lib/platforms/instagram.ts
+++ b/plugins/auto-embed/lib/platforms/instagram.ts
@@ -1,0 +1,38 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Instagram 임베딩 플랫폼
+ * 지원: 포스트(p), 릴스(reel)
+ */
+export const instagram: EmbedPlatform = {
+    name: 'instagram',
+    patterns: [
+        /(?:www\.)?instagram\.com\/p\/([a-zA-Z0-9_-]+)/,
+        /(?:www\.)?instagram\.com\/reel\/([a-zA-Z0-9_-]+)/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        for (const pattern of this.patterns) {
+            const match = url.match(pattern);
+            if (match) {
+                const contentId = match[1];
+                const isReel = url.includes('/reel/');
+
+                return {
+                    platform: isReel ? 'instagram-reel' : 'instagram',
+                    id: contentId,
+                    url,
+                    aspectRatio: isReel ? 177.78 : 100,
+                    maxWidth: isReel ? 400 : 540
+                };
+            }
+        }
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        const embedUrl = `https://www.instagram.com/${info.platform === 'instagram-reel' ? 'reel' : 'p'}/${info.id}/embed/captioned/`;
+
+        return `<iframe src="${embedUrl}" title="Instagram embed" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/kakao-tv.ts
+++ b/plugins/auto-embed/lib/platforms/kakao-tv.ts
@@ -1,0 +1,50 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Kakao TV 임베딩 플랫폼
+ */
+export const kakaoTv: EmbedPlatform = {
+    name: 'kakao-tv',
+    patterns: [
+        /tv\.kakao\.com\/(v|l)\/([A-Za-z0-9]+)/,
+        /tv\.kakao\.com\/channel\/\d+\/(livelink|cliplink)\/([A-Za-z0-9]+)/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        // 채널 URL: tv.kakao.com/channel/123/cliplink/456
+        const channelMatch = url.match(
+            /tv\.kakao\.com\/channel\/\d+\/(livelink|cliplink)\/([A-Za-z0-9]+)/
+        );
+        if (channelMatch) {
+            return {
+                platform: 'kakao-tv',
+                id: channelMatch[2],
+                url,
+                aspectRatio: 56.25,
+                params: { type: channelMatch[1] }
+            };
+        }
+
+        // 단축 URL: tv.kakao.com/v/VIDEO_ID 또는 tv.kakao.com/l/LIVE_ID
+        const shortMatch = url.match(/tv\.kakao\.com\/(v|l)\/([A-Za-z0-9]+)/);
+        if (shortMatch) {
+            const type = shortMatch[1] === 'v' ? 'cliplink' : 'livelink';
+            return {
+                platform: 'kakao-tv',
+                id: shortMatch[2],
+                url,
+                aspectRatio: 56.25,
+                params: { type }
+            };
+        }
+
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        const type = info.params?.type || 'cliplink';
+        const embedUrl = `https://tv.kakao.com/embed/player/${type}/${info.id}?width=640&height=360&service=kakao_tv`;
+
+        return `<iframe src="${embedUrl}" title="Kakao TV player" frameborder="0" scrolling="no" allowfullscreen></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/reddit.ts
+++ b/plugins/auto-embed/lib/platforms/reddit.ts
@@ -1,0 +1,36 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Reddit 임베딩 플랫폼
+ */
+export const reddit: EmbedPlatform = {
+    name: 'reddit',
+    patterns: [
+        /(?:www\.)?reddit\.com\/(r|user)\/[\w:.]{2,21}\/comments\/\w{5,9}/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        const match = url.match(
+            /(?:www\.)?reddit\.com\/(r|user)\/([\w:.]{2,21})\/comments\/(\w{5,9})(?:\/([\w%\\-]+))?/
+        );
+        if (match) {
+            return {
+                platform: 'reddit',
+                id: match[3],
+                url,
+                params: {
+                    type: match[1],
+                    subreddit: match[2],
+                    slug: match[4] || ''
+                }
+            };
+        }
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        const postUrl = `https://www.reddit.com/${info.params?.type}/${info.params?.subreddit}/comments/${info.id}${info.params?.slug ? '/' + info.params.slug : ''}`;
+
+        return `<blockquote class="reddit-embed-bq" style="height:500px" data-embed-height="740"><a href="${postUrl}">Reddit 게시글</a></blockquote>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/tiktok.ts
+++ b/plugins/auto-embed/lib/platforms/tiktok.ts
@@ -1,0 +1,45 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * TikTok 임베딩 플랫폼
+ */
+export const tiktok: EmbedPlatform = {
+    name: 'tiktok',
+    patterns: [
+        /(?:www\.)?tiktok\.com\/@[\w.-]+\/video\/(\d+)/,
+        /vm\.tiktok\.com\/([a-zA-Z0-9]+)/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        const videoMatch = url.match(/tiktok\.com\/@[\w.-]+\/video\/(\d+)/);
+        if (videoMatch) {
+            return {
+                platform: 'tiktok',
+                id: videoMatch[1],
+                url,
+                aspectRatio: 177.78,
+                maxWidth: 325
+            };
+        }
+
+        const shortMatch = url.match(/vm\.tiktok\.com\/([a-zA-Z0-9]+)/);
+        if (shortMatch) {
+            return {
+                platform: 'tiktok',
+                id: shortMatch[1],
+                url,
+                aspectRatio: 177.78,
+                maxWidth: 325,
+                params: { isShortUrl: 'true' }
+            };
+        }
+
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        const embedUrl = `https://www.tiktok.com/embed/v2/${info.id}`;
+
+        return `<iframe src="${embedUrl}" title="TikTok video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/twitch.ts
+++ b/plugins/auto-embed/lib/platforms/twitch.ts
@@ -1,0 +1,74 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Twitch 임베딩 플랫폼
+ * 지원: 클립, VOD, 채널 라이브
+ */
+export const twitch: EmbedPlatform = {
+    name: 'twitch',
+    patterns: [
+        /(?:www\.)?twitch\.tv\/\w+\/clip\/([a-zA-Z0-9_-]+)/,
+        /clips\.twitch\.tv\/([a-zA-Z0-9_-]+)/,
+        /(?:www\.)?twitch\.tv\/videos\/(\d+)/,
+        /(?:www\.)?twitch\.tv\/([a-zA-Z0-9_]+)$/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        const clipMatch =
+            url.match(/twitch\.tv\/\w+\/clip\/([a-zA-Z0-9_-]+)/) ||
+            url.match(/clips\.twitch\.tv\/([a-zA-Z0-9_-]+)/);
+        if (clipMatch) {
+            return {
+                platform: 'twitch-clip',
+                id: clipMatch[1],
+                url,
+                aspectRatio: 56.25,
+                params: { type: 'clip' }
+            };
+        }
+
+        const videoMatch = url.match(/twitch\.tv\/videos\/(\d+)/);
+        if (videoMatch) {
+            return {
+                platform: 'twitch-video',
+                id: videoMatch[1],
+                url,
+                aspectRatio: 56.25,
+                params: { type: 'video' }
+            };
+        }
+
+        const channelMatch = url.match(/twitch\.tv\/([a-zA-Z0-9_]+)$/);
+        if (channelMatch && !url.includes('/videos/') && !url.includes('/clip/')) {
+            return {
+                platform: 'twitch-channel',
+                id: channelMatch[1],
+                url,
+                aspectRatio: 56.25,
+                params: { type: 'channel' }
+            };
+        }
+
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        const parent = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+        let embedUrl: string;
+
+        switch (info.params?.type) {
+            case 'clip':
+                embedUrl = `https://clips.twitch.tv/embed?clip=${info.id}&parent=${parent}`;
+                break;
+            case 'video':
+                embedUrl = `https://player.twitch.tv/?video=${info.id}&parent=${parent}`;
+                break;
+            case 'channel':
+            default:
+                embedUrl = `https://player.twitch.tv/?channel=${info.id}&parent=${parent}`;
+                break;
+        }
+
+        return `<iframe src="${embedUrl}" title="Twitch embed" frameborder="0" allowfullscreen></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/twitter.ts
+++ b/plugins/auto-embed/lib/platforms/twitter.ts
@@ -1,0 +1,38 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Twitter/X 임베딩 플랫폼
+ */
+export const twitter: EmbedPlatform = {
+    name: 'twitter',
+    patterns: [
+        /(?:www\.)?twitter\.com\/\w+\/status\/(\d+)/,
+        /(?:www\.)?x\.com\/\w+\/status\/(\d+)/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        for (const pattern of this.patterns) {
+            const match = url.match(pattern);
+            if (match) {
+                const tweetId = match[1];
+
+                const userMatch = url.match(/(?:twitter|x)\.com\/(\w+)\/status/);
+                const username = userMatch ? userMatch[1] : '';
+
+                return {
+                    platform: 'twitter',
+                    id: tweetId,
+                    url,
+                    params: username ? { username } : undefined
+                };
+            }
+        }
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        const embedUrl = `https://platform.twitter.com/embed/Tweet.html?id=${info.id}&theme=light`;
+
+        return `<iframe src="${embedUrl}" title="Twitter post" frameborder="0" scrolling="no" allowtransparency="true" allowfullscreen style="min-height: 250px;"></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/vimeo.ts
+++ b/plugins/auto-embed/lib/platforms/vimeo.ts
@@ -1,0 +1,46 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * Vimeo 임베딩 플랫폼
+ */
+export const vimeo: EmbedPlatform = {
+    name: 'vimeo',
+    patterns: [
+        /(?:www\.)?vimeo\.com\/(\d+)/,
+        /player\.vimeo\.com\/video\/(\d+)/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        for (const pattern of this.patterns) {
+            const match = url.match(pattern);
+            if (match) {
+                const videoId = match[1];
+                const params: Record<string, string> = {};
+
+                const hashMatch = url.match(/vimeo\.com\/\d+\/([a-f0-9]+)/);
+                if (hashMatch) {
+                    params.h = hashMatch[1];
+                }
+
+                return {
+                    platform: 'vimeo',
+                    id: videoId,
+                    url,
+                    aspectRatio: 56.25,
+                    params: Object.keys(params).length > 0 ? params : undefined
+                };
+            }
+        }
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        let embedUrl = `https://player.vimeo.com/video/${info.id}`;
+
+        if (info.params?.h) {
+            embedUrl += `?h=${info.params.h}`;
+        }
+
+        return `<iframe src="${embedUrl}" title="Vimeo video player" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/platforms/youtube.ts
+++ b/plugins/auto-embed/lib/platforms/youtube.ts
@@ -1,0 +1,64 @@
+import type { EmbedInfo, EmbedPlatform } from '../types';
+
+/**
+ * YouTube 임베딩 플랫폼
+ * 지원: 일반 영상, Shorts, Live, 재생목록
+ */
+export const youtube: EmbedPlatform = {
+    name: 'youtube',
+    patterns: [
+        /(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/,
+        /youtu\.be\/([a-zA-Z0-9_-]{11})/,
+        /(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+        /(?:www\.)?youtube\.com\/live\/([a-zA-Z0-9_-]{11})/,
+        /(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/
+    ],
+
+    extract(url: string): EmbedInfo | null {
+        for (const pattern of this.patterns) {
+            const match = url.match(pattern);
+            if (match) {
+                const videoId = match[1];
+                const isShorts = url.includes('/shorts/');
+                const params: Record<string, string> = {};
+
+                const timeMatch = url.match(/[?&]t=(\d+)/);
+                if (timeMatch) {
+                    params.start = timeMatch[1];
+                }
+
+                const listMatch = url.match(/[?&]list=([a-zA-Z0-9_-]+)/);
+                if (listMatch) {
+                    params.list = listMatch[1];
+                }
+
+                return {
+                    platform: isShorts ? 'youtube-shorts' : 'youtube',
+                    id: videoId,
+                    url,
+                    aspectRatio: isShorts ? 177.78 : 56.25,
+                    maxWidth: isShorts ? 400 : undefined,
+                    params: Object.keys(params).length > 0 ? params : undefined
+                };
+            }
+        }
+        return null;
+    },
+
+    render(info: EmbedInfo): string {
+        let embedUrl = `https://www.youtube.com/embed/${info.id}`;
+
+        const queryParams: string[] = [];
+        if (info.params?.start) {
+            queryParams.push(`start=${info.params.start}`);
+        }
+        if (info.params?.list) {
+            queryParams.push(`list=${info.params.list}`);
+        }
+        if (queryParams.length > 0) {
+            embedUrl += '?' + queryParams.join('&');
+        }
+
+        return `<iframe src="${embedUrl}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>`;
+    }
+};

--- a/plugins/auto-embed/lib/types.ts
+++ b/plugins/auto-embed/lib/types.ts
@@ -1,0 +1,38 @@
+/**
+ * 자동 임베딩 플러그인 타입 정의
+ */
+
+export interface EmbedInfo {
+    /** 플랫폼 이름 (youtube, instagram 등) */
+    platform: string;
+    /** 콘텐츠 ID (비디오 ID, 포스트 ID 등) */
+    id: string;
+    /** 원본 URL */
+    url: string;
+    /** 가로세로 비율 (height/width * 100, 기본값 56.25% = 16:9) */
+    aspectRatio?: number;
+    /** 최대 너비 (세로 영상용, px 단위) */
+    maxWidth?: number;
+    /** 추가 파라미터 (시작 시간, 재생목록 등) */
+    params?: Record<string, string>;
+}
+
+export interface EmbedPlatform {
+    /** 플랫폼 이름 */
+    name: string;
+    /** URL 패턴 목록 (정규식) */
+    patterns: RegExp[];
+    /** URL에서 임베드 정보 추출 */
+    extract(url: string): EmbedInfo | null;
+    /** 임베드 HTML 렌더링 */
+    render(info: EmbedInfo): string;
+}
+
+export interface EmbedResult {
+    /** 임베딩 성공 여부 */
+    success: boolean;
+    /** 임베드 정보 */
+    info?: EmbedInfo;
+    /** 렌더링된 HTML */
+    html?: string;
+}

--- a/plugins/auto-embed/plugin.json
+++ b/plugins/auto-embed/plugin.json
@@ -1,0 +1,32 @@
+{
+    "id": "auto-embed",
+    "name": "URL 자동 임베딩",
+    "version": "1.0.0",
+    "description": "YouTube, Instagram, Twitter/X, Reddit, Bluesky 등 URL을 자동으로 임베드합니다.",
+    "author": {
+        "name": "Damoang Team",
+        "url": "https://damoang.net"
+    },
+    "hooks": [
+        {
+            "name": "post_content",
+            "type": "filter",
+            "callback": "hooks/content-filter.ts",
+            "priority": 10
+        },
+        {
+            "name": "comment_content",
+            "type": "filter",
+            "callback": "hooks/comment-filter.ts",
+            "priority": 10
+        }
+    ],
+    "settings": {
+        "enabled": {
+            "label": "활성화",
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "tags": ["임베드", "YouTube", "Instagram", "Twitter"]
+}

--- a/plugins/bracket-image/hooks/comment-filter.ts
+++ b/plugins/bracket-image/hooks/comment-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * 숏코드 댓글 본문 필터
+ * comment_content 필터에 등록하여 [img URL], {video:URL} 등을 HTML로 변환
+ */
+
+import { processBracketShortcodes } from '../lib/shortcode-parser';
+
+/**
+ * 댓글 본문에서 숏코드를 HTML로 변환하는 필터 콜백
+ *
+ * @param content - 댓글 본문 HTML
+ * @returns 숏코드가 렌더링된 HTML
+ */
+export default function bracketImageCommentFilter(content: string): string {
+    if (!content) return content;
+    return processBracketShortcodes(content);
+}

--- a/plugins/bracket-image/hooks/content-filter.ts
+++ b/plugins/bracket-image/hooks/content-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * 숏코드 게시글 본문 필터
+ * post_content 필터에 등록하여 [img URL], {video:URL} 등을 HTML로 변환
+ */
+
+import { processBracketShortcodes } from '../lib/shortcode-parser';
+
+/**
+ * 게시글 본문에서 숏코드를 HTML로 변환하는 필터 콜백
+ *
+ * @param content - 게시글 본문 HTML
+ * @returns 숏코드가 렌더링된 HTML
+ */
+export default function bracketImageContentFilter(content: string): string {
+    if (!content) return content;
+    return processBracketShortcodes(content);
+}

--- a/plugins/bracket-image/lib/shortcode-parser.ts
+++ b/plugins/bracket-image/lib/shortcode-parser.ts
@@ -1,0 +1,223 @@
+/**
+ * 숏코드 파서
+ *
+ * [https://s3.damoang.net/image.jpg] → <img> 태그
+ * {video:URL} / {동영상:URL} → 플랫폼별 iframe
+ *
+ * 보안:
+ * - 허용된 도메인만 이미지로 변환
+ * - 이미지 확장자만 허용
+ * - XSS 방지를 위한 URL 검증
+ *
+ * 주의: marked.parse()가 URL을 <a> 태그로 자동 변환하므로
+ *       raw text와 HTML 두 형태 모두 처리해야 합니다.
+ */
+
+/** 허용된 이미지 도메인 목록 */
+const ALLOWED_IMAGE_DOMAINS = [
+    's3.damoang.net',
+    'damoang.net',
+    'cdn.damoang.net',
+    'i.imgur.com',
+    'imgur.com',
+    'media.tenor.com',
+    'tenor.com',
+    'c.tenor.com',
+    'media.giphy.com',
+    'i.giphy.com',
+    'giphy.com',
+    'pbs.twimg.com',
+    'upload.wikimedia.org'
+];
+
+/** 허용된 이미지 확장자 */
+const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg'];
+
+/**
+ * HTML에서 실제 URL 추출
+ * marked가 자동 링크한 경우: <a href="URL">URL</a> → URL
+ * 원본 텍스트인 경우: URL → URL
+ */
+function extractUrlFromHtml(content: string): string {
+    const trimmed = content.trim();
+    // marked autolink: <a href="URL">URL</a> 형태에서 href 추출
+    const hrefMatch = trimmed.match(/<a[^>]+href="([^"]+)"[^>]*>/i);
+    if (hrefMatch) {
+        return hrefMatch[1];
+    }
+    return trimmed;
+}
+
+/**
+ * URL이 허용된 이미지 도메인인지 확인
+ */
+function isAllowedImageDomain(url: string): boolean {
+    try {
+        const urlObj = new URL(url);
+        return ALLOWED_IMAGE_DOMAINS.some(
+            (domain) => urlObj.hostname === domain || urlObj.hostname.endsWith('.' + domain)
+        );
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * URL이 이미지 확장자를 가지는지 확인
+ */
+function hasImageExtension(url: string): boolean {
+    try {
+        const urlObj = new URL(url);
+        const pathname = urlObj.pathname.toLowerCase();
+        return IMAGE_EXTENSIONS.some((ext) => pathname.endsWith(ext));
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * 이미지 URL 검증 (XSS 방지)
+ */
+function isValidImageUrl(url: string): boolean {
+    if (!url.startsWith('https://') && !url.startsWith('http://')) {
+        return false;
+    }
+    if (url.includes('javascript:') || url.includes('data:')) {
+        return false;
+    }
+    return isAllowedImageDomain(url) && hasImageExtension(url);
+}
+
+/**
+ * 파일명에서 alt 텍스트 추출
+ */
+function extractAltText(url: string): string {
+    try {
+        const urlObj = new URL(url);
+        const pathname = urlObj.pathname;
+        const filename = pathname.split('/').pop() || '';
+        return filename.replace(/\.[^.]+$/, '') || '이미지';
+    } catch {
+        return '이미지';
+    }
+}
+
+/**
+ * YouTube 영상 ID 추출
+ */
+function extractYouTubeId(url: string): { id: string; isShorts: boolean } | null {
+    const patterns = [
+        { regex: /(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/, shorts: true },
+        { regex: /(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/, shorts: false },
+        { regex: /youtu\.be\/([a-zA-Z0-9_-]{11})/, shorts: false },
+        { regex: /(?:www\.)?youtube\.com\/live\/([a-zA-Z0-9_-]{11})/, shorts: false },
+        { regex: /(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/, shorts: false }
+    ];
+
+    for (const { regex, shorts } of patterns) {
+        const match = url.match(regex);
+        if (match) {
+            return { id: match[1], isShorts: shorts };
+        }
+    }
+    return null;
+}
+
+/**
+ * 동영상 URL을 iframe으로 변환
+ */
+function renderVideoEmbed(url: string): string | null {
+    // YouTube
+    const yt = extractYouTubeId(url);
+    if (yt) {
+        const aspectRatio = yt.isShorts ? '177.78%' : '56.25%';
+        const maxWidth = yt.isShorts ? '400px' : '100%';
+        const platform = yt.isShorts ? 'youtube-shorts' : 'youtube';
+
+        // 시작 시간 추출
+        const timeMatch = url.match(/[?&]t=(\d+)/);
+        const startParam = timeMatch ? `?start=${timeMatch[1]}` : '';
+
+        return `<div class="embed-container" data-platform="${platform}" style="--aspect-ratio: ${aspectRatio}; --max-width: ${maxWidth};"><iframe src="https://www.youtube.com/embed/${yt.id}${startParam}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>`;
+    }
+
+    // Vimeo
+    const vimeoMatch = url.match(/(?:www\.)?vimeo\.com\/(\d+)/);
+    if (vimeoMatch) {
+        return `<div class="embed-container" data-platform="vimeo" style="--aspect-ratio: 56.25%; --max-width: 100%;"><iframe src="https://player.vimeo.com/video/${vimeoMatch[1]}" title="Vimeo video player" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe></div>`;
+    }
+
+    return null;
+}
+
+/**
+ * 대괄호 이미지 처리: [https://...image.jpg] → <img>
+ * marked autolink 후: [<a href="URL">URL</a>] 형태도 처리
+ */
+function processBracketImages(content: string): string {
+    // 1) raw text: [https://...image.jpg]
+    const rawPattern = /\[(https?:\/\/[^\]\s]+)\]/gi;
+    let result = content.replace(rawPattern, (match, url) => {
+        if (!isValidImageUrl(url)) {
+            return match;
+        }
+        const alt = extractAltText(url);
+        return `<img src="${url}" alt="${alt}" class="bracket-image" loading="lazy" />`;
+    });
+
+    // 2) autolinked: [<a href="URL">URL</a>]
+    const linkedPattern = /\[<a[^>]+href="(https?:\/\/[^"]+)"[^>]*>[^<]*<\/a>\]/gi;
+    result = result.replace(linkedPattern, (match, url) => {
+        if (!isValidImageUrl(url)) {
+            return match;
+        }
+        const alt = extractAltText(url);
+        return `<img src="${url}" alt="${alt}" class="bracket-image" loading="lazy" />`;
+    });
+
+    return result;
+}
+
+/**
+ * 동영상 숏코드 처리: {video:URL} 또는 {동영상:URL} → iframe
+ * marked autolink 후: {video: <a href="URL">URL</a> } 형태도 처리
+ */
+function processVideoShortcodes(content: string): string {
+    const pattern = /\{(video|동영상)\s*:\s*([^}]+)\}/gi;
+
+    return content.replace(pattern, (match, _type: string, rawContent: string) => {
+        // <a> 태그가 포함된 경우 href에서 URL 추출
+        const url = extractUrlFromHtml(rawContent);
+
+        if (!url.startsWith('https://') && !url.startsWith('http://')) {
+            return match;
+        }
+        if (url.includes('javascript:') || url.includes('data:')) {
+            return match;
+        }
+
+        const embed = renderVideoEmbed(url);
+        return embed || match;
+    });
+}
+
+/**
+ * 모든 숏코드를 처리하는 메인 함수
+ *
+ * 처리 순서:
+ * 1. 대괄호 이미지: [https://...jpg] → <img>
+ * 2. 동영상 숏코드: {video:URL} → iframe
+ */
+export function processBracketShortcodes(content: string): string {
+    if (!content) return content;
+
+    let result = content;
+
+    // 1. 대괄호 이미지 처리
+    result = processBracketImages(result);
+
+    // 2. 동영상 숏코드 처리
+    result = processVideoShortcodes(result);
+
+    return result;
+}

--- a/plugins/bracket-image/plugin.json
+++ b/plugins/bracket-image/plugin.json
@@ -1,0 +1,32 @@
+{
+    "id": "bracket-image",
+    "name": "숏코드 변환",
+    "version": "1.0.0",
+    "description": "[img URL], [link URL], {video:URL} 숏코드를 HTML로 변환합니다.",
+    "author": {
+        "name": "Damoang Team",
+        "url": "https://damoang.net"
+    },
+    "hooks": [
+        {
+            "name": "post_content",
+            "type": "filter",
+            "callback": "hooks/content-filter.ts",
+            "priority": 7
+        },
+        {
+            "name": "comment_content",
+            "type": "filter",
+            "callback": "hooks/comment-filter.ts",
+            "priority": 7
+        }
+    ],
+    "settings": {
+        "enabled": {
+            "label": "활성화",
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "tags": ["이미지", "숏코드", "동영상"]
+}

--- a/plugins/emoticon/hooks/emoticon-comment-filter.ts
+++ b/plugins/emoticon/hooks/emoticon-comment-filter.ts
@@ -4,7 +4,6 @@
  */
 
 import { replaceEmoticons } from '../lib/parser';
-import { getApiBaseUrl } from '../lib/api';
 
 /**
  * 댓글 본문에서 이모티콘 코드를 이미지로 변환하는 필터 콜백
@@ -14,5 +13,5 @@ import { getApiBaseUrl } from '../lib/api';
  */
 export default function emoticonCommentFilter(content: string): string {
     if (!content) return content;
-    return replaceEmoticons(content, getApiBaseUrl());
+    return replaceEmoticons(content);
 }

--- a/plugins/emoticon/hooks/emoticon-content-filter.ts
+++ b/plugins/emoticon/hooks/emoticon-content-filter.ts
@@ -4,7 +4,6 @@
  */
 
 import { replaceEmoticons } from '../lib/parser';
-import { getApiBaseUrl } from '../lib/api';
 
 /**
  * 게시글 본문에서 이모티콘 코드를 이미지로 변환하는 필터 콜백
@@ -14,5 +13,5 @@ import { getApiBaseUrl } from '../lib/api';
  */
 export default function emoticonContentFilter(content: string): string {
     if (!content) return content;
-    return replaceEmoticons(content, getApiBaseUrl());
+    return replaceEmoticons(content);
 }

--- a/plugins/emoticon/lib/api.ts
+++ b/plugins/emoticon/lib/api.ts
@@ -4,8 +4,13 @@
 
 import type { EmoticonPack, EmoticonItem } from './types';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081';
-const PLUGIN_API = `${API_BASE}/api/plugins/emoticon`;
+/**
+ * 브라우저에서는 상대 경로 사용 (nginx/Vite 프록시를 통해 백엔드로 전달)
+ * SSR에서는 내부 URL 사용
+ */
+const PLUGIN_API = typeof window !== 'undefined'
+    ? '/api/plugins/emoticon'
+    : `${import.meta.env.VITE_API_BASE_URL || 'http://localhost:8082'}/api/plugins/emoticon`;
 
 /**
  * 활성 팩 목록 조회

--- a/plugins/emoticon/lib/parser.ts
+++ b/plugins/emoticon/lib/parser.ts
@@ -39,15 +39,17 @@ export function parseEmoticonCode(code: string): EmoticonParseResult | null {
 
 /**
  * 콘텐츠 내 {emo:...} 코드를 <img> 태그로 변환
+ *
+ * 이미지는 /static/emoticons/ 디렉터리에서 정적 파일로 서빙
  */
-export function replaceEmoticons(content: string, baseUrl: string): string {
+export function replaceEmoticons(content: string, _baseUrl?: string): string {
     return content.replace(EMO_PATTERN, (_match, code: string) => {
         const result = parseEmoticonCode(code);
         if (!result) {
-            return renderFallback(baseUrl);
+            return renderFallback();
         }
 
-        const src = escapeHtml(`${baseUrl}/image/${result.filename}`);
+        const src = escapeHtml(`/emoticons/${result.filename}`);
         return `<img src="${src}" width="${result.width}" class="emoticon" loading="lazy" alt="emoticon" />`;
     });
 }
@@ -55,8 +57,8 @@ export function replaceEmoticons(content: string, baseUrl: string): string {
 /**
  * 삭제된 이모티콘 폴백 렌더링
  */
-function renderFallback(baseUrl: string): string {
-    const src = escapeHtml(`${baseUrl}/image/damoang-emo-010.gif`);
+function renderFallback(): string {
+    const src = escapeHtml('/emoticons/damoang-emo-010.gif');
     return `(삭제된 이모지) <img src="${src}" width="${DEFAULT_WIDTH}" class="emoticon" loading="lazy" alt="deleted emoticon" />`;
 }
 


### PR DESCRIPTION
## Summary
- **bracket-image** 플러그인 신규 생성: `[img URL]`, `{video:URL}` 숏코드를 HTML로 변환
- **auto-embed** 플러그인 신규 생성: YouTube, Instagram, Twitter/X, Reddit, Bluesky 등 URL 자동 임베드
- `markdown.svelte`, `comment-list.svelte`에서 인라인 하드코딩 제거 → `applyFilter('post_content')` / `applyFilter('comment_content')` 훅 연동
- `hook-state.svelte.ts` 추가: Svelte 5 reactive hook 버전 추적 (`$effect` 재실행용)
- emoticon 플러그인: API URL 대신 `/emoticons/` 정적 파일 경로 사용
- `hooks.server.ts`: `/api/plugins/*` Go 백엔드 프록시 제거 (SvelteKit API 라우트와 충돌하여 플러그인 관리/댓글 렌더링 장애 유발)

## 변경 아키텍처
```
BEFORE (하드코딩):
  게시글: content → transformEmoticons() → marked.parse() → processEmbeds() → DOMPurify
  댓글:   content → transformEmoticons() → \n→<br> → processBracketImages() → processEmbeds() → DOMPurify

AFTER (플러그인 훅):
  게시글: content → marked.parse() → applyFilter('post_content') → DOMPurify
  댓글:   content → \n→<br> → applyFilter('comment_content') → DOMPurify
```

## Test plan
- [ ] 이모티콘 `{emo:파일:크기}` → 이미지 변환 확인
- [ ] 대괄호 이미지 `[https://...jpg]` → `<img>` 변환 확인
- [ ] YouTube URL → iframe 임베드 확인
- [ ] 댓글 줄바꿈 → `<br>` 변환 확인
- [ ] `/admin/plugins`에서 4개 플러그인 모두 표시 확인