### PR TITLE
fix: ads 서버 URL 공통 config 모듈 분리 (런타임 환경변수)

### DIFF
--- a/apps/web/src/lib/server/ads/config.ts
+++ b/apps/web/src/lib/server/ads/config.ts
@@ -1,0 +1,11 @@
+/**
+ * Ads 서버 설정
+ *
+ * 환경변수 ADS_SERVER_URL을 런타임에 읽습니다.
+ * SvelteKit의 $env/dynamic/private를 사용하여 빌드 시 하드코딩을 방지합니다.
+ */
+import { env } from '$env/dynamic/private';
+
+export function getAdsServerUrl(): string {
+    return env.ADS_SERVER_URL || 'http://localhost:9090';
+}

--- a/apps/web/src/lib/server/ads/promotion.ts
+++ b/apps/web/src/lib/server/ads/promotion.ts
@@ -6,13 +6,9 @@
  * 30초 TTL 인메모리 캐시로 반복 호출을 최소화합니다.
  */
 
-import { env } from '$env/dynamic/private';
+import { getAdsServerUrl } from './config';
 
 const PROMOTION_CACHE_TTL = 30_000; // 30초
-
-function getAdsServerUrl(): string {
-    return env.ADS_SERVER_URL || 'http://localhost:9090';
-}
 
 let promotionCache: { data: unknown; expiresAt: number } | null = null;
 

--- a/apps/web/src/routes/api/ads/banners/+server.ts
+++ b/apps/web/src/routes/api/ads/banners/+server.ts
@@ -1,11 +1,11 @@
 import { json } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
+import { getAdsServerUrl } from '$lib/server/ads/config';
 import type { RequestHandler } from './$types';
 
 // GET /api/ads/banners?position=board-head&limit=1
 // ads.damoang.net 프록시 (Cloudflare 우회)
 export const GET: RequestHandler = async ({ url }) => {
-    const adsServerUrl = env.ADS_SERVER_URL || 'http://localhost:9090';
+    const adsServerUrl = getAdsServerUrl();
     const position = url.searchParams.get('position') || '';
     const limit = url.searchParams.get('limit') || '1';
 

--- a/apps/web/src/routes/api/ads/promotion-posts/+server.ts
+++ b/apps/web/src/routes/api/ads/promotion-posts/+server.ts
@@ -1,11 +1,11 @@
 import { json } from '@sveltejs/kit';
-import { env } from '$env/dynamic/private';
+import { getAdsServerUrl } from '$lib/server/ads/config';
 import type { RequestHandler } from './$types';
 
 // GET /api/ads/promotion-posts
 // damoang-ads 서버 프록시 (직접홍보 게시글)
 export const GET: RequestHandler = async () => {
-    const adsServerUrl = env.ADS_SERVER_URL || 'http://localhost:9090';
+    const adsServerUrl = getAdsServerUrl();
     try {
         const response = await fetch(`${adsServerUrl}/api/v1/serve/promotion-posts`);
         if (!response.ok) {


### PR DESCRIPTION
빌드 결과: private_env.ADS_SERVER_URL (런타임 참조) 확인 완료. 공통 모듈로 분리하여 관리.