### PR TITLE
fix: PWA manifest 동적 생성 (VITE_SITE_NAME 반영)

### DIFF
--- a/apps/web/src/routes/manifest.json/+server.ts
+++ b/apps/web/src/routes/manifest.json/+server.ts
@@ -1,0 +1,43 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = () => {
+    const siteName = import.meta.env.VITE_SITE_NAME || 'Angple';
+
+    return json(
+        {
+            name: `${siteName} 종합 커뮤니티`,
+            short_name: siteName,
+            description: '누구나 자유롭게 커뮤니티를 만들 수 있는 오픈소스 플랫폼',
+            start_url: '/',
+            display: 'standalone',
+            background_color: '#ffffff',
+            theme_color: '#1a1a1a',
+            orientation: 'any',
+            categories: ['social', 'news'],
+            icons: [
+                {
+                    src: '/icons/icon-192.png',
+                    sizes: '192x192',
+                    type: 'image/png'
+                },
+                {
+                    src: '/icons/icon-512.png',
+                    sizes: '512x512',
+                    type: 'image/png'
+                },
+                {
+                    src: '/icons/icon-512.png',
+                    sizes: '512x512',
+                    type: 'image/png',
+                    purpose: 'maskable'
+                }
+            ]
+        },
+        {
+            headers: {
+                'Cache-Control': 'public, max-age=86400'
+            }
+        }
+    );
+};


### PR DESCRIPTION
## Summary
- **#7734** 안드로이드 크롬 홈화면 추가 시 이름 오류 수정
- 정적 manifest.json 대신 서버 라우트로 VITE_SITE_NAME 환경변수 반영
- 다모앙: "다모앙 종합 커뮤니티" / short_name: "다모앙"