### PR TITLE
fix: 배포 스크립트에 types 패키지 빌드 단계 추가

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -46,6 +46,8 @@ fi
 # 1. 빌드
 echo ""
 echo -e "${BLUE}📦 [1/4] 빌드 중...${NC}"
+cd "$DEV_DIR/packages/types"
+pnpm build 2>&1
 cd "$DEV_DIR/apps/web"
 pnpm build 2>&1 | tail -3
 

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -15,6 +15,8 @@ LOG_FILE="/tmp/angple-dev.log"
 case "$1" in
     start|restart)
         echo "📦 빌드 중..."
+        cd "$DEV_DIR/packages/types"
+        pnpm build 2>&1
         cd "$DEV_DIR/apps/web"
         npm run build 2>&1 | tail -3
 


### PR DESCRIPTION
## Summary
- deploy.sh, dev-server.sh에서 웹앱 빌드 전 packages/types를 먼저 빌드
- safeValidateExtensionManifest 등 미빌드 export로 인한 빌드 실패 방지