### PR TITLE
fix: sidebar-1 position 매핑 추가

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -268,6 +268,7 @@
         'comment-top': 'banner-compact',
         'sidebar-sticky': 'banner-halfpage',
         sidebar: 'banner-square',
+        'sidebar-1': 'banner-square',
         'sidebar-2': 'banner-square',
         'sidebar-b2b': 'banner-square',
         'wing-left': 'banner-vertical',


### PR DESCRIPTION
## Summary
- 사이드바 위젯의 `sidebar-1` position이 POSITION_MAP에 누락되어 추가
- 이전 PR #336의 후속 수정

## Test plan
- [ ] 사이드바 광고 정상 표시 확인