### PR TITLE
feat: 읽은 글 색상 구분 기능 홈페이지/사이드바 적용

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -4,6 +4,7 @@
     import { apiClient } from '$lib/api/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import { layoutRegistry, initCoreLayouts } from './layouts/index.js';
     import CompactLayout from './layouts/list/compact.svelte';
@@ -59,6 +60,16 @@
     let posts = $state<FreePost[]>([]);
     let loading = $state(true);
     let error = $state<string | null>(null);
+
+    // 읽은 글 표시 (하이드레이션 깜빡임 방지)
+    let showReadState = $state(false);
+    onMount(() => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                showReadState = true;
+            });
+        });
+    });
 
     // 페이지네이션
     let currentPage = $state(1);
@@ -161,7 +172,12 @@
     <div class={wrapperClass}>
         {#each posts as post, i (post.id)}
             <div class={post.id === currentPostId ? 'current-post-highlight' : ''}>
-                <LayoutComponent {post} {displaySettings} href="/{boardId}/{post.id}" />
+                <LayoutComponent
+                    {post}
+                    {displaySettings}
+                    href="/{boardId}/{post.id}"
+                    isRead={showReadState && readPostsStore.isRead(boardId, post.id)}
+                />
             </div>
             {#if shuffledPromos.length > 0 && i + 1 === 10}
                 {#each shuffledPromos.slice(0, 2) as promo (promo.wrId)}

--- a/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
+++ b/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
@@ -1,11 +1,29 @@
 <script lang="ts">
+    import { onMount } from 'svelte';
     import type { EconomyPost } from '$lib/api/types.js';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
 
     type Props = {
         posts: EconomyPost[];
     };
 
     let { posts }: Props = $props();
+
+    // URL에서 boardId 추출 (/{boardId}/{postId} 형태)
+    function getBoardId(url: string): string {
+        const parts = url.split('/').filter(Boolean);
+        return parts[0] || '';
+    }
+
+    // 읽은 글 표시 (하이드레이션 깜빡임 방지)
+    let showReadState = $state(false);
+    onMount(() => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                showReadState = true;
+            });
+        });
+    });
 </script>
 
 {#if posts.length > 0}
@@ -19,7 +37,10 @@
                 >
                     <div class="flex items-center gap-2">
                         <div
-                            class="text-foreground min-w-0 flex-1 truncate text-[17px] font-medium"
+                            class="min-w-0 flex-1 truncate text-[17px] font-medium {showReadState &&
+                            readPostsStore.isRead(getBoardId(post.url), post.id)
+                                ? 'text-muted-foreground'
+                                : 'text-foreground'}"
                         >
                             {post.title}
                         </div>

--- a/apps/web/src/lib/components/features/gallery/components/gallery-card.svelte
+++ b/apps/web/src/lib/components/features/gallery/components/gallery-card.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
     import type { GalleryPost } from '$lib/api/types.js';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { browser } from '$app/environment';
 
     type Props = {
         post: GalleryPost;
     };
 
     let { post }: Props = $props();
+
+    // URL에서 boardId 추출
+    function getBoardId(url: string): string {
+        const parts = url.split('/').filter(Boolean);
+        return parts[0] || '';
+    }
+
+    const isRead = $derived(browser && readPostsStore.isRead(getBoardId(post.url), post.id));
 </script>
 
 <a
@@ -43,6 +53,12 @@
 
     <!-- 제목만 -->
     <div class="p-2.5">
-        <p class="text-foreground line-clamp-2 text-[15px] font-medium">{post.title}</p>
+        <p
+            class="line-clamp-2 text-[15px] font-medium {isRead
+                ? 'text-muted-foreground'
+                : 'text-foreground'}"
+        >
+            {post.title}
+        </p>
     </div>
 </a>

--- a/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
+++ b/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+    import { onMount } from 'svelte';
     import type { GroupPost } from '$lib/api/types.js';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { formatNumber, getRecommendBadgeClass } from '../../../recommended/utils/index.js';
 
     type Props = {
@@ -7,6 +9,22 @@
     };
 
     let { posts }: Props = $props();
+
+    // URL에서 boardId 추출 (/{boardId}/{postId} 형태)
+    function getBoardId(url: string): string {
+        const parts = url.split('/').filter(Boolean);
+        return parts[0] || '';
+    }
+
+    // 읽은 글 표시 (하이드레이션 깜빡임 방지)
+    let showReadState = $state(false);
+    onMount(() => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                showReadState = true;
+            });
+        });
+    });
 </script>
 
 {#if posts.length > 0}
@@ -27,7 +45,10 @@
                             {formatNumber(post.recommend_count)}
                         </span>
                         <div
-                            class="text-foreground min-w-0 flex-1 truncate text-[17px] font-medium"
+                            class="min-w-0 flex-1 truncate text-[17px] font-medium {showReadState &&
+                            readPostsStore.isRead(getBoardId(post.url), post.id)
+                                ? 'text-muted-foreground'
+                                : 'text-foreground'}"
                         >
                             {post.title}
                         </div>

--- a/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
+    import { onMount } from 'svelte';
     import type { NewsPost } from '$lib/api/types.js';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
 
     type Props = {
         posts: NewsPost[];
     };
 
     let { posts }: Props = $props();
+
+    // 읽은 글 표시 (하이드레이션 깜빡임 방지)
+    let showReadState = $state(false);
+    onMount(() => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                showReadState = true;
+            });
+        });
+    });
 </script>
 
 {#if posts.length > 0}
@@ -19,7 +31,10 @@
                 >
                     <div class="flex items-center gap-2">
                         <div
-                            class="text-foreground min-w-0 flex-1 truncate text-[17px] font-medium"
+                            class="min-w-0 flex-1 truncate text-[17px] font-medium {showReadState &&
+                            readPostsStore.isRead(post.board, post.id)
+                                ? 'text-muted-foreground'
+                                : 'text-foreground'}"
                         >
                             {post.title}
                         </div>

--- a/widgets/post-list/layouts/list-view.svelte
+++ b/widgets/post-list/layouts/list-view.svelte
@@ -3,6 +3,8 @@
      * 목록형 레이아웃
      */
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { browser } from '$app/environment';
 
     interface Post {
         id: number;
@@ -51,7 +53,12 @@
                             href={post.url ?? `#`}
                             class="hover:text-primary flex items-center justify-between gap-2 text-sm transition-colors"
                         >
-                            <span class="min-w-0 flex-1 truncate">{post.title}</span>
+                            <span
+                                class="min-w-0 flex-1 truncate {browser &&
+                                readPostsStore.isRead(boardId, post.id)
+                                    ? 'text-muted-foreground'
+                                    : ''}">{post.title}</span
+                            >
                             <span
                                 class="text-muted-foreground flex shrink-0 items-center gap-2 text-xs"
                             >


### PR DESCRIPTION
## Summary
- 홈페이지 위젯(새소식, 알뜰구매, 소모임, 갤러리)에 읽은 글 표시 적용
- 게시글 상세 페이지 사이드바(최근글)에 읽은 글 표시 적용
- 범용 위젯 목록(list-view)에도 읽은 글 표시 적용
- 기존 게시판 목록에서만 동작하던 기능을 사이트 전체로 확대

## 변경 파일
- `recent-posts.svelte` — readPostsStore import, isRead prop 전달
- `simple-post-list.svelte` — 새소식 탭 읽은 글 표시
- `economy-post-list.svelte` — 알뜰구매 탭 읽은 글 표시
- `group-post-list.svelte` — 소모임 탭 읽은 글 표시
- `gallery-card.svelte` — 갤러리 카드 읽은 글 표시
- `list-view.svelte` — 범용 위젯 목록 읽은 글 표시

## Test plan
- [ ] 홈페이지에서 글 클릭 후 돌아왔을 때 해당 글이 흐리게 표시되는지 확인
- [ ] 사이드바 최근글 목록에서 읽은 글이 흐리게 표시되는지 확인
- [ ] SSR 시 깜빡임 없이 하이드레이션 후 부드럽게 표시되는지 확인