### PR TITLE
fix: 앙티콘 iOS Safari 깨짐 및 레이아웃 밀림 수정

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -140,12 +140,7 @@
             title={display.label}
         >
             {#if display.renderType === 'image' && display.url}
-                <img
-                    src={display.url}
-                    alt={display.label}
-                    class="h-5 w-5 object-contain"
-                    loading="lazy"
-                />
+                <img src={display.url} alt={display.label} class="h-5 w-5 object-scale-down" />
             {:else}
                 <span class="text-base leading-none">{display.emoji}</span>
             {/if}
@@ -219,8 +214,7 @@
                                 <img
                                     src={emo.url}
                                     alt={emo.reaction}
-                                    class="h-7 w-7 object-contain"
-                                    loading="lazy"
+                                    class="h-7 w-7 object-scale-down"
                                 />
                             {:else}
                                 <span class="text-xl leading-none">{emo.emoji}</span>

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -1,6 +1,7 @@
 /* 모바일 좌우 스크롤 방지 (긴 URL, 광고 등으로 인한 레이아웃 밀림 차단) */
 html {
     overflow-x: hidden;
+    overflow-y: scroll;
     max-width: 100vw;
     /* 스크롤바 공간 예약 — 드롭다운/모달 열릴 때 콘텐츠 밀림 방지 */
     scrollbar-gutter: stable;


### PR DESCRIPTION
## Summary
- **앙티콘 iOS Safari 깨짐 (#7709)**: reaction-bar에서 GIF 이미지의 `loading="lazy"` 제거 + `object-contain` → `object-scale-down` 변경
- **레이아웃 밀림 보강 (#7717)**: html에 `overflow-y: scroll` 추가하여 스크롤바 항상 표시 (`scrollbar-gutter: stable`과 함께)

## Test plan
- [ ] iOS Safari에서 앙티콘(GIF) 표시 확인
- [ ] 데스크톱에서 모달/드롭다운 열릴 때 레이아웃 밀림 없는지 확인
- [ ] 모바일에서 좌우 스크롤 방지 유지 확인