### PR TITLE
fix: 모바일 추천글 탭 가로 스크롤로 변경

### DIFF
--- a/apps/web/src/lib/components/features/recommended/components/tabs/recommended-tabs.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/tabs/recommended-tabs.svelte
@@ -27,13 +27,13 @@
     }
 </script>
 
-<!-- Pill 스타일 탭 -->
-<div class="flex flex-wrap justify-end gap-1">
+<!-- Pill 스타일 탭 (모바일: 가로 스크롤) -->
+<div class="flex gap-1 overflow-x-auto" style="-ms-overflow-style:none;scrollbar-width:none">
     {#each tabs as tab (tab.id)}
         {#if !tab.hidden}
             <button
                 type="button"
-                class="rounded-md px-2 py-1 text-xs font-medium transition-all duration-200 ease-out sm:px-2.5 sm:text-[15px]
+                class="shrink-0 whitespace-nowrap rounded-md px-2 py-1 text-xs font-medium transition-all duration-200 ease-out sm:px-2.5 sm:text-[15px]
                     {activeTab === tab.id
                     ? 'bg-primary text-primary-foreground'
                     : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"


### PR DESCRIPTION
## Summary
- 모바일에서 추천글 시간 탭이 2줄로 넘어가는 문제 개선
- `flex-wrap` → `overflow-x-auto` 가로 스크롤로 변경
- 스크롤바 숨김 처리

Ref: https://damoang.net/bug/7774

## Test plan
- [ ] 모바일에서 추천글 탭이 한 줄 가로 스크롤로 표시되는지 확인
- [ ] 데스크톱에서 기존과 동일하게 표시되는지 확인