### PR TITLE
feat: 축하메시지 롤링 UI 개선

### DIFF
--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -20,10 +20,12 @@
         return mount();
     });
 
-    function getDisplayText(banner: { target_member_nick?: string }): string {
-        const nick = banner.target_member_nick || '';
-        if (nick) return nick;
-        return '축하합니다!';
+    function getNick(banner: { target_member_nick?: string }): string {
+        return banner.target_member_nick || '축하합니다';
+    }
+
+    function getMessage(banner: { content?: string }): string {
+        return banner.content || '';
     }
 </script>
 
@@ -52,14 +54,17 @@
         <div class="relative h-7 min-w-0 flex-1 overflow-hidden">
             {#each celebrations as banner, i (banner.id)}
                 <span
-                    class="text-foreground absolute inset-0 flex items-center truncate text-sm transition-all duration-500 ease-in-out
+                    class="absolute inset-0 flex items-center gap-1.5 truncate text-sm transition-all duration-500 ease-in-out
                         {i === currentIndex
                         ? 'translate-y-0 opacity-100'
                         : i < currentIndex
                           ? '-translate-y-full opacity-0'
                           : 'translate-y-full opacity-0'}"
                 >
-                    {getDisplayText(banner)}
+                    <span class="text-foreground font-medium">{getNick(banner)}</span>
+                    {#if getMessage(banner)}
+                        <span class="text-muted-foreground truncate">{getMessage(banner)}</span>
+                    {/if}
                 </span>
             {/each}
         </div>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -355,13 +355,6 @@
                     {/if}
                 </div>
 
-                <!-- 축하 메시지 롤링 (인라인) -->
-                {#if !isSearching}
-                    <div class="min-w-0 flex-1">
-                        <CelebrationRolling />
-                    </div>
-                {/if}
-
                 {#if canWrite()}
                     <Button onclick={goToWrite} class="shrink-0">
                         <Pencil class="mr-2 h-4 w-4" />
@@ -379,6 +372,13 @@
                     </Button>
                 {/if}
             </div>
+
+            <!-- 축하 메시지 롤링 -->
+            {#if !isSearching}
+                <div class="mb-4">
+                    <CelebrationRolling />
+                </div>
+            {/if}
 
             <!-- 검색 폼 -->
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- 축하메시지 텍스트를 [프사][닉네임][메시지] 형식으로 변경
- 목록 페이지: 헤더 인라인에서 헤더 아래 별도 블록으로 위치 이동 (상세 페이지와 동일한 배치)

## 변경 파일
- `celebration-rolling.svelte`: 닉네임 + 메시지 분리 표시
- `[boardId]/+page.svelte`: CelebrationRolling 위치 이동