### PR TITLE
fix: Tiptap 에디터 붙여넣기 시 이미지 링크 보존

### DIFF
--- a/apps/web/src/lib/components/features/editor/index.ts
+++ b/apps/web/src/lib/components/features/editor/index.ts
@@ -1,1 +1,2 @@
 export { default as TiptapEditor } from './tiptap-editor.svelte';
+export { LinkedImage } from './linked-image.js';

--- a/apps/web/src/lib/components/features/editor/linked-image.ts
+++ b/apps/web/src/lib/components/features/editor/linked-image.ts
@@ -1,0 +1,58 @@
+import { mergeAttributes } from '@tiptap/core';
+import Image from '@tiptap/extension-image';
+
+/**
+ * LinkedImage — @tiptap/extension-image 확장
+ *
+ * 붙여넣기 시 <a href="..."><img src="..."></a> 형태의 링크를 보존한다.
+ * ProseMirror의 Image 노드는 marks를 허용하지 않아 Link mark가 자동 제거되는데,
+ * 이를 우회하기 위해 href/linkTarget을 노드 attribute로 관리한다.
+ */
+export const LinkedImage = Image.extend({
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			// 이미지를 감싸는 <a> 태그의 href
+			href: { default: null },
+			// <a> 태그의 target 속성
+			linkTarget: { default: null },
+		};
+	},
+
+	parseHTML() {
+		return [
+			{
+				tag: this.options.allowBase64 ? 'img[src]' : 'img[src]:not([src^="data:"])',
+				getAttrs: (dom: HTMLElement) => {
+					const img = dom as HTMLImageElement;
+					// 상위 <a> 태그에서 href 추출 (SunEditor: figure>a>img, 일반: a>img)
+					const link = img.closest('a');
+					return {
+						src: img.getAttribute('src'),
+						alt: img.getAttribute('alt'),
+						title: img.getAttribute('title'),
+						width: img.getAttribute('width'),
+						height: img.getAttribute('height'),
+						href: link?.getAttribute('href') || null,
+						linkTarget: link?.getAttribute('target') || null,
+					};
+				},
+			},
+		];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		const { href, linkTarget, ...imgAttrs } = HTMLAttributes;
+		const mergedImgAttrs = mergeAttributes(this.options.HTMLAttributes, imgAttrs);
+
+		if (href) {
+			return [
+				'a',
+				{ href, target: linkTarget || '_blank', rel: 'noopener noreferrer' },
+				['img', mergedImgAttrs],
+			];
+		}
+
+		return ['img', mergedImgAttrs];
+	},
+});

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -3,7 +3,7 @@
     import { Editor } from '@tiptap/core';
     import StarterKit from '@tiptap/starter-kit';
     import Link from '@tiptap/extension-link';
-    import Image from '@tiptap/extension-image';
+    import { LinkedImage } from './linked-image.js';
     import Placeholder from '@tiptap/extension-placeholder';
     import Underline from '@tiptap/extension-underline';
     import Mention from '@tiptap/extension-mention';
@@ -166,7 +166,7 @@
                         class: 'text-primary underline'
                     }
                 }),
-                Image.configure({
+                LinkedImage.configure({
                     inline: false,
                     allowBase64: true,
                     HTMLAttributes: {


### PR DESCRIPTION
## Summary
- `@tiptap/extension-image`를 확장한 `LinkedImage` 커스텀 extension 생성
- 붙여넣기 시 `<a href="..."><img></a>` 형태의 링크가 소실되던 문제 수정
- ProseMirror Image 노드가 marks를 허용하지 않아 Link mark가 제거되던 근본 원인을 href를 노드 attribute로 관리하여 해결

## 변경 파일
- `linked-image.ts` (신규) — LinkedImage 커스텀 extension
- `tiptap-editor.svelte` — Image → LinkedImage 교체
- `index.ts` — LinkedImage export 추가

## Test plan
- [ ] 새 글 작성 → HTML에서 `<a><img></a>` 붙여넣기 → 저장 후 링크 클릭 작동 확인
- [ ] 기존 글(215249) 편집 모드 진입 → `<a>` 태그 보존 확인
- [ ] 일반 이미지(링크 없는) 삽입이 기존과 동일하게 동작하는지 확인