### PR TITLE
fix: .dockerignore 수정으로 .npmrc 포함

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,7 +61,7 @@ tmp/
 # sub directory
 **/README.md
 **/.gitignore
-**/.npmrc
+# **/.npmrc  # Commented out - needed for pnpm hoisting config
 **/.prettier*
 **/eslint*
 **/playwright*


### PR DESCRIPTION
Docker 빌드 시 .npmrc 파일 필요 (pnpm hoisting 설정)