### PR TITLE
perf: 동접 1만명 대응 성능 최적화

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -90,10 +90,14 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                     } else {
                         const token = await generateAccessToken(member);
                         event.locals.accessToken = token;
-                        // 캐시 크기 제한
-                        if (jwtCache.size > MAX_JWT_CACHE_SIZE) {
-                            for (const [key, entry] of jwtCache) {
-                                if (now >= entry.expiry) jwtCache.delete(key);
+                        // 캐시 크기 제한: 한계 도달 시 가장 오래된 25% 제거 (O(n) sweep 대신 batch eviction)
+                        if (jwtCache.size >= MAX_JWT_CACHE_SIZE) {
+                            const evictCount = Math.floor(MAX_JWT_CACHE_SIZE * 0.25);
+                            let removed = 0;
+                            for (const key of jwtCache.keys()) {
+                                if (removed >= evictCount) break;
+                                jwtCache.delete(key);
+                                removed++;
                             }
                         }
                         jwtCache.set(session.mbId, { token, expiry: now + JWT_CACHE_TTL });

--- a/apps/web/src/lib/server/ads/promotion.ts
+++ b/apps/web/src/lib/server/ads/promotion.ts
@@ -14,6 +14,59 @@ let promotionCache: { data: unknown; expiresAt: number } | null = null;
 
 const EMPTY_RESPONSE = { success: false, data: { posts: [] } };
 
+interface PromotionBoardPostsResponse {
+    success: boolean;
+    data: PromotionBoardPost[];
+    meta: { total: number; advertiser_count: number };
+}
+
+interface PromotionBoardPost {
+    wr_id: number;
+    wr_subject: string;
+    wr_content: string;
+    mb_id: string;
+    wr_name: string;
+    wr_datetime: string;
+    wr_hit: number;
+    wr_good: number;
+    wr_comment: number;
+    wr_link1: string;
+    wr_link2: string;
+    wr_option: string;
+    advertiser_name: string;
+    pin_to_top: boolean;
+    thumbnail: string;
+    file_count: number;
+}
+
+let promotionBoardCache: { data: PromotionBoardPostsResponse; expiresAt: number } | null = null;
+
+const EMPTY_BOARD_RESPONSE: PromotionBoardPostsResponse = {
+    success: false,
+    data: [],
+    meta: { total: 0, advertiser_count: 0 }
+};
+
+export async function fetchPromotionBoardPosts(): Promise<PromotionBoardPostsResponse> {
+    const now = Date.now();
+    if (promotionBoardCache && now < promotionBoardCache.expiresAt) {
+        return promotionBoardCache.data;
+    }
+    try {
+        const res = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-board-posts`, {
+            signal: AbortSignal.timeout(5_000)
+        });
+        if (!res.ok) return EMPTY_BOARD_RESPONSE;
+        const data = await res.json();
+        promotionBoardCache = { data, expiresAt: now + PROMOTION_CACHE_TTL };
+        return data;
+    } catch {
+        return EMPTY_BOARD_RESPONSE;
+    }
+}
+
+export type { PromotionBoardPost, PromotionBoardPostsResponse };
+
 export async function fetchPromotionPosts(): Promise<unknown> {
     const now = Date.now();
     if (promotionCache && now < promotionCache.expiresAt) {

--- a/apps/web/src/lib/server/db.ts
+++ b/apps/web/src/lib/server/db.ts
@@ -21,7 +21,11 @@ const pool = mysql.createPool({
     waitForConnections: true,
     connectionLimit: 200,
     queueLimit: 500,
-    timezone: '+09:00'
+    timezone: '+09:00',
+    connectTimeout: 5_000,
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 30_000,
+    idleTimeout: 60_000
 });
 
 /**
@@ -38,7 +42,11 @@ const readPool: mysql.Pool = env.DB_READ_HOST
           waitForConnections: true,
           connectionLimit: 400,
           queueLimit: 1000,
-          timezone: '+09:00'
+          timezone: '+09:00',
+          connectTimeout: 5_000,
+          enableKeepAlive: true,
+          keepAliveInitialDelay: 30_000,
+          idleTimeout: 60_000
       })
     : pool;
 

--- a/apps/web/src/lib/server/settings/json-provider.ts
+++ b/apps/web/src/lib/server/settings/json-provider.ts
@@ -32,6 +32,11 @@ export class JsonSettingsProvider implements SettingsProvider {
     private filePath: string;
     private lock = false;
 
+    // 인메모리 캐시: 매 요청마다 디스크 I/O 방지 (30초 TTL)
+    private cachedSettings: Settings | null = null;
+    private cacheExpiry = 0;
+    private static readonly CACHE_TTL = 30_000; // 30초
+
     constructor(filePath?: string) {
         this.filePath = filePath || path.join(process.cwd(), 'data', 'settings.json');
     }
@@ -50,6 +55,12 @@ export class JsonSettingsProvider implements SettingsProvider {
         this.lock = false;
     }
 
+    /** 캐시 무효화 (쓰기 후 호출) */
+    private invalidateCache(): void {
+        this.cachedSettings = null;
+        this.cacheExpiry = 0;
+    }
+
     /**
      * 설정 파일이 없으면 생성
      */
@@ -65,19 +76,27 @@ export class JsonSettingsProvider implements SettingsProvider {
     }
 
     /**
-     * 설정 읽기
+     * 설정 읽기 (인메모리 캐시 사용, 30초 TTL)
      */
     private async read(): Promise<Settings> {
+        const now = Date.now();
+        if (this.cachedSettings && now < this.cacheExpiry) {
+            return this.cachedSettings;
+        }
         await this.ensureFile();
         const data = await fs.readFile(this.filePath, 'utf-8');
-        return JSON.parse(data);
+        const settings = JSON.parse(data);
+        this.cachedSettings = settings;
+        this.cacheExpiry = now + JsonSettingsProvider.CACHE_TTL;
+        return settings;
     }
 
     /**
-     * 설정 쓰기
+     * 설정 쓰기 (캐시 무효화)
      */
     private async write(settings: Settings): Promise<void> {
         await fs.writeFile(this.filePath, JSON.stringify(settings, null, 2), 'utf-8');
+        this.invalidateCache();
     }
 
     // ========== Interface 구현 ==========

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -1,7 +1,8 @@
 import { error as svelteError } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 import type { FreePost, Board, SearchField } from '$lib/api/types.js';
-import { fetchPromotionPosts } from '$lib/server/ads/promotion.js';
+import { fetchPromotionPosts, fetchPromotionBoardPosts } from '$lib/server/ads/promotion.js';
+import type { PromotionBoardPost } from '$lib/server/ads/promotion.js';
 import { backendFetch as bFetch, createAuthHeaders } from '$lib/server/backend-fetch.js';
 
 /**
@@ -77,8 +78,44 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         return `/api/v1/boards/${boardId}/posts?${queryParams.toString()}`;
     };
 
+    // 프로모션 게시판 전용: 광고주별 post_count 제한 적용 (검색/태그 필터 없을 때만)
+    const isPromotionBoard = boardId === 'promotion' && !isSearching && !isTagFiltering;
+
     // Promise (await 하지 않음 → SvelteKit이 스트리밍)
     const postsDataPromise = (async () => {
+        if (isPromotionBoard) {
+            // 프로모션 게시판: ads 서버에서 광고주별 제한된 게시글 조회
+            const [promoBoardResult, noticesResult] = await Promise.allSettled([
+                fetchPromotionBoardPosts(),
+                bFetch(`/api/v1/boards/${boardId}/notices`, { headers }).then(async (res) => {
+                    if (!res.ok) return [];
+                    const json = await res.json();
+                    return (json.data as FreePost[]) || [];
+                })
+            ]);
+
+            let posts: FreePost[] = [];
+            let error: string | null = null;
+
+            if (promoBoardResult.status === 'fulfilled' && promoBoardResult.value.success) {
+                posts = promoBoardResult.value.data.map(mapPromotionBoardPostToFreePost);
+            } else {
+                console.error('프로모션 게시판 로딩 에러:', promoBoardResult);
+                error = '게시글을 불러오는데 실패했습니다.';
+            }
+
+            const notices = noticesResult.status === 'fulfilled' ? noticesResult.value : [];
+            const pagination = {
+                total: posts.length,
+                page: 1,
+                limit: posts.length || 1,
+                totalPages: 1
+            };
+
+            return { posts, notices, promotionPosts: [], pagination, error };
+        }
+
+        // 일반 게시판 (또는 프로모션 게시판 검색/태그 필터)
         const [postsResult, noticesResult, promotionResult] = await Promise.allSettled([
             bFetch(buildPostsUrl(), { headers }).then(async (res) => {
                 if (!res.ok) throw new Error(`Posts API error: ${res.status}`);
@@ -143,3 +180,22 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         }
     };
 };
+
+function mapPromotionBoardPostToFreePost(p: PromotionBoardPost): FreePost {
+    return {
+        id: p.wr_id,
+        title: p.wr_subject,
+        content: p.wr_content,
+        author: p.wr_name,
+        author_id: p.mb_id,
+        board_id: 'promotion',
+        views: p.wr_hit,
+        likes: p.wr_good,
+        comments_count: p.wr_comment,
+        created_at: p.wr_datetime,
+        has_file: p.file_count > 0,
+        thumbnail: p.thumbnail || undefined,
+        link1: p.wr_link1 || undefined,
+        link2: p.wr_link2 || undefined
+    };
+}


### PR DESCRIPTION
## Summary
- JsonSettingsProvider 30초 인메모리 캐시 (매 요청 디스크 I/O 제거)
- DB pool connectTimeout(5s), enableKeepAlive, idleTimeout(60s) 추가
- jwtCache eviction 개선: O(n) full sweep → 25% batch eviction
- 프로모션 게시판 ads 서버 연동 및 광고주별 post_count 제한

## 예상 효과
- Settings 디스크 I/O: 초당 수천 회 → 0 (30초 캐시)
- DB 연결 안정성: stale 연결 자동 정리, 5초 연결 타임아웃
- JWT 캐시: 50,000 엔트리 한계 도달 시 O(n) → O(n/4) batch eviction

## Test plan
- [x] pnpm build 성공
- [x] svelte-check 0 errors
- [ ] CI 빌드 통과 확인
- [ ] 배포 후 사이트 정상 동작 확인