### PR TITLE
fix: 애플/카카오 로그인 수정

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -198,6 +198,14 @@ const WRITE_API_RATE = { maxRequests: 60, windowMs: 60_000 }; // 쓰기 분당 6
 export const handle: Handle = async ({ event, resolve }) => {
     const { pathname } = event.url;
 
+    // Apple Sign In form_post: cross-origin POST이므로 SvelteKit CSRF 우회
+    // OAuth state 쿠키가 자체 CSRF 보호 제공
+    if (pathname.startsWith('/auth/callback/') && event.request.method === 'POST') {
+        const headers = new Headers(event.request.headers);
+        headers.set('origin', event.url.origin);
+        Object.defineProperty(event.request, 'headers', { value: headers });
+    }
+
     // 개발/내부 전용 경로 차단 (프로덕션)
     if (!dev && DEV_ONLY_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
         return new Response('Not Found', { status: 404 });

--- a/apps/web/src/lib/server/auth/oauth/state.ts
+++ b/apps/web/src/lib/server/auth/oauth/state.ts
@@ -34,8 +34,8 @@ export function createOAuthState(
     cookies.set(STATE_COOKIE_NAME, JSON.stringify(data), {
         path: '/',
         httpOnly: true,
-        sameSite: 'lax',
-        secure: !dev,
+        sameSite: 'none', // Apple Sign In form_post (cross-site POST)에서 쿠키 전송 필요
+        secure: true, // SameSite=None은 Secure 필수
         maxAge: STATE_MAX_AGE,
         ...(COOKIE_DOMAIN && { domain: COOKIE_DOMAIN })
     });


### PR DESCRIPTION
## Summary
- Apple Sign In form_post: SvelteKit CSRF checkOrigin이 cross-origin POST 차단 → Origin 헤더 보정으로 우회
- OAuth state 쿠키 SameSite=Lax → None 변경 (Apple cross-site POST에서 쿠키 미전송 문제)
- OAuth state 쿠키는 httpOnly + 10분 만료 + 랜덤 32바이트로 자체 CSRF 보호

## Test plan
- [ ] 카카오 로그인 정상 동작 확인
- [ ] 애플 로그인 정상 동작 확인
- [ ] 네이버/구글/트위터 로그인 영향 없음 확인