### PR TITLE
fix: CodeQL 보안 취약점 8건 수정

### DIFF
--- a/apps/web/src/lib/server/plugins/github-installer.ts
+++ b/apps/web/src/lib/server/plugins/github-installer.ts
@@ -91,12 +91,23 @@ function parsePackageName(input: string): ParsedPackageName {
     };
 }
 
+/** URL이 GitHub 호스트인지 hostname으로 정확히 검증 */
+function isGitHubUrl(urlStr: string): boolean {
+    try {
+        const url = new URL(urlStr);
+        return url.hostname === 'github.com' || url.hostname === 'www.github.com';
+    } catch {
+        return false;
+    }
+}
+
 /**
  * GitHub URL에서 패키지명 추출
  *
  * @example extractFromGitHubUrl('https://github.com/angple/plugin-xxx')
  */
 function extractFromGitHubUrl(url: string): string | null {
+    if (!isGitHubUrl(url)) return null;
     const match = url.match(/github\.com\/([a-z0-9-]+)\/([a-z0-9-]+)/i);
     if (match) {
         return `@${match[1]}/${match[2]}`;
@@ -216,7 +227,7 @@ export class GitHubPluginInstaller {
             let packageName = request.packageName;
 
             // GitHub URL 처리
-            if (packageName.startsWith('https://github.com')) {
+            if (isGitHubUrl(packageName)) {
                 const extracted = extractFromGitHubUrl(packageName);
                 if (!extracted) {
                     throw new Error('잘못된 GitHub URL 형식입니다.');
@@ -352,7 +363,7 @@ export class GitHubPluginInstaller {
     }> {
         try {
             // GitHub URL 처리
-            if (packageName.startsWith('https://github.com')) {
+            if (isGitHubUrl(packageName)) {
                 const extracted = extractFromGitHubUrl(packageName);
                 if (!extracted) {
                     throw new Error('잘못된 GitHub URL 형식입니다.');

--- a/apps/web/src/lib/server/sanitize.ts
+++ b/apps/web/src/lib/server/sanitize.ts
@@ -93,16 +93,20 @@ export function sanitizePostContent(html: string): string {
 export function sanitizePostContentStrict(html: string): string {
     let sanitized = sanitizePostContent(html);
 
-    // iframe src가 YouTube가 아닌 경우 제거
-    sanitized = sanitized.replace(
-        /<iframe\s[^>]*src="([^"]*)"[^>]*>[\s\S]*?<\/iframe>/gi,
-        (match, src: string) => {
-            if (YOUTUBE_REGEX.test(src)) {
-                return match;
+    // iframe src가 YouTube가 아닌 경우 반복 제거 (중첩 태그 우회 방지)
+    let prev;
+    do {
+        prev = sanitized;
+        sanitized = sanitized.replace(
+            /<iframe\s[^>]*src="([^"]*)"[^>]*>[\s\S]*?<\/iframe>/gi,
+            (match, src: string) => {
+                if (YOUTUBE_REGEX.test(src)) {
+                    return match;
+                }
+                return '';
             }
-            return '';
-        }
-    );
+        );
+    } while (sanitized !== prev);
 
     return sanitized;
 }

--- a/apps/web/src/routes/api/giving/+server.ts
+++ b/apps/web/src/routes/api/giving/+server.ts
@@ -44,6 +44,16 @@ interface CountRow extends RowDataPacket {
     cnt: number;
 }
 
+/** S3 URL인지 hostname으로 정확히 검증 */
+function isS3DamoangUrl(urlStr: string): boolean {
+    try {
+        const url = new URL(urlStr);
+        return url.hostname === 's3.damoang.net';
+    } catch {
+        return false;
+    }
+}
+
 export const GET: RequestHandler = async ({ url }) => {
     const tab = url.searchParams.get('tab') || 'active';
     const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
@@ -164,8 +174,8 @@ export const GET: RequestHandler = async ({ url }) => {
                 }
             }
 
-            // S3 URL인 경우 Lambda 썸네일 URL로 변환
-            if (thumbnail && thumbnail.includes('s3.damoang.net')) {
+            // S3 URL인 경우 Lambda 썸네일 URL로 변환 (hostname으로 정확히 검증)
+            if (thumbnail && isS3DamoangUrl(thumbnail)) {
                 const match = thumbnail.match(
                     /^(https?:\/\/s3\.damoang\.net\/.+\/)([^/]+)\.([a-zA-Z0-9]+)$/
                 );

--- a/apps/web/src/routes/api/mentions/notify/+server.ts
+++ b/apps/web/src/routes/api/mentions/notify/+server.ts
@@ -19,6 +19,17 @@ interface NotifyRequest {
     senderNick: string; // 발신자 닉네임
 }
 
+/** HTML 태그를 반복 제거 (중첩 태그 우회 방지) */
+function stripHtmlTags(str: string): string {
+    let result = str;
+    let prev;
+    do {
+        prev = result;
+        result = result.replace(/<[^>]+>/g, '');
+    } while (result !== prev);
+    return result;
+}
+
 export const POST: RequestHandler = async ({ request, cookies }) => {
     const accessToken =
         cookies.get('access_token') || request.headers.get('authorization')?.replace('Bearer ', '');
@@ -60,7 +71,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
             ? `/${boardId}/${postId}#comment-${commentId}`
             : `/${boardId}/${postId}`;
 
-        const excerpt = content.replace(/<[^>]+>/g, '').substring(0, 80);
+        const excerpt = stripHtmlTags(content).substring(0, 80);
         let sentCount = 0;
 
         for (const row of rows) {

--- a/apps/web/src/routes/api/plugins/install-github/+server.ts
+++ b/apps/web/src/routes/api/plugins/install-github/+server.ts
@@ -8,6 +8,16 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getGitHubInstaller, type InstallRequest } from '$lib/server/plugins/github-installer';
 
+/** URL이 GitHub 호스트인지 hostname으로 정확히 검증 */
+function isGitHubUrl(urlStr: string): boolean {
+    try {
+        const url = new URL(urlStr);
+        return url.hostname === 'github.com' || url.hostname === 'www.github.com';
+    } catch {
+        return false;
+    }
+}
+
 /** 요청 body 인터페이스 */
 interface InstallRequestBody {
     packageName: string;
@@ -26,11 +36,8 @@ export const POST: RequestHandler = async ({ request }) => {
             throw error(400, { message: 'packageName은 필수 입력 항목입니다.' });
         }
 
-        // 패키지명 형식 검증
-        if (
-            !body.packageName.startsWith('@') &&
-            !body.packageName.startsWith('https://github.com')
-        ) {
+        // 패키지명 형식 검증 (URL은 hostname으로 정확히 검증)
+        if (!body.packageName.startsWith('@') && !isGitHubUrl(body.packageName)) {
             throw error(400, {
                 message: '패키지명은 @scope/package-name 형식이거나 GitHub URL이어야 합니다.'
             });

--- a/apps/web/src/routes/rss/+server.ts
+++ b/apps/web/src/routes/rss/+server.ts
@@ -49,9 +49,7 @@ export const GET: RequestHandler = async ({ url }) => {
                     allPosts.push({
                         title: escapeXml(post.wr_subject),
                         link: `${siteUrl}/${board.bo_table}/${post.wr_id}`,
-                        description: escapeXml(
-                            post.wr_content.replace(/<[^>]+>/g, '').slice(0, 200)
-                        ),
+                        description: escapeXml(stripHtmlTags(post.wr_content).slice(0, 200)),
                         author: escapeXml(post.wr_name),
                         pubDate: new Date(post.wr_datetime).toUTCString(),
                         boardSubject: escapeXml(board.bo_subject)
@@ -103,6 +101,17 @@ ${items}
         }
     });
 };
+
+/** HTML 태그를 반복 제거 (중첩 태그 우회 방지) */
+function stripHtmlTags(str: string): string {
+    let result = str;
+    let prev;
+    do {
+        prev = result;
+        result = result.replace(/<[^>]+>/g, '');
+    } while (result !== prev);
+    return result;
+}
 
 function escapeXml(str: string): string {
     return str

--- a/apps/web/src/routes/rss/[boardId]/+server.ts
+++ b/apps/web/src/routes/rss/[boardId]/+server.ts
@@ -52,7 +52,7 @@ export const GET: RequestHandler = async ({ url, params }) => {
                 (post) => `    <item>
       <title>${escapeXml(post.wr_subject)}</title>
       <link>${siteUrl}/${boardId}/${post.wr_id}</link>
-      <description>${escapeXml(post.wr_content.replace(/<[^>]+>/g, '').slice(0, 200))}</description>
+      <description>${escapeXml(stripHtmlTags(post.wr_content).slice(0, 200))}</description>
       <author>${escapeXml(post.wr_name)}</author>
       <pubDate>${new Date(post.wr_datetime).toUTCString()}</pubDate>
       <guid isPermaLink="true">${siteUrl}/${boardId}/${post.wr_id}</guid>
@@ -83,6 +83,17 @@ ${items}
         }
     });
 };
+
+/** HTML 태그를 반복 제거 (중첩 태그 우회 방지) */
+function stripHtmlTags(str: string): string {
+    let result = str;
+    let prev;
+    do {
+        prev = result;
+        result = result.replace(/<[^>]+>/g, '');
+    } while (result !== prev);
+    return result;
+}
 
 function escapeXml(str: string): string {
     return str


### PR DESCRIPTION
- Incomplete multi-character sanitization (4건): HTML 태그 제거 시 단일 replace 대신 반복 제거로 중첩 태그 우회 방지 (rss/+server.ts, rss/[boardId]/+server.ts, mentions/notify, sanitize.ts)

- Incomplete URL substring sanitization (4건): startsWith/includes 대신 new URL() 파싱 후 hostname 정확 비교 (github-installer.ts, install-github/+server.ts, giving/+server.ts)