### PR TITLE
fix: Sphinx 검색 운영 환경 연결 수정

### DIFF
--- a/apps/web/src/lib/server/sphinx.ts
+++ b/apps/web/src/lib/server/sphinx.ts
@@ -7,8 +7,8 @@
 import mysql from 'mysql2/promise';
 
 const sphinxPool = mysql.createPool({
-    host: '127.0.0.1',
-    port: 9306,
+    host: process.env.SPHINX_HOST || '127.0.0.1',
+    port: parseInt(process.env.SPHINX_PORT || '9306'),
     waitForConnections: true,
     connectionLimit: 10,
     queueLimit: 50,


### PR DESCRIPTION
## Summary
- Sphinx 검색 연결을 환경변수(`SPHINX_HOST`, `SPHINX_PORT`) 기반으로 변경
- 운영 Pod(`hostNetwork: false`)에서 `127.0.0.1`로 Sphinx 접근 불가 문제 해결
- 기본값 `127.0.0.1:9306` 유지로 dev 환경 호환

## 배포 시 추가 작업
```bash
kubectl apply -f /home/angple/k8s/prod/angple-config.yaml
```
ConfigMap에 `SPHINX_HOST: 10.160.20.165`, `SPHINX_PORT: "9306"` 추가 필요

## Test plan
- [ ] `pnpm build` 성공 확인
- [ ] 운영 ConfigMap 적용 후 Pod 재시작
- [ ] `curl http://localhost:3000/api/search?q=테스트` 정상 응답 확인
- [ ] damoang.net 검색 자동완성 + 검색 페이지 정상 작동 확인