### PR TITLE
fix: manualChunks 제거 — 순환 참조 런타임 에러

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,45 +19,6 @@ export default defineConfig(({ mode }) => {
     return {
         plugins: [tailwindcss(), sveltekit()],
         build: {
-            rollupOptions: {
-                output: {
-                    manualChunks(id) {
-                        if (id.includes('.svelte-kit/') || id.includes('src/routes/')) return;
-                        if (id.includes('node_modules/')) {
-                            if (id.includes('/svelte/')) return 'svelte-runtime';
-                            if (
-                                id.includes('bits-ui') ||
-                                id.includes('melt-ui') ||
-                                id.includes('@floating-ui') ||
-                                id.includes('@lucide')
-                            )
-                                return 'ui-lib';
-                            // 나머지 주요 node_modules 라이브러리 통합
-                            if (
-                                id.includes('clsx') ||
-                                id.includes('tailwind-merge') ||
-                                id.includes('tailwind-variants')
-                            )
-                                return 'ui-lib';
-                            if (id.includes('date-fns') || id.includes('@internationalized'))
-                                return 'vendor-utils';
-                            if (
-                                id.includes('dompurify') ||
-                                id.includes('marked') ||
-                                id.includes('highlight.js')
-                            )
-                                return 'vendor-content';
-                            if (
-                                id.includes('runed') ||
-                                id.includes('nanoid') ||
-                                id.includes('devalue') ||
-                                id.includes('esm-env')
-                            )
-                                return 'svelte-runtime';
-                        }
-                    }
-                }
-            },
             assetsInlineLimit: 8192
         },
         ssr: {


### PR DESCRIPTION
## 긴급 수정

manualChunks가 Svelte 런타임 모듈 간 순환 참조를 발생시켜 `Cannot access 'Ct' before initialization` 에러 유발.

manualChunks 전체 제거, assetsInlineLimit(8KB)만 유지.