### PR TITLE
feat: 태그 네비 축하메시지 메뉴 추가

### DIFF
--- a/apps/web/src/lib/components/features/widget-editor/widget-settings-dialog.svelte
+++ b/apps/web/src/lib/components/features/widget-editor/widget-settings-dialog.svelte
@@ -29,7 +29,8 @@
         { key: 'economy', text: '알뜰구매', url: '/economy', show: true },
         { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
         { key: 'qa', text: '질문과답변', url: '/qa', show: true },
-        { key: 'lecture', text: '강좌&팁', url: '/lecture', show: true }
+        { key: 'lecture', text: '강좌&팁', url: '/lecture', show: true },
+        { key: 'message', text: '축하메시지', url: '/message', show: true }
     ];
 
     // 로컬 설정 상태 (게시판 필터용)

--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -21,7 +21,8 @@
         { key: 'economy', text: '알뜰구매', url: '/economy', show: true },
         { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
         { key: 'qa', text: '질문과답변', url: '/qa', show: true },
-        { key: 'lecture', text: '강좌&팁', url: '/lecture', show: true }
+        { key: 'lecture', text: '강좌&팁', url: '/lecture', show: true },
+        { key: 'message', text: '축하메시지', url: '/message', show: true }
     ];
 
     let { menus = DEFAULT_MENUS, class: className = '' }: Props = $props();


### PR DESCRIPTION
## Summary
- DEFAULT_MENUS에 축하메시지 메뉴 추가 (`/message`)
- tag-nav.svelte + widget-settings-dialog.svelte 둘 다 동기화

## Test plan
- [ ] 태그 네비에 "축하메시지" 탭 표시 확인
- [ ] 위젯 설정 초기화 시 축하메시지 메뉴 포함 확인