### PR TITLE
fix: 메모 배지를 닉네임 앞으로 이동

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -770,13 +770,13 @@
                                         level={memberLevelStore.getLevel(comment.author_id)}
                                         size="md"
                                     />
+                                    {#if !isDeleted && memoPluginActive && MemoBadge}
+                                        <MemoBadge memberId={comment.author_id} showIcon={true} />
+                                    {/if}
                                     <AuthorLink
                                         authorId={comment.author_id}
                                         authorName={comment.author}
                                     />
-                                    {#if !isDeleted && memoPluginActive && MemoBadge}
-                                        <MemoBadge memberId={comment.author_id} showIcon={true} />
-                                    {/if}
                                     {#if comment.is_secret}
                                         <Lock class="text-muted-foreground h-3.5 w-3.5" />
                                     {/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -202,10 +202,10 @@
                             onerror={handleIconError}
                         />
                     {/if}
-                    <AuthorLink authorId={post.author_id} authorName={post.author} />
                     {#if memoPluginActive && MemoBadge}
                         <MemoBadge memberId={post.author_id} />
                     {/if}
+                    <AuthorLink authorId={post.author_id} authorName={post.author} />
                 </span>
 
                 <!-- 날짜 (col 4, 데스크톱만) -->
@@ -240,10 +240,10 @@
                                 onerror={handleIconError}
                             />
                         {/if}
-                        <AuthorLink authorId={post.author_id} authorName={post.author} />
                         {#if memoPluginActive && MemoBadge}
                             <MemoBadge memberId={post.author_id} />
                         {/if}
+                        <AuthorLink authorId={post.author_id} authorName={post.author} />
                     </span>
                     <span class="mobile-meta-sep {isToday(post.created_at) ? 'date-today' : ''}">
                         {formatDate(post.created_at)}


### PR DESCRIPTION
## Summary
- classic 레이아웃: 메모 배지를 닉네임 뒤→앞으로 이동 (데스크톱/모바일)
- 댓글: 메모 배지를 닉네임 뒤→앞으로 이동
- 닉네임이 길어도 메모가 항상 보이도록 위치 개선

## 관련 제보
- https://damoang.net/bug/7612 (메모 왼쪽으로 이동 요청)
- https://damoang.net/bug/7613 (메모 표시 길이/방법 개선)

## Test plan
- [ ] classic 레이아웃에서 메모가 닉네임 앞에 표시되는지 확인
- [ ] 댓글에서 메모가 닉네임 앞에 표시되는지 확인
- [ ] 닉네임이 긴 경우에도 메모가 보이는지 확인