### PR TITLE
feat: ECR 빌드 완료 시 Telegram/Discord 알림 추가

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,9 @@ yarn.lock
 apps/web/static/
 apps/admin/static/
 
+# CI/CD workflows
+.github/
+
 # Generated files
 .DS_Store
 *.log


### PR DESCRIPTION
## Summary
- ECR 이미지 빌드 완료 후 Telegram과 Discord로 알림 전송
- 커밋 SHA, 메시지, 이미지 태그 정보 포함
- Discord에는 ops.damoang.net/deploy 배포 대시보드 링크 포함

## Changes
- `.github/workflows/deploy-binary.yml`: build job에 Telegram/Discord 알림 step 추가