### PR TITLE
fix: 버튼 cursor:pointer + 마지막 댓글 padding 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1267,7 +1267,7 @@
         padding-top: calc(var(--comment-pad-extra, 3px));
     }
     .comment-item:last-child {
-        padding-bottom: calc(var(--comment-pad-extra, 3px) + 0.75rem);
+        padding-bottom: var(--comment-pad-extra, 3px);
     }
 
     /* 댓글 본문 문단 간격 축소 */

--- a/apps/web/src/lib/components/ui/button/button.svelte
+++ b/apps/web/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
     import { type VariantProps, tv } from 'tailwind-variants';
 
     export const buttonVariants = tv({
-        base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        base: "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         variants: {
             variant: {
                 default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',


### PR DESCRIPTION
## Summary
- Button 컴포넌트 base 스타일에 `cursor-pointer` 추가 (모든 버튼에 포인터 커서 적용)
- 마지막 댓글의 padding-bottom이 다른 댓글보다 0.75rem 더 크던 문제 수정

## Test plan
- [ ] 버튼 hover 시 pointer 커서 표시 확인
- [ ] 댓글 목록 마지막 댓글의 하단 여백이 적절한지 확인