### PR TITLE
fix: 이모티콘 팝업 모바일 위치 개선

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -52,11 +52,14 @@
             <!-- 외부 클릭으로 닫기 -->
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
-                class="fixed inset-0 z-40"
+                class="fixed inset-0 z-40 bg-black/20 sm:bg-transparent"
                 onclick={() => (showEmoticonPicker = false)}
                 onkeydown={(e) => e.key === 'Escape' && (showEmoticonPicker = false)}
             ></div>
-            <div class="absolute bottom-full left-0 z-50 mb-1">
+            <!-- 모바일: 화면 하단 고정, PC: 버튼 위에 팝업 -->
+            <div
+                class="fixed inset-x-0 bottom-0 z-50 sm:absolute sm:inset-auto sm:bottom-full sm:left-0 sm:mb-1"
+            >
                 <EmoticonPicker
                     onInsertEmoticon={handleInsertEmoticon}
                     onClose={() => (showEmoticonPicker = false)}

--- a/apps/web/src/lib/components/features/board/emoticon-picker.svelte
+++ b/apps/web/src/lib/components/features/board/emoticon-picker.svelte
@@ -113,7 +113,7 @@
     }
 </script>
 
-<div class="bg-background w-[340px] rounded-lg border p-3 shadow-lg">
+<div class="bg-background w-full rounded-t-lg border p-3 shadow-lg sm:w-[340px] sm:rounded-lg">
     {#if loading}
         <div class="flex h-[280px] items-center justify-center">
             <span class="text-muted-foreground text-sm">로딩 중...</span>


### PR DESCRIPTION
## Summary
- 모바일: 이모티콘 팝업을 화면 하단에 고정 (bottom sheet 패턴)
- 모바일: 반투명 배경 오버레이 추가
- PC: 기존 동작 유지 (버튼 위 팝업)
- 이모티콘 피커 모바일에서 전체 너비 사용

## Test plan
- [ ] 모바일에서 이모티콘 버튼 클릭 → 하단에 피커 표시
- [ ] PC에서 이모티콘 버튼 클릭 → 버튼 위에 피커 표시
- [ ] 이모티콘 선택 후 댓글 입력란에 삽입 확인
- [ ] 배경 클릭 또는 Escape로 닫기 동작 확인