### PR TITLE
fix: 배포 후 흰 화면 자동 복구

### DIFF
--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -12,9 +12,41 @@ function sendDantry(payload: Record<string, unknown>) {
     }).catch(() => {});
 }
 
+/**
+ * 배포 후 chunk 로드 실패 감지 및 자동 새로고침
+ * - 새 배포 시 이전 JS chunk 파일명이 변경되어 404 발생
+ * - 사용자에게 캐시 초기화를 요구하지 않고 자동으로 페이지 새로고침
+ */
+const RELOAD_KEY = '__angple_reload_attempt__';
+
+function isChunkLoadError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message.toLowerCase();
+    return (
+        msg.includes('failed to fetch dynamically imported module') ||
+        msg.includes('importing a module script failed') ||
+        msg.includes('error loading dynamically imported module') ||
+        msg.includes('chunkloaderror') ||
+        (msg.includes('load') && msg.includes('chunk'))
+    );
+}
+
 // SvelteKit 에러 훅 (라우트 에러, 로드 에러 등)
 export const handleError: HandleClientError = ({ error, event, status }) => {
     const err = error instanceof Error ? error : new Error(String(error));
+
+    // 배포 후 chunk 로드 실패 → 자동 새로고침 (1회만)
+    if (isChunkLoadError(error)) {
+        const lastReload = sessionStorage.getItem(RELOAD_KEY);
+        const now = Date.now();
+        // 마지막 새로고침으로부터 30초 이내면 중복 방지
+        if (!lastReload || now - Number(lastReload) > 30_000) {
+            sessionStorage.setItem(RELOAD_KEY, String(now));
+            window.location.reload();
+            return;
+        }
+    }
+
     sendDantry({
         type: 'sveltekit_error',
         message: err.message,

--- a/apps/web/static/sw.js
+++ b/apps/web/static/sw.js
@@ -10,7 +10,7 @@
  * - 오프라인 시: 캐시된 오프라인 페이지 표시
  */
 
-const CACHE_NAME = 'angple-v5';
+const CACHE_NAME = 'angple-v6';
 
 // 앱 셸 프리캐시 목록 (빈 배열 — 오프라인 페이지 없으므로 프리캐시 불필요)
 const PRECACHE_URLS = [];


### PR DESCRIPTION
## Summary
- 배포 후 이전 JS가 새 chunk를 로드 실패 시 → 자동 새로고침 (사용자 개입 불필요)
- 서비스 워커 v6으로 업그레이드 (이전 캐시 자동 정리)
- `sessionStorage`로 30초 내 중복 새로고침 방지

## 근본 원인
SvelteKit 배포 시 JS chunk 파일명이 변경됨. 이전 페이지의 클라이언트 라우터가 새 chunk를 동적 import 시도 → 404 → 흰 화면.