### PR TITLE
fix: .npmrc로 lucide 호이스팅 해결

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -16,7 +16,7 @@ RUN adduser -D -u 1001 -s /bin/sh devuser
 WORKDIR /app
 
 # Copy workspace configuration files
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
 
 # Copy packages (workspace dependencies)
 COPY packages ./packages
@@ -60,21 +60,21 @@ ENV VITE_SSR=$VITE_SSR
 WORKDIR /app
 
 # Copy workspace configuration files
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
 
 # Copy workspace packages (workspace:* dependencies)
 COPY packages ./packages
 
-# Copy application source
-COPY apps/web ./apps/web
-
-# Install dependencies first
-RUN pnpm install --frozen-lockfile --filter web...
-
-# Copy themes/plugins/widgets AFTER install so they can access node_modules
+# Copy themes/plugins/widgets before install (needed for build)
 COPY themes ./themes
 COPY plugins ./plugins
 COPY widgets ./widgets
+
+# Copy application source
+COPY apps/web ./apps/web
+
+# Install dependencies (with .npmrc hoisting for plugins)
+RUN pnpm install --frozen-lockfile --filter web...
 # 워크스페이스 패키지 먼저 빌드 (의존성 순서대로)
 RUN pnpm --filter @angple/types run build
 RUN pnpm --filter @angple/i18n run build


### PR DESCRIPTION
.npmrc를 Dockerfile에 복사하여 public-hoist-pattern 적용, plugins가 @lucide/svelte 접근 가능