### PR TITLE
fix: @멘션이 URL/이메일 내 @를 프로필 링크로 오버라이드하는 버그 수정

### DIFF
--- a/apps/web/src/lib/utils/mention-parser.ts
+++ b/apps/web/src/lib/utils/mention-parser.ts
@@ -3,14 +3,15 @@
  * plain text 및 HTML에서 @멘션을 추출하고 변환
  */
 
-/** 멘션 정규식: @닉네임 패턴 (한글, 영문, 숫자, 언더스코어) */
-const MENTION_REGEX = /@([a-zA-Z0-9_가-힣]+)/g;
+/** 멘션 정규식: @닉네임 패턴 — URL/이메일 내 @는 제외 */
+const MENTION_REGEX = /(?<![a-zA-Z0-9.+_\-/])@([a-zA-Z0-9_가-힣]+)/g;
 
 /** HTML data-mention 속성에서 멘션 추출 정규식 */
 const HTML_MENTION_REGEX = /data-mention="([^"]+)"/g;
 
 /**
  * plain text 또는 HTML에서 멘션된 닉네임 추출 (중복 제거)
+ * HTML 태그 내부 및 URL/이메일 내 @는 무시
  */
 export function extractMentions(content: string): string[] {
     if (!content) return [];
@@ -24,9 +25,10 @@ export function extractMentions(content: string): string[] {
         mentions.add(match[1]);
     }
 
-    // plain text @닉네임 패턴에서 추출
+    // HTML 태그를 제거한 텍스트에서 @닉네임 추출
+    const textOnly = content.replace(/<[^>]+>/g, ' ');
     const textRegex = new RegExp(MENTION_REGEX.source, 'g');
-    while ((match = textRegex.exec(content)) !== null) {
+    while ((match = textRegex.exec(textOnly)) !== null) {
         mentions.add(match[1]);
     }
 
@@ -36,13 +38,23 @@ export function extractMentions(content: string): string[] {
 /**
  * plain text의 @닉네임을 클릭 가능한 링크로 변환
  * DOMPurify를 통과할 수 있도록 <a> 태그 사용
+ * HTML 태그 내부 및 URL/이메일 내 @는 변환하지 않음
  */
 export function highlightMentions(content: string): string {
     if (!content) return content;
 
-    return content.replace(
-        MENTION_REGEX,
-        (_match, nick) =>
-            `<a href="/profile/${encodeURIComponent(nick)}" class="mention-link text-primary font-medium hover:underline" data-mention="${nick}">@${nick}</a>`
-    );
+    // HTML 태그를 분리하여 텍스트 노드에서만 변환
+    const parts = content.split(/(<[^>]+>)/g);
+    return parts
+        .map((part) => {
+            if (part.startsWith('<')) return part;
+            // 텍스트 노드: URL/이메일 내 @는 건너뜀
+            // (?<![a-zA-Z0-9.+_\-/]) → @앞에 URL경로(/), 이메일(영숫자.) 문자가 오면 무시
+            return part.replace(
+                /(?<![a-zA-Z0-9.+_\-/])@([a-zA-Z0-9_가-힣]+)/g,
+                (_match, nick) =>
+                    `<a href="/profile/${encodeURIComponent(nick)}" class="mention-link text-primary font-medium hover:underline" data-mention="${nick}">@${nick}</a>`
+            );
+        })
+        .join('');
 }


### PR DESCRIPTION
## Summary
- `highlightMentions`가 URL(`https://x.com/@user`) 및 이메일(`user@example.com`) 내부의 `@`도 프로필 링크로 변환하는 버그 수정
- `MENTION_REGEX`에 negative lookbehind `(?<![a-zA-Z0-9.+_\-/])` 추가하여 URL 경로·이메일 문자 뒤의 `@`는 매칭 제외
- `highlightMentions`: HTML 태그 분리 후 텍스트 노드에서만 멘션 변환
- `extractMentions`: HTML 태그 제거 후 텍스트에서만 멘션 추출

## Test plan
- [x] 댓글에 `@닉네임` 입력 → 프로필 링크로 변환 확인
- [x] 댓글에 `https://x.com/@username` URL 입력 → URL이 깨지지 않고 그대로 표시 확인
- [x] 댓글에 `user@example.com` 이메일 입력 → 멘션으로 변환되지 않음 확인
- [x] `(@닉네임)` 괄호 안 멘션 → 정상 변환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)