### PR TITLE
fix: P0 모바일 좌우 스크롤 + 임베드 깨짐 수정

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -582,9 +582,16 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        max-width: 100%;
+        overflow: hidden;
     }
 
     .gam-ad-slot:empty {
         display: none;
+    }
+
+    /* 광고 iframe이 컨테이너를 넘지 않도록 */
+    .gam-ad-slot :global(iframe) {
+        max-width: 100% !important;
     }
 </style>

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -242,6 +242,7 @@
 <div
     bind:this={proseEl}
     class="prose prose-neutral dark:prose-invert max-w-none text-lg {className}"
+    style="overflow-wrap: break-word; word-wrap: break-word; overflow-x: hidden;"
 >
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html renderedHtml}
@@ -334,6 +335,8 @@
     .prose :global(a) {
         color: var(--primary);
         text-decoration: underline;
+        overflow-wrap: break-word;
+        word-break: break-all;
     }
 
     .prose :global(a:hover) {
@@ -408,11 +411,18 @@
     }
 
     /* 임베드 컨테이너 스타일 */
+    /* 모든 iframe/video가 컨테이너를 넘지 않도록 */
+    .prose :global(iframe),
+    .prose :global(video) {
+        max-width: 100%;
+    }
+
     .prose :global(.embed-container) {
         position: relative;
         width: 100%;
         max-width: var(--max-width, 100%);
         margin: 1rem 0;
+        overflow: hidden;
     }
 
     .prose :global(.embed-container)::before {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -825,7 +825,7 @@
 
 <SeoHead config={seoConfig} />
 
-<div class="mx-auto pt-2">
+<div class="mx-auto overflow-x-hidden pt-2">
     <!-- 상단 배너 -->
     {#if widgetLayoutStore.hasEnabledAds}
         <div class="mb-6">

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -1,3 +1,10 @@
+/* 모바일 좌우 스크롤 방지 (긴 URL, 광고 등으로 인한 레이아웃 밀림 차단) */
+html,
+body {
+    overflow-x: hidden;
+    max-width: 100vw;
+}
+
 @layer components {
     .snb-backdrop-left,
     .snb-backdrop-right {


### PR DESCRIPTION
## Summary
- P0 모바일 좌우 스크롤/화면 밀림 해결 (7649, 7625, 7622, 7599, 7569)
- 유튜브/트위터 임베드 레이아웃 깨짐 수정 (7674, 7695)
- 글 작성 엔터키 미반영 수정 (7694)
- 글 공감자 이전 데이터 표시 수정 (7679)

## Changes
- html/body에 overflow-x: hidden (글로벌 좌우 스크롤 차단)
- 긴 URL에 word-break: break-all + overflow-wrap: break-word
- prose 내 모든 iframe/video에 max-width: 100%
- 빈 p 태그 min-height 추가 (에디터 엔터키)
- 글 이동 시 추천자 목록 state 리셋

## Test plan
- [ ] 모바일에서 긴 URL 포함 글 열어서 좌우 스크롤 없는지 확인
- [ ] 유튜브/트위터 임베드가 화면 밖으로 안 넘치는지 확인
- [ ] 에디터에서 엔터 여러 번 → 본문에 줄바꿈 반영 확인
- [ ] A글→B글 이동 시 공감자 목록 초기화 확인