### PR TITLE
perf: SSR 성능 최적화 — 홈페이지 캐시, singleflight, async I/O

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -13,6 +13,11 @@ const jwtCache = new Map<string, { token: string; expiry: number }>();
 const JWT_CACHE_TTL = 5 * 60 * 1000; // 5분
 const MAX_JWT_CACHE_SIZE = 50000;
 
+// --- SSR 응답 캐시 (비로그인 홈페이지) ---
+const ssrCache = new Map<string, { body: string; timestamp: number }>();
+const SSR_CACHE_TTL = 10_000; // 10초
+let ssrCachePending: Promise<Response> | null = null;
+
 /**
  * SvelteKit Server Hooks
  *
@@ -353,6 +358,84 @@ export const handle: Handle = async ({ event, resolve }) => {
 
     // /api/plugins/* 프록시는 더 이상 사용하지 않음
     // 모든 /api/plugins/* 요청은 SvelteKit API 라우트에서 처리
+
+    // --- 비로그인 홈페이지 SSR 응답 캐시 ---
+    // Pod 재시작 시 캐시 자동 소멸 → 배포 시 구 JS 경로 문제 없음
+    if (!event.locals.user && pathname === '/') {
+        const cached = ssrCache.get('/');
+        if (cached && Date.now() - cached.timestamp < SSR_CACHE_TTL) {
+            return new Response(cached.body, {
+                status: 200,
+                headers: {
+                    'Content-Type': 'text/html; charset=utf-8',
+                    'Cache-Control': 'private, no-store, no-cache, must-revalidate',
+                    Vary: 'Cookie',
+                    'X-Content-Type-Options': 'nosniff',
+                    'X-Frame-Options': 'SAMEORIGIN',
+                    'Referrer-Policy': 'strict-origin-when-cross-origin',
+                    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+                    ...(!dev ? { 'Content-Security-Policy': cspHeader } : {}),
+                    'X-SSR-Cache': 'HIT'
+                }
+            });
+        }
+
+        // Singleflight: 동시 요청 시 1개만 SSR 실행
+        if (ssrCachePending) {
+            try {
+                const result = await ssrCachePending;
+                return result.clone();
+            } catch {
+                // pending 실패 시 아래에서 직접 렌더링
+            }
+        }
+
+        const renderPromise = (async () => {
+            const themeMode = event.cookies.get('angple_theme_mode') || '';
+            const htmlClass =
+                themeMode === 'dark' ? 'dark' : themeMode === 'amoled' ? 'amoled' : '';
+            const density = event.cookies.get('angple_ui_density') || 'balanced';
+            const dPad = density === 'compact' ? '0px' : density === 'relaxed' ? '6px' : '3px';
+
+            const response = await resolve(event, {
+                transformPageChunk: ({ html }) => {
+                    const cls = htmlClass ? ` class="${htmlClass}"` : '';
+                    const sty = ` style="--row-pad-extra:${dPad};--comment-pad-extra:${dPad}"`;
+                    return html.replace('<html lang="ko">', `<html lang="ko"${cls}${sty}>`);
+                }
+            });
+
+            if (response.status === 200) {
+                const body = await response.text();
+                ssrCache.set('/', { body, timestamp: Date.now() });
+
+                return new Response(body, {
+                    status: 200,
+                    headers: {
+                        'Content-Type': 'text/html; charset=utf-8',
+                        'Cache-Control': 'private, no-store, no-cache, must-revalidate',
+                        Vary: 'Cookie',
+                        'X-Content-Type-Options': 'nosniff',
+                        'X-Frame-Options': 'SAMEORIGIN',
+                        'Referrer-Policy': 'strict-origin-when-cross-origin',
+                        'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+                        ...(!dev ? { 'Content-Security-Policy': cspHeader } : {}),
+                        'X-SSR-Cache': 'MISS'
+                    }
+                });
+            }
+
+            return response;
+        })();
+
+        ssrCachePending = renderPromise;
+        try {
+            const result = await renderPromise;
+            return result;
+        } finally {
+            ssrCachePending = null;
+        }
+    }
 
     // SSR 다크모드: 쿠키에서 테마 읽어 <html> 클래스 주입 (FOUC 방지)
     const themeMode = event.cookies.get('angple_theme_mode') || '';

--- a/apps/web/src/lib/server/cache.ts
+++ b/apps/web/src/lib/server/cache.ts
@@ -44,6 +44,7 @@ export interface Cache<T> {
 export function createCache<T>(options?: Partial<CacheOptions>): Cache<T> {
     const config = { ...DEFAULT_OPTIONS, ...options };
     const store = new Map<string, CacheEntry<T>>();
+    const pending = new Map<string, Promise<T>>();
 
     function isExpired(entry: CacheEntry<T>): boolean {
         return Date.now() > entry.expiresAt;
@@ -87,9 +88,23 @@ export function createCache<T>(options?: Partial<CacheOptions>): Cache<T> {
             const cached = this.get(key);
             if (cached !== undefined) return cached;
 
-            const value = await factory();
-            this.set(key, value);
-            return value;
+            // Singleflight: 동일 key에 대한 중복 factory 실행 방지
+            const inflight = pending.get(key);
+            if (inflight) return inflight;
+
+            const promise = factory()
+                .then((value) => {
+                    this.set(key, value);
+                    pending.delete(key);
+                    return value;
+                })
+                .catch((err) => {
+                    pending.delete(key);
+                    throw err;
+                });
+
+            pending.set(key, promise);
+            return promise;
         },
 
         delete(key: string): void {
@@ -124,9 +139,11 @@ export class TieredCache<T> {
     private readonly l1TtlMs: number;
     private readonly l2TtlSec: number;
     private readonly maxL1Size: number;
+    private readonly pending: Map<string, Promise<T>>;
 
     constructor(prefix: string, l1TtlMs: number, l2TtlSec: number, maxL1Size = 5000) {
         this.l1 = new Map();
+        this.pending = new Map();
         this.prefix = prefix;
         this.l1TtlMs = l1TtlMs;
         this.l2TtlSec = l2TtlSec;
@@ -179,14 +196,28 @@ export class TieredCache<T> {
         }
     }
 
-    /** L1 + L2 조회 → 미스 시 factory 실행 후 저장 */
+    /** L1 + L2 조회 → 미스 시 factory 실행 후 저장 (singleflight) */
     async getOrFetch(key: string, factory: () => Promise<T>): Promise<T> {
         const cached = await this.get(key);
         if (cached !== null) return cached;
 
-        const data = await factory();
-        await this.set(key, data);
-        return data;
+        // Singleflight: 동일 key에 대한 중복 factory 실행 방지
+        const inflight = this.pending.get(key);
+        if (inflight) return inflight;
+
+        const promise = factory()
+            .then(async (data) => {
+                await this.set(key, data);
+                this.pending.delete(key);
+                return data;
+            })
+            .catch((err) => {
+                this.pending.delete(key);
+                throw err;
+            });
+
+        this.pending.set(key, promise);
+        return promise;
     }
 
     /** L1만 삭제 */

--- a/apps/web/src/lib/server/index-widgets-builder.ts
+++ b/apps/web/src/lib/server/index-widgets-builder.ts
@@ -42,7 +42,7 @@ interface BackendBoardResponse {
 }
 
 const JSON_PATH = '/home/damoang/www/data/cache/recommended/index-widgets.json';
-const CACHE_TTL_MS = 30_000; // 30초 (파일은 5분마다 갱신)
+const CACHE_TTL_MS = 60_000; // 60초 (파일은 5분마다 갱신)
 
 const EMPTY_RESULT: IndexWidgetsData = {
     news_tabs: [],

--- a/apps/web/src/lib/server/plugins/index.ts
+++ b/apps/web/src/lib/server/plugins/index.ts
@@ -48,7 +48,7 @@ export async function getInstalledPlugins(): Promise<Map<string, InstalledPlugin
     const plugins = new Map<string, InstalledPlugin>();
 
     // 1. 파일 시스템에서 플러그인 스캔
-    const manifests = scanPlugins();
+    const manifests = await scanPlugins();
 
     // 2. 활성 플러그인 ID 목록 조회
     const activePluginIds = await pluginSettingsProvider.getActivePlugins();
@@ -60,9 +60,9 @@ export async function getInstalledPlugins(): Promise<Map<string, InstalledPlugin
         plugins.set(pluginId, {
             manifest,
             currentSettings,
-            path: getPluginPath(pluginId),
+            path: await getPluginPath(pluginId),
             isActive: activePluginIds.includes(pluginId),
-            source: isCustomPlugin(pluginId) ? 'custom' : 'official'
+            source: (await isCustomPlugin(pluginId)) ? 'custom' : 'official'
         });
     }
 
@@ -73,11 +73,11 @@ export async function getInstalledPlugins(): Promise<Map<string, InstalledPlugin
  * 특정 플러그인 정보 가져오기
  */
 export async function getPluginById(pluginId: string): Promise<InstalledPlugin | null> {
-    if (!isPluginInstalled(pluginId)) {
+    if (!(await isPluginInstalled(pluginId))) {
         return null;
     }
 
-    const manifest = getPluginManifest(pluginId);
+    const manifest = await getPluginManifest(pluginId);
     if (!manifest) {
         return null;
     }
@@ -88,9 +88,9 @@ export async function getPluginById(pluginId: string): Promise<InstalledPlugin |
     return {
         manifest,
         currentSettings,
-        path: getPluginPath(pluginId),
+        path: await getPluginPath(pluginId),
         isActive: activePluginIds.includes(pluginId),
-        source: isCustomPlugin(pluginId) ? 'custom' : 'official'
+        source: (await isCustomPlugin(pluginId)) ? 'custom' : 'official'
     };
 }
 
@@ -132,7 +132,7 @@ export function invalidateActivePluginsCache(): void {
  */
 export async function activatePlugin(pluginId: string): Promise<boolean> {
     // 플러그인이 설치되어 있는지 확인
-    if (!isPluginInstalled(pluginId)) {
+    if (!(await isPluginInstalled(pluginId))) {
         console.error(`[Plugin API] 플러그인이 설치되지 않음: ${pluginId}`);
         return false;
     }

--- a/apps/web/src/lib/server/plugins/scanner.ts
+++ b/apps/web/src/lib/server/plugins/scanner.ts
@@ -3,6 +3,7 @@
  *
  * plugins/ 및 custom-plugins/ 디렉터리를 스캔하여 설치된 플러그인 목록을 가져옵니다.
  * 테마 스캐너(scanner.ts)와 동일한 패턴으로 구현되었습니다.
+ * 모든 파일 I/O는 비동기로 처리하여 event loop 블로킹 방지.
  *
  * ExtensionManifest 스키마 사용:
  * - plugin.json 또는 extension.json 파일 모두 지원
@@ -10,11 +11,20 @@
  * - category 필드로 테마/플러그인 구분
  */
 
-import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { readFile, readdir, stat, access } from 'fs/promises';
 import { join, resolve } from 'path';
 import type { ExtensionManifest } from '@angple/types';
 import { safeValidateExtensionManifest } from '@angple/types';
 import { sanitizePath } from '../path-utils';
+
+async function fileExists(path: string): Promise<boolean> {
+    try {
+        await access(path);
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 /**
  * 프로젝트 루트 디렉터리 찾기
@@ -50,17 +60,17 @@ const CUSTOM_EXTENSIONS_DIR = join(PROJECT_ROOT, 'custom-extensions');
  *
  * plugin.json 또는 extension.json 파일이 있으면 유효한 플러그인으로 간주
  */
-function isValidPluginDirectory(pluginPath: string): boolean {
-    if (!existsSync(pluginPath)) return false;
+async function isValidPluginDirectory(pluginPath: string): Promise<boolean> {
+    if (!(await fileExists(pluginPath))) return false;
 
-    const stat = statSync(pluginPath);
-    if (!stat.isDirectory()) return false;
+    const s = await stat(pluginPath);
+    if (!s.isDirectory()) return false;
 
     // plugin.json 또는 extension.json 파일 존재 확인
     const pluginJsonPath = join(pluginPath, 'plugin.json'); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const extensionJsonPath = join(pluginPath, 'extension.json'); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
 
-    return existsSync(pluginJsonPath) || existsSync(extensionJsonPath);
+    return (await fileExists(pluginJsonPath)) || (await fileExists(extensionJsonPath));
 }
 
 /**
@@ -70,7 +80,10 @@ function isValidPluginDirectory(pluginPath: string): boolean {
  * @param baseDir 플러그인이 위치한 기본 디렉터리 (PLUGINS_DIR 또는 CUSTOM_PLUGINS_DIR)
  * @returns ExtensionManifest 또는 null (category가 'plugin'이 아니거나 검증 실패 시)
  */
-function loadPluginManifest(pluginDir: string, baseDir: string): ExtensionManifest | null {
+async function loadPluginManifest(
+    pluginDir: string,
+    baseDir: string
+): Promise<ExtensionManifest | null> {
     // pluginDir는 readdir()에서 온 안전한 디렉터리명
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const pluginJsonPath = join(baseDir, pluginDir, 'plugin.json');
@@ -79,16 +92,16 @@ function loadPluginManifest(pluginDir: string, baseDir: string): ExtensionManife
 
     // plugin.json 우선, 없으면 extension.json 시도
     let manifestPath: string;
-    if (existsSync(pluginJsonPath)) {
+    if (await fileExists(pluginJsonPath)) {
         manifestPath = pluginJsonPath;
-    } else if (existsSync(extensionJsonPath)) {
+    } else if (await fileExists(extensionJsonPath)) {
         manifestPath = extensionJsonPath;
     } else {
         return null;
     }
 
     try {
-        const manifestJson = readFileSync(manifestPath, 'utf-8');
+        const manifestJson = await readFile(manifestPath, 'utf-8');
         const manifestData = JSON.parse(manifestJson);
 
         // 기본값 제공 (기존 플러그인 호환성)
@@ -126,34 +139,37 @@ function loadPluginManifest(pluginDir: string, baseDir: string): ExtensionManife
 /**
  * 특정 디렉터리에서 플러그인 스캔 헬퍼
  */
-function scanDirectory(baseDir: string, plugins: Map<string, ExtensionManifest>): number {
-    if (!existsSync(baseDir)) {
+async function scanDirectory(
+    baseDir: string,
+    plugins: Map<string, ExtensionManifest>
+): Promise<number> {
+    if (!(await fileExists(baseDir))) {
         return 0;
     }
 
     let scannedCount = 0;
-    const entries = readdirSync(baseDir, { withFileTypes: true });
+    const entries = await readdir(baseDir, { withFileTypes: true });
 
     for (const entry of entries) {
         // 디렉터리만 처리 (심링크 → 디렉터리도 허용: 개발 환경 플러그인 링크 지원)
         if (!entry.isDirectory()) {
             if (!entry.isSymbolicLink()) continue;
-            const targetStat = statSync(join(baseDir, entry.name));
+            const targetStat = await stat(join(baseDir, entry.name));
             if (!targetStat.isDirectory()) continue;
         }
 
         const pluginDir = entry.name;
-        // pluginDir는 readdirSync()에서 반환된 실제 디렉터리명 (사용자 입력 아님)
+        // pluginDir는 readdir()에서 반환된 실제 디렉터리명 (사용자 입력 아님)
         // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
         const pluginPath = join(baseDir, pluginDir);
 
         // 유효한 플러그인 디렉터리인지 확인
-        if (!isValidPluginDirectory(pluginPath)) {
+        if (!(await isValidPluginDirectory(pluginPath))) {
             continue;
         }
 
         // 매니페스트 로드 및 검증
-        const manifest = loadPluginManifest(pluginDir, baseDir);
+        const manifest = await loadPluginManifest(pluginDir, baseDir);
         if (!manifest) continue;
 
         // 디렉터리 이름과 ID가 일치하는지 확인 (불일치 시 디렉터리 이름을 ID로 사용)
@@ -172,18 +188,16 @@ function scanDirectory(baseDir: string, plugins: Map<string, ExtensionManifest>)
  *
  * @returns 플러그인 ID를 key로 하는 ExtensionManifest 맵
  */
-export function scanPlugins(): Map<string, ExtensionManifest> {
+export async function scanPlugins(): Promise<Map<string, ExtensionManifest>> {
     const plugins = new Map<string, ExtensionManifest>();
 
     try {
-        // 공식 플러그인 스캔 (Git 추적)
-        scanDirectory(PLUGINS_DIR, plugins);
-
-        // 커스텀 플러그인 스캔 (사용자 업로드)
-        scanDirectory(CUSTOM_PLUGINS_DIR, plugins);
-
-        // GitHub Packages에서 설치된 확장 스캔
-        scanDirectory(CUSTOM_EXTENSIONS_DIR, plugins);
+        // 병렬 스캔
+        await Promise.all([
+            scanDirectory(PLUGINS_DIR, plugins),
+            scanDirectory(CUSTOM_PLUGINS_DIR, plugins),
+            scanDirectory(CUSTOM_EXTENSIONS_DIR, plugins)
+        ]);
     } catch (error) {
         console.error('[Plugin Scanner] 플러그인 스캔 실패:', error);
     }
@@ -195,27 +209,27 @@ export function scanPlugins(): Map<string, ExtensionManifest> {
  * 플러그인이 어느 디렉터리에 있는지 찾기
  * @returns [baseDir, isCustom] 튜플 또는 null
  */
-function findPluginDirectory(pluginId: string): [string, boolean] | null {
+async function findPluginDirectory(pluginId: string): Promise<[string, boolean] | null> {
     const sanitizedId = sanitizePath(pluginId);
 
     // 1. 공식 플러그인 디렉터리 확인
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const officialPath = join(PLUGINS_DIR, sanitizedId);
-    if (isValidPluginDirectory(officialPath)) {
+    if (await isValidPluginDirectory(officialPath)) {
         return [PLUGINS_DIR, false];
     }
 
     // 2. 커스텀 플러그인 디렉터리 확인
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const customPath = join(CUSTOM_PLUGINS_DIR, sanitizedId);
-    if (isValidPluginDirectory(customPath)) {
+    if (await isValidPluginDirectory(customPath)) {
         return [CUSTOM_PLUGINS_DIR, true];
     }
 
     // 3. GitHub Packages에서 설치된 확장 디렉터리 확인
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const extensionPath = join(CUSTOM_EXTENSIONS_DIR, sanitizedId);
-    if (isValidPluginDirectory(extensionPath)) {
+    if (await isValidPluginDirectory(extensionPath)) {
         return [CUSTOM_EXTENSIONS_DIR, true];
     }
 
@@ -225,8 +239,8 @@ function findPluginDirectory(pluginId: string): [string, boolean] | null {
 /**
  * 특정 플러그인의 매니페스트 가져오기
  */
-export function getPluginManifest(pluginId: string): ExtensionManifest | null {
-    const result = findPluginDirectory(pluginId);
+export async function getPluginManifest(pluginId: string): Promise<ExtensionManifest | null> {
+    const result = await findPluginDirectory(pluginId);
     if (!result) return null;
 
     const [baseDir] = result;
@@ -237,8 +251,8 @@ export function getPluginManifest(pluginId: string): ExtensionManifest | null {
 /**
  * 플러그인 디렉터리 절대 경로 반환
  */
-export function getPluginPath(pluginId: string): string {
-    const result = findPluginDirectory(pluginId);
+export async function getPluginPath(pluginId: string): Promise<string> {
+    const result = await findPluginDirectory(pluginId);
     const sanitizedId = sanitizePath(pluginId);
 
     if (!result) {
@@ -255,15 +269,15 @@ export function getPluginPath(pluginId: string): string {
 /**
  * 플러그인이 설치되어 있는지 확인
  */
-export function isPluginInstalled(pluginId: string): boolean {
-    return findPluginDirectory(pluginId) !== null;
+export async function isPluginInstalled(pluginId: string): Promise<boolean> {
+    return (await findPluginDirectory(pluginId)) !== null;
 }
 
 /**
  * 플러그인이 커스텀 플러그인인지 확인
  */
-export function isCustomPlugin(pluginId: string): boolean {
-    const result = findPluginDirectory(pluginId);
+export async function isCustomPlugin(pluginId: string): Promise<boolean> {
+    const result = await findPluginDirectory(pluginId);
     return result ? result[1] : false;
 }
 

--- a/apps/web/src/lib/server/recommended-loader.ts
+++ b/apps/web/src/lib/server/recommended-loader.ts
@@ -24,7 +24,7 @@ const PERIOD_FILES: Record<string, { base: string; ai: string }> = {
 
 /** 인메모리 캐시 (period별) */
 const cache = new Map<string, { data: RecommendedDataWithAI; timestamp: number }>();
-const CACHE_TTL_MS = 30_000; // 30초
+const CACHE_TTL_MS = 60_000; // 60초 (PHP cron 주기적 업데이트)
 
 /**
  * 시간대별 기본 탭 결정 (PHP 원본 로직)

--- a/apps/web/src/lib/server/themes/index.ts
+++ b/apps/web/src/lib/server/themes/index.ts
@@ -43,7 +43,7 @@ export async function getInstalledThemes(): Promise<Map<string, InstalledTheme>>
     const themes = new Map<string, InstalledTheme>();
 
     // 1. 파일 시스템에서 테마 스캔
-    const manifests = scanThemes();
+    const manifests = await scanThemes();
 
     // 2. 활성 테마 ID 조회
     const activeThemeId = await settingsProvider.getActiveTheme();
@@ -55,9 +55,9 @@ export async function getInstalledThemes(): Promise<Map<string, InstalledTheme>>
         themes.set(themeId, {
             manifest,
             currentSettings,
-            path: getThemePath(themeId),
+            path: await getThemePath(themeId),
             isActive: themeId === activeThemeId,
-            source: isCustomTheme(themeId) ? 'custom' : 'official'
+            source: (await isCustomTheme(themeId)) ? 'custom' : 'official'
         });
     }
 
@@ -68,11 +68,11 @@ export async function getInstalledThemes(): Promise<Map<string, InstalledTheme>>
  * 특정 테마 정보 가져오기
  */
 export async function getThemeById(themeId: string): Promise<InstalledTheme | null> {
-    if (!isThemeInstalled(themeId)) {
+    if (!(await isThemeInstalled(themeId))) {
         return null;
     }
 
-    const manifest = getThemeManifest(themeId);
+    const manifest = await getThemeManifest(themeId);
     if (!manifest) {
         return null;
     }
@@ -83,9 +83,9 @@ export async function getThemeById(themeId: string): Promise<InstalledTheme | nu
     return {
         manifest,
         currentSettings,
-        path: getThemePath(themeId),
+        path: await getThemePath(themeId),
         isActive: themeId === activeThemeId,
-        source: isCustomTheme(themeId) ? 'custom' : 'official'
+        source: (await isCustomTheme(themeId)) ? 'custom' : 'official'
     };
 }
 
@@ -94,7 +94,7 @@ export async function getThemeById(themeId: string): Promise<InstalledTheme | nu
  * 매 요청마다 scanThemes() 디스크 I/O를 방지
  */
 let activeThemeCache: { data: InstalledTheme | null; expiry: number } | null = null;
-const THEME_CACHE_TTL = 30_000; // 30초
+const THEME_CACHE_TTL = 5 * 60_000; // 5분 (관리자만 변경, invalidate 함수 존재)
 
 /**
  * 활성 테마 가져오기 (캐시 적용)
@@ -123,7 +123,7 @@ export async function getActiveTheme(): Promise<InstalledTheme | null> {
  */
 export async function activateTheme(themeId: string): Promise<boolean> {
     // 테마가 설치되어 있는지 확인
-    if (!isThemeInstalled(themeId)) {
+    if (!(await isThemeInstalled(themeId))) {
         console.error(`[Theme API] 테마가 설치되지 않음: ${themeId}`);
         return false;
     }

--- a/apps/web/src/lib/server/themes/scanner.ts
+++ b/apps/web/src/lib/server/themes/scanner.ts
@@ -2,13 +2,23 @@
  * 테마 스캔 및 로드 함수
  *
  * themes/ 디렉터리를 스캔하여 설치된 테마 목록을 가져옵니다.
+ * 모든 파일 I/O는 비동기로 처리하여 event loop 블로킹 방지.
  */
 
-import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { readFile, readdir, stat, access } from 'fs/promises';
 import { join, resolve } from 'path';
 import type { ThemeManifest } from '$lib/types/theme';
 import { safeValidateThemeManifest } from '$lib/types/theme';
 import { sanitizePath } from '../path-utils';
+
+async function fileExists(path: string): Promise<boolean> {
+    try {
+        await access(path);
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 /**
  * 프로젝트 루트 디렉터리 찾기
@@ -39,15 +49,15 @@ const CUSTOM_THEMES_DIR = join(PROJECT_ROOT, 'custom-themes');
 /**
  * 테마 디렉터리가 유효한지 확인
  */
-function isValidThemeDirectory(themePath: string): boolean {
-    if (!existsSync(themePath)) return false;
+async function isValidThemeDirectory(themePath: string): Promise<boolean> {
+    if (!(await fileExists(themePath))) return false;
 
-    const stat = statSync(themePath);
-    if (!stat.isDirectory()) return false;
+    const s = await stat(themePath);
+    if (!s.isDirectory()) return false;
 
     // theme.json 파일이 있어야 함
     const manifestPath = join(themePath, 'theme.json'); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
-    return existsSync(manifestPath);
+    return fileExists(manifestPath);
 }
 
 /**
@@ -55,13 +65,13 @@ function isValidThemeDirectory(themePath: string): boolean {
  * @param themeDir 테마 디렉터리명 (안전한 이름, readdir에서 반환)
  * @param baseDir 테마가 위치한 기본 디렉터리 (THEMES_DIR 또는 CUSTOM_THEMES_DIR)
  */
-function loadThemeManifest(themeDir: string, baseDir: string): ThemeManifest | null {
+async function loadThemeManifest(themeDir: string, baseDir: string): Promise<ThemeManifest | null> {
     // themeDir는 readdir()에서 온 안전한 디렉터리명
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const manifestPath = join(baseDir, themeDir, 'theme.json');
 
     try {
-        const manifestJson = readFileSync(manifestPath, 'utf-8');
+        const manifestJson = await readFile(manifestPath, 'utf-8');
         const manifestData = JSON.parse(manifestJson);
 
         // Zod 검증
@@ -83,34 +93,34 @@ function loadThemeManifest(themeDir: string, baseDir: string): ThemeManifest | n
 /**
  * 특정 디렉터리에서 테마 스캔 헬퍼
  */
-function scanDirectory(baseDir: string, themes: Map<string, ThemeManifest>): number {
-    if (!existsSync(baseDir)) {
+async function scanDirectory(baseDir: string, themes: Map<string, ThemeManifest>): Promise<number> {
+    if (!(await fileExists(baseDir))) {
         return 0;
     }
 
     let scannedCount = 0;
-    const entries = readdirSync(baseDir, { withFileTypes: true });
+    const entries = await readdir(baseDir, { withFileTypes: true });
 
     for (const entry of entries) {
         // 디렉터리만 처리 (심링크 → 디렉터리도 허용: 개발 환경 테마 링크 지원)
         if (!entry.isDirectory()) {
             if (!entry.isSymbolicLink()) continue;
-            const targetStat = statSync(join(baseDir, entry.name));
+            const targetStat = await stat(join(baseDir, entry.name));
             if (!targetStat.isDirectory()) continue;
         }
 
         const themeDir = entry.name;
-        // themeDir는 readdirSync()에서 반환된 실제 디렉터리명 (사용자 입력 아님)
+        // themeDir는 readdir()에서 반환된 실제 디렉터리명 (사용자 입력 아님)
         // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
         const themePath = join(baseDir, themeDir);
 
         // 유효한 테마 디렉터리인지 확인
-        if (!isValidThemeDirectory(themePath)) {
+        if (!(await isValidThemeDirectory(themePath))) {
             continue;
         }
 
         // 매니페스트 로드 및 검증
-        const manifest = loadThemeManifest(themeDir, baseDir);
+        const manifest = await loadThemeManifest(themeDir, baseDir);
         if (!manifest) continue;
 
         // 디렉터리 이름과 ID가 일치하는지 확인
@@ -127,7 +137,7 @@ function scanDirectory(baseDir: string, themes: Map<string, ThemeManifest>): num
  *
  * @returns 테마 ID를 key로 하는 매니페스트 맵
  */
-export function scanThemes(): Map<string, ThemeManifest> {
+export async function scanThemes(): Promise<Map<string, ThemeManifest>> {
     const themes = new Map<string, ThemeManifest>();
 
     try {
@@ -136,6 +146,8 @@ export function scanThemes(): Map<string, ThemeManifest> {
 
         // 커스텀 테마 스캔 (사용자 업로드)
         const customCount = scanDirectory(CUSTOM_THEMES_DIR, themes);
+
+        await Promise.all([officialCount, customCount]);
     } catch (error) {
         console.error('[Theme Scanner] 테마 스캔 실패:', error);
     }
@@ -147,20 +159,20 @@ export function scanThemes(): Map<string, ThemeManifest> {
  * 테마가 어느 디렉터리에 있는지 찾기
  * @returns [baseDir, isCustom] 튜플 또는 null
  */
-function findThemeDirectory(themeId: string): [string, boolean] | null {
+async function findThemeDirectory(themeId: string): Promise<[string, boolean] | null> {
     const sanitizedId = sanitizePath(themeId);
 
     // 1. 공식 테마 디렉터리 확인
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const officialPath = join(THEMES_DIR, sanitizedId);
-    if (isValidThemeDirectory(officialPath)) {
+    if (await isValidThemeDirectory(officialPath)) {
         return [THEMES_DIR, false];
     }
 
     // 2. 커스텀 테마 디렉터리 확인
     // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     const customPath = join(CUSTOM_THEMES_DIR, sanitizedId);
-    if (isValidThemeDirectory(customPath)) {
+    if (await isValidThemeDirectory(customPath)) {
         return [CUSTOM_THEMES_DIR, true];
     }
 
@@ -170,8 +182,8 @@ function findThemeDirectory(themeId: string): [string, boolean] | null {
 /**
  * 특정 테마의 매니페스트 가져오기
  */
-export function getThemeManifest(themeId: string): ThemeManifest | null {
-    const result = findThemeDirectory(themeId);
+export async function getThemeManifest(themeId: string): Promise<ThemeManifest | null> {
+    const result = await findThemeDirectory(themeId);
     if (!result) return null;
 
     const [baseDir] = result;
@@ -182,8 +194,8 @@ export function getThemeManifest(themeId: string): ThemeManifest | null {
 /**
  * 테마 디렉터리 절대 경로 반환
  */
-export function getThemePath(themeId: string): string {
-    const result = findThemeDirectory(themeId);
+export async function getThemePath(themeId: string): Promise<string> {
+    const result = await findThemeDirectory(themeId);
     const sanitizedId = sanitizePath(themeId);
 
     if (!result) {
@@ -200,14 +212,14 @@ export function getThemePath(themeId: string): string {
 /**
  * 테마가 설치되어 있는지 확인
  */
-export function isThemeInstalled(themeId: string): boolean {
-    return findThemeDirectory(themeId) !== null;
+export async function isThemeInstalled(themeId: string): Promise<boolean> {
+    return (await findThemeDirectory(themeId)) !== null;
 }
 
 /**
  * 테마가 커스텀 테마인지 확인
  */
-export function isCustomTheme(themeId: string): boolean {
-    const result = findThemeDirectory(themeId);
+export async function isCustomTheme(themeId: string): Promise<boolean> {
+    const result = await findThemeDirectory(themeId);
     return result ? result[1] : false;
 }

--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -7,6 +7,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
+import { createCache } from '$lib/server/cache';
 
 interface Banner {
     id: number;
@@ -49,97 +50,107 @@ function extractFirstImage(content: string): string | null {
     return null;
 }
 
+// 축하 데이터는 하루에 한번 바뀜 → 60초 캐시 (singleflight 포함)
+const celebrationCache = createCache<Banner[]>({ ttl: 60_000, maxSize: 10 });
+
+async function fetchBanners(isRecent: boolean): Promise<Banner[]> {
+    const banners: Banner[] = [];
+
+    // 1차: celebration_banners 테이블 (신규)
+    // mode=recent: 날짜 무관 최근 8건 (메인 위젯용)
+    // 기본: 오늘 날짜만 (롤링 텍스트/사이드바 배너용)
+    try {
+        const dateFilter = isRecent
+            ? ''
+            : "AND cb.display_date = DATE(CONVERT_TZ(NOW(), '+00:00', '+09:00'))";
+        const [rows] = await pool.execute<RowDataPacket[]>(
+            `SELECT cb.id, cb.title, cb.content, cb.image_url, cb.link_url,
+                    cb.external_url, cb.display_date, cb.target_member_id,
+                    cb.link_target, cb.sort_order, cb.display_type,
+                    cb.source_wr_id,
+                    m.mb_nick AS target_member_nick,
+                    m.mb_image_url AS target_member_image_url
+             FROM celebration_banners cb
+             LEFT JOIN g5_member m ON cb.target_member_id COLLATE utf8mb4_unicode_ci = m.mb_id
+             WHERE cb.is_active = 1 ${dateFilter}
+             ORDER BY cb.display_date DESC, cb.sort_order ASC, cb.id DESC
+             LIMIT 8`
+        );
+
+        for (const row of rows as RowDataPacket[]) {
+            // link_url 결정: external_url 우선 → source_wr_id → link_url
+            const linkUrl =
+                row.external_url ||
+                (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
+
+            banners.push({
+                id: row.source_wr_id || row.id,
+                title: row.title,
+                content: row.content || '',
+                image_url: row.image_url || '',
+                link_url: linkUrl,
+                display_date: row.display_date,
+                is_active: true,
+                target_member_id: row.target_member_id || undefined,
+                target_member_nick: row.target_member_nick || undefined,
+                target_member_photo: getMemberPhotoUrl(row.target_member_image_url),
+                external_link: row.external_url || undefined,
+                link_target: row.link_target || '_blank',
+                sort_order: row.sort_order || 0,
+                display_type: row.display_type || 'image'
+            });
+        }
+    } catch {
+        // celebration_banners 테이블이 없을 수 있음 — 무시하고 fallback으로
+    }
+
+    // 2차: g5_write_message fallback (마이그레이션 전까지)
+    // mode=recent: 최근 글 표시, 기본: 오늘 날짜만
+    if (banners.length === 0) {
+        const legacyDateFilter = isRecent
+            ? ''
+            : "AND (wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(),'+00:00','+09:00'),'%Y.%m.%d') OR wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(),'+00:00','+09:00'),'%Y-%m-%d'))";
+        const [rows] = await pool.execute<RowDataPacket[]>(
+            `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
+                    m.mb_nick, m.mb_image_url
+             FROM g5_write_message wm
+             LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
+             WHERE wm.wr_is_comment = 0 ${legacyDateFilter}
+             ORDER BY wm.wr_id DESC
+             LIMIT 8`
+        );
+
+        for (const row of rows as RowDataPacket[]) {
+            const imageUrl = extractFirstImage(row.wr_content);
+            if (imageUrl) {
+                banners.push({
+                    id: row.wr_id,
+                    title: row.wr_subject,
+                    content: row.wr_content,
+                    image_url: imageUrl,
+                    link_url: row.wr_link2 || `/message/${row.wr_id}`,
+                    display_date: row.wr_subject,
+                    is_active: true,
+                    target_member_id: row.mb_id || undefined,
+                    target_member_nick: row.mb_nick || undefined,
+                    target_member_photo: getMemberPhotoUrl(row.mb_image_url),
+                    external_link: row.wr_link2 || undefined,
+                    display_type: 'image'
+                });
+            }
+        }
+    }
+
+    return banners;
+}
+
 export const GET: RequestHandler = async ({ url }) => {
     const mode = url.searchParams.get('mode');
     const isRecent = mode === 'recent';
+    const cacheKey = isRecent ? 'recent' : 'today';
 
     try {
-        const banners: Banner[] = [];
-
-        // 1차: celebration_banners 테이블 (신규)
-        // mode=recent: 날짜 무관 최근 8건 (메인 위젯용)
-        // 기본: 오늘 날짜만 (롤링 텍스트/사이드바 배너용)
-        try {
-            const dateFilter = isRecent
-                ? ''
-                : "AND cb.display_date = DATE(CONVERT_TZ(NOW(), '+00:00', '+09:00'))";
-            const [rows] = await pool.execute<RowDataPacket[]>(
-                `SELECT cb.id, cb.title, cb.content, cb.image_url, cb.link_url,
-                        cb.external_url, cb.display_date, cb.target_member_id,
-                        cb.link_target, cb.sort_order, cb.display_type,
-                        cb.source_wr_id,
-                        m.mb_nick AS target_member_nick,
-                        m.mb_image_url AS target_member_image_url
-                 FROM celebration_banners cb
-                 LEFT JOIN g5_member m ON cb.target_member_id COLLATE utf8mb4_unicode_ci = m.mb_id
-                 WHERE cb.is_active = 1 ${dateFilter}
-                 ORDER BY cb.display_date DESC, cb.sort_order ASC, cb.id DESC
-                 LIMIT 8`
-            );
-
-            for (const row of rows as RowDataPacket[]) {
-                // link_url 결정: external_url 우선 → source_wr_id → link_url
-                const linkUrl =
-                    row.external_url ||
-                    (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
-
-                banners.push({
-                    id: row.source_wr_id || row.id,
-                    title: row.title,
-                    content: row.content || '',
-                    image_url: row.image_url || '',
-                    link_url: linkUrl,
-                    display_date: row.display_date,
-                    is_active: true,
-                    target_member_id: row.target_member_id || undefined,
-                    target_member_nick: row.target_member_nick || undefined,
-                    target_member_photo: getMemberPhotoUrl(row.target_member_image_url),
-                    external_link: row.external_url || undefined,
-                    link_target: row.link_target || '_blank',
-                    sort_order: row.sort_order || 0,
-                    display_type: row.display_type || 'image'
-                });
-            }
-        } catch {
-            // celebration_banners 테이블이 없을 수 있음 — 무시하고 fallback으로
-        }
-
-        // 2차: g5_write_message fallback (마이그레이션 전까지)
-        // mode=recent: 최근 글 표시, 기본: 오늘 날짜만
-        if (banners.length === 0) {
-            const legacyDateFilter = isRecent
-                ? ''
-                : "AND (wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(),'+00:00','+09:00'),'%Y.%m.%d') OR wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(),'+00:00','+09:00'),'%Y-%m-%d'))";
-            const [rows] = await pool.execute<RowDataPacket[]>(
-                `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
-                        m.mb_nick, m.mb_image_url
-                 FROM g5_write_message wm
-                 LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
-                 WHERE wm.wr_is_comment = 0 ${legacyDateFilter}
-                 ORDER BY wm.wr_id DESC
-                 LIMIT 8`
-            );
-
-            for (const row of rows as RowDataPacket[]) {
-                const imageUrl = extractFirstImage(row.wr_content);
-                if (imageUrl) {
-                    banners.push({
-                        id: row.wr_id,
-                        title: row.wr_subject,
-                        content: row.wr_content,
-                        image_url: imageUrl,
-                        link_url: row.wr_link2 || `/message/${row.wr_id}`,
-                        display_date: row.wr_subject,
-                        is_active: true,
-                        target_member_id: row.mb_id || undefined,
-                        target_member_nick: row.mb_nick || undefined,
-                        target_member_photo: getMemberPhotoUrl(row.mb_image_url),
-                        external_link: row.wr_link2 || undefined,
-                        display_type: 'image'
-                    });
-                }
-            }
-        }
+        const banners = await celebrationCache.getOrSet(cacheKey, () => fetchBanners(isRecent));
 
         return json({
             success: true,

--- a/apps/web/src/routes/api/plugins/marketplace/install/+server.ts
+++ b/apps/web/src/routes/api/plugins/marketplace/install/+server.ts
@@ -37,7 +37,7 @@ export const POST: RequestHandler = async ({ request }) => {
         }
 
         // 커스텀 플러그인은 마켓플레이스에서 설치 불가
-        if (isCustomPlugin(pluginId)) {
+        if (await isCustomPlugin(pluginId)) {
             return json(
                 {
                     success: false,

--- a/apps/web/src/routes/api/themes/[id]/+server.ts
+++ b/apps/web/src/routes/api/themes/[id]/+server.ts
@@ -32,7 +32,7 @@ export const DELETE: RequestHandler = async ({ params }) => {
 
     try {
         // 1. 공식 테마 보호
-        if (!isCustomTheme(themeId)) {
+        if (!(await isCustomTheme(themeId))) {
             return json(
                 {
                     error: '공식 테마는 삭제할 수 없습니다.',
@@ -56,7 +56,7 @@ export const DELETE: RequestHandler = async ({ params }) => {
         }
 
         // 3. 테마 디렉터리 경로 가져오기
-        const themePath = getThemePath(themeId);
+        const themePath = await getThemePath(themeId);
 
         if (!existsSync(themePath)) {
             return json(

--- a/apps/web/src/routes/api/themes/marketplace/install/+server.ts
+++ b/apps/web/src/routes/api/themes/marketplace/install/+server.ts
@@ -28,7 +28,7 @@ export const POST: RequestHandler = async ({ request, fetch: serverFetch }) => {
         }
 
         // 1. 이미 설치되어 있는지 확인
-        if (isThemeInstalled(themeId)) {
+        if (await isThemeInstalled(themeId)) {
             return json({ success: false, error: '이미 설치된 테마입니다.' }, { status: 409 });
         }
 

--- a/apps/web/src/routes/api/themes/marketplace/update/+server.ts
+++ b/apps/web/src/routes/api/themes/marketplace/update/+server.ts
@@ -27,7 +27,7 @@ export const POST: RequestHandler = async ({ request, fetch: serverFetch }) => {
         }
 
         // 1. 테마가 설치되어 있는지 확인
-        if (!isThemeInstalled(themeId)) {
+        if (!(await isThemeInstalled(themeId))) {
             return json(
                 { success: false, error: '설치되지 않은 테마입니다. 먼저 설치해주세요.' },
                 { status: 404 }

--- a/apps/web/src/routes/api/themes/upload/+server.ts
+++ b/apps/web/src/routes/api/themes/upload/+server.ts
@@ -180,7 +180,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
             rmSync(tempZipPath);
 
             // 테마 재스캔
-            scanThemes();
+            await scanThemes();
 
             return json({
                 success: true,

--- a/apps/web/src/routes/install/+page.server.ts
+++ b/apps/web/src/routes/install/+page.server.ts
@@ -16,15 +16,17 @@ export const load: PageServerLoad = async () => {
     }
 
     // 설치 가능한 테마 목록 로드
-    const themesMap = scanThemes();
-    const themes = Array.from(themesMap.values()).map((theme) => {
+    const themesMap = await scanThemes();
+    const themes: { id: string; name: string; description: string; screenshot: string | null }[] =
+        [];
+    for (const theme of themesMap.values()) {
         // 스크린샷 파일 실제 존재 여부 확인
         let screenshotPath: string | null = null;
         if (theme.screenshot) {
             // 보안: path traversal 방지 - 파일명만 허용 (영문, 숫자, ., -, _)
             const safeScreenshot = theme.screenshot.replace(/[^a-zA-Z0-9._-]/g, '');
             if (safeScreenshot && safeScreenshot.length > 0) {
-                const themePath = getThemePath(theme.id);
+                const themePath = await getThemePath(theme.id);
                 // nosemgrep: path-join-resolve-traversal (safeScreenshot은 위에서 sanitize됨)
                 const fullScreenshotPath = resolve(themePath, safeScreenshot);
                 // 추가 검증: 결과 경로가 테마 디렉터리 내에 있는지 확인
@@ -34,13 +36,13 @@ export const load: PageServerLoad = async () => {
             }
         }
 
-        return {
+        themes.push({
             id: theme.id,
             name: theme.name,
             description: theme.description || '',
             screenshot: screenshotPath
-        };
-    });
+        });
+    }
 
     // damoang-default를 첫 번째로 정렬
     themes.sort((a, b) => {


### PR DESCRIPTION
## Summary
- 비로그인 홈페이지 SSR 응답 10초 인메모리 캐시 (Pod 재시작 시 자동 소멸, 배포 안전)
- celebrationData API 60초 캐시 추가 (DB 쿼리 60x 감소)
- createCache/TieredCache에 singleflight 패턴 추가 (캐시 만료 시 thundering herd 방지)
- themes/plugins scanner: fs sync → fs/promises async 전환 (event loop 블로킹 제거)
- activeTheme TTL 30s→5min, indexWidgets/recommendedData TTL 30s→60s

## 목표
Pod 수 9-11개 → 4-6개, CPU 70% 이하 안정화

## Test plan
- [x] `pnpm check` 0 errors
- [x] `pnpm build` 성공
- [ ] 배포 후 `kubectl top pods -n angple` CPU 확인
- [ ] `kubectl get hpa -n angple` pod 수 감소 확인
- [ ] `curl` 홈페이지 응답 시간 측정 (X-SSR-Cache 헤더 확인)