### PR TITLE
feat: dev.damoang.net HMR 즉시 반영 전환

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -32,6 +32,13 @@ export default defineConfig(({ mode }) => {
         server: {
             port,
             allowedHosts,
+            hmr: env.VITE_HMR_HOST
+                ? {
+                      host: env.VITE_HMR_HOST,
+                      protocol: env.VITE_HMR_PROTOCOL || 'wss',
+                      clientPort: parseInt(env.VITE_HMR_CLIENT_PORT || '443')
+                  }
+                : true,
             fs: {
                 allow: ['.', '../..', '../../..']
             },


### PR DESCRIPTION
## Summary
- dev.damoang.net에서 코드 수정 시 즉시 브라우저 반영 (HMR) 활성화
- Vite HMR WebSocket이 `wss://dev.damoang.net:443`을 통해 nginx 리버스 프록시로 연결되도록 조건부 설정 추가
- `VITE_HMR_HOST` 환경변수 없으면 기본 동작 유지 (로컬 개발 영향 없음)

## 변경 내용
- `apps/web/vite.config.ts`: HMR 리버스 프록시 설정 (`VITE_HMR_HOST`, `VITE_HMR_PROTOCOL`, `VITE_HMR_CLIENT_PORT` 환경변수 기반)

## 이미 적용된 설정 (이전 커밋)
- `.env.dev`: HMR 환경변수 + `NODE_ENV=development`
- `scripts/dev-server.sh`: `pnpm dev` 모드 전환 + `build` 폴백
- nginx: 포트 3011 + WebSocket 프록시 + 300s 타임아웃

## 효과
- 기존: 코드 수정 → `pnpm build` (~39초) → 서버 재시작 → 확인
- 변경: 코드 수정 → 저장 → 브라우저 자동 반영 (~1초)

## Test plan
- [ ] `curl http://localhost:3011/` → HTTP 200
- [ ] `https://dev.damoang.net` → 정상 렌더링
- [ ] DevTools WS 탭 → `wss://dev.damoang.net/__vite_ws` 연결 확인
- [ ] `.svelte` 파일 수정 → 브라우저 자동 반영 (콘솔: `[vite] hot updated:`)
- [ ] 롤백: `./scripts/dev-server.sh build`로 프로덕션 빌드 모드 전환