### PR TITLE
fix: 게시판 목록 메모 배지 위치 이동

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -195,6 +195,11 @@
                     {#if post.comments_count > 0}
                         <span class="comment-count shrink-0">+{post.comments_count}</span>
                     {/if}
+                    {#if memoPluginActive && MemoBadge}
+                        <span class="ml-auto shrink-0">
+                            <MemoBadge memberId={post.author_id} />
+                        </span>
+                    {/if}
                 </div>
 
                 <!-- 이름 (col 3, 데스크톱만) — legacy: 13px, 100px wide -->
@@ -208,9 +213,6 @@
                             class="h-5 w-5 shrink-0 rounded-full object-cover"
                             onerror={handleIconError}
                         />
-                    {/if}
-                    {#if memoPluginActive && MemoBadge}
-                        <MemoBadge memberId={post.author_id} />
                     {/if}
                     <AuthorLink authorId={post.author_id} authorName={post.author} />
                 </span>
@@ -246,9 +248,6 @@
                                 class="h-5 w-5 shrink-0 rounded-full object-cover"
                                 onerror={handleIconError}
                             />
-                        {/if}
-                        {#if memoPluginActive && MemoBadge}
-                            <MemoBadge memberId={post.author_id} />
                         {/if}
                         <AuthorLink authorId={post.author_id} authorName={post.author} />
                     </span>


### PR DESCRIPTION
## Summary
- 메모 배지를 작성자 컬럼에서 제목 행(댓글 수 뒤)으로 이동
- 모바일/데스크톱 동일하게 제목 옆에 표시되도록 통일
- 모바일 메타 영역에서 중복 배지 제거

## Test plan
- [ ] `/free` 게시판 목록에서 메모 배지가 제목 행에 표시되는지 확인
- [ ] 모바일에서도 동일하게 표시되는지 확인
- [ ] 메모가 없는 회원은 배지가 보이지 않는지 확인