### PR TITLE
feat: 이메일 변경 시 인증 메일 발송 필수

### DIFF
--- a/apps/web/src/lib/server/auth/member-update.ts
+++ b/apps/web/src/lib/server/auth/member-update.ts
@@ -5,7 +5,13 @@
 import pool from '$lib/server/db.js';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import bcrypt from 'bcryptjs';
+import { randomBytes } from 'crypto';
 import { validateNickname } from './register.js';
+import { sendMail } from '$lib/server/mailer.js';
+import { env } from '$env/dynamic/private';
+
+const SITE_URL = env.SITE_URL || 'https://damoang.net';
+const SITE_NAME = env.VITE_SITE_NAME || 'Angple';
 
 /** 프로필 전체 정보 조회 */
 export interface MemberFullProfile {
@@ -87,13 +93,14 @@ export async function updateNickname(
 }
 
 /**
- * 이메일 변경
- * - 형식 검증 + 중복 체크
+ * 이메일 변경 요청 (인증 메일 발송)
+ * - 형식 검증 + 중복 체크 → 인증 토큰 생성 → 메일 발송
+ * - mb_email_certify2에 "새이메일|토큰|타임스탬프" 저장
  */
 export async function updateEmail(
     mbId: string,
     newEmail: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; message?: string }> {
     const trimmed = newEmail.trim().toLowerCase();
 
     // 이메일 형식 검증
@@ -120,13 +127,104 @@ export async function updateEmail(
         return { success: false, error: '이미 사용 중인 이메일입니다.' };
     }
 
-    // UPDATE
-    await pool.query<ResultSetHeader>('UPDATE g5_member SET mb_email = ? WHERE mb_id = ?', [
-        trimmed,
-        mbId
-    ]);
+    // 인증 토큰 생성
+    const token = randomBytes(24).toString('hex');
+    const timestamp = Date.now().toString(36);
 
-    return { success: true };
+    // mb_email_certify2에 "새이메일|토큰|타임스탬프" 저장
+    await pool.query<ResultSetHeader>(
+        'UPDATE g5_member SET mb_email_certify2 = ? WHERE mb_id = ?',
+        [`${trimmed}|${token}|${timestamp}`, mbId]
+    );
+
+    // 인증 메일 발송
+    const verifyUrl = `${SITE_URL}/member/settings/verify-email?token=${token}&mb_id=${encodeURIComponent(mbId)}`;
+    await sendMail({
+        to: trimmed,
+        subject: `[${SITE_NAME}] 이메일 변경 인증`,
+        html: `
+            <div style="max-width:600px;margin:0 auto;font-family:sans-serif;">
+                <h2 style="color:#333;">이메일 변경 인증</h2>
+                <p>${profile.mb_nick}님, 안녕하세요.</p>
+                <p>이메일을 <strong>${trimmed}</strong>으로 변경하시려면 아래 버튼을 클릭해주세요.</p>
+                <p style="margin:30px 0;">
+                    <a href="${verifyUrl}"
+                       style="background:#2563eb;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:bold;">
+                        이메일 변경 확인
+                    </a>
+                </p>
+                <p style="color:#666;font-size:14px;">
+                    이 링크는 24시간 동안 유효합니다.<br/>
+                    본인이 요청하지 않았다면 이 메일을 무시하세요.
+                </p>
+                <hr style="border:0;border-top:1px solid #eee;margin:30px 0;">
+                <p style="color:#999;font-size:12px;">${SITE_NAME}</p>
+            </div>
+        `
+    });
+
+    return {
+        success: true,
+        message: `${trimmed}으로 인증 메일을 발송했습니다. 메일의 링크를 클릭해주세요.`
+    };
+}
+
+/**
+ * 이메일 변경 인증 토큰 검증 및 변경 확정
+ * - mb_email_certify2에서 토큰 검증 → 이메일 변경
+ */
+export async function confirmEmailChange(
+    mbId: string,
+    token: string
+): Promise<{ success: boolean; error?: string; newEmail?: string }> {
+    const TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+    const [rows] = await pool.query<RowDataPacket[]>(
+        'SELECT mb_email_certify2 FROM g5_member WHERE mb_id = ? LIMIT 1',
+        [mbId]
+    );
+
+    if (!rows[0]?.mb_email_certify2) {
+        return { success: false, error: '이메일 변경 요청을 찾을 수 없습니다.' };
+    }
+
+    const parts = (rows[0].mb_email_certify2 as string).split('|');
+    if (parts.length < 3) {
+        return { success: false, error: '잘못된 인증 정보입니다.' };
+    }
+
+    const [storedEmail, storedToken, storedTimestamp] = parts;
+
+    // 토큰 검증
+    if (storedToken !== token) {
+        return { success: false, error: '유효하지 않은 인증 링크입니다.' };
+    }
+
+    // 만료 체크 (24시간)
+    const createdAt = parseInt(storedTimestamp, 36);
+    if (Date.now() - createdAt > TOKEN_EXPIRY_MS) {
+        return {
+            success: false,
+            error: '만료된 인증 링크입니다. 이메일 변경을 다시 요청해주세요.'
+        };
+    }
+
+    // 중복 체크 (토큰 생성 후 다른 회원이 같은 이메일 등록했을 수 있음)
+    const [dupRows] = await pool.query<RowDataPacket[]>(
+        'SELECT COUNT(*) as cnt FROM g5_member WHERE mb_email = ? AND mb_id != ?',
+        [storedEmail, mbId]
+    );
+    if ((dupRows[0]?.cnt || 0) > 0) {
+        return { success: false, error: '이미 다른 회원이 사용 중인 이메일입니다.' };
+    }
+
+    // 이메일 변경 확정 + 인증 정보 초기화
+    await pool.query<ResultSetHeader>(
+        'UPDATE g5_member SET mb_email = ?, mb_email_certify2 = ? WHERE mb_id = ?',
+        [storedEmail, '', mbId]
+    );
+
+    return { success: true, newEmail: storedEmail };
 }
 
 /**

--- a/apps/web/src/routes/member/settings/+page.server.ts
+++ b/apps/web/src/routes/member/settings/+page.server.ts
@@ -89,7 +89,7 @@ export const actions: Actions = {
             return fail(400, { error: result.error });
         }
 
-        return { success: true, message: '이메일이 변경되었습니다.' };
+        return { success: true, message: result.message };
     },
 
     changePassword: async ({ request, locals }) => {

--- a/apps/web/src/routes/member/settings/+page.svelte
+++ b/apps/web/src/routes/member/settings/+page.svelte
@@ -379,7 +379,7 @@
 
                     <Separator />
 
-                    <!-- 이메일 변경 -->
+                    <!-- 이메일 변경 (인증 메일 발송) -->
                     <form
                         method="POST"
                         action="?/updateEmail"
@@ -388,7 +388,9 @@
                             emailError = null;
                             return async ({ result }) => {
                                 if (result.type === 'success') {
-                                    emailSuccess = '이메일이 변경되었습니다.';
+                                    emailSuccess =
+                                        (result.data?.message as string) ||
+                                        '인증 메일을 발송했습니다. 메일의 링크를 클릭해주세요.';
                                 } else if (result.type === 'failure') {
                                     emailError =
                                         (result.data?.error as string) || '변경에 실패했습니다.';
@@ -404,10 +406,16 @@
                                     name="email"
                                     type="email"
                                     value={data.profile.mb_email}
-                                    placeholder="이메일"
+                                    placeholder="새 이메일 주소"
                                 />
-                                <Button type="submit" variant="outline">변경</Button>
+                                <Button type="submit" variant="outline">
+                                    <Mail class="mr-1 h-4 w-4" />
+                                    인증
+                                </Button>
                             </div>
+                            <p class="text-muted-foreground text-xs">
+                                변경할 이메일로 인증 메일이 발송됩니다.
+                            </p>
                             {#if emailSuccess}
                                 <p class="flex items-center gap-1 text-xs text-green-600">
                                     <CircleCheck class="h-3 w-3" />{emailSuccess}

--- a/apps/web/src/routes/member/settings/verify-email/+page.server.ts
+++ b/apps/web/src/routes/member/settings/verify-email/+page.server.ts
@@ -1,0 +1,23 @@
+/**
+ * 이메일 변경 인증 확인 페이지
+ * URL: /member/settings/verify-email?token=xxx&mb_id=xxx
+ */
+import type { PageServerLoad } from './$types';
+import { confirmEmailChange } from '$lib/server/auth/member-update.js';
+
+export const load: PageServerLoad = async ({ url }) => {
+    const token = url.searchParams.get('token');
+    const mbId = url.searchParams.get('mb_id');
+
+    if (!token || !mbId) {
+        return { success: false, error: '유효하지 않은 인증 링크입니다.' };
+    }
+
+    const result = await confirmEmailChange(mbId, token);
+
+    return {
+        success: result.success,
+        error: result.error || null,
+        newEmail: result.newEmail || null
+    };
+};

--- a/apps/web/src/routes/member/settings/verify-email/+page.svelte
+++ b/apps/web/src/routes/member/settings/verify-email/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import CircleCheck from '@lucide/svelte/icons/circle-check';
+    import CircleAlert from '@lucide/svelte/icons/circle-alert';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+    <title>이메일 변경 인증 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<div class="mx-auto max-w-md px-4 py-16">
+    <Card>
+        <CardHeader class="text-center">
+            <CardTitle>이메일 변경 인증</CardTitle>
+        </CardHeader>
+        <CardContent class="text-center">
+            {#if data.success}
+                <div class="space-y-4">
+                    <CircleCheck class="mx-auto h-12 w-12 text-green-600" />
+                    <p class="text-foreground text-lg font-medium">이메일이 변경되었습니다</p>
+                    <p class="text-muted-foreground text-sm">
+                        새 이메일: <strong>{data.newEmail}</strong>
+                    </p>
+                    <Button href="/member/settings" variant="outline">설정으로 돌아가기</Button>
+                </div>
+            {:else}
+                <div class="space-y-4">
+                    <CircleAlert class="mx-auto h-12 w-12 text-red-600" />
+                    <p class="text-foreground text-lg font-medium">인증 실패</p>
+                    <p class="text-muted-foreground text-sm">{data.error}</p>
+                    <Button href="/member/settings" variant="outline">설정으로 돌아가기</Button>
+                </div>
+            {/if}
+        </CardContent>
+    </Card>
+</div>


### PR DESCRIPTION
## Summary
이메일 변경을 바로 적용하지 않고, 새 이메일로 인증 메일을 발송하여 소유자 확인 후 변경 확정

## 플로우
1. 사용자가 설정 페이지에서 새 이메일 입력 → "인증" 버튼 클릭
2. 서버: 토큰 생성 → `mb_email_certify2`에 저장 → 새 이메일로 인증 메일 발송
3. 사용자가 메일의 링크 클릭 → `/member/settings/verify-email?token=...`
4. 토큰 검증 → 이메일 변경 확정

## 변경 파일
- `member-update.ts`: updateEmail → 인증 토큰 + 메일 발송, confirmEmailChange 추가
- `verify-email/+page.server.ts`: 인증 토큰 검증 라우트
- `verify-email/+page.svelte`: 인증 결과 UI
- 설정 페이지: "인증" 버튼 + 안내 메시지

## 보안
- 토큰: 24바이트 랜덤 hex (48자)
- 유효기간: 24시간
- 변경 확정 시 중복 이메일 재검증