### PR TITLE
fix: 홈페이지에서 로고/홈 클릭 시 새로고침

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -130,7 +130,17 @@
     <div class="container mx-auto flex h-12 items-center justify-between md:h-16">
         <!-- 로고 -->
         <div class="flex items-center">
-            <a href="/" data-sveltekit-reload class="flex items-center ps-4 md:ps-0">
+            <a
+                href="/"
+                data-sveltekit-reload
+                class="flex items-center ps-4 md:ps-0"
+                onclick={(e: MouseEvent) => {
+                    if (window.location.pathname === '/') {
+                        e.preventDefault();
+                        window.location.reload();
+                    }
+                }}
+            >
                 <img src={Logo} alt="damoang" class="h-12" />
             </a>
         </div>
@@ -141,6 +151,12 @@
                 href="/"
                 data-sveltekit-reload
                 class="text-foreground hover:text-primary flex items-center transition-all duration-200 ease-out"
+                onclick={(e: MouseEvent) => {
+                    if (window.location.pathname === '/') {
+                        e.preventDefault();
+                        window.location.reload();
+                    }
+                }}
             >
                 <Home class="mr-2 h-5 w-5" />
                 홈


### PR DESCRIPTION
## Summary
- 홈페이지(`/`)에서 로고 또는 홈 버튼 클릭 시 `window.location.reload()`로 강제 새로고침
- 다른 페이지에서 클릭 시 기존 동작(홈으로 이동) 유지

## Test plan
- [ ] 홈페이지에서 로고 클릭 → 페이지 새로고침 확인
- [ ] 홈페이지에서 홈 버튼 클릭 → 페이지 새로고침 확인
- [ ] 다른 페이지에서 로고/홈 클릭 → 홈으로 이동 확인