### PR TITLE
fix: 초대 플로우 Turnstile CAPTCHA 스킵

### DIFF
--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -97,14 +97,17 @@ export const actions: Actions = {
         }
         recordAttempt(clientIp, 'register');
 
-        // Turnstile CAPTCHA 검증
-        const turnstileToken = (formData.get('cf-turnstile-response') as string) || '';
-        const captchaValid = await verifyTurnstile(turnstileToken, clientIp);
-        if (!captchaValid) {
-            return fail(400, {
-                error: '자동 가입 방지 확인에 실패했습니다. 다시 시도해주세요.',
-                nickname
-            });
+        // Turnstile CAPTCHA 검증 (초대 플로우는 소셜 인증 완료 상태이므로 스킵)
+        const isInviteFlow = redirectUrl.includes('ads.damoang.net/invite/');
+        if (!isInviteFlow) {
+            const turnstileToken = (formData.get('cf-turnstile-response') as string) || '';
+            const captchaValid = await verifyTurnstile(turnstileToken, clientIp);
+            if (!captchaValid) {
+                return fail(400, {
+                    error: '자동 가입 방지 확인에 실패했습니다. 다시 시도해주세요.',
+                    nickname
+                });
+            }
         }
 
         // 쿠키에서 소셜 프로필 정보 조회
@@ -140,9 +143,6 @@ export const actions: Actions = {
                 nickname
             });
         }
-
-        // 초대 플로우 감지
-        const isInviteFlow = redirectUrl.includes('ads.damoang.net/invite/');
 
         // 닉네임: 초대 플로우는 중복되지 않는 값으로 자동 생성, 일반은 검증
         let finalNickname = nickname;

--- a/apps/web/src/routes/register/+page.svelte
+++ b/apps/web/src/routes/register/+page.svelte
@@ -311,8 +311,8 @@
                 {#if agreePolicy}
                     <input type="hidden" name="agree_policy" value="on" />
                 {/if}
-                <!-- Turnstile CAPTCHA -->
-                {#if PUBLIC_TURNSTILE_SITE_KEY}
+                <!-- Turnstile CAPTCHA (초대 플로우는 스킵) -->
+                {#if PUBLIC_TURNSTILE_SITE_KEY && !data.isInviteFlow}
                     <div bind:this={turnstileRef} class="flex justify-center"></div>
                 {/if}
 


### PR DESCRIPTION
## Summary
- 초대 플로우 가입 시 Turnstile CAPTCHA 스킵 (소셜 인증 완료 상태)
- Turnstile 무한 루프로 가입 불가 문제 해결

## Test plan
- [ ] 초대 링크 → 소셜 로그인 → 가입 페이지에 Turnstile 없음 → 가입 성공 → ads 리다이렉트
- [ ] 일반 가입은 Turnstile 정상 표시