### PR TITLE
fix: 글 목록 페이지 유지 + 알림 레이아웃 밀림 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -29,6 +29,7 @@
         boardTitle: string;
         currentPostId: number;
         limit?: number;
+        initialPage?: number;
         promotionPosts?: PromotionPost[];
         displaySettings?: BoardDisplaySettings;
     }
@@ -38,6 +39,7 @@
         boardTitle,
         currentPostId,
         limit = 10,
+        initialPage = 1,
         promotionPosts = [],
         displaySettings
     }: Props = $props();
@@ -104,8 +106,10 @@
         if (!browser) return;
 
         try {
-            const response = await apiClient.getBoardPosts(boardId, 1, limit);
+            const startPage = Math.max(1, initialPage);
+            const response = await apiClient.getBoardPosts(boardId, startPage, limit);
             posts = response.items;
+            currentPage = response.page;
             totalPages = response.total_pages;
             totalItems = response.total;
 
@@ -175,7 +179,7 @@
                 <LayoutComponent
                     {post}
                     {displaySettings}
-                    href="/{boardId}/{post.id}"
+                    href="/{boardId}/{post.id}{currentPage > 1 ? `?page=${currentPage}` : ''}"
                     isRead={showReadState && readPostsStore.isRead(boardId, post.id)}
                 />
             </div>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -50,11 +50,13 @@
 
     // Board Layout System
     import { layoutRegistry, initCoreLayouts } from '$lib/components/features/board/layouts';
-    import registerGivingLayouts from '../../../../../plugins/giving/hooks/register-layouts.js';
-
     // 코어 레이아웃 초기화 (최초 1회)
     initCoreLayouts();
-    registerGivingLayouts();
+    import('../../../../../plugins/giving/hooks/register-layouts.js')
+        .then((m) => m.default())
+        .catch(() => {
+            /* giving 플러그인 미설치 시 무시 */
+        });
 
     let { data }: { data: PageData } = $props();
 
@@ -109,6 +111,9 @@
 
     // 검색 중인지 여부
     const isSearching = $derived(Boolean(data.searchParams));
+
+    // 현재 페이지 번호 (글 링크에 전달용)
+    const listPage = $derived(Number($page.url.searchParams.get('page')) || 1);
 
     // 읽은 글 표시 지연 — SSR에서는 모든 글이 "안읽음"으로 렌더링되므로,
     // 하이드레이션 직후 즉시 변경하면 깜빡임 발생. 2프레임 대기 후 부드럽게 전환.
@@ -698,7 +703,9 @@
                                         <LayoutComponent
                                             {post}
                                             displaySettings={data.board?.display_settings}
-                                            href="/{boardId}/{post.id}"
+                                            href="/{boardId}/{post.id}{listPage > 1
+                                                ? `?page=${listPage}`
+                                                : ''}"
                                             isRead={showReadState &&
                                                 readPostsStore.isRead(boardId, post.id)}
                                         />
@@ -708,7 +715,9 @@
                                 <LayoutComponent
                                     {post}
                                     displaySettings={data.board?.display_settings}
-                                    href="/{boardId}/{post.id}"
+                                    href="/{boardId}/{post.id}{listPage > 1
+                                        ? `?page=${listPage}`
+                                        : ''}"
                                     isRead={showReadState &&
                                         readPostsStore.isRead(boardId, post.id)}
                                 />

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -57,7 +57,6 @@
         initCoreLayouts
     } from '$lib/components/features/board/layouts/index.js';
     import ScrapButton from '$lib/components/post/scrap-button.svelte';
-    import registerGivingLayouts from '../../../../../../plugins/giving/hooks/register-layouts.js';
 
     // Q&A 게시판 슬롯 등록
     postSlotRegistry.register('post.before_content', {
@@ -96,7 +95,11 @@
 
     // 코어 레이아웃 초기화
     initCoreLayouts();
-    registerGivingLayouts();
+    import('../../../../../../plugins/giving/hooks/register-layouts.js')
+        .then((m) => m.default())
+        .catch(() => {
+            /* giving 플러그인 미설치 시 무시 */
+        });
 
     // 뷰 레이아웃 동적 resolve
     const viewLayoutId = $derived(data.board?.display_settings?.view_layout || 'basic');
@@ -1124,6 +1127,7 @@
                 {boardTitle}
                 currentPostId={data.post.id}
                 limit={25}
+                initialPage={Number($page.url.searchParams.get('page')) || 1}
                 promotionPosts={promotionPosts as any[]}
                 displaySettings={data.board?.display_settings}
             />

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -304,7 +304,7 @@
                             {#if p.mb_certify}
                                 <CheckCircle
                                     class="text-muted-foreground h-4 w-4 shrink-0"
-                                    title="본인확인 완료"
+                                    aria-label="본인확인 완료"
                                 />
                             {/if}
                         </div>

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -1,5 +1,11 @@
 /* 모바일 좌우 스크롤 방지 (긴 URL, 광고 등으로 인한 레이아웃 밀림 차단) */
-html,
+html {
+    overflow-x: hidden;
+    max-width: 100vw;
+    /* 스크롤바 공간 예약 — 드롭다운/모달 열릴 때 콘텐츠 밀림 방지 */
+    scrollbar-gutter: stable;
+}
+
 body {
     overflow-x: hidden;
     max-width: 100vw;


### PR DESCRIPTION
## Summary
- 게시판 목록에서 글 클릭 시 `?page=N` 전달 → 글 상세 하단 목록이 해당 페이지 시작
- `scrollbar-gutter: stable` 적용 → 드롭다운/모달 열릴 때 콘텐츠 밀림 방지

## 버그 수정
- Row 12: 글 내부 목록 페이지 항상 1페이지 고정 (wr_id 7586, 7643)
- Row 16: PC 알림(종) 버튼 → 레이아웃 밀림 (wr_id 7634, 7573)

## Test plan
- [ ] 게시판 2페이지에서 글 클릭 → 하단 목록이 2페이지로 표시
- [ ] 하단 목록에서 다른 글 클릭 → 페이지 번호 유지
- [ ] 알림 드롭다운 열 때 배경 밀림 없음 확인