### PR TITLE
fix: 기본 페이지 타이틀에 종합 커뮤니티 추가

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -224,7 +224,7 @@
 <svelte:window onkeydown={keyboardShortcuts.handleKeydown} />
 
 <svelte:head>
-    <title>{import.meta.env.VITE_SITE_NAME || '다모앙'}</title>
+    <title>{import.meta.env.VITE_SITE_NAME || '다모앙'} - 종합 커뮤니티</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href={favicon} />
 </svelte:head>


### PR DESCRIPTION
## Summary
- title이 없는 페이지에서 `angple - 종합 커뮤니티`로 표시되도록 변경

## Test plan
- [ ] 홈페이지 브라우저 탭 타이틀 확인