### PR TITLE
fix: webzine content null 체크 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -28,6 +28,7 @@
 
     // HTML 태그 제거하여 미리보기 텍스트 생성
     const previewText = $derived(() => {
+        if (!post.content) return '';
         const maxLen = displaySettings?.preview_length || 200;
         const stripped = post.content
             .replace(/<[^>]*>/g, '')


### PR DESCRIPTION
post.content가 undefined일 때 500 에러 방지