### PR TITLE
fix: SSM 배포 변수 확장 문제 해결

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,6 +12,11 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  ECR_REGISTRY: 891376997084.dkr.ecr.ap-northeast-2.amazonaws.com
+  ECR_REPOSITORY: damoang
+  INSTANCE_ID: i-038a1d1f00798d94b
+
 jobs:
   deploy:
     name: Deploy to Production
@@ -36,48 +41,89 @@ jobs:
           role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
           aws-region: ap-northeast-2
 
-      - name: Deploy via SSM
+      - name: Create deploy script
         env:
           IMAGE_TAG: ${{ steps.set-tag.outputs.tag }}
         run: |
+          cat > /tmp/deploy.sh << 'DEPLOY_SCRIPT'
+          #!/bin/bash
+          set -e
+
+          export HOME=/home/damoang
+          cd /home/damoang/angple
+
+          git config --global --add safe.directory /home/damoang/angple
+          git fetch origin
+          git checkout -f main
+          git reset --hard origin/main
+          git clean -fd
+
+          ECR_REGISTRY="891376997084.dkr.ecr.ap-northeast-2.amazonaws.com"
+          REPOSITORY="damoang"
+          IMAGE_TAG="__IMAGE_TAG__"
+
+          echo "Deploying angple with tag: $IMAGE_TAG"
+
+          # Docker Hub 크리덴셜 충돌 방지
+          export DOCKER_CONFIG=/tmp/docker-deploy-config
+          rm -rf "$DOCKER_CONFIG" && mkdir -p "$DOCKER_CONFIG"
+
+          aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+          docker build -f apps/web/Dockerfile --target production \
+            -t "$ECR_REGISTRY/$REPOSITORY:web-$IMAGE_TAG" \
+            -t "$ECR_REGISTRY/$REPOSITORY:web-latest" .
+
+          docker build -f apps/admin/Dockerfile --target production \
+            -t "$ECR_REGISTRY/$REPOSITORY:admin-$IMAGE_TAG" \
+            -t "$ECR_REGISTRY/$REPOSITORY:admin-latest" .
+
+          docker push "$ECR_REGISTRY/$REPOSITORY:web-$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/$REPOSITORY:web-latest"
+          docker push "$ECR_REGISTRY/$REPOSITORY:admin-$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/$REPOSITORY:admin-latest"
+
+          docker rm -f angple-web angple-admin 2>/dev/null || true
+          sleep 3
+
+          docker run -d --name angple-web \
+            -p 3010:3000 \
+            --restart unless-stopped \
+            --memory=2g --cpus=1.0 \
+            -e NODE_ENV=production \
+            -e INTERNAL_API_URL=http://angple-api:8081/api/v2 \
+            -e PUBLIC_API_BASE_URL=https://api.damoang.net \
+            "$ECR_REGISTRY/$REPOSITORY:web-$IMAGE_TAG"
+
+          docker run -d --name angple-admin \
+            -p 3011:80 \
+            --restart unless-stopped \
+            --memory=1g --cpus=0.5 \
+            "$ECR_REGISTRY/$REPOSITORY:admin-$IMAGE_TAG"
+
+          docker network connect angple-network angple-web 2>/dev/null || true
+          docker network connect angple-network angple-admin 2>/dev/null || true
+          docker network connect proxy-network angple-web 2>/dev/null || true
+          docker network connect proxy-network angple-admin 2>/dev/null || true
+
+          sleep 10
+          docker ps | grep -E "angple-"
+          docker image prune -f
+          echo "Deployed at $(date)"
+          DEPLOY_SCRIPT
+
+          # IMAGE_TAG 치환
+          sed -i "s/__IMAGE_TAG__/$IMAGE_TAG/g" /tmp/deploy.sh
+
+      - name: Deploy via SSM
+        run: |
+          # 스크립트를 base64로 인코딩하여 SSM에 전달
+          SCRIPT_B64=$(base64 -w0 /tmp/deploy.sh)
+
           COMMAND_ID=$(aws ssm send-command \
-            --instance-ids "i-038a1d1f00798d94b" \
+            --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --parameters "commands=[
-              'set -e',
-              'export HOME=/home/damoang',
-              'cd /home/damoang/angple',
-              'git config --global --add safe.directory /home/damoang/angple',
-              'git fetch origin',
-              'git checkout -f main',
-              'git reset --hard origin/main',
-              'git clean -fd',
-              'IMAGE_TAG=$IMAGE_TAG',
-              'ECR_REGISTRY=891376997084.dkr.ecr.ap-northeast-2.amazonaws.com',
-              'REPOSITORY=damoang',
-              'echo Deploying angple with tag: $IMAGE_TAG',
-              'export DOCKER_CONFIG=/tmp/docker-deploy-config',
-              'rm -rf $DOCKER_CONFIG && mkdir -p $DOCKER_CONFIG',
-              'aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin $ECR_REGISTRY',
-              'docker build -f apps/web/Dockerfile --target production -t $ECR_REGISTRY/$REPOSITORY:web-$IMAGE_TAG -t $ECR_REGISTRY/$REPOSITORY:web-latest .',
-              'docker build -f apps/admin/Dockerfile --target production -t $ECR_REGISTRY/$REPOSITORY:admin-$IMAGE_TAG -t $ECR_REGISTRY/$REPOSITORY:admin-latest .',
-              'docker push $ECR_REGISTRY/$REPOSITORY:web-$IMAGE_TAG',
-              'docker push $ECR_REGISTRY/$REPOSITORY:web-latest',
-              'docker push $ECR_REGISTRY/$REPOSITORY:admin-$IMAGE_TAG',
-              'docker push $ECR_REGISTRY/$REPOSITORY:admin-latest',
-              'docker rm -f angple-web angple-admin 2>/dev/null || true',
-              'sleep 3',
-              'docker run -d --name angple-web -p 3010:3000 --restart unless-stopped --memory=2g --cpus=1.0 -e NODE_ENV=production -e INTERNAL_API_URL=http://angple-api:8081/api/v2 -e PUBLIC_API_BASE_URL=https://api.damoang.net $ECR_REGISTRY/$REPOSITORY:web-$IMAGE_TAG',
-              'docker run -d --name angple-admin -p 3011:80 --restart unless-stopped --memory=1g --cpus=0.5 $ECR_REGISTRY/$REPOSITORY:admin-$IMAGE_TAG',
-              'docker network connect angple-network angple-web 2>/dev/null || true',
-              'docker network connect angple-network angple-admin 2>/dev/null || true',
-              'docker network connect proxy-network angple-web 2>/dev/null || true',
-              'docker network connect proxy-network angple-admin 2>/dev/null || true',
-              'sleep 10',
-              'docker ps | grep -E angple-',
-              'docker image prune -f',
-              'echo Deployed at $(date)'
-            ]" \
+            --parameters "commands=['echo $SCRIPT_B64 | base64 -d | bash']" \
             --timeout-seconds 600 \
             --query "Command.CommandId" \
             --output text)
@@ -88,12 +134,12 @@ jobs:
           echo "Waiting for command to complete..."
           aws ssm wait command-executed \
             --command-id "$COMMAND_ID" \
-            --instance-id "i-038a1d1f00798d94b" || true
+            --instance-id "$INSTANCE_ID" || true
 
           # 결과 확인
           STATUS=$(aws ssm get-command-invocation \
             --command-id "$COMMAND_ID" \
-            --instance-id "i-038a1d1f00798d94b" \
+            --instance-id "$INSTANCE_ID" \
             --query "Status" \
             --output text)
 
@@ -102,7 +148,7 @@ jobs:
           # 출력 로그
           aws ssm get-command-invocation \
             --command-id "$COMMAND_ID" \
-            --instance-id "i-038a1d1f00798d94b" \
+            --instance-id "$INSTANCE_ID" \
             --query "StandardOutputContent" \
             --output text
 
@@ -110,7 +156,7 @@ jobs:
             echo "Error output:"
             aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
-              --instance-id "i-038a1d1f00798d94b" \
+              --instance-id "$INSTANCE_ID" \
               --query "StandardErrorContent" \
               --output text
             exit 1


### PR DESCRIPTION
기존 deploy-prod.yml에서 `--parameters "commands=[...]"` 방식 사용 시
`$ECR_REGISTRY`, `$REPOSITORY`, `$DOCKER_CONFIG` 등이 GHA bash에서
빈 문자열로 확장되는 근본적 문제 해결.

- 스크립트를 heredoc으로 생성 → base64 인코딩 → SSM 전달
- Docker Hub 크리덴셜 충돌 방지 (DOCKER_CONFIG 격리)
- git checkout -f, git clean -fd 추가