### PR TITLE
fix: 에디터 모드 전환 시 본문 사라짐 수정

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -962,16 +962,17 @@
     </div>
 
     <!-- 에디터 영역 -->
-    {#if editorMode === 'wysiwyg'}
-        <div
-            class="tiptap-content min-h-[300px] p-4"
-            class:uploading={isUploading}
-            bind:this={editorElement}
-            ondrop={handleDrop}
-            ondragover={(e) => e.preventDefault()}
-            onpaste={handlePaste}
-        ></div>
-    {:else}
+    <!-- WYSIWYG: hidden 속성으로 표시/숨김 (DOM 유지 — TipTap 에디터가 참조하는 요소 파괴 방지) -->
+    <div
+        class="tiptap-content min-h-[300px] p-4"
+        class:uploading={isUploading}
+        hidden={editorMode !== 'wysiwyg'}
+        bind:this={editorElement}
+        ondrop={handleDrop}
+        ondragover={(e) => e.preventDefault()}
+        onpaste={handlePaste}
+    ></div>
+    {#if editorMode !== 'wysiwyg'}
         <!-- 마크다운/HTML 텍스트 에디터 -->
         <textarea
             class="bg-background text-foreground min-h-[300px] w-full resize-y p-4 font-mono text-sm focus:outline-none"


### PR DESCRIPTION
## Summary
- WYSIWYG ↔ Markdown/HTML 모드 전환 후 WYSIWYG로 돌아올 때 본문이 사라지는 버그 수정
- 원인: `{#if}` 블록이 TipTap 에디터의 DOM 요소를 파괴 → 에디터가 파괴된 DOM 참조
- 수정: `hidden` 속성으로 변경하여 DOM 요소 유지

## Test plan
- [ ] 글 작성 페이지에서 내용 입력
- [ ] WYSIWYG → Markdown 전환: 마크다운으로 변환되는지 확인
- [ ] Markdown → WYSIWYG 전환: 본문이 정상 표시되는지 확인
- [ ] WYSIWYG → HTML 전환 → WYSIWYG 복귀: 본문 유지 확인
- [ ] 모드 전환 후 글 저장 정상 동작 확인