### PR TITLE
feat: 알림 그룹화 UI + 필터 탭

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -33,6 +33,7 @@ import type {
     PointHistoryResponse,
     NotificationSummary,
     NotificationListResponse,
+    GroupedNotificationListResponse,
     MessageKind,
     MessageListResponse,
     Message,
@@ -1522,6 +1523,46 @@ class ApiClient {
      */
     async deleteNotification(notificationId: number): Promise<void> {
         await this.request<void>(`/notifications/${notificationId}`, {
+            method: 'DELETE'
+        });
+    }
+
+    /**
+     * 그룹화 알림 목록 조회
+     */
+    async getGroupedNotifications(
+        page: number = 1,
+        limit: number = 20,
+        filterType: string = ''
+    ): Promise<GroupedNotificationListResponse> {
+        const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+        if (filterType) params.set('type', filterType);
+        const response = await this.request<GroupedNotificationListResponse>(
+            `/notifications/grouped?${params}`
+        );
+        return response.data;
+    }
+
+    /**
+     * 그룹 알림 읽음 처리
+     */
+    async markGroupAsRead(boTable: string, wrId: number, fromCase: string): Promise<void> {
+        await this.request<void>('/notifications/group/read', {
+            method: 'POST',
+            body: JSON.stringify({ bo_table: boTable, wr_id: wrId, from_case: fromCase })
+        });
+    }
+
+    /**
+     * 그룹 알림 삭제
+     */
+    async deleteNotificationGroup(boTable: string, wrId: number, fromCase: string): Promise<void> {
+        const params = new URLSearchParams({
+            bo_table: boTable,
+            wr_id: String(wrId),
+            from_case: fromCase
+        });
+        await this.request<void>(`/notifications/group?${params}`, {
             method: 'DELETE'
         });
     }

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -718,6 +718,33 @@ export interface NotificationListResponse {
     total_pages: number;
 }
 
+// 그룹화 알림
+export interface GroupedNotification {
+    type: NotificationType;
+    bo_table: string;
+    wr_id: number;
+    title: string;
+    url?: string;
+    parent_subject?: string;
+    content?: string;
+    latest_sender: string;
+    senders: string[];
+    sender_count: number;
+    unread_count: number;
+    has_unread: boolean;
+    latest_at: string;
+    from_case: string;
+}
+
+export interface GroupedNotificationListResponse {
+    items: GroupedNotification[];
+    total: number;
+    unread_count: number;
+    page: number;
+    limit: number;
+    total_pages: number;
+}
+
 // 쪽지 관련 타입
 export type MessageKind = 'recv' | 'send'; // 받은쪽지 / 보낸쪽지
 

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -3,7 +3,7 @@
     import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
     import { apiClient } from '$lib/api/index.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
-    import type { Notification, NotificationListResponse } from '$lib/api/types.js';
+    import type { GroupedNotification } from '$lib/api/types.js';
     import { onMount } from 'svelte';
     import { goto } from '$app/navigation';
     import Bell from '@lucide/svelte/icons/bell';
@@ -11,19 +11,16 @@
     import Reply from '@lucide/svelte/icons/reply';
     import AtSign from '@lucide/svelte/icons/at-sign';
     import Heart from '@lucide/svelte/icons/heart';
-    import Mail from '@lucide/svelte/icons/mail';
     import Info from '@lucide/svelte/icons/info';
     import Check from '@lucide/svelte/icons/check';
     import Loader2 from '@lucide/svelte/icons/loader-2';
 
-    // 상태
-    let notifications = $state<Notification[]>([]);
+    let notifications = $state<GroupedNotification[]>([]);
     let unreadCount = $state(0);
     let isLoading = $state(false);
     let isOpen = $state(false);
 
-    // 알림 타입별 아이콘
-    function getNotificationIcon(type: Notification['type']) {
+    function getNotificationIcon(type: string) {
         switch (type) {
             case 'comment':
                 return MessageSquare;
@@ -33,16 +30,12 @@
                 return AtSign;
             case 'like':
                 return Heart;
-            case 'message':
-                return Mail;
-            case 'system':
             default:
                 return Info;
         }
     }
 
-    // 알림 타입별 색상
-    function getNotificationColor(type: Notification['type']): string {
+    function getNotificationColor(type: string): string {
         switch (type) {
             case 'comment':
                 return 'text-blue-500';
@@ -52,15 +45,11 @@
                 return 'text-purple-500';
             case 'like':
                 return 'text-red-500';
-            case 'message':
-                return 'text-orange-500';
-            case 'system':
             default:
                 return 'text-muted-foreground';
         }
     }
 
-    // 시간 포맷
     function formatTime(dateString: string): string {
         const date = new Date(dateString);
         const now = new Date();
@@ -82,7 +71,6 @@
         });
     }
 
-    // 읽지 않은 알림 수 로드
     async function loadUnreadCount(): Promise<void> {
         if (!authStore.isAuthenticated) return;
 
@@ -94,13 +82,12 @@
         }
     }
 
-    // 알림 목록 로드
     async function loadNotifications(): Promise<void> {
         if (!authStore.isAuthenticated) return;
 
         isLoading = true;
         try {
-            const response = await apiClient.getNotifications(1, 10);
+            const response = await apiClient.getGroupedNotifications(1, 10);
             notifications = response.items;
             unreadCount = response.unread_count;
         } catch (err) {
@@ -110,24 +97,25 @@
         }
     }
 
-    // 알림 클릭 처리
-    async function handleNotificationClick(notification: Notification): Promise<void> {
-        // 읽음 처리
-        if (!notification.is_read) {
+    async function handleNotificationClick(notification: GroupedNotification): Promise<void> {
+        if (notification.has_unread) {
             try {
-                await apiClient.markNotificationAsRead(notification.id);
-                notification.is_read = true;
-                unreadCount = Math.max(0, unreadCount - 1);
+                await apiClient.markGroupAsRead(
+                    notification.bo_table,
+                    notification.wr_id,
+                    notification.from_case
+                );
+                notification.has_unread = false;
+                unreadCount = Math.max(0, unreadCount - notification.unread_count);
+                notification.unread_count = 0;
             } catch (err) {
                 console.error('Failed to mark as read:', err);
             }
         }
 
-        // URL이 있으면 이동
         if (notification.url) {
             isOpen = false;
             let url = notification.url;
-            // 추천 알림에 앵커가 없으면 #likes 추가
             if (notification.type === 'like' && !url.includes('#')) {
                 url += '#likes';
             }
@@ -135,18 +123,20 @@
         }
     }
 
-    // 모두 읽음 처리
     async function handleMarkAllAsRead(): Promise<void> {
         try {
             await apiClient.markAllNotificationsAsRead();
-            notifications = notifications.map((n) => ({ ...n, is_read: true }));
+            notifications = notifications.map((n) => ({
+                ...n,
+                has_unread: false,
+                unread_count: 0
+            }));
             unreadCount = 0;
         } catch (err) {
             console.error('Failed to mark all as read:', err);
         }
     }
 
-    // 드롭다운 열릴 때 알림 로드
     function handleOpenChange(open: boolean): void {
         isOpen = open;
         if (open) {
@@ -154,7 +144,6 @@
         }
     }
 
-    // 초기 로드 + Page Visibility API 기반 폴링
     onMount(() => {
         loadUnreadCount();
 
@@ -174,14 +163,13 @@
 
         function handleVisibilityChange() {
             if (document.visibilityState === 'visible') {
-                loadUnreadCount(); // 탭 복귀 시 즉시 1회 호출
+                loadUnreadCount();
                 startPolling();
             } else {
                 stopPolling();
             }
         }
 
-        // 탭이 보일 때만 폴링
         if (document.visibilityState === 'visible') {
             startPolling();
         }
@@ -229,33 +217,33 @@
             {:else if notifications.length === 0}
                 <div class="text-muted-foreground py-8 text-center text-sm">알림이 없습니다</div>
             {:else}
-                {#each notifications as notification (notification.id)}
+                {#each notifications as notification, i}
                     {@const Icon = getNotificationIcon(notification.type)}
                     <DropdownMenu.Item
-                        class="flex cursor-pointer items-start gap-3 p-3 {notification.is_read
-                            ? 'opacity-60'
-                            : 'bg-muted/30'}"
+                        class="flex cursor-pointer items-start gap-2.5 px-3 py-2 {notification.has_unread
+                            ? 'bg-muted/30'
+                            : 'opacity-60'}"
                         onclick={() => handleNotificationClick(notification)}
                     >
                         <div class="mt-0.5 shrink-0">
                             <Icon class="h-4 w-4 {getNotificationColor(notification.type)}" />
                         </div>
                         <div class="min-w-0 flex-1">
-                            <p class="text-foreground line-clamp-1 text-sm font-medium">
+                            <p class="text-foreground line-clamp-1 text-[13px] font-medium">
                                 {notification.title}
                             </p>
                             {#if notification.parent_subject}
-                                <p class="text-muted-foreground mt-0.5 line-clamp-1 text-xs">
-                                    "{notification.parent_subject}"
+                                <p class="text-muted-foreground mt-0.5 line-clamp-1 text-[11px]">
+                                    {notification.parent_subject}
                                 </p>
                             {/if}
-                            <p class="text-muted-foreground mt-0.5 text-[11px]">
-                                {formatTime(notification.created_at)}
+                            <p class="text-muted-foreground mt-0.5 text-[10px]">
+                                {formatTime(notification.latest_at)}
                             </p>
                         </div>
-                        {#if !notification.is_read}
-                            <div class="shrink-0">
-                                <div class="bg-primary h-2 w-2 rounded-full"></div>
+                        {#if notification.has_unread}
+                            <div class="mt-1 shrink-0">
+                                <div class="bg-primary h-1.5 w-1.5 rounded-full"></div>
                             </div>
                         {/if}
                     </DropdownMenu.Item>
@@ -290,15 +278,7 @@
         overflow: hidden;
     }
 
-    .line-clamp-2 {
-        display: -webkit-box;
-        line-clamp: 2;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-    }
-
-    /* 벨 흔들림 애니메이션 (asis 스타일) */
+    /* 벨 흔들림 애니메이션 */
     .bell-ring {
         animation: bell-ring 6s 0.7s infinite;
         transform-origin: 50% 4px;

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -1,33 +1,40 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import type { PageData } from './$types.js';
     import { apiClient } from '$lib/api/index.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
-    import type { Notification, NotificationListResponse } from '$lib/api/types.js';
+    import type { GroupedNotificationListResponse, GroupedNotification } from '$lib/api/types.js';
     import { onMount } from 'svelte';
     import Bell from '@lucide/svelte/icons/bell';
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import Reply from '@lucide/svelte/icons/reply';
     import AtSign from '@lucide/svelte/icons/at-sign';
     import Heart from '@lucide/svelte/icons/heart';
-    import Mail from '@lucide/svelte/icons/mail';
     import Info from '@lucide/svelte/icons/info';
     import Check from '@lucide/svelte/icons/check';
     import Trash2 from '@lucide/svelte/icons/trash-2';
     import Loader2 from '@lucide/svelte/icons/loader-2';
     import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+    import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+    import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
     let { data }: { data: PageData } = $props();
 
-    // 상태
-    let notificationData = $state<NotificationListResponse | null>(null);
+    let notificationData = $state<GroupedNotificationListResponse | null>(null);
     let isLoading = $state(true);
     let error = $state<string | null>(null);
+    let activeFilter = $state('');
 
-    // 알림 타입별 아이콘
-    function getNotificationIcon(type: Notification['type']) {
+    const filters = [
+        { key: '', label: '전체' },
+        { key: 'comment', label: '댓글' },
+        { key: 'like', label: '추천' },
+        { key: 'mention', label: '멘션' },
+        { key: 'system', label: '시스템' }
+    ];
+
+    function getNotificationIcon(type: string) {
         switch (type) {
             case 'comment':
                 return MessageSquare;
@@ -37,16 +44,12 @@
                 return AtSign;
             case 'like':
                 return Heart;
-            case 'message':
-                return Mail;
-            case 'system':
             default:
                 return Info;
         }
     }
 
-    // 알림 타입별 색상
-    function getNotificationColor(type: Notification['type']): string {
+    function getNotificationColor(type: string): string {
         switch (type) {
             case 'comment':
                 return 'text-blue-500';
@@ -56,34 +59,11 @@
                 return 'text-purple-500';
             case 'like':
                 return 'text-red-500';
-            case 'message':
-                return 'text-orange-500';
-            case 'system':
             default:
                 return 'text-muted-foreground';
         }
     }
 
-    // 알림 타입 한글
-    function getNotificationTypeLabel(type: Notification['type']): string {
-        switch (type) {
-            case 'comment':
-                return '댓글';
-            case 'reply':
-                return '답글';
-            case 'mention':
-                return '멘션';
-            case 'like':
-                return '추천';
-            case 'message':
-                return '쪽지';
-            case 'system':
-            default:
-                return '시스템';
-        }
-    }
-
-    // 시간 포맷
     function formatTime(dateString: string): string {
         const date = new Date(dateString);
         const now = new Date();
@@ -100,15 +80,11 @@
         if (days < 7) return `${days}일 전`;
 
         return date.toLocaleDateString('ko-KR', {
-            year: 'numeric',
             month: 'short',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit'
+            day: 'numeric'
         });
     }
 
-    // 알림 목록 로드
     async function loadNotifications(): Promise<void> {
         if (!authStore.isAuthenticated) {
             authStore.redirectToLogin();
@@ -119,7 +95,11 @@
         error = null;
 
         try {
-            notificationData = await apiClient.getNotifications(data.page, data.limit);
+            notificationData = await apiClient.getGroupedNotifications(
+                data.page,
+                data.limit,
+                activeFilter
+            );
         } catch (err) {
             error = err instanceof Error ? err.message : '알림을 불러오는데 실패했습니다.';
         } finally {
@@ -127,30 +107,38 @@
         }
     }
 
-    // 페이지 변경
     function goToPage(pageNum: number): void {
         goto(`/notifications?page=${pageNum}`);
     }
 
-    // 알림 클릭 처리
-    async function handleNotificationClick(notification: Notification): Promise<void> {
-        // 읽음 처리
-        if (!notification.is_read) {
+    function setFilter(key: string): void {
+        activeFilter = key;
+        loadNotifications();
+    }
+
+    async function handleNotificationClick(notification: GroupedNotification): Promise<void> {
+        if (notification.has_unread) {
             try {
-                await apiClient.markNotificationAsRead(notification.id);
-                notification.is_read = true;
+                await apiClient.markGroupAsRead(
+                    notification.bo_table,
+                    notification.wr_id,
+                    notification.from_case
+                );
+                notification.has_unread = false;
+                notification.unread_count = 0;
                 if (notificationData) {
-                    notificationData.unread_count = Math.max(0, notificationData.unread_count - 1);
+                    notificationData.unread_count = Math.max(
+                        0,
+                        notificationData.unread_count - notification.unread_count
+                    );
                 }
             } catch (err) {
                 console.error('Failed to mark as read:', err);
             }
         }
 
-        // URL이 있으면 이동
         if (notification.url) {
             let url = notification.url;
-            // 추천 알림에 앵커가 없으면 #likes 추가
             if (notification.type === 'like' && !url.includes('#')) {
                 url += '#likes';
             }
@@ -158,14 +146,14 @@
         }
     }
 
-    // 모두 읽음 처리
     async function handleMarkAllAsRead(): Promise<void> {
         try {
             await apiClient.markAllNotificationsAsRead();
             if (notificationData) {
                 notificationData.items = notificationData.items.map((n) => ({
                     ...n,
-                    is_read: true
+                    has_unread: false,
+                    unread_count: 0
                 }));
                 notificationData.unread_count = 0;
             }
@@ -175,38 +163,40 @@
         }
     }
 
-    // 알림 삭제
-    async function handleDeleteNotification(notificationId: number, event: Event): Promise<void> {
+    async function handleDeleteGroup(
+        notification: GroupedNotification,
+        event: Event
+    ): Promise<void> {
         event.stopPropagation();
-
-        if (!confirm('이 알림을 삭제하시겠습니까?')) return;
+        if (!confirm('이 알림 그룹을 삭제하시겠습니까?')) return;
 
         try {
-            await apiClient.deleteNotification(notificationId);
+            await apiClient.deleteNotificationGroup(
+                notification.bo_table,
+                notification.wr_id,
+                notification.from_case
+            );
             if (notificationData) {
-                const deletedNotification = notificationData.items.find(
-                    (n) => n.id === notificationId
-                );
                 notificationData.items = notificationData.items.filter(
-                    (n) => n.id !== notificationId
+                    (n) =>
+                        !(
+                            n.bo_table === notification.bo_table &&
+                            n.wr_id === notification.wr_id &&
+                            n.from_case === notification.from_case
+                        )
                 );
                 notificationData.total--;
-                if (deletedNotification && !deletedNotification.is_read) {
-                    notificationData.unread_count = Math.max(0, notificationData.unread_count - 1);
-                }
             }
         } catch (err) {
-            console.error('Failed to delete notification:', err);
+            console.error('Failed to delete group:', err);
             alert('알림 삭제에 실패했습니다.');
         }
     }
 
-    // 초기 로드
     onMount(() => {
         loadNotifications();
     });
 
-    // 페이지 변경 시 다시 로드
     $effect(() => {
         if (data.page) {
             loadNotifications();
@@ -218,166 +208,151 @@
     <title>알림 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
 </svelte:head>
 
-<div class="mx-auto max-w-4xl pt-4">
+<div class="mx-auto max-w-3xl px-4 pt-4">
     <!-- 헤더 -->
-    <div class="mb-6 flex items-center justify-between">
-        <div class="flex items-center gap-4">
-            <Button variant="ghost" size="sm" onclick={() => goto('/my')}>
-                <ArrowLeft class="mr-1 h-4 w-4" />
-                마이페이지
-            </Button>
-            <h1 class="text-foreground flex items-center gap-2 text-2xl font-bold">
-                <Bell class="h-6 w-6" />
+    <div class="mb-4 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+            <button
+                onclick={() => goto('/my')}
+                class="text-muted-foreground hover:text-foreground transition-colors"
+            >
+                <ArrowLeft class="h-5 w-5" />
+            </button>
+            <h1 class="text-foreground flex items-center gap-2 text-lg font-semibold">
+                <Bell class="h-5 w-5" />
                 알림
+                {#if notificationData && notificationData.unread_count > 0}
+                    <span
+                        class="bg-destructive text-destructive-foreground rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+                    >
+                        {notificationData.unread_count}
+                    </span>
+                {/if}
             </h1>
         </div>
         {#if notificationData && notificationData.unread_count > 0}
-            <Button variant="outline" size="sm" onclick={handleMarkAllAsRead}>
-                <Check class="mr-2 h-4 w-4" />
+            <Button variant="ghost" size="sm" class="text-xs" onclick={handleMarkAllAsRead}>
+                <Check class="mr-1 h-3.5 w-3.5" />
                 모두 읽음
             </Button>
         {/if}
     </div>
 
+    <!-- 필터 탭 -->
+    <div class="border-border mb-3 flex gap-1 border-b pb-2">
+        {#each filters as filter}
+            <button
+                onclick={() => setFilter(filter.key)}
+                class="rounded-md px-3 py-1.5 text-xs font-medium transition-colors {activeFilter ===
+                filter.key
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+            >
+                {filter.label}
+            </button>
+        {/each}
+    </div>
+
     {#if isLoading}
-        <div class="flex items-center justify-center py-20">
-            <Loader2 class="text-primary h-8 w-8 animate-spin" />
+        <div class="flex items-center justify-center py-16">
+            <Loader2 class="text-primary h-6 w-6 animate-spin" />
         </div>
     {:else if error}
-        <Card class="border-destructive">
-            <CardContent class="pt-6">
-                <p class="text-destructive text-center">{error}</p>
-            </CardContent>
-        </Card>
+        <div class="text-destructive py-8 text-center text-sm">{error}</div>
     {:else if notificationData}
-        <Card class="bg-background">
-            <CardHeader>
-                <CardTitle class="flex items-center gap-2">
-                    전체 알림
-                    <span class="text-muted-foreground text-sm font-normal">
-                        ({notificationData.total}개)
-                    </span>
-                    {#if notificationData.unread_count > 0}
-                        <span
-                            class="bg-destructive text-destructive-foreground rounded-full px-2 py-0.5 text-xs font-medium"
+        {#if notificationData.items.length > 0}
+            <div class="divide-border divide-y">
+                {#each notificationData.items as notification}
+                    {@const Icon = getNotificationIcon(notification.type)}
+                    <div
+                        role="button"
+                        tabindex="0"
+                        onclick={() => handleNotificationClick(notification)}
+                        onkeydown={(e) => {
+                            if (e.key === 'Enter') handleNotificationClick(notification);
+                        }}
+                        class="hover:bg-accent/50 group flex w-full cursor-pointer items-center gap-3 px-1 py-2.5 text-left transition-colors {notification.has_unread
+                            ? 'bg-muted/30'
+                            : ''}"
+                    >
+                        <!-- 아이콘 -->
+                        <div
+                            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full {notification.has_unread
+                                ? 'bg-primary/10'
+                                : 'bg-muted'}"
                         >
-                            {notificationData.unread_count}개 읽지 않음
-                        </span>
-                    {/if}
-                </CardTitle>
-            </CardHeader>
-            <CardContent>
-                {#if notificationData.items.length > 0}
-                    <ul class="divide-border divide-y">
-                        {#each notificationData.items as notification (notification.id)}
-                            {@const Icon = getNotificationIcon(notification.type)}
-                            <li class="py-3 first:pt-0 last:pb-0">
-                                <button
-                                    type="button"
-                                    onclick={() => handleNotificationClick(notification)}
-                                    class="hover:bg-accent -m-1 w-full rounded-md p-3 text-left transition-colors {!notification.is_read
-                                        ? 'bg-muted/50'
-                                        : ''}"
+                            <Icon class="h-4 w-4 {getNotificationColor(notification.type)}" />
+                        </div>
+
+                        <!-- 내용 -->
+                        <div class="min-w-0 flex-1">
+                            <div class="flex items-center gap-1.5">
+                                <span
+                                    class="truncate text-sm {notification.has_unread
+                                        ? 'text-foreground font-semibold'
+                                        : 'text-foreground/80'}"
                                 >
-                                    <div class="flex items-start gap-3">
-                                        <!-- 아이콘 -->
-                                        <div
-                                            class="bg-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
-                                        >
-                                            <Icon
-                                                class="h-5 w-5 {getNotificationColor(
-                                                    notification.type
-                                                )}"
-                                            />
-                                        </div>
+                                    {notification.title}
+                                </span>
+                                {#if notification.has_unread}
+                                    <span class="bg-primary h-1.5 w-1.5 shrink-0 rounded-full"
+                                    ></span>
+                                {/if}
+                            </div>
+                            {#if notification.parent_subject}
+                                <p class="text-muted-foreground mt-0.5 truncate text-xs">
+                                    {notification.parent_subject}
+                                </p>
+                            {/if}
+                        </div>
 
-                                        <!-- 내용 -->
-                                        <div class="min-w-0 flex-1">
-                                            <div class="mb-1 flex items-center gap-2">
-                                                <span
-                                                    class="bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-[10px] font-medium"
-                                                >
-                                                    {getNotificationTypeLabel(notification.type)}
-                                                </span>
-                                                {#if !notification.is_read}
-                                                    <span
-                                                        class="bg-primary text-primary-foreground rounded px-1.5 py-0.5 text-[10px] font-medium"
-                                                    >
-                                                        NEW
-                                                    </span>
-                                                {/if}
-                                            </div>
-                                            <p class="text-foreground font-medium">
-                                                {notification.title}
-                                            </p>
-                                            {#if notification.parent_subject}
-                                                <p
-                                                    class="text-muted-foreground mt-1 line-clamp-1 text-sm"
-                                                >
-                                                    "{notification.parent_subject}"
-                                                </p>
-                                            {/if}
-                                            <p class="text-muted-foreground mt-1 text-xs">
-                                                {formatTime(notification.created_at)}
-                                            </p>
-                                        </div>
-
-                                        <!-- 삭제 버튼 -->
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            class="text-muted-foreground hover:text-destructive h-8 w-8 shrink-0"
-                                            onclick={(e: Event) =>
-                                                handleDeleteNotification(notification.id, e)}
-                                        >
-                                            <Trash2 class="h-4 w-4" />
-                                        </Button>
-                                    </div>
-                                </button>
-                            </li>
-                        {/each}
-                    </ul>
-                {:else}
-                    <p class="text-muted-foreground py-8 text-center">알림이 없습니다.</p>
-                {/if}
-            </CardContent>
-        </Card>
+                        <!-- 시간 + 삭제 -->
+                        <div class="flex shrink-0 items-center gap-1">
+                            <span class="text-muted-foreground text-[11px]">
+                                {formatTime(notification.latest_at)}
+                            </span>
+                            <button
+                                type="button"
+                                onclick={(e: Event) => handleDeleteGroup(notification, e)}
+                                class="text-muted-foreground hover:text-destructive ml-1 rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+                            >
+                                <Trash2 class="h-3.5 w-3.5" />
+                            </button>
+                        </div>
+                    </div>
+                {/each}
+            </div>
+        {:else}
+            <p class="text-muted-foreground py-16 text-center text-sm">알림이 없습니다.</p>
+        {/if}
 
         <!-- 페이지네이션 -->
         {#if notificationData.total_pages > 1}
-            <div class="mt-6 flex items-center justify-center gap-2">
+            <div class="mt-4 flex items-center justify-center gap-2 pb-4">
                 <Button
-                    variant="outline"
-                    size="sm"
+                    variant="ghost"
+                    size="icon"
+                    class="h-8 w-8"
                     disabled={data.page === 1}
                     onclick={() => goToPage(data.page - 1)}
                 >
-                    이전
+                    <ChevronLeft class="h-4 w-4" />
                 </Button>
 
-                <span class="text-muted-foreground px-4 text-sm">
+                <span class="text-muted-foreground text-xs">
                     {data.page} / {notificationData.total_pages}
                 </span>
 
                 <Button
-                    variant="outline"
-                    size="sm"
+                    variant="ghost"
+                    size="icon"
+                    class="h-8 w-8"
                     disabled={data.page === notificationData.total_pages}
                     onclick={() => goToPage(data.page + 1)}
                 >
-                    다음
+                    <ChevronRight class="h-4 w-4" />
                 </Button>
             </div>
         {/if}
     {/if}
 </div>
-
-<style>
-    .line-clamp-2 {
-        display: -webkit-box;
-        line-clamp: 2;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-    }
-</style>


### PR DESCRIPTION
## Summary
- 그룹화 알림 API 연동 ("OOO님 외 N명이 댓글을 달았습니다" 형태)
- 필터 탭 추가 (전체/댓글/추천/멘션/시스템)
- 컴팩트 레이아웃으로 높이 축소
- 드롭다운도 그룹화 알림으로 변경
- GroupedNotification 타입 + API 클라이언트 메서드 추가

## Test plan
- [ ] /notifications 페이지에서 그룹화 알림 표시 확인
- [ ] 필터 탭 전환 시 해당 타입만 표시 확인
- [ ] 헤더 알림 드롭다운에서 그룹화 알림 표시 확인
- [ ] 읽음/삭제 동작 정상 확인