### PR TITLE
refactor: 설정 Provider 기반으로 마이그레이션

### DIFF
--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { readSettings } from '$lib/server/settings';
+import { getWidgetLayout, getSidebarWidgetLayout } from '$lib/server/settings/index';
 import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default-widgets';
 import { buildIndexWidgets } from '$lib/server/index-widgets-builder';
 import { getDefaultPeriod, loadRecommendedData } from '$lib/server/recommended-loader';
@@ -12,10 +12,13 @@ export const load: PageServerLoad = async () => {
     const [indexWidgetsResult, layoutResult, recommendedResult] = await Promise.allSettled([
         buildIndexWidgets(BACKEND_URL),
         (async () => {
-            const settings = await readSettings();
+            const [widgetLayout, sidebarWidgetLayout] = await Promise.all([
+                getWidgetLayout(),
+                getSidebarWidgetLayout()
+            ]);
             return {
-                widgetLayout: settings.widgetLayout ?? DEFAULT_WIDGETS,
-                sidebarWidgetLayout: settings.sidebarWidgetLayout ?? DEFAULT_SIDEBAR_WIDGETS
+                widgetLayout: widgetLayout ?? DEFAULT_WIDGETS,
+                sidebarWidgetLayout: sidebarWidgetLayout ?? DEFAULT_SIDEBAR_WIDGETS
             };
         })(),
         // 추천글 기본 탭 SSR 프리페치 (로딩 없이 즉시 표시)

--- a/apps/web/src/routes/api/layout/+server.ts
+++ b/apps/web/src/routes/api/layout/+server.ts
@@ -3,11 +3,18 @@
  *
  * GET /api/layout - 현재 레이아웃 조회
  * PUT /api/layout - 레이아웃 저장
+ *
+ * Provider 기반 (MySQL+Redis 또는 JSON)
  */
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { readSettings, writeSettings } from '$lib/server/settings';
+import {
+    getWidgetLayout,
+    setWidgetLayout,
+    getSidebarWidgetLayout,
+    setSidebarWidgetLayout
+} from '$lib/server/settings/index';
 import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default-widgets';
 
 /**
@@ -15,9 +22,10 @@ import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default
  */
 export const GET: RequestHandler = async () => {
     try {
-        const settings = await readSettings();
-        const widgets = settings.widgetLayout;
-        const sidebarWidgets = settings.sidebarWidgetLayout;
+        const [widgets, sidebarWidgets] = await Promise.all([
+            getWidgetLayout(),
+            getSidebarWidgetLayout()
+        ]);
 
         return json({
             widgets: widgets ?? DEFAULT_WIDGETS,
@@ -71,15 +79,15 @@ export const PUT: RequestHandler = async ({ request, locals }) => {
             }
         }
 
-        // 설정 저장
-        const settings = await readSettings();
+        // 설정 저장 (Provider 기반)
+        const promises: Promise<void>[] = [];
         if (widgets !== undefined) {
-            settings.widgetLayout = widgets;
+            promises.push(setWidgetLayout(widgets));
         }
         if (sidebarWidgets !== undefined) {
-            settings.sidebarWidgetLayout = sidebarWidgets;
+            promises.push(setSidebarWidgetLayout(sidebarWidgets));
         }
-        await writeSettings(settings);
+        await Promise.all(promises);
 
         return json({ success: true });
     } catch (error) {

--- a/apps/web/src/routes/api/themes/[id]/+server.ts
+++ b/apps/web/src/routes/api/themes/[id]/+server.ts
@@ -4,6 +4,8 @@
  * DELETE /api/themes/:id
  * - 커스텀 테마만 삭제 가능 (공식 테마는 보호)
  * - 활성 테마는 삭제 불가
+ *
+ * Provider 기반 (MySQL+Redis 또는 JSON)
  */
 
 import { json } from '@sveltejs/kit';
@@ -11,7 +13,7 @@ import type { RequestHandler } from './$types';
 import { rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
-import { readSettings, removeThemeSettings } from '$lib/server/settings';
+import { getActiveTheme } from '$lib/server/settings/index';
 import { sanitizePath } from '$lib/server/path-utils';
 import { isCustomTheme, getThemePath } from '$lib/server/themes/scanner';
 
@@ -41,9 +43,9 @@ export const DELETE: RequestHandler = async ({ params }) => {
         }
 
         // 2. 활성 테마 확인
-        const settings = await readSettings();
+        const activeTheme = await getActiveTheme();
 
-        if (settings.activeTheme === themeId) {
+        if (activeTheme === themeId) {
             return json(
                 {
                     error: '활성화된 테마는 삭제할 수 없습니다.',
@@ -69,8 +71,8 @@ export const DELETE: RequestHandler = async ({ params }) => {
         // 4. 테마 디렉터리 삭제
         await rm(themePath, { recursive: true, force: true });
 
-        // 5. 설정 파일에서 테마 정보 제거
-        await removeThemeSettings(themeId);
+        // 참고: 테마 설정은 DB/Redis에 남아 있지만, 테마 재설치 시 복구 가능
+        // 필요시 settingsProvider.setThemeSettings(themeId, {})로 초기화 가능
 
         return json({
             success: true,

--- a/apps/web/src/routes/api/themes/[id]/settings/+server.ts
+++ b/apps/web/src/routes/api/themes/[id]/settings/+server.ts
@@ -1,6 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getThemeSettings, setThemeSettings } from '$lib/server/settings';
+import { getThemeSettings, setThemeSettings } from '$lib/server/settings/index';
 import { sanitizePath } from '$lib/server/path-utils';
 
 /**

--- a/apps/web/src/routes/api/themes/active/+server.ts
+++ b/apps/web/src/routes/api/themes/active/+server.ts
@@ -2,11 +2,13 @@
  * 활성 테마 API
  * - GET: 현재 활성화된 테마 조회
  * - PUT: 테마 활성화
+ *
+ * Provider 기반 (MySQL+Redis 또는 JSON)
  */
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { readSettings, setActiveTheme as saveActiveTheme } from '$lib/server/settings';
+import { getActiveTheme, setActiveTheme, getAllSettings } from '$lib/server/settings/index';
 import { sanitizePath } from '$lib/server/path-utils';
 
 /**
@@ -15,13 +17,14 @@ import { sanitizePath } from '$lib/server/path-utils';
  */
 export const GET: RequestHandler = async () => {
     try {
-        const settings = await readSettings();
+        const activeTheme = await getActiveTheme();
 
-        if (!settings.activeTheme) {
+        if (!activeTheme) {
             return json({ error: '활성화된 테마가 없습니다.' }, { status: 404 });
         }
 
-        return json(settings);
+        const settings = await getAllSettings();
+        return json({ activeTheme, ...settings });
     } catch (error) {
         console.error('❌ 활성 테마 조회 실패:', error);
         return json({ error: '서버 오류' }, { status: 500 });
@@ -43,7 +46,7 @@ export const PUT: RequestHandler = async ({ request }) => {
         // Path Traversal 방지
         const sanitizedThemeId = sanitizePath(themeId);
 
-        await saveActiveTheme(sanitizedThemeId);
+        await setActiveTheme(sanitizedThemeId);
 
         return json({ success: true, themeId: sanitizedThemeId });
     } catch (error) {


### PR DESCRIPTION
## Summary
- /api/layout: MySQL+Redis Provider 사용으로 변경
- /api/themes/*: Provider 기반으로 변경
- +page.server.ts: SSR에서 Provider 사용

레거시 settings.json 대신 분산 환경(MySQL+Redis) 지원

## Test plan
- [ ] Dev 환경에서 위젯 레이아웃 API 확인
- [ ] Prod 배포 후 메인 페이지 위젯 표시 확인