### PR TITLE
feat: 게시판 레이아웃 3종 추가 (나눔, 축하메시지, 거래)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+    /**
+     * 나눔 게시판 레이아웃
+     *
+     * 나눔 게시글을 카드 형태로 표시합니다.
+     * - 실시간 카운트다운 타이머
+     * - 응모 건수 표시 (0건, 1-20건, 20건+, 50건+ 축제)
+     * - 상태 뱃지 (진행중, 대기중, 일시정지, 종료)
+     *
+     * Design System: "Soft Modern" - 카드 기반, 부드러운 전환
+     *
+     * 확장 필드 매핑:
+     * - extra_4: 시작일시 (wr_4)
+     * - extra_5: 종료일시 (wr_5)
+     * - extra_7: 상태 (0=활성, 1=일시정지, 2=강제종료) (wr_7)
+     * - extra_2: 응모수/포인트 (wr_2)
+     */
+    import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
+    import Gift from '@lucide/svelte/icons/gift';
+    import Clock from '@lucide/svelte/icons/clock';
+    import Users from '@lucide/svelte/icons/users';
+    import Pause from '@lucide/svelte/icons/pause';
+    import PlayCircle from '@lucide/svelte/icons/play-circle';
+    import Timer from '@lucide/svelte/icons/timer';
+    import MessageSquare from '@lucide/svelte/icons/message-square';
+
+    let {
+        post,
+        displaySettings,
+        href,
+        isRead = false
+    }: {
+        post: FreePost;
+        displaySettings?: BoardDisplaySettings;
+        href: string;
+        isRead?: boolean;
+    } = $props();
+
+    // 삭제된 글
+    const isDeleted = $derived(!!post.deleted_at);
+
+    // 썸네일 표시
+    const thumbnailUrl = $derived(post.thumbnail || post.images?.[0] || '');
+    const hasImage = $derived(Boolean(thumbnailUrl));
+
+    // 나눔 확장 필드 (wr_1 ~ wr_10 매핑)
+    // extra_4: 시작일시, extra_5: 종료일시, extra_7: 상태, extra_2: 응모수
+    const givingStart = $derived(post.extra_4);
+    const givingEnd = $derived(post.extra_5);
+    const isPaused = $derived(post.extra_7 === '1');
+    const bidCount = $derived(parseInt(post.extra_2 || '0', 10) || 0);
+
+    // 현재 시간 (반응형)
+    let now = $state(Date.now());
+    $effect(() => {
+        const interval = setInterval(() => {
+            now = Date.now();
+        }, 1000);
+        return () => clearInterval(interval);
+    });
+
+    // 나눔 상태 계산
+    type GivingStatus = 'active' | 'waiting' | 'paused' | 'ended' | 'no_giving';
+
+    function getGivingStatus(): {
+        status: GivingStatus;
+        text: string;
+        icon: typeof Gift;
+        class: string;
+    } {
+        if (!givingStart || !givingEnd) {
+            return {
+                status: 'no_giving',
+                text: '일반글',
+                icon: Gift,
+                class: 'bg-muted text-muted-foreground'
+            };
+        }
+
+        const start = new Date(givingStart).getTime();
+        const end = new Date(givingEnd).getTime();
+
+        if (isPaused) {
+            return {
+                status: 'paused',
+                text: '일시정지',
+                icon: Pause,
+                class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400'
+            };
+        }
+
+        if (now >= start && now <= end) {
+            return {
+                status: 'active',
+                text: '진행중',
+                icon: PlayCircle,
+                class: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400'
+            };
+        }
+
+        if (now > end) {
+            return {
+                status: 'ended',
+                text: '종료',
+                icon: Clock,
+                class: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+            };
+        }
+
+        return {
+            status: 'waiting',
+            text: '대기중',
+            icon: Timer,
+            class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400'
+        };
+    }
+
+    const statusInfo = $derived(getGivingStatus());
+    const isEnded = $derived(statusInfo.status === 'ended');
+
+    // 카운트다운 포맷
+    function formatCountdown(): string {
+        if (!givingEnd) return '';
+        const end = new Date(givingEnd).getTime();
+        const diff = end - now;
+
+        if (diff <= 0) return '종료';
+
+        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+        const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+        if (days > 0) {
+            return `${days}일 ${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        }
+        return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    }
+
+    // 응모 건수 스타일
+    function getBidCountStyle(): string {
+        if (bidCount === 0) return 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400';
+        if (bidCount < 20)
+            return 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400';
+        if (bidCount >= 50)
+            return 'bg-gradient-to-r from-rose-500 to-amber-500 text-white animate-pulse';
+        return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400';
+    }
+
+    // 날짜 포맷
+    function formatDate(dateStr?: string): string {
+        if (!dateStr) return '';
+        const date = new Date(dateStr);
+        return `${(date.getMonth() + 1).toString().padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')} ${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+    }
+</script>
+
+<!-- 나눔 카드 -->
+{#if isDeleted}
+    <div
+        class="border-border bg-background flex flex-col overflow-hidden rounded-xl border opacity-50"
+    >
+        <div class="bg-muted flex aspect-[4/3] items-center justify-center">
+            <span class="text-muted-foreground text-sm">[삭제됨]</span>
+        </div>
+    </div>
+{:else}
+    <a
+        {href}
+        class="border-border bg-background group flex flex-col overflow-hidden rounded-xl border shadow-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md {isEnded
+            ? 'opacity-75'
+            : ''}"
+        data-sveltekit-preload-data="hover"
+    >
+        <!-- 썸네일 -->
+        <div
+            class="bg-muted relative aspect-[4/3] overflow-hidden {isEnded
+                ? 'grayscale-[30%]'
+                : ''}"
+        >
+            {#if hasImage}
+                <img
+                    src={thumbnailUrl}
+                    alt={post.title}
+                    class="h-full w-full object-cover transition-transform duration-300 {isEnded
+                        ? ''
+                        : 'group-hover:scale-105'}"
+                    loading="lazy"
+                />
+            {:else}
+                <div class="text-muted-foreground flex h-full w-full items-center justify-center">
+                    <Gift class="h-12 w-12 opacity-30" />
+                </div>
+            {/if}
+
+            <!-- 상태 뱃지 -->
+            <div class="absolute right-2 top-2">
+                <span
+                    class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold {statusInfo.class}"
+                >
+                    {#if statusInfo.status === 'active'}
+                        <PlayCircle class="h-3 w-3" />
+                    {:else if statusInfo.status === 'waiting'}
+                        <Timer class="h-3 w-3" />
+                    {:else if statusInfo.status === 'paused'}
+                        <Pause class="h-3 w-3" />
+                    {:else if statusInfo.status === 'ended'}
+                        <Clock class="h-3 w-3" />
+                    {:else}
+                        <Gift class="h-3 w-3" />
+                    {/if}
+                    {statusInfo.text}
+                </span>
+            </div>
+
+            <!-- 참여 인원 뱃지 (종료된 경우) -->
+            {#if isEnded && bidCount > 0}
+                <div class="absolute left-2 top-2">
+                    <span
+                        class="inline-flex items-center gap-1 rounded-full bg-black/70 px-2 py-0.5 text-xs font-semibold text-white"
+                    >
+                        <Users class="h-3 w-3" />
+                        {bidCount.toLocaleString()}명
+                    </span>
+                </div>
+            {/if}
+        </div>
+
+        <!-- 콘텐츠 -->
+        <div class="flex flex-1 flex-col p-3">
+            <h4
+                class="line-clamp-2 text-sm font-medium {isRead
+                    ? 'text-muted-foreground'
+                    : 'text-foreground'}"
+            >
+                {post.title}
+            </h4>
+            {#if post.comments_count > 0}
+                <span class="text-primary ml-1 inline-flex items-center gap-0.5 text-xs">
+                    <MessageSquare class="h-3 w-3" />
+                    {post.comments_count}
+                </span>
+            {/if}
+
+            <!-- 나눔 시간 정보 -->
+            {#if givingStart && givingEnd}
+                <div class="text-muted-foreground mt-2 space-y-1 text-xs">
+                    <div class="flex justify-between">
+                        <span>시작</span>
+                        <span class="font-medium">{formatDate(givingStart)}</span>
+                    </div>
+                    <div class="flex justify-between">
+                        <span>종료</span>
+                        <span class="font-medium">{formatDate(givingEnd)}</span>
+                    </div>
+                </div>
+
+                <!-- 카운트다운 -->
+                {#if statusInfo.status === 'active'}
+                    <div class="mt-2 text-center">
+                        <span class="font-mono text-sm font-bold text-red-600">
+                            {formatCountdown()}
+                        </span>
+                    </div>
+                {:else if statusInfo.status === 'waiting'}
+                    <div class="mt-2 text-center">
+                        <span
+                            class="border-border text-muted-foreground inline-flex items-center rounded-full border px-2 py-0.5 text-xs"
+                        >
+                            {formatDate(givingStart)} 시작
+                        </span>
+                    </div>
+                {/if}
+
+                <!-- 응모 건수 -->
+                {#if !isEnded}
+                    <div class="mt-auto pt-2">
+                        <div
+                            class="rounded-lg px-3 py-1.5 text-center text-sm font-semibold {getBidCountStyle()}"
+                        >
+                            {bidCount}건 응모
+                        </div>
+                    </div>
+                {/if}
+            {/if}
+
+            <!-- 작성자 -->
+            <div class="text-muted-foreground mt-2 flex items-center gap-2 pt-2 text-xs">
+                <span class="truncate">
+                    {post.author}
+                </span>
+            </div>
+        </div>
+    </a>
+{/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/index.ts
+++ b/apps/web/src/lib/components/features/board/layouts/list/index.ts
@@ -17,6 +17,9 @@ import PosterGalleryLayout from './poster-gallery.svelte';
 import MarketCardLayout from './market-card.svelte';
 import ClassicLayout from './classic.svelte';
 import NoticeLayout from './notice.svelte';
+import MessageLayout from './message.svelte';
+import GivingLayout from './giving.svelte';
+import TradeLayout from './trade.svelte';
 
 /** 코어 목록 레이아웃 매니페스트 */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -101,6 +104,33 @@ const coreListLayouts: { manifest: LayoutManifest; component: any }[] = [
             wrapperClass: 'space-y-2'
         },
         component: NoticeLayout
+    },
+    {
+        manifest: {
+            id: 'message',
+            name: '축하 메시지',
+            description: '축하 카드 형태로 표시 (그라데이션 헤더, 무지개 아바타)',
+            wrapperClass: 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
+        },
+        component: MessageLayout
+    },
+    {
+        manifest: {
+            id: 'giving',
+            name: '나눔',
+            description: '나눔 게시판 전용 (카운트다운, 응모수, 상태 뱃지)',
+            wrapperClass: 'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+        },
+        component: GivingLayout
+    },
+    {
+        manifest: {
+            id: 'trade',
+            name: '거래',
+            description: '중고거래/판매 게시판 전용 (가격, 상태, 거래방식)',
+            wrapperClass: 'grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5'
+        },
+        component: TradeLayout
     }
 ];
 
@@ -126,5 +156,8 @@ export {
     PosterGalleryLayout,
     MarketCardLayout,
     ClassicLayout,
-    NoticeLayout
+    NoticeLayout,
+    MessageLayout,
+    GivingLayout,
+    TradeLayout
 };

--- a/apps/web/src/lib/components/features/board/layouts/list/message.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/message.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+    /**
+     * 축하 메시지 게시판 레이아웃
+     *
+     * 회원 축하/기념 게시글을 카드 형태로 표시합니다.
+     * - 그라데이션 헤더 (회원 아이디 기반 일관된 색상)
+     * - 레벨 배지 아바타
+     * - 배너 이미지 오버레이
+     *
+     * Design System: "Soft Modern" - 부드러운 카드, 호버 리프트 효과
+     */
+    import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
+    import Heart from '@lucide/svelte/icons/heart';
+    import ExternalLink from '@lucide/svelte/icons/external-link';
+    import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
+    import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
+
+    let {
+        post,
+        displaySettings,
+        href,
+        isRead = false
+    }: {
+        post: FreePost;
+        displaySettings?: BoardDisplaySettings;
+        href: string;
+        isRead?: boolean;
+    } = $props();
+
+    // 삭제된 글
+    const isDeleted = $derived(!!post.deleted_at);
+
+    // 썸네일 표시
+    const thumbnailUrl = $derived(post.thumbnail || post.images?.[0] || '');
+    const hasImage = $derived(Boolean(thumbnailUrl));
+
+    // 회원 아이디 기반 그라데이션 번호 (1-5, 일관된 색상)
+    function getGradientNumber(memberId?: string): number {
+        if (!memberId) return Math.floor(Math.random() * 5) + 1;
+        let hash = 0;
+        for (let i = 0; i < memberId.length; i++) {
+            hash = (hash << 5) - hash + memberId.charCodeAt(i);
+            hash |= 0;
+        }
+        return (Math.abs(hash) % 5) + 1;
+    }
+
+    // 그라데이션 색상 매핑
+    const gradients: Record<number, string> = {
+        1: 'from-indigo-500 to-purple-600',
+        2: 'from-pink-400 to-rose-500',
+        3: 'from-cyan-400 to-teal-500',
+        4: 'from-emerald-400 to-cyan-500',
+        5: 'from-rose-400 to-amber-400'
+    };
+
+    const gradNum = $derived(getGradientNumber(post.author_id));
+    const grad = $derived(gradients[gradNum]);
+
+    // 외부 링크 추출 (확장 필드 - link1 사용)
+    const externalLink = $derived(post.link1);
+</script>
+
+<!-- 축하 메시지 카드 -->
+{#if isDeleted}
+    <div
+        class="border-border bg-background flex h-full flex-col overflow-hidden rounded-2xl border opacity-50"
+    >
+        <div class="flex flex-1 items-center justify-center p-4">
+            <span class="text-muted-foreground text-sm">[삭제된 게시물입니다]</span>
+        </div>
+    </div>
+{:else}
+    <div
+        class="border-border bg-background group flex h-full flex-col overflow-hidden rounded-2xl border shadow-sm transition-all duration-200 ease-out hover:-translate-y-1 hover:shadow-lg"
+    >
+        <!-- 상단 헤더: 그라데이션 + 닉네임 -->
+        <div class="flex items-center gap-2 bg-gradient-to-r px-3 py-2 text-white {grad}">
+            <Heart class="h-4 w-4" />
+            <span class="text-sm font-bold drop-shadow-md">
+                {post.author ?? '축하합니다'}
+                {post.author ? '님' : ''}
+            </span>
+            {#if externalLink}
+                <a
+                    href={externalLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="ml-auto flex items-center gap-1 rounded-full bg-white/20 px-2 py-0.5 text-xs transition-colors hover:bg-white/30"
+                    onclick={(e) => e.stopPropagation()}
+                >
+                    <ExternalLink class="h-3 w-3" />
+                    바로가기
+                </a>
+            {/if}
+        </div>
+
+        <!-- 본문: 프로필 + 배너 -->
+        <a {href} class="relative flex min-h-[70px] flex-1" data-sveltekit-preload-data="hover">
+            <!-- 프로필 레벨 배지 (왼쪽 중앙) -->
+            <div class="absolute left-3 top-1/2 z-10 -translate-y-1/2">
+                <div
+                    class="flex h-12 w-12 items-center justify-center rounded-full border-2 border-white/50 bg-gradient-to-br shadow-lg {grad}"
+                >
+                    <LevelBadge level={memberLevelStore.getLevel(post.author_id)} size="md" />
+                </div>
+            </div>
+
+            <!-- 배너 이미지 or 텍스트 영역 -->
+            {#if hasImage}
+                <div class="relative h-full w-full">
+                    <img
+                        src={thumbnailUrl}
+                        alt={post.title}
+                        class="h-full min-h-[70px] w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                        loading="lazy"
+                    />
+                    <!-- 오버레이 -->
+                    <div
+                        class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-3 py-2 pl-20"
+                    >
+                        <p
+                            class="line-clamp-2 text-sm font-semibold text-white drop-shadow-md {isRead
+                                ? 'opacity-70'
+                                : ''}"
+                        >
+                            {post.title}
+                        </p>
+                    </div>
+                </div>
+            {:else}
+                <div class="bg-muted flex w-full flex-col justify-center py-4 pl-20 pr-4">
+                    <p
+                        class="line-clamp-2 text-sm font-semibold {isRead
+                            ? 'text-muted-foreground'
+                            : 'text-foreground'}"
+                    >
+                        {post.title}
+                    </p>
+                </div>
+            {/if}
+        </a>
+    </div>
+{/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+    /**
+     * 거래 게시판 레이아웃
+     *
+     * 중고거래/판매 게시글을 카드 형태로 표시합니다.
+     * - 가격 표시
+     * - 거래 상태 (판매중, 예약중, 판매완료)
+     * - 거래 방식 (택배 가능 여부)
+     * - 지역 정보
+     * - 찜/좋아요 카운트
+     *
+     * Design System: "Soft Modern" - 깔끔한 상품 카드, 가격 강조
+     *
+     * 확장 필드 매핑 (used-market.ts 기준):
+     * - extra_1: 가격
+     * - extra_2: 상태 (selling/reserved/sold)
+     * - extra_4: 위치
+     * - extra_5: 택배 가능 여부 (1 = true)
+     */
+    import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
+    import { parseMarketInfo, formatPrice, type MarketStatus } from '$lib/types/used-market.js';
+    import ShoppingBag from '@lucide/svelte/icons/shopping-bag';
+    import MapPin from '@lucide/svelte/icons/map-pin';
+    import Heart from '@lucide/svelte/icons/heart';
+    import Truck from '@lucide/svelte/icons/truck';
+    import Clock from '@lucide/svelte/icons/clock';
+    import CheckCircle from '@lucide/svelte/icons/check-circle';
+    import Tag from '@lucide/svelte/icons/tag';
+    import MessageSquare from '@lucide/svelte/icons/message-square';
+
+    let {
+        post,
+        displaySettings,
+        href,
+        isRead = false
+    }: {
+        post: FreePost;
+        displaySettings?: BoardDisplaySettings;
+        href: string;
+        isRead?: boolean;
+    } = $props();
+
+    // 삭제된 글
+    const isDeleted = $derived(!!post.deleted_at);
+
+    // 썸네일 표시
+    const thumbnailUrl = $derived(post.thumbnail || post.images?.[0] || '');
+    const hasImage = $derived(Boolean(thumbnailUrl));
+
+    // 중고 마켓 정보 파싱
+    const market = $derived(parseMarketInfo(post));
+    const isSold = $derived(market.status === 'sold');
+
+    // 거래 상태 스타일
+    const statusStyles: Record<MarketStatus, { text: string; class: string; icon: typeof Tag }> = {
+        selling: {
+            text: '판매중',
+            class: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400',
+            icon: Tag
+        },
+        reserved: {
+            text: '예약중',
+            class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400',
+            icon: Clock
+        },
+        sold: {
+            text: '판매완료',
+            class: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+            icon: CheckCircle
+        }
+    };
+
+    const statusInfo = $derived(statusStyles[market.status] ?? statusStyles.selling);
+
+    // 날짜 포맷
+    function formatDate(dateStr?: string): string {
+        if (!dateStr) return '';
+        const date = new Date(dateStr);
+        const nowDate = new Date();
+        const diffMs = nowDate.getTime() - date.getTime();
+        const diffM = Math.floor(diffMs / (1000 * 60));
+        const diffH = Math.floor(diffMs / (1000 * 60 * 60));
+        const diffD = Math.floor(diffH / 24);
+
+        if (diffM < 1) return '방금 전';
+        if (diffM < 60) return `${diffM}분 전`;
+        if (diffH < 24) return `${diffH}시간 전`;
+        if (diffD < 7) return `${diffD}일 전`;
+        return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+    }
+</script>
+
+<!-- 거래 카드 -->
+{#if isDeleted}
+    <div
+        class="border-border bg-background flex flex-col overflow-hidden rounded-xl border opacity-50"
+    >
+        <div class="bg-muted flex aspect-square items-center justify-center">
+            <span class="text-muted-foreground text-sm">[삭제됨]</span>
+        </div>
+    </div>
+{:else}
+    <a
+        {href}
+        class="border-border bg-background group flex flex-col overflow-hidden rounded-xl border shadow-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md {isSold
+            ? 'opacity-60'
+            : ''}"
+        data-sveltekit-preload-data="hover"
+    >
+        <!-- 썸네일 -->
+        <div class="bg-muted relative aspect-square overflow-hidden">
+            {#if hasImage}
+                <img
+                    src={thumbnailUrl}
+                    alt={post.title}
+                    class="h-full w-full object-cover transition-transform duration-300 {isSold
+                        ? 'grayscale'
+                        : 'group-hover:scale-105'}"
+                    loading="lazy"
+                />
+            {:else}
+                <div class="text-muted-foreground flex h-full w-full items-center justify-center">
+                    <ShoppingBag class="h-16 w-16 opacity-20" />
+                </div>
+            {/if}
+
+            <!-- 상태 뱃지 (판매중이 아닌 경우만) -->
+            {#if market.status === 'reserved'}
+                <div class="absolute left-2 top-2">
+                    <span
+                        class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold {statusInfo.class}"
+                    >
+                        <Clock class="h-3 w-3" />
+                        {statusInfo.text}
+                    </span>
+                </div>
+            {:else if market.status === 'sold'}
+                <div class="absolute left-2 top-2">
+                    <span
+                        class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold {statusInfo.class}"
+                    >
+                        <CheckCircle class="h-3 w-3" />
+                        {statusInfo.text}
+                    </span>
+                </div>
+            {/if}
+
+            <!-- 택배 가능 뱃지 -->
+            {#if market.shippingAvailable}
+                <div class="absolute right-2 top-2">
+                    <span
+                        class="inline-flex items-center rounded-full bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                        title="택배 가능"
+                    >
+                        <Truck class="h-3 w-3" />
+                    </span>
+                </div>
+            {/if}
+
+            <!-- 찜 아이콘 (호버시) -->
+            <div
+                class="absolute bottom-2 right-2 opacity-0 transition-opacity group-hover:opacity-100"
+            >
+                <button
+                    type="button"
+                    class="text-muted-foreground flex h-8 w-8 items-center justify-center rounded-full bg-white/90 shadow-sm transition-colors hover:text-rose-500 dark:bg-gray-800/90"
+                    onclick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                    }}
+                >
+                    <Heart class="h-4 w-4" />
+                </button>
+            </div>
+        </div>
+
+        <!-- 콘텐츠 -->
+        <div class="flex flex-1 flex-col p-3">
+            <!-- 제목 -->
+            <h4
+                class="line-clamp-2 text-sm font-medium leading-snug {isRead
+                    ? 'text-muted-foreground'
+                    : 'text-foreground'}"
+            >
+                {post.title}
+            </h4>
+
+            <!-- 가격 -->
+            <div class="mt-2">
+                <span
+                    class="text-base font-bold {market.price === 0
+                        ? 'text-emerald-600 dark:text-emerald-400'
+                        : 'text-foreground'}"
+                >
+                    {formatPrice(market.price)}
+                </span>
+            </div>
+
+            <!-- 메타 정보 -->
+            <div
+                class="text-muted-foreground mt-auto flex flex-wrap items-center gap-1.5 pt-2 text-xs"
+            >
+                {#if market.location}
+                    <span class="inline-flex items-center gap-0.5">
+                        <MapPin class="h-3 w-3" />
+                        {market.location}
+                    </span>
+                {/if}
+            </div>
+
+            <!-- 하단: 좋아요/댓글/시간 -->
+            <div
+                class="border-border text-muted-foreground mt-2 flex items-center justify-between border-t pt-2 text-xs"
+            >
+                <div class="flex items-center gap-2">
+                    {#if post.likes > 0}
+                        <span class="inline-flex items-center gap-0.5">
+                            <Heart class="h-3 w-3" />
+                            {post.likes}
+                        </span>
+                    {/if}
+                    {#if post.comments_count > 0}
+                        <span class="inline-flex items-center gap-0.5">
+                            <MessageSquare class="h-3 w-3" />
+                            {post.comments_count}
+                        </span>
+                    {/if}
+                </div>
+                <span>{formatDate(post.created_at)}</span>
+            </div>
+        </div>
+    </a>
+{/if}

--- a/widgets/post-list/index.svelte
+++ b/widgets/post-list/index.svelte
@@ -17,6 +17,9 @@
     import GalleryView from './layouts/gallery-view.svelte';
     import GridView from './layouts/grid-view.svelte';
     import CardView from './layouts/card-view.svelte';
+    import MessageView from './layouts/message-view.svelte';
+    import GivingView from './layouts/giving-view.svelte';
+    import TradeView from './layouts/trade-view.svelte';
 
     let { config, slot, isEditMode = false, prefetchData }: WidgetProps = $props();
 
@@ -111,6 +114,12 @@
         <GridView posts={fetchedPosts} {showTitle} {boardId} />
     {:else if layout === 'card'}
         <CardView posts={fetchedPosts} {showTitle} {boardId} />
+    {:else if layout === 'message'}
+        <MessageView posts={fetchedPosts} {showTitle} {boardId} />
+    {:else if layout === 'giving'}
+        <GivingView posts={fetchedPosts} {showTitle} {boardId} />
+    {:else if layout === 'trade'}
+        <TradeView posts={fetchedPosts} {showTitle} {boardId} />
     {:else}
         <ListView posts={fetchedPosts} {showTitle} {boardId} />
     {/if}

--- a/widgets/post-list/layouts/giving-view.svelte
+++ b/widgets/post-list/layouts/giving-view.svelte
@@ -1,0 +1,401 @@
+<script lang="ts">
+    /**
+     * 나눔 게시판 레이아웃
+     *
+     * 나눔 게시글을 탭 (진행중/종료)으로 분류하여 표시합니다.
+     * - 실시간 카운트다운 타이머
+     * - 응모 건수 표시 (0건, 1-20건, 20건+, 50건+ 축제)
+     * - 상태 뱃지 (진행중, 대기중, 일시정지, 종료)
+     *
+     * Design System: "Soft Modern" - 카드 기반, 부드러운 전환
+     */
+    import { Card } from '$lib/components/ui/card';
+    import { Badge } from '$lib/components/ui/badge';
+    import * as Tabs from '$lib/components/ui/tabs';
+    import Gift from '@lucide/svelte/icons/gift';
+    import Clock from '@lucide/svelte/icons/clock';
+    import Users from '@lucide/svelte/icons/users';
+    import Pause from '@lucide/svelte/icons/pause';
+    import PlayCircle from '@lucide/svelte/icons/play-circle';
+    import Timer from '@lucide/svelte/icons/timer';
+
+    interface GivingPost {
+        id: number;
+        title: string;
+        url?: string;
+        thumbnail_url?: string;
+        author?: {
+            id?: string;
+            nickname?: string;
+            avatar_url?: string;
+        };
+        giving_start?: string;
+        giving_end?: string;
+        is_paused?: boolean;
+        bid_count?: number;
+        comment_count?: number;
+        created_at?: string;
+    }
+
+    let {
+        posts = [],
+        showTitle = true,
+        boardId = ''
+    }: {
+        posts: GivingPost[];
+        showTitle?: boolean;
+        boardId?: string;
+    } = $props();
+
+    // 현재 시간 (반응형)
+    let now = $state(Date.now());
+    $effect(() => {
+        const interval = setInterval(() => {
+            now = Date.now();
+        }, 1000);
+        return () => clearInterval(interval);
+    });
+
+    // 나눔 상태 계산
+    type GivingStatus = 'active' | 'waiting' | 'paused' | 'ended' | 'no_giving';
+
+    function getGivingStatus(post: GivingPost): {
+        status: GivingStatus;
+        text: string;
+        icon: typeof Gift;
+        class: string;
+    } {
+        if (!post.giving_start || !post.giving_end) {
+            return {
+                status: 'no_giving',
+                text: '일반글',
+                icon: Gift,
+                class: 'bg-muted text-muted-foreground'
+            };
+        }
+
+        const start = new Date(post.giving_start).getTime();
+        const end = new Date(post.giving_end).getTime();
+
+        if (post.is_paused) {
+            return {
+                status: 'paused',
+                text: '일시정지',
+                icon: Pause,
+                class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400'
+            };
+        }
+
+        if (now >= start && now <= end) {
+            return {
+                status: 'active',
+                text: '진행중',
+                icon: PlayCircle,
+                class: 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400'
+            };
+        }
+
+        if (now > end) {
+            return {
+                status: 'ended',
+                text: '종료',
+                icon: Clock,
+                class: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+            };
+        }
+
+        return {
+            status: 'waiting',
+            text: '대기중',
+            icon: Timer,
+            class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400'
+        };
+    }
+
+    // 활성/종료 목록 분류
+    const activeList = $derived(
+        posts.filter((p) => {
+            const status = getGivingStatus(p).status;
+            return status === 'active' || status === 'waiting' || status === 'paused';
+        })
+    );
+
+    const endedList = $derived(
+        posts.filter((p) => {
+            const status = getGivingStatus(p).status;
+            return status === 'ended';
+        })
+    );
+
+    // 카운트다운 포맷
+    function formatCountdown(endTime: string): string {
+        const end = new Date(endTime).getTime();
+        const diff = end - now;
+
+        if (diff <= 0) return '종료';
+
+        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+        const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+        if (days > 0) {
+            return `${days}일 ${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        }
+        return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    }
+
+    // 응모 건수 스타일
+    function getBidCountStyle(count: number): string {
+        if (count === 0) return 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400';
+        if (count < 20) return 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400';
+        if (count >= 50)
+            return 'bg-gradient-to-r from-rose-500 to-amber-500 text-white animate-pulse';
+        return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400';
+    }
+
+    // 날짜 포맷
+    function formatDate(dateStr?: string): string {
+        if (!dateStr) return '';
+        const date = new Date(dateStr);
+        return `${(date.getMonth() + 1).toString().padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')} ${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+    }
+
+    let currentTab = $state('active');
+</script>
+
+<Card class="gap-0 overflow-hidden">
+    {#if showTitle}
+        <div class="border-border flex items-center gap-2 border-b px-4 py-2.5">
+            <Gift class="h-4 w-4 text-emerald-500" />
+            <h3 class="text-sm font-semibold">나눔</h3>
+        </div>
+    {/if}
+
+    <Tabs.Root bind:value={currentTab} class="w-full">
+        <Tabs.List class="border-border bg-muted/30 grid w-full grid-cols-2 border-b">
+            <Tabs.Trigger value="active" class="data-[state=active]:bg-background gap-2">
+                <span>진행중</span>
+                <Badge variant="secondary" class="ml-1 h-5 px-1.5 text-xs">
+                    {activeList.length}
+                </Badge>
+            </Tabs.Trigger>
+            <Tabs.Trigger value="ended" class="data-[state=active]:bg-background gap-2">
+                <span>종료</span>
+                <Badge variant="secondary" class="ml-1 h-5 px-1.5 text-xs">
+                    {endedList.length}
+                </Badge>
+            </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="active" class="p-4">
+            {#if activeList.length === 0}
+                <div class="flex flex-col items-center justify-center py-10 text-center">
+                    <Gift class="text-muted-foreground/50 mb-3 h-10 w-10" />
+                    <p class="text-muted-foreground">현재 진행중인 나눔이 없습니다.</p>
+                </div>
+            {:else}
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {#each activeList as post (post.id)}
+                        {@const status = getGivingStatus(post)}
+                        <a
+                            href={post.url ?? '#'}
+                            class="border-border bg-background group flex flex-col overflow-hidden rounded-xl border shadow-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md"
+                        >
+                            <!-- 썸네일 -->
+                            <div class="bg-muted relative aspect-[4/3] overflow-hidden">
+                                {#if post.thumbnail_url}
+                                    <img
+                                        src={post.thumbnail_url}
+                                        alt={post.title}
+                                        class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                                        loading="lazy"
+                                    />
+                                {:else}
+                                    <div
+                                        class="text-muted-foreground flex h-full w-full items-center justify-center"
+                                    >
+                                        <Gift class="h-12 w-12 opacity-30" />
+                                    </div>
+                                {/if}
+
+                                <!-- 상태 뱃지 -->
+                                <div class="absolute right-2 top-2">
+                                    <span
+                                        class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold {status.class}"
+                                    >
+                                        <svelte:component this={status.icon} class="h-3 w-3" />
+                                        {status.text}
+                                    </span>
+                                </div>
+                            </div>
+
+                            <!-- 콘텐츠 -->
+                            <div class="flex flex-1 flex-col p-3">
+                                <h4 class="text-foreground line-clamp-2 text-sm font-medium">
+                                    {post.title}
+                                </h4>
+                                {#if post.comment_count}
+                                    <span class="text-primary ml-1 text-xs"
+                                        >+{post.comment_count}</span
+                                    >
+                                {/if}
+
+                                <!-- 나눔 시간 정보 -->
+                                {#if post.giving_start && post.giving_end}
+                                    <div class="text-muted-foreground mt-2 space-y-1 text-xs">
+                                        <div class="flex justify-between">
+                                            <span>시작</span>
+                                            <span class="font-medium"
+                                                >{formatDate(post.giving_start)}</span
+                                            >
+                                        </div>
+                                        <div class="flex justify-between">
+                                            <span>종료</span>
+                                            <span class="font-medium"
+                                                >{formatDate(post.giving_end)}</span
+                                            >
+                                        </div>
+                                    </div>
+
+                                    <!-- 카운트다운 -->
+                                    {#if status.status === 'active'}
+                                        <div class="mt-2 text-center">
+                                            <span class="font-mono text-sm font-bold text-red-600">
+                                                {formatCountdown(post.giving_end)}
+                                            </span>
+                                        </div>
+                                    {:else if status.status === 'waiting'}
+                                        <div class="mt-2 text-center">
+                                            <Badge variant="outline" class="text-xs">
+                                                {formatDate(post.giving_start)} 시작
+                                            </Badge>
+                                        </div>
+                                    {/if}
+                                {/if}
+
+                                <!-- 응모 건수 -->
+                                {#if post.bid_count !== undefined && post.giving_start && post.giving_end}
+                                    <div class="mt-auto pt-2">
+                                        <div
+                                            class="rounded-lg px-3 py-1.5 text-center text-sm font-semibold {getBidCountStyle(
+                                                post.bid_count
+                                            )}"
+                                        >
+                                            {post.bid_count}건 응모
+                                        </div>
+                                    </div>
+                                {/if}
+
+                                <!-- 작성자 -->
+                                {#if post.author}
+                                    <div class="mt-2 flex items-center gap-2 pt-2">
+                                        {#if post.author.avatar_url}
+                                            <img
+                                                src={post.author.avatar_url}
+                                                alt=""
+                                                class="h-5 w-5 rounded-full object-cover"
+                                            />
+                                        {/if}
+                                        <span class="text-muted-foreground truncate text-xs">
+                                            {post.author.nickname ?? post.author.id}
+                                        </span>
+                                    </div>
+                                {/if}
+                            </div>
+                        </a>
+                    {/each}
+                </div>
+            {/if}
+        </Tabs.Content>
+
+        <Tabs.Content value="ended" class="p-4">
+            {#if endedList.length === 0}
+                <div class="flex flex-col items-center justify-center py-10 text-center">
+                    <Clock class="text-muted-foreground/50 mb-3 h-10 w-10" />
+                    <p class="text-muted-foreground">종료된 나눔이 없습니다.</p>
+                </div>
+            {:else}
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {#each endedList as post (post.id)}
+                        {@const status = getGivingStatus(post)}
+                        <a
+                            href={post.url ?? '#'}
+                            class="border-border bg-background group flex flex-col overflow-hidden rounded-xl border opacity-75 shadow-sm transition-all duration-200 ease-out hover:opacity-100 hover:shadow-md"
+                        >
+                            <!-- 썸네일 -->
+                            <div
+                                class="bg-muted relative aspect-[4/3] overflow-hidden grayscale-[30%]"
+                            >
+                                {#if post.thumbnail_url}
+                                    <img
+                                        src={post.thumbnail_url}
+                                        alt={post.title}
+                                        class="h-full w-full object-cover"
+                                        loading="lazy"
+                                    />
+                                {:else}
+                                    <div
+                                        class="text-muted-foreground flex h-full w-full items-center justify-center"
+                                    >
+                                        <Gift class="h-12 w-12 opacity-30" />
+                                    </div>
+                                {/if}
+
+                                <!-- 상태 뱃지 -->
+                                <div class="absolute right-2 top-2">
+                                    <span
+                                        class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold {status.class}"
+                                    >
+                                        <Clock class="h-3 w-3" />
+                                        종료
+                                    </span>
+                                </div>
+
+                                <!-- 참여 인원 뱃지 -->
+                                {#if post.bid_count && post.bid_count > 0}
+                                    <div class="absolute left-2 top-2">
+                                        <span
+                                            class="inline-flex items-center gap-1 rounded-full bg-black/70 px-2 py-0.5 text-xs font-semibold text-white"
+                                        >
+                                            <Users class="h-3 w-3" />
+                                            {post.bid_count.toLocaleString()}명
+                                        </span>
+                                    </div>
+                                {/if}
+                            </div>
+
+                            <!-- 콘텐츠 -->
+                            <div class="flex flex-1 flex-col p-3">
+                                <h4 class="text-foreground line-clamp-2 text-sm font-medium">
+                                    {post.title}
+                                </h4>
+                                {#if post.comment_count}
+                                    <span class="text-primary ml-1 text-xs"
+                                        >+{post.comment_count}</span
+                                    >
+                                {/if}
+
+                                <!-- 작성자 -->
+                                {#if post.author}
+                                    <div class="mt-auto flex items-center gap-2 pt-2">
+                                        {#if post.author.avatar_url}
+                                            <img
+                                                src={post.author.avatar_url}
+                                                alt=""
+                                                class="h-5 w-5 rounded-full object-cover"
+                                            />
+                                        {/if}
+                                        <span class="text-muted-foreground truncate text-xs">
+                                            {post.author.nickname ?? post.author.id}
+                                        </span>
+                                    </div>
+                                {/if}
+                            </div>
+                        </a>
+                    {/each}
+                </div>
+            {/if}
+        </Tabs.Content>
+    </Tabs.Root>
+</Card>

--- a/widgets/post-list/layouts/message-view.svelte
+++ b/widgets/post-list/layouts/message-view.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+    /**
+     * 축하 메시지 카드 레이아웃
+     *
+     * 회원 축하/기념 게시글을 카드 형태로 표시합니다.
+     * - 그라데이션 헤더 (회원 아이디 기반 일관된 색상)
+     * - 무지개 테두리 회전 애니메이션 아바타
+     * - 배너 이미지 오버레이
+     *
+     * Design System: "Soft Modern" - 부드러운 카드, 호버 리프트 효과
+     */
+    import { Card } from '$lib/components/ui/card';
+    import User from '@lucide/svelte/icons/user';
+    import Heart from '@lucide/svelte/icons/heart';
+    import ExternalLink from '@lucide/svelte/icons/external-link';
+
+    interface MessagePost {
+        id: number;
+        title: string;
+        url?: string;
+        thumbnail_url?: string;
+        author?: {
+            id?: string;
+            nickname?: string;
+            avatar_url?: string;
+            profile_url?: string;
+        };
+        external_link?: string;
+        created_at?: string;
+    }
+
+    let {
+        posts = [],
+        showTitle = true,
+        boardId = ''
+    }: {
+        posts: MessagePost[];
+        showTitle?: boolean;
+        boardId?: string;
+    } = $props();
+
+    // 회원 아이디 기반 그라데이션 번호 (1-5, 일관된 색상)
+    function getGradientNumber(memberId?: string): number {
+        if (!memberId) return Math.floor(Math.random() * 5) + 1;
+        let hash = 0;
+        for (let i = 0; i < memberId.length; i++) {
+            hash = (hash << 5) - hash + memberId.charCodeAt(i);
+            hash |= 0;
+        }
+        return (Math.abs(hash) % 5) + 1;
+    }
+
+    // 그라데이션 색상 매핑
+    const gradients: Record<number, { header: string; avatar: string }> = {
+        1: {
+            header: 'from-indigo-500 to-purple-600',
+            avatar: 'from-indigo-500 to-purple-600'
+        },
+        2: {
+            header: 'from-pink-400 to-rose-500',
+            avatar: 'from-pink-400 to-rose-500'
+        },
+        3: {
+            header: 'from-cyan-400 to-teal-500',
+            avatar: 'from-cyan-400 to-teal-500'
+        },
+        4: {
+            header: 'from-emerald-400 to-cyan-500',
+            avatar: 'from-emerald-400 to-cyan-500'
+        },
+        5: {
+            header: 'from-rose-400 to-amber-400',
+            avatar: 'from-rose-400 to-amber-400'
+        }
+    };
+</script>
+
+<Card class="gap-0 overflow-hidden">
+    {#if showTitle}
+        <div class="border-border flex items-center gap-2 border-b px-4 py-2.5">
+            <Heart class="h-4 w-4 text-rose-500" />
+            <h3 class="text-sm font-semibold">축하 메시지</h3>
+        </div>
+    {/if}
+
+    {#if posts.length === 0}
+        <!-- 빈 상태: "Inviting Spaces" -->
+        <div class="flex flex-col items-center justify-center py-12 text-center">
+            <div
+                class="mb-4 bg-gradient-to-br from-indigo-500 to-purple-600 bg-clip-text text-5xl text-transparent"
+            >
+                <Heart class="h-12 w-12" />
+            </div>
+            <p class="text-foreground text-lg font-semibold">아직 축하 메시지가 없습니다</p>
+            <p class="text-muted-foreground mt-1 text-sm">첫 번째 축하 메시지를 남겨보세요!</p>
+        </div>
+    {:else}
+        <div class="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+            {#each posts as post (post.id)}
+                {@const gradNum = getGradientNumber(post.author?.id)}
+                {@const grad = gradients[gradNum]}
+                <div
+                    class="border-border bg-background group flex h-full flex-col overflow-hidden rounded-2xl border shadow-sm transition-all duration-200 ease-out hover:-translate-y-1 hover:shadow-lg"
+                >
+                    <!-- 상단 헤더: 그라데이션 + 닉네임 -->
+                    <div
+                        class="flex items-center gap-2 bg-gradient-to-r px-3 py-2 text-white {grad.header}"
+                    >
+                        <Heart class="h-4 w-4" />
+                        <span class="text-sm font-bold drop-shadow-md">
+                            {post.author?.nickname ?? '축하합니다'}
+                            {post.author?.nickname ? '님' : ''}
+                        </span>
+                        {#if post.external_link}
+                            <a
+                                href={post.external_link}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="ml-auto flex items-center gap-1 rounded-full bg-white/20 px-2 py-0.5 text-xs transition-colors hover:bg-white/30"
+                            >
+                                <ExternalLink class="h-3 w-3" />
+                                바로가기
+                            </a>
+                        {/if}
+                    </div>
+
+                    <!-- 본문: 프로필 + 배너 -->
+                    <div class="relative flex min-h-[70px] flex-1">
+                        <!-- 프로필 아바타 (왼쪽 중앙) -->
+                        <div class="absolute left-3 top-1/2 z-10 -translate-y-1/2">
+                            {#if post.author?.profile_url}
+                                <a
+                                    href={post.author.profile_url}
+                                    class="block transition-transform duration-200 hover:scale-110"
+                                >
+                                    {#if post.author?.avatar_url}
+                                        <img
+                                            src={post.author.avatar_url}
+                                            alt=""
+                                            class="rainbow-border h-14 w-14 rounded-full border-[3px] border-transparent object-cover shadow-lg"
+                                            loading="lazy"
+                                        />
+                                    {:else}
+                                        <div
+                                            class="flex h-14 w-14 items-center justify-center rounded-full border-[3px] border-white/50 bg-gradient-to-br text-white shadow-lg {grad.avatar}"
+                                        >
+                                            <User class="h-6 w-6" />
+                                        </div>
+                                    {/if}
+                                </a>
+                            {:else if post.author?.avatar_url}
+                                <img
+                                    src={post.author.avatar_url}
+                                    alt=""
+                                    class="rainbow-border h-14 w-14 rounded-full border-[3px] border-transparent object-cover shadow-lg"
+                                    loading="lazy"
+                                />
+                            {:else}
+                                <div
+                                    class="flex h-14 w-14 items-center justify-center rounded-full border-[3px] border-white/50 bg-gradient-to-br text-white shadow-lg {grad.avatar}"
+                                >
+                                    <User class="h-6 w-6" />
+                                </div>
+                            {/if}
+                        </div>
+
+                        <!-- 배너 이미지 or 텍스트 영역 -->
+                        {#if post.thumbnail_url}
+                            <a href={post.url ?? '#'} class="block w-full overflow-hidden">
+                                <div class="relative h-full w-full">
+                                    <img
+                                        src={post.thumbnail_url}
+                                        alt={post.title}
+                                        class="h-full min-h-[70px] w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                                        loading="lazy"
+                                    />
+                                    <!-- 오버레이 -->
+                                    <div
+                                        class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-3 py-2 pl-20"
+                                    >
+                                        <p
+                                            class="line-clamp-2 text-sm font-semibold text-white drop-shadow-md"
+                                        >
+                                            {post.title}
+                                        </p>
+                                    </div>
+                                </div>
+                            </a>
+                        {:else}
+                            <a
+                                href={post.url ?? '#'}
+                                class="bg-muted flex w-full flex-col justify-center py-4 pl-20 pr-4"
+                            >
+                                <p class="text-foreground line-clamp-2 text-sm font-semibold">
+                                    {post.title}
+                                </p>
+                            </a>
+                        {/if}
+                    </div>
+                </div>
+            {/each}
+        </div>
+    {/if}
+</Card>
+
+<style>
+    /* 무지개 테두리 회전 애니메이션 */
+    @property --border-angle {
+        syntax: '<angle>';
+        initial-value: 0deg;
+        inherits: false;
+    }
+
+    @keyframes rainbow-rotate {
+        from {
+            --border-angle: 0deg;
+        }
+        to {
+            --border-angle: 360deg;
+        }
+    }
+
+    .rainbow-border {
+        --border-angle: 0deg;
+        background:
+            linear-gradient(white, white) padding-box,
+            conic-gradient(
+                    from var(--border-angle),
+                    #ff0000,
+                    #ff8000,
+                    #ffff00,
+                    #80ff00,
+                    #00ff80,
+                    #00ffff,
+                    #0080ff,
+                    #8000ff,
+                    #ff00ff,
+                    #ff0000
+                )
+                border-box;
+        animation: rainbow-rotate 3s linear infinite;
+    }
+
+    :global(.dark) .rainbow-border {
+        background:
+            linear-gradient(#1f2937, #1f2937) padding-box,
+            conic-gradient(
+                    from var(--border-angle),
+                    #ff0000,
+                    #ff8000,
+                    #ffff00,
+                    #80ff00,
+                    #00ff80,
+                    #00ffff,
+                    #0080ff,
+                    #8000ff,
+                    #ff00ff,
+                    #ff0000
+                )
+                border-box;
+    }
+</style>

--- a/widgets/post-list/layouts/trade-view.svelte
+++ b/widgets/post-list/layouts/trade-view.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+    /**
+     * 거래 게시판 레이아웃
+     *
+     * 중고거래/판매 게시글을 카드 형태로 표시합니다.
+     * - 가격 표시 (원가, 할인가)
+     * - 거래 상태 (판매중, 예약중, 판매완료)
+     * - 거래 방식 (직거래, 택배)
+     * - 지역 정보
+     * - 찜/좋아요 카운트
+     *
+     * Design System: "Soft Modern" - 깔끔한 상품 카드, 가격 강조
+     */
+    import { Card } from '$lib/components/ui/card';
+    import { Badge } from '$lib/components/ui/badge';
+    import ShoppingBag from '@lucide/svelte/icons/shopping-bag';
+    import MapPin from '@lucide/svelte/icons/map-pin';
+    import Heart from '@lucide/svelte/icons/heart';
+    import Truck from '@lucide/svelte/icons/truck';
+    import UserCircle from '@lucide/svelte/icons/user-circle';
+    import Clock from '@lucide/svelte/icons/clock';
+    import CheckCircle from '@lucide/svelte/icons/check-circle';
+    import Tag from '@lucide/svelte/icons/tag';
+
+    interface TradePost {
+        id: number;
+        title: string;
+        url?: string;
+        thumbnail_url?: string;
+        author?: {
+            id?: string;
+            nickname?: string;
+            avatar_url?: string;
+        };
+        price?: number;
+        original_price?: number;
+        status?: 'selling' | 'reserved' | 'sold';
+        trade_type?: 'direct' | 'shipping' | 'both';
+        location?: string;
+        like_count?: number;
+        view_count?: number;
+        comment_count?: number;
+        created_at?: string;
+        is_free?: boolean;
+        is_negotiable?: boolean;
+    }
+
+    let {
+        posts = [],
+        showTitle = true,
+        boardId = ''
+    }: {
+        posts: TradePost[];
+        showTitle?: boolean;
+        boardId?: string;
+    } = $props();
+
+    // 거래 상태 스타일
+    const statusStyles: Record<string, { text: string; class: string; icon: typeof Tag }> = {
+        selling: {
+            text: '판매중',
+            class: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400',
+            icon: Tag
+        },
+        reserved: {
+            text: '예약중',
+            class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400',
+            icon: Clock
+        },
+        sold: {
+            text: '판매완료',
+            class: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+            icon: CheckCircle
+        }
+    };
+
+    // 거래 방식 텍스트
+    const tradeTypeLabels: Record<string, string> = {
+        direct: '직거래',
+        shipping: '택배',
+        both: '직거래/택배'
+    };
+
+    // 가격 포맷
+    function formatPrice(price?: number): string {
+        if (price === undefined || price === null) return '';
+        if (price === 0) return '무료나눔';
+        return price.toLocaleString() + '원';
+    }
+
+    // 날짜 포맷
+    function formatDate(dateStr?: string): string {
+        if (!dateStr) return '';
+        const date = new Date(dateStr);
+        const now = new Date();
+        const diffMs = now.getTime() - date.getTime();
+        const diffM = Math.floor(diffMs / (1000 * 60));
+        const diffH = Math.floor(diffMs / (1000 * 60 * 60));
+        const diffD = Math.floor(diffH / 24);
+
+        if (diffM < 1) return '방금 전';
+        if (diffM < 60) return `${diffM}분 전`;
+        if (diffH < 24) return `${diffH}시간 전`;
+        if (diffD < 7) return `${diffD}일 전`;
+        return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+    }
+
+    // 할인율 계산
+    function getDiscountPercent(original?: number, current?: number): number | null {
+        if (!original || !current || original <= current) return null;
+        return Math.round(((original - current) / original) * 100);
+    }
+
+    // 상태별 분류
+    const sellingPosts = $derived(
+        posts.filter((p) => !p.status || p.status === 'selling' || p.status === 'reserved')
+    );
+    const soldPosts = $derived(posts.filter((p) => p.status === 'sold'));
+</script>
+
+<Card class="gap-0 overflow-hidden">
+    {#if showTitle}
+        <div class="border-border flex items-center justify-between border-b px-4 py-2.5">
+            <div class="flex items-center gap-2">
+                <ShoppingBag class="text-primary h-4 w-4" />
+                <h3 class="text-sm font-semibold">거래</h3>
+            </div>
+            <span class="text-muted-foreground text-xs">
+                {posts.length}개의 상품
+            </span>
+        </div>
+    {/if}
+
+    {#if posts.length === 0}
+        <!-- 빈 상태 -->
+        <div class="flex flex-col items-center justify-center py-12 text-center">
+            <ShoppingBag class="text-muted-foreground/40 mb-3 h-12 w-12" />
+            <p class="text-foreground text-lg font-medium">등록된 상품이 없습니다</p>
+            <p class="text-muted-foreground mt-1 text-sm">첫 번째 상품을 등록해보세요!</p>
+        </div>
+    {:else}
+        <div class="p-4">
+            <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                {#each posts as post (post.id)}
+                    {@const status = statusStyles[post.status ?? 'selling']}
+                    {@const discount = getDiscountPercent(post.original_price, post.price)}
+                    {@const isSold = post.status === 'sold'}
+                    <a
+                        href={post.url ?? '#'}
+                        class="border-border bg-background group flex flex-col overflow-hidden rounded-xl border shadow-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md {isSold
+                            ? 'opacity-60'
+                            : ''}"
+                    >
+                        <!-- 썸네일 -->
+                        <div class="bg-muted relative aspect-square overflow-hidden">
+                            {#if post.thumbnail_url}
+                                <img
+                                    src={post.thumbnail_url}
+                                    alt={post.title}
+                                    class="h-full w-full object-cover transition-transform duration-300 {isSold
+                                        ? 'grayscale'
+                                        : 'group-hover:scale-105'}"
+                                    loading="lazy"
+                                />
+                            {:else}
+                                <div
+                                    class="text-muted-foreground flex h-full w-full items-center justify-center"
+                                >
+                                    <ShoppingBag class="h-16 w-16 opacity-20" />
+                                </div>
+                            {/if}
+
+                            <!-- 상태 뱃지 (판매중이 아닌 경우만) -->
+                            {#if post.status && post.status !== 'selling'}
+                                <div class="absolute left-2 top-2">
+                                    <span
+                                        class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold {status.class}"
+                                    >
+                                        <svelte:component this={status.icon} class="h-3 w-3" />
+                                        {status.text}
+                                    </span>
+                                </div>
+                            {/if}
+
+                            <!-- 할인율 뱃지 -->
+                            {#if discount && !isSold}
+                                <div class="absolute right-2 top-2">
+                                    <span
+                                        class="rounded-full bg-red-500 px-2 py-0.5 text-xs font-bold text-white"
+                                    >
+                                        {discount}%
+                                    </span>
+                                </div>
+                            {/if}
+
+                            <!-- 찜 아이콘 (호버시) -->
+                            <div
+                                class="absolute bottom-2 right-2 opacity-0 transition-opacity group-hover:opacity-100"
+                            >
+                                <button
+                                    type="button"
+                                    class="text-muted-foreground flex h-8 w-8 items-center justify-center rounded-full bg-white/90 shadow-sm transition-colors hover:text-rose-500 dark:bg-gray-800/90"
+                                    onclick={(e) => e.preventDefault()}
+                                >
+                                    <Heart class="h-4 w-4" />
+                                </button>
+                            </div>
+                        </div>
+
+                        <!-- 콘텐츠 -->
+                        <div class="flex flex-1 flex-col p-3">
+                            <!-- 제목 -->
+                            <h4
+                                class="text-foreground line-clamp-2 text-sm font-medium leading-snug"
+                            >
+                                {post.title}
+                            </h4>
+
+                            <!-- 가격 -->
+                            <div class="mt-2">
+                                {#if post.is_free || post.price === 0}
+                                    <span class="text-base font-bold text-emerald-600"
+                                        >무료나눔</span
+                                    >
+                                {:else}
+                                    <div class="flex flex-wrap items-baseline gap-1">
+                                        <span class="text-foreground text-base font-bold">
+                                            {formatPrice(post.price)}
+                                        </span>
+                                        {#if post.original_price && post.original_price > (post.price ?? 0)}
+                                            <span
+                                                class="text-muted-foreground text-xs line-through"
+                                            >
+                                                {formatPrice(post.original_price)}
+                                            </span>
+                                        {/if}
+                                    </div>
+                                    {#if post.is_negotiable}
+                                        <span class="text-muted-foreground text-xs"
+                                            >가격제안 가능</span
+                                        >
+                                    {/if}
+                                {/if}
+                            </div>
+
+                            <!-- 메타 정보 -->
+                            <div
+                                class="text-muted-foreground mt-auto flex flex-wrap items-center gap-1.5 pt-2 text-xs"
+                            >
+                                {#if post.location}
+                                    <span class="inline-flex items-center gap-0.5">
+                                        <MapPin class="h-3 w-3" />
+                                        {post.location}
+                                    </span>
+                                {/if}
+                                {#if post.trade_type}
+                                    <span class="inline-flex items-center gap-0.5">
+                                        {#if post.trade_type === 'shipping' || post.trade_type === 'both'}
+                                            <Truck class="h-3 w-3" />
+                                        {:else}
+                                            <UserCircle class="h-3 w-3" />
+                                        {/if}
+                                        {tradeTypeLabels[post.trade_type]}
+                                    </span>
+                                {/if}
+                            </div>
+
+                            <!-- 하단: 찜/시간 -->
+                            <div
+                                class="border-border text-muted-foreground mt-2 flex items-center justify-between border-t pt-2 text-xs"
+                            >
+                                <div class="flex items-center gap-2">
+                                    {#if post.like_count}
+                                        <span class="inline-flex items-center gap-0.5">
+                                            <Heart class="h-3 w-3" />
+                                            {post.like_count}
+                                        </span>
+                                    {/if}
+                                    {#if post.comment_count}
+                                        <span>댓글 {post.comment_count}</span>
+                                    {/if}
+                                </div>
+                                {#if post.created_at}
+                                    <span>{formatDate(post.created_at)}</span>
+                                {/if}
+                            </div>
+                        </div>
+                    </a>
+                {/each}
+            </div>
+        </div>
+    {/if}
+</Card>


### PR DESCRIPTION
## Summary
- 나눔 게시판 전용 레이아웃 (카운트다운, 응모수, 상태 뱃지)
- 축하 메시지 카드 레이아웃 (그라데이션 헤더, 무지개 아바타)
- 중고거래 게시판 레이아웃 (가격, 상태, 거래방식)
- 위젯용 레이아웃 뷰 추가

## Test plan
- [ ] dev.damoang.net에서 각 레이아웃 확인
- [ ] 위젯에서 레이아웃 적용 확인