### PR TITLE
fix: 광고 서버 URL 환경변수화 및 긴급 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -15,7 +15,7 @@
     import DOMPurify from 'dompurify';
     import { applyFilter } from '$lib/hooks/registry';
     import { getHookVersion } from '$lib/hooks/hook-state.svelte';
-    import { getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon.js';
     import { SvelteMap, SvelteSet } from 'svelte/reactivity';
     import type { Component } from 'svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';

--- a/apps/web/src/lib/components/layout/user-widget.svelte
+++ b/apps/web/src/lib/components/layout/user-widget.svelte
@@ -9,7 +9,7 @@
     import Coins from '@lucide/svelte/icons/coins';
     import Star from '@lucide/svelte/icons/star';
     import { getUser, getIsLoggedIn, getIsLoading, authActions } from '$lib/stores/auth.svelte';
-    import { getMemberIconUrl } from '$lib/utils/member-icon';
+    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon';
 
     let isLoggingOut = $state(false);
 
@@ -64,8 +64,8 @@
         user?.as_max !== undefined && user.mb_exp !== undefined ? user.as_max - user.mb_exp : 0
     );
 
-    // 아바타 URL (mb_image 우선, 없으면 member_image 경로로 생성)
-    let avatarUrl = $derived(user?.mb_image || getMemberIconUrl(user?.mb_id) || null);
+    // 아바타 URL (mb_image 우선 → avatar_url → member_image 경로 폴백)
+    let avatarUrl = $derived(getAvatarUrl(user?.mb_image) || getMemberIconUrl(user?.mb_id) || null);
     let avatarFailed = $state(false);
 
     // user 변경 시 실패 상태 리셋

--- a/apps/web/src/lib/server/ads/promotion.ts
+++ b/apps/web/src/lib/server/ads/promotion.ts
@@ -1,12 +1,13 @@
 /**
  * 직접홍보 광고 데이터 fetcher (인메모리 캐시)
  *
- * ads 서버(localhost:9090)에서 프로모션 게시글을 직접 가져옵니다.
+ * ads 서버에서 프로모션 게시글을 직접 가져옵니다.
  * SvelteKit self-call 프록시를 거치지 않아 hooks.server.ts 재진입을 방지합니다.
  * 30초 TTL 인메모리 캐시로 반복 호출을 최소화합니다.
  */
+import { env } from '$env/dynamic/private';
 
-const ADS_SERVER_URL = 'http://localhost:9090';
+const ADS_SERVER_URL = env.ADS_SERVER_URL || 'http://localhost:9090';
 const PROMOTION_CACHE_TTL = 30_000; // 30초
 
 let promotionCache: { data: unknown; expiresAt: number } | null = null;

--- a/apps/web/src/lib/utils/member-icon.ts
+++ b/apps/web/src/lib/utils/member-icon.ts
@@ -1,12 +1,31 @@
 /**
  * 회원 아이콘 URL 생성 유틸리티
- * 그누보드 회원 아이콘 경로: /data/member_image/{mb_id 앞 2글자}/{mb_id}.gif
+ * 1순위: API에서 받은 avatar_url (mb_image_url)
+ * 2순위: S3 경로 기반 폴백 (data/member_image/{prefix}/{mb_id}.gif)
  */
 
+const CDN_BASE_URL = 'https://s3.damoang.net';
 const LEGACY_BASE_URL = 'https://damoang.net';
 
 /**
- * 회원 ID로 아이콘 URL 생성
+ * avatar_url 또는 mb_image_url로 전체 URL 생성
+ * @param avatarUrl API에서 받은 avatar_url (예: data/member_image/ad/admin_1760156943.webp)
+ * @returns 전체 URL 또는 null
+ */
+export function getAvatarUrl(avatarUrl: string | null | undefined): string | null {
+    if (!avatarUrl) return null;
+
+    // 이미 전체 URL이면 그대로 반환
+    if (avatarUrl.startsWith('http://') || avatarUrl.startsWith('https://')) {
+        return avatarUrl;
+    }
+
+    // 상대 경로면 CDN 베이스 추가
+    return `${CDN_BASE_URL}/${avatarUrl}`;
+}
+
+/**
+ * 회원 ID로 아이콘 URL 생성 (폴백용)
  * @param mbId 회원 ID (예: google_78ca0772, naver_889808c8)
  * @returns 아이콘 URL 또는 null
  */

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -108,10 +108,10 @@ export const load: PageServerLoad = async ({ params, fetch: svelteKitFetch, loca
 
         const post = postResult.value;
 
-        // 삭제된 게시글 처리 (410 Gone - SEO 최적화)
-        // Google은 410을 받으면 해당 URL을 인덱스에서 더 빠르게 제거함
+        // 삭제된 게시글: 에러 대신 데이터 전달 (PHP 호환: "삭제된 게시물입니다" 표시)
+        // 본문 내용은 제거하고 삭제 상태만 전달
         if (post.deleted_at) {
-            throw error(410, '삭제된 게시글입니다.');
+            post.content = '';
         }
         let board = boardResult.status === 'fulfilled' ? boardResult.value : null;
 

--- a/apps/web/src/routes/api/ads/banners/+server.ts
+++ b/apps/web/src/routes/api/ads/banners/+server.ts
@@ -1,5 +1,8 @@
 import { json } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
+
+const ADS_SERVER_URL = env.ADS_SERVER_URL || 'http://localhost:9090';
 
 // GET /api/ads/banners?position=board-head&limit=1
 // ads.damoang.net 프록시 (Cloudflare 우회)
@@ -9,7 +12,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
     try {
         const response = await fetch(
-            `http://localhost:9090/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
+            `${ADS_SERVER_URL}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
         );
         if (!response.ok) {
             return json({ success: false, data: { banners: [], count: 0 } });

--- a/apps/web/src/routes/api/ads/promotion-posts/+server.ts
+++ b/apps/web/src/routes/api/ads/promotion-posts/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
+
+const ADS_SERVER_URL = env.ADS_SERVER_URL || 'http://localhost:9090';
 
 // GET /api/ads/promotion-posts
 // damoang-ads 서버 프록시 (직접홍보 게시글)
 export const GET: RequestHandler = async () => {
     try {
-        const response = await fetch('http://localhost:9090/api/v1/serve/promotion-posts');
+        const response = await fetch(`${ADS_SERVER_URL}/api/v1/serve/promotion-posts`);
         if (!response.ok) {
             return json({ success: false, data: { posts: [], count: 0 } });
         }


### PR DESCRIPTION
## Summary
- ads API: `localhost:9090` 하드코딩 → `ADS_SERVER_URL` 환경변수 (prod K8s 서비스 디스커버리)
- member-icon: `getAvatarUrl()` 추가 (CDN URL 기반 아바타 지원)  
- user-widget: `getAvatarUrl` 우선 사용
- 삭제된 게시글: 410 에러 대신 데이터 전달 (PHP 호환 "삭제된 게시물입니다" 표시)

## 긴급 사유
- 운영 환경에서 b2b 이미지+텍스트 배너 광고가 안 보임 (매출 직결)
- 원인: SvelteKit pod에서 `localhost:9090`으로 ads 서버 접근 불가 (다른 namespace)
- ConfigMap에 `ADS_SERVER_URL=http://ads-server-svc.damoang.svc.cluster.local:9090` 이미 추가 완료

## Test plan
- [x] Dev 환경에서 `/api/ads/banners` 정상 응답 확인
- [x] `pnpm build` 성공
- [ ] Prod 배포 후 광고 표시 확인
- [ ] 프로필 이미지 표시 확인 (Backend 배포 필요)
- [ ] 삭제된 게시글 접근 시 "삭제된 게시물입니다" 표시 확인 (Backend 배포 필요)