### PR TITLE
fix: 플러그인 hook 로더 .ts/.js 확장자 매칭 수정

### DIFF
--- a/apps/web/src/lib/hooks/plugin-loader.ts
+++ b/apps/web/src/lib/hooks/plugin-loader.ts
@@ -88,15 +88,22 @@ export async function loadPluginHooks(
                 }
 
                 // Hook 파일 경로 생성
+                // Vite 빌드 시 .ts → .js로 변환되므로 두 확장자 모두 시도
                 const officialPath = `../../../../../plugins/${pluginId}/${callback}`;
                 const customPath = `../../../../../custom-plugins/${pluginId}/${callback}`;
+                const officialPathJs = officialPath.replace(/\.ts$/, '.js');
+                const customPathJs = customPath.replace(/\.ts$/, '.js');
 
                 let hookModule: { default?: unknown } | null = null;
 
                 if (officialPath in allPluginHooks) {
                     hookModule = (await allPluginHooks[officialPath]()) as { default?: unknown };
+                } else if (officialPathJs in allPluginHooks) {
+                    hookModule = (await allPluginHooks[officialPathJs]()) as { default?: unknown };
                 } else if (customPath in allPluginHooks) {
                     hookModule = (await allPluginHooks[customPath]()) as { default?: unknown };
+                } else if (customPathJs in allPluginHooks) {
+                    hookModule = (await allPluginHooks[customPathJs]()) as { default?: unknown };
                 }
 
                 if (!hookModule) {


### PR DESCRIPTION
## Summary

- Vite 빌드 시 `import.meta.glob` 키가 `.ts` → `.js`로 변환됨
- `plugin.json`의 callback 경로(`hooks/register-layouts.ts`)와 불일치
- `.ts`로 먼저 매칭 시도, 없으면 `.js`로 fallback 추가

## Test plan

- [ ] 운영에서 `register-layouts.js 404` 에러 사라짐 확인