### PR TITLE
fix: 추천인 IP 마스킹 (보안)

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
@@ -10,6 +10,17 @@ import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
 import { getAuthUser } from '$lib/server/auth';
 
+/** IP 마스킹: 두 번째 옥텟을 ♡로 (예: 222.114.55.158 → 222.♡.55.158) */
+function maskIp(ip: string | null | undefined): string {
+    if (!ip) return '';
+    const parts = ip.split('.');
+    if (parts.length === 4) {
+        parts[1] = '♡';
+        return parts.join('.');
+    }
+    return ip.slice(0, 3) + '.♡';
+}
+
 interface LikerRow extends RowDataPacket {
     mb_id: string;
     mb_nick: string;
@@ -71,7 +82,7 @@ export const GET: RequestHandler = async ({ params, url, cookies }) => {
             mb_id: row.mb_id,
             mb_name: row.mb_name,
             mb_nick: row.mb_nick,
-            bg_ip: isAuthenticated ? row.bg_ip || '' : '',
+            bg_ip: isAuthenticated ? maskIp(row.bg_ip) : '',
             liked_at: row.bg_datetime
         }));
 


### PR DESCRIPTION
## Summary
- 추천자 목록 API에서 IP 전체 노출 → 두 번째 옥텟 ♡ 마스킹
- 예: `222.114.55.158` → `222.♡.55.158` (그누보드 스타일)
- 비로그인 사용자에게는 IP 미표시 유지

## Test plan
- [ ] 댓글 추천자 목록에서 IP가 `222.♡.55.158` 형태로 표시되는지 확인
- [ ] 비로그인 시 IP가 보이지 않는지 확인