### PR TITLE
fix: Apple 로그인 cross-origin POST 허용

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -241,14 +241,6 @@ const WRITE_API_RATE = { maxRequests: 60, windowMs: 60_000 }; // 쓰기 분당 6
 export const handle: Handle = async ({ event, resolve }) => {
     const { pathname } = event.url;
 
-    // Apple Sign In form_post: cross-origin POST이므로 SvelteKit CSRF 우회
-    // OAuth state 쿠키가 자체 CSRF 보호 제공
-    if (pathname.startsWith('/auth/callback/') && event.request.method === 'POST') {
-        const headers = new Headers(event.request.headers);
-        headers.set('origin', event.url.origin);
-        Object.defineProperty(event.request, 'headers', { value: headers });
-    }
-
     // 개발/내부 전용 경로 차단 (프로덕션)
     if (!dev && DEV_ONLY_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
         return new Response('Not Found', { status: 404 });

--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -164,16 +164,6 @@
         <UserWidget />
     </div>
 
-    <div class="px-2">
-        <a
-            href="/message"
-            class="text-muted-foreground hover:text-primary flex items-center gap-1.5 text-xs transition-colors"
-        >
-            <Gift class="h-3.5 w-3.5" />
-            축하메시지
-        </a>
-    </div>
-
     <!-- 즐겨찾기 단축키 메뉴 (2열 그리드) -->
     {#if boardFavoritesStore.normalSlots.length > 0 || boardFavoritesStore.shiftSlots.length > 0}
         <div class="px-2">

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -34,8 +34,9 @@ const config = {
             $plugins: '../../plugins'
         },
         csrf: {
-            // 개발 환경에서 localhost CSRF 허용
-            checkOrigin: process.env.NODE_ENV === 'production'
+            // 자체 CSRF 보호 사용 (세션 기반 double-submit cookie, hooks.server.ts)
+            // Apple Sign In form_post 등 cross-origin POST 허용을 위해 비활성화
+            checkOrigin: false
         },
         output: {
             // preload-js: <link rel="preload" as="script"> 대신 사용 (modulepreload보다 Link 헤더 축소)


### PR DESCRIPTION
## Summary
- SvelteKit `checkOrigin`이 `handle` 훅 이전에 실행되어 Apple Sign In `form_post` 차단
- 자체 CSRF 보호(세션 기반 double-submit cookie)가 있으므로 `checkOrigin: false`로 안전하게 비활성화
- 작동하지 않던 Origin 스푸핑 코드 제거
- 사이드바 축하메시지 하드코딩 제거

## Test plan
- [ ] Apple 로그인 시 "Cross-site POST form submissions are forbidden" 오류 없이 정상 콜백
- [ ] 다른 소셜 로그인(Google, Kakao, Naver) 정상 동작 확인
- [ ] CSRF 보호 정상 동작 확인 (로그인 후 POST 요청)