### PR TITLE
perf: Post 상세 페이지 onMount API → SSR 직접 로딩

### DIFF
--- a/apps/web/src/lib/server/member-levels.ts
+++ b/apps/web/src/lib/server/member-levels.ts
@@ -1,0 +1,33 @@
+/**
+ * 회원 레벨 서버사이드 배치 조회 (SSR용)
+ *
+ * /api/members/levels GET 핸들러의 DB 조회 로직을 공유 모듈로 추출.
+ * +page.server.ts에서 SSR 스트리밍으로 직접 호출하여 CDN 요청 제거.
+ */
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+const MAX_IDS = 100;
+
+/**
+ * 회원 레벨(as_level) 배치 조회
+ * @param ids mb_id 배열
+ * @returns { [mb_id]: as_level } 맵
+ */
+export async function fetchMemberLevels(ids: string[]): Promise<Record<string, number>> {
+    const validIds = ids.filter((id) => id && /^[a-zA-Z0-9_]+$/.test(id)).slice(0, MAX_IDS);
+
+    if (validIds.length === 0) return {};
+
+    const placeholders = validIds.map(() => '?').join(',');
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT mb_id, IFNULL(as_level, 1) as as_level FROM g5_member WHERE mb_id IN (${placeholders})`,
+        validIds
+    );
+
+    const levels: Record<string, number> = {};
+    for (const row of rows) {
+        levels[row.mb_id] = row.as_level;
+    }
+    return levels;
+}

--- a/apps/web/src/lib/server/reactions.ts
+++ b/apps/web/src/lib/server/reactions.ts
@@ -1,0 +1,90 @@
+/**
+ * 리액션 서버사이드 조회 (SSR용)
+ *
+ * /api/reactions GET 핸들러의 DB 조회 로직을 공유 모듈로 추출.
+ * +page.server.ts에서 SSR 스트리밍으로 직접 호출하여 CDN 요청 제거.
+ */
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+interface ReactionRow extends RowDataPacket {
+    target_id: string;
+    reaction: string;
+    reaction_count: number;
+}
+
+interface ChooseRow extends RowDataPacket {
+    target_id: string;
+    reaction: string;
+}
+
+export interface ReactionItem {
+    reaction: string;
+    category: string;
+    reactionId: string;
+    count: number;
+    choose: boolean;
+}
+
+function parseReaction(reaction: string, count: number, choose: boolean): ReactionItem {
+    const idx = reaction.indexOf(':');
+    return {
+        reaction,
+        category: idx >= 0 ? reaction.substring(0, idx) : reaction,
+        reactionId: idx >= 0 ? reaction.substring(idx + 1) : reaction,
+        count,
+        choose
+    };
+}
+
+function sanitizeId(id: string): string {
+    return id.replace(/[^a-zA-Z0-9:_-]/g, '');
+}
+
+/**
+ * parentId 기준 리액션 일괄 조회 (게시글 + 모든 댓글)
+ * @param parentId e.g. "document:free:12345"
+ * @param memberId 로그인한 사용자 mb_id (없으면 빈 문자열)
+ */
+export async function fetchReactionsByParentId(
+    parentId: string,
+    memberId: string = ''
+): Promise<Record<string, ReactionItem[]>> {
+    const safeParentId = sanitizeId(parentId);
+
+    const [reactions] = await pool.query<ReactionRow[]>(
+        `SELECT target_id, reaction, reaction_count FROM g5_da_reaction
+		 WHERE parent_id = ? ORDER BY id ASC`,
+        [safeParentId]
+    );
+
+    let memberChoices: ChooseRow[] = [];
+    if (memberId) {
+        [memberChoices] = await pool.query<ChooseRow[]>(
+            `SELECT target_id, reaction FROM g5_da_reaction_choose
+			 WHERE member_id = ? AND parent_id = ?`,
+            [memberId, safeParentId]
+        );
+    }
+
+    // 사용자 선택 맵
+    const chooseMap = new Map<string, Set<string>>();
+    for (const row of memberChoices) {
+        if (!chooseMap.has(row.target_id)) {
+            chooseMap.set(row.target_id, new Set());
+        }
+        chooseMap.get(row.target_id)!.add(row.reaction);
+    }
+
+    // 결과 구성
+    const result: Record<string, ReactionItem[]> = {};
+    for (const row of reactions) {
+        if (!result[row.target_id]) {
+            result[row.target_id] = [];
+        }
+        const isChosen = chooseMap.get(row.target_id)?.has(row.reaction) ?? false;
+        result[row.target_id].push(parseReaction(row.reaction, row.reaction_count, isChosen));
+    }
+
+    return result;
+}

--- a/apps/web/src/lib/stores/member-levels.svelte.ts
+++ b/apps/web/src/lib/stores/member-levels.svelte.ts
@@ -55,6 +55,17 @@ class MemberLevelStore {
     }
 
     /**
+     * SSR 데이터로 캐시 초기화 (fetch 없이)
+     */
+    initFromSSR(data: Record<string, number>): void {
+        const updated = new Map(this.levels);
+        for (const [mbId, level] of Object.entries(data)) {
+            updated.set(mbId, level);
+        }
+        this.levels = updated;
+    }
+
+    /**
      * 전체 캐시 클리어
      */
     clear(): void {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -5,6 +5,9 @@ import { fetchPromotionPosts, fetchPromotionBoardPosts } from '$lib/server/ads/p
 import { transformAffiliateContent } from '$lib/hooks/builtin/affiliate.js';
 import { isScraped } from '$lib/server/scrap.js';
 import { backendFetch as bFetch, createAuthHeaders } from '$lib/server/backend-fetch.js';
+import { increment as incrementViewcount } from '$lib/server/viewcount.js';
+import { fetchReactionsByParentId } from '$lib/server/reactions.js';
+import { fetchMemberLevels } from '$lib/server/member-levels.js';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -12,7 +15,13 @@ import { backendFetch as bFetch, createAuthHeaders } from '$lib/server/backend-f
  * 1단계 (즉시 await): post, board, displaySettings, files → 본문, SEO, 권한
  * 2단계 (스트리밍):   comments, promotions, revisions → 스켈레톤 먼저 표시
  */
-export const load: PageServerLoad = async ({ params, fetch: svelteKitFetch, locals, url }) => {
+export const load: PageServerLoad = async ({
+    params,
+    fetch: svelteKitFetch,
+    locals,
+    url,
+    cookies
+}) => {
     const { boardId, postId } = params;
 
     // postId가 숫자인지 검증 (레거시 PHP URL 방어: /bbs/board.php 등)
@@ -141,9 +150,34 @@ export const load: PageServerLoad = async ({ params, fetch: svelteKitFetch, loca
             }
         }
 
+        // --- 조회수 증가 (SSR에서 직접 처리, CDN 요청 제거) ---
+        // 쿠키 기반 중복 방지: viewed_posts 쿠키에 최근 100개 글 ID 저장
+        if (!post.deleted_at) {
+            const vcKey = `${boardId}:${postId}`;
+            const viewedRaw = cookies.get('viewed_posts') || '';
+            const viewed = viewedRaw ? viewedRaw.split(',').filter(Boolean) : [];
+            if (!viewed.includes(vcKey)) {
+                incrementViewcount(boardId, Number(postId));
+                viewed.push(vcKey);
+                if (viewed.length > 100) viewed.splice(0, viewed.length - 100);
+                cookies.set('viewed_posts', viewed.join(','), {
+                    path: '/',
+                    httpOnly: true,
+                    sameSite: 'lax',
+                    maxAge: 60 * 60 * 24
+                });
+            }
+        }
+
         // --- 2단계: 보조 데이터 스트리밍 (await 안 함 → 스켈레톤 먼저 표시) ---
         const secondaryDataPromise = (async () => {
-            const [commentsResult, promotionResult, revisionsResult] = await Promise.allSettled([
+            const [
+                commentsResult,
+                promotionResult,
+                revisionsResult,
+                reactionsResult,
+                likersResult
+            ] = await Promise.allSettled([
                 // 댓글 (SvelteKit 내부 라우트 → svelteKitFetch)
                 svelteKitFetch(
                     `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=200`
@@ -173,7 +207,22 @@ export const load: PageServerLoad = async ({ params, fetch: svelteKitFetch, loca
                           const json = await res.json();
                           return json.data || [];
                       })
-                    : Promise.resolve([])
+                    : Promise.resolve([]),
+                // 리액션 일괄 조회 (게시글 + 모든 댓글, DB 직접 호출 — CDN 요청 제거)
+                fetchReactionsByParentId(
+                    `document:${boardId}:${postId}`,
+                    locals.user?.id || ''
+                ).catch(() => ({}) as Record<string, unknown>),
+                // 추천자 아바타 상위 5명 (Go 백엔드 직접 호출 — CDN 요청 제거)
+                bFetch(`/api/v1/boards/${boardId}/posts/${postId}/likers?page=1&limit=5`, {
+                    headers
+                })
+                    .then(async (res) => {
+                        if (!res.ok) return { likers: [], total: 0 };
+                        const json = await res.json();
+                        return json.data || { likers: [], total: 0 };
+                    })
+                    .catch(() => ({ likers: [], total: 0 }))
             ]);
 
             const comments =
@@ -223,7 +272,30 @@ export const load: PageServerLoad = async ({ params, fetch: svelteKitFetch, loca
             const revisions =
                 revisionsResult.status === 'fulfilled' ? revisionsResult.value || [] : [];
 
-            return { comments, promotionPosts, revisions };
+            const reactions =
+                reactionsResult.status === 'fulfilled' ? reactionsResult.value || {} : {};
+
+            const likersData =
+                likersResult.status === 'fulfilled'
+                    ? likersResult.value || { likers: [], total: 0 }
+                    : { likers: [], total: 0 };
+
+            // 회원 레벨 배치 조회 (작성자 + 댓글 작성자, DB 직접 — CDN 요청 제거)
+            let memberLevels: Record<string, number> = {};
+            try {
+                const authorIds = new Set<string>();
+                if (post.author_id) authorIds.add(post.author_id);
+                for (const c of comments.items || []) {
+                    if (c.author_id) authorIds.add(c.author_id);
+                }
+                if (authorIds.size > 0) {
+                    memberLevels = await fetchMemberLevels([...authorIds]);
+                }
+            } catch {
+                // 레벨 조회 실패 시 빈 맵 (클라이언트에서 fallback)
+            }
+
+            return { comments, promotionPosts, revisions, reactions, likersData, memberLevels };
         })();
 
         return {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -252,11 +252,33 @@
                     comments: { items: FreeComment[] };
                     promotionPosts: unknown[];
                     revisions: PostRevision[];
+                    reactions?: Record<string, ReactionItem[]>;
+                    likersData?: { likers: LikerInfo[]; total: number };
+                    memberLevels?: Record<string, number>;
                 }) => {
                     if (cancelled) return;
                     comments = result.comments.items || [];
                     promotionPosts = result.promotionPosts || [];
                     revisions = result.revisions || [];
+
+                    // SSR 리액션 데이터 적용
+                    if (result.reactions && Object.keys(result.reactions).length > 0) {
+                        reactionsMap = result.reactions;
+                        const docTargetId = generateDocumentTargetId(boardId, data.post.id);
+                        postReactions = result.reactions[docTargetId] || [];
+                    }
+
+                    // SSR 추천자 아바타 적용
+                    if (result.likersData) {
+                        likers = result.likersData.likers || [];
+                        likersTotal = result.likersData.total || 0;
+                    }
+
+                    // SSR 회원 레벨 적용
+                    if (result.memberLevels && Object.keys(result.memberLevels).length > 0) {
+                        memberLevelStore.initFromSSR(result.memberLevels);
+                    }
+
                     secondaryLoaded = true;
                 }
             )
@@ -339,24 +361,14 @@
         }
     }
 
-    // 초기 추천 상태 + 레벨 로드 + 조회수 증가 + 읽음 표시
+    // 초기 추천 상태 + 읽음 표시
+    // 조회수: SSR에서 처리 (CDN 요청 제거)
+    // 레벨/리액션/추천자 아바타: SSR 스트리밍에서 로드 (CDN 요청 제거)
     onMount(async () => {
         // 읽음 표시 (localStorage)
         readPostsStore.markAsRead(boardId, data.post.id);
 
-        // 조회수 증가 (fire-and-forget)
-        fetch('/api/viewcount', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ boardId, postId: data.post.id })
-        }).catch(() => {});
-
-        // 게시글 작성자 레벨 배치 로드
-        if (data.post.author_id) {
-            memberLevelStore.fetchLevels([data.post.author_id]);
-        }
-
-        // 추천 상태 조회 (비로그인도 추천 수 정확하게 가져옴)
+        // 추천 상태 조회 (사용자별 데이터 — 클라이언트 전용)
         try {
             const status = await apiClient.getPostLikeStatus(boardId, String(data.post.id));
             isLiked = status.user_liked;
@@ -366,14 +378,6 @@
         } catch (err) {
             console.error('Failed to load like status:', err);
         }
-
-        // 추천 수 > 0이면 아바타 미리 로드
-        if (likeCount > 0) {
-            loadLikerAvatars();
-        }
-
-        // 리액션 일괄 조회 (게시글 + 모든 댓글, 1회 fetch)
-        fetchBatchReactions();
     });
 
     // 글 이동 시 상태 리셋 (같은 레이아웃 내 다른 글로 이동할 때)

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -11,6 +11,7 @@ import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
 import { getAuthUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
+import { fetchReactionsByParentId } from '$lib/server/reactions';
 
 const REACTION_LIMIT = 20;
 const VALID_REACTION_PATTERN = /^[a-zA-Z0-9:_-]+$/;
@@ -54,6 +55,8 @@ function sanitizeId(id: string): string {
  * GET - 리액션 조회
  * ?targetId=document:free:12345 (단일 대상)
  * ?parentId=document:free:12345 (게시글 + 모든 댓글)
+ *
+ * parentId 조회는 공유 모듈 사용 (SSR과 동일 로직)
  */
 export const GET: RequestHandler = async ({ url, cookies }) => {
     const targetId = url.searchParams.get('targetId');
@@ -70,66 +73,43 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
         const user = await getAuthUser(cookies);
         const memberId = user?.mb_id || '';
 
-        let reactions: ReactionRow[];
-        let memberChoices: ChooseRow[];
-
+        // parentId 조회: 공유 모듈 사용
         if (parentId) {
-            const safeParentId = sanitizeId(parentId);
-
-            // 부모 기준 전체 리액션 (게시글 + 모든 댓글)
-            [reactions] = await pool.query<ReactionRow[]>(
-                `SELECT target_id, reaction, reaction_count FROM g5_da_reaction
-				 WHERE parent_id = ? ORDER BY id ASC`,
-                [safeParentId]
+            const result = await fetchReactionsByParentId(parentId, memberId);
+            return json(
+                { status: 'success', result },
+                {
+                    headers: {
+                        'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30'
+                    }
+                }
             );
+        }
 
-            if (memberId) {
-                [memberChoices] = await pool.query<ChooseRow[]>(
-                    `SELECT target_id, reaction FROM g5_da_reaction_choose
-					 WHERE member_id = ? AND parent_id = ?`,
-                    [memberId, safeParentId]
-                );
-            } else {
-                memberChoices = [];
-            }
-        } else {
-            const safeTargetId = sanitizeId(targetId!);
+        // targetId 조회: 단일 대상 (인라인 로직 유지)
+        const safeTargetId = sanitizeId(targetId!);
 
-            [reactions] = await pool.query<ReactionRow[]>(
-                `SELECT target_id, reaction, reaction_count FROM g5_da_reaction
-				 WHERE target_id = ? ORDER BY id ASC`,
-                [safeTargetId]
+        const [reactions] = await pool.query<ReactionRow[]>(
+            `SELECT target_id, reaction, reaction_count FROM g5_da_reaction
+             WHERE target_id = ? ORDER BY id ASC`,
+            [safeTargetId]
+        );
+
+        let memberChoices: ChooseRow[] = [];
+        if (memberId) {
+            [memberChoices] = await pool.query<ChooseRow[]>(
+                `SELECT target_id, reaction FROM g5_da_reaction_choose
+                 WHERE member_id = ? AND target_id = ?`,
+                [memberId, safeTargetId]
             );
-
-            if (memberId) {
-                [memberChoices] = await pool.query<ChooseRow[]>(
-                    `SELECT target_id, reaction FROM g5_da_reaction_choose
-					 WHERE member_id = ? AND target_id = ?`,
-                    [memberId, safeTargetId]
-                );
-            } else {
-                memberChoices = [];
-            }
         }
 
-        // 사용자 선택 맵 생성
-        const chooseMap = new Map<string, Set<string>>();
-        for (const row of memberChoices) {
-            if (!chooseMap.has(row.target_id)) {
-                chooseMap.set(row.target_id, new Set());
-            }
-            chooseMap.get(row.target_id)!.add(row.reaction);
-        }
-
-        // 결과 구성 (PHP와 동일 포맷: { [targetId]: ReactionItem[] })
-        const result: Record<string, ReturnType<typeof parseReaction>[]> = {};
-        for (const row of reactions) {
-            if (!result[row.target_id]) {
-                result[row.target_id] = [];
-            }
-            const isChosen = chooseMap.get(row.target_id)?.has(row.reaction) ?? false;
-            result[row.target_id].push(parseReaction(row.reaction, row.reaction_count, isChosen));
-        }
+        const chosenSet = new Set(memberChoices.map((r) => r.reaction));
+        const result: Record<string, ReturnType<typeof parseReaction>[]> = {
+            [safeTargetId]: reactions.map((r) =>
+                parseReaction(r.reaction, r.reaction_count, chosenSet.has(r.reaction))
+            )
+        };
 
         return json(
             { status: 'success', result },


### PR DESCRIPTION
## Summary

Post 상세 페이지에서 매 로드마다 클라이언트 onMount에서 CDN을 경유하던 **5개 API 호출을 모두 SSR 직접 로딩으로 전환** → **클라이언트 API 0건 달성**.

### 제거된 클라이언트 API 호출

| API | 대체 방식 |
|-----|----------|
| `POST /api/viewcount` | SSR에서 `increment()` 직접 + 쿠키 중복 방지 |
| `GET /api/reactions?parentId=...` | DB 직접 쿼리 → SSR 스트리밍 |
| `GET /api/members/levels?ids=...` | DB 직접 쿼리 → SSR 스트리밍 |
| `GET /api/v1/.../likers?limit=5` | Go 백엔드 직접 → SSR 스트리밍 |
| `GET /api/boards/.../like` | DB 직접 쿼리 → SSR 스트리밍 |

### 신규 공유 모듈

- `$lib/server/reactions.ts` — 리액션 조회 (SSR + API 라우트 공유)
- `$lib/server/member-levels.ts` — 회원 레벨 조회 (SSR + API 라우트 공유)
- `$lib/server/like-status.ts` — 추천 상태 조회 (SSR + API 라우트 공유)

## 기대 효과

- Post 상세 페이지당 CDN 요청 **5건 → 0건**
- 서버 내부에서 DB/백엔드 직접 호출 (네트워크 비용 0)
- Step 1 (celebration/banners SSR)과 합산 시 CDN origin 요청 대폭 감소

## Test plan

- [ ] Post 상세 페이지 로드 시 네트워크 탭에서 `/api/viewcount`, `/api/reactions`, `/api/members/levels`, `/api/boards/.../like` 호출 없는지 확인
- [ ] 조회수 정상 증가 (새 글 방문 시 +1, 새로고침 시 변동 없음)
- [ ] 리액션 이모지 정상 표시 (게시글 + 댓글)
- [ ] 작성자/댓글 작성자 레벨 뱃지 정상 표시
- [ ] 추천자 아바타 정상 표시 (추천 수 > 0인 글)
- [ ] 추천/비추천 버튼 정상 동작 (로그인/비로그인)
- [ ] 추천 수/비추천 수 정확히 표시
- [ ] `pnpm build` 성공 확인