### PR TITLE
fix: default-layout 상단 위젯 제거

### DIFF
--- a/apps/web/src/lib/layouts/default-layout.svelte
+++ b/apps/web/src/lib/layouts/default-layout.svelte
@@ -9,9 +9,6 @@
     import LeftBanner from '$lib/components/layout/left-banner.svelte';
     import RightBanner from '$lib/components/layout/right-banner.svelte';
     import { authActions } from '$lib/stores/auth.svelte';
-    import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
-    import { DamoangBanner } from '$lib/components/ui/damoang-banner';
-    import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
 
     /**
      * 기본 레이아웃 컴포넌트
@@ -43,17 +40,6 @@
 
     <div class="container relative z-10 flex w-full flex-1 flex-col">
         <Header />
-
-        <!-- 헤더 아래 광고 (축하이미지 → 다모앙광고 → GAM 폴백) -->
-        {#if widgetLayoutStore.hasEnabledAds}
-            <div class="mx-auto w-full px-4 py-2 lg:px-0">
-                <DamoangBanner position="index" height="90px" />
-            </div>
-
-            <div class="mx-auto w-full px-4 py-2 lg:px-0">
-                <AdSlot position="index-head" height="90px" />
-            </div>
-        {/if}
 
         <div class="mx-auto flex w-full flex-1">
             {#if snbPosition === 'right'}


### PR DESCRIPTION
## Summary
- default-layout.svelte에서 상단 위젯 (DamoangBanner, AdSlot) 제거
- 테마 레이아웃과 fallback 레이아웃의 일관성 확보

## 문제
- 운영 환경에서 테마 로드 실패 시 DefaultLayout 사용
- DefaultLayout에만 상단 위젯이 있어 의도치 않게 표시됨

## 해결
- DefaultLayout에서 상단 위젯 코드 완전 제거
- 테마 로드 여부와 관계없이 동일한 동작 보장