### PR TITLE
fix: 멘션 알림 API에 mentions 배열 미전송 버그 수정

### DIFF
--- a/apps/web/src/lib/utils/mention-notify.ts
+++ b/apps/web/src/lib/utils/mention-notify.ts
@@ -23,7 +23,13 @@ export async function sendMentionNotifications(params: MentionNotifyParams): Pro
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',
-            body: JSON.stringify(params)
+            body: JSON.stringify({
+                mentions,
+                boardId: params.boardId,
+                postId: params.postId,
+                content: params.content,
+                senderNick: params.senderName
+            })
         });
     } catch {
         // fire-and-forget: 멘션 알림 실패는 무시


### PR DESCRIPTION
## Summary
- `sendMentionNotifications`에서 `extractMentions()`로 닉네임 추출 후 API에 mentions 배열을 포함하지 않고 원본 params를 그대로 전송하는 버그 수정
- API가 기대하는 형식(`mentions`, `senderNick`)으로 요청 바디 재구성
- 이 버그로 인해 **모든 @멘션 알림이 조용히 실패**하고 있었음

## Test plan
- [ ] 댓글에 `@닉네임` 멘션 후 대상 사용자에게 알림 수신 확인
- [ ] 게시글 작성 시 `@닉네임` 멘션 알림 확인
- [ ] 멘션 없는 댓글/게시글은 알림 API 호출 안 함 확인