### PR TITLE
fix: ang-gnu 방식으로 단축키 폴백 수정

### DIFF
--- a/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
+++ b/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
@@ -181,9 +181,9 @@ class KeyboardShortcutService {
             return;
         }
 
-        // 시스템 단축키 체크
-        const systemUrl = this.systemShortcuts.get(code);
-        if (systemUrl && systemUrl !== DEFAULT_URL) {
+        // 시스템 단축키 체크 (A-Z 키)
+        if (code.startsWith('Key')) {
+            const systemUrl = this.systemShortcuts.get(code) ?? DEFAULT_URL;
             event.preventDefault();
             this.navigate(systemUrl);
             return;


### PR DESCRIPTION
## Summary
- H키가 `DEFAULT_URL('/')`과 동일하여 조건문에서 무시되던 버그 수정
- 미할당 A-Z 키 입력 시 홈(`/`)으로 이동하도록 폴백 추가 (ang-gnu 동작 방식과 동일)

## Test plan
- [x] H키 → 홈으로 이동 확인
- [x] 할당된 키 → 해당 URL로 이동 확인
- [x] 미할당 키 → 홈으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)