### PR TITLE
fix: 축하 메시지 롤링 링크를 /message 페이지로 변경

### DIFF
--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -41,10 +41,8 @@
 
 {#if celebrations.length > 0}
     <a
-        href={celebrations[currentIndex]?.external_link ||
-            celebrations[currentIndex]?.link_url ||
-            '#'}
-        target={celebrations[currentIndex]?.link_target || '_self'}
+        href="/message"
+        target="_self"
         rel="nofollow noopener"
         class="border-border bg-background hover:bg-accent flex h-9 items-center gap-2 overflow-hidden rounded-lg border px-3 transition-colors {className}"
     >


### PR DESCRIPTION
축하 메시지 롤링 클릭 시 /message 페이지로 이동하도록 변경