### PR TITLE
fix: 검색-목록, 목록-본문 사이 광고 높이 축소

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -313,7 +313,7 @@
             <!-- 최상단 배너 (축하이미지 → 다모앙광고 → GAM 폴백) -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-4">
-                    <DamoangBanner position="board-list" height="90px" showCelebration={false} />
+                    <DamoangBanner position="board-list" height="45px" showCelebration={false} />
                 </div>
             {/if}
 
@@ -396,7 +396,7 @@
             <!-- 검색 폼 아래 GAM 광고 -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-4">
-                    <AdSlot position="board-head" height="90px" />
+                    <AdSlot position="board-head" height="45px" />
                 </div>
             {/if}
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -982,7 +982,7 @@
     <!-- 상단 배너 -->
     {#if widgetLayoutStore.hasEnabledAds}
         <div class="mb-6">
-            <DamoangBanner position="board-view" showCelebration={false} height="90px" />
+            <DamoangBanner position="board-view" showCelebration={false} height="45px" />
         </div>
     {/if}
 
@@ -1055,7 +1055,7 @@
     <!-- 네비게이션 아래 GAM 광고 (알뜰구매/중고장터 등 특정 게시판에서만 표시) -->
     {#if widgetLayoutStore.hasEnabledAds && (boardType === 'economy' || boardType === 'used-market')}
         <div class="mb-6">
-            <AdSlot position="board-view-top" height="90px" />
+            <AdSlot position="board-view-top" height="45px" />
         </div>
     {/if}
 


### PR DESCRIPTION
## Summary
- 게시판 검색-목록, 목록-본문 사이 광고 슬롯 높이를 90px → 45px로 축소
- 대상: board-head, board-list, board-view, board-view-top

## Test plan
- [ ] dev.damoang.net 게시판 목록에서 광고 높이 확인
- [ ] 게시글 본문에서 상단 광고 높이 확인