### PR TITLE
fix: 배포 시 404 에러 근본 해결

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -180,7 +180,7 @@ jobs:
             --instance-ids "i-038a1d1f00798d94b" \
             --document-name "AWS-RunShellScript" \
             --parameters 'commands=[
-              "kubectl set image deployment/angple-web -n angple web='"${{ env.ECR_REGISTRY }}"'/'"${{ env.ECR_REPOSITORY }}"':'"$IMAGE_TAG"'",
+              "kubectl set image deployment/angple-web -n angple web='"${{ env.ECR_REGISTRY }}"'/'"${{ env.ECR_REPOSITORY }}"':'"$IMAGE_TAG"' copy-immutable-assets='"${{ env.ECR_REGISTRY }}"'/'"${{ env.ECR_REPOSITORY }}"':'"$IMAGE_TAG"'",
               "kubectl rollout status deployment/angple-web -n angple --timeout=120s"
             ]' \
             --timeout-seconds 300 \

--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -29,21 +29,33 @@ function isChunkLoadError(error: unknown): boolean {
 }
 
 /**
- * Chunk error 시 자동 새로고침 (최대 1회)
+ * Chunk error 시 자동 새로고침 (최대 2회)
  * sessionStorage 카운터로 무한 루프 방지
+ * 2회 실패 시 사용자에게 새 버전 배포 안내 UI 표시
  */
 const RELOAD_KEY = '__angple_chunk_reload_count__';
 
 function tryChunkReload(): void {
     const count = Number(sessionStorage.getItem(RELOAD_KEY) || '0');
-    if (count < 1) {
+    if (count < 2) {
         sessionStorage.setItem(RELOAD_KEY, String(count + 1));
         window.location.reload();
     } else {
-        // 1회 재시도 후에도 실패하면 카운터 리셋하고 포기
         sessionStorage.removeItem(RELOAD_KEY);
-        console.error('[Angple] Chunk load failed after retry. Please clear browser cache.');
+        showUpdateNotice();
     }
+}
+
+function showUpdateNotice(): void {
+    document.body.innerHTML = `
+        <div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;flex-direction:column;gap:16px;text-align:center;padding:20px;background:#fafafa;color:#333">
+            <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#2563eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 16h5v5"/></svg>
+            <h2 style="margin:0;font-size:20px;font-weight:600">새 버전이 배포되었습니다</h2>
+            <p style="margin:0;color:#666;font-size:14px">페이지를 새로고침하면 최신 버전으로 이용할 수 있습니다.</p>
+            <button onclick="location.reload()" style="margin-top:8px;padding:12px 32px;font-size:15px;cursor:pointer;border-radius:8px;border:none;background:#2563eb;color:white;font-weight:500;transition:background 0.2s" onmouseover="this.style.background='#1d4ed8'" onmouseout="this.style.background='#2563eb'">
+                새로고침
+            </button>
+        </div>`;
 }
 
 // 성공적으로 페이지 로드되면 카운터 리셋
@@ -57,7 +69,7 @@ if (typeof window !== 'undefined') {
 export const handleError: HandleClientError = ({ error, event, status }) => {
     const err = error instanceof Error ? error : new Error(String(error));
 
-    // 배포 후 chunk 로드 실패 → 자동 새로고침 (1회만)
+    // 배포 후 chunk 로드 실패 → 자동 새로고침 (최대 2회)
     if (isChunkLoadError(error)) {
         tryChunkReload();
         return;


### PR DESCRIPTION
## Summary
- chunk load error 자동 새로고침 1회→2회로 증가, 최종 실패 시 "새 버전 배포" 안내 UI 표시
- deploy workflow에서 initContainer(`copy-immutable-assets`) 이미지도 함께 업데이트하도록 수정

## 배경
롤링 업데이트 시 JS hash 불일치로 404 발생 → 자동 reload 1회로는 부족한 경우 있음

## 변경 내용
- `hooks.client.ts`: retry 1→2, `showUpdateNotice()` 안내 화면 추가
- `deploy-binary.yml`: `kubectl set image`에 `copy-immutable-assets` 컨테이너 포함

## 추가 작업 (별도)
- Cloudflare Cache Rule: `/_app/immutable/*` Edge TTL 30일 설정 (Dashboard)
- K8s hostPath 볼륨 + initContainer 적용: `k8s/prod/angple-web.yaml`
- Cron 정리 스크립트: `k8s/prod/cleanup-immutable-assets.sh`

## Test plan
- [ ] 배포 후 이전 hash JS 직접 요청 → 404 → 자동 reload 2회 → 안내 UI 표시 확인
- [ ] 정상 페이지 로드 시 reload 카운터 리셋 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)