### PR TITLE
fix: SSR 페이지 전환 속도 최적화

### DIFF
--- a/apps/web/src/lib/server/board-cache.ts
+++ b/apps/web/src/lib/server/board-cache.ts
@@ -1,0 +1,41 @@
+/**
+ * 게시판 정보 공유 캐시 모듈
+ *
+ * [boardId]/+page.server.ts, [boardId]/[postId]/+page.server.ts 에서 공유.
+ * board 정보는 관리자 변경 시만 바뀌므로 300초 TTL.
+ */
+import type { Board } from '$lib/api/types.js';
+import { backendFetch as bFetch } from '$lib/server/backend-fetch.js';
+import { createCache } from '$lib/server/cache.js';
+
+const boardInfoCache = createCache<Board>({ ttl: 300_000, maxSize: 200 });
+
+/**
+ * 게시판 정보 조회 (캐시 우선)
+ * board + display_settings 를 병합하여 반환
+ */
+export async function getCachedBoard(
+    boardId: string,
+    headers: Record<string, string>
+): Promise<Board | null> {
+    const cached = boardInfoCache.get(boardId);
+    if (cached) return cached;
+
+    const [boardRes, displaySettingsRes] = await Promise.all([
+        bFetch(`/api/v1/boards/${boardId}`, { headers, timeout: 3_000 }),
+        bFetch(`/api/v1/boards/${boardId}/display-settings`, { headers, timeout: 3_000 })
+    ]);
+
+    let board: Board | null = boardRes.ok ? ((await boardRes.json()).data as Board) : null;
+
+    if (board && displaySettingsRes.ok) {
+        const displaySettings = (await displaySettingsRes.json()).data;
+        board = { ...board, display_settings: displaySettings };
+    }
+
+    if (board) {
+        boardInfoCache.set(boardId, board);
+    }
+
+    return board;
+}

--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -65,7 +65,7 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
 					m.mb_nick AS target_member_nick,
 					m.mb_image_url AS target_member_image_url
 			 FROM celebration_banners cb
-			 LEFT JOIN g5_member m ON cb.target_member_id COLLATE utf8mb4_unicode_ci = m.mb_id
+			 LEFT JOIN g5_member m ON cb.target_member_id = m.mb_id
 			 WHERE cb.is_active = 1 ${dateFilter}
 			 ORDER BY cb.display_date DESC, cb.sort_order ASC, cb.id DESC
 			 LIMIT 8`

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -13,8 +13,7 @@ import { getCachedBannersByPositions } from '$lib/server/ads/banners';
  *
  * celebration + banners: SSR에서 직접 로드하여 클라이언트 /api/init CDN 요청 제거
  */
-export const load: LayoutServerLoad = async ({ locals, url }) => {
-    void url.pathname; // URL 변경 시 load 재실행 → SPA 네비게이션마다 SSR 데이터 갱신
+export const load: LayoutServerLoad = async ({ locals }) => {
     // 병렬로 모든 데이터 로드 (allSettled: 개별 실패 허용)
     const [themeResult, pluginsResult, menusResult, celebrationResult, bannersResult] =
         await Promise.allSettled([

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -5,9 +5,7 @@ import { fetchPromotionPosts, fetchPromotionBoardPosts } from '$lib/server/ads/p
 import type { PromotionBoardPost } from '$lib/server/ads/promotion.js';
 import { backendFetch as bFetch, createAuthHeaders } from '$lib/server/backend-fetch.js';
 import { createCache } from '$lib/server/cache.js';
-
-// --- 인메모리 캐시: board 정보 (60초 TTL, 거의 안 바뀜) ---
-const boardInfoCache = createCache<Board>({ ttl: 60_000, maxSize: 200 });
+import { getCachedBoard } from '$lib/server/board-cache.js';
 
 // --- 인메모리 캐시: 비로그인 게시글 목록 (15초 TTL) ---
 interface PostsCacheData {
@@ -42,30 +40,10 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
     const headers = createAuthHeaders(locals.accessToken);
 
     // --- 1단계: board 정보 즉시 await (헤더, SEO, 권한 체크) ---
-    // board 메타데이터는 관리자 변경 시만 바뀌므로 60초 인메모리 캐시
+    // board 메타데이터는 관리자 변경 시만 바뀌므로 300초 인메모리 캐시 (board-cache.ts 공유)
     let board: Board | null = null;
     try {
-        const cached = boardInfoCache.get(boardId);
-        if (cached) {
-            board = cached;
-        } else {
-            const [boardRes, displaySettingsRes] = await Promise.all([
-                bFetch(`/api/v1/boards/${boardId}`, { headers, timeout: 3_000 }),
-                bFetch(`/api/v1/boards/${boardId}/display-settings`, { headers, timeout: 3_000 })
-            ]);
-            board = boardRes.ok ? ((await boardRes.json()).data as Board) : null;
-
-            // display_settings 병합
-            if (board && displaySettingsRes.ok) {
-                const displaySettings = (await displaySettingsRes.json()).data;
-                board = { ...board, display_settings: displaySettings };
-            }
-
-            // 캐시 저장 (board가 null이 아닐 때만)
-            if (board) {
-                boardInfoCache.set(boardId, board);
-            }
-        }
+        board = await getCachedBoard(boardId, headers);
 
         // 게시판이 존재하지 않으면 404
         if (!board) {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -5,6 +5,7 @@ import { fetchPromotionPosts, fetchPromotionBoardPosts } from '$lib/server/ads/p
 import { transformAffiliateContent } from '$lib/hooks/builtin/affiliate.js';
 import { isScraped } from '$lib/server/scrap.js';
 import { backendFetch as bFetch, createAuthHeaders } from '$lib/server/backend-fetch.js';
+import { getCachedBoard } from '$lib/server/board-cache.js';
 import { increment as incrementViewcount } from '$lib/server/viewcount.js';
 import { fetchReactionsByParentId } from '$lib/server/reactions.js';
 import { fetchMemberLevels } from '$lib/server/member-levels.js';
@@ -35,42 +36,27 @@ export const load: PageServerLoad = async ({
 
     try {
         // --- 1단계: 필수 데이터 즉시 await (본문, SEO, 권한 체크) ---
-        const [postResult, boardResult, displaySettingsResult, filesResult] =
-            await Promise.allSettled([
-                // 게시글 (Go 백엔드 직접 호출)
-                bFetch(`/api/v1/boards/${boardId}/posts/${postId}`, {
-                    headers,
-                    timeout: 8_000
-                }).then(async (res) => {
-                    if (!res.ok) throw new Error(`Post API error: ${res.status}`);
-                    const json = await res.json();
-                    return json.data as FreePost;
-                }),
-                // 게시판 정보 (가벼움, 캐시됨)
-                bFetch(`/api/v1/boards/${boardId}`, { headers, timeout: 3_000 }).then(
-                    async (res) => {
-                        if (!res.ok) return null;
-                        const json = await res.json();
-                        return json.data;
-                    }
-                ),
-                // 게시판 표시 설정 (가벼움)
-                bFetch(`/api/v1/boards/${boardId}/display-settings`, {
-                    headers,
-                    timeout: 3_000
-                }).then(async (res) => {
+        // board는 공유 캐시(300초 TTL)에서 조회, post/files는 병렬로 fetch
+        const [postResult, boardResult, filesResult] = await Promise.allSettled([
+            // 게시글 (Go 백엔드 직접 호출)
+            bFetch(`/api/v1/boards/${boardId}/posts/${postId}`, {
+                headers,
+                timeout: 5_000
+            }).then(async (res) => {
+                if (!res.ok) throw new Error(`Post API error: ${res.status}`);
+                const json = await res.json();
+                return json.data as FreePost;
+            }),
+            // 게시판 정보 (공유 캐시, 캐시 히트 시 0ms)
+            getCachedBoard(boardId, headers),
+            // 첨부 파일 (SvelteKit 내부 라우트)
+            svelteKitFetch(`${url.origin}/api/boards/${boardId}/posts/${postId}/files`).then(
+                async (res) => {
                     if (!res.ok) return null;
-                    const json = await res.json();
-                    return json.data;
-                }),
-                // 첨부 파일 (SvelteKit 내부 라우트)
-                svelteKitFetch(`${url.origin}/api/boards/${boardId}/posts/${postId}/files`).then(
-                    async (res) => {
-                        if (!res.ok) return null;
-                        return res.json();
-                    }
-                )
-            ]);
+                    return res.json();
+                }
+            )
+        ]);
 
         // 게시글 필수 — 실패 시 404
         if (postResult.status === 'rejected') {
@@ -89,12 +75,7 @@ export const load: PageServerLoad = async ({
             post.content = '';
         }
 
-        let board = boardResult.status === 'fulfilled' ? boardResult.value : null;
-
-        // display_settings 병합
-        if (board && displaySettingsResult.status === 'fulfilled' && displaySettingsResult.value) {
-            board = { ...board, display_settings: displaySettingsResult.value };
-        }
+        const board = boardResult.status === 'fulfilled' ? boardResult.value : null;
 
         // 게시판 접근 권한 체크 (list_level, read_level 중 높은 값)
         if (board) {


### PR DESCRIPTION
## Summary
- `+layout.server.ts`에서 `void url.pathname` 제거 → SPA 네비게이션마다 layout 서버 왕복 차단 (가장 큰 병목, ~100-500ms 절감)
- board 정보 공유 캐시 모듈 분리 (`board-cache.ts`, TTL 300초) → 게시판 목록/게시글 상세에서 캐시 공유
- 게시글 상세 post API 타임아웃 8초→5초
- celebration.ts COLLATE 제거 → 인덱스 활용 가능

## Test plan
- [ ] dev.damoang.net에서 게시판 목록 → 게시글 클릭 시 전환 속도 체감 확인
- [ ] 게시판 간 이동 시 Network 탭에서 layout 서버 재호출 없는지 확인
- [ ] celebration/banners가 첫 로드에서 정상 표시되는지 확인
- [ ] board 정보가 캐시 히트되는지 확인 (같은 게시판 내 게시글 이동 시)