### PR TITLE
fix: CodeQL incomplete multi-character sanitization 4건 수정

### DIFF
--- a/apps/web/src/lib/server/new-posts.ts
+++ b/apps/web/src/lib/server/new-posts.ts
@@ -50,8 +50,13 @@ function extractContentPreview(rawContent: string, maxLen = 100): string {
         '&gt;': '>',
         '&amp;': '&'
     };
-    const plainText = rawContent
-        .replace(/<[^>]*>/g, '') // HTML 태그 제거
+    let stripped = rawContent;
+    let prev;
+    do {
+        prev = stripped;
+        stripped = stripped.replace(/<[^>]*>/g, '');
+    } while (stripped !== prev);
+    const plainText = stripped
         .replace(/\{emo:[^}]+\}/g, '') // 이모지 코드 {emo:xxx} 제거
         .replace(/&(?:nbsp|lt|gt|amp);/g, (m) => entityMap[m])
         .replace(/\s+/g, ' ')

--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -134,7 +134,12 @@ export function transformBacktickCodeBlocks(text: string): string {
     if (!text || !text.includes('```')) return text;
 
     return text.replace(BACKTICK_CODE_BLOCK_PATTERN, (_match, lang: string, code: string) => {
-        const cleaned = code.replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]*>/g, '');
+        let cleaned = code.replace(/<br\s*\/?>/gi, '\n');
+        let prev;
+        do {
+            prev = cleaned;
+            cleaned = cleaned.replace(/<[^>]*>/g, '');
+        } while (cleaned !== prev);
         const trimmed = cleaned.replace(/^\n+|\n+$/g, '');
         const langAttr = lang ? ` class="language-${lang}"` : '';
         return `<pre><code${langAttr}>${trimmed}</code></pre>`;
@@ -159,10 +164,12 @@ export function transformCodeBlocks(html: string): string {
 
     return html.replace(CODE_BLOCK_PATTERN, (_match, lang: string | undefined, code: string) => {
         // HTML 태그 제거 (에디터가 삽입한 <br>, <p> 등)
-        const cleaned = code
-            .replace(/<br\s*\/?>/gi, '\n')
-            .replace(/<\/?p>/gi, '\n')
-            .replace(/<[^>]*>/g, '');
+        let cleaned = code.replace(/<br\s*\/?>/gi, '\n').replace(/<\/?p>/gi, '\n');
+        let prevC;
+        do {
+            prevC = cleaned;
+            cleaned = cleaned.replace(/<[^>]*>/g, '');
+        } while (cleaned !== prevC);
 
         // 앞뒤 빈 줄 제거
         const trimmed = cleaned.replace(/^\n+|\n+$/g, '');

--- a/apps/web/src/routes/api/members/[id]/activity/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/activity/+server.ts
@@ -136,8 +136,13 @@ export const GET: RequestHandler = async ({ params, url }) => {
                     '&gt;': '>',
                     '&amp;': '&'
                 };
-                const preview = w.wr_content
-                    .replace(/<[^>]*>/g, '') // HTML 태그 제거
+                let contentStripped = w.wr_content;
+                let prevContent;
+                do {
+                    prevContent = contentStripped;
+                    contentStripped = contentStripped.replace(/<[^>]*>/g, '');
+                } while (contentStripped !== prevContent);
+                const preview = contentStripped
                     .replace(/\{emo:[^}]+\}/g, '') // 이모지 코드 {emo:xxx} 제거
                     .replace(/&(?:nbsp|lt|gt|amp);/g, (m) => entityMap[m])
                     .replace(/\s+/g, ' ') // 연속 공백 정리


### PR DESCRIPTION
## Summary
- HTML 태그 제거 시 단일 `.replace(/<[^>]*>/g, '')` 호출로는 중첩 태그(`<scr<b>ipt>` → `<script>`)가 살아남는 보안 취약점 수정
- 기존 `transformVideos`에서 이미 사용 중인 반복 루프 패턴을 나머지 4곳에도 적용
- 대상 파일:
  - `content-transform.ts`: `transformBacktickCodeBlocks`, `transformCodeBlocks`
  - `new-posts.ts`: `extractContentPreview`
  - `api/members/[id]/activity/+server.ts`: 댓글 미리보기

## CodeQL Alerts
- #65: `api/members/[id]/activity/+server.ts:139`
- #71: `new-posts.ts:53`
- #79: `content-transform.ts:137`
- #80: `content-transform.ts:162`

## 변경 범위
- 로직 변경 없음: 단일 `.replace()` → 반복 루프 (정상 입력 시 동일 결과, 1회 실행)
- 기존 `transformVideos` (line 88-92)에서 이미 검증된 패턴

## Test plan
- [x] 코드 리뷰: 4곳 모두 동일한 반복 루프 패턴 적용 확인
- [ ] CodeQL 재스캔 후 4건 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)