### PR TITLE
fix: 게시판 목록 GAM 광고 높이 수정 + 댓글 새로고침 버튼

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -8,6 +8,7 @@
     import type { BoardPermissions } from '$lib/api/types.js';
     import { apiClient } from '$lib/api/index.js';
     import Send from '@lucide/svelte/icons/send';
+    import RefreshCw from '@lucide/svelte/icons/refresh-cw';
     import X from '@lucide/svelte/icons/x';
     import CornerDownRight from '@lucide/svelte/icons/corner-down-right';
     import Lock from '@lucide/svelte/icons/lock';
@@ -35,6 +36,10 @@
         requiredCommentLevel?: number;
         /** 게시판 ID (이미지 업로드용) */
         boardId?: string;
+        /** 댓글 새로고침 콜백 */
+        onRefresh?: () => void;
+        /** 새로고침 중 여부 */
+        isRefreshing?: boolean;
     }
 
     let {
@@ -48,7 +53,9 @@
         showSecretOption = true,
         permissions,
         requiredCommentLevel = 3,
-        boardId = 'free'
+        boardId = 'free',
+        onRefresh,
+        isRefreshing = false
     }: Props = $props();
 
     // 댓글/답글 작성 권한 체크
@@ -321,6 +328,17 @@
                                 {isReplyMode ? '답글 작성' : '댓글 작성'}
                             {/if}
                         </Button>
+                        {#if onRefresh}
+                            <button
+                                type="button"
+                                onclick={onRefresh}
+                                disabled={isRefreshing}
+                                class="text-muted-foreground hover:text-foreground rounded-md p-1.5 transition-colors disabled:opacity-50"
+                                title="댓글 새로고침"
+                            >
+                                <RefreshCw class="size-4 {isRefreshing ? 'animate-spin' : ''}" />
+                            </button>
+                        {/if}
                     </div>
                 </div>
 

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -316,7 +316,7 @@
             <!-- 최상단 배너 (축하이미지 → 다모앙광고 → GAM 폴백) -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-4">
-                    <DamoangBanner position="board-list" height="45px" showCelebration={false} />
+                    <DamoangBanner position="board-list" height="90px" showCelebration={false} />
                 </div>
             {/if}
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1298,6 +1298,8 @@
                             permissions={data.board?.permissions}
                             requiredCommentLevel={data.board?.comment_level ?? 3}
                             {boardId}
+                            onRefresh={refreshComments}
+                            isRefreshing={isRefreshingComments}
                         />
                     </div>
                 </CardContent>


### PR DESCRIPTION
## Summary
- 게시판 목록 DamoangBanner height 45px→90px — GAM 728x90 광고가 공간 부족으로 미노출되던 문제 수정
- 댓글 작성 버튼 오른쪽에 새로고침 버튼 추가 (comment-form에 onRefresh prop)

## Test plan
- [ ] 게시판 목록에서 GAM 광고가 정상 노출되는지 확인
- [ ] 댓글 작성 버튼 옆 새로고침 버튼 클릭 시 댓글 목록 갱신 확인
- [ ] 새로고침 중 스피너 애니메이션 확인