### PR TITLE
fix: exclude .server.ts from plugin glob

### DIFF
--- a/apps/web/src/lib/utils/plugin-optional-loader.ts
+++ b/apps/web/src/lib/utils/plugin-optional-loader.ts
@@ -9,10 +9,12 @@ import type { Component } from 'svelte';
 
 // Glob all plugin components (lazy, not eager)
 const pluginComponents = import.meta.glob('../../../../../plugins/*/components/*.svelte');
+// Note: Exclude .server.ts files from glob to prevent server-only code from being bundled for client
 const pluginLibs = import.meta.glob([
     '../../../../../plugins/*/lib/*.svelte',
     '../../../../../plugins/*/lib/*.svelte.ts',
-    '../../../../../plugins/*/lib/*.ts'
+    '../../../../../plugins/*/lib/*.ts',
+    '!../../../../../plugins/*/lib/*.server.ts'
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Plugin loader now excludes `.server.ts` files from client-side bundles
- Fixes build error: "Cannot import $env/dynamic/private into code that runs in the browser"

## Test plan
- Build should succeed without import errors
- Deployment workflow should complete successfully