### PR TITLE
fix: 서버 장애 복원력 강화 (circuit breaker + timeout + stale cache + retry)

### DIFF
--- a/apps/web/src/lib/server/cache.ts
+++ b/apps/web/src/lib/server/cache.ts
@@ -34,6 +34,8 @@ const DEFAULT_OPTIONS: CacheOptions = {
 
 export interface Cache<T> {
     get(key: string): T | undefined;
+    /** TTL 만료되어도 stale 데이터 반환 (에러 fallback용) */
+    getStale(key: string): T | undefined;
     set(key: string, value: T): void;
     getOrSet(key: string, factory: () => Promise<T>): Promise<T>;
     delete(key: string): void;
@@ -65,6 +67,11 @@ export function createCache<T>(options?: Partial<CacheOptions>): Cache<T> {
                 return undefined;
             }
             return entry.value;
+        },
+
+        getStale(key: string): T | undefined {
+            const entry = store.get(key);
+            return entry?.value;
         },
 
         set(key: string, value: T): void {

--- a/apps/web/src/lib/server/circuit-breaker.ts
+++ b/apps/web/src/lib/server/circuit-breaker.ts
@@ -75,6 +75,6 @@ export class CircuitBreaker {
 
 /** 글로벌 백엔드 Circuit Breaker (싱글톤) */
 export const backendCircuitBreaker = new CircuitBreaker('backend', {
-    failureThreshold: 5,
-    resetTimeoutMs: 30_000
+    failureThreshold: 15,
+    resetTimeoutMs: 10_000
 });

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -50,8 +50,8 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
             board = cached;
         } else {
             const [boardRes, displaySettingsRes] = await Promise.all([
-                bFetch(`/api/v1/boards/${boardId}`, { headers }),
-                bFetch(`/api/v1/boards/${boardId}/display-settings`, { headers })
+                bFetch(`/api/v1/boards/${boardId}`, { headers, timeout: 3_000 }),
+                bFetch(`/api/v1/boards/${boardId}/display-settings`, { headers, timeout: 3_000 })
             ]);
             board = boardRes.ok ? ((await boardRes.json()).data as Board) : null;
 
@@ -138,11 +138,13 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
             // 프로모션 게시판: ads 서버에서 광고주별 제한된 게시글 조회
             const [promoBoardResult, noticesResult] = await Promise.allSettled([
                 fetchPromotionBoardPosts(),
-                bFetch(`/api/v1/boards/${boardId}/notices`, { headers }).then(async (res) => {
-                    if (!res.ok) return [];
-                    const json = await res.json();
-                    return (json.data as FreePost[]) || [];
-                })
+                bFetch(`/api/v1/boards/${boardId}/notices`, { headers, timeout: 3_000 }).then(
+                    async (res) => {
+                        if (!res.ok) return [];
+                        const json = await res.json();
+                        return (json.data as FreePost[]) || [];
+                    }
+                )
             ]);
 
             let posts: FreePost[] = [];
@@ -191,11 +193,13 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
             }),
             isSearching
                 ? Promise.resolve([])
-                : bFetch(`/api/v1/boards/${boardId}/notices`, { headers }).then(async (res) => {
-                      if (!res.ok) return [];
-                      const json = await res.json();
-                      return (json.data as FreePost[]) || [];
-                  }),
+                : bFetch(`/api/v1/boards/${boardId}/notices`, { headers, timeout: 3_000 }).then(
+                      async (res) => {
+                          if (!res.ok) return [];
+                          const json = await res.json();
+                          return (json.data as FreePost[]) || [];
+                      }
+                  ),
             fetchPromotionPosts()
         ]);
 
@@ -216,6 +220,11 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
             };
         } else {
             console.error('게시판 로딩 에러:', boardId, postsResult.reason);
+            // stale-while-error: 캐시 만료된 데이터라도 에러보다 나음
+            const stale = postsCache.getStale(postsCacheKey);
+            if (stale) {
+                return { ...stale, error: null };
+            }
             error = '게시글을 불러오는데 실패했습니다.';
         }
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -39,21 +39,25 @@ export const load: PageServerLoad = async ({
             await Promise.allSettled([
                 // 게시글 (Go 백엔드 직접 호출)
                 bFetch(`/api/v1/boards/${boardId}/posts/${postId}`, {
-                    headers
+                    headers,
+                    timeout: 8_000
                 }).then(async (res) => {
                     if (!res.ok) throw new Error(`Post API error: ${res.status}`);
                     const json = await res.json();
                     return json.data as FreePost;
                 }),
-                // 게시판 정보
-                bFetch(`/api/v1/boards/${boardId}`, { headers }).then(async (res) => {
-                    if (!res.ok) return null;
-                    const json = await res.json();
-                    return json.data;
-                }),
-                // 게시판 표시 설정
+                // 게시판 정보 (가벼움, 캐시됨)
+                bFetch(`/api/v1/boards/${boardId}`, { headers, timeout: 3_000 }).then(
+                    async (res) => {
+                        if (!res.ok) return null;
+                        const json = await res.json();
+                        return json.data;
+                    }
+                ),
+                // 게시판 표시 설정 (가벼움)
                 bFetch(`/api/v1/boards/${boardId}/display-settings`, {
-                    headers
+                    headers,
+                    timeout: 3_000
                 }).then(async (res) => {
                     if (!res.ok) return null;
                     const json = await res.json();
@@ -201,7 +205,8 @@ export const load: PageServerLoad = async ({
                 // 리비전 히스토리 (관리자 level ≥ 10일 때만)
                 (locals.user?.level ?? 0) >= 10
                     ? bFetch(`/api/v1/boards/${boardId}/posts/${postId}/revisions`, {
-                          headers
+                          headers,
+                          timeout: 3_000
                       }).then(async (res) => {
                           if (!res.ok) return [];
                           const json = await res.json();
@@ -215,7 +220,8 @@ export const load: PageServerLoad = async ({
                 ).catch(() => ({}) as Record<string, unknown>),
                 // 추천자 아바타 상위 5명 (Go 백엔드 직접 호출 — CDN 요청 제거)
                 bFetch(`/api/v1/boards/${boardId}/posts/${postId}/likers?page=1&limit=5`, {
-                    headers
+                    headers,
+                    timeout: 3_000
                 })
                     .then(async (res) => {
                         if (!res.ok) return { likers: [], total: 0 };

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -303,8 +303,26 @@
                     secondaryLoaded = true;
                 }
             )
-            .catch(() => {
+            .catch(async () => {
                 if (cancelled) return;
+                // 스트리밍 실패 시 클라이언트에서 댓글만 직접 재시도 (1회)
+                if (browser) {
+                    try {
+                        const res = await fetch(
+                            `/api/boards/${boardId}/posts/${data.post.id}/comments?page=1&limit=200`
+                        );
+                        if (res.ok) {
+                            const json = await res.json();
+                            if (json.success && json.data) {
+                                comments = json.data.comments || [];
+                                secondaryLoaded = true;
+                                return;
+                            }
+                        }
+                    } catch {
+                        // 재시도도 실패
+                    }
+                }
                 secondaryError = true;
                 secondaryLoaded = true;
             });


### PR DESCRIPTION
## Summary
- Circuit Breaker 완화: threshold 5→15, reset 30초→10초
- API별 timeout 차등: 보조 3초, 게시글 본문 8초
- stale-while-error: 목록 fetch 실패 시 만료 캐시 데이터 반환
- 댓글 클라이언트 재시도: SSR 스트리밍 실패 시 1회 자동 retry

## 문제 시나리오 (개선 전)
1. 백엔드 일시 지연 → 5회 timeout → Circuit Breaker OPEN
2. 30초간 **모든 페이지** SSR 차단 → 목록/댓글/홈 전부 실패
3. 사용자 새로고침 → 부하 폭증 → 악순환

## 개선 후
- 15회까지 허용 → 일시적 지연에 과민 반응 안 함
- OPEN 시 10초만 차단 → 빠른 복구
- 목록: 캐시 만료 데이터라도 표시 (빈 화면 방지)
- 댓글: SSR 실패해도 클라이언트에서 자동 재시도

## Test plan
- [ ] 게시판 목록 정상 로딩 확인
- [ ] 게시글 상세 + 댓글 정상 로딩 확인
- [ ] 빌드 성공 확인 (완료)