### PR TITLE
fix: SSM wait timeout 증가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -142,18 +142,27 @@ jobs:
 
           echo "Command ID: $COMMAND_ID"
 
-          # 완료 대기
+          # 완료 대기 (10분 timeout with polling)
           echo "Waiting for command to complete..."
-          aws ssm wait command-executed \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" || true
+          MAX_WAIT=600  # 10 minutes
+          WAIT_INTERVAL=15
+          ELAPSED=0
 
-          # 결과 확인
-          STATUS=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "$INSTANCE_ID" \
-            --query "Status" \
-            --output text)
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+
+            if [ "$STATUS" = "Success" ] || [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ]; then
+              break
+            fi
+
+            echo "Status: $STATUS (${ELAPSED}s/${MAX_WAIT}s)"
+            sleep $WAIT_INTERVAL
+            ELAPSED=$((ELAPSED + WAIT_INTERVAL))
+          done
 
           echo "Command Status: $STATUS"
 


### PR DESCRIPTION
Docker build 완료 대기 시간 부족 문제 해결. 15초 간격 폴링으로 최대 10분 대기