### PR TITLE
fix: 홈페이지 추천글/새소식 탭 개선 + 읽은 글 표시

### DIFF
--- a/apps/web/src/lib/components/features/new-board/components/tabs/news-tabs.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/tabs/news-tabs.svelte
@@ -21,7 +21,7 @@
     }
 </script>
 
-<div class="flex gap-1">
+<div class="flex flex-wrap justify-end gap-1">
     {#each tabs as tab (tab.id)}
         <button
             type="button"

--- a/apps/web/src/lib/components/features/new-board/new-board.svelte
+++ b/apps/web/src/lib/components/features/new-board/new-board.svelte
@@ -23,8 +23,8 @@
 </script>
 
 <Card class="gap-0">
-    <CardHeader class="flex flex-row items-center justify-between space-y-0 px-4 py-3">
-        <div class="flex items-center gap-2">
+    <CardHeader class="flex flex-row items-center justify-between gap-2 space-y-0 px-4 py-3">
+        <div class="flex shrink-0 items-center gap-2">
             <div
                 class="flex h-7 w-7 items-center justify-center rounded-lg bg-blue-100 dark:bg-blue-900/30"
             >

--- a/apps/web/src/lib/components/features/recommended/components/header/recommended-header.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/header/recommended-header.svelte
@@ -2,7 +2,7 @@
     import Flame from '@lucide/svelte/icons/flame';
 </script>
 
-<div class="flex items-center gap-2">
+<div class="flex shrink-0 items-center gap-2">
     <div
         class="flex h-7 w-7 items-center justify-center rounded-lg bg-orange-100 dark:bg-orange-900/30"
     >

--- a/apps/web/src/lib/components/features/recommended/components/tabs/recommended-tabs.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/tabs/recommended-tabs.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <!-- Pill 스타일 탭 -->
-<div class="flex gap-1">
+<div class="flex flex-wrap justify-end gap-1">
     {#each tabs as tab (tab.id)}
         {#if !tab.hidden}
             <button

--- a/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
+++ b/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
@@ -24,9 +24,30 @@
         | undefined;
     const hasSSRData = !!ssrData?.data;
 
-    let activeTab = $state<RecommendedPeriod>(hasSSRData ? ssrData!.period : defaultTab);
-    let data = $state<RecommendedDataWithAI | null>(hasSSRData ? ssrData!.data : null);
-    let loading = $state(!hasSSRData);
+    // 마지막 선택 탭 복원 (localStorage > SSR period > 시간대 기본값)
+    function getSavedTab(): RecommendedPeriod | null {
+        if (typeof window === 'undefined') return null;
+        try {
+            const saved = localStorage.getItem(
+                'angple_recommended_tab'
+            ) as RecommendedPeriod | null;
+            if (saved && ['1h', '3h', '6h', '12h', '24h', '48h'].includes(saved)) {
+                return saved;
+            }
+        } catch {
+            /* ignore */
+        }
+        return null;
+    }
+
+    const savedTab = getSavedTab();
+    const initialTab = savedTab ?? (hasSSRData ? ssrData!.period : defaultTab);
+    // SSR 데이터가 초기 탭과 같은 period인 경우에만 즉시 사용
+    const canUseSSR = hasSSRData && ssrData!.period === initialTab;
+
+    let activeTab = $state<RecommendedPeriod>(initialTab);
+    let data = $state<RecommendedDataWithAI | null>(canUseSSR ? ssrData!.data : null);
+    let loading = $state(!canUseSSR);
     let error = $state<string | null>(null);
 
     // 탭별 데이터 캐시
@@ -71,18 +92,24 @@
     function handleTabChange(tabId: RecommendedPeriod) {
         activeTab = tabId;
         loadData(tabId);
+        // 탭 선택 저장 (뒤로가기 시 복원)
+        try {
+            localStorage.setItem('angple_recommended_tab', tabId);
+        } catch {
+            /* ignore */
+        }
     }
 
     onMount(() => {
-        // SSR 데이터가 있으면 초기 fetch 불필요
-        if (!hasSSRData) {
+        // SSR 데이터가 없거나 저장된 탭과 다르면 클라이언트에서 fetch
+        if (!canUseSSR) {
             loadData(activeTab, true);
         }
     });
 </script>
 
 <Card class="gap-0">
-    <CardHeader class="flex flex-row items-center justify-between space-y-0 px-4 py-3">
+    <CardHeader class="flex flex-row items-center justify-between gap-2 space-y-0 px-4 py-3">
         <RecommendedHeader />
         <RecommendedTabs bind:activeTab onTabChange={handleTabChange} />
     </CardHeader>

--- a/apps/web/src/lib/components/ui/post-card/post-card.svelte
+++ b/apps/web/src/lib/components/ui/post-card/post-card.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
+    import { onMount } from 'svelte';
     import type { RecommendedPost } from '$lib/api/types.js';
     import {
         formatNumber,
         getRecommendBadgeClass
     } from '../../features/recommended/utils/index.js';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { getReadPostClasses } from '$lib/stores/read-post-style.svelte.js';
 
     let { post }: { post: RecommendedPost } = $props();
+
+    function getBoardId(url: string): string {
+        const parts = url.split('/').filter(Boolean);
+        return parts[0] || '';
+    }
+
+    let showReadState = $state(false);
+    onMount(() => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                showReadState = true;
+            });
+        });
+    });
 </script>
 
 <!-- PHP 원본 list-group-item 스타일 재현 -->
@@ -25,7 +42,11 @@
                 {formatNumber(post.recommend_count)}
             </span>
             <!-- text-truncate -->
-            <div class="text-foreground min-w-0 flex-1 truncate text-[17px] font-medium">
+            <div
+                class="min-w-0 flex-1 truncate text-[15px] leading-relaxed {getReadPostClasses(
+                    showReadState && readPostsStore.isRead(getBoardId(post.url), post.id)
+                )}"
+            >
                 {post.title}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- 추천글 시간탭 localStorage 저장/복원 (뒤로가기 시 마지막 선택 탭 유지)
- 추천글/새소식 탭 `flex-wrap` 적용 (Galaxy Ultra, iPhone SE 등 소형 화면 overflow 방지)
- 추천글 카드 읽은 글 표시 (`readPostsStore` 연동 + hydration flicker 방지)
- 디자인 시스템 적용: `text-[15px] leading-relaxed`, `font-medium` 제거

## Related
- 카테고리 탭 내용 불일치 (#7719): `widgets.yaml` config 수정 (별도 서버 작업 완료)
- 추천글 탭 잘림 (#7727)
- 시간대 탭 뒤로가기 리셋 (#5898365)

## Test plan
- [ ] 추천글 6시간 탭 선택 → 글 클릭 → 뒤로가기 → 6시간 탭 유지 확인
- [ ] 읽은 추천글 색상 변경 확인 (dimmed 스타일)
- [ ] 모바일 작은 화면에서 탭 줄바꿈 정상 확인
- [ ] 새로운 소식 > 사용기 탭에 사용기 게시판 글 표시 확인