### PR TITLE
fix: 네비게이션 시 메뉴/테마/플러그인 깜빡임 제거

### DIFF
--- a/apps/web/src/lib/stores/menu.svelte.ts
+++ b/apps/web/src/lib/stores/menu.svelte.ts
@@ -18,7 +18,7 @@ function filterMenus(menus: MenuItem[]): MenuItem[] {
 
 class MenuStore {
     menus = $state<MenuItem[]>([]);
-    loading = $state(true);
+    loading = $state(false);
     error = $state<string | null>(null);
 
     /**
@@ -40,11 +40,17 @@ class MenuStore {
     }
 
     /**
-     * SSR 데이터로 메뉴 초기화
+     * SSR 데이터로 메뉴 초기화 (동일 데이터 시 리렌더 방지)
      */
     initFromServer(menus: MenuItem[]) {
-        this.menus = filterMenus(menus);
-        this.loading = false;
+        const filtered = filterMenus(menus);
+        if (
+            this.menus.length === filtered.length &&
+            JSON.stringify(this.menus) === JSON.stringify(filtered)
+        ) {
+            return;
+        }
+        this.menus = filtered;
         this.error = null;
     }
 }

--- a/apps/web/src/lib/stores/plugin.svelte.ts
+++ b/apps/web/src/lib/stores/plugin.svelte.ts
@@ -42,9 +42,12 @@ class PluginStore {
     });
 
     /**
-     * SSR 데이터로 플러그인 초기화 (깜박임 방지)
+     * SSR 데이터로 플러그인 초기화 (동일 데이터 시 리렌더 방지)
      */
     initFromServer(activePlugins: ActivePlugin[]) {
+        const currentIds = this.state.activePlugins.map((p) => p.id).join(',');
+        const newIds = activePlugins.map((p) => p.id).join(',');
+        if (currentIds === newIds && !this.state.isLoading) return;
         this.state = {
             activePlugins,
             isLoading: false,

--- a/apps/web/src/lib/stores/theme.svelte.ts
+++ b/apps/web/src/lib/stores/theme.svelte.ts
@@ -19,9 +19,10 @@ class ThemeStore {
     error = $state<string | null>(null);
 
     /**
-     * SSR 데이터로 테마 초기화 (깜박임 방지)
+     * SSR 데이터로 테마 초기화 (동일 테마 시 리렌더 방지)
      */
     initFromServer(activeTheme: string | null) {
+        if (this.currentTheme.activeTheme === activeTheme) return;
         this.currentTheme = {
             activeTheme,
             settings: {}


### PR DESCRIPTION
## Summary

- **menuStore.loading 초기값 `true` → `false`**: SSR에서 이미 메뉴 데이터가 주입되므로 "메뉴 로딩 중..." 텍스트 표시 불필요
- **3개 스토어 동일성 체크**: 매 네비게이션마다 layout 서버가 동일한 데이터를 다시 보내도 새 배열 참조 생성을 스킵 → 불필요한 DOM 리렌더 방지

## Test plan

- [ ] 페이지 전환 시 메뉴 깜빡임 없는지 확인
- [ ] 사이드바 "메뉴 로딩 중..." 텍스트 표시되지 않는지 확인
- [ ] 테마/플러그인 변경 후 정상 반영되는지 확인