### PR TITLE
fix: 로그인 페이지 소셜 우선 표시 및 추천 배지 색상 통일

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -22,23 +22,21 @@
     // 회원 아이콘 URL
     const iconUrl = $derived(getMemberIconUrl(post.author_id));
 
-    // 추천 색상 단계 (PHP get_color_step_f20240616 재현)
-    const likesStep = $derived.by(() => {
+    // 추천 색상 단계 (게시판용 임계값: 0, ≤5, ≤10, ≤50, >50)
+    const likesStepClass = $derived.by(() => {
         const likes = post.likes;
-        if (likes === 0) return 'step0';
-        if (likes <= 5) return 'step1';
-        if (likes <= 10) return 'step2';
-        if (likes <= 50) return 'step3';
-        return 'step4';
+        if (likes === 0) {
+            return 'bg-[rgba(172,172,172,0.08)] text-foreground/20';
+        } else if (likes <= 5) {
+            return 'bg-[rgba(172,172,172,0.2)] text-foreground';
+        } else if (likes <= 10) {
+            return 'bg-[rgba(59,130,246,0.3)] text-foreground';
+        } else if (likes <= 50) {
+            return 'bg-[rgba(59,130,246,0.6)] text-foreground';
+        } else {
+            return 'bg-[rgba(0,102,255,0.75)] text-white';
+        }
     });
-
-    const stepClasses: Record<string, string> = {
-        step0: 'bg-muted text-muted-foreground',
-        step1: 'bg-accent text-accent-foreground',
-        step2: 'bg-secondary text-secondary-foreground',
-        step3: 'bg-liked/10 text-liked',
-        step4: 'bg-destructive/10 text-destructive'
-    };
 
     // 삭제된 글
     const isDeleted = $derived(!!post.deleted_at);
@@ -91,9 +89,7 @@
                     </div>
                 {:else}
                     <div
-                        class="flex h-7 w-10 items-center justify-center rounded-md text-sm font-semibold {stepClasses[
-                            likesStep
-                        ]}"
+                        class="flex h-7 w-10 items-center justify-center rounded-md text-sm font-semibold {likesStepClass}"
                     >
                         {post.likes.toLocaleString()}
                     </div>
@@ -188,9 +184,7 @@
                             <span>·</span>
                             <span class="inline-flex items-center gap-0.5">
                                 <span
-                                    class="inline-flex h-4 items-center rounded px-1 text-[10px] font-semibold {stepClasses[
-                                        likesStep
-                                    ]}"
+                                    class="inline-flex h-4 items-center rounded px-1 text-[10px] font-semibold {likesStepClass}"
                                 >
                                     👍 {post.likes}
                                 </span>

--- a/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
+++ b/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
@@ -20,7 +20,7 @@
                 >
                     <div class="flex items-center gap-2">
                         <span
-                            class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center rounded px-2 py-0.5 text-[15px] font-bold {getRecommendBadgeClass(
+                            class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center rounded-full px-2 py-0.5 text-xs font-bold {getRecommendBadgeClass(
                                 post.recommend_count
                             )}"
                         >

--- a/apps/web/src/lib/components/features/recommended/utils/recommend-badge.test.ts
+++ b/apps/web/src/lib/components/features/recommended/utils/recommend-badge.test.ts
@@ -2,27 +2,30 @@ import { describe, it, expect } from 'vitest';
 import { getRecommendBadgeClass } from './recommend-badge';
 
 describe('getRecommendBadgeClass', () => {
-    it('15 이하 → 파란색', () => {
-        expect(getRecommendBadgeClass(0)).toContain('blue');
-        expect(getRecommendBadgeClass(15)).toContain('blue');
+    it('0건 → 매우 연한 배경 + 연한 글자', () => {
+        const cls = getRecommendBadgeClass(0);
+        expect(cls).toContain('0.08');
+        expect(cls).toContain('text-foreground/20');
     });
 
-    it('16~25 → 보라색', () => {
-        expect(getRecommendBadgeClass(16)).toContain('purple');
-        expect(getRecommendBadgeClass(25)).toContain('purple');
+    it('1~15 → 회색 계열', () => {
+        expect(getRecommendBadgeClass(1)).toContain('172,172,172');
+        expect(getRecommendBadgeClass(15)).toContain('0.2');
     });
 
-    it('26~50 → 핑크색', () => {
-        expect(getRecommendBadgeClass(26)).toContain('pink');
-        expect(getRecommendBadgeClass(50)).toContain('pink');
+    it('16~25 → 연한 파란색', () => {
+        expect(getRecommendBadgeClass(16)).toContain('59,130,246');
+        expect(getRecommendBadgeClass(25)).toContain('0.3');
     });
 
-    it('51 이상 → 빨간색', () => {
-        expect(getRecommendBadgeClass(51)).toContain('red');
-        expect(getRecommendBadgeClass(100)).toContain('red');
+    it('26~50 → 중간 파란색', () => {
+        expect(getRecommendBadgeClass(26)).toContain('59,130,246');
+        expect(getRecommendBadgeClass(50)).toContain('0.6');
     });
 
-    it('다크모드 클래스 포함', () => {
-        expect(getRecommendBadgeClass(10)).toContain('dark:');
+    it('51 이상 → 진한 파란색 + 흰 글자', () => {
+        expect(getRecommendBadgeClass(51)).toContain('0,102,255');
+        expect(getRecommendBadgeClass(51)).toContain('text-white');
+        expect(getRecommendBadgeClass(100)).toContain('text-white');
     });
 });

--- a/apps/web/src/lib/components/features/recommended/utils/recommend-badge.ts
+++ b/apps/web/src/lib/components/features/recommended/utils/recommend-badge.ts
@@ -1,20 +1,23 @@
 /**
- * 추천수 기반 배지 컬러 클래스 반환 (PHP rcmd-box step1-4 Tailwind 변환)
+ * 추천수 기반 배지 컬러 클래스 반환 (현세대 rcmd-box step0-4 일치)
  * @param recommendCount 추천수
  * @returns Tailwind CSS 클래스 문자열
  */
 export function getRecommendBadgeClass(recommendCount: number): string {
-    if (recommendCount <= 15) {
-        // step1: 파란색
-        return 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200';
+    if (recommendCount === 0) {
+        // step0: 추천 0건 - 매우 연한 배경
+        return 'bg-[rgba(172,172,172,0.08)] text-foreground/20';
+    } else if (recommendCount <= 15) {
+        // step1: 회색 계열
+        return 'bg-[rgba(172,172,172,0.2)] text-foreground';
     } else if (recommendCount <= 25) {
-        // step2: 보라색
-        return 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-200';
+        // step2: 연한 파란색
+        return 'bg-[rgba(59,130,246,0.3)] text-foreground';
     } else if (recommendCount <= 50) {
-        // step3: 핑크색
-        return 'bg-pink-100 text-pink-700 dark:bg-pink-900 dark:text-pink-200';
+        // step3: 중간 파란색
+        return 'bg-[rgba(59,130,246,0.6)] text-foreground';
     } else {
-        // step4: 빨간색
-        return 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200';
+        // step4: 진한 파란색 + 흰 글자
+        return 'bg-[rgba(0,102,255,0.75)] text-white';
     }
 }

--- a/apps/web/src/lib/components/ui/post-card/post-card.svelte
+++ b/apps/web/src/lib/components/ui/post-card/post-card.svelte
@@ -18,7 +18,7 @@
         <div class="flex items-center gap-2">
             <!-- rcmd-box + rcmd-sm 스타일 -->
             <span
-                class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center rounded px-2 py-0.5 text-sm font-bold {getRecommendBadgeClass(
+                class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center rounded-full px-2 py-0.5 text-xs font-bold {getRecommendBadgeClass(
                     post.recommend_count
                 )}"
             >

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -14,14 +14,13 @@
     import { Label } from '$lib/components/ui/label/index.js';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import { Separator } from '$lib/components/ui/separator/index.js';
-    import { authStore, authActions } from '$lib/stores/auth.svelte.js';
+    import { authStore } from '$lib/stores/auth.svelte.js';
     import { apiClient } from '$lib/api/index.js';
     import type { OAuthProvider } from '$lib/api/types.js';
     import Loader2 from '@lucide/svelte/icons/loader-2';
     import LogIn from '@lucide/svelte/icons/log-in';
     import Mail from '@lucide/svelte/icons/mail';
     import Lock from '@lucide/svelte/icons/lock';
-    import ExternalLink from '@lucide/svelte/icons/external-link';
 
     // 성공 메시지 매핑
     const successMessages: Record<string, string> = {
@@ -47,22 +46,22 @@
     let isLoading = $state(false);
     let error = $state<string | null>(null);
     let isRedirecting = $state(false);
+    let successMessage = $state<string | null>(null);
+
+    // URL 파라미터로 ID/PW 폼 표시 여부 결정
+    const showIdLogin = $derived($page.url.searchParams.get('type') === 'id');
 
     // 리다이렉트 URL
     const redirectUrl = $derived($page.url.searchParams.get('redirect') || '/');
 
-    // web.damoang.net 도메인 체크
-    const isWebDamoang = $derived(
-        browser &&
-            (window.location.hostname === 'web.damoang.net' ||
-                window.location.hostname === 'localhost')
-    );
+    // "아이디로 로그인" 링크 URL 생성
+    const idLoginUrl = $derived(() => {
+        const params = new URLSearchParams($page.url.searchParams);
+        params.set('type', 'id');
+        return `/login?${params.toString()}`;
+    });
 
     // 이미 로그인되어 있으면 리다이렉트
-    // onMount에서 폴링하여 컴포넌트 트리가 완전히 마운트된 후에만 리다이렉트
-    // 성공 메시지 상태
-    let successMessage = $state<string | null>(null);
-
     onMount(() => {
         // OAuth 에러 메시지 표시
         const oauthError = $page.url.searchParams.get('error');
@@ -76,17 +75,6 @@
             successMessage = successMessages[message] || null;
         }
 
-        // OAuth 로그인 성공 시 access_token 쿠키 처리
-        const atCookie = document.cookie.split('; ').find((r) => r.startsWith('access_token='));
-        if (atCookie) {
-            const token = atCookie.split('=')[1];
-            if (token) {
-                apiClient.setAccessToken(token);
-                // 쿠키 삭제 (메모리로 이동 완료)
-                document.cookie = 'access_token=; path=/; max-age=0';
-            }
-        }
-
         function checkAndRedirect() {
             if (isRedirecting) return;
             if (!authStore.isLoading && authStore.isAuthenticated) {
@@ -94,7 +82,6 @@
                 window.location.href = redirectUrl;
                 return;
             }
-            // auth 로딩 중이면 100ms 후 재확인
             if (authStore.isLoading) {
                 setTimeout(checkAndRedirect, 100);
             }
@@ -121,7 +108,7 @@
                 remember
             });
 
-            // 풀 페이지 리로드로 리다이렉트 (Svelte 내부 라우팅 race condition 방지)
+            // 풀 페이지 리로드로 리다이렉트 (세션 쿠키 반영)
             window.location.href = redirectUrl;
         } catch (err) {
             console.error('Login failed:', err);
@@ -138,12 +125,6 @@
             redirect: redirectUrl
         });
         window.location.href = `/plugin/social/start?${params.toString()}`;
-    }
-
-    // JWT 로그인 (기존 damoang.net 로그인 활용 - 마이그레이션 완료 전까지)
-    function handleJwtLogin(): void {
-        const currentUrl = browser ? window.location.href : 'https://web.damoang.net';
-        window.location.href = `https://damoang.net/bbs/login.php?url=${encodeURIComponent(currentUrl)}`;
     }
 
     // OAuth 프로바이더 설정
@@ -236,118 +217,100 @@
                 </div>
             {/if}
 
-            <!-- OAuth 에러 메시지 -->
-            {#if error && !import.meta.env.DEV}
+            <!-- 에러 메시지 -->
+            {#if error}
                 <div class="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
                     {error}
                 </div>
             {/if}
 
-            <!-- OAuth 로그인 버튼들 (web.damoang.net이 아닐 때만 표시) -->
-            {#if !isWebDamoang}
-                <div class="space-y-3">
-                    {#each oauthProviders as provider}
-                        <button
-                            class="flex w-full items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-colors {provider.bgClass} {provider.textClass} {provider.hoverClass}"
-                            onclick={() => handleOAuthLogin(provider.id)}
-                        >
-                            {#if provider.icon === 'google'}
-                                <svg class="h-5 w-5" viewBox="0 0 24 24">
-                                    <path
-                                        fill="#4285F4"
-                                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                                    />
-                                    <path
-                                        fill="#34A853"
-                                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                                    />
-                                    <path
-                                        fill="#FBBC05"
-                                        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                                    />
-                                    <path
-                                        fill="#EA4335"
-                                        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                                    />
-                                </svg>
-                            {:else if provider.icon === 'kakao'}
-                                <svg class="h-5 w-5" viewBox="0 0 24 24">
-                                    <path
-                                        fill="#191919"
-                                        d="M12 3c-5.065 0-9.167 3.355-9.167 7.5 0 2.625 1.757 4.937 4.403 6.278-.193.705-.7 2.555-.804 2.953-.127.497.182.49.385.357.159-.104 2.534-1.72 3.565-2.42.514.073 1.047.112 1.618.112 5.065 0 9.167-3.355 9.167-7.5S17.065 3 12 3"
-                                    />
-                                </svg>
-                            {:else if provider.icon === 'naver'}
-                                <svg class="h-5 w-5" viewBox="0 0 24 24">
-                                    <path
-                                        fill="white"
-                                        d="M16.273 12.845 7.376 0H0v24h7.727V11.155L16.624 24H24V0h-7.727z"
-                                    />
-                                </svg>
-                            {:else if provider.icon === 'apple'}
-                                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
-                                    <path
-                                        d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"
-                                    />
-                                </svg>
-                            {:else if provider.icon === 'facebook'}
-                                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
-                                    <path
-                                        d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"
-                                    />
-                                </svg>
-                            {:else if provider.icon === 'twitter'}
-                                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
-                                    <path
-                                        d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
-                                    />
-                                </svg>
-                            {:else if provider.icon === 'payco'}
-                                <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
-                                    <text
-                                        x="2"
-                                        y="18"
-                                        font-size="14"
-                                        font-weight="bold"
-                                        font-family="Arial">P</text
-                                    >
-                                </svg>
-                            {/if}
-                            {provider.name}으로 로그인
-                        </button>
-                    {/each}
-                </div>
-            {/if}
-
-            <!-- JWT 직접 로그인 버튼 -->
-            <div>
-                {#if !isWebDamoang}
-                    <Separator class="mb-4" />
-                {/if}
-                <Button variant="outline" class="w-full" onclick={handleJwtLogin}>
-                    <ExternalLink class="mr-2 h-4 w-4" />
-                    로그인
-                </Button>
+            <!-- 소셜 로그인 -->
+            <div class="space-y-2">
+                {#each oauthProviders as provider}
+                    <button
+                        class="flex w-full items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-colors {provider.bgClass} {provider.textClass} {provider.hoverClass}"
+                        onclick={() => handleOAuthLogin(provider.id)}
+                    >
+                        {#if provider.icon === 'google'}
+                            <svg class="h-5 w-5" viewBox="0 0 24 24">
+                                <path
+                                    fill="#4285F4"
+                                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                                />
+                                <path
+                                    fill="#34A853"
+                                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                                />
+                                <path
+                                    fill="#FBBC05"
+                                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                                />
+                                <path
+                                    fill="#EA4335"
+                                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                                />
+                            </svg>
+                        {:else if provider.icon === 'kakao'}
+                            <svg class="h-5 w-5" viewBox="0 0 24 24">
+                                <path
+                                    fill="#191919"
+                                    d="M12 3c-5.065 0-9.167 3.355-9.167 7.5 0 2.625 1.757 4.937 4.403 6.278-.193.705-.7 2.555-.804 2.953-.127.497.182.49.385.357.159-.104 2.534-1.72 3.565-2.42.514.073 1.047.112 1.618.112 5.065 0 9.167-3.355 9.167-7.5S17.065 3 12 3"
+                                />
+                            </svg>
+                        {:else if provider.icon === 'naver'}
+                            <svg class="h-5 w-5" viewBox="0 0 24 24">
+                                <path
+                                    fill="white"
+                                    d="M16.273 12.845 7.376 0H0v24h7.727V11.155L16.624 24H24V0h-7.727z"
+                                />
+                            </svg>
+                        {:else if provider.icon === 'apple'}
+                            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
+                                <path
+                                    d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"
+                                />
+                            </svg>
+                        {:else if provider.icon === 'facebook'}
+                            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
+                                <path
+                                    d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"
+                                />
+                            </svg>
+                        {:else if provider.icon === 'twitter'}
+                            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
+                                <path
+                                    d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+                                />
+                            </svg>
+                        {:else if provider.icon === 'payco'}
+                            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="white">
+                                <text
+                                    x="2"
+                                    y="18"
+                                    font-size="14"
+                                    font-weight="bold"
+                                    font-family="Arial">P</text
+                                >
+                            </svg>
+                        {/if}
+                        {provider.name}으로 로그인
+                    </button>
+                {/each}
             </div>
 
-            {#if import.meta.env.DEV}
+            <!-- 아이디로 로그인 링크 또는 폼 -->
+            {#if showIdLogin}
                 <div class="relative">
                     <div class="absolute inset-0 flex items-center">
                         <Separator class="w-full" />
                     </div>
                     <div class="relative flex justify-center text-xs uppercase">
-                        <span class="bg-card text-muted-foreground px-2">개발 전용</span>
+                        <span class="bg-card text-muted-foreground px-2">또는</span>
                     </div>
                 </div>
 
-                <!-- 아이디/비밀번호 로그인 폼 (DEV 전용) -->
+                <!-- 아이디/비밀번호 로그인 폼 -->
                 <form onsubmit={handleLogin} class="space-y-4">
-                    {#if error}
-                        <div class="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
-                            {error}
-                        </div>
-                    {/if}
-
                     <div class="space-y-2">
                         <Label for="mb_id">아이디</Label>
                         <div class="relative">
@@ -404,6 +367,15 @@
                         {/if}
                     </Button>
                 </form>
+            {:else}
+                <div class="text-center">
+                    <a
+                        href={idLoginUrl()}
+                        class="text-muted-foreground hover:text-foreground text-sm hover:underline"
+                    >
+                        아이디로 로그인
+                    </a>
+                </div>
             {/if}
 
             <div class="text-center text-sm">


### PR DESCRIPTION
## Summary
- 로그인 페이지: 소셜 로그인을 기본 표시, ID/PW 폼은 `?type=id` 파라미터로만 노출
- 추천 배지 색상: blue/purple/pink/red → gray→blue 그라데이션으로 현세대와 통일 (step0~4)
- 추천 배지 모양: 디자인 가이드 기준 `rounded-full` pill shape 적용
- 클래식 레이아웃(게시판 목록) 추천 박스도 동일 색상 체계 적용

## Test plan
- [x] `/login` → 소셜 로그인만 표시, "아이디로 로그인" 링크 노출
- [x] `/login?type=id` → 소셜 로그인 + ID/PW 폼 모두 표시
- [x] 추천 배지 색상: 0건(연한) → ≤15(gray) → ≤25(연파) → ≤50(중파) → >50(진파+흰글자)
- [x] 클래식 레이아웃 게시판 목록도 동일 색상 적용 확인
- [x] `pnpm test:unit` 5개 테스트 통과
- [x] 프로덕션 배포 완료 (web.damoang.net)