### PR TITLE
fix: 배포 시 SHA 태그 사용으로 롤아웃 누락 방지

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -157,13 +157,19 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.confirm == 'deploy'
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Set image tag
         id: tag
         run: |
           if [ -n "${{ inputs.image_tag }}" ]; then
             echo "TAG=${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
           else
-            echo "TAG=latest" >> $GITHUB_OUTPUT
+            # latest 대신 SHA 태그 사용 (K8s가 이미지 변경을 감지하도록)
+            SHA=$(git rev-parse HEAD)
+            echo "TAG=sha-${SHA}" >> $GITHUB_OUTPUT
           fi
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary
- deploy job에서 기본 이미지 태그를 `latest` → `sha-{commit SHA}`로 변경
- `latest` 태그는 K8s가 스펙 변경 없음으로 판단해 파드 재시작 누락됨
- SHA 태그는 매 배포마다 고유하므로 `kubectl set image`가 항상 롤아웃 트리거

## 근본 원인
`kubectl set image ... :latest` → 이미 `:latest`인 경우 → 스펙 변경 없음 → 롤아웃 안 함

## Test plan
- [ ] `gh workflow run deploy-binary.yml --field confirm=deploy` 실행
- [ ] 파드가 자동 재시작되는지 확인