### PR TITLE
fix: 클래식 레이아웃 목록 제목 bold 제거

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -276,7 +276,6 @@
     .post-title,
     .post-title-read {
         font-size: 1rem;
-        font-weight: 600;
         transition: color 0.8s ease-in-out;
     }
 


### PR DESCRIPTION
## Summary
- 클래식 스킨 게시글 목록 제목에서 `font-weight: 600` 제거
- 기본 굵기(normal)로 표시

## Test plan
- [ ] 클래식 레이아웃 목록에서 제목 굵기 확인