### PR TITLE
fix: dompurify XSS 및 tar path traversal 보안 패치

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -96,10 +96,10 @@
         "@types/turndown": "^5.0.6",
         "adm-zip": "^0.5.16",
         "bcryptjs": "^3.0.3",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.3.2",
         "highlight.js": "^11.11.1",
         "ioredis": "^5.10.0",
-        "isomorphic-dompurify": "3.0.0-rc.2",
+        "isomorphic-dompurify": "3.0.0",
         "jose": "^6.1.3",
         "kisa-seed": "^1.0.1",
         "lowlight": "^3.3.0",
@@ -110,7 +110,7 @@
         "svelte-dnd-action": "^0.9.54",
         "svelte-sonner": "^1.0.7",
         "svelte-tiptap": "^3.0.1",
-        "tar": "^7.5.9",
+        "tar": "^7.5.10",
         "turndown": "^7.2.2",
         "zod": "^4.2.1"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       dompurify:
-        specifier: ^3.3.1
-        version: 3.3.1
+        specifier: ^3.3.2
+        version: 3.3.2
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -150,8 +150,8 @@ importers:
         specifier: ^5.10.0
         version: 5.10.0
       isomorphic-dompurify:
-        specifier: 3.0.0-rc.2
-        version: 3.0.0-rc.2
+        specifier: 3.0.0
+        version: 3.0.0
       jose:
         specifier: ^6.1.3
         version: 6.1.3
@@ -2746,8 +2746,9 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.3.2:
+    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
+    engines: {node: '>=20'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3308,8 +3309,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isomorphic-dompurify@3.0.0-rc.2:
-    resolution: {integrity: sha512-krCa8psVRnfeJxZnCk+USqMKvcDOkQCGbAeFXQwaJiIcRFOGp9GDa2h06QzVIdVbM+onpro2Vg4uLe2RHI1McA==}
+  isomorphic-dompurify@3.0.0:
+    resolution: {integrity: sha512-5K+MYP7Nrg74+Bi+QmQGzQ/FgEOyVHWsN8MuJy5wYQxxBRxPnWsD25Tjjt5FWYhan3OQ+vNLubyNJH9dfG03lQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   istanbul-lib-coverage@3.2.2:
@@ -7097,7 +7098,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.3.1
+      dompurify: 3.3.2
 
   '@types/estree@1.0.8': {}
 
@@ -7772,7 +7773,7 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  dompurify@3.3.1:
+  dompurify@3.3.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8409,9 +8410,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-dompurify@3.0.0-rc.2:
+  isomorphic-dompurify@3.0.0:
     dependencies:
-      dompurify: 3.3.1
+      dompurify: 3.3.2
       jsdom: 28.0.0
     transitivePeerDependencies:
       - '@noble/hashes'


### PR DESCRIPTION
## Summary
- dompurify: ^3.3.1 → ^3.3.2 (XSS 취약점 수정)
- isomorphic-dompurify: 3.0.0-rc.2 → 3.0.0 (안정 버전)
- tar: ^7.5.9 → ^7.5.10 (path traversal 취약점 수정)

기존 PR #320 재생성 (브랜치 삭제로 인해 reopen 불가)