### PR TITLE
fix: 축하메시지 싱크 + 공지 고정 API + 가변폰트 굵기 수정

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -274,6 +274,22 @@
         font-weight: 700;
         font-variation-settings: 'wght' 700;
     }
+
+    /* 5) Tailwind font-weight 클래스에 가변축(wght) 연동
+     *    body의 font-variation-settings: 'wght' 400 고정이
+     *    상속되면서 font-weight가 시각적으로 무시되는 문제 해결 */
+    .font-medium {
+        font-variation-settings: 'wght' 500;
+    }
+    .font-semibold {
+        font-variation-settings: 'wght' 600;
+    }
+    .font-bold {
+        font-variation-settings: 'wght' 700;
+    }
+    .font-extrabold {
+        font-variation-settings: 'wght' 800;
+    }
 }
 
 @layer utilities {

--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import { browser } from '$app/environment';
+    import {
+        getCelebrations,
+        getCurrentIndex,
+        mount as celebrationMount,
+        type CelebrationBanner
+    } from '$lib/stores/celebration.svelte.js';
 
     interface Props {
         class?: string;
@@ -8,59 +13,12 @@
 
     let { class: className = '' }: Props = $props();
 
-    interface CelebrationBanner {
-        id: number;
-        title: string;
-        content: string;
-        image_url: string;
-        link_url: string;
-        target_member_nick?: string;
-        target_member_photo?: string;
-        external_link?: string;
-        link_target?: string;
-        display_type?: 'image' | 'text';
-    }
-
-    let celebrations = $state<CelebrationBanner[]>([]);
-    let currentIndex = $state(0);
+    let celebrations = $derived(getCelebrations());
+    let currentIndex = $derived(getCurrentIndex());
 
     onMount(() => {
-        fetchCelebrations();
+        return celebrationMount();
     });
-
-    // 4초 간격 롤링 (2개 이상일 때만)
-    $effect(() => {
-        if (celebrations.length <= 1) return;
-
-        currentIndex = 0;
-
-        const intervalId = setInterval(() => {
-            currentIndex = (currentIndex + 1) % celebrations.length;
-        }, 4000);
-
-        return () => clearInterval(intervalId);
-    });
-
-    async function fetchCelebrations(): Promise<void> {
-        if (!browser) return;
-
-        try {
-            const response = await fetch('/api/ads/celebration/today', {
-                method: 'GET',
-                headers: { Accept: 'application/json' }
-            });
-
-            if (!response.ok) return;
-
-            const result = await response.json();
-
-            if (result.data?.length > 0) {
-                celebrations = result.data;
-            }
-        } catch (error) {
-            console.warn('CelebrationRolling: 축하메시지 로드 실패', error);
-        }
-    }
 
     function stripHtml(html: string): string {
         return html.replace(/<[^>]*>/g, '').trim();

--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -2,6 +2,13 @@
     import { onMount } from 'svelte';
     import { browser } from '$app/environment';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
+    import {
+        getCelebrations,
+        getCurrentIndex,
+        setCurrentIndex,
+        mount as celebrationMount,
+        type CelebrationBanner
+    } from '$lib/stores/celebration.svelte.js';
 
     interface Props {
         position: 'index' | 'board-list' | 'board-view' | 'sidebar';
@@ -20,20 +27,8 @@
     }: Props = $props();
 
     // API 엔드포인트
-    // 축하메시지 API는 SvelteKit에서 처리 (상대 경로 사용)
-    const DAMOANG_API_BASE = '';
     // 트래킹은 브라우저→외부 직접 (sendBeacon은 Cloudflare 통과)
     const ADS_TRACKING_BASE = 'https://ads.damoang.net';
-
-    // 축하메시지 배너 타입
-    interface CelebrationBanner {
-        id: number;
-        image_url: string;
-        link_url: string;
-        alt_text?: string;
-        target?: string;
-        display_type?: 'image' | 'text';
-    }
 
     // 다모앙 광고 배너 타입
     interface AdsBanner {
@@ -45,16 +40,20 @@
         trackingId?: string;
     }
 
-    let celebrationBanners = $state<CelebrationBanner[]>([]);
-    let currentBannerIndex = $state(0);
+    // 전체 축하메시지 (CelebrationRolling과 동일 리스트 + 인덱스 공유)
+    let allCelebrations = $derived(showCelebration ? getCelebrations() : []);
+    // 이미지 표시 가능한 배너만 (렌더링용)
+    let celebrationBanners = $derived(
+        allCelebrations.filter(
+            (b: CelebrationBanner) => !b.display_type || b.display_type === 'image'
+        )
+    );
+    let currentBannerIndex = $derived(getCurrentIndex());
     let adsBanner = $state<AdsBanner | null>(null);
     let loading = $state(true);
     let useFallback = $state(false);
 
     // position → 다모앙 광고 서버 position 매핑
-    // index → index-top (메인 페이지용, 현재 배너 0개 → GAM 폴백)
-    // board-list/board-view → board-head (게시판/글 페이지용)
-    // sidebar → sidebar (사이드바용)
     const ADS_POSITION_MAP: Record<string, string> = {
         index: 'index-top',
         'board-list': 'board-head',
@@ -74,7 +73,17 @@
     const gamPosition = $derived(gamPositionProp || GAM_POSITION_MAP[position] || 'board-head');
 
     onMount(() => {
+        let cleanupCelebration: (() => void) | undefined;
+
+        if (showCelebration) {
+            cleanupCelebration = celebrationMount();
+        }
+
         fetchBanners();
+
+        return () => {
+            cleanupCelebration?.();
+        };
     });
 
     async function fetchBanners() {
@@ -82,9 +91,9 @@
 
         // 1. 축하메시지 (showCelebration=true인 경우만)
         if (showCelebration) {
-            const banners = await fetchCelebrationBanners();
-            if (banners.length > 0) {
-                celebrationBanners = banners;
+            // 스토어에서 데이터가 로드될 때까지 짧은 대기
+            await waitForCelebrations();
+            if (allCelebrations.length > 0) {
                 loading = false;
                 return;
             }
@@ -103,28 +112,11 @@
         loading = false;
     }
 
-    async function fetchCelebrationBanners(): Promise<CelebrationBanner[]> {
-        try {
-            const response = await fetch(`${DAMOANG_API_BASE}/api/ads/celebration/today`, {
-                method: 'GET',
-                headers: { Accept: 'application/json' }
-            });
-
-            if (!response.ok) return [];
-
-            const result = await response.json();
-
-            if (result.success && result.data?.length > 0) {
-                // display_type === 'image'인 것만 필터링 (text 타입은 CelebrationRolling에서 처리)
-                const imageBanners = result.data.filter(
-                    (b: CelebrationBanner) => !b.display_type || b.display_type === 'image'
-                );
-                return imageBanners;
-            }
-            return [];
-        } catch (error) {
-            console.warn('DamoangBanner: 축하메시지 로드 실패', error);
-            return [];
+    async function waitForCelebrations(): Promise<void> {
+        // 스토어의 fetch가 완료될 때까지 최대 3초 대기
+        for (let i = 0; i < 30; i++) {
+            if (getCelebrations().length > 0) return;
+            await new Promise((r) => setTimeout(r, 100));
         }
     }
 
@@ -156,15 +148,6 @@
         }
     }
 
-    // 5초 자동 롤링
-    $effect(() => {
-        if (celebrationBanners.length <= 1) return;
-        const id = setInterval(() => {
-            currentBannerIndex = (currentBannerIndex + 1) % celebrationBanners.length;
-        }, 5000);
-        return () => clearInterval(id);
-    });
-
     // 터치 스와이프
     let touchStartX = 0;
     function handleTouchStart(e: TouchEvent) {
@@ -172,12 +155,12 @@
     }
     function handleTouchEnd(e: TouchEvent) {
         const diff = touchStartX - e.changedTouches[0].clientX;
-        if (Math.abs(diff) > 50) {
-            currentBannerIndex =
+        if (Math.abs(diff) > 50 && allCelebrations.length > 1) {
+            const newIndex =
                 diff > 0
-                    ? (currentBannerIndex + 1) % celebrationBanners.length
-                    : (currentBannerIndex - 1 + celebrationBanners.length) %
-                      celebrationBanners.length;
+                    ? (currentBannerIndex + 1) % allCelebrations.length
+                    : (currentBannerIndex - 1 + allCelebrations.length) % allCelebrations.length;
+            setCurrentIndex(newIndex);
         }
     }
 </script>
@@ -195,41 +178,43 @@
             </div>
         </div>
     {:else if celebrationBanners.length > 0}
-        <!-- 축하메시지 캐러셀 -->
+        <!-- 축하메시지 캐러셀 (allCelebrations 기준 인덱스로 싱크) -->
         <div
             class="border-border relative overflow-hidden rounded-xl border"
             ontouchstart={handleTouchStart}
             ontouchend={handleTouchEnd}
         >
-            {#each celebrationBanners as banner, i (banner.id)}
-                <a
-                    href={banner.link_url}
-                    target={banner.target || '_blank'}
-                    rel="nofollow noopener"
-                    class="w-full transition-transform duration-500 ease-in-out {i ===
-                    currentBannerIndex
-                        ? 'relative block translate-x-0'
-                        : i < currentBannerIndex
-                          ? 'absolute inset-0 block -translate-x-full'
-                          : 'absolute inset-0 block translate-x-full'}"
-                >
-                    <img
-                        src={banner.image_url}
-                        alt={banner.alt_text || '축하메시지'}
-                        class="w-full object-contain"
-                        style:max-height={height}
-                        loading="lazy"
-                    />
-                </a>
+            {#each allCelebrations as banner, i (banner.id)}
+                {#if !banner.display_type || banner.display_type === 'image'}
+                    <a
+                        href={banner.link_url}
+                        target={banner.target || '_blank'}
+                        rel="nofollow noopener"
+                        class="w-full transition-transform duration-500 ease-in-out {i ===
+                        currentBannerIndex
+                            ? 'relative block translate-x-0'
+                            : i < currentBannerIndex
+                              ? 'absolute inset-0 block -translate-x-full'
+                              : 'absolute inset-0 block translate-x-full'}"
+                    >
+                        <img
+                            src={banner.image_url}
+                            alt={banner.alt_text || '축하메시지'}
+                            class="w-full object-contain"
+                            style:max-height={height}
+                            loading="lazy"
+                        />
+                    </a>
+                {/if}
             {/each}
-            {#if celebrationBanners.length > 1}
+            {#if allCelebrations.length > 1}
                 <div class="absolute bottom-2 left-1/2 flex -translate-x-1/2 gap-1.5">
-                    {#each celebrationBanners as _, i}
+                    {#each allCelebrations as _, i}
                         <button
                             class="h-2 w-2 rounded-full transition-colors {i === currentBannerIndex
                                 ? 'bg-white'
                                 : 'bg-white/50'}"
-                            onclick={() => (currentBannerIndex = i)}
+                            onclick={() => setCurrentIndex(i)}
                             aria-label="배너 {i + 1}번으로 이동"
                         ></button>
                     {/each}

--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -1,0 +1,100 @@
+/**
+ * 축하메시지 공유 스토어
+ *
+ * CelebrationRolling(텍스트)과 DamoangBanner(이미지)가
+ * 동일한 데이터와 인덱스를 공유하여 싱크 롤링
+ */
+import { browser } from '$app/environment';
+
+export interface CelebrationBanner {
+    id: number;
+    title: string;
+    content: string;
+    image_url: string;
+    link_url: string;
+    target_member_nick?: string;
+    target_member_photo?: string;
+    external_link?: string;
+    link_target?: string;
+    display_type?: 'image' | 'text';
+    alt_text?: string;
+    target?: string;
+}
+
+let celebrations = $state<CelebrationBanner[]>([]);
+let currentIndex = $state(0);
+let fetched = false;
+let fetchPromise: Promise<void> | null = null;
+let refCount = 0;
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+async function doFetch(): Promise<void> {
+    if (!browser) return;
+
+    try {
+        const response = await fetch('/api/ads/celebration/today', {
+            method: 'GET',
+            headers: { Accept: 'application/json' }
+        });
+
+        if (!response.ok) return;
+
+        const result = await response.json();
+
+        if (result.data?.length > 0) {
+            celebrations = result.data;
+        }
+    } catch (error) {
+        console.warn('CelebrationStore: 축하메시지 로드 실패', error);
+    }
+}
+
+function startRotation(): void {
+    if (intervalId) return;
+    intervalId = setInterval(() => {
+        if (celebrations.length > 1) {
+            currentIndex = (currentIndex + 1) % celebrations.length;
+        }
+    }, 5000);
+}
+
+function stopRotation(): void {
+    if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+    }
+}
+
+export function getCelebrations(): CelebrationBanner[] {
+    return celebrations;
+}
+
+export function getCurrentIndex(): number {
+    return currentIndex;
+}
+
+export function setCurrentIndex(index: number): void {
+    currentIndex = index;
+}
+
+/** 컴포넌트 마운트 시 호출. fetch + rotation 시작. cleanup 함수 반환 */
+export function mount(): () => void {
+    refCount++;
+
+    if (!fetched && !fetchPromise) {
+        fetchPromise = doFetch().then(() => {
+            fetched = true;
+            fetchPromise = null;
+        });
+    }
+
+    startRotation();
+
+    return () => {
+        refCount--;
+        if (refCount <= 0) {
+            refCount = 0;
+            stopRotation();
+        }
+    };
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -321,11 +321,19 @@
     async function toggleNotice(type: 'normal' | 'important' | null): Promise<void> {
         isTogglingNotice = true;
         try {
-            await apiClient.toggleNotice(boardId, data.post.id, type);
+            const res = await fetch(`/api/boards/${boardId}/posts/${data.post.id}/notice`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ notice_type: type })
+            });
+            if (!res.ok) {
+                const err = await res.json().catch(() => null);
+                throw new Error(err?.error || '공지 설정에 실패했습니다.');
+            }
             noticeType = type;
         } catch (err) {
             console.error('Failed to toggle notice:', err);
-            alert('공지 설정에 실패했습니다.');
+            alert(err instanceof Error ? err.message : '공지 설정에 실패했습니다.');
         } finally {
             isTogglingNotice = false;
         }

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/notice/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/notice/+server.ts
@@ -1,0 +1,74 @@
+/**
+ * 게시글 공지 고정/해제 API
+ * PATCH /api/boards/[boardId]/posts/[postId]/notice
+ * 관리자(mb_level >= 10)만 사용 가능
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+import { getAuthUser } from '$lib/server/auth';
+
+export const PATCH: RequestHandler = async ({ params, request, cookies }) => {
+    const { boardId, postId } = params;
+
+    const user = await getAuthUser(cookies);
+    if (!user) {
+        return json({ success: false, error: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    // 관리자만 공지 설정 가능
+    if (user.mb_level < 10) {
+        return json({ success: false, error: '관리자 권한이 필요합니다.' }, { status: 403 });
+    }
+
+    try {
+        const body = await request.json();
+        const noticeType = body.notice_type as string | null;
+
+        // 게시글 존재 확인
+        const tableName = `g5_write_${boardId}`;
+        const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT wr_id FROM ?? WHERE wr_id = ? AND wr_is_comment = 0`,
+            [tableName, postId]
+        );
+
+        if (!rows[0]) {
+            return json({ success: false, error: '게시글을 찾을 수 없습니다.' }, { status: 404 });
+        }
+
+        // g5_board.bo_notice에서 현재 공지 목록 조회
+        const [boardRows] = await pool.query<RowDataPacket[]>(
+            `SELECT bo_notice FROM g5_board WHERE bo_table = ?`,
+            [boardId]
+        );
+
+        if (!boardRows[0]) {
+            return json({ success: false, error: '게시판을 찾을 수 없습니다.' }, { status: 404 });
+        }
+
+        const currentNotice = (boardRows[0].bo_notice as string) || '';
+        const noticeIds = currentNotice
+            .split(',')
+            .map((id: string) => id.trim())
+            .filter((id: string) => id !== '' && id !== postId);
+
+        if (noticeType) {
+            // 공지 추가
+            noticeIds.push(String(postId));
+        }
+        // noticeType이 null이면 제거만 (이미 filter에서 제거됨)
+
+        const newNotice = noticeIds.join(',');
+
+        await pool.query(`UPDATE g5_board SET bo_notice = ? WHERE bo_table = ?`, [
+            newNotice,
+            boardId
+        ]);
+
+        return json({ success: true, data: { notice_type: noticeType } });
+    } catch (error) {
+        console.error('Notice API error:', error);
+        return json({ success: false, error: '공지 설정에 실패했습니다.' }, { status: 500 });
+    }
+};


### PR DESCRIPTION
## Summary
- 축하메시지 공유 스토어(`celebration.svelte.ts`) 생성: CelebrationRolling(텍스트)과 DamoangBanner(이미지)가 동일 인덱스로 싱크 롤링
- 공지 고정/해제 SvelteKit 서버 라우트 추가 (`/api/boards/{boardId}/posts/{postId}/notice`) — Go 백엔드 404 해결
- Wanted Sans Variable 가변폰트에서 `font-weight` 클래스(`font-medium` ~ `font-extrabold`)가 시각적으로 반영되도록 `font-variation-settings: 'wght'` 연동

## Test plan
- [ ] 게시글 상세에서 상단 텍스트 롤링과 사이드바 이미지 캐러셀이 동시에 같은 항목 가리키는지 확인
- [ ] 관리자 로그인 후 공지 고정/해제 동작 확인
- [ ] 사이트 전체에서 bold/semibold 텍스트가 올바른 굵기로 표시되는지 확인