### PR TITLE
fix: 배포 후 SW 캐시 미정리로 인한 접속 불가 수정

### DIFF
--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -35,28 +35,30 @@ function isChunkLoadError(error: unknown): boolean {
  */
 const RELOAD_KEY = '__angple_chunk_reload_count__';
 
-function clearCachesAndReload(): void {
-    // SW 해제 + Cache Storage 전체 삭제 후 캐시 무시 리로드
-    const tasks: Promise<void>[] = [];
+async function clearCachesAndReload(): Promise<void> {
+    // 1. 대기 중인 새 SW가 있으면 즉시 활성화 요청
+    if (navigator.serviceWorker?.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: 'SKIP_WAITING' });
+    }
+
+    // 2. SW 해제 (모든 unregister Promise를 await)
     if (navigator.serviceWorker) {
-        tasks.push(
-            navigator.serviceWorker.getRegistrations().then((regs) => {
-                regs.forEach((r) => r.unregister());
-            })
-        );
+        const regs = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(regs.map((r) => r.unregister()));
     }
+
+    // 3. Cache Storage 전체 삭제 (모든 delete Promise를 await)
     if (window.caches) {
-        tasks.push(
-            caches.keys().then((names) => {
-                names.forEach((name) => caches.delete(name));
-            })
-        );
+        const names = await caches.keys();
+        await Promise.all(names.map((name) => caches.delete(name)));
     }
-    Promise.all(tasks).finally(() => {
-        // cache-busting query로 브라우저 캐시 우회
-        const url = location.href.split('?')[0];
-        location.replace(url + '?_v=' + Date.now());
-    });
+
+    // 4. SW 해제 반영 대기 후 cache-busting 리로드
+    //    unregister 후에도 현재 페이지 세션에서는 SW가 활성 상태일 수 있으므로
+    //    짧은 대기로 브라우저가 SW 상태를 갱신할 시간 확보
+    await new Promise((r) => setTimeout(r, 100));
+    const url = location.href.split('?')[0];
+    location.replace(url + '?_v=' + Date.now());
 }
 
 function tryChunkReload(): void {

--- a/apps/web/static/sw.js
+++ b/apps/web/static/sw.js
@@ -24,6 +24,13 @@ self.addEventListener('install', (event) => {
     );
 });
 
+// 클라이언트에서 SKIP_WAITING 메시지 수신 시 대기 중인 SW 즉시 활성화
+self.addEventListener('message', (event) => {
+    if (event.data?.type === 'SKIP_WAITING') {
+        self.skipWaiting();
+    }
+});
+
 // 활성화: 모든 이전 캐시 정리 + 즉시 제어권 획득
 self.addEventListener('activate', (event) => {
     event.waitUntil(


### PR DESCRIPTION
## Summary
- 배포 후 "새로고침하면 된다" 메시지만 나오고 접속 불가한 문제 수정
- SW unregister/cache delete Promise를 await하지 않아 캐시 정리 전에 리로드되는 버그

## 원인
`clearCachesAndReload()`에서 `forEach`로 `unregister()`와 `caches.delete()`를 호출하면서 반환된 Promise를 무시. 캐시 정리가 완료되기 전에 `location.replace()`가 실행되어 이전 SW가 여전히 stale 캐시를 제공.

## 변경 내역
- `hooks.client.ts`: `async/await`로 SW 해제 → 캐시 삭제 → 리로드 순차 보장
- `sw.js`: `SKIP_WAITING` 메시지 핸들러 추가 (대기 중인 새 SW 즉시 활성화)

## 사용자 영향
- Before: 수동으로 브라우저 캐시 전체 삭제 필요
- After: 배너의 "새로고침" 버튼 한 번으로 복구

Ref: https://damoang.net/free/5900985

## Test plan
- [ ] 배포 후 기존 SW 캐시가 남아있는 상태에서 chunk error 발생 시 자동 복구 확인
- [ ] 배너 새로고침 버튼 클릭 시 정상 로딩 확인
- [ ] 새 SW 대기 중일 때 SKIP_WAITING으로 즉시 활성화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)