### PR TITLE
feat: UI 개선 (위젯 스타일, 제목 볼드, 알림 힌트)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -702,6 +702,7 @@ export interface Notification {
     sender_name?: string; // 발신자 이름
     is_read: boolean;
     created_at: string;
+    parent_subject?: string; // 원본 글 제목 (힌트)
 }
 
 export interface NotificationSummary {

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -13,6 +13,7 @@
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { readPostStyleStore } from '$lib/stores/read-post-style.svelte.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     // 메모 플러그인
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
@@ -179,7 +180,10 @@
                             {post.category}
                         </span>
                     {/if}
-                    <span class="truncate {readClass}">
+                    <span
+                        class="truncate {readClass}"
+                        class:font-bold={uiSettingsStore.titleBold && !isRead}
+                    >
                         {post.title}
                     </span>
                     <!-- 부가 아이콘: N, 이미지, 동영상, 댓글 -->

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -244,10 +244,12 @@
                             <p class="text-foreground line-clamp-1 text-sm font-medium">
                                 {notification.title}
                             </p>
-                            <p class="text-muted-foreground mt-0.5 line-clamp-2 text-xs">
-                                {notification.content}
-                            </p>
-                            <p class="text-muted-foreground mt-1 text-xs">
+                            {#if notification.parent_subject}
+                                <p class="text-muted-foreground mt-0.5 line-clamp-1 text-xs">
+                                    "{notification.parent_subject}"
+                                </p>
+                            {/if}
+                            <p class="text-muted-foreground mt-0.5 text-[11px]">
                                 {formatTime(notification.created_at)}
                             </p>
                         </div>

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -228,20 +228,31 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
             const commentAuthorId = writeRows[0].mb_id;
             if (commentAuthorId && commentAuthorId !== user.mb_id) {
                 const userNick = user.mb_nick || user.mb_name || user.mb_id;
-                pool.query(
-                    `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
-                     VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', NOW(), '', ?)`,
-                    [
-                        safeBoardId,
-                        safeCommentId,
-                        commentAuthorId,
-                        user.mb_id,
-                        userNick,
-                        `${userNick}님이 회원님의 댓글을 추천했습니다.`,
-                        `/${safeBoardId}/${params.postId}#c_${safeCommentId}`,
-                        parseInt(params.postId!, 10)
-                    ]
-                ).catch(() => {});
+                // 부모 글 제목 조회
+                const safeParentPostId = parseInt(params.postId!, 10);
+                pool.query<WriteRow[]>(`SELECT wr_subject FROM ?? WHERE wr_id = ?`, [
+                    tableName,
+                    safeParentPostId
+                ])
+                    .then(([parentRows]) => {
+                        const parentSubject = (parentRows[0] as any)?.wr_subject || '';
+                        pool.query(
+                            `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
+                         VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', NOW(), ?, ?)`,
+                            [
+                                safeBoardId,
+                                safeCommentId,
+                                commentAuthorId,
+                                user.mb_id,
+                                userNick,
+                                `${userNick}님이 회원님의 댓글을 추천했습니다.`,
+                                `/${safeBoardId}/${params.postId}#c_${safeCommentId}`,
+                                parentSubject,
+                                safeParentPostId
+                            ]
+                        );
+                    })
+                    .catch(() => {});
             }
         }
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -20,6 +20,7 @@ interface WriteRow extends RowDataPacket {
     wr_good: number;
     wr_nogood: number;
     mb_id: string;
+    wr_subject?: string;
 }
 
 /**
@@ -151,7 +152,7 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
 
         // 게시글 존재 확인 + 본인 글 추천 방지
         const [writeRows] = await conn.query<WriteRow[]>(
-            `SELECT wr_good, wr_nogood, mb_id FROM ?? WHERE wr_id = ? AND wr_is_comment = 0`,
+            `SELECT wr_good, wr_nogood, mb_id, wr_subject FROM ?? WHERE wr_id = ? AND wr_is_comment = 0`,
             [tableName, safePostId]
         );
 
@@ -232,9 +233,10 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
             const postAuthorId = writeRows[0].mb_id;
             if (postAuthorId && postAuthorId !== user.mb_id) {
                 const userNick = user.mb_nick || user.mb_name || user.mb_id;
+                const postSubject = writeRows[0].wr_subject || '';
                 pool.query(
                     `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
-                     VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', NOW(), '', ?)`,
+                     VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', NOW(), ?, ?)`,
                     [
                         safeBoardId,
                         safePostId,
@@ -243,6 +245,7 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
                         userNick,
                         `${userNick}님이 회원님의 글을 추천했습니다.`,
                         `/${safeBoardId}/${safePostId}`,
+                        postSubject,
                         safePostId
                     ]
                 ).catch(() => {});

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -247,10 +247,10 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
                 const wrId = parseInt(targetParts[2], 10);
                 if (!isNaN(wrId)) {
                     pool.query<RowDataPacket[]>(
-                        `SELECT mb_id, wr_parent FROM g5_write_${boardTable} WHERE wr_id = ?`,
+                        `SELECT mb_id, wr_parent, wr_subject FROM g5_write_${boardTable} WHERE wr_id = ?`,
                         [wrId]
                     )
-                        .then(([rows]) => {
+                        .then(async ([rows]) => {
                             const authorId = rows[0]?.mb_id;
                             const wrParent = rows[0]?.wr_parent ?? wrId;
                             if (authorId && authorId !== user.mb_id) {
@@ -259,9 +259,18 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
                                 const targetLabel = isComment ? '댓글' : '글';
                                 const urlHash = isComment ? `#c_${wrId}` : '';
                                 const postId = isComment ? wrParent : wrId;
+                                // 부모 글 제목
+                                let parentSubject = rows[0]?.wr_subject || '';
+                                if (isComment && wrParent !== wrId) {
+                                    const [parentRows] = await pool.query<RowDataPacket[]>(
+                                        `SELECT wr_subject FROM g5_write_${boardTable} WHERE wr_id = ?`,
+                                        [wrParent]
+                                    );
+                                    parentSubject = parentRows[0]?.wr_subject || '';
+                                }
                                 pool.query(
                                     `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
-                                     VALUES ('reaction', 'reaction', ?, ?, ?, ?, ?, ?, ?, 'N', NOW(), '', ?)`,
+                                     VALUES ('reaction', 'reaction', ?, ?, ?, ?, ?, ?, ?, 'N', NOW(), ?, ?)`,
                                     [
                                         boardTable,
                                         wrId,
@@ -270,6 +279,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
                                         userNick,
                                         `${userNick}님이 회원님의 ${targetLabel}에 리액션을 남겼습니다.`,
                                         `/${boardTable}/${postId}${urlHash}`,
+                                        parentSubject,
                                         postId
                                     ]
                                 ).catch(() => {});

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -310,12 +310,14 @@
                                             <p class="text-foreground font-medium">
                                                 {notification.title}
                                             </p>
-                                            <p
-                                                class="text-muted-foreground mt-1 line-clamp-2 text-sm"
-                                            >
-                                                {notification.content}
-                                            </p>
-                                            <p class="text-muted-foreground mt-2 text-xs">
+                                            {#if notification.parent_subject}
+                                                <p
+                                                    class="text-muted-foreground mt-1 line-clamp-1 text-sm"
+                                                >
+                                                    "{notification.parent_subject}"
+                                                </p>
+                                            {/if}
+                                            <p class="text-muted-foreground mt-1 text-xs">
                                                 {formatTime(notification.created_at)}
                                             </p>
                                         </div>

--- a/widgets/post-list/layouts/list-view.svelte
+++ b/widgets/post-list/layouts/list-view.svelte
@@ -4,6 +4,7 @@
      */
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { getReadPostClasses } from '$lib/stores/read-post-style.svelte.js';
     import { browser } from '$app/environment';
 
     interface Post {
@@ -46,18 +47,17 @@
         {#if posts.length === 0}
             <p class="text-muted-foreground py-4 text-center text-sm">게시글이 없습니다.</p>
         {:else}
-            <ul class="divide-border divide-y">
+            <ul>
                 {#each posts as post (post.id)}
-                    <li class="py-2">
+                    <li>
                         <a
                             href={post.url ?? `#`}
-                            class="hover:text-primary flex items-center justify-between gap-2 text-sm transition-colors"
+                            class="hover:bg-muted flex items-center justify-between gap-2 rounded px-2 py-1.5 transition-all duration-200 ease-out"
                         >
                             <span
-                                class="min-w-0 flex-1 truncate {browser &&
-                                readPostsStore.isRead(boardId, post.id)
-                                    ? 'text-muted-foreground'
-                                    : ''}">{post.title}</span
+                                class="min-w-0 flex-1 truncate text-[15px] leading-relaxed {getReadPostClasses(
+                                    browser && readPostsStore.isRead(boardId, post.id)
+                                )}">{post.title}</span
                             >
                             <span
                                 class="text-muted-foreground flex shrink-0 items-center gap-2 text-xs"


### PR DESCRIPTION
## Summary
- 게시판 목록 제목 볼드 옵션(`titleBold`) 실제 적용 (classic 레이아웃)
- post-list 위젯 스타일을 추천글 위젯과 동일하게 통일 (폰트, hover)
- 알림에 원글 제목(`parent_subject`) 힌트 표시 (드롭다운 + 전체 페이지)
- 알림 INSERT 시 `wr_subject`를 `parent_subject`에 저장 (추천, 댓글 추천, 리액션)

## 관련
- 백엔드 `noti_handler.go` 변경은 별도 PR로 진행

## Test plan
- [ ] 게시판 목록에서 titleBold 설정 ON 시 미읽은 글 제목 볼드 확인
- [ ] post-list 위젯 스타일이 추천글 위젯과 동일한지 확인
- [ ] 글/댓글 추천 후 알림에 원글 제목 힌트가 표시되는지 확인