### PR TITLE
fix: 회원 프로필 아바타 이미지 URL 처리 및 폴백 개선

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -130,13 +130,8 @@ export const GET: RequestHandler = async ({ params }) => {
             [memberId]
         );
 
-        // 이미지 URL 처리
-        let imageUrl = '';
-        if (member.mb_image_url) {
-            imageUrl = member.mb_image_url.startsWith('http')
-                ? member.mb_image_url
-                : `/data/member/${memberId}.gif`;
-        }
+        // 이미지 URL: 원본 값 그대로 전달 (프론트에서 getAvatarUrl로 CDN URL 변환)
+        const imageUrl = member.mb_image_url || '';
 
         return json({
             success: true,

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -6,7 +6,7 @@
     import * as Tabs from '$lib/components/ui/tabs/index.js';
     import type { PageData } from './$types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
-    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl, getMemberIconUrl, handleIconError } from '$lib/utils/member-icon.js';
     import { apiClient } from '$lib/api/index.js';
     import { goto } from '$app/navigation';
     import { onMount } from 'svelte';
@@ -62,13 +62,12 @@
     let { data }: { data: PageData & { profile: any } } = $props();
     const p = $derived(data.profile);
 
-    let profileAvatarUrl = $derived(
-        getAvatarUrl(p?.mb_image) || getMemberIconUrl(p?.mb_id) || null
+    const profileIconUrl = $derived(
+        getAvatarUrl(p?.mb_image) || getMemberIconUrl(p?.mb_id)
     );
-    let profileAvatarFailed = $state(false);
-
+    let profileIconFailed = $state(false);
     $effect(() => {
-        if (p) profileAvatarFailed = false;
+        if (p) profileIconFailed = false;
     });
 
     // 본인 프로필
@@ -328,25 +327,23 @@
             <CardContent class="pt-6">
                 <div class="flex items-center gap-4">
                     <!-- 프로필 이미지 -->
-                    <div
-                        class="flex h-16 w-16 shrink-0 items-center justify-center rounded-full {profileAvatarUrl &&
-                        !profileAvatarFailed
-                            ? 'overflow-hidden'
-                            : 'bg-primary text-primary-foreground'}"
-                    >
-                        {#if profileAvatarUrl && !profileAvatarFailed}
-                            <img
-                                src={profileAvatarUrl}
-                                alt={p.mb_name}
-                                class="h-full w-full object-cover"
-                                onerror={() => {
-                                    profileAvatarFailed = true;
-                                }}
-                            />
-                        {:else}
-                            <User class="h-8 w-8" />
-                        {/if}
-                    </div>
+                    {#if profileIconUrl && !profileIconFailed}
+                        <img
+                            src={profileIconUrl}
+                            alt={p.mb_name}
+                            class="size-16 shrink-0 rounded-full object-cover"
+                            onerror={(e) => {
+                                handleIconError(e);
+                                profileIconFailed = true;
+                            }}
+                        />
+                    {:else}
+                        <div
+                            class="bg-muted text-muted-foreground flex size-16 shrink-0 items-center justify-center rounded-full text-xl font-bold"
+                        >
+                            {p.mb_name.charAt(0).toUpperCase()}
+                        </div>
+                    {/if}
 
                     <div class="min-w-0 flex-1">
                         <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- API에서 `mb_image_url`을 `/data/member/${id}.gif`로 잘못 변환하던 로직 제거 → 원본 값 그대로 전달하여 프론트의 `getAvatarUrl`이 CDN URL로 정상 변환
- 프론트 아바타 폴백을 댓글과 동일한 패턴으로 통일: `handleIconError` + 닉네임 첫 글자 폴백
- PR #385 머지 후 프로덕션에서 아바타가 더미 아이콘으로 표시되는 문제 수정

## Test plan
- [ ] 스테이징에서 프로필 이미지가 있는 회원 → 아바타 정상 표시
- [ ] 프로필 이미지가 없는 회원 → 닉네임 첫 글자 폴백
- [ ] CDN 이미지 로드 실패 시 → 닉네임 첫 글자 폴백

🤖 Generated with [Claude Code](https://claude.com/claude-code)