### PR TITLE
fix: 마지막 댓글 padding 통일 + 목록 페이지 이동 시 스크롤

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1267,7 +1267,7 @@
         padding-top: calc(var(--comment-pad-extra, 3px));
     }
     .comment-item:last-child {
-        padding-bottom: calc(var(--comment-pad-extra, 3px));
+        padding-bottom: calc(var(--comment-pad-extra, 3px) + 0.75rem);
     }
 
     /* 댓글 본문 문단 간격 축소 */

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -147,7 +147,11 @@
 </script>
 
 <!-- 헤더 -->
-<div bind:this={listContainer} class="mb-3 flex items-center justify-between">
+<div
+    bind:this={listContainer}
+    class="mb-3 flex items-center justify-between"
+    style="scroll-margin-top: 1rem"
+>
     <a
         href="/{boardId}"
         class="text-foreground hover:text-primary text-lg font-bold transition-colors"


### PR DESCRIPTION
## Summary
- 마지막 댓글의 padding-bottom을 다른 댓글과 동일하게 수정 (`.comment-item:last-child`)
- 글 하단 최근글 목록 페이지 이동 시 목록 헤더로 스크롤되도록 `scroll-margin-top` 추가

## 관련 제보
- https://damoang.net/free/5919498 (마지막 댓글 padding)
- https://damoang.net/free/5919497 (목록 페이지 원글 따라옴)

## Test plan
- [ ] 댓글이 3개 이상인 글에서 마지막 댓글의 하단 여백이 중간 댓글과 동일한지 확인
- [ ] 글 상세 하단 목록에서 페이지 이동 시 목록 헤더 위치로 스크롤되는지 확인