### PR TITLE
feat: 피드백 대응 UI 수정 + 성능 최적화

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -418,6 +418,10 @@ export const handle: Handle = async ({ event, resolve }) => {
         response.headers.set('Vary', 'Cookie');
     }
 
+    // SvelteKit modulepreload Link 헤더 제거 (8KB+ → 응답 헤더 축소)
+    // HTML 내 <link> 태그로 이미 preload되므로 헤더는 불필요
+    response.headers.delete('Link');
+
     return response;
 };
 

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -4,7 +4,6 @@
     import Search from '@lucide/svelte/icons/search';
     import User from '@lucide/svelte/icons/user';
     import Bell from '@lucide/svelte/icons/bell';
-    import Menu from '@lucide/svelte/icons/menu';
     import X from '@lucide/svelte/icons/x';
     import Home from '@lucide/svelte/icons/home';
     import Rss from '@lucide/svelte/icons/rss';
@@ -13,6 +12,7 @@
     import Smartphone from '@lucide/svelte/icons/smartphone';
     import Logo from '$lib/assets/logo.svg';
     import AlignJustify from '@lucide/svelte/icons/align-justify';
+    import Shield from '@lucide/svelte/icons/shield';
     import Mail from '@lucide/svelte/icons/mail';
     import Sidebar from './sidebar.svelte';
     import { NotificationDropdown } from '$lib/components/features/notification/index.js';
@@ -130,15 +130,7 @@
     <div class="container mx-auto flex h-12 items-center justify-between md:h-16">
         <!-- 로고 -->
         <div class="flex items-center">
-            <!-- 햄버거 메뉴 (추가 메뉴) - 2xl 미만에서 보임 -->
-            <button
-                onclick={toggleDrawer}
-                class="hover:bg-accent mr-3 block rounded-lg pe-2 ps-4 transition-all duration-200 ease-out md:-ml-1 md:ps-0 2xl:hidden"
-                aria-label="추가 메뉴"
-            >
-                <AlignJustify class="text-muted-foreground h-6 w-6" />
-            </button>
-            <a href="/" data-sveltekit-reload class="flex items-center">
+            <a href="/" data-sveltekit-reload class="flex items-center ps-4 md:ps-0">
                 <img src={Logo} alt="damoang" class="h-12" />
             </a>
         </div>
@@ -159,6 +151,15 @@
             >
                 <Rss class="mr-2 h-5 w-5" />
                 피드
+            </a>
+            <a
+                href="https://web.damoang.net"
+                target="_blank"
+                rel="noopener"
+                class="text-foreground hover:text-primary flex items-center transition-all duration-200 ease-out"
+            >
+                <Shield class="mr-2 h-5 w-5" />
+                대피소
             </a>
         </nav>
 
@@ -263,10 +264,10 @@
             <!-- 햄버거 메뉴 (추가 메뉴) -->
             <button
                 onclick={toggleDrawer}
-                class="hover:bg-accent hidden rounded-lg p-2 transition-all duration-200 ease-out 2xl:block"
+                class="hover:bg-accent rounded-lg p-2 transition-all duration-200 ease-out"
                 aria-label="추가 메뉴"
             >
-                <Menu class="text-muted-foreground h-5 w-5" />
+                <AlignJustify class="text-muted-foreground h-5 w-5" />
             </button>
         </div>
     </div>
@@ -289,8 +290,8 @@
     class:translate-x-full={!isDrawerOpen}
     class:translate-x-0={isDrawerOpen}
 >
-    <div class="p-6">
-        <div class="mb-8 flex items-center justify-between">
+    <div class="flex h-full flex-col p-6">
+        <div class="mb-8 flex shrink-0 items-center justify-between">
             <h2 class="text-foreground text-xl font-bold">추가 메뉴</h2>
             <button
                 onclick={toggleDrawer}
@@ -302,7 +303,7 @@
         </div>
 
         <!-- 사이드바 메뉴 -->
-        <div class="overflow-y-auto">
+        <div class="min-h-0 flex-1 overflow-y-auto">
             <Sidebar />
         </div>
     </div>

--- a/apps/web/src/lib/components/widget-renderer/widget-wrapper.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-wrapper.svelte
@@ -7,6 +7,7 @@
      */
     import { widgetLayoutStore, type WidgetConfig } from '$lib/stores/widget-layout.svelte';
     import { getWidgetName } from '$lib/utils/widget-component-loader';
+    import { authStore } from '$lib/stores/auth.svelte';
     import GripVertical from '@lucide/svelte/icons/grip-vertical';
     import Trash2 from '@lucide/svelte/icons/trash-2';
     import EyeOff from '@lucide/svelte/icons/eye-off';
@@ -24,6 +25,7 @@
     const { widget, zone, children }: Props = $props();
 
     const isEditMode = $derived(widgetLayoutStore.isEditMode);
+    const isAdmin = $derived((authStore.user?.mb_level ?? 0) >= 10);
     let settingsOpen = $state(false);
 
     function handleRemove() {
@@ -46,7 +48,7 @@
 </script>
 
 <div
-    class="widget-wrapper relative {isEditMode
+    class="widget-wrapper group/widget relative {isEditMode
         ? 'ring-dashed ring-primary/40 rounded-lg ring-2'
         : ''} {!widget.enabled && isEditMode ? 'opacity-50' : ''}"
 >
@@ -93,6 +95,20 @@
                 </button>
             </div>
         </div>
+    {:else if isAdmin}
+        <!-- 관리자: 비편집 모드에서도 톱니바퀴 표시 -->
+        <div
+            class="absolute right-2 top-1 z-10 opacity-0 transition-opacity hover:opacity-100 group-hover/widget:opacity-100"
+        >
+            <button
+                type="button"
+                onclick={() => (settingsOpen = true)}
+                class="bg-muted/80 text-muted-foreground hover:bg-accent rounded p-1 transition-all duration-200 ease-out"
+                title="위젯 설정"
+            >
+                <SettingsIcon class="h-3.5 w-3.5" />
+            </button>
+        </div>
     {/if}
 
     <!-- 위젯 콘텐츠 -->
@@ -103,7 +119,7 @@
     </div>
 </div>
 
-{#if isEditMode}
+{#if isEditMode || isAdmin}
     <WidgetSettingsDialog
         {widget}
         {zone}

--- a/apps/web/src/lib/server/new-posts.ts
+++ b/apps/web/src/lib/server/new-posts.ts
@@ -79,7 +79,10 @@ export async function getNewPosts(
     const cached = await feedCache.get(feedCacheKey);
     if (cached) return cached;
 
-    const conditions: string[] = ['b.bo_use_search = 1'];
+    const conditions: string[] = [
+        'b.bo_use_search = 1',
+        'bn.bn_datetime > DATE_SUB(NOW(), INTERVAL 7 DAY)'
+    ];
     const params: (string | number)[] = [];
 
     // 원글/댓글 필터
@@ -111,7 +114,10 @@ export async function getNewPosts(
         total = cachedCount.total;
     } else {
         // 커서 조건 제외한 원본 WHERE로 카운트
-        const countConditions: string[] = ['b.bo_use_search = 1'];
+        const countConditions: string[] = [
+            'b.bo_use_search = 1',
+            'bn.bn_datetime > DATE_SUB(NOW(), INTERVAL 7 DAY)'
+        ];
         const countParams: (string | number)[] = [];
         if (view === 'w') countConditions.push('bn.wr_id = bn.wr_parent');
         else if (view === 'c') countConditions.push('bn.wr_id != bn.wr_parent');

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
     import { onMount, untrack } from 'svelte';
     import type { Component } from 'svelte';
     import { afterNavigate } from '$app/navigation';
-    import { page } from '$app/stores';
+    import { page, updated } from '$app/stores';
     import { configureSeo } from '$lib/seo';
     import { authActions, authStore } from '$lib/stores/auth.svelte';
     import { themeStore } from '$lib/stores/theme.svelte';
@@ -72,6 +72,13 @@
         untrack(() => {
             keyboardShortcuts.buildFromMenus(menus);
         });
+    });
+
+    // 새 버전 감지 시 다음 네비게이션에서 캐시 무효화 후 풀 리로드
+    afterNavigate(({ type }) => {
+        if ($updated && type !== 'enter') {
+            location.reload();
+        }
     });
 
     // 광고 추적: 매 네비게이션마다 observer 재설정

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -805,13 +805,10 @@
     {/if}
 
     <!-- 상단 네비게이션 -->
-    <div class="bg-background sticky top-12 z-40 -mx-1 mb-6 flex items-center gap-3 py-2 md:top-16">
+    <div class="-mx-1 mb-2 flex items-center gap-3 py-2">
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">← 목록으로</Button>
 
-        <!-- 축하 메시지 롤링 (인라인) -->
-        <div class="min-w-0 flex-1">
-            <CelebrationRolling />
-        </div>
+        <div class="flex-1"></div>
 
         <div class="flex shrink-0 gap-2">
             {#if authStore.isAuthenticated}
@@ -868,8 +865,13 @@
         </div>
     </div>
 
-    <!-- 네비게이션 아래 GAM 광고 -->
-    {#if widgetLayoutStore.hasEnabledAds}
+    <!-- 축하 메시지 롤링 -->
+    <div class="mb-4">
+        <CelebrationRolling />
+    </div>
+
+    <!-- 네비게이션 아래 GAM 광고 (알뜰구매/중고장터 등 특정 게시판에서만 표시) -->
+    {#if widgetLayoutStore.hasEnabledAds && (boardType === 'economy' || boardType === 'used-market')}
         <div class="mb-6">
             <AdSlot position="board-view-top" height="90px" />
         </div>

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -36,6 +36,14 @@ const config = {
         csrf: {
             // 개발 환경에서 localhost CSRF 허용
             checkOrigin: process.env.NODE_ENV === 'production'
+        },
+        output: {
+            // preload-js: <link rel="preload" as="script"> 대신 사용 (modulepreload보다 Link 헤더 축소)
+            preloadStrategy: 'preload-js'
+        },
+        version: {
+            // 빌드 시 자동 생성되는 버전 해시로 새 배포 감지
+            pollInterval: 60000 // 60초마다 서버 버전 확인
         }
     },
     compilerOptions: {


### PR DESCRIPTION
## Summary
- 햄버거 메뉴 우측 이동 + 드로워 스크롤 수정
- 상단 메뉴에 대피소(web.damoang.net) 추가
- 축하메시지 sticky 해제, 별도 줄 분리
- 본문 상단 광고 economy/used-market만 표시
- 관리자 위젯 톱니바퀴 hover 시 항상 표시
- g5_board_new 7일 날짜 필터 (384만 row → 최근 7일)
- HTTP Link 헤더 제거 + preload-js 전환
- 버전 폴링(60초) + 자동 새로고침으로 배포 후 캐시 문제 해소

## Test plan
- [ ] 모바일에서 햄버거 메뉴 우측 표시 확인
- [ ] 드로워 메뉴 스크롤 가능 확인
- [ ] 데스크톱에서 대피소 링크 표시 확인
- [ ] 게시글 상단 축하메시지 비고정 확인
- [ ] 관리자 로그인 후 위젯 hover 시 톱니바퀴 표시
- [ ] 피드 페이지 로드 속도 개선 확인