### PR TITLE
fix: ads API 런타임 환경변수 (SvelteKit 모범사례)

### DIFF
--- a/apps/web/src/lib/server/ads/promotion.ts
+++ b/apps/web/src/lib/server/ads/promotion.ts
@@ -6,10 +6,12 @@
  * 30초 TTL 인메모리 캐시로 반복 호출을 최소화합니다.
  */
 
+import { env } from '$env/dynamic/private';
+
 const PROMOTION_CACHE_TTL = 30_000; // 30초
 
 function getAdsServerUrl(): string {
-    return process.env.ADS_SERVER_URL || 'http://localhost:9090';
+    return env.ADS_SERVER_URL || 'http://localhost:9090';
 }
 
 let promotionCache: { data: unknown; expiresAt: number } | null = null;

--- a/apps/web/src/routes/api/ads/banners/+server.ts
+++ b/apps/web/src/routes/api/ads/banners/+server.ts
@@ -1,19 +1,17 @@
 import { json } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
-
-function getAdsServerUrl(): string {
-    return process.env.ADS_SERVER_URL || 'http://localhost:9090';
-}
 
 // GET /api/ads/banners?position=board-head&limit=1
 // ads.damoang.net 프록시 (Cloudflare 우회)
 export const GET: RequestHandler = async ({ url }) => {
+    const adsServerUrl = env.ADS_SERVER_URL || 'http://localhost:9090';
     const position = url.searchParams.get('position') || '';
     const limit = url.searchParams.get('limit') || '1';
 
     try {
         const response = await fetch(
-            `${getAdsServerUrl()}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
+            `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
         );
         if (!response.ok) {
             return json({ success: false, data: { banners: [], count: 0 } });

--- a/apps/web/src/routes/api/ads/promotion-posts/+server.ts
+++ b/apps/web/src/routes/api/ads/promotion-posts/+server.ts
@@ -1,15 +1,13 @@
 import { json } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import type { RequestHandler } from './$types';
-
-function getAdsServerUrl(): string {
-    return process.env.ADS_SERVER_URL || 'http://localhost:9090';
-}
 
 // GET /api/ads/promotion-posts
 // damoang-ads 서버 프록시 (직접홍보 게시글)
 export const GET: RequestHandler = async () => {
+    const adsServerUrl = env.ADS_SERVER_URL || 'http://localhost:9090';
     try {
-        const response = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-posts`);
+        const response = await fetch(`${adsServerUrl}/api/v1/serve/promotion-posts`);
         if (!response.ok) {
             return json({ success: false, data: { posts: [], count: 0 } });
         }


### PR DESCRIPTION
## Summary
- `process.env` → `$env/dynamic/private` (SvelteKit 공식 모범사례)
- 핸들러 함수 내부에서 `env.ADS_SERVER_URL` 접근 (모듈 레벨 초기화 ❌)
- 빌드 결과: `private_env.ADS_SERVER_URL || "http://localhost:9090"` (런타임 참조)

## 근본 원인
- `process.env.X`는 Vite 빌드 시 `undefined`로 치환 → fallback 값으로 하드코딩됨
- `$env/dynamic/private`는 SvelteKit이 런타임에 `process.env`를 읽는 프록시 객체
- 모듈 최상위가 아닌 **함수 내부**에서 접근해야 런타임 동작 보장