### PR TITLE
fix: 사이드바 직접홍보 완전 제거, GAM 폴백 적용

### DIFF
--- a/apps/web/src/lib/components/features/sidebar-widgets/sidebar-ad-widget.svelte
+++ b/apps/web/src/lib/components/features/sidebar-widgets/sidebar-ad-widget.svelte
@@ -4,7 +4,6 @@
      * type: 'damoang' (DamoangBanner, 기본값), 'image' (ImageBanner), 'image-text' (ImageTextBanner), 'gam' (AdSlot - GAM 광고)
      */
     import DamoangBanner from '$lib/components/ui/damoang-banner/damoang-banner.svelte';
-    import ImageBanner from '$lib/components/ui/image-banner/image-banner.svelte';
     import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
 
@@ -21,11 +20,6 @@
 
     const adType = $derived(settings.type ?? 'damoang');
     const adPosition = $derived(settings.position ?? 'sidebar');
-
-    // AdSense 설정
-    const ADSENSE_SLOTS = {
-        square: '7466402991'
-    };
 </script>
 
 <div class:ring-2={isEditMode} class:ring-blue-500={isEditMode} class:rounded-lg={isEditMode}>
@@ -37,14 +31,7 @@
     {:else if adType === 'damoang'}
         <DamoangBanner position="sidebar" height="250px" showCelebration={false} />
     {:else if adType === 'image'}
-        <ImageBanner
-            position="sidebar"
-            width="280px"
-            height="140px"
-            fallbackToAdsense={true}
-            adsenseSlot={ADSENSE_SLOTS.square}
-            adsenseFormat="rectangle"
-        />
+        <AdSlot position={adPosition} height="250px" />
     {:else}
         <ImageTextBanner position="side-image-text-banner" />
     {/if}

--- a/apps/web/src/lib/components/ui/image-banner/image-banner.svelte
+++ b/apps/web/src/lib/components/ui/image-banner/image-banner.svelte
@@ -22,18 +22,6 @@
         adsenseFormat = 'auto'
     }: Props = $props();
 
-    // 직접홍보 게시글 타입
-    interface PromotionPost {
-        wrId: number;
-        subject: string;
-        imageUrl: string;
-        linkUrl: string;
-        advertiserName: string;
-        memberId: string;
-        pinToTop: boolean;
-        createdAt: string;
-    }
-
     // 내부에서 사용할 정규화된 배너 타입
     interface NormalizedBanner {
         id: number | string;
@@ -75,29 +63,7 @@
                 // ads 배너 실패 시 다음 단계로
             }
 
-            // 2단계: 직접홍보 게시물
-            const response = await fetch('/api/ads/promotion-posts');
-            const result = await response.json();
-
-            const posts: PromotionPost[] = result.data?.posts || [];
-            const withImage = posts.filter((p) => p.imageUrl);
-
-            if (withImage.length > 0) {
-                const pinned = withImage.filter((p) => p.pinToTop);
-                const pool = pinned.length > 0 ? pinned : withImage;
-                const selected = pool[Math.floor(Math.random() * pool.length)];
-
-                banner = {
-                    id: selected.wrId,
-                    imageUrl: selected.imageUrl,
-                    linkUrl: selected.linkUrl,
-                    altText: selected.subject,
-                    target: '_blank'
-                };
-                return;
-            }
-
-            // 3단계: AdSense 폴백
+            // 2단계: AdSense 폴백
             if (fallbackToAdsense && adsenseSlot) {
                 showAdsense = true;
                 loadAdsense();
@@ -168,7 +134,7 @@
             </svg>
         </div>
     {:else if banner}
-        <!-- 직접홍보 배너 -->
+        <!-- ads 배너 -->
         <a
             href={banner.linkUrl}
             target={banner.target || '_blank'}

--- a/apps/web/src/lib/utils/widget-component-loader.ts
+++ b/apps/web/src/lib/utils/widget-component-loader.ts
@@ -46,6 +46,10 @@ function scanWidgets(): Map<string, ScannedWidget> {
         const id = extractWidgetId(path);
         const manifest =
             (module as { default?: WidgetManifest }).default ?? (module as WidgetManifest);
+
+        // enabled: false인 위젯은 건너뛰기
+        if ((manifest as WidgetManifest & { enabled?: boolean }).enabled === false) continue;
+
         const componentPath = path.replace('widget.json', 'index.svelte');
 
         if (builtinComponents[componentPath]) {
@@ -62,6 +66,10 @@ function scanWidgets(): Map<string, ScannedWidget> {
         const id = extractWidgetId(path);
         const manifest =
             (module as { default?: WidgetManifest }).default ?? (module as WidgetManifest);
+
+        // enabled: false인 위젯은 건너뛰기
+        if ((manifest as WidgetManifest & { enabled?: boolean }).enabled === false) continue;
+
         const componentPath = path.replace('widget.json', 'index.svelte');
 
         if (customComponents[componentPath]) {

--- a/widgets/ad/index.svelte
+++ b/widgets/ad/index.svelte
@@ -5,7 +5,6 @@
      * 메인 영역과 사이드바 모두 지원합니다.
      * slot과 settings에 따라 적절한 광고 형태를 렌더링합니다.
      */
-    import { onMount } from 'svelte';
     import type { WidgetProps } from '$lib/types/widget-props';
     import { AdSlot } from '$lib/components/ui/ad-slot';
     import { DamoangBanner } from '$lib/components/ui/damoang-banner/index';
@@ -32,39 +31,6 @@
         'board-head': 'board-list'
     };
     const bannerPosition = $derived(WIDGET_TO_BANNER[position] || 'board-list');
-
-    // 사이드바 이미지 배너 상태
-    interface SidebarBanner {
-        imageUrl: string;
-        landingUrl: string;
-        altText: string;
-        target: string;
-    }
-    let sidebarBanner = $state<SidebarBanner | null>(null);
-    let sidebarLoading = $state(true);
-
-    onMount(async () => {
-        if (!isSidebar || adType !== 'image') {
-            sidebarLoading = false;
-            return;
-        }
-        try {
-            const res = await fetch('/api/ads/banners?position=sidebar&limit=1');
-            const result = await res.json();
-            if (result.success && result.data?.banners?.length > 0) {
-                const b = result.data.banners[0];
-                sidebarBanner = {
-                    imageUrl: b.imageUrl,
-                    landingUrl: b.landingUrl,
-                    altText: b.altText || '',
-                    target: b.target || '_blank'
-                };
-            }
-        } catch {
-            /* 배너 로드 실패 시 GAM으로 폴백 */
-        }
-        sidebarLoading = false;
-    });
 </script>
 
 {#if isSidebar}
@@ -74,29 +40,12 @@
             <span class="text-xs font-medium text-slate-500">AD</span>
         </div>
         {#if adType === 'image'}
-            {#if sidebarLoading}
-                <div
-                    class="animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800"
-                    style="width: 280px; height: 140px;"
-                ></div>
-            {:else if sidebarBanner}
-                <a
-                    href={sidebarBanner.landingUrl}
-                    target={sidebarBanner.target}
-                    rel="nofollow noopener"
-                    class="border-border block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
-                    style="width: 280px; height: 140px;"
-                >
-                    <img
-                        src={sidebarBanner.imageUrl}
-                        alt={sidebarBanner.altText || '광고'}
-                        style="width: 100%; height: 100%; object-fit: cover;"
-                        loading="eager"
-                    />
-                </a>
-            {:else}
-                <AdSlot position="sidebar" height="250px" />
-            {/if}
+            <DamoangBanner
+                position="sidebar"
+                showCelebration={false}
+                height="250px"
+                gamPosition={position}
+            />
         {:else if adType === 'image-text'}
             <ImageTextBanner position="side-image-text-banner" />
         {:else}

--- a/widgets/promotion-list/widget.json
+++ b/widgets/promotion-list/widget.json
@@ -8,5 +8,6 @@
     "slots": ["sidebar"],
     "icon": "Megaphone",
     "allowMultiple": false,
-    "main": "index.svelte"
+    "main": "index.svelte",
+    "enabled": false
 }


### PR DESCRIPTION
## Summary
- 사이드바 광고에서 직접홍보 게시글 fetch 로직 완전 제거
- `widgets/ad`의 sidebar+image 케이스를 `DamoangBanner`로 교체하여 ads API → GAM 폴백 체인 적용
- `promotion-list` 위젯을 `enabled:false`로 비활성화하고, widget-component-loader에서 필터링 추가

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `widgets/ad/index.svelte` | sidebar+image → DamoangBanner (핵심 변경) |
| `image-banner.svelte` | 직접홍보 fetch 로직 제거 (PromotionPost 인터페이스 삭제) |
| `sidebar-ad-widget.svelte` | image 타입에 AdSlot(GAM) 폴백, 미사용 import/변수 제거 |
| `widget-component-loader.ts` | enabled:false 위젯 스캔 시 건너뛰기 |
| `widgets/promotion-list/widget.json` | enabled:false 추가 |

## 동작 방식
```
sidebar 광고 로딩 순서:
1. ads.damoang.net API에서 sidebar 배너 조회
2. 배너 없으면 → GAM 광고 폴백
3. (직접홍보 단계 완전 제거)
```

## Test plan
- [ ] dev.damoang.net 하드 리프레시 후 직접홍보 사라짐 확인
- [ ] Network 탭: `/api/ads/promotion-posts` 호출 없음 확인
- [ ] 사이드바에 GAM 광고 또는 ads 배너 정상 표시
- [ ] 프로덕션 배포 후 web.damoang.net 동일 검증