### PR TITLE
fix: Docker config 정리로 배포 인증 오류 해결

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -56,7 +56,7 @@ jobs:
               'ECR_REGISTRY=891376997084.dkr.ecr.ap-northeast-2.amazonaws.com',
               'REPOSITORY=damoang',
               'echo Deploying angple with tag: $IMAGE_TAG',
-              'docker logout 2>/dev/null || true',
+              'rm -f /root/.docker/config.json /home/damoang/.docker/config.json 2>/dev/null || true',
               'aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin $ECR_REGISTRY',
               'docker build -f apps/web/Dockerfile --target production -t $ECR_REGISTRY/$REPOSITORY:web-$IMAGE_TAG -t $ECR_REGISTRY/$REPOSITORY:web-latest .',
               'docker build -f apps/admin/Dockerfile --target production -t $ECR_REGISTRY/$REPOSITORY:admin-$IMAGE_TAG -t $ECR_REGISTRY/$REPOSITORY:admin-latest .',


### PR DESCRIPTION
Docker Hub 만료 크리덴셜이 ECR 빌드를 방해하는 문제. config.json 제거 후 ECR만 재로그인.