### PR TITLE
fix: 게시판 목록 읽은 글 이탤릭에 font-synthesis: style 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -304,6 +304,7 @@
     .post-title-read-italic {
         color: var(--color-muted-foreground);
         font-style: italic;
+        font-synthesis: style;
     }
 
     .post-title-read-underline {


### PR DESCRIPTION
## Summary
- 게시판 목록(classic 레이아웃)에서 읽은 게시물 제목 이탤릭 스타일에 `font-synthesis: style` 추가
- 한글 폰트에 이탤릭 글리프가 없어 기울어지지 않는 문제 수정 (#347 후속)

## Test plan
- [x] 게시판 목록에서 읽은 글 스타일을 '이탤릭'으로 설정 후 한글 제목이 기울어지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)