### PR TITLE
feat: 메인 상단 광고 슬롯에 DamoangBanner 적용

### DIFF
--- a/widgets/ad-slot/index.svelte
+++ b/widgets/ad-slot/index.svelte
@@ -8,6 +8,7 @@
     import type { WidgetProps } from '$lib/types/widget-props';
     import { AdSlot } from '$lib/components/ui/ad-slot';
     import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
+    import { DamoangBanner } from '$lib/components/ui/damoang-banner';
 
     let { config, slot, isEditMode = false }: WidgetProps = $props();
 
@@ -31,6 +32,9 @@
             <AdSlot {position} height={isSticky ? '500px' : '250px'} />
         {/if}
     </div>
+{:else if position === 'index-head'}
+    <!-- 메인 상단: 축하메시지 → 프리미엄배너 → GAM 폴백 -->
+    <DamoangBanner position="index" showCelebration={true} {height} gamPosition="index-head" />
 {:else}
     <!-- 메인 영역 광고 (GAM) -->
     <AdSlot {position} {height} />


### PR DESCRIPTION
## Summary
- index-head position일 때 DamoangBanner 컴포넌트로 렌더링
- 우선순위: 축하메시지 → 프리미엄 긴배너(셔플) → GAM 폴백

## Test plan
- [ ] 메인 페이지 상단 배너 슬롯에서 DamoangBanner 렌더링 확인
- [ ] 프리미엄 배너 없을 때 GAM 폴백 동작 확인
- [ ] 게시판 페이지는 기존 동작 유지 확인