### PR TITLE
fix: 빠른 이동 네비게이션 메뉴 순서 변경

### DIFF
--- a/apps/web/src/lib/components/features/widget-editor/widget-settings-dialog.svelte
+++ b/apps/web/src/lib/components/features/widget-editor/widget-settings-dialog.svelte
@@ -22,14 +22,14 @@
     const { widget, zone, open, onOpenChange }: Props = $props();
 
     const DEFAULT_TAG_NAV_MENUS: TagNavMenu[] = [
-        { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
         { key: 'free', text: '자유게시판', url: '/free', show: true },
-        { key: 'group', text: '소모임', url: '/groups', show: true },
+        { key: 'qa', text: '질문과답변', url: '/qa', show: true },
         { key: 'new', text: '새로운소식', url: '/new', show: true },
         { key: 'economy', text: '알뜰구매', url: '/economy', show: true },
         { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
-        { key: 'qa', text: '질문과답변', url: '/qa', show: true },
         { key: 'lecture', text: '강좌&팁', url: '/lecture', show: true },
+        { key: 'group', text: '소모임', url: '/groups', show: true },
+        { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
         { key: 'message', text: '축하메시지', url: '/message', show: true }
     ];
 

--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -14,14 +14,14 @@
     }
 
     const DEFAULT_MENUS: TagNavMenu[] = [
-        { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
         { key: 'free', text: '자유게시판', url: '/free', show: true },
-        { key: 'group', text: '소모임', url: '/groups', show: true },
+        { key: 'qa', text: '질문과답변', url: '/qa', show: true },
         { key: 'new', text: '새로운소식', url: '/new', show: true },
         { key: 'economy', text: '알뜰구매', url: '/economy', show: true },
         { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
-        { key: 'qa', text: '질문과답변', url: '/qa', show: true },
         { key: 'lecture', text: '강좌&팁', url: '/lecture', show: true },
+        { key: 'group', text: '소모임', url: '/groups', show: true },
+        { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
         { key: 'message', text: '축하메시지', url: '/message', show: true }
     ];
 


### PR DESCRIPTION
## Summary
- 빠른 이동(TagNav) 메뉴 순서를 변경
- 변경 후: 자유게시판 → 질문과답변 → 새로운소식 → 알뜰구매 → 직접홍보 → 강좌&팁 → 소모임 → 사용기 → 축하메시지

## 수정 파일
- `tag-nav.svelte` — DEFAULT_MENUS 순서 변경
- `widget-settings-dialog.svelte` — DEFAULT_TAG_NAV_MENUS 순서 동일하게 변경