### PR TITLE
fix: 프로필 사진 변경, 모바일 댓글 메뉴, 답글 레이아웃 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -231,10 +231,11 @@
         {/if}
 
         <div class="flex items-start gap-3">
-            <!-- 사용자 아바타 -->
+            <!-- 사용자 아바타 (답글 모드에서는 모바일 숨김) -->
             <div
-                class="flex size-10 shrink-0 items-center justify-center rounded-full {commentAvatarUrl &&
-                !commentAvatarFailed
+                class="flex size-10 shrink-0 items-center justify-center rounded-full {isReplyMode
+                    ? 'hidden sm:flex'
+                    : ''} {commentAvatarUrl && !commentAvatarFailed
                     ? 'overflow-hidden'
                     : 'bg-primary text-primary-foreground'}"
             >

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -678,7 +678,7 @@
         <li
             id="c_{comment.id}"
             style="margin-left: {Math.min(depth, 2) * 1}rem; scroll-margin-top: 100px"
-            class="comment-item transition-colors duration-200
+            class="comment-item overflow-hidden transition-colors duration-200
                 {commentLayout === 'chat'
                 ? 'flex items-start gap-2.5' + (isAuthor ? ' flex-row-reverse' : '')
                 : commentLayout === 'bordered'

--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -46,7 +46,7 @@
             title="이모티콘"
         >
             <Smile class="h-4 w-4" />
-            <span class="ml-1 text-xs">이모티콘</span>
+            <span class="ml-1 hidden text-xs sm:inline">이모티콘</span>
         </Button>
         {#if showEmoticonPicker}
             <!-- 외부 클릭으로 닫기 -->
@@ -79,7 +79,7 @@
         title="GIF"
     >
         <Film class="h-4 w-4" />
-        <span class="ml-1 text-xs">GIF</span>
+        <span class="ml-1 hidden text-xs sm:inline">GIF</span>
     </Button>
 
     <!-- 사진 버튼 -->
@@ -93,7 +93,7 @@
         title="사진"
     >
         <ImageIcon class="h-4 w-4" />
-        <span class="ml-1 text-xs">사진</span>
+        <span class="ml-1 hidden text-xs sm:inline">사진</span>
     </Button>
 
     <!-- 빈댓글 버튼 -->
@@ -107,7 +107,7 @@
         title="빈댓글"
     >
         <Space class="h-4 w-4" />
-        <span class="ml-1 text-xs">빈댓글</span>
+        <span class="ml-1 hidden text-xs sm:inline">빈댓글</span>
     </Button>
 </div>
 

--- a/apps/web/src/routes/member/settings/+page.svelte
+++ b/apps/web/src/routes/member/settings/+page.svelte
@@ -97,7 +97,7 @@
             }
 
             const result = await res.json();
-            const uploadedUrl = result.url || result.cdnUrl;
+            const uploadedUrl = result.data?.cdn_url || result.data?.url;
             if (!uploadedUrl) throw new Error('업로드 URL을 받지 못했습니다.');
 
             // form action으로 DB 업데이트


### PR DESCRIPTION
## Summary
- **#7722 프로필 사진 변경 불가**: API 응답이 `{ data: { cdn_url, url } }` 구조인데 `result.url`로 읽던 버그 수정
- **#7737 모바일 댓글 메뉴 잘림**: 툴바 버튼 텍스트 라벨을 모바일에서 숨김 (아이콘만 표시, sm: 이상에서 텍스트 표시)
- **#7717 답글 시 레이아웃 밀림**: 댓글 아이템에 `overflow-hidden` 추가 + 답글 모드에서 모바일 아바타 숨김

## Test plan
- [ ] 설정 페이지에서 프로필 사진 업로드 → S3 업로드 후 DB 저장 확인
- [ ] 모바일 뷰에서 댓글 툴바 버튼 4개 (이모티콘/GIF/사진/빈댓글) 모두 표시 확인
- [ ] 대댓글 작성 시 레이아웃 가로 밀림 없는지 확인 (특히 depth 2 이상)