### PR TITLE
fix: 다크모드 시스템 테마 연동 및 광고 눈부심 완화

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -112,10 +112,34 @@
                 themeMode = e.newValue as 'light' | 'dark' | 'amoled';
             }
         }
+
+        // OS 다크모드 변경 감지 (사용자가 명시적 테마 설정 안 한 경우만)
+        const darkMq = window.matchMedia('(prefers-color-scheme: dark)');
+        function handleSystemThemeChange(e: MediaQueryListEvent) {
+            // 쿠키나 localStorage에 명시적 설정이 있으면 무시
+            const hasCookie = /angple_theme_mode=\w+/.test(document.cookie);
+            let hasLocal = false;
+            try {
+                hasLocal = !!localStorage.getItem('themeMode');
+            } catch {}
+            if (hasCookie || hasLocal) return;
+
+            const el = document.documentElement;
+            el.classList.remove('dark', 'amoled');
+            if (e.matches) {
+                el.classList.add('dark');
+                themeMode = 'dark';
+            } else {
+                themeMode = 'light';
+            }
+        }
+        darkMq.addEventListener('change', handleSystemThemeChange);
+
         window.addEventListener('storage', handleStorageChange);
         window.addEventListener('scroll', handleScroll, { passive: true });
 
         return () => {
+            darkMq.removeEventListener('change', handleSystemThemeChange);
             window.removeEventListener('storage', handleStorageChange);
             window.removeEventListener('scroll', handleScroll);
         };

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -578,6 +578,13 @@
         background: transparent;
     }
 
+    /* 다크모드: 광고 iframe 흰 배경 완화 (눈부심 방지) */
+    :global(.dark) .ad-slot-loaded,
+    :global(.amoled) .ad-slot-loaded {
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 0.5rem;
+    }
+
     .gam-ad-slot {
         display: flex;
         justify-content: center;
@@ -593,5 +600,11 @@
     /* 광고 iframe이 컨테이너를 넘지 않도록 */
     .gam-ad-slot :global(iframe) {
         max-width: 100% !important;
+    }
+
+    /* 다크모드: 광고 iframe 밝기 낮춤 (눈부심 완화) */
+    :global(.dark) .gam-ad-slot :global(iframe),
+    :global(.amoled) .gam-ad-slot :global(iframe) {
+        filter: brightness(0.9);
     }
 </style>


### PR DESCRIPTION
## Summary
- OS 다크/라이트 모드 전환 시 자동 반영 (사용자가 명시적 테마 설정 안 한 경우만 적용)
- 다크모드에서 광고 iframe `brightness(0.9)` 필터 + 미세 테두리로 흰 배경 눈부심 완화

## Related
- 버그 #7591: 다크/라이트 모드 토글이 시스템 설정을 따르지 않음
- 버그 #7618: 다크모드에서 흰 배경 광고 슬롯 눈부심

## Test plan
- [ ] OS 테마를 다크→라이트 전환 시 사이트가 자동으로 따라가는지 확인 (첫 방문 or 테마 미설정 사용자)
- [ ] 수동으로 테마 설정한 사용자는 OS 변경에 영향 안 받는지 확인
- [ ] 다크모드에서 광고 슬롯이 덜 눈부신지 확인