### PR TITLE
fix: 댓글창 세로폭 축소

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -229,7 +229,7 @@
 </script>
 
 {#if canComment()}
-    <form onsubmit={handleSubmit} class="space-y-3">
+    <form onsubmit={handleSubmit} class="space-y-2">
         {#if isReplyMode}
             <!-- 대댓글 모드 표시 -->
             <div class="text-muted-foreground flex items-center gap-2 text-sm">
@@ -267,7 +267,7 @@
                     bind:ref={textareaRef}
                     bind:value={content}
                     placeholder={actualPlaceholder}
-                    rows={isReplyMode ? 2 : 3}
+                    rows={isReplyMode ? 1 : 2}
                     class={error ? 'border-destructive' : ''}
                     disabled={isLoading}
                     onpaste={handlePaste}


### PR DESCRIPTION
## Summary
- 댓글 입력 textarea rows 3→2, 대댓글 2→1로 축소
- form 내부 수직 여백 space-y-3 → space-y-2 축소

## Test plan
- [ ] 일반 댓글 입력창 높이가 이전보다 줄었는지 확인
- [ ] 대댓글 입력창 높이 확인
- [ ] 여전히 충분한 입력 공간이 있는지 확인