### PR TITLE
fix: ADS_SERVER_URL 런타임 환경변수 + 본문 폰트 증가

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -15,7 +15,12 @@
         showLinkWarning?: boolean;
     }
 
-    let { content, class: className = '', enableEmbed = true, showLinkWarning = true }: Props = $props();
+    let {
+        content,
+        class: className = '',
+        enableEmbed = true,
+        showLinkWarning = true
+    }: Props = $props();
 
     /**
      * URL에서 도메인 추출 (프로토콜, www, 경로 제거)
@@ -223,7 +228,7 @@
     });
 </script>
 
-<div class="prose prose-neutral dark:prose-invert max-w-none {className}">
+<div class="prose prose-neutral dark:prose-invert max-w-none text-base {className}">
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html renderedHtml}
 </div>
@@ -254,7 +259,8 @@
     .prose :global(p) {
         margin-top: 0.75rem;
         margin-bottom: 0.75rem;
-        line-height: 1.75;
+        font-size: 1rem;
+        line-height: 1.8;
     }
 
     .prose :global(ul),

--- a/apps/web/src/lib/server/ads/promotion.ts
+++ b/apps/web/src/lib/server/ads/promotion.ts
@@ -5,10 +5,12 @@
  * SvelteKit self-call 프록시를 거치지 않아 hooks.server.ts 재진입을 방지합니다.
  * 30초 TTL 인메모리 캐시로 반복 호출을 최소화합니다.
  */
-import { env } from '$env/dynamic/private';
 
-const ADS_SERVER_URL = env.ADS_SERVER_URL || 'http://localhost:9090';
 const PROMOTION_CACHE_TTL = 30_000; // 30초
+
+function getAdsServerUrl(): string {
+    return process.env.ADS_SERVER_URL || 'http://localhost:9090';
+}
 
 let promotionCache: { data: unknown; expiresAt: number } | null = null;
 
@@ -20,7 +22,7 @@ export async function fetchPromotionPosts(): Promise<unknown> {
         return promotionCache.data;
     }
     try {
-        const res = await fetch(`${ADS_SERVER_URL}/api/v1/serve/promotion-posts`);
+        const res = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-posts`);
         if (!res.ok) return EMPTY_RESPONSE;
         const data = await res.json();
         promotionCache = { data, expiresAt: now + PROMOTION_CACHE_TTL };

--- a/apps/web/src/routes/api/ads/banners/+server.ts
+++ b/apps/web/src/routes/api/ads/banners/+server.ts
@@ -1,8 +1,9 @@
 import { json } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 
-const ADS_SERVER_URL = env.ADS_SERVER_URL || 'http://localhost:9090';
+function getAdsServerUrl(): string {
+    return process.env.ADS_SERVER_URL || 'http://localhost:9090';
+}
 
 // GET /api/ads/banners?position=board-head&limit=1
 // ads.damoang.net 프록시 (Cloudflare 우회)
@@ -12,7 +13,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
     try {
         const response = await fetch(
-            `${ADS_SERVER_URL}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
+            `${getAdsServerUrl()}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
         );
         if (!response.ok) {
             return json({ success: false, data: { banners: [], count: 0 } });

--- a/apps/web/src/routes/api/ads/promotion-posts/+server.ts
+++ b/apps/web/src/routes/api/ads/promotion-posts/+server.ts
@@ -1,14 +1,15 @@
 import { json } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
 
-const ADS_SERVER_URL = env.ADS_SERVER_URL || 'http://localhost:9090';
+function getAdsServerUrl(): string {
+    return process.env.ADS_SERVER_URL || 'http://localhost:9090';
+}
 
 // GET /api/ads/promotion-posts
 // damoang-ads 서버 프록시 (직접홍보 게시글)
 export const GET: RequestHandler = async () => {
     try {
-        const response = await fetch(`${ADS_SERVER_URL}/api/v1/serve/promotion-posts`);
+        const response = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-posts`);
         if (!response.ok) {
             return json({ success: false, data: { posts: [], count: 0 } });
         }


### PR DESCRIPTION
## Summary
- `$env/dynamic/private` → `process.env` 직접 사용하여 빌드 시 하드코딩 문제 해결
- 함수 내부에서 `process.env.ADS_SERVER_URL` 읽기로 변경 (모듈 레벨 초기화 문제 방지)
- 본문 Markdown: `text-base` (16px) + `line-height: 1.8` 적용으로 가독성 개선

## 근본 원인
`$env/dynamic/private`를 모듈 최상위에서 사용하면 Vite 빌드 시 상수로 치환됨.
`process.env`를 함수 내에서 호출하면 Node.js 런타임에 실제 환경변수 값을 읽음.

## Test plan
- [x] `pnpm build` 성공
- [x] 빌드 결과에 `process.env.ADS_SERVER_URL` 확인 (하드코딩 아님)
- [ ] Prod 배포 후 광고 배너 표시 확인