### PR TITLE
feat: Sphinx 기반 글로벌 검색

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1091,11 +1091,13 @@ class ApiClient {
             limit: String(limit)
         });
 
-        const response = await this.request<GlobalSearchResponse>(
-            `/search?${queryParams.toString()}`
-        );
-
-        return response.data;
+        // Sphinx 기반 SvelteKit API route 직접 호출 (/api/search)
+        const res = await fetch(`/api/search?${queryParams.toString()}`);
+        const json = await res.json();
+        if (!json.success) {
+            throw new Error(json.error || '검색 실패');
+        }
+        return json.data;
     }
 
     // ========================================

--- a/apps/web/src/lib/server/sphinx.ts
+++ b/apps/web/src/lib/server/sphinx.ts
@@ -1,0 +1,19 @@
+/**
+ * Sphinx Search Connection (SphinxQL)
+ *
+ * SphinxQL은 MySQL 프로토콜 호환이므로 mysql2를 그대로 사용.
+ * 포트: 9306 (sphinx.conf의 listen = 9306:mysql41)
+ */
+import mysql from 'mysql2/promise';
+
+const sphinxPool = mysql.createPool({
+    host: '127.0.0.1',
+    port: 9306,
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 50,
+    connectTimeout: 3_000
+});
+
+export { sphinxPool };
+export default sphinxPool;

--- a/apps/web/src/routes/api/search/+server.ts
+++ b/apps/web/src/routes/api/search/+server.ts
@@ -1,0 +1,223 @@
+/**
+ * 글로벌 검색 API — Sphinx 기반
+ *
+ * GET /api/search?q=키워드&sfl=title_content&limit=5
+ *
+ * sfl: title | content | title_content | author
+ * limit: 게시판당 최대 결과 수 (기본 5)
+ *
+ * SphinxQL로 all_boards_unified_dist 인덱스 검색 후
+ * 게시판별로 그룹핑하여 GlobalSearchResponse 형태로 반환.
+ *
+ * NOTE: SphinxQL은 prepared statement를 지원하지 않으므로
+ *       pool.query()를 사용하고 MATCH 표현식은 수동 이스케이프.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types.js';
+import sphinxPool from '$lib/server/sphinx.js';
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+
+interface SphinxRow extends RowDataPacket {
+    id: number;
+    bo_table: string;
+    wr_id: number;
+    wr_subject: string;
+    wr_content: string;
+    wr_hit: number;
+    wr_good: number;
+    wr_comment: number;
+    wr_datetime: number;
+    wr_is_comment: number;
+}
+
+interface BoardRow extends RowDataPacket {
+    bo_table: string;
+    bo_subject: string;
+}
+
+interface PostAuthorRow extends RowDataPacket {
+    wr_id: number;
+    wr_name: string;
+    mb_id: string;
+}
+
+interface BoardFileRow extends RowDataPacket {
+    wr_id: number;
+}
+
+/** SphinxQL MATCH용 이스케이프 */
+function escapeSphinxMatch(str: string): string {
+    return str.replace(/([\\()|\-!@~"&/^$=<>])/g, '\\$1');
+}
+
+// 검색 필드별 Sphinx MATCH 표현식
+function buildMatchExpr(query: string, field: string): string {
+    const escaped = escapeSphinxMatch(query);
+
+    switch (field) {
+        case 'title':
+            return `@wr_subject "${escaped}"`;
+        case 'content':
+            return `@wr_content "${escaped}"`;
+        case 'author':
+            return `@(mb_id,wr_name) "${escaped}"`;
+        case 'title_content':
+        default:
+            return `@(wr_subject,wr_content) "${escaped}"`;
+    }
+}
+
+export const GET: RequestHandler = async ({ url }) => {
+    const query = url.searchParams.get('q')?.trim();
+    const field = url.searchParams.get('sfl') || 'title_content';
+    const limitPerBoard = Math.min(Number(url.searchParams.get('limit')) || 5, 20);
+
+    if (!query || query.length < 2) {
+        return json({
+            success: true,
+            data: { results: [], total: 0, query: query || '' }
+        });
+    }
+
+    try {
+        const matchExpr = buildMatchExpr(query, field);
+
+        // 1) Sphinx에서 검색 (최대 200건, 댓글 제외)
+        // mb_id, wr_name은 full-text field only (stored attribute 아님) → SELECT 불가
+        // 싱글쿼트 이스케이프 for SphinxQL
+        const safeMatch = matchExpr.replace(/'/g, "\\'");
+        const sphinxSql =
+            `SELECT id, bo_table, wr_id, wr_subject, wr_content, ` +
+            `wr_hit, wr_good, wr_comment, wr_datetime ` +
+            `FROM all_boards_unified_dist ` +
+            `WHERE MATCH('${safeMatch}') AND wr_is_comment = 0 ` +
+            `ORDER BY wr_datetime DESC ` +
+            `LIMIT 200`;
+
+        const [sphinxRows] = await sphinxPool.query<SphinxRow[]>(sphinxSql);
+
+        if (!sphinxRows.length) {
+            return json({
+                success: true,
+                data: { results: [], total: 0, query }
+            });
+        }
+
+        // 2) 게시판별 그룹핑
+        const boardMap = new Map<string, SphinxRow[]>();
+        for (const row of sphinxRows) {
+            const boardId = row.bo_table;
+            if (!boardMap.has(boardId)) {
+                boardMap.set(boardId, []);
+            }
+            boardMap.get(boardId)!.push(row);
+        }
+
+        // 3) 게시판 이름 조회 + 작성자 정보 + 첨부파일 병렬 조회
+        const boardIds = [...boardMap.keys()];
+
+        // 게시판 이름 조회
+        const placeholders = boardIds.map(() => '?').join(',');
+        const boardNamePromise = readPool
+            .execute<
+                BoardRow[]
+            >(`SELECT bo_table, bo_subject FROM g5_board WHERE bo_table IN (${placeholders})`, boardIds)
+            .then(([rows]) => {
+                const map = new Map<string, string>();
+                for (const b of rows) map.set(b.bo_table, b.bo_subject);
+                return map;
+            });
+
+        // 게시판별 작성자 정보 + 첨부파일 병렬 조회
+        const authorMap = new Map<string, { wr_name: string; mb_id: string }>();
+        const fileSet = new Set<string>();
+
+        const perBoardPromises = boardIds.map(async (boardId) => {
+            const rows = boardMap.get(boardId)!;
+            const wrIds = rows.slice(0, limitPerBoard).map((r) => r.wr_id);
+            if (!wrIds.length) return;
+
+            const ph = wrIds.map(() => '?').join(',');
+
+            // 작성자 정보 조회
+            try {
+                const [authorRows] = await readPool.execute<PostAuthorRow[]>(
+                    `SELECT wr_id, wr_name, mb_id FROM g5_write_${boardId} WHERE wr_id IN (${ph})`,
+                    wrIds
+                );
+                for (const a of authorRows) {
+                    authorMap.set(`${boardId}:${a.wr_id}`, {
+                        wr_name: a.wr_name,
+                        mb_id: a.mb_id
+                    });
+                }
+            } catch {
+                // 테이블 없는 경우 무시
+            }
+
+            // 첨부파일 존재 여부
+            try {
+                const [fileRows] = await readPool.execute<BoardFileRow[]>(
+                    `SELECT DISTINCT wr_id FROM g5_board_file WHERE bo_table = ? AND wr_id IN (${ph})`,
+                    [boardId, ...wrIds]
+                );
+                for (const f of fileRows) {
+                    fileSet.add(`${boardId}:${f.wr_id}`);
+                }
+            } catch {
+                // 무시
+            }
+        });
+
+        const [boardNameMap] = await Promise.all([boardNamePromise, ...perBoardPromises]);
+
+        // 4) 결과 조립 (게시판별 limitPerBoard개, 총 결과 수 기준 내림차순)
+        const results = boardIds
+            .map((boardId) => {
+                const rows = boardMap.get(boardId)!;
+                return {
+                    board_id: boardId,
+                    board_name: boardNameMap.get(boardId) || boardId,
+                    total: rows.length,
+                    posts: rows.slice(0, limitPerBoard).map((row) => {
+                        const author = authorMap.get(`${boardId}:${row.wr_id}`);
+                        return {
+                            id: row.wr_id,
+                            title: row.wr_subject,
+                            content: stripHtml(row.wr_content).slice(0, 200),
+                            author: author?.wr_name || '',
+                            author_id: author?.mb_id || '',
+                            board_id: boardId,
+                            views: row.wr_hit,
+                            likes: row.wr_good,
+                            comments_count: row.wr_comment,
+                            created_at: new Date(row.wr_datetime * 1000).toISOString(),
+                            has_file: fileSet.has(`${boardId}:${row.wr_id}`)
+                        };
+                    })
+                };
+            })
+            .sort((a, b) => b.total - a.total);
+
+        return json({
+            success: true,
+            data: {
+                results,
+                total: sphinxRows.length,
+                query
+            }
+        });
+    } catch (err) {
+        console.error('Sphinx search error:', err);
+        return json({ success: false, error: '검색 중 오류가 발생했습니다.' }, { status: 500 });
+    }
+};
+
+/** HTML 태그 제거 */
+function stripHtml(html: string): string {
+    return html
+        .replace(/<[^>]+>/g, '')
+        .replace(/&[^;]+;/g, ' ')
+        .trim();
+}

--- a/apps/web/src/routes/search/+page.ts
+++ b/apps/web/src/routes/search/+page.ts
@@ -1,12 +1,10 @@
-import { apiClient } from '$lib/api/index.js';
 import type { PageLoad } from './$types.js';
-import type { SearchField, GlobalSearchResponse } from '$lib/api/types.js';
+import type { SearchField } from '$lib/api/types.js';
 
-export const load: PageLoad = async ({ url }) => {
+export const load: PageLoad = async ({ url, fetch }) => {
     const query = url.searchParams.get('q') || '';
     const field = (url.searchParams.get('sfl') as SearchField) || 'title_content';
 
-    // 검색어가 없으면 빈 결과 반환
     if (!query.trim()) {
         return {
             searchResults: null,
@@ -16,10 +14,12 @@ export const load: PageLoad = async ({ url }) => {
     }
 
     try {
-        const searchResults = await apiClient.searchGlobal(query, field, 5);
+        const params = new URLSearchParams({ q: query, sfl: field, limit: '5' });
+        const res = await fetch(`/api/search?${params.toString()}`);
+        const json = await res.json();
 
         return {
-            searchResults,
+            searchResults: json.success ? json.data : null,
             query,
             field
         };


### PR DESCRIPTION
## Summary
- Go 백엔드 프록시 대신 SvelteKit에서 SphinxQL(9306)로 직접 검색
- `all_boards_unified_dist` 인덱스로 전체 게시판 통합 검색
- 게시판별 그룹핑, 작성자/첨부파일 정보 MySQL 병렬 조회
- 검색 페이지(`/search`) + 자동완성 모두 Sphinx 사용

## Changes
- `src/lib/server/sphinx.ts` — SphinxQL 커넥션 풀 (mysql2, port 9306)
- `src/routes/api/search/+server.ts` — Sphinx 검색 API 엔드포인트
- `src/routes/search/+page.ts` — SvelteKit fetch 사용으로 변경
- `src/lib/api/client.ts` — searchGlobal()이 `/api/search` 호출

## Test plan
- [ ] `/search?q=키보드&sfl=title` 검색 결과 확인
- [ ] `/search?q=다모앙&sfl=title_content` 게시판별 그룹핑 확인
- [ ] 자동완성 드롭다운 동작 확인
- [ ] 작성자 검색 (`sfl=author`) 동작 확인