### PR TITLE
feat: KG이니시스 간편인증 + 회원가입 약관 동의

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -101,6 +101,7 @@
         "ioredis": "^5.10.0",
         "isomorphic-dompurify": "3.0.0-rc.2",
         "jose": "^6.1.3",
+        "kisa-seed": "^1.0.1",
         "lowlight": "^3.3.0",
         "marked": "^17.0.1",
         "mysql2": "^3.16.3",

--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -1,0 +1,146 @@
+/**
+ * KG이니시스 실명인증 설정 및 유틸리티
+ * g5_config 테이블에서 cf_cert_* 설정값을 읽어옴
+ */
+import pool, { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+import { createHash } from 'crypto';
+import { env } from '$env/dynamic/private';
+
+const SEED_IV = 'SASHOSTSIRIAS000';
+const CERT_TOKEN_KEY = env.CERT_TOKEN_ENCRYPTION_KEY || '';
+
+interface CertConfigRow extends RowDataPacket {
+    cf_cert_use: number;
+    cf_cert_req: number;
+    cf_cert_kg_mid: string;
+    cf_cert_kg_cd: string;
+}
+
+export interface CertConfig {
+    /** 인증 사용 여부 (0=미사용, 1=테스트, 2=운영) */
+    certUse: number;
+    /** 인증 필수 여부 (0=선택, 1=필수) */
+    certReq: number;
+    /** KG이니시스 상점 MID */
+    kgMid: string;
+    /** KG이니시스 상점 코드 */
+    kgCd: string;
+}
+
+/** g5_config에서 실명인증 설정 조회 */
+export async function getCertConfig(): Promise<CertConfig> {
+    const [rows] = await readPool.query<CertConfigRow[]>(
+        'SELECT cf_cert_use, cf_cert_req, cf_cert_kg_mid, cf_cert_kg_cd FROM g5_config LIMIT 1'
+    );
+
+    if (rows[0]) {
+        return {
+            certUse: Number(rows[0].cf_cert_use) || 0,
+            certReq: Number(rows[0].cf_cert_req) || 0,
+            kgMid: String(rows[0].cf_cert_kg_mid || ''),
+            kgCd: String(rows[0].cf_cert_kg_cd || '')
+        };
+    }
+
+    return { certUse: 0, certReq: 0, kgMid: '', kgCd: '' };
+}
+
+/** 인증 요청에 필요한 MID, apiKey, authHash 등 생성 */
+export async function buildCertRequest(): Promise<{
+    mid: string;
+    apiKey: string;
+    mTxId: string;
+    authHash: string;
+    reqSvcCd: string;
+    reservedMsg: string;
+}> {
+    const config = await getCertConfig();
+
+    // 최대 cr_id 조회
+    const [crRows] = await readPool.query<RowDataPacket[]>(
+        'SELECT MAX(cr_id) as max_cr_id FROM g5_cert_history LIMIT 1'
+    );
+    const maxCrId = crRows[0]?.max_cr_id || 0;
+
+    let mid: string;
+    let apiKey: string;
+
+    if (config.certUse === 2) {
+        // 운영
+        mid = 'SRA' + config.kgMid;
+        apiKey = config.kgCd;
+    } else {
+        // 테스트
+        mid = env.CERT_INICIS_TEST_MID || 'SRAiasTest';
+        apiKey = env.CERT_INICIS_TEST_API_KEY || '';
+    }
+
+    const mTxId = ('SIR_' + maxCrId + '_' + Date.now()).substring(0, 16);
+    const reqSvcCd = '01'; // 간편인증
+    const authHash = createHash('sha256')
+        .update(mid + mTxId + apiKey)
+        .digest('hex');
+    const reservedMsg = 'isUseToken=Y'; // SEED 암호화 응답 요청
+
+    return { mid, apiKey, mTxId, authHash, reqSvcCd, reservedMsg };
+}
+
+/** CI 기반 mb_dupinfo 생성 (PHP 호환) */
+export function buildDupinfo(ci: string): string {
+    return createHash('sha256')
+        .update(ci + CERT_TOKEN_KEY)
+        .digest('hex');
+}
+
+/** 이니시스 결과 URL 검증 */
+export function isValidInicisUrl(url: string): boolean {
+    return url.startsWith('https://kssa.inicis.com') || url.startsWith('https://fcsa.inicis.com');
+}
+
+/** 인증 결과를 DB에 저장 (g5_member 업데이트 + 인증 이력) */
+export async function saveCertResult(
+    mbId: string,
+    dupinfo: string,
+    birthDay: string
+): Promise<void> {
+    const adult_day = new Date();
+    adult_day.setFullYear(adult_day.getFullYear() - 19);
+    const adultDayStr = adult_day.toISOString().slice(0, 10).replace(/-/g, '');
+    const adult = parseInt(birthDay) <= parseInt(adultDayStr) ? 1 : 0;
+
+    await pool.query(
+        `UPDATE g5_member SET mb_certify = 'simple', mb_dupinfo = ?, mb_adult = ? WHERE mb_id = ?`,
+        [dupinfo, adult, mbId]
+    );
+
+    // 인증 이력 저장
+    await pool.query(
+        `INSERT INTO g5_member_cert_history (mb_id, ch_type, ch_ci, ch_datetime) VALUES (?, 'simple', ?, NOW())`,
+        [mbId, dupinfo]
+    );
+}
+
+/** 이미 인증된 dupinfo가 존재하는지 체크 */
+export async function checkDupinfo(mbId: string, dupinfo: string): Promise<string | null> {
+    const [rows] = await readPool.query<RowDataPacket[]>(
+        'SELECT mb_id FROM g5_member WHERE mb_id <> ? AND mb_dupinfo = ?',
+        [mbId, dupinfo]
+    );
+    if (rows[0]) {
+        return rows[0].mb_id as string;
+    }
+
+    // history 테이블에서도 체크
+    const [histRows] = await readPool.query<RowDataPacket[]>(
+        'SELECT count(*) as cnt FROM g5_member_cert_history WHERE mb_id <> ? AND ch_ci = ?',
+        [mbId, dupinfo]
+    );
+    if (histRows[0]?.cnt > 0) {
+        return '(탈퇴 또는 기존 계정)';
+    }
+
+    return null;
+}
+
+export { SEED_IV };

--- a/apps/web/src/routes/cert/inicis/+page.server.ts
+++ b/apps/web/src/routes/cert/inicis/+page.server.ts
@@ -1,0 +1,32 @@
+/**
+ * KG이니시스 간편인증 요청 페이지
+ * sa.inicis.com/auth 로 자동 POST하는 폼 데이터 생성
+ */
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+import { buildCertRequest } from '$lib/server/auth/cert-inicis.js';
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+    if (!locals.user) {
+        redirect(303, '/login');
+    }
+
+    const pageType = url.searchParams.get('pageType') || 'register';
+    const certData = await buildCertRequest();
+
+    // 결과 수신 URL
+    const origin = url.origin;
+    const resultUrl = `${origin}/cert/inicis/result`;
+
+    return {
+        mid: certData.mid,
+        reqSvcCd: certData.reqSvcCd,
+        mTxId: certData.mTxId,
+        authHash: certData.authHash,
+        reservedMsg: certData.reservedMsg,
+        mbId: locals.user.mb_id,
+        successUrl: resultUrl,
+        failUrl: resultUrl,
+        pageType
+    };
+};

--- a/apps/web/src/routes/cert/inicis/+page.svelte
+++ b/apps/web/src/routes/cert/inicis/+page.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    onMount(() => {
+        // 페이지 로드 시 자동으로 이니시스로 POST
+        const form = document.getElementById('saForm') as HTMLFormElement;
+        if (form) {
+            form.submit();
+        }
+    });
+</script>
+
+<svelte:head>
+    <title>KG이니시스 간편인증</title>
+</svelte:head>
+
+<div class="flex min-h-screen items-center justify-center">
+    <p class="text-muted-foreground text-sm">인증 페이지로 이동 중...</p>
+</div>
+
+<form id="saForm" method="post" action="https://sa.inicis.com/auth">
+    <input type="hidden" name="mid" value={data.mid} />
+    <input type="hidden" name="reqSvcCd" value={data.reqSvcCd} />
+    <input type="hidden" name="mTxId" value={data.mTxId} />
+    <input type="hidden" name="authHash" value={data.authHash} />
+    <input type="hidden" name="flgFixedUser" value="N" />
+    <input type="hidden" name="userName" value="" />
+    <input type="hidden" name="userPhone" value="" />
+    <input type="hidden" name="userBirth" value="" />
+    <input type="hidden" name="userHash" value="" />
+    <input type="hidden" name="reservedMsg" value={data.reservedMsg} />
+    <input type="hidden" name="mbId" value={data.mbId} />
+    <input type="hidden" name="directAgency" value="" />
+    <input type="hidden" name="successUrl" value={data.successUrl} />
+    <input type="hidden" name="failUrl" value={data.failUrl} />
+</form>

--- a/apps/web/src/routes/cert/inicis/result/+server.ts
+++ b/apps/web/src/routes/cert/inicis/result/+server.ts
@@ -1,0 +1,116 @@
+/**
+ * KG이니시스 간편인증 결과 수신
+ * 이니시스에서 POST로 결과를 전송하면 처리 후 팝업 창에 결과 표시
+ */
+import type { RequestHandler } from './$types';
+import { KISA_SEED_CBC } from 'kisa-seed';
+import {
+    SEED_IV,
+    buildDupinfo,
+    isValidInicisUrl,
+    saveCertResult,
+    checkDupinfo
+} from '$lib/server/auth/cert-inicis.js';
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+    const formData = await request.formData();
+    const txId = (formData.get('txId') as string) || '';
+    const resultCode = (formData.get('resultCode') as string) || '';
+    const resultMsg = (formData.get('resultMsg') as string) || '';
+    const authRequestUrl = (formData.get('authRequestUrl') as string) || '';
+    const seedKey = (formData.get('token') as string) || '';
+
+    // 인증 실패
+    if (resultCode !== '0000') {
+        return certResultPage(false, `인증 실패: ${decodeURIComponent(resultMsg || resultCode)}`);
+    }
+
+    // URL 검증
+    if (!isValidInicisUrl(authRequestUrl)) {
+        return certResultPage(false, '잘못된 요청입니다.');
+    }
+
+    // 이니시스 서버에 결과 조회
+    const mid = txId.substring(6, 16);
+    const response = await fetch(authRequestUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ mid, txId })
+    });
+
+    const resData = await response.json();
+
+    if (resData.resultCode !== '0000') {
+        return certResultPage(
+            false,
+            `인증 실패: ${decodeURIComponent(resData.resultMsg || resData.resultCode)}`
+        );
+    }
+
+    // SEED 복호화
+    let userName = resData.userName || '';
+    let userPhone = resData.userPhone || '';
+    let userBirthday = resData.userBirthday || '';
+    let userCi = resData.userCi || '';
+
+    if (seedKey) {
+        try {
+            userName = KISA_SEED_CBC.decrypt(seedKey, SEED_IV, userName);
+            userPhone = KISA_SEED_CBC.decrypt(seedKey, SEED_IV, userPhone);
+            userBirthday = KISA_SEED_CBC.decrypt(seedKey, SEED_IV, userBirthday);
+            userCi = KISA_SEED_CBC.decrypt(seedKey, SEED_IV, userCi);
+        } catch {
+            return certResultPage(false, '인증 데이터 복호화에 실패했습니다.');
+        }
+    }
+
+    if (!userPhone) {
+        return certResultPage(false, '정상적인 인증이 아닙니다.');
+    }
+
+    // CI 기반 dupinfo 생성
+    const mbDupinfo = buildDupinfo(userCi);
+
+    // 로그인 사용자 확인
+    const mbId = locals.user?.mb_id;
+    if (!mbId) {
+        return certResultPage(false, '로그인 세션이 만료되었습니다.');
+    }
+
+    // 중복 인증 체크
+    const existingId = await checkDupinfo(mbId, mbDupinfo);
+    if (existingId) {
+        return certResultPage(false, '입력하신 본인확인 정보로 이미 가입된 내역이 존재합니다.');
+    }
+
+    // DB 업데이트
+    try {
+        await saveCertResult(mbId, mbDupinfo, userBirthday);
+    } catch (err) {
+        console.error('[Cert] DB 저장 실패:', err);
+        return certResultPage(false, '인증 정보 저장에 실패했습니다.');
+    }
+
+    return certResultPage(true, '본인인증이 완료되었습니다.');
+};
+
+/** 인증 결과를 부모 창에 postMessage로 전달하는 HTML 페이지 */
+function certResultPage(success: boolean, message: string) {
+    const html = `<!DOCTYPE html>
+<html>
+<head><title>인증 결과</title></head>
+<body>
+<script>
+    alert(${JSON.stringify(message)});
+    if (window.opener) {
+        window.opener.postMessage({ type: 'cert_complete', success: ${success} }, '*');
+    }
+    window.close();
+</script>
+</body>
+</html>`;
+
+    return new Response(html, {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' }
+    });
+}

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -248,13 +248,10 @@
                 {/each}
             </div>
 
-            <!-- 회원가입 링크 -->
-            <div class="text-center text-sm">
-                <span class="text-muted-foreground">계정이 없으신가요?</span>
-                <a href="/register" class="text-primary ml-1 font-medium hover:underline"
-                    >회원가입</a
-                >
-            </div>
+            <!-- 회원가입 안내 -->
+            <p class="text-muted-foreground text-center text-xs">
+                계정이 없으신가요? 위 소셜 로그인으로 자동 회원가입됩니다.
+            </p>
         </CardContent>
     </Card>
 </div>

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -22,8 +22,14 @@ import {
     SESSION_COOKIE_MAX_AGE
 } from '$lib/server/auth/session-store.js';
 import type { OAuthUserProfile, SocialProvider } from '$lib/server/auth/oauth/types.js';
+import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { verifyTurnstile } from '$lib/server/captcha.js';
 import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
+import { getCertConfig } from '$lib/server/auth/cert-inicis.js';
+import { getContent, getSiteTitle, replaceContentVariables } from '$lib/server/content.js';
+import { env } from '$env/dynamic/private';
+
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || undefined;
 
 export const load: PageServerLoad = async ({ url, cookies }) => {
     const provider = url.searchParams.get('provider') || '';
@@ -44,16 +50,28 @@ export const load: PageServerLoad = async ({ url, cookies }) => {
         redirect(302, '/login');
     }
 
+    // 약관/개인정보처리방침 내용 로드
+    const [termsContent, privacyContent, siteTitle] = await Promise.all([
+        getContent('provision'),
+        getContent('privacy'),
+        getSiteTitle()
+    ]);
+
     return {
         provider: socialProfile.provider || provider,
         email: socialProfile.email || email,
         displayName: socialProfile.displayName || '',
-        redirectUrl
+        redirectUrl,
+        termsHtml: termsContent ? replaceContentVariables(termsContent.co_content, siteTitle) : '',
+        privacyHtml: privacyContent
+            ? replaceContentVariables(privacyContent.co_content, siteTitle)
+            : ''
     };
 };
 
 export const actions: Actions = {
     default: async ({ request, cookies, getClientAddress }) => {
+        console.log('[Register] Action started');
         const clientIp = getClientAddress();
         const formData = await request.formData();
         const nickname = (formData.get('nickname') as string)?.trim() || '';
@@ -170,13 +188,16 @@ export const actions: Actions = {
                 ip: clientIp
             });
 
+            const domainOpt = COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {};
+
             // 세션 쿠키 설정
             cookies.set(SESSION_COOKIE_NAME, session.sessionId, {
                 path: '/',
                 httpOnly: true,
                 sameSite: 'lax',
                 secure: !dev,
-                maxAge: SESSION_COOKIE_MAX_AGE
+                maxAge: SESSION_COOKIE_MAX_AGE,
+                ...domainOpt
             });
 
             cookies.set(CSRF_COOKIE_NAME, session.csrfToken, {
@@ -184,7 +205,8 @@ export const actions: Actions = {
                 httpOnly: false,
                 sameSite: 'strict',
                 secure: !dev,
-                maxAge: SESSION_COOKIE_MAX_AGE
+                maxAge: SESSION_COOKIE_MAX_AGE,
+                ...domainOpt
             });
 
             // 레거시 호환: refresh_token도 생성
@@ -196,14 +218,24 @@ export const actions: Actions = {
                 httpOnly: true,
                 sameSite: 'lax',
                 secure: !dev,
-                maxAge: 60 * 60 * 24 * 7
+                maxAge: 60 * 60 * 24 * 7,
+                ...domainOpt
             });
+
+            // SSO 쿠키 설정 (ads.damoang.net 등 Go 서비스 인증용)
+            try {
+                await setDamoangSSOCookie(cookies, {
+                    mb_id: member.mb_id,
+                    mb_level: member.mb_level ?? 0,
+                    mb_name: member.mb_name || member.mb_nick,
+                    mb_email: member.mb_email
+                });
+            } catch {
+                // SSO 쿠키 실패해도 가입은 진행
+            }
 
             // 가입 완료 후 임시 쿠키 삭제
             cookies.delete('pending_social_register', { path: '/' });
-
-            // 리다이렉트
-            redirect(302, redirectUrl);
         } catch (err) {
             // SvelteKit redirect는 다시 throw
             if (err && typeof err === 'object' && 'status' in err) {
@@ -216,5 +248,22 @@ export const actions: Actions = {
                 nickname
             });
         }
+
+        // 실명인증 활성화 시 인증 페이지로
+        try {
+            const certConfig = await getCertConfig();
+            console.log('[Register] certConfig:', JSON.stringify(certConfig));
+            if (certConfig.certUse > 0) {
+                console.log('[Register] Redirecting to /register/cert');
+                redirect(302, '/register/cert');
+            }
+        } catch (err) {
+            if (err && typeof err === 'object' && 'status' in err) {
+                throw err;
+            }
+            console.error('[Register] getCertConfig error:', err);
+        }
+
+        redirect(302, redirectUrl);
     }
 };

--- a/apps/web/src/routes/register/+page.svelte
+++ b/apps/web/src/routes/register/+page.svelte
@@ -31,6 +31,38 @@
     let isSubmitting = $state(false);
     let turnstileRef: HTMLDivElement | undefined = $state();
     let turnstileWidgetId: string | undefined = $state();
+    let nicknameRef: HTMLDivElement | undefined = $state();
+
+    // 닉네임 관련 에러인지 판별
+    const nicknameErrors = ['닉네임', '사용할 수 없는'];
+    let isNicknameError = $derived(
+        form?.error ? nicknameErrors.some((k) => form!.error!.includes(k)) : false
+    );
+
+    // 에러 발생 시 닉네임 필드로 스크롤
+    $effect(() => {
+        if (isNicknameError && nicknameRef) {
+            nicknameRef.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    });
+
+    // 약관/개인정보 스크롤 끝까지 읽었는지 여부
+    let termsRead = $state(!data.termsHtml);
+    let privacyRead = $state(!data.privacyHtml);
+
+    function handleTermsScroll(e: Event) {
+        const el = e.target as HTMLDivElement;
+        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+            termsRead = true;
+        }
+    }
+
+    function handlePrivacyScroll(e: Event) {
+        const el = e.target as HTMLDivElement;
+        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+            privacyRead = true;
+        }
+    }
 
     // Turnstile 렌더링 (에러 시 자동 재시도)
     onMount(() => {
@@ -41,7 +73,6 @@
                 retry: 'auto',
                 'retry-interval': 5000,
                 'error-callback': () => {
-                    // challenge 실패 시 3초 후 자동 리셋
                     setTimeout(() => {
                         if (turnstileWidgetId !== undefined && window.turnstile) {
                             window.turnstile.reset(turnstileWidgetId);
@@ -72,7 +103,7 @@
 </svelte:head>
 
 <div class="flex min-h-[calc(100vh-200px)] items-center justify-center px-4 py-12">
-    <Card class="w-full max-w-md">
+    <Card class="w-full max-w-lg">
         <CardHeader class="text-center">
             <CardTitle class="text-2xl font-bold">회원가입</CardTitle>
             <CardDescription>
@@ -84,8 +115,8 @@
             </CardDescription>
         </CardHeader>
         <CardContent>
-            <!-- 에러 메시지 -->
-            {#if form?.error}
+            <!-- 일반 에러 메시지 (닉네임 외) -->
+            {#if form?.error && !isNicknameError}
                 <div class="bg-destructive/10 text-destructive mb-4 rounded-md p-3 text-sm">
                     {form.error}
                 </div>
@@ -105,7 +136,7 @@
                 <input type="hidden" name="redirect" value={data.redirectUrl} />
 
                 <!-- 닉네임 입력 -->
-                <div class="space-y-2">
+                <div class="space-y-2" bind:this={nicknameRef}>
                     <Label for="nickname">닉네임 <span class="text-destructive">*</span></Label>
                     <Input
                         id="nickname"
@@ -117,56 +148,91 @@
                         minlength={2}
                         required
                         disabled={isSubmitting}
+                        class={isNicknameError ? 'border-destructive' : ''}
                     />
+                    {#if isNicknameError}
+                        <p class="text-destructive text-xs font-medium">{form?.error}</p>
+                    {/if}
                     <p class="text-muted-foreground text-xs">
                         한글, 영문, 숫자, 점(.), 밑줄(_) 사용 가능 (2~20자)
                     </p>
                 </div>
 
-                <!-- 약관 동의 -->
-                <div class="space-y-3">
-                    <div class="flex items-start gap-3">
+                <!-- 이용약관 -->
+                <div class="space-y-2">
+                    <Label class="font-medium">
+                        이용약관 <span class="text-destructive">*</span>
+                    </Label>
+                    {#if data.termsHtml}
+                        <div
+                            class="terms-content border-border bg-muted/30 max-h-48 overflow-y-auto rounded-md border p-3 text-xs leading-relaxed"
+                            onscroll={handleTermsScroll}
+                        >
+                            {@html data.termsHtml}
+                        </div>
+                    {/if}
+                    <div class="flex items-center gap-3">
                         <Checkbox
                             id="agree_terms"
-                            name="agree_terms"
                             bind:checked={agreeTerms}
-                            disabled={isSubmitting}
+                            disabled={isSubmitting || !termsRead}
                         />
-                        <div>
-                            <Label for="agree_terms" class="cursor-pointer font-normal">
-                                <a
-                                    href="/terms"
-                                    target="_blank"
-                                    class="text-primary hover:underline"
-                                >
-                                    이용약관
-                                </a>에 동의합니다
-                                <span class="text-destructive">*</span>
-                            </Label>
-                        </div>
-                    </div>
-
-                    <div class="flex items-start gap-3">
-                        <Checkbox
-                            id="agree_privacy"
-                            name="agree_privacy"
-                            bind:checked={agreePrivacy}
-                            disabled={isSubmitting}
-                        />
-                        <div>
-                            <Label for="agree_privacy" class="cursor-pointer font-normal">
-                                <a
-                                    href="/privacy"
-                                    target="_blank"
-                                    class="text-primary hover:underline"
-                                >
-                                    개인정보처리방침
-                                </a>에 동의합니다
-                                <span class="text-destructive">*</span>
-                            </Label>
-                        </div>
+                        <Label
+                            for="agree_terms"
+                            class="cursor-pointer text-sm {termsRead
+                                ? ''
+                                : 'text-muted-foreground'}"
+                        >
+                            {#if termsRead}
+                                이용약관에 동의합니다
+                            {:else}
+                                약관을 끝까지 읽어주세요
+                            {/if}
+                        </Label>
                     </div>
                 </div>
+
+                <!-- 개인정보처리방침 -->
+                <div class="space-y-2">
+                    <Label class="font-medium">
+                        개인정보처리방침 <span class="text-destructive">*</span>
+                    </Label>
+                    {#if data.privacyHtml}
+                        <div
+                            class="terms-content border-border bg-muted/30 max-h-48 overflow-y-auto rounded-md border p-3 text-xs leading-relaxed"
+                            onscroll={handlePrivacyScroll}
+                        >
+                            {@html data.privacyHtml}
+                        </div>
+                    {/if}
+                    <div class="flex items-center gap-3">
+                        <Checkbox
+                            id="agree_privacy"
+                            bind:checked={agreePrivacy}
+                            disabled={isSubmitting || !privacyRead}
+                        />
+                        <Label
+                            for="agree_privacy"
+                            class="cursor-pointer text-sm {privacyRead
+                                ? ''
+                                : 'text-muted-foreground'}"
+                        >
+                            {#if privacyRead}
+                                개인정보처리방침에 동의합니다
+                            {:else}
+                                방침을 끝까지 읽어주세요
+                            {/if}
+                        </Label>
+                    </div>
+                </div>
+
+                <!-- 체크박스 값 전송용 hidden input -->
+                {#if agreeTerms}
+                    <input type="hidden" name="agree_terms" value="on" />
+                {/if}
+                {#if agreePrivacy}
+                    <input type="hidden" name="agree_privacy" value="on" />
+                {/if}
 
                 <!-- Turnstile CAPTCHA -->
                 {#if PUBLIC_TURNSTILE_SITE_KEY}
@@ -196,3 +262,27 @@
         </CardContent>
     </Card>
 </div>
+
+<style>
+    .terms-content :global(h1),
+    .terms-content :global(h2),
+    .terms-content :global(h3) {
+        font-weight: 600;
+        margin-top: 0.75rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .terms-content :global(p) {
+        margin-bottom: 0.5rem;
+    }
+
+    .terms-content :global(ul),
+    .terms-content :global(ol) {
+        padding-left: 1.25rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .terms-content :global(li) {
+        margin-bottom: 0.25rem;
+    }
+</style>

--- a/apps/web/src/routes/register/cert/+page.server.ts
+++ b/apps/web/src/routes/register/cert/+page.server.ts
@@ -1,0 +1,41 @@
+/**
+ * 실명인증 페이지 서버 로직
+ * 회원가입 완료 후 리다이렉트되어 옴
+ */
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+import { getCertConfig } from '$lib/server/auth/cert-inicis.js';
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+
+interface MemberCertRow extends RowDataPacket {
+    mb_certify: string;
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+    // 로그인 필수
+    if (!locals.user) {
+        redirect(303, '/login');
+    }
+
+    // 실명인증 설정 확인
+    const certConfig = await getCertConfig();
+    if (certConfig.certUse === 0) {
+        // 실명인증 미사용 시 메인으로
+        redirect(302, '/');
+    }
+
+    // 이미 인증 완료 여부 확인
+    const [rows] = await readPool.query<MemberCertRow[]>(
+        'SELECT mb_certify FROM g5_member WHERE mb_id = ?',
+        [locals.user.mb_id]
+    );
+
+    const mbCertify = rows[0]?.mb_certify || '';
+    const isCertified = !!mbCertify;
+
+    return {
+        isCertified,
+        certRequired: certConfig.certReq === 1
+    };
+};

--- a/apps/web/src/routes/register/cert/+page.svelte
+++ b/apps/web/src/routes/register/cert/+page.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+    import {
+        Card,
+        CardContent,
+        CardHeader,
+        CardTitle,
+        CardDescription
+    } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import ShieldCheck from '@lucide/svelte/icons/shield-check';
+    import ShieldAlert from '@lucide/svelte/icons/shield-alert';
+    import ExternalLink from '@lucide/svelte/icons/external-link';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    function openCertPopup() {
+        const width = 500;
+        const height = 600;
+        const left = (screen.width - width) / 2;
+        const top = (screen.height - height) / 2;
+        window.open(
+            '/cert/inicis?pageType=register',
+            'cert_popup',
+            `width=${width},height=${height},left=${left},top=${top},scrollbars=yes`
+        );
+    }
+
+    // 팝업에서 인증 완료 시 메시지 수신
+    function handleMessage(e: MessageEvent) {
+        if (e.data?.type === 'cert_complete' && e.data?.success) {
+            location.reload();
+        }
+    }
+
+    $effect(() => {
+        window.addEventListener('message', handleMessage);
+        return () => window.removeEventListener('message', handleMessage);
+    });
+</script>
+
+<svelte:head>
+    <title>실명인증 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<div class="flex min-h-[calc(100vh-200px)] items-center justify-center px-4 py-12">
+    <Card class="w-full max-w-md">
+        <CardHeader class="text-center">
+            <CardTitle class="text-2xl font-bold">실명인증</CardTitle>
+            <CardDescription>
+                {#if data.isCertified}
+                    본인확인이 완료되었습니다
+                {:else}
+                    서비스 이용을 위해 본인확인이 필요합니다
+                {/if}
+            </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-6">
+            {#if data.isCertified}
+                <!-- 인증 완료 상태 -->
+                <div
+                    class="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950"
+                >
+                    <ShieldCheck class="h-6 w-6 shrink-0 text-green-600 dark:text-green-400" />
+                    <div>
+                        <p class="font-medium text-green-800 dark:text-green-200">인증 완료</p>
+                        <p class="text-sm text-green-600 dark:text-green-400">
+                            본인확인이 정상적으로 완료되었습니다.
+                        </p>
+                    </div>
+                </div>
+                <Button class="w-full" onclick={() => (window.location.href = '/')}>
+                    메인으로 이동
+                </Button>
+            {:else}
+                <!-- 인증 필요 상태 -->
+                <div
+                    class="flex items-center gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-950"
+                >
+                    <ShieldAlert class="h-6 w-6 shrink-0 text-yellow-600 dark:text-yellow-400" />
+                    <div>
+                        <p class="font-medium text-yellow-800 dark:text-yellow-200">인증 필요</p>
+                        <p class="text-sm text-yellow-600 dark:text-yellow-400">
+                            {#if data.certRequired}
+                                본인확인을 완료해야 서비스를 이용할 수 있습니다.
+                            {:else}
+                                일부 게시판 이용 시 본인확인이 필요할 수 있습니다.
+                            {/if}
+                        </p>
+                    </div>
+                </div>
+
+                <div class="space-y-3">
+                    <Button class="w-full" onclick={openCertPopup}>
+                        <ShieldCheck class="mr-2 h-4 w-4" />
+                        간편인증 하기
+                    </Button>
+
+                    <a
+                        href="https://damoang.net/verification/45"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-muted-foreground hover:text-foreground flex items-center justify-center gap-1 text-sm underline-offset-4 hover:underline"
+                    >
+                        해외 거주자 실명인증 안내
+                        <ExternalLink class="h-3 w-3" />
+                    </a>
+                </div>
+
+                {#if !data.certRequired}
+                    <div class="border-border border-t pt-4">
+                        <Button
+                            variant="ghost"
+                            class="text-muted-foreground w-full"
+                            onclick={() => (window.location.href = '/')}
+                        >
+                            나중에 하기
+                        </Button>
+                    </div>
+                {/if}
+            {/if}
+        </CardContent>
+    </Card>
+</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       jose:
         specifier: ^6.1.3
         version: 6.1.3
+      kisa-seed:
+        specifier: ^1.0.1
+        version: 1.0.1
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
@@ -3391,6 +3394,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kisa-seed@1.0.1:
+    resolution: {integrity: sha512-NaVmqDJVMBT/5b1nw4K0UXvUIxU6Ihgf9ziOAsQkuxQZ0iXnuNd5CWpDxzdSYeQxs47C9k2+fse8xA6vp+ra5Q==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -8523,6 +8529,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kisa-seed@1.0.1: {}
 
   kleur@4.1.5: {}
 


### PR DESCRIPTION
## Summary
- KG이니시스 간편인증 모듈 추가 (`cert-inicis.ts`)
- 인증 요청/결과 처리 라우트 (`/cert/inicis`, `/cert/inicis/result`)
- 회원가입 완료 후 실명인증 페이지 연동 (`/register/cert`)
- 회원가입 페이지에 이용약관/개인정보처리방침 동의 UI 추가 (스크롤 끝까지 읽기 필수)
- 로그인 페이지 회원가입 안내 문구 변경 (소셜 로그인 자동 가입 안내)
- SSO 쿠키 + COOKIE_DOMAIN 지원 추가

## Test plan
- [ ] 회원가입 페이지에서 약관/개인정보 스크롤 끝까지 읽어야 동의 체크 가능 확인
- [ ] 실명인증 설정(cf_cert_use > 0) 시 가입 후 `/register/cert`로 리다이렉트 확인
- [ ] 이니시스 간편인증 팝업 → 인증 완료 → DB 반영 확인
- [ ] 실명인증 미사용(cf_cert_use = 0) 시 기존 가입 흐름 유지 확인