### PR TITLE
fix: JS 로드 실패 시 새로고침 안내 배너

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -85,6 +85,29 @@
     <body data-sveltekit-preload-data="hover">
         <div style="display: contents">%sveltekit.body%</div>
         <script>
+            // JS 로드 실패 감지: script 에러 시 캐시 삭제 + 안내 배너
+            (function () {
+                var errorCount = 0;
+                window.addEventListener('error', function (e) {
+                    // JS/CSS 리소스 로드 실패만 감지 (script, link 태그)
+                    var t = e.target;
+                    if (t && (t.tagName === 'SCRIPT' || t.tagName === 'LINK')) {
+                        errorCount++;
+                        if (errorCount >= 2) showReloadBanner();
+                    }
+                }, true); // capture phase로 리소스 에러 잡기
+
+                function showReloadBanner() {
+                    if (document.getElementById('reload-banner')) return;
+                    var d = document.createElement('div');
+                    d.id = 'reload-banner';
+                    d.style.cssText = 'position:fixed;bottom:0;left:0;right:0;z-index:99999;background:#1e293b;color:white;padding:14px 20px;display:flex;align-items:center;justify-content:center;gap:12px;font-family:-apple-system,sans-serif;font-size:14px;box-shadow:0 -2px 10px rgba(0,0,0,.2)';
+                    d.innerHTML = '<span>새 버전이 배포되었습니다. 정상 이용을 위해 새로고침이 필요합니다.</span><button onclick="caches&&caches.keys().then(function(n){n.forEach(function(k){caches.delete(k)})});location.reload()" style="padding:8px 16px;font-size:13px;cursor:pointer;border-radius:6px;border:none;background:#3b82f6;color:white;white-space:nowrap">새로고침</button>';
+                    document.body.appendChild(d);
+                }
+            })();
+        </script>
+        <script>
             if ('serviceWorker' in navigator) {
                 if (location.hostname === 'localhost' || location.hostname.startsWith('dev.')) {
                     // dev 환경: SW 해제 + Cache Storage 전체 삭제


### PR DESCRIPTION
## Summary
- 배포 후 브라우저 캐시로 인해 이전 JS chunk 로드 실패 시 하단에 안내 배너 표시
- 인라인 스크립트로 외부 JS 의존 없이 동작 (SSR HTML만 로드되면 작동)
- script/link 태그 로드 에러 2건 이상 감지 시 활성화
- "새로고침" 버튼: Cache Storage 삭제 + page reload

## Test plan
- [ ] 정상 페이지에서는 배너 미표시 확인
- [ ] JS 로드 실패 시 하단 배너 표시 확인