### PR TITLE
fix: Safari bfcache 복원 시 stale 상태 방지

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -84,6 +84,15 @@
     </head>
     <body data-sveltekit-preload-data="hover">
         <div style="display: contents">%sveltekit.body%</div>
+        <!-- Safari bfcache 복원 시 stale 상태 방지 -->
+        <script>
+            window.addEventListener('pageshow', function (e) {
+                if (e.persisted) {
+                    // bfcache에서 복원됨 — SvelteKit 라우터 상태 갱신 위해 리로드
+                    location.reload();
+                }
+            });
+        </script>
         <!-- JS chunk 로드 실패는 hooks.client.ts에서 자동 새로고침 처리 -->
         <script>
             if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- iOS Safari에서 뒤로가기 시 bfcache에서 복원된 stale 페이지 문제 해결
- `pageshow` 이벤트의 `persisted` 플래그로 bfcache 복원 감지 후 리로드

## Related
- 버그 #7697, #7627: 아이폰 사파리 뒤로가기/이전페이지 동작 이상

## Test plan
- [ ] iOS Safari에서 게시글 → 뒤로가기 시 정상 동작 확인
- [ ] Chrome/Firefox에서 뒤로가기 기존 동작에 영향 없는지 확인