### PR TITLE
fix: $updated 리로드 횟수 제한 (무한 새로고침 방지)

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -94,10 +94,15 @@
         });
     });
 
-    // 새 버전 감지 시 다음 네비게이션에서 캐시 무효화 후 풀 리로드
+    // 새 버전 감지 시 다음 네비게이션에서 풀 리로드 (최대 2회, 무한 루프 방지)
+    const UPDATED_RELOAD_KEY = '__angple_updated_reload__';
     afterNavigate(({ type }) => {
         if ($updated && type !== 'enter') {
-            location.reload();
+            const count = Number(sessionStorage.getItem(UPDATED_RELOAD_KEY) || '0');
+            if (count < 2) {
+                sessionStorage.setItem(UPDATED_RELOAD_KEY, String(count + 1));
+                location.reload();
+            }
         }
     });
 
@@ -177,6 +182,9 @@
     });
 
     onMount(() => {
+        // $updated 리로드 카운터 리셋 (정상 로드 확인 후)
+        setTimeout(() => sessionStorage.removeItem(UPDATED_RELOAD_KEY), 10000);
+
         // Built-in Hooks 초기화 (콘텐츠 임베딩, 게시판 필터 등)
         initBuiltinHooks();
 


### PR DESCRIPTION
## Summary
- 배포 후 `$updated`가 true인 상태에서 CDN/SW 캐시 문제로 구 청크가 계속 서빙되면 `location.reload()`가 무한 반복되는 문제 수정
- `hooks.client.ts`의 chunk error 핸들러와 동일한 패턴: sessionStorage 카운터로 최대 2회 제한
- 정상 로드 후 10초 뒤 카운터 리셋

## Test plan
- [ ] 배포 후 무한 새로고침 없이 정상 로드 확인
- [ ] 정상 네비게이션 시 기존 동작(버전 감지 → 리로드) 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)