### PR TITLE
fix: Dantry 에러 노이즈 필터링 강화 및 state_unsafe_mutation 수정

### DIFF
--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -14,12 +14,23 @@ const IGNORED_PATTERNS = [
     'cross-origin frame',
     'zGetBack is not defined',
     '@context',
-    'currentPage.innerText'
+    'currentPage.innerText',
+    'affiliateDomainData',
+    'getBack is not defined',
+    '__gCrWeb',
+    'Blocked a frame',
+    'querySelectorAll',
+    'getAttribute',
+    '.regional',
+    'popover is not a function',
+    'parentNode.parentNode'
 ];
 
 function shouldIgnore(message: string): boolean {
     if (!message) return true;
     if (message === '[object Object]') return true;
+    if (message === '(unknown)') return true;
+    if (message === 'Rejected') return true;
     return IGNORED_PATTERNS.some((p) => message.includes(p));
 }
 

--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
     import { Button } from '$lib/components/ui/button/index.js';
     import { Textarea } from '$lib/components/ui/textarea/index.js';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
@@ -72,7 +73,7 @@
     let commentAvatarFailed = $state(false);
 
     $effect(() => {
-        if (authStore.user) commentAvatarFailed = false;
+        if (authStore.user) untrack(() => (commentAvatarFailed = false));
     });
 
     let content = $state('');

--- a/apps/web/src/lib/components/features/recommended/components/ai-trend/headline-rotator.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/ai-trend/headline-rotator.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { untrack } from 'svelte';
+
     let { headlines }: { headlines: string[] } = $props();
 
     let currentIndex = $state(0);
@@ -7,7 +9,7 @@
     $effect(() => {
         if (headlines.length <= 1) return;
 
-        currentIndex = 0;
+        untrack(() => (currentIndex = 0));
 
         const intervalId = setInterval(() => {
             currentIndex = (currentIndex + 1) % headlines.length;

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
+    import { onMount, untrack } from 'svelte';
     import { goto, afterNavigate } from '$app/navigation';
     import Search from '@lucide/svelte/icons/search';
     import User from '@lucide/svelte/icons/user';
@@ -30,7 +30,7 @@
 
     // user 변경 시 실패 상태 리셋
     $effect(() => {
-        if (authStore.user) headerAvatarFailed = false;
+        if (authStore.user) untrack(() => (headerAvatarFailed = false));
     });
 
     // 스크롤 상태 관리


### PR DESCRIPTION
## Summary
- `hooks.client.ts`: IGNORED_PATTERNS 9개 추가 (affiliateDomainData, getBack, __gCrWeb, Blocked a frame, querySelectorAll, getAttribute, .regional, popover, parentNode) + shouldIgnore에 빈 rejection 필터 ('(unknown)', 'Rejected')
- `header.svelte`, `comment-form.svelte`, `headline-rotator.svelte`: `$effect` 내 state mutation을 `untrack()`으로 감싸서 `state_unsafe_mutation` 에러 방지

## Expected Impact
- 노이즈 ~1.35M/주 제거 (PHP 레거시, 브라우저 확장, 외부 스크립트)
- state_unsafe_mutation 67.3K/주 → 0 목표
- 전체: 1.5M/주 → 100K/주 이하 목표

## Test plan
- [x] `pnpm build` 성공
- [ ] 배포 후 Dantry 에러 급감 확인