### PR TITLE
fix: linked-image.ts Prettier 포맷팅 수정

### DIFF
--- a/apps/web/src/lib/components/features/editor/linked-image.ts
+++ b/apps/web/src/lib/components/features/editor/linked-image.ts
@@ -9,50 +9,50 @@ import Image from '@tiptap/extension-image';
  * 이를 우회하기 위해 href/linkTarget을 노드 attribute로 관리한다.
  */
 export const LinkedImage = Image.extend({
-	addAttributes() {
-		return {
-			...this.parent?.(),
-			// 이미지를 감싸는 <a> 태그의 href
-			href: { default: null },
-			// <a> 태그의 target 속성
-			linkTarget: { default: null },
-		};
-	},
+    addAttributes() {
+        return {
+            ...this.parent?.(),
+            // 이미지를 감싸는 <a> 태그의 href
+            href: { default: null },
+            // <a> 태그의 target 속성
+            linkTarget: { default: null }
+        };
+    },
 
-	parseHTML() {
-		return [
-			{
-				tag: this.options.allowBase64 ? 'img[src]' : 'img[src]:not([src^="data:"])',
-				getAttrs: (dom: HTMLElement) => {
-					const img = dom as HTMLImageElement;
-					// 상위 <a> 태그에서 href 추출 (SunEditor: figure>a>img, 일반: a>img)
-					const link = img.closest('a');
-					return {
-						src: img.getAttribute('src'),
-						alt: img.getAttribute('alt'),
-						title: img.getAttribute('title'),
-						width: img.getAttribute('width'),
-						height: img.getAttribute('height'),
-						href: link?.getAttribute('href') || null,
-						linkTarget: link?.getAttribute('target') || null,
-					};
-				},
-			},
-		];
-	},
+    parseHTML() {
+        return [
+            {
+                tag: this.options.allowBase64 ? 'img[src]' : 'img[src]:not([src^="data:"])',
+                getAttrs: (dom: HTMLElement) => {
+                    const img = dom as HTMLImageElement;
+                    // 상위 <a> 태그에서 href 추출 (SunEditor: figure>a>img, 일반: a>img)
+                    const link = img.closest('a');
+                    return {
+                        src: img.getAttribute('src'),
+                        alt: img.getAttribute('alt'),
+                        title: img.getAttribute('title'),
+                        width: img.getAttribute('width'),
+                        height: img.getAttribute('height'),
+                        href: link?.getAttribute('href') || null,
+                        linkTarget: link?.getAttribute('target') || null
+                    };
+                }
+            }
+        ];
+    },
 
-	renderHTML({ HTMLAttributes }) {
-		const { href, linkTarget, ...imgAttrs } = HTMLAttributes;
-		const mergedImgAttrs = mergeAttributes(this.options.HTMLAttributes, imgAttrs);
+    renderHTML({ HTMLAttributes }) {
+        const { href, linkTarget, ...imgAttrs } = HTMLAttributes;
+        const mergedImgAttrs = mergeAttributes(this.options.HTMLAttributes, imgAttrs);
 
-		if (href) {
-			return [
-				'a',
-				{ href, target: linkTarget || '_blank', rel: 'noopener noreferrer' },
-				['img', mergedImgAttrs],
-			];
-		}
+        if (href) {
+            return [
+                'a',
+                { href, target: linkTarget || '_blank', rel: 'noopener noreferrer' },
+                ['img', mergedImgAttrs]
+            ];
+        }
 
-		return ['img', mergedImgAttrs];
-	},
+        return ['img', mergedImgAttrs];
+    }
 });


### PR DESCRIPTION
## Summary
- `linked-image.ts` 파일의 들여쓰기를 탭에서 스페이스로 변환하여 Prettier 검사 통과

## Test plan
- [ ] CI Prettier 검사 통과 확인