### PR TITLE
fix: 회원 아이콘 403 에러 반복 요청 방지

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -18,7 +18,7 @@
     import { getHookVersion } from '$lib/hooks/hook-state.svelte';
     import { tick } from 'svelte';
     import { highlightAllCodeBlocks } from '$lib/utils/code-highlight';
-    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl, getMemberIconUrl, handleIconError } from '$lib/utils/member-icon.js';
     import { SvelteMap, SvelteSet } from 'svelte/reactivity';
     import type { Component } from 'svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
@@ -704,7 +704,12 @@
             <!-- Chat: 사이드 아바타 -->
             {#if commentLayout === 'chat'}
                 {#if iconUrl}
-                    <img src={iconUrl} alt="" class="size-8 shrink-0 rounded-full object-cover" />
+                    <img
+                        src={iconUrl}
+                        alt=""
+                        class="size-8 shrink-0 rounded-full object-cover"
+                        onerror={handleIconError}
+                    />
                 {:else}
                     <div
                         class="bg-muted text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-full text-xs"

--- a/apps/web/src/lib/components/ui/avatar-stack/avatar-stack.svelte
+++ b/apps/web/src/lib/components/ui/avatar-stack/avatar-stack.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getMemberIconUrl, handleIconError } from '$lib/utils/member-icon.js';
 
     interface AvatarItem {
         mb_id: string;
@@ -40,9 +40,9 @@
                     title={nick}
                     class="{sizeClass} ring-background rounded-full object-cover ring-2"
                     onerror={(e) => {
-                        const img = e.currentTarget as HTMLImageElement;
-                        img.style.display = 'none';
-                        const fallback = img.nextElementSibling as HTMLElement;
+                        handleIconError(e);
+                        const fallback = (e.currentTarget as HTMLElement)
+                            .nextElementSibling as HTMLElement;
                         if (fallback) fallback.style.display = 'flex';
                     }}
                 />

--- a/apps/web/src/lib/utils/member-icon.ts
+++ b/apps/web/src/lib/utils/member-icon.ts
@@ -8,6 +8,11 @@ const CDN_BASE_URL = 'https://s3.damoang.net';
 const LEGACY_BASE_URL = 'https://damoang.net';
 
 /**
+ * 이미지 로드 실패한 mb_id 캐시 (세션 내 재요청 방지)
+ */
+const failedIconCache = new Set<string>();
+
+/**
  * avatar_url 또는 mb_image_url로 전체 URL 생성
  * @param avatarUrl API에서 받은 avatar_url (예: data/member_image/ad/admin_1760156943.webp)
  * @returns 전체 URL 또는 null
@@ -26,11 +31,13 @@ export function getAvatarUrl(avatarUrl: string | null | undefined): string | nul
 
 /**
  * 회원 ID로 아이콘 URL 생성 (폴백용)
+ * 이전에 로드 실패한 ID는 null 반환 (불필요한 403 요청 방지)
  * @param mbId 회원 ID (예: google_78ca0772, naver_889808c8)
  * @returns 아이콘 URL 또는 null
  */
 export function getMemberIconUrl(mbId: string | null | undefined): string | null {
     if (!mbId || mbId.length < 2) return null;
+    if (failedIconCache.has(mbId)) return null;
 
     const prefix = mbId.substring(0, 2).toLowerCase();
     return `${LEGACY_BASE_URL}/data/member_image/${prefix}/${mbId}.gif`;
@@ -43,6 +50,10 @@ export function getMemberIconUrl(mbId: string | null | undefined): string | null
 export function handleIconError(event: Event): void {
     const img = event.target as HTMLImageElement;
     if (img) {
+        const match = img.src.match(/\/member_image\/\w+\/([^.]+)\.\w+/);
+        if (match) {
+            failedIconCache.add(match[1]);
+        }
         img.style.display = 'none';
     }
 }


### PR DESCRIPTION
## Summary
- 프로필 이미지 없는 회원의 아이콘 URL 403 에러가 반복 발생하는 문제 수정
- `failedIconCache` Set으로 실패한 mb_id를 메모리 캐시하여 동일 세션 내 재요청 차단
- `handleIconError`에서 src URL 파싱 후 캐시에 등록, 이후 `getMemberIconUrl`에서 null 반환

## Test plan
- [ ] 프로필 이미지 없는 회원 댓글에서 403 에러가 1회만 발생하는지 확인
- [ ] 프로필 이미지 있는 회원은 정상 표시되는지 확인
- [ ] avatar-stack(추천인 목록)에서도 동일하게 동작하는지 확인