### PR TITLE
fix: 최고관리자 글쓰기 권한 바이패스 + 파일 업로드 제한 + 버그 제보 버튼

### DIFF
--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -533,8 +533,8 @@
                 <Label>첨부파일</Label>
                 <FileUploader
                     {boardId}
-                    maxFiles={10}
-                    maxSizeMB={50}
+                    maxFiles={20}
+                    maxSizeMB={10}
                     files={uploadedFiles}
                     onUpload={handleFileUpload}
                     onRemove={handleFileRemove}

--- a/apps/web/src/lib/components/features/uploader/file-uploader.svelte
+++ b/apps/web/src/lib/components/features/uploader/file-uploader.svelte
@@ -29,8 +29,8 @@
     let {
         boardId = 'free',
         postId,
-        maxFiles = 5,
-        maxSizeMB = 50,
+        maxFiles = 20,
+        maxSizeMB = 10,
         allowedExtensions = [],
         files = [],
         onUpload,

--- a/apps/web/src/lib/components/features/widget-editor/edit-mode-toggle.svelte
+++ b/apps/web/src/lib/components/features/widget-editor/edit-mode-toggle.svelte
@@ -2,6 +2,7 @@
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { getUser } from '$lib/stores/auth.svelte';
     import Settings from '@lucide/svelte/icons/settings';
+    import Bug from '@lucide/svelte/icons/bug';
     import X from '@lucide/svelte/icons/x';
     import Save from '@lucide/svelte/icons/save';
     import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
@@ -18,6 +19,8 @@
 
     // 스토어 상태
     const isEditMode = $derived(widgetLayoutStore.isEditMode);
+    // 관리자 FAB이 표시될 때 버그 버튼 위치 조정
+    const bugBtnRight = $derived(isAdmin && !isEditMode ? 'right-20' : 'right-6');
     const isSaving = $derived(widgetLayoutStore.isSaving);
     const hasChanges = $derived(widgetLayoutStore.hasChanges);
 
@@ -125,3 +128,12 @@
         </button>
     {/if}
 {/if}
+
+<!-- 버그 제보 FAB 버튼 (모든 사용자) -->
+<a
+    href="/bugs"
+    class="bg-destructive text-destructive-foreground hover:bg-destructive/90 fixed bottom-6 z-50 flex h-12 w-12 items-center justify-center rounded-full shadow-lg transition-all hover:scale-105 {bugBtnRight}"
+    title="버그 제보"
+>
+    <Bug class="h-5 w-5" />
+</a>

--- a/apps/web/src/routes/[boardId]/[postId]/edit/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/edit/+page.server.ts
@@ -25,7 +25,8 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 
         if (board) {
             const requiredLevel = board.write_level ?? 1;
-            if (userLevel < requiredLevel) {
+            const isSuperAdmin = userLevel >= 10;
+            if (!isSuperAdmin && userLevel < requiredLevel) {
                 error(403, '이 게시판에 글을 작성할 권한이 없습니다.');
             }
         }

--- a/apps/web/src/routes/[boardId]/write/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/write/+page.server.ts
@@ -24,14 +24,16 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 
         if (board) {
             const userLevel = locals.user.level ?? 0;
+            const isSuperAdmin = userLevel >= 10;
             const requiredLevel = board.write_level ?? 1;
-            if (userLevel < requiredLevel) {
+            if (!isSuperAdmin && userLevel < requiredLevel) {
                 error(403, '이 게시판에 글을 작성할 권한이 없습니다.');
             }
         }
 
-        // ExtendedSettings 기반 글쓰기 제한 체크 (서버 사이드 사전 검증)
-        if (locals.accessToken) {
+        // ExtendedSettings 기반 글쓰기 제한 체크 (서버 사이드 사전 검증, 최고관리자 제외)
+        const isSuperAdmin = (locals.user.level ?? 0) >= 10;
+        if (locals.accessToken && !isSuperAdmin) {
             try {
                 const permRes = await backendFetch(`/api/v1/boards/${boardId}/write-permission`, {
                     headers

--- a/apps/web/src/routes/api/media/images/+server.ts
+++ b/apps/web/src/routes/api/media/images/+server.ts
@@ -42,7 +42,7 @@ const ALLOWED_EXTENSIONS = new Set([
     '.csv',
     '.json'
 ]);
-const MAX_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
 function getExt(filename: string): string {
     const dot = filename.lastIndexOf('.');


### PR DESCRIPTION
## Summary
- 최고관리자(level>=10) write_level 및 ExtendedSettings 글쓰기 제한 바이패스
- 파일 업로드 MAX_SIZE 50MB→10MB, maxFiles 20개로 조정
- 모든 사용자에게 /bugs 버그 제보 FAB 버튼 추가 (오른쪽 하단)

## Test plan
- [ ] 최고관리자로 /promotion/write 접근 가능 확인
- [ ] 일반 사용자 이미지 업로드 동작 확인
- [ ] 10MB 초과 파일 업로드 거부 확인
- [ ] 버그 제보 버튼 표시 및 /bugs 이동 확인