### PR TITLE
fix: AuthUser 인터페이스에 mb_nick 필드 추가

### DIFF
--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -15,6 +15,7 @@ import type { Cookies } from '@sveltejs/kit';
 export interface AuthUser {
     mb_id: string;
     mb_name: string;
+    mb_nick: string;
     mb_level: number;
     mb_email: string;
 }
@@ -34,6 +35,7 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
                     return {
                         mb_id: member.mb_id,
                         mb_name: member.mb_nick || member.mb_name,
+                        mb_nick: member.mb_nick || '',
                         mb_level: member.mb_level ?? 0,
                         mb_email: member.mb_email || ''
                     };
@@ -52,6 +54,7 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
             return {
                 mb_id: payload.sub,
                 mb_name: payload.nickname,
+                mb_nick: payload.nickname,
                 mb_level: payload.level,
                 mb_email: payload.email
             };
@@ -69,6 +72,7 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
                     return {
                         mb_id: member.mb_id,
                         mb_name: member.mb_nick || member.mb_name,
+                        mb_nick: member.mb_nick || '',
                         mb_level: member.mb_level ?? 0,
                         mb_email: member.mb_email || ''
                     };
@@ -88,6 +92,7 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
                 return {
                     mb_id: payload.sub,
                     mb_name: payload.nickname,
+                    mb_nick: payload.nickname,
                     mb_level: payload.level,
                     mb_email: payload.email
                 };


### PR DESCRIPTION
## Summary
- `AuthUser` 인터페이스에 `mb_nick` 필드 추가
- 추천/리액션 알림에서 `user.mb_nick` 참조 시 TypeScript 타입 에러 수정
- 세션/JWT/레거시 인증 경로 모두에서 `mb_nick` 값 세팅

## 영향 파일
- `like/+server.ts` (게시글 추천 알림)
- `comments/[commentId]/like/+server.ts` (댓글 추천 알림)  
- `reactions/+server.ts` (리액션 알림)