### PR TITLE
feat: 댓글 Alt+Enter 단축키 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -271,6 +271,14 @@
                     class={error ? 'border-destructive' : ''}
                     disabled={isLoading}
                     onpaste={handlePaste}
+                    onkeydown={(e: KeyboardEvent) => {
+                        if ((e.altKey || e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                            e.preventDefault();
+                            if (canSubmit && !isLoading) {
+                                handleSubmit(e);
+                            }
+                        }
+                    }}
                 />
                 <MentionAutocomplete textarea={textareaRef} />
 
@@ -331,7 +339,12 @@
                                 취소
                             </Button>
                         {/if}
-                        <Button type="submit" size="sm" disabled={isLoading || !canSubmit}>
+                        <Button
+                            type="submit"
+                            size="sm"
+                            disabled={isLoading || !canSubmit}
+                            title="Alt+Enter / Ctrl+Enter"
+                        >
                             {#if isLoading}
                                 작성 중...
                             {:else}


### PR DESCRIPTION
## Summary
- 댓글 작성 Textarea에서 Alt+Enter, Ctrl+Enter, Cmd+Enter 단축키로 댓글 제출 가능
- 제출 버튼에 `title="Alt+Enter / Ctrl+Enter"` tooltip 추가

## Test plan
- [ ] 댓글 입력 후 Alt+Enter로 제출되는지 확인
- [ ] Ctrl+Enter, Cmd+Enter도 동일하게 작동하는지 확인
- [ ] 답글 모드에서도 단축키 작동 확인
- [ ] 내용 없이 단축키 누르면 제출되지 않는지 확인