### PR TITLE
fix: @멘션이 URL/이메일 내 @를 프로필 링크로 오버라이드하는 버그 수정

### DIFF
--- a/apps/web/src/lib/utils/mention-parser.ts
+++ b/apps/web/src/lib/utils/mention-parser.ts
@@ -3,14 +3,15 @@
  * plain text 및 HTML에서 @멘션을 추출하고 변환
  */
 
-/** 멘션 정규식: @닉네임 패턴 (한글, 영문, 숫자, 언더스코어) */
-const MENTION_REGEX = /@([a-zA-Z0-9_가-힣]+)/g;
+/** 멘션 정규식: @닉네임 패턴 — URL/이메일 내 @는 제외 */
+const MENTION_REGEX = /(?<![a-zA-Z0-9.+_\-/])@([a-zA-Z0-9_가-힣]+)/g;
 
 /** HTML data-mention 속성에서 멘션 추출 정규식 */
 const HTML_MENTION_REGEX = /data-mention="([^"]+)"/g;
 
 /**
  * plain text 또는 HTML에서 멘션된 닉네임 추출 (중복 제거)
+ * HTML 태그 내부 및 URL/이메일 내 @는 무시
  */
 export function extractMentions(content: string): string[] {
     if (!content) return [];
@@ -24,9 +25,10 @@ export function extractMentions(content: string): string[] {
         mentions.add(match[1]);
     }
 
-    // plain text @닉네임 패턴에서 추출
+    // HTML 태그를 제거한 텍스트에서 @닉네임 추출
+    const textOnly = content.replace(/<[^>]+>/g, ' ');
     const textRegex = new RegExp(MENTION_REGEX.source, 'g');
-    while ((match = textRegex.exec(content)) !== null) {
+    while ((match = textRegex.exec(textOnly)) !== null) {
         mentions.add(match[1]);
     }
 
@@ -36,13 +38,21 @@ export function extractMentions(content: string): string[] {
 /**
  * plain text의 @닉네임을 클릭 가능한 링크로 변환
  * DOMPurify를 통과할 수 있도록 <a> 태그 사용
+ * HTML 태그 내부 및 URL/이메일 내 @는 변환하지 않음
  */
 export function highlightMentions(content: string): string {
     if (!content) return content;
 
-    return content.replace(
-        MENTION_REGEX,
-        (_match, nick) =>
-            `<a href="/profile/${encodeURIComponent(nick)}" class="mention-link text-primary font-medium hover:underline" data-mention="${nick}">@${nick}</a>`
-    );
+    // HTML 태그를 분리하여 텍스트 노드에서만 변환
+    const parts = content.split(/(<[^>]+>)/g);
+    return parts
+        .map((part) => {
+            if (part.startsWith('<')) return part;
+            return part.replace(
+                /(?<![a-zA-Z0-9.+_\-/])@([a-zA-Z0-9_가-힣]+)/g,
+                (_match, nick) =>
+                    `<a href="/profile/${encodeURIComponent(nick)}" class="mention-link text-primary font-medium hover:underline" data-mention="${nick}">@${nick}</a>`
+            );
+        })
+        .join('');
 }


### PR DESCRIPTION
## Summary
- MENTION_REGEX에 negative lookbehind 추가하여 URL/이메일 내 @ 제외
- highlightMentions: HTML 태그를 분리하여 텍스트 노드에서만 변환
- extractMentions: HTML 태그 제거 후 텍스트에서만 추출

기존 PR #318 재생성 (브랜치 삭제로 인해 reopen 불가)