### PR TITLE
fix: GAM 지연 로드 슬롯 광고 미노출 수정

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -396,7 +396,6 @@
             }
 
             if (!mgr.servicesEnabled) {
-                googletag.pubads().enableSingleRequest();
                 googletag.pubads().collapseEmptyDivs();
                 googletag.pubads().enableLazyLoad({
                     fetchMarginPercent: 200,


### PR DESCRIPTION
## Summary
- `enableSingleRequest()` 제거: SRA 모드에서 서비스 활성화 후 추가되는 슬롯(DamoangBanner GAM fallback)에 광고 요청이 안 가는 문제 수정
- 수익 직결 이슈 긴급 수정

## 원인
PR #370에서 추가된 `enableSingleRequest()`가 SRA 모드를 활성화하면서, `DamoangBanner`처럼 자체 배너 확인 후 fallback으로 GAM 슬롯을 생성하는 경우 이미 서비스가 활성화된 후라 광고 요청이 누락됨