### PR TITLE
fix: 프로필 링크를 회원 링크로 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
+++ b/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
@@ -130,7 +130,7 @@
                                             size="sm"
                                         />
                                         <a
-                                            href="/profile/{liker.mb_id}"
+                                            href="/member/{liker.mb_id}"
                                             class="text-foreground hover:text-primary truncate text-sm font-medium"
                                         >
                                             {liker.mb_nick || liker.mb_name}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1369,7 +1369,7 @@
                                             size="sm"
                                         />
                                         <a
-                                            href="/profile/{liker.mb_id}"
+                                            href="/member/{liker.mb_id}"
                                             class="text-foreground hover:text-primary truncate text-sm font-medium"
                                         >
                                             {liker.mb_nick || liker.mb_name}


### PR DESCRIPTION
This pull request updates user profile link URLs in two Svelte components to ensure consistency in routing. The links to user profiles now use the `/member/{mb_id}` path instead of `/profile/{mb_id}`.

Routing consistency improvements:

* Updated the `href` attribute in `comment-likers-dialog.svelte` to use `/member/{liker.mb_id}` for user profile links.
* Updated the `href` attribute in `[boardId]/[postId]/+page.svelte` to use `/member/{liker.mb_id}` for user profile links. ([apps/web/src/routes/[boardId]/[postId]/+page.svelteL1372-R1372](diffhunk://#diff-5c04c7ddbba44a04f0226417ec907570a571781b1454affdd0bb4fdcf091409cL1372-R1372))

(Copilot이 작성했습니다.)