### PR TITLE
fix: 모바일 게시판 목록 GAM 광고 높이 축소

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -188,6 +188,37 @@
                 ]
             ]
         },
+        'banner-medium-compact': {
+            unit: AD_UNIT_PATHS.sub,
+            sizes: [
+                [728, 90],
+                [320, 100]
+            ],
+            responsive: [
+                [728, [[728, 90]]],
+                [0, [[320, 100]]]
+            ]
+        },
+        'banner-large-compact': {
+            unit: AD_UNIT_PATHS.main,
+            sizes: [
+                [970, 250],
+                [970, 90],
+                [728, 90],
+                [320, 100]
+            ],
+            responsive: [
+                [
+                    970,
+                    [
+                        [970, 250],
+                        [970, 90]
+                    ]
+                ],
+                [728, [[728, 90]]],
+                [0, [[320, 100]]]
+            ]
+        },
         'banner-large-728': {
             unit: AD_UNIT_PATHS.main,
             sizes: [
@@ -242,6 +273,17 @@
                 ]
             ]
         },
+        'infeed-compact': {
+            unit: AD_UNIT_PATHS.curation,
+            sizes: [
+                [728, 90],
+                [320, 100]
+            ],
+            responsive: [
+                [728, [[728, 90]]],
+                [0, [[320, 100]]]
+            ]
+        },
         'banner-vertical': {
             unit: AD_UNIT_PATHS.sub,
             sizes: [[160, 600]],
@@ -253,8 +295,8 @@
     const POSITION_MAP: Record<string, string> = {
         'board-view-top': 'banner-small',
         'board-head': 'banner-horizontal',
-        'board-list-head': 'banner-medium',
-        'board-list-bottom': 'banner-large',
+        'board-list-head': 'banner-medium-compact',
+        'board-list-bottom': 'banner-large-compact',
         'board-content': 'banner-responsive',
         'board-content-bottom': 'banner-large',
         'board-before-comments': 'banner-responsive',
@@ -268,7 +310,7 @@
         'index-middle-3': 'banner-horizontal',
         'index-bottom': 'banner-large',
         'header-after': 'banner-horizontal',
-        'board-list-infeed': 'infeed',
+        'board-list-infeed': 'infeed-compact',
         'comment-infeed': 'infeed',
         'comment-top': 'banner-compact',
         'sidebar-sticky': 'banner-halfpage',


### PR DESCRIPTION
## Summary
- 게시판 목록 페이지의 GAM 광고가 모바일에서 정사각형(300x250, 250px)으로 표시되어 이질감이 큼
- 모바일에서 배너형(320x100, 100px)만 허용하여 높이 60% 축소
- board-list-head, board-list-infeed, board-list-bottom 3곳에 compact 변형 적용
- PC(728px+)는 기존과 동일, 다른 위치(본문/댓글/사이드바)도 영향 없음

## Test plan
- [ ] 모바일에서 게시판 목록 진입 시 GAM 광고가 배너형(낮은 높이)으로 표시되는지 확인
- [ ] PC에서는 기존과 동일하게 표시되는지 확인
- [ ] 게시글 상세 등 다른 페이지의 광고는 영향 없는지 확인