### PR TITLE
fix: 제목 굵게 토글 미작동 + 이용제한 기록 메모 표시

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -70,6 +70,7 @@ export interface DisciplineLogListItem {
     penalty_date_from: string;
     violation_types: number[];
     violation_titles: string[];
+    memo?: string;
 }
 
 export interface DisciplineLogDetail {
@@ -81,6 +82,7 @@ export interface DisciplineLogDetail {
     penalty_date_to?: string;
     violation_types: ViolationType[];
     reported_items?: ReportedItem[];
+    memo?: string;
     created_by: string;
     created_at: string;
     status: 'pending' | 'approved' | 'rejected';

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -125,6 +125,10 @@ function createUiSettingsStore() {
         get titleBold() {
             return settings.titleBold;
         },
+        set titleBold(v: boolean) {
+            settings.titleBold = v;
+            save();
+        },
         get lineHeight() {
             return settings.lineHeight;
         },

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -73,6 +73,7 @@
                                 <th class="p-3 text-left font-medium">시작일</th>
                                 <th class="p-3 text-center font-medium">기간</th>
                                 <th class="p-3 text-left font-medium">사유</th>
+                                <th class="p-3 text-left font-medium">메모</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -114,6 +115,11 @@
                                             {/if}
                                         </div>
                                     </td>
+                                    <td
+                                        class="text-muted-foreground max-w-[200px] truncate p-3 text-sm"
+                                    >
+                                        {log.memo || ''}
+                                    </td>
                                 </tr>
                             {/each}
                         </tbody>
@@ -151,6 +157,11 @@
                                         >
                                     {/if}
                                 </div>
+                                {#if log.memo}
+                                    <div class="text-muted-foreground mt-1 truncate text-xs">
+                                        {log.memo}
+                                    </div>
+                                {/if}
                             </div>
                         </a>
                     {/each}

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -197,6 +197,21 @@
             </Card.Content>
         </Card.Root>
 
+        <!-- Memo -->
+        {#if log.memo}
+            <Card.Root class="mb-4">
+                <Card.Header>
+                    <Card.Title class="flex items-center gap-2">
+                        <FileText class="h-5 w-5" />
+                        메모
+                    </Card.Title>
+                </Card.Header>
+                <Card.Content>
+                    <p class="whitespace-pre-wrap text-sm">{log.memo}</p>
+                </Card.Content>
+            </Card.Root>
+        {/if}
+
         <!-- Reported Items -->
         {#if log.reported_items && log.reported_items.length > 0}
             <Card.Root class="mb-4">


### PR DESCRIPTION
## Summary
- **제목 굵게 토글**: ui-settings에 titleBold setter 누락으로 토글 미작동 수정
- **이용제한 기록 메모**: discipline-log 목록/상세 페이지에 메모 필드 표시 추가

## Test plan
- [ ] 게시판 목록에서 "제목 굵게" 버튼 토글 on/off 확인
- [ ] 이용제한 기록 목록에서 메모 컬럼 표시 확인
- [ ] 이용제한 기록 상세에서 메모 섹션 표시 확인