### PR TITLE
fix: 에디터 인용문/코드 주석에 font-synthesis: style 추가

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -1394,6 +1394,7 @@
         margin-left: 0;
         margin-bottom: 0.75rem;
         font-style: italic;
+        font-synthesis: style;
         color: var(--muted-foreground);
     }
 
@@ -1538,6 +1539,7 @@
     :global(.tiptap-content .tiptap .hljs-comment) {
         color: #6c7086;
         font-style: italic;
+        font-synthesis: style;
     }
     :global(.tiptap-content .tiptap .hljs-number) {
         color: #fab387;


### PR DESCRIPTION
## Summary
- Tiptap 에디터의 `blockquote`(인용문)와 `.hljs-comment`(코드 주석)에 `font-synthesis: style` 추가
- 한글 폰트에 이탤릭 글리프가 없어 `font-style: italic`이 무시되는 문제 수정
- 기존 markdown.svelte, comment-list.svelte, classic.svelte에는 이미 적용되어 있었으나 에디터에만 누락

## Test plan
- [ ] 에디터에서 인용문(blockquote) 작성 시 한글 이탤릭 렌더링 확인
- [ ] 에디터에서 코드 블록 내 한글 주석 이탤릭 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)