### PR TITLE
fix: celebration-rolling API 응답 체크 수정

### DIFF
--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -54,7 +54,7 @@
 
             const result = await response.json();
 
-            if (result.success && result.data?.length > 0) {
+            if (result.data?.length > 0) {
                 celebrations = result.data;
             }
         } catch (error) {


### PR DESCRIPTION
API 응답이 {data: [...]} 형식이므로 result.success 체크 제거

🤖 Generated with Claude Code