### PR TITLE
fix: 비로그인 사용자 공개 게시판 403 오류 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -33,7 +33,7 @@ export const load: PageServerLoad = async ({ url, params, fetch: svelteKitFetch,
 
         // 게시판 접근 권한 체크 (list_level)
         if (board) {
-            const userLevel = locals.user?.level ?? 0;
+            const userLevel = locals.user?.level ?? 1;
             const requiredLevel = board.list_level ?? 1;
             if (userLevel < requiredLevel) {
                 svelteError(403, '이 게시판에 접근할 권한이 없습니다.');

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -85,7 +85,7 @@ export const load: PageServerLoad = async ({ params, fetch: svelteKitFetch, loca
 
         // 게시판 접근 권한 체크 (list_level, read_level 중 높은 값)
         if (board) {
-            const userLevel = locals.user?.level ?? 0;
+            const userLevel = locals.user?.level ?? 1;
             const requiredLevel = Math.max(board.list_level ?? 1, board.read_level ?? 1);
             if (userLevel < requiredLevel) {
                 throw error(403, '이 게시판에 접근할 권한이 없습니다.');


### PR DESCRIPTION
## Summary
- 비회원 기본 레벨을 0에서 1로 변경
- list_level=1, read_level=1인 공개 게시판에서 비로그인 사용자 403 발생하던 문제 수정

## 변경 파일
- `[boardId]/+page.server.ts` - 목록 페이지
- `[boardId]/[postId]/+page.server.ts` - 상세 페이지