### PR TITLE
fix: GAM 광고 슬롯 배치 초기화로 빈 광고 해결

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -166,6 +166,60 @@
             ],
             responsive: null
         },
+        'banner-medium': {
+            unit: AD_UNIT_PATHS.sub,
+            sizes: [
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
+            responsive: [
+                [728, [[728, 90]]],
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
+            ]
+        },
+        'banner-large-728': {
+            unit: AD_UNIT_PATHS.main,
+            sizes: [
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
+            responsive: [
+                [728, [[728, 90]]],
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
+            ]
+        },
+        'banner-horizontal-728': {
+            unit: AD_UNIT_PATHS.article,
+            sizes: [
+                [728, 90],
+                [320, 100],
+                [300, 250]
+            ],
+            responsive: [
+                [728, [[728, 90]]],
+                [
+                    0,
+                    [
+                        [320, 100],
+                        [300, 250]
+                    ]
+                ]
+            ]
+        },
         infeed: {
             unit: AD_UNIT_PATHS.curation,
             sizes: [
@@ -195,10 +249,11 @@
     const POSITION_MAP: Record<string, string> = {
         'board-view-top': 'banner-small',
         'board-head': 'banner-horizontal',
-        'board-list-head': 'banner-responsive',
+        'board-list-head': 'banner-medium',
         'board-list-bottom': 'banner-large',
-        'board-content': 'banner-view-content',
-        'board-content-bottom': 'banner-horizontal',
+        'board-content': 'banner-responsive',
+        'board-content-bottom': 'banner-large',
+        'board-before-comments': 'banner-responsive',
         'board-after-comments': 'banner-responsive',
         'board-footer': 'banner-horizontal',
         'index-head': 'banner-small',
@@ -236,6 +291,7 @@
         'board-list-bottom': '목록 하단',
         'board-content': '본문 광고',
         'board-content-bottom': '본문 하단',
+        'board-before-comments': '댓글 상단',
         'board-after-comments': '댓글 하단',
         'board-footer': '게시판 하단',
         'comment-infeed': '댓글 인피드',


### PR DESCRIPTION
## Summary
- SPA 환경에서 GAM 광고가 빈 자리로 나오는 문제 해결
- 각 슬롯이 개별적으로 `enableServices()`를 호출하던 방식을 전역 배치 매니저 패턴으로 변경
- PHP의 `enableSingleRequest()` 동작과 동일하게 한 번에 모든 슬롯 처리

## Changes
- 전역 `BatchManager` 싱글톤으로 슬롯 등록 수집 (50ms 디바운스)
- `enableServices()` 1회만 호출하도록 변경
- `display()` + `refresh()`를 배치 단위로 실행
- PHP GAM 설정과 광고 사이즈/반응형 매핑 동기화 (300x250 등 누락 사이즈 추가)

## Test plan
- [ ] dev.damoang.net에서 광고 슬롯이 정상 표시되는지 확인
- [ ] 메인 페이지, 게시판, 게시글 상세의 모든 광고 위치 확인
- [ ] 모바일/데스크톱 반응형 광고 사이즈 확인
- [ ] 광고 자동 새로고침(60초) 정상 동작 확인