### PR TITLE
feat: SSR 최적화 및 CDN 비용 절감

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -13,10 +13,12 @@ const jwtCache = new Map<string, { token: string; expiry: number }>();
 const JWT_CACHE_TTL = 5 * 60 * 1000; // 5분
 const MAX_JWT_CACHE_SIZE = 50000;
 
-// --- SSR 응답 캐시 (비로그인 홈페이지) ---
+// --- SSR 응답 캐시 (비로그인: 홈 + 게시판 목록) ---
 const ssrCache = new Map<string, { body: string; timestamp: number }>();
-const SSR_CACHE_TTL = 10_000; // 10초
-let ssrCachePending: Promise<Response> | null = null;
+const SSR_CACHE_TTL_HOME = 10_000; // 홈 10초
+const SSR_CACHE_TTL_BOARD = 30_000; // 게시판 목록 30초
+const MAX_SSR_CACHE_SIZE = 50; // 캐시할 최대 페이지 수
+const ssrCachePending = new Map<string, Promise<Response>>();
 
 /**
  * SvelteKit Server Hooks
@@ -134,14 +136,20 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                     } else {
                         const token = await generateAccessToken(member);
                         event.locals.accessToken = token;
-                        // 캐시 크기 제한: 한계 도달 시 가장 오래된 25% 제거 (O(n) sweep 대신 batch eviction)
+                        // 캐시 크기 제한: 만료 항목만 정리 (O(n) 랜덤 삭제 → 정밀 eviction)
                         if (jwtCache.size >= MAX_JWT_CACHE_SIZE) {
-                            const evictCount = Math.floor(MAX_JWT_CACHE_SIZE * 0.25);
-                            let removed = 0;
-                            for (const key of jwtCache.keys()) {
-                                if (removed >= evictCount) break;
-                                jwtCache.delete(key);
-                                removed++;
+                            for (const [key, entry] of jwtCache) {
+                                if (now >= entry.expiry) jwtCache.delete(key);
+                            }
+                            // 만료 정리 후에도 초과면 가장 오래된 10% 제거
+                            if (jwtCache.size >= MAX_JWT_CACHE_SIZE) {
+                                const evictCount = Math.floor(MAX_JWT_CACHE_SIZE * 0.1);
+                                let removed = 0;
+                                for (const key of jwtCache.keys()) {
+                                    if (removed >= evictCount) break;
+                                    jwtCache.delete(key);
+                                    removed++;
+                                }
                             }
                         }
                         jwtCache.set(session.mbId, { token, expiry: now + JWT_CACHE_TTL });
@@ -352,11 +360,16 @@ export const handle: Handle = async ({ event, resolve }) => {
     // /api/plugins/* 프록시는 더 이상 사용하지 않음
     // 모든 /api/plugins/* 요청은 SvelteKit API 라우트에서 처리
 
-    // --- 비로그인 홈페이지 SSR 응답 캐시 ---
+    // --- 비로그인 SSR 응답 캐시 (홈 + 게시판 목록) ---
     // Pod 재시작 시 캐시 자동 소멸 → 배포 시 구 JS 경로 문제 없음
-    if (!event.locals.user && pathname === '/') {
-        const cached = ssrCache.get('/');
-        if (cached && Date.now() - cached.timestamp < SSR_CACHE_TTL) {
+    const isHomePage = pathname === '/';
+    const isBoardList = isBoardListPath(pathname, event.url.searchParams);
+    if (!event.locals.user && (isHomePage || isBoardList)) {
+        const cacheKey = isHomePage ? '/' : pathname;
+        const cacheTtl = isHomePage ? SSR_CACHE_TTL_HOME : SSR_CACHE_TTL_BOARD;
+
+        const cached = ssrCache.get(cacheKey);
+        if (cached && Date.now() - cached.timestamp < cacheTtl) {
             return new Response(cached.body, {
                 status: 200,
                 headers: {
@@ -374,9 +387,10 @@ export const handle: Handle = async ({ event, resolve }) => {
         }
 
         // Singleflight: 동시 요청 시 1개만 SSR 실행
-        if (ssrCachePending) {
+        const pending = ssrCachePending.get(cacheKey);
+        if (pending) {
             try {
-                const result = await ssrCachePending;
+                const result = await pending;
                 return result.clone();
             } catch {
                 // pending 실패 시 아래에서 직접 렌더링
@@ -400,7 +414,16 @@ export const handle: Handle = async ({ event, resolve }) => {
 
             if (response.status === 200) {
                 const body = await response.text();
-                ssrCache.set('/', { body, timestamp: Date.now() });
+
+                // 캐시 크기 제한: 오래된 항목 정리
+                if (ssrCache.size >= MAX_SSR_CACHE_SIZE) {
+                    const now = Date.now();
+                    for (const [key, entry] of ssrCache) {
+                        const ttl = key === '/' ? SSR_CACHE_TTL_HOME : SSR_CACHE_TTL_BOARD;
+                        if (now - entry.timestamp > ttl) ssrCache.delete(key);
+                    }
+                }
+                ssrCache.set(cacheKey, { body, timestamp: Date.now() });
 
                 return new Response(body, {
                     status: 200,
@@ -421,12 +444,12 @@ export const handle: Handle = async ({ event, resolve }) => {
             return response;
         })();
 
-        ssrCachePending = renderPromise;
+        ssrCachePending.set(cacheKey, renderPromise);
         try {
             const result = await renderPromise;
             return result;
         } finally {
-            ssrCachePending = null;
+            ssrCachePending.delete(cacheKey);
         }
     }
 

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -162,7 +162,7 @@
 
         function startPolling() {
             if (interval) return;
-            interval = setInterval(loadUnreadCount, 300000);
+            interval = setInterval(loadUnreadCount, 600000);
         }
 
         function stopPolling() {

--- a/apps/web/src/lib/server/ads/banners.ts
+++ b/apps/web/src/lib/server/ads/banners.ts
@@ -1,0 +1,45 @@
+/**
+ * 배너 데이터 공유 모듈
+ *
+ * +layout.server.ts, /api/init 에서 공유.
+ * 60초 인메모리 캐시 + singleflight 포함.
+ */
+import { createCache } from '$lib/server/cache';
+import { getAdsServerUrl } from './config';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const bannerCache = createCache<Record<string, any[]>>({ ttl: 60_000, maxSize: 10 });
+
+/** ads 서버에서 배너 데이터 조회 (60초 캐시, singleflight) */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getCachedBannersByPositions(
+    positions: string[]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<Record<string, any[]>> {
+    const cacheKey = [...positions].sort().join(',');
+    return bannerCache.getOrSet(cacheKey, async () => {
+        const adsServerUrl = getAdsServerUrl();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result: Record<string, any[]> = {};
+
+        await Promise.all(
+            positions.map(async (position) => {
+                try {
+                    const response = await fetch(
+                        `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=10`
+                    );
+                    if (response.ok) {
+                        const data = await response.json();
+                        if (data.success && data.data?.banners) {
+                            result[position] = data.data.banners;
+                        }
+                    }
+                } catch {
+                    // 개별 position 실패는 무시
+                }
+            })
+        );
+
+        return result;
+    });
+}

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -3,35 +3,7 @@ import { getActiveTheme } from '$lib/server/themes';
 import { getActivePlugins } from '$lib/server/plugins';
 import { loadMenus } from '$lib/server/menu-loader';
 import { getCachedCelebrations } from '$lib/server/celebration';
-import { getAdsServerUrl } from '$lib/server/ads/config';
-
-/** ads 서버에서 배너 데이터 내부 호출 (CDN 우회, localhost:9090 직접) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function fetchBannersByPositions(positions: string[]): Promise<Record<string, any[]>> {
-    const adsServerUrl = getAdsServerUrl();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: Record<string, any[]> = {};
-
-    await Promise.all(
-        positions.map(async (position) => {
-            try {
-                const response = await fetch(
-                    `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=10`
-                );
-                if (response.ok) {
-                    const data = await response.json();
-                    if (data.success && data.data?.banners) {
-                        result[position] = data.data.banners;
-                    }
-                }
-            } catch {
-                // 개별 position 실패는 무시
-            }
-        })
-    );
-
-    return result;
-}
+import { getCachedBannersByPositions } from '$lib/server/ads/banners';
 
 /**
  * 서버 사이드 데이터 로드
@@ -41,7 +13,8 @@ async function fetchBannersByPositions(positions: string[]): Promise<Record<stri
  *
  * celebration + banners: SSR에서 직접 로드하여 클라이언트 /api/init CDN 요청 제거
  */
-export const load: LayoutServerLoad = async ({ locals }) => {
+export const load: LayoutServerLoad = async ({ locals, url }) => {
+    void url.pathname; // URL 변경 시 load 재실행 → SPA 네비게이션마다 SSR 데이터 갱신
     // 병렬로 모든 데이터 로드 (allSettled: 개별 실패 허용)
     const [themeResult, pluginsResult, menusResult, celebrationResult, bannersResult] =
         await Promise.allSettled([
@@ -49,7 +22,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
             getActivePlugins(),
             loadMenus(),
             getCachedCelebrations(),
-            fetchBannersByPositions(['index-top', 'board-head', 'sidebar'])
+            getCachedBannersByPositions(['index-top', 'board-head', 'sidebar'])
         ]);
 
     const activeTheme = themeResult.status === 'fulfilled' ? themeResult.value : null;

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -116,8 +116,8 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
     const isPromotionBoard = boardId === 'promotion' && !isSearching && !isTagFiltering;
 
     // 비로그인 + 검색/태그 필터 없는 경우: 게시글 목록 캐시 사용 (15초)
-    const usePostsCache = !locals.user && !isSearching && !isTagFiltering && !category;
-    const postsCacheKey = `${boardId}:p${page}:l${limit}`;
+    const usePostsCache = !locals.user && !isSearching && !isTagFiltering;
+    const postsCacheKey = `${boardId}:p${page}:l${limit}${category ? `:c${category}` : ''}`;
 
     if (usePostsCache) {
         const cachedPosts = postsCache.get(postsCacheKey);

--- a/apps/web/src/routes/api/ads/banners/+server.ts
+++ b/apps/web/src/routes/api/ads/banners/+server.ts
@@ -1,22 +1,32 @@
 import { json } from '@sveltejs/kit';
 import { getAdsServerUrl } from '$lib/server/ads/config';
+import { createCache } from '$lib/server/cache';
 import type { RequestHandler } from './$types';
 
+// 인메모리 캐시 (60초 TTL, singleflight 내장)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const bannerProxyCache = createCache<any>({ ttl: 60_000, maxSize: 50 });
+
 // GET /api/ads/banners?position=board-head&limit=1
-// ads.damoang.net 프록시 (Cloudflare 우회)
+// ads.damoang.net 프록시 (Cloudflare 우회, 60초 singleflight 캐시)
 export const GET: RequestHandler = async ({ url }) => {
-    const adsServerUrl = getAdsServerUrl();
     const position = url.searchParams.get('position') || '';
     const limit = url.searchParams.get('limit') || '1';
+    const cacheKey = `${position}:${limit}`;
 
     try {
-        const response = await fetch(
-            `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
-        );
-        if (!response.ok) {
-            return json({ success: false, data: { banners: [], count: 0 } });
-        }
-        return json(await response.json(), {
+        const data = await bannerProxyCache.getOrSet(cacheKey, async () => {
+            const adsServerUrl = getAdsServerUrl();
+            const response = await fetch(
+                `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
+            );
+            if (!response.ok) {
+                return { success: false, data: { banners: [], count: 0 } };
+            }
+            return response.json();
+        });
+
+        return json(data, {
             headers: {
                 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600'
             }

--- a/apps/web/src/routes/api/init/+server.ts
+++ b/apps/web/src/routes/api/init/+server.ts
@@ -10,34 +10,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getCachedCelebrations } from '$lib/server/celebration';
-import { getAdsServerUrl } from '$lib/server/ads/config';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function fetchBannersByPositions(positions: string[]): Promise<Record<string, any>> {
-    const adsServerUrl = getAdsServerUrl();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: Record<string, any> = {};
-
-    await Promise.all(
-        positions.map(async (position) => {
-            try {
-                const response = await fetch(
-                    `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=10`
-                );
-                if (response.ok) {
-                    const data = await response.json();
-                    if (data.success && data.data?.banners) {
-                        result[position] = data.data.banners;
-                    }
-                }
-            } catch {
-                // 개별 position 실패는 무시
-            }
-        })
-    );
-
-    return result;
-}
+import { getCachedBannersByPositions } from '$lib/server/ads/banners';
 
 export const GET: RequestHandler = async ({ url }) => {
     const positionsParam = url.searchParams.get('positions') || '';
@@ -49,7 +22,7 @@ export const GET: RequestHandler = async ({ url }) => {
     try {
         const [celebration, banners] = await Promise.all([
             getCachedCelebrations(),
-            positions.length > 0 ? fetchBannersByPositions(positions) : {}
+            positions.length > 0 ? getCachedBannersByPositions(positions) : {}
         ]);
 
         return json(

--- a/apps/web/src/routes/my/points/+page.server.ts
+++ b/apps/web/src/routes/my/points/+page.server.ts
@@ -3,14 +3,6 @@ import type { PointHistoryResponse } from '$lib/api/types.js';
 import { pool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 
-interface MemberPointRow extends RowDataPacket {
-    mb_point: number;
-}
-
-interface SumRow extends RowDataPacket {
-    total: number;
-}
-
 interface CountRow extends RowDataPacket {
     cnt: number;
 }
@@ -50,38 +42,36 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 
         const offset = (page - 1) * limit;
 
-        // 요약 3쿼리 + 카운트 + 데이터 병렬 실행
-        const [[memberRows], [earnedRows], [usedRows], [countRows], [itemRows]] = await Promise.all(
-            [
-                pool.query<MemberPointRow[]>('SELECT mb_point FROM g5_member WHERE mb_id = ?', [
-                    mbId
-                ]),
-                pool.query<SumRow[]>(
-                    'SELECT COALESCE(SUM(po_point), 0) AS total FROM g5_point WHERE mb_id = ? AND po_point > 0',
-                    [mbId]
-                ),
-                pool.query<SumRow[]>(
-                    'SELECT COALESCE(ABS(SUM(po_point)), 0) AS total FROM g5_point WHERE mb_id = ? AND po_point < 0',
-                    [mbId]
-                ),
-                pool.query<CountRow[]>(
-                    `SELECT COUNT(*) AS cnt FROM g5_point WHERE mb_id = ?${filterClause}`,
-                    [mbId]
-                ),
-                // pool.query 사용: pool.execute의 prepared statement는 LIMIT 파라미터 타입 오류 발생
-                pool.query<PointRow[]>(
-                    `SELECT po_id, mb_id, po_content, po_point, po_use_point, po_datetime,
+        // 요약(1쿼리) + 카운트 + 데이터 병렬 실행 (5→3쿼리 최적화)
+        const [[summaryRows], [countRows], [itemRows]] = await Promise.all([
+            pool.query<RowDataPacket[]>(
+                `SELECT
+                    m.mb_point,
+                    COALESCE(SUM(CASE WHEN p.po_point > 0 THEN p.po_point ELSE 0 END), 0) AS total_earned,
+                    COALESCE(ABS(SUM(CASE WHEN p.po_point < 0 THEN p.po_point ELSE 0 END)), 0) AS total_used
+                 FROM g5_member m
+                 LEFT JOIN g5_point p ON p.mb_id = m.mb_id
+                 WHERE m.mb_id = ?
+                 GROUP BY m.mb_id`,
+                [mbId]
+            ),
+            pool.query<CountRow[]>(
+                `SELECT COUNT(*) AS cnt FROM g5_point WHERE mb_id = ?${filterClause}`,
+                [mbId]
+            ),
+            // pool.query 사용: pool.execute의 prepared statement는 LIMIT 파라미터 타입 오류 발생
+            pool.query<PointRow[]>(
+                `SELECT po_id, mb_id, po_content, po_point, po_use_point, po_datetime,
 				        po_expired, po_expire_date, po_mb_point, po_rel_table, po_rel_id, po_rel_action
 				 FROM g5_point WHERE mb_id = ?${filterClause}
 				 ORDER BY po_id DESC LIMIT ? OFFSET ?`,
-                    [mbId, limit, offset]
-                )
-            ]
-        );
+                [mbId, limit, offset]
+            )
+        ]);
 
-        const totalPoint = memberRows[0]?.mb_point ?? 0;
-        const totalEarned = earnedRows[0]?.total ?? 0;
-        const totalUsed = usedRows[0]?.total ?? 0;
+        const totalPoint = summaryRows[0]?.mb_point ?? 0;
+        const totalEarned = summaryRows[0]?.total_earned ?? 0;
+        const totalUsed = summaryRows[0]?.total_used ?? 0;
         const total = countRows[0]?.cnt ?? 0;
         const totalPages = Math.ceil(total / limit);
 


### PR DESCRIPTION
## Summary
- **SSR 캐시 확장**: 비로그인 게시판 목록 페이지까지 SSR 캐시 적용 (홈 10초, 게시판 30초)
- **배너 공유 캐시 모듈**: `+layout.server.ts`와 `/api/init`에서 중복되던 배너 조회를 `lib/server/ads/banners.ts`로 통합 (60초 캐시 + singleflight)
- **배너 프록시 캐시**: `/api/ads/banners` 엔드포인트에 60초 singleflight 캐시 추가
- **게시글 캐시 확대**: 카테고리 필터 포함하여 캐시 범위 확장
- **포인트 쿼리 최적화**: 요약 5쿼리 → 3쿼리로 병합
- **JWT eviction 개선**: 랜덤 25% 삭제 → 만료 항목 우선 정리
- **알림 폴링 완화**: 5분 → 10분

## Test plan
- [x] `pnpm build` 성공
- [ ] 배포 후 CloudFront 요청 수 감소 확인
- [ ] 게시판 목록 페이지 응답 속도 확인