### PR TITLE
fix: PWA orientation을 natural로 변경하여 Android 회전 잠금 존중

### DIFF
--- a/apps/web/src/routes/manifest.json/+server.ts
+++ b/apps/web/src/routes/manifest.json/+server.ts
@@ -13,7 +13,7 @@ export const GET: RequestHandler = () => {
             display: 'standalone',
             background_color: '#ffffff',
             theme_color: '#1a1a1a',
-            orientation: 'any',
+            orientation: 'natural',
             categories: ['social', 'news'],
             icons: [
                 {

--- a/apps/web/static/manifest.json
+++ b/apps/web/static/manifest.json
@@ -6,7 +6,7 @@
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#1a1a1a",
-    "orientation": "any",
+    "orientation": "natural",
     "categories": ["social", "news"],
     "icons": [
         {


### PR DESCRIPTION
## Summary
- PWA manifest의 `orientation`을 `"any"` → `"natural"`로 변경
- Android에서 기기 회전 잠금 설정 시에도 PWA가 회전되는 문제 수정
- iOS는 manifest orientation을 무시하므로 영향 없음

## 변경 파일
- `apps/web/src/routes/manifest.json/+server.ts` (동적 manifest)
- `apps/web/static/manifest.json` (정적 폴백)

## Test plan
- [ ] Android: 홈 화면 PWA에서 회전 잠금 ON → 화면 고정 확인
- [ ] Android: 회전 잠금 OFF → 자유 회전 확인
- [ ] Android: 영상 전체화면 → 가로 전환 정상 동작 확인
- [ ] iOS: 기존과 동일하게 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)