### PR TITLE
fix: 다크모드 유지, 사이드바 배너, 분석 링크 추가

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -16,6 +16,11 @@
         %sveltekit.head%
     </head>
     <body data-sveltekit-preload-data="hover">
+        <script>
+            if (localStorage.getItem('darkMode') === 'true') {
+                document.documentElement.classList.add('dark');
+            }
+        </script>
         <div style="display: contents">%sveltekit.body%</div>
         <script>
             if ('serviceWorker' in navigator && location.hostname !== 'localhost') {

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -52,10 +52,18 @@
     function toggleDarkMode() {
         isDarkMode = !isDarkMode;
         document.documentElement.classList.toggle('dark');
+        localStorage.setItem('darkMode', String(isDarkMode));
     }
 
     // 컴포넌트 마운트 시 스크롤 이벤트 등록
     onMount(() => {
+        // 다크모드 상태 복원
+        const saved = localStorage.getItem('darkMode');
+        if (saved === 'true') {
+            isDarkMode = true;
+            document.documentElement.classList.add('dark');
+        }
+
         window.addEventListener('scroll', handleScroll, { passive: true });
 
         return () => {

--- a/apps/web/src/lib/components/layout/user-widget.svelte
+++ b/apps/web/src/lib/components/layout/user-widget.svelte
@@ -162,7 +162,7 @@
                     {/if}
                 </div>
             {/if}
-            <div class="grid grid-cols-3 gap-1">
+            <div class="grid grid-cols-4 gap-1">
                 <a
                     href="/my?tab=posts"
                     class="border-border text-muted-foreground hover:border-primary/30 hover:text-primary flex items-center justify-center rounded border px-2 py-1.5 transition-colors"
@@ -180,6 +180,14 @@
                     class="border-border text-muted-foreground hover:border-primary/30 hover:text-primary flex items-center justify-center rounded border px-2 py-1.5 transition-colors"
                 >
                     전체
+                </a>
+                <a
+                    href="https://damoang.net/my"
+                    rel="external"
+                    target="_blank"
+                    class="border-border text-muted-foreground hover:border-primary/30 hover:text-primary flex items-center justify-center rounded border px-2 py-1.5 transition-colors"
+                >
+                    분석
                 </a>
             </div>
         </div>

--- a/widgets/ad/index.svelte
+++ b/widgets/ad/index.svelte
@@ -54,7 +54,7 @@
                 adsenseFormat="rectangle"
             />
         {:else if adType === 'image-text'}
-            <ImageTextBanner position="list-inline" />
+            <ImageTextBanner position="side-image-text-banner" />
         {:else}
             <AdSlot {position} height="250px" />
         {/if}


### PR DESCRIPTION
## Summary
- 다크모드 토글 시 localStorage 저장/복원 + SSR 깜박임 방지 인라인 스크립트
- 사이드바 image-text 배너 position을 `side-image-text-banner`로 변경 (지니렌탈 배너 연동)
- 유저 위젯에 "분석" 링크 추가 (`damoang.net/my` 외부 링크)
- DB에서 중복 중고장터 메뉴(id=262) 삭제 완료 (코드 변경 없음)

## Test plan
- [ ] dev.damoang.net에서 다크모드 토글 → 새로고침 → 유지 확인
- [ ] 사이드바에서 지니렌탈 미니배너 4칸 그리드 표시 확인
- [ ] 사이드바 메뉴에서 중고장터 1개만 표시 확인
- [ ] 로그인 후 유저 위젯에서 "분석" 링크 확인