### PR TITLE
fix: 글꼴 크기 통일 (text-xs/sm → 고정 px)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -504,7 +504,7 @@
                         <div>
                             <p
                                 class="text-foreground font-medium {isReply
-                                    ? 'text-sm'
+                                    ? 'text-[15px]'
                                     : ''} flex items-center gap-1.5"
                             >
                                 <LevelBadge
@@ -524,7 +524,11 @@
                                     <Lock class="text-muted-foreground h-3.5 w-3.5" />
                                 {/if}
                             </p>
-                            <p class="text-secondary-foreground {isReply ? 'text-xs' : 'text-sm'}">
+                            <p
+                                class="text-secondary-foreground {isReply
+                                    ? 'text-[13px]'
+                                    : 'text-[15px]'}"
+                            >
                                 {formatDate(comment.created_at)}
                             </p>
                         </div>
@@ -590,7 +594,9 @@
                     {/if}
 
                     <!-- 오른쪽 정렬: 비추천, 답글/수정/삭제 -->
-                    <div class="text-secondary-foreground ml-auto flex items-center gap-4 text-sm">
+                    <div
+                        class="text-secondary-foreground ml-auto flex items-center gap-4 text-[15px]"
+                    >
                         <!-- 댓글 비추천 버튼 (게시판 설정에서 활성화된 경우만) -->
                         {#if useNogood}
                             {#if onDislike && authStore.isAuthenticated}
@@ -624,7 +630,7 @@
                                         disabled={isReplyingTo}
                                     >
                                         <Reply class="h-4 w-4" />
-                                        <span class="ml-1 text-xs">답글</span>
+                                        <span class="ml-1 text-[13px]">답글</span>
                                     </Button>
                                 {/if}
 
@@ -688,14 +694,18 @@
                     {#if comment.is_secret && !canViewSecretComment(comment)}
                         <div
                             class="text-muted-foreground flex items-center gap-2 italic {isReply
-                                ? 'text-sm'
+                                ? 'text-[15px]'
                                 : ''}"
                         >
                             <Lock class="h-4 w-4" />
                             비밀댓글입니다.
                         </div>
                     {:else}
-                        <div class="text-foreground whitespace-pre-wrap {isReply ? 'text-sm' : ''}">
+                        <div
+                            class="text-foreground whitespace-pre-wrap {isReply
+                                ? 'text-[15px]'
+                                : ''}"
+                        >
                             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
                             {@html processedComments.get(comment.id) ?? ''}
                         </div>

--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -93,7 +93,7 @@
                             {post.title}
                         </CardTitle>
                         <div
-                            class="text-secondary-foreground flex flex-wrap items-center gap-2 text-sm"
+                            class="text-secondary-foreground flex flex-wrap items-center gap-2 text-[15px]"
                         >
                             <span>👍 {post.likes}</span>
                             <span>💬 {post.comments_count}</span>
@@ -116,7 +116,7 @@
                     <div class="flex flex-shrink-0 flex-wrap gap-1.5">
                         {#if post.category}
                             <span
-                                class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium"
+                                class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
                             >
                                 {post.category}
                             </span>

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -91,7 +91,7 @@
                 {/if}
                 {post.title}
             </h3>
-            <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-[13px]">
+            <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-[15px]">
                 <span>👍 {post.likes}</span>
                 <span>💬 {post.comments_count}</span>
                 <span>•</span>
@@ -111,7 +111,9 @@
         <!-- 우측: 카테고리 + 태그 -->
         <div class="flex flex-shrink-0 flex-wrap items-center gap-1.5">
             {#if post.category}
-                <span class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium">
+                <span
+                    class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
+                >
                     {post.category}
                 </span>
             {/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -64,7 +64,9 @@
                     {/if}
                     {post.title}
                 </CardTitle>
-                <div class="text-secondary-foreground flex flex-wrap items-center gap-2 text-sm">
+                <div
+                    class="text-secondary-foreground flex flex-wrap items-center gap-2 text-[15px]"
+                >
                     <span>👍 {post.likes}</span>
                     <span>💬 {post.comments_count}</span>
                     <span>•</span>
@@ -83,7 +85,7 @@
             <div class="flex flex-shrink-0 flex-wrap gap-1.5">
                 {#if post.category}
                     <span
-                        class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium"
+                        class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
                     >
                         {post.category}
                     </span>

--- a/apps/web/src/lib/components/features/board/skins/card.svelte
+++ b/apps/web/src/lib/components/features/board/skins/card.svelte
@@ -91,7 +91,7 @@
                             {post.title}
                         </CardTitle>
                         <div
-                            class="text-secondary-foreground flex flex-wrap items-center gap-2 text-sm"
+                            class="text-secondary-foreground flex flex-wrap items-center gap-2 text-[15px]"
                         >
                             <span>{post.author}</span>
                             {#if memoPluginActive}
@@ -106,7 +106,7 @@
                     <div class="flex flex-shrink-0 flex-wrap gap-1.5">
                         {#if post.category}
                             <span
-                                class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium"
+                                class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
                             >
                                 {post.category}
                             </span>
@@ -126,7 +126,7 @@
                         {post.content}
                     </p>
                 {/if}
-                <div class="text-secondary-foreground flex items-center gap-4 text-sm">
+                <div class="text-secondary-foreground flex items-center gap-4 text-[15px]">
                     <span>👍 {post.likes}</span>
                     <span>💬 {post.comments_count}</span>
                 </div>

--- a/apps/web/src/lib/components/features/board/skins/compact.svelte
+++ b/apps/web/src/lib/components/features/board/skins/compact.svelte
@@ -89,7 +89,7 @@
                 {/if}
                 {post.title}
             </h3>
-            <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-[13px]">
+            <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-[15px]">
                 <span>{post.author}</span>
                 <span>•</span>
                 <span>{formatDate(post.created_at)}</span>
@@ -105,7 +105,9 @@
         <!-- 우측: 카테고리 + 태그 -->
         <div class="flex flex-shrink-0 flex-wrap items-center gap-1.5">
             {#if post.category}
-                <span class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium">
+                <span
+                    class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
+                >
                     {post.category}
                 </span>
             {/if}

--- a/apps/web/src/lib/components/features/board/skins/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/skins/detailed.svelte
@@ -62,7 +62,9 @@
                     {/if}
                     {post.title}
                 </CardTitle>
-                <div class="text-secondary-foreground flex flex-wrap items-center gap-2 text-sm">
+                <div
+                    class="text-secondary-foreground flex flex-wrap items-center gap-2 text-[15px]"
+                >
                     <span>{post.author}</span>
                     <span>•</span>
                     <span>{formatDate(post.created_at)}</span>
@@ -73,7 +75,7 @@
             <div class="flex flex-shrink-0 flex-wrap gap-1.5">
                 {#if post.category}
                     <span
-                        class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium"
+                        class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
                     >
                         {post.category}
                     </span>
@@ -110,7 +112,7 @@
                         {post.content}
                     </p>
                 {/if}
-                <div class="text-secondary-foreground flex items-center gap-4 text-sm">
+                <div class="text-secondary-foreground flex items-center gap-4 text-[15px]">
                     <span>👍 {post.likes}</span>
                     <span>💬 {post.comments_count}</span>
                 </div>

--- a/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
+++ b/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
@@ -17,7 +17,9 @@
                     class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
                 >
                     <div class="flex items-center gap-2">
-                        <div class="text-foreground min-w-0 flex-1 truncate text-sm font-medium">
+                        <div
+                            class="text-foreground min-w-0 flex-1 truncate text-[15px] font-medium"
+                        >
                             {post.title}
                         </div>
                     </div>

--- a/apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte
+++ b/apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte
@@ -25,7 +25,7 @@
     {#each tabs as tab (tab.id)}
         <button
             type="button"
-            class="rounded-md px-2.5 py-1 text-sm font-medium transition-all duration-200 ease-out
+            class="rounded-md px-2.5 py-1 text-[15px] font-medium transition-all duration-200 ease-out
                 {activeTab === tab.id
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"

--- a/apps/web/src/lib/components/features/gallery/components/gallery-card.svelte
+++ b/apps/web/src/lib/components/features/gallery/components/gallery-card.svelte
@@ -43,6 +43,6 @@
 
     <!-- 제목만 -->
     <div class="p-2.5">
-        <p class="text-foreground line-clamp-2 text-sm font-medium">{post.title}</p>
+        <p class="text-foreground line-clamp-2 text-[15px] font-medium">{post.title}</p>
     </div>
 </a>

--- a/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
+++ b/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
@@ -27,7 +27,7 @@
         <a
             href="/gallery"
             rel="external"
-            class="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1 text-sm transition-all duration-200 ease-out"
+            class="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1 text-[15px] transition-all duration-200 ease-out"
         >
             더보기
             <ChevronRight class="h-4 w-4" />

--- a/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
+++ b/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
@@ -19,13 +19,15 @@
                 >
                     <div class="flex items-center gap-2">
                         <span
-                            class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center rounded px-2 py-0.5 text-sm font-bold {getRecommendBadgeClass(
+                            class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center rounded px-2 py-0.5 text-[15px] font-bold {getRecommendBadgeClass(
                                 post.recommend_count
                             )}"
                         >
                             {formatNumber(post.recommend_count)}
                         </span>
-                        <div class="text-foreground min-w-0 flex-1 truncate text-sm font-medium">
+                        <div
+                            class="text-foreground min-w-0 flex-1 truncate text-[15px] font-medium"
+                        >
                             {post.title}
                         </div>
                     </div>

--- a/apps/web/src/lib/components/features/group/components/tabs/group-tabs.svelte
+++ b/apps/web/src/lib/components/features/group/components/tabs/group-tabs.svelte
@@ -25,7 +25,7 @@
     {#each tabs as tab (tab.id)}
         <button
             type="button"
-            class="rounded-md px-2.5 py-1 text-sm font-medium transition-all duration-200 ease-out
+            class="rounded-md px-2.5 py-1 text-[15px] font-medium transition-all duration-200 ease-out
                 {activeTab === tab.id
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"

--- a/apps/web/src/lib/components/features/group/group-tabs.svelte
+++ b/apps/web/src/lib/components/features/group/group-tabs.svelte
@@ -31,7 +31,7 @@
             <a
                 href="/bbs/group.php?gr_id=group"
                 rel="external"
-                class="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-all duration-200 ease-out"
+                class="text-muted-foreground hover:text-foreground flex items-center gap-1 text-[15px] transition-all duration-200 ease-out"
             >
                 더보기
                 <ChevronRight class="h-4 w-4" />

--- a/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
@@ -17,7 +17,9 @@
                     class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
                 >
                     <div class="flex items-center gap-2">
-                        <div class="text-foreground min-w-0 flex-1 truncate text-sm font-medium">
+                        <div
+                            class="text-foreground min-w-0 flex-1 truncate text-[15px] font-medium"
+                        >
                             {post.title}
                         </div>
                     </div>

--- a/apps/web/src/lib/components/features/new-board/components/tabs/news-tabs.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/tabs/news-tabs.svelte
@@ -25,7 +25,7 @@
     {#each tabs as tab (tab.id)}
         <button
             type="button"
-            class="rounded-md px-2.5 py-1 text-sm font-medium transition-all duration-200 ease-out
+            class="rounded-md px-2.5 py-1 text-[15px] font-medium transition-all duration-200 ease-out
                 {activeTab === tab.id
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"

--- a/apps/web/src/lib/components/features/recommended/components/ai-trend/ai-trend-card.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/ai-trend/ai-trend-card.svelte
@@ -48,7 +48,7 @@
             <!-- 통계 (데스크톱에서만) -->
             {#if stats}
                 <div
-                    class="hidden items-center gap-3 text-xs sm:flex"
+                    class="hidden items-center gap-3 text-[13px] sm:flex"
                     role="list"
                     aria-label="트렌드 통계"
                 >

--- a/apps/web/src/lib/components/features/recommended/components/ai-trend/headline-rotator.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/ai-trend/headline-rotator.svelte
@@ -21,7 +21,7 @@
 <div class="relative h-6 overflow-hidden">
     {#each headlines as headline, i (i)}
         <p
-            class="text-foreground absolute inset-0 truncate text-sm font-bold transition-all duration-500 ease-in-out
+            class="text-foreground absolute inset-0 truncate text-[15px] font-bold transition-all duration-500 ease-in-out
                 {i === currentIndex
                 ? 'translate-y-0 opacity-100'
                 : i < currentIndex

--- a/apps/web/src/lib/components/features/recommended/components/ai-trend/keyword-badges.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/ai-trend/keyword-badges.svelte
@@ -10,7 +10,7 @@
 <div class="flex flex-wrap gap-1.5" role="list" aria-label="트렌드 키워드">
     {#each displayKeywords as keyword (keyword.name)}
         <span
-            class="inline-flex items-center rounded-full bg-amber-400 px-2 py-0.5 text-xs font-medium text-slate-900 transition-colors hover:bg-amber-500 dark:bg-amber-500 dark:text-slate-900"
+            class="inline-flex items-center rounded-full bg-amber-400 px-2 py-0.5 text-[13px] font-medium text-slate-900 transition-colors hover:bg-amber-500 dark:bg-amber-500 dark:text-slate-900"
             role="listitem"
         >
             {keyword.name}

--- a/apps/web/src/lib/components/features/recommended/components/tabs/recommended-tabs.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/tabs/recommended-tabs.svelte
@@ -33,7 +33,7 @@
         {#if !tab.hidden}
             <button
                 type="button"
-                class="rounded-md px-2.5 py-1 text-sm font-medium transition-all duration-200 ease-out
+                class="rounded-md px-2.5 py-1 text-[15px] font-medium transition-all duration-200 ease-out
                     {activeTab === tab.id
                     ? 'bg-primary text-primary-foreground'
                     : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"

--- a/apps/web/src/lib/components/features/sidebar-widgets/notice-widget.svelte
+++ b/apps/web/src/lib/components/features/sidebar-widgets/notice-widget.svelte
@@ -14,7 +14,7 @@
     class:ring-2={isEditMode}
     class:ring-blue-500={isEditMode}
 >
-    <h3 class="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-300">
+    <h3 class="mb-3 text-[15px] font-semibold text-slate-700 dark:text-slate-300">
         <svg class="mr-1 inline h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
                 stroke-linecap="round"
@@ -25,7 +25,7 @@
         </svg>
         공지사항
     </h3>
-    <ul class="space-y-2 text-xs text-slate-600 dark:text-slate-400">
+    <ul class="space-y-2 text-[13px] text-slate-600 dark:text-slate-400">
         <li class="truncate">• 서비스 점검 안내</li>
         <li class="truncate">• 새로운 기능 업데이트</li>
         <li class="truncate">• 커뮤니티 가이드라인</li>

--- a/apps/web/src/lib/components/features/sidebar-widgets/sharing-board-widget.svelte
+++ b/apps/web/src/lib/components/features/sidebar-widgets/sharing-board-widget.svelte
@@ -14,7 +14,7 @@
     class:ring-2={isEditMode}
     class:ring-blue-500={isEditMode}
 >
-    <h3 class="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-300">
+    <h3 class="mb-3 text-[15px] font-semibold text-slate-700 dark:text-slate-300">
         <svg class="mr-1 inline h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
                 stroke-linecap="round"
@@ -25,7 +25,7 @@
         </svg>
         나눔 게시판
     </h3>
-    <ul class="space-y-2 text-xs text-slate-600 dark:text-slate-400">
+    <ul class="space-y-2 text-[13px] text-slate-600 dark:text-slate-400">
         <li class="hover:text-primary cursor-pointer truncate">• [진행중] 연말 특별 나눔 이벤트</li>
         <li class="hover:text-primary cursor-pointer truncate">• [마감] 기프티콘 나눔</li>
         <li class="hover:text-primary cursor-pointer truncate">• [진행중] 책 나눔합니다</li>

--- a/apps/web/src/lib/components/ui/post-card/post-card.svelte
+++ b/apps/web/src/lib/components/ui/post-card/post-card.svelte
@@ -24,7 +24,7 @@
                 {formatNumber(post.recommend_count)}
             </span>
             <!-- text-truncate -->
-            <div class="text-foreground min-w-0 flex-1 truncate text-[15px] font-medium">
+            <div class="text-foreground min-w-0 flex-1 truncate text-[17px] font-medium">
                 {post.title}
             </div>
         </div>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -557,7 +557,7 @@
                 {#if data.post.category}
                     <div class="mb-3 flex flex-wrap gap-1.5">
                         <span
-                            class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-xs font-medium"
+                            class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
                         >
                             {data.post.category}
                         </span>
@@ -617,14 +617,14 @@
                                 >
                             {/if}
                         </p>
-                        <p class="text-secondary-foreground text-sm">
+                        <p class="text-secondary-foreground text-[15px]">
                             {formatDate(data.post.created_at)}
                         </p>
                     </div>
                 </div>
 
                 <div
-                    class="text-secondary-foreground ml-auto flex gap-2 text-xs sm:gap-4 sm:text-sm"
+                    class="text-secondary-foreground ml-auto flex gap-2 text-[13px] sm:gap-4 sm:text-[15px]"
                 >
                     <span>조회 {data.post.views.toLocaleString()}</span>
                     <span>추천 {likeCount.toLocaleString()}</span>
@@ -752,7 +752,7 @@
 
     <!-- 수정/삭제 시간 표시 -->
     {#if data.post.updated_at && data.post.updated_at !== data.post.created_at}
-        <p class="text-muted-foreground mt-4 text-center text-sm">
+        <p class="text-muted-foreground mt-4 text-center text-[15px]">
             마지막 수정: {formatDate(data.post.updated_at)}
         </p>
     {/if}
@@ -775,7 +775,7 @@
     <!-- 중고게시판 상태 변경 (작성자/관리자만) -->
     {#if isUsedMarket && (isAuthor || isAdmin)}
         <div class="mb-6 flex items-center gap-3 rounded-lg border p-4">
-            <span class="text-sm font-medium">판매 상태:</span>
+            <span class="text-[15px] font-medium">판매 상태:</span>
             <div class="flex gap-2">
                 {#each ['selling', 'reserved', 'sold'] as const as status (status)}
                     <Button


### PR DESCRIPTION
## Summary
- text-xs → text-[13px], text-sm → text-[15px] 전체 적용
- 게시판 목록/상세, 댓글, 갤러리, 사이드바 위젯 등 24개 파일
- 브라우저/디바이스 간 글꼴 크기 일관성 확보

## Test plan
- [ ] 게시판 목록 글꼴 크기 확인
- [ ] 게시글 상세 페이지 글꼴 크기 확인
- [ ] 모바일 뷰 글꼴 크기 확인