### PR TITLE
fix: 배너 스타일, 알림 UTC 버그, 제목 굵게 토글

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -180,10 +180,7 @@
                             {post.category}
                         </span>
                     {/if}
-                    <span
-                        class="truncate {readClass}"
-                        class:font-bold={uiSettingsStore.titleBold && !isRead}
-                    >
+                    <span class="truncate {readClass}" class:font-bold={uiSettingsStore.titleBold}>
                         {post.title}
                     </span>
                     <!-- 부가 아이콘: N, 이미지, 동영상, 댓글 -->

--- a/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
+++ b/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
@@ -170,22 +170,23 @@
                             class="block"
                         >
                             {#if slot.imageUrl}
-                                <figure class="m-0">
+                                <figure class="relative m-0">
                                     <img
                                         src={slot.imageUrl}
                                         alt={slot.altText || '광고'}
-                                        class="h-[60px] w-full object-cover"
+                                        class="mx-auto h-[78px] w-[139px] object-fill"
                                         loading="lazy"
                                     />
                                     <figcaption
-                                        class="truncate bg-white px-2 py-1 text-center text-[10px] text-blue-600 dark:bg-slate-800 dark:text-blue-400"
+                                        class="absolute bottom-0 left-0 right-0 truncate px-2 py-0.5 text-center text-[10px] font-bold text-white"
+                                        style="text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;"
                                     >
                                         {slot.altText || '광고'}
                                     </figcaption>
                                 </figure>
                             {:else}
                                 <div
-                                    class="flex h-[60px] items-center justify-center bg-slate-50 p-2 dark:bg-slate-700"
+                                    class="flex h-[80px] items-center justify-center bg-slate-50 p-2 dark:bg-slate-700"
                                 >
                                     <span
                                         class="text-center text-[10px] text-blue-600 dark:text-blue-400"

--- a/apps/web/src/lib/server/db.ts
+++ b/apps/web/src/lib/server/db.ts
@@ -28,11 +28,16 @@ const pool = mysql.createPool({
     idleTimeout: 60_000
 });
 
+// RDS 시스템 timezone이 UTC이므로, 세션 timezone을 KST로 설정하여 NOW() 등이 KST를 반환하도록 함
+pool.on('connection', (connection: { query: (sql: string) => void }) => {
+    connection.query("SET time_zone = '+09:00'");
+});
+
 /**
  * Read Replica pool (SELECT 전용)
  * DB_READ_HOST가 없으면 writer pool 재사용 (비용 0)
  */
-const readPool: mysql.Pool = env.DB_READ_HOST
+const _readPool: mysql.Pool | null = env.DB_READ_HOST
     ? mysql.createPool({
           host: env.DB_READ_HOST,
           port: parseInt(env.DB_READ_PORT || env.DB_PORT || '3306', 10),
@@ -48,7 +53,15 @@ const readPool: mysql.Pool = env.DB_READ_HOST
           keepAliveInitialDelay: 30_000,
           idleTimeout: 60_000
       })
-    : pool;
+    : null;
+
+if (_readPool) {
+    _readPool.on('connection', (connection: { query: (sql: string) => void }) => {
+        connection.query("SET time_zone = '+09:00'");
+    });
+}
+
+const readPool: mysql.Pool = _readPool ?? pool;
 
 export { pool, readPool };
 export default pool;

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -36,6 +36,7 @@
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { densityStore } from '$lib/stores/density.svelte.js';
     import { readPostStyleStore, type ReadPostStyle } from '$lib/stores/read-post-style.svelte.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import BoardListSkeleton from '$lib/components/features/board/board-list-skeleton.svelte';
 
     // 특수 게시판 컴포넌트 (플러그인 레지스트리 기반)
@@ -686,6 +687,15 @@
                                         onclick={() => densityStore.set('relaxed')}>여유</button
                                     >
                                 </div>
+                                <!-- 제목 굵게 -->
+                                <button
+                                    class="rounded px-1.5 py-0.5 text-[10px] transition-colors {uiSettingsStore.titleBold
+                                        ? 'bg-foreground/10 text-foreground'
+                                        : 'text-muted-foreground hover:text-foreground'}"
+                                    onclick={() =>
+                                        (uiSettingsStore.titleBold = !uiSettingsStore.titleBold)}
+                                    >제목 굵게</button
+                                >
                             </div>
                         </div>
                         <div


### PR DESCRIPTION
## Summary
- 배너 이미지 139x78 고정 + 자막 스타일 오버레이 텍스트
- MySQL 세션 timezone KST 설정 (NOW() UTC 버그 수정)
- 제목 굵게: 읽은 글에도 적용 + 클래식 목록 상단 토글 버튼

## Test plan
- [ ] 배너 이미지가 잘리지 않고 전체 표시되는지 확인
- [ ] 추천 알림 시간이 KST로 정상 표시되는지 확인
- [ ] 제목 굵게 토글이 모든 글에 적용되는지 확인