### PR TITLE
fix: 댓글 리액션 피커 가려짐 수정 (#7788)

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -30,6 +30,8 @@
     let isReacting = $state(false);
     let showPicker = $state(false);
     let activeCategory = $state('angticon');
+    let pickerStyle = $state('');
+    let addBtnEl: HTMLButtonElement | undefined = $state();
 
     // target/parent ID 생성 (da_reaction 호환)
     const targetId = $derived(
@@ -103,10 +105,31 @@
         react(reaction, 'toggle');
     }
 
+    // 피커 위치 계산 (fixed positioning으로 overflow-hidden 부모 탈출)
+    function updatePickerPosition(): void {
+        if (!addBtnEl) return;
+        const rect = addBtnEl.getBoundingClientRect();
+        const pickerW = 288; // w-72 = 18rem = 288px
+        const pickerH = 260;
+        let left = rect.left;
+        let top = rect.top - pickerH - 8;
+
+        // 화면 밖으로 나가면 조정
+        if (left + pickerW > window.innerWidth) {
+            left = window.innerWidth - pickerW - 8;
+        }
+        if (left < 8) left = 8;
+        if (top < 8) {
+            top = rect.bottom + 8; // 위에 공간 없으면 아래에 표시
+        }
+
+        pickerStyle = `position:fixed;left:${left}px;top:${top}px;z-index:9999;`;
+    }
+
     // 피커 외부 클릭
     function handleClickOutside(event: MouseEvent): void {
         const el = event.target as HTMLElement;
-        if (!el.closest('.reaction-bar-root')) {
+        if (!el.closest('.reaction-bar-root') && !el.closest('.reaction-picker-fixed')) {
             showPicker = false;
         }
     }
@@ -150,6 +173,7 @@
 
     <!-- 리액션 추가 버튼 -->
     <button
+        bind:this={addBtnEl}
         type="button"
         onclick={(e) => {
             e.stopPropagation();
@@ -158,74 +182,79 @@
                 return;
             }
             showPicker = !showPicker;
+            if (showPicker) {
+                requestAnimationFrame(() => updatePickerPosition());
+            }
         }}
         class="border-border bg-muted/30 text-muted-foreground hover:border-primary/30 hover:bg-primary/5 hover:text-foreground inline-flex h-8 items-center gap-1 rounded-full border px-2 text-sm transition-colors"
         title="리액션 추가"
     >
         <SmilePlus class="h-4 w-4" />
     </button>
+</div>
 
-    <!-- 이모티콘 피커 -->
-    {#if showPicker}
-        <div
-            class="bg-popover border-border absolute bottom-full left-0 z-50 mb-2 w-72 overflow-hidden rounded-xl border shadow-xl"
-            onclick={(e) => e.stopPropagation()}
-            onkeydown={(e: KeyboardEvent) => {
-                if (e.key === 'Escape') {
-                    showPicker = false;
-                }
-            }}
-            role="dialog"
-            tabindex="-1"
-        >
-            <!-- 카테고리 탭 -->
-            <div class="border-border flex border-b">
-                {#each REACTION_CATEGORIES as cat (cat.category)}
+<!-- 이모티콘 피커 (fixed positioning으로 overflow-hidden 부모 탈출) -->
+{#if showPicker}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+        class="reaction-picker-fixed bg-popover border-border w-72 overflow-hidden rounded-xl border shadow-xl"
+        style={pickerStyle}
+        onclick={(e) => e.stopPropagation()}
+        onkeydown={(e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                showPicker = false;
+            }
+        }}
+        role="dialog"
+        tabindex="-1"
+    >
+        <!-- 카테고리 탭 -->
+        <div class="border-border flex border-b">
+            {#each REACTION_CATEGORIES as cat (cat.category)}
+                <button
+                    type="button"
+                    onclick={() => (activeCategory = cat.category)}
+                    class="flex-1 px-2 py-1.5 text-xs font-medium transition-colors
+						{activeCategory === cat.category
+                        ? 'bg-primary/10 text-primary border-primary border-b-2'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"
+                >
+                    {cat.title}
+                </button>
+            {/each}
+        </div>
+
+        <!-- 이모티콘 그리드 -->
+        <div class="max-h-48 overflow-y-auto p-2">
+            <div
+                class="grid gap-0.5"
+                style="grid-template-columns: repeat({activeCategory === 'emoji'
+                    ? 9
+                    : 6}, minmax(0, 1fr));"
+            >
+                {#each categoryEmoticons as emo (emo.reaction)}
                     <button
                         type="button"
-                        onclick={() => (activeCategory = cat.category)}
-                        class="flex-1 px-2 py-1.5 text-xs font-medium transition-colors
-							{activeCategory === cat.category
-                            ? 'bg-primary/10 text-primary border-primary border-b-2'
-                            : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"
+                        onclick={() => react(emo.reaction, 'add')}
+                        disabled={isReacting}
+                        class="hover:bg-accent flex items-center justify-center rounded-lg p-1 transition-all hover:scale-110"
+                        title={emo.emoji || emo.reaction}
                     >
-                        {cat.title}
+                        {#if emo.renderType === 'image' && emo.url}
+                            <img
+                                src={emo.url}
+                                alt={emo.reaction}
+                                class="h-7 w-7 object-scale-down"
+                            />
+                        {:else}
+                            <span class="text-xl leading-none">{emo.emoji}</span>
+                        {/if}
                     </button>
                 {/each}
             </div>
-
-            <!-- 이모티콘 그리드 -->
-            <div class="max-h-48 overflow-y-auto p-2">
-                <div
-                    class="grid grid-cols-{activeCategory === 'emoji' ? '9' : '6'} gap-0.5"
-                    style="grid-template-columns: repeat({activeCategory === 'emoji'
-                        ? 9
-                        : 6}, minmax(0, 1fr));"
-                >
-                    {#each categoryEmoticons as emo (emo.reaction)}
-                        <button
-                            type="button"
-                            onclick={() => react(emo.reaction, 'add')}
-                            disabled={isReacting}
-                            class="hover:bg-accent flex items-center justify-center rounded-lg p-1 transition-all hover:scale-110"
-                            title={emo.emoji || emo.reaction}
-                        >
-                            {#if emo.renderType === 'image' && emo.url}
-                                <img
-                                    src={emo.url}
-                                    alt={emo.reaction}
-                                    class="h-7 w-7 object-scale-down"
-                                />
-                            {:else}
-                                <span class="text-xl leading-none">{emo.emoji}</span>
-                            {/if}
-                        </button>
-                    {/each}
-                </div>
-            </div>
         </div>
-    {/if}
-</div>
+    </div>
+{/if}
 
 <style>
     .da-reaction-badge:active {


### PR DESCRIPTION
## Summary
- 댓글 아이템의 `overflow-hidden` CSS로 인해 리액션 피커(이모지 선택 팝업)가 잘리는 현상 수정
- 피커를 `absolute` → `fixed` 포지셔닝으로 전환하여 overflow 컨텍스트에서 탈출
- 버튼 위치 기반으로 뷰포트 좌표 계산 + 화면 밖 넘침 방지 로직 추가

## Test plan
- [ ] 댓글의 리액션 추가 버튼(😊+) 클릭 시 피커가 정상 표시되는지 확인
- [ ] 피커가 다른 요소에 가려지지 않는지 확인 (Chrome, Firefox)
- [ ] 화면 하단 댓글에서 피커가 위쪽으로 표시되는지, 상단이면 아래로 표시되는지 확인
- [ ] 피커 외부 클릭 시 닫히는지 확인
- [ ] ESC 키로 피커 닫히는지 확인