### PR TITLE
fix: API rate limit 완화 — nginx sidecar IP 문제 대응

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -192,8 +192,8 @@ const cspHeader = buildCsp();
 const DEV_ONLY_PATHS = ['/api-test', '/api-docs', '/api-doc', '/install'];
 
 /** 글로벌 API rate limiting (IP당 요청 수) */
-const GLOBAL_API_RATE = { maxRequests: 120, windowMs: 60_000 }; // 분당 120회
-const WRITE_API_RATE = { maxRequests: 30, windowMs: 60_000 }; // 쓰기 분당 30회
+const GLOBAL_API_RATE = { maxRequests: 600, windowMs: 60_000 }; // 분당 600회 (페이지당 ~10 API 호출)
+const WRITE_API_RATE = { maxRequests: 60, windowMs: 60_000 }; // 쓰기 분당 60회
 
 export const handle: Handle = async ({ event, resolve }) => {
     const { pathname } = event.url;


### PR DESCRIPTION
## Summary
- nginx sidecar 도입 후 `getClientAddress()`가 모든 요청에 대해 동일 IP(127.0.0.1/10.42.0.1) 반환
- 전체 사용자가 하나의 rate limit bucket 공유 → 429 폭발 → 사이트 장애
- rate limit 완화: READ 120→600/분, WRITE 30→60/분
- K8s ConfigMap에 `ADDRESS_HEADER=x-real-ip` 추가 (별도 적용 완료)
- nginx `X-Real-IP`를 `$http_cf_connecting_ip`으로 변경 (별도 적용 완료)

## Test plan
- [x] 배포 후 429 에러 없이 API 정상 응답 확인
- [x] 댓글, 추천, 광고 등 클라이언트 API 호출 정상 확인