### PR TITLE
feat: 마이페이지·댓글폼 아바타 이미지 표시

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -243,14 +243,19 @@
         <div class="flex items-start gap-3">
             <!-- 사용자 아바타 -->
             <div
-                class="flex size-10 shrink-0 items-center justify-center rounded-full {commentAvatarUrl && !commentAvatarFailed ? 'overflow-hidden' : 'bg-primary text-primary-foreground'}"
+                class="flex size-10 shrink-0 items-center justify-center rounded-full {commentAvatarUrl &&
+                !commentAvatarFailed
+                    ? 'overflow-hidden'
+                    : 'bg-primary text-primary-foreground'}"
             >
                 {#if commentAvatarUrl && !commentAvatarFailed}
                     <img
                         src={commentAvatarUrl}
                         alt={authStore.user?.mb_name || ''}
                         class="h-full w-full object-cover"
-                        onerror={() => { commentAvatarFailed = true; }}
+                        onerror={() => {
+                            commentAvatarFailed = true;
+                        }}
                     />
                 {:else}
                     {authStore.user?.mb_name.charAt(0).toUpperCase() || 'U'}

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -64,14 +64,19 @@
         <div class="flex items-center gap-4">
             {#if authStore.user}
                 <div
-                    class="flex h-16 w-16 shrink-0 items-center justify-center rounded-full text-xl font-bold {myAvatarUrl && !myAvatarFailed ? 'overflow-hidden' : 'bg-primary text-primary-foreground'}"
+                    class="flex h-16 w-16 shrink-0 items-center justify-center rounded-full text-xl font-bold {myAvatarUrl &&
+                    !myAvatarFailed
+                        ? 'overflow-hidden'
+                        : 'bg-primary text-primary-foreground'}"
                 >
                     {#if myAvatarUrl && !myAvatarFailed}
                         <img
                             src={myAvatarUrl}
                             alt={authStore.user.mb_name}
                             class="h-full w-full object-cover"
-                            onerror={() => { myAvatarFailed = true; }}
+                            onerror={() => {
+                                myAvatarFailed = true;
+                            }}
                         />
                     {:else}
                         {authStore.user.mb_name.charAt(0).toUpperCase()}


### PR DESCRIPTION
## Summary
<img width="930" height="429" alt="image" src="https://github.com/user-attachments/assets/c98ca4b5-3d83-4a36-a3fc-0cad9d091b7d" />
<img width="928" height="432" alt="image" src="https://github.com/user-attachments/assets/c8b25147-7467-4e74-9867-b703d9cf7145" />

- 마이페이지(`/my`)와 댓글 폼에서 이니셜(첫 글자)만 표시하던 아바타를 실제 회원 프로필 이미지로 교체
- `getAvatarUrl` → `getMemberIconUrl` → 이니셜 폴백 순서로 user-widget.svelte와 동일한 패턴 적용
- 이미지 로드 실패 시 기존 이니셜 표시로 폴백

## Changed files
- `apps/web/src/routes/my/+page.svelte` — 마이페이지 프로필 아바타
- `apps/web/src/lib/components/features/board/comment-form.svelte` — 댓글 폼 아바타

## Test plan
- [x] 마이페이지에서 아바타 이미지 표시 확인
- [x] 댓글 폼에서 아바타 이미지 표시 확인
- [ ] 아바타 이미지 없는 회원 로그인 시 이니셜 폴백 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)