### PR TITLE
fix: state_unsafe_mutation 에러 해결 (17만건/일)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -225,7 +225,7 @@
                 updateActiveState();
             },
             onTransaction: () => {
-                updateActiveState();
+                setTimeout(() => updateActiveState(), 0);
             }
         });
 

--- a/apps/web/src/lib/components/features/shortcut-buttons/shortcut-buttons.svelte
+++ b/apps/web/src/lib/components/features/shortcut-buttons/shortcut-buttons.svelte
@@ -39,7 +39,9 @@
     }
 
     function handleFocusOut() {
-        hidden = false;
+        setTimeout(() => {
+            hidden = false;
+        }, 0);
     }
 
     onMount(() => {


### PR DESCRIPTION
## Summary
- shortcut-buttons: `handleFocusOut`에서 `setTimeout`으로 `$state` 업데이트 지연
- tiptap-editor: `onTransaction` 콜백에서 `setTimeout`으로 `$state` 업데이트 지연
- Svelte teardown 중 DOM 제거 → focusout/blur 이벤트 → `$state` 변경 시 `state_unsafe_mutation` 에러 발생하는 문제 해결

## 원인
Svelte가 페이지 네비게이션 시 DOM을 제거하면, 브라우저가 `focusout` 이벤트를 동기적으로 발생시킴. 이때 `$state` 변경이 Svelte의 내부 teardown 컨텍스트에서 실행되어 금지된 mutation으로 에러 발생.

## 영향
- Dantry 기준 일 17만 건 (전체 에러의 ~80%) 제거 예상