### PR TITLE
fix: 쿠키 도메인 불일치로 인한 로그인 꼬임 방지

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -31,6 +31,11 @@ INTERNAL_API_URL=http://localhost:8081/api/v2
 # API 프록시 타겟 (Vite dev server)
 VITE_API_PROXY_TARGET=http://localhost:8081
 
+# 쿠키 도메인 (서브도메인 간 인증 공유, 예: ".example.com")
+# Go 백엔드의 cookieDomain()과 일치시켜야 합니다
+# 로컬 개발 시 비워두면 현재 호스트만 사용
+COOKIE_DOMAIN=
+
 # --------------------------------------------
 # 레거시 연동
 # --------------------------------------------

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -16,6 +16,13 @@ import { mapGnuboardUrl, mapRhymixUrl } from '$lib/server/url-compat.js';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8090';
 
+// 쿠키 도메인: 서브도메인 간 공유 (예: ".damoang.net")
+// Go 백엔드의 cookieDomain()과 일치시켜야 쿠키 충돌 방지
+// nginx가 /api/v2/를 Go 백엔드로 직접 라우팅하므로,
+// Go가 설정한 쿠키(.damoang.net)와 SSR이 재설정하는 쿠키의 domain이 달라지면
+// 브라우저에 refresh_token 쿠키가 2개 생겨 인증이 꼬임
+const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || '';
+
 // CSP에 추가할 사이트별 도메인 (런타임 환경변수)
 const ADS_URL = process.env.ADS_URL || '';
 const LEGACY_URL = process.env.LEGACY_URL || '';
@@ -71,7 +78,8 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                                 httpOnly: true,
                                 sameSite: 'lax',
                                 secure: !dev,
-                                maxAge: 60 * 60 * 24 * 7
+                                maxAge: 60 * 60 * 24 * 7,
+                                ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {})
                             });
                         }
                     }

--- a/apps/web/src/routes/api/auth/logout/+server.ts
+++ b/apps/web/src/routes/api/auth/logout/+server.ts
@@ -4,6 +4,9 @@ import type { RequestHandler } from './$types';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8090';
 
+// 쿠키 도메인: Go 백엔드 cookieDomain()과 일치 (쿠키 충돌 방지)
+const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || '';
+
 /**
  * POST /api/auth/logout
  * 로그아웃 처리: Go 백엔드 로그아웃 + 모든 인증 쿠키 삭제
@@ -25,10 +28,12 @@ export const POST: RequestHandler = async ({ cookies, fetch }) => {
     }
 
     // 2. 모든 인증 쿠키 삭제
+    const domainOpt = COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {};
     const cookieOpts = {
         path: '/',
         secure: !dev,
-        httpOnly: true
+        httpOnly: true,
+        ...domainOpt
     } as const;
 
     cookies.delete('refresh_token', cookieOpts);

--- a/apps/web/src/routes/api/v2/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v2/[...path]/+server.ts
@@ -11,6 +11,9 @@ import { dev } from '$app/environment';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8090';
 
+// 쿠키 도메인: Go 백엔드 cookieDomain()과 일치 (쿠키 충돌 방지)
+const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || '';
+
 // 공통 프록시 로직
 async function proxyRequest(
     method: string,
@@ -82,7 +85,8 @@ async function proxyRequest(
                 httpOnly: isRefresh,
                 sameSite: 'lax',
                 secure: !dev,
-                maxAge: value ? 60 * 60 * 24 * 7 : 0
+                maxAge: value ? 60 * 60 * 24 * 7 : 0,
+                ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {})
             });
         }
 


### PR DESCRIPTION
## Summary
- nginx가 `/api/v2/`를 Go 백엔드로 직접 라우팅하여 Go가 `Domain=.damoang.net`으로 설정한 `refresh_token` 쿠키와 SvelteKit SSR이 domain 없이 재설정한 쿠키가 충돌하는 문제 수정
- `COOKIE_DOMAIN` 환경변수 도입으로 Go 백엔드의 `cookieDomain()`과 일치시킴
- hooks.server.ts, v2 프록시, 로그아웃 핸들러 3곳에 동일 도메인 적용

## Test plan
- [ ] dev.damoang.net 로그인 후 DevTools > Cookies에서 `refresh_token` Domain이 `.damoang.net`인지 확인
- [ ] damoang.net ↔ web.damoang.net 간 로그인 상태 유지 확인
- [ ] 로그아웃 시 쿠키 정상 삭제 확인