### PR TITLE
fix: 테마 FOUC 제거 — 조기 로딩 및 레이아웃 시프트 방지

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -240,7 +240,7 @@
     <!-- 테마 레이아웃 전환 시 fade-in으로 레이아웃 시프트 완화 -->
     {#key data.activeTheme}
         {#if typeof ThemeLayout === 'function'}
-            <div class="contents theme-layout-enter">
+            <div class="theme-layout-enter contents">
                 <ThemeLayout>
                     {@render children()}
                 </ThemeLayout>
@@ -252,7 +252,7 @@
 {:else if data.activeTheme}
     <!-- 테마 레이아웃 로드 대기 중 -->
     <!-- visibility:hidden으로 content 100% 너비 flash 방지 (SSR 콘텐츠는 DOM에 유지) -->
-    <div class="invisible pointer-events-none min-h-screen">
+    <div class="pointer-events-none invisible min-h-screen">
         {@render children()}
     </div>
 {:else}


### PR DESCRIPTION
## 문제

새로고침 시 3단계 깜빡임 발생:
1. "테마를 선택해주세요 🎨" 화면 순간 출력
2. 콘텐츠가 사이드바 없이 100% 너비로 표시
3. 실제 테마 레이아웃 렌더

**근본 원인**: SSR에서 `$effect`가 실행되지 않아 `activeTheme`(store 파생값)이 null → 잘못된 분기 진입

## 변경 사항

### `+layout.svelte`

- `browser` import 추가, 스크립트 본문에서 즉시 theme layout async import 시작 (조기 로딩)
- 테마 로딩 effect가 `activeTheme`(store) 대신 `data.activeTheme`(props)를 직접 감시 → 렌더 사이클 1회 절감
- 로딩 대기 중 분기 조건을 `data.activeTheme`으로 변경 → SSR에서 올바른 분기 진입
- 로딩 대기 div에 `visibility:hidden` 적용 → 100% 너비 콘텐츠 flash 방지
- ThemeLayout 진입 시 `theme-layout-enter` fade-in 적용

## 결과

```
전: "테마 선택" → 100% 너비 콘텐츠 → 레이아웃 점프 (3단계)
후: 흰 화면 (invisible) → fade-in → 완성된 레이아웃 (1단계)
```