### PR TITLE
fix: 한글 폰트 이탤릭 미적용 — font-synthesis: style 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1325,6 +1325,20 @@
         font-size: 0.875em;
     }
 
+    /* 댓글 이탤릭/인용문 */
+    :global(.comment-body em) {
+        font-style: italic;
+        font-synthesis: style;
+    }
+    :global(.comment-body blockquote) {
+        border-left: 4px solid var(--border);
+        padding-left: 1rem;
+        margin: 0.5em 0;
+        color: var(--muted-foreground);
+        font-style: italic;
+        font-synthesis: style;
+    }
+
     /* 연속 줄바꿈 간격 축소 */
     :global(.comment-body br + br) {
         display: block;

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -310,6 +310,7 @@
         margin: 1rem 0;
         color: var(--muted-foreground);
         font-style: italic;
+        font-synthesis: style;
     }
 
     .prose :global(code) {
@@ -409,6 +410,7 @@
 
     .prose :global(em) {
         font-style: italic;
+        font-synthesis: style;
     }
 
     /* 임베드 컨테이너 스타일 */


### PR DESCRIPTION
## Summary
- 전역 font-synthesis-style: none으로 한글 이탤릭 미렌더링 문제 수정
- comment-list: em, blockquote에 font-synthesis: style 추가
- markdown: em, blockquote에 font-synthesis: style 추가

기존 PR #316 재생성 (브랜치 삭제로 인해 reopen 불가)