### PR TITLE
fix: 빌드 전 stale 캐시 삭제

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -69,7 +69,9 @@ jobs:
         env:
           VITE_GAM_NETWORK_CODE: '23338387889'
           VITE_GAM_SITE_NAME: 'damoang'
-        run: pnpm --filter web build
+        run: |
+          rm -rf apps/web/.svelte-kit apps/web/build
+          pnpm --filter web build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
빌드 전 .svelte-kit과 build 디렉토리를 삭제하여 이전 chunk가 재사용되는 문제 방지