### PR TITLE
fix: JS 청크 로드 실패 시 사이트 다운 방지

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -93,40 +93,121 @@
                 }
             });
         </script>
-        <!-- JS chunk 로드 실패 시 자동 새로고침 (배포 후 캐시 불일치 대응) -->
+        <!-- 통합 청크 에러 핸들러 (app.html + hooks.client.ts 공유) -->
         <script>
             (function () {
-                var reloadKey = '_angple_reload';
-                var reloaded = sessionStorage.getItem(reloadKey);
+                var KEY = '__angple_chunk_error__';
+                var MAX_RELOADS = 2;
+                var WINDOW_MS = 60000;
+
+                function getState() {
+                    try {
+                        var raw = sessionStorage.getItem(KEY);
+                        if (raw) return JSON.parse(raw);
+                    } catch (e) {}
+                    return { count: 0, ts: 0, exhausted: false };
+                }
+
+                function setState(s) {
+                    try { sessionStorage.setItem(KEY, JSON.stringify(s)); } catch (e) {}
+                }
+
+                function isChunkError(msg) {
+                    if (!msg) return false;
+                    var m = msg.toLowerCase();
+                    return m.indexOf('failed to fetch dynamically imported module') !== -1 ||
+                        m.indexOf('importing a module script failed') !== -1 ||
+                        m.indexOf('error loading dynamically imported module') !== -1 ||
+                        m.indexOf('chunkloaderror') !== -1 ||
+                        (m.indexOf('load') !== -1 && m.indexOf('chunk') !== -1);
+                }
+
+                function handle() {
+                    var s = getState();
+                    var now = Date.now();
+                    // 윈도우 만료 시 리셋
+                    if (now - s.ts > WINDOW_MS) {
+                        s = { count: 0, ts: now, exhausted: false };
+                    }
+                    s.count++;
+                    s.ts = now;
+                    if (s.count <= MAX_RELOADS) {
+                        setState(s);
+                        location.reload();
+                    } else {
+                        s.exhausted = true;
+                        setState(s);
+                        // hooks.client.ts에서 배너 표시하도록 이벤트 발송
+                        try {
+                            window.dispatchEvent(new CustomEvent('angple:chunk-error-exhausted'));
+                        } catch (e) {}
+                    }
+                }
+
+                // 전역 노출 (hooks.client.ts와 공유)
+                window.__angpleChunkError = { getState: getState, handle: handle };
+
+                // <script>/<link> error 이벤트 캡처
                 window.addEventListener('error', function (e) {
-                    // immutable JS/CSS 로드 실패 감지
                     if (
                         e.target &&
                         (e.target.tagName === 'SCRIPT' || e.target.tagName === 'LINK') &&
-                        e.target.href &&
-                        e.target.href.indexOf('/_app/immutable/') !== -1 &&
-                        !reloaded
+                        (e.target.src || e.target.href || '').indexOf('/_app/immutable/') !== -1
                     ) {
-                        sessionStorage.setItem(reloadKey, '1');
-                        location.reload();
+                        handle();
                     }
                 }, true);
+
                 // 모듈 import 실패 감지
                 window.addEventListener('unhandledrejection', function (e) {
-                    if (
-                        e.reason &&
-                        e.reason.message &&
-                        e.reason.message.indexOf('Failed to fetch dynamically imported module') !== -1 &&
-                        !reloaded
-                    ) {
-                        sessionStorage.setItem(reloadKey, '1');
-                        location.reload();
+                    if (e.reason && e.reason.message && isChunkError(e.reason.message)) {
+                        handle();
                     }
                 });
-                // 정상 로드 시 플래그 제거
+
+                // 정상 로드 + hydration 완료 후 카운터 리셋 (10초 딜레이)
                 window.addEventListener('load', function () {
-                    sessionStorage.removeItem(reloadKey);
+                    setTimeout(function () {
+                        var s = getState();
+                        if (!s.exhausted) {
+                            try { sessionStorage.removeItem(KEY); } catch (e) {}
+                        }
+                    }, 10000);
                 });
+            })();
+        </script>
+        <!-- Raw JSON 감지: JS 로드 실패 시 __data.json이 화면에 표시되는 것 방지 -->
+        <script>
+            (function () {
+                setTimeout(function () {
+                    try {
+                        var text = document.body.innerText;
+                        if (!text) return;
+                        var trimmed = text.trim();
+                        if (
+                            trimmed.indexOf('{"type":"data","nodes":[') === 0 ||
+                            trimmed.indexOf('{"type":"redirect"') === 0
+                        ) {
+                            var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                            var bg = isDark ? '#111827' : '#f9fafb';
+                            var fg = isDark ? '#f9fafb' : '#111827';
+                            var cardBg = isDark ? '#1f2937' : '#fff';
+                            var borderColor = isDark ? '#374151' : '#e5e7eb';
+                            var btnBg = '#2563eb';
+                            document.documentElement.innerHTML =
+                                '<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>페이지 로딩 오류</title></head>' +
+                                '<body style="font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;background:' + bg + ';color:' + fg + ';padding:24px;margin:0">' +
+                                '<div style="background:' + cardBg + ';border:1px solid ' + borderColor + ';border-radius:12px;padding:40px;max-width:480px;width:100%;text-align:center">' +
+                                '<div style="font-size:48px;font-weight:700;color:#6b7280;margin-bottom:8px">!</div>' +
+                                '<h1 style="font-size:20px;font-weight:600;margin-bottom:12px">페이지를 불러올 수 없습니다</h1>' +
+                                '<p style="font-size:14px;color:#6b7280;margin-bottom:24px;line-height:1.6">새 버전이 배포되어 페이지를 표시할 수 없습니다.<br>아래 버튼을 눌러 새로고침해 주세요.</p>' +
+                                '<div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap">' +
+                                '<button onclick="location.reload()" style="padding:10px 20px;font-size:14px;font-weight:500;border-radius:8px;border:none;background:' + btnBg + ';color:#fff;cursor:pointer">새로고침</button>' +
+                                '<button onclick="if(navigator.serviceWorker){navigator.serviceWorker.getRegistrations().then(function(r){r.forEach(function(s){s.unregister()})})};if(window.caches){caches.keys().then(function(n){n.forEach(function(k){caches.delete(k)})})};setTimeout(function(){location.replace(location.href.split(\'?\')[0]+\'?_v=\'+Date.now())},300)" style="padding:10px 20px;font-size:14px;font-weight:500;border-radius:8px;border:1px solid ' + borderColor + ';background:transparent;color:' + fg + ';cursor:pointer">캐시 삭제 후 새로고침</button>' +
+                                '</div></div></body>';
+                        }
+                    } catch (e) {}
+                }, 3000);
             })();
         </script>
         <script>

--- a/apps/web/src/error.html
+++ b/apps/web/src/error.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="ko">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>오류 발생 - %sveltekit.status%</title>
+        <style>
+            *,
+            *::before,
+            *::after {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                min-height: 100vh;
+                background: #f9fafb;
+                color: #111827;
+                padding: 24px;
+            }
+            @media (prefers-color-scheme: dark) {
+                body {
+                    background: #111827;
+                    color: #f9fafb;
+                }
+                .card {
+                    background: #1f2937 !important;
+                    border-color: #374151 !important;
+                }
+                .btn {
+                    border-color: #4b5563 !important;
+                    color: #f9fafb !important;
+                }
+                .btn:hover {
+                    background: #374151 !important;
+                }
+                .btn-primary {
+                    background: #2563eb !important;
+                    border-color: #2563eb !important;
+                    color: #fff !important;
+                }
+                .btn-primary:hover {
+                    background: #1d4ed8 !important;
+                }
+                .status {
+                    color: #9ca3af !important;
+                }
+            }
+            .card {
+                background: #fff;
+                border: 1px solid #e5e7eb;
+                border-radius: 12px;
+                padding: 40px;
+                max-width: 480px;
+                width: 100%;
+                text-align: center;
+            }
+            .status {
+                font-size: 48px;
+                font-weight: 700;
+                color: #6b7280;
+                margin-bottom: 8px;
+            }
+            h1 {
+                font-size: 20px;
+                font-weight: 600;
+                margin-bottom: 12px;
+            }
+            p {
+                font-size: 14px;
+                color: #6b7280;
+                margin-bottom: 24px;
+                line-height: 1.6;
+            }
+            .actions {
+                display: flex;
+                gap: 12px;
+                justify-content: center;
+                flex-wrap: wrap;
+            }
+            .btn {
+                display: inline-flex;
+                align-items: center;
+                padding: 10px 20px;
+                font-size: 14px;
+                font-weight: 500;
+                border-radius: 8px;
+                border: 1px solid #d1d5db;
+                background: transparent;
+                color: #374151;
+                cursor: pointer;
+                text-decoration: none;
+                transition: background 0.15s;
+            }
+            .btn:hover {
+                background: #f3f4f6;
+            }
+            .btn-primary {
+                background: #2563eb;
+                border-color: #2563eb;
+                color: #fff;
+            }
+            .btn-primary:hover {
+                background: #1d4ed8;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="card">
+            <div class="status">%sveltekit.status%</div>
+            <h1>페이지를 불러올 수 없습니다</h1>
+            <p>%sveltekit.error.message%</p>
+            <div class="actions">
+                <button class="btn btn-primary" onclick="location.reload()">새로고침</button>
+                <button
+                    class="btn"
+                    onclick="if(navigator.serviceWorker){navigator.serviceWorker.getRegistrations().then(function(r){r.forEach(function(s){s.unregister()})})};if(window.caches){caches.keys().then(function(n){n.forEach(function(k){caches.delete(k)})})};setTimeout(function(){location.replace(location.href.split('?')[0]+'?_v='+Date.now())},300)"
+                >
+                    캐시 삭제 후 새로고침
+                </button>
+            </div>
+        </div>
+    </body>
+</html>

--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -61,14 +61,9 @@ function isChunkLoadError(error: unknown): boolean {
 }
 
 /**
- * Chunk error 시 자동 새로고침 (최대 2회)
- * sessionStorage 카운터로 무한 루프 방지
- * 2회 실패 시 사용자에게 새 버전 배포 안내 UI 표시
+ * 캐시 전체 삭제 후 리로드 (배너 새로고침 버튼에서 사용)
  */
-const RELOAD_KEY = '__angple_chunk_reload_count__';
-
 function clearCachesAndReload(): void {
-    // SW 해제 + Cache Storage 전체 삭제 후 캐시 무시 리로드
     const tasks: Promise<void>[] = [];
     if (navigator.serviceWorker) {
         tasks.push(
@@ -85,21 +80,9 @@ function clearCachesAndReload(): void {
         );
     }
     Promise.all(tasks).finally(() => {
-        // cache-busting query로 브라우저 캐시 우회
         const url = location.href.split('?')[0];
         location.replace(url + '?_v=' + Date.now());
     });
-}
-
-function tryChunkReload(): void {
-    const count = Number(sessionStorage.getItem(RELOAD_KEY) || '0');
-    if (count < 2) {
-        sessionStorage.setItem(RELOAD_KEY, String(count + 1));
-        clearCachesAndReload();
-    } else {
-        sessionStorage.removeItem(RELOAD_KEY);
-        showUpdateNotice();
-    }
 }
 
 function showUpdateNotice(): void {
@@ -142,13 +125,24 @@ function showUpdateNotice(): void {
     });
 }
 
-// 성공적으로 페이지 로드 + hydration 완료 후 카운터 리셋
-// load 직후 제거하면 hydration 중 chunk error로 카운터가 리셋되어 무한 리로드 발생
+// app.html 통합 핸들러와 연동: exhausted 상태면 배너 표시
 if (typeof window !== 'undefined') {
-    window.addEventListener('load', () => {
-        setTimeout(() => {
-            sessionStorage.removeItem(RELOAD_KEY);
-        }, 10000);
+    // 페이지 로드 시 exhausted 체크
+    const chunkError = (window as any).__angpleChunkError;
+    if (chunkError) {
+        const state = chunkError.getState();
+        if (state.exhausted) {
+            // DOM 준비 후 배너 표시
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', () => showUpdateNotice());
+            } else {
+                showUpdateNotice();
+            }
+        }
+    }
+    // 리로드 한도 초과 이벤트 수신
+    window.addEventListener('angple:chunk-error-exhausted', () => {
+        showUpdateNotice();
     });
 }
 
@@ -156,9 +150,12 @@ if (typeof window !== 'undefined') {
 export const handleError: HandleClientError = ({ error, event, status }) => {
     const err = error instanceof Error ? error : new Error(String(error));
 
-    // 배포 후 chunk 로드 실패 → 자동 새로고침 (최대 2회)
+    // 배포 후 chunk 로드 실패 → app.html 통합 핸들러에 위임
     if (isChunkLoadError(error)) {
-        tryChunkReload();
+        const chunkError = (window as any).__angpleChunkError;
+        if (chunkError) {
+            chunkError.handle();
+        }
         return;
     }
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -95,8 +95,16 @@
     });
 
     // 새 버전 감지 시 다음 네비게이션에서 캐시 무효화 후 풀 리로드
+    // 단, chunk error 리로드 한도 초과 시 스킵 (리로드 루프 방지)
     afterNavigate(({ type }) => {
         if ($updated && type !== 'enter') {
+            try {
+                const raw = sessionStorage.getItem('__angple_chunk_error__');
+                if (raw) {
+                    const s = JSON.parse(raw);
+                    if (s.count >= 2 || s.exhausted) return;
+                }
+            } catch {}
             location.reload();
         }
     });

--- a/apps/web/static/sw.js
+++ b/apps/web/static/sw.js
@@ -67,6 +67,12 @@ self.addEventListener('fetch', (event) => {
         return;
     }
 
+    // __data.json Circuit Breaker: 연속 실패 시 서버 요청 폭풍 차단
+    if (url.pathname.endsWith('/__data.json')) {
+        event.respondWith(dataJsonWithCircuitBreaker(request));
+        return;
+    }
+
     // HTML 내비게이션: Network Only (오프라인 폴백 없음)
     if (request.mode === 'navigate') {
         return;
@@ -132,6 +138,48 @@ self.addEventListener('notificationclick', (event) => {
         })
     );
 });
+
+/** __data.json Circuit Breaker */
+let dataJsonFailCount = 0;
+let dataJsonCooldownUntil = 0;
+const DATA_JSON_MAX_FAILS = 3;
+const DATA_JSON_COOLDOWN_MS = 10000;
+
+async function dataJsonWithCircuitBreaker(request) {
+    const now = Date.now();
+    // 쿨다운 중이면 즉시 503 반환
+    if (dataJsonFailCount >= DATA_JSON_MAX_FAILS && now < dataJsonCooldownUntil) {
+        return new Response(
+            JSON.stringify({ error: 'Circuit breaker open — too many failures' }),
+            { status: 503, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+    // 쿨다운 만료 시 리셋
+    if (now >= dataJsonCooldownUntil && dataJsonFailCount >= DATA_JSON_MAX_FAILS) {
+        dataJsonFailCount = 0;
+    }
+    try {
+        const response = await fetch(request);
+        if (response.ok) {
+            dataJsonFailCount = 0; // 성공 시 즉시 리셋
+        } else {
+            dataJsonFailCount++;
+            if (dataJsonFailCount >= DATA_JSON_MAX_FAILS) {
+                dataJsonCooldownUntil = Date.now() + DATA_JSON_COOLDOWN_MS;
+            }
+        }
+        return response;
+    } catch {
+        dataJsonFailCount++;
+        if (dataJsonFailCount >= DATA_JSON_MAX_FAILS) {
+            dataJsonCooldownUntil = Date.now() + DATA_JSON_COOLDOWN_MS;
+        }
+        return new Response(
+            JSON.stringify({ error: 'Network error' }),
+            { status: 503, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+}
 
 /** 정적 자산 판별 */
 function isStaticAsset(pathname) {


### PR DESCRIPTION
## Summary

- **통합 청크 에러 핸들러**: `app.html`과 `hooks.client.ts`의 중복 핸들러를 단일 `__angple_chunk_error__` 키로 통합. 60초 윈도우 내 최대 2회 리로드, 한도 초과 시 배너 표시
- **Raw JSON 감지**: JS 로드 실패로 `__data.json`이 화면에 표시되면 에러 페이지로 교체
- **`__data.json` Circuit Breaker (SW)**: 3회 연속 네트워크 실패 시 즉시 503 반환, 10초 쿨다운 후 리셋
- **`error.html`**: SvelteKit SSR 렌더링 실패 시 정적 fallback 페이지 (다크모드 지원)
- **`$updated` 리로드 가드**: chunk error exhausted 상태에서 `afterNavigate` 리로드 루프 방지

## Test plan

- [ ] DevTools에서 `_app/immutable/` JS 파일 1개 차단 → 에러 페이지 표시 (raw JSON 아님)
- [ ] 리로드 2회 후 배너 표시 확인
- [ ] Network 탭에서 `__data.json` 요청 폭풍 없음 확인
- [ ] 정상 로드 시 아무 영향 없음 확인