### PR TITLE
feat: [spoiler] 태그 기능 구현 (#7704)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -529,7 +529,9 @@
                             'code',
                             'strong',
                             'em',
-                            'del'
+                            'del',
+                            'details',
+                            'summary'
                         ],
                         ALLOWED_ATTR: [
                             'src',
@@ -1383,5 +1385,40 @@
     /* 이미지 로딩 실패 시 숨김 처리 */
     :global(.bracket-image[src='']) {
         display: none;
+    }
+
+    /* 댓글 스포일러 블록 */
+    :global(.comment-body .spoiler-block) {
+        border: 1px solid var(--border);
+        border-radius: 0.375rem;
+        margin: 0.5em 0;
+        overflow: hidden;
+    }
+    :global(.comment-body .spoiler-block summary) {
+        cursor: pointer;
+        padding: 0.375rem 0.625rem;
+        background-color: var(--muted);
+        font-weight: 500;
+        font-size: 0.8125rem;
+        color: var(--muted-foreground);
+        user-select: none;
+        list-style: none;
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+    }
+    :global(.comment-body .spoiler-block summary::-webkit-details-marker) {
+        display: none;
+    }
+    :global(.comment-body .spoiler-block summary::before) {
+        content: '▶';
+        font-size: 0.5625rem;
+        transition: transform 0.2s;
+    }
+    :global(.comment-body .spoiler-block[open] summary::before) {
+        transform: rotate(90deg);
+    }
+    :global(.comment-body .spoiler-content) {
+        padding: 0.5rem 0.625rem;
     }
 </style>

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -135,7 +135,9 @@
             'video',
             'audio',
             'source',
-            'span'
+            'span',
+            'details',
+            'summary'
         ],
         ALLOWED_ATTR: [
             'href',
@@ -166,7 +168,8 @@
             'muted',
             'loop',
             'playsinline',
-            'preload'
+            'preload',
+            'open'
         ]
     };
 
@@ -479,6 +482,50 @@
         position: relative;
         min-height: 250px;
         height: auto;
+    }
+
+    /* 스포일러 블록 [spoiler]...[/spoiler] */
+    .prose :global(.spoiler-block) {
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        margin: 0.75rem 0;
+        overflow: hidden;
+    }
+
+    .prose :global(.spoiler-block summary) {
+        cursor: pointer;
+        padding: 0.5rem 0.75rem;
+        background-color: var(--muted);
+        font-weight: 500;
+        font-size: 0.875rem;
+        color: var(--muted-foreground);
+        user-select: none;
+        list-style: none;
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+    }
+
+    .prose :global(.spoiler-block summary::-webkit-details-marker) {
+        display: none;
+    }
+
+    .prose :global(.spoiler-block summary::before) {
+        content: '▶';
+        font-size: 0.625rem;
+        transition: transform 0.2s;
+    }
+
+    .prose :global(.spoiler-block[open] summary::before) {
+        transform: rotate(90deg);
+    }
+
+    .prose :global(.spoiler-block summary:hover) {
+        background-color: color-mix(in srgb, var(--muted) 80%, var(--foreground) 5%);
+    }
+
+    .prose :global(.spoiler-content) {
+        padding: 0.75rem;
     }
 
     /* 직접 비디오 파일 ({video:} 패턴) */

--- a/apps/web/src/lib/hooks/builtin/comment-content.ts
+++ b/apps/web/src/lib/hooks/builtin/comment-content.ts
@@ -12,7 +12,8 @@ import {
     transformInlineCode,
     transformInlineMarkdown,
     transformOembed,
-    transformEscapedMedia
+    transformEscapedMedia,
+    transformSpoilers
 } from '$lib/utils/content-transform';
 import { processContent } from '$lib/plugins/auto-embed';
 
@@ -53,6 +54,15 @@ export function initCommentContent(): void {
         'comment_content',
         (html: unknown) => transformCodeBlocks(html as string),
         3,
+        'core',
+        'filter'
+    );
+
+    // [spoiler]...[/spoiler] BBCode → <details>
+    registerHook(
+        'comment_content',
+        (html: unknown) => transformSpoilers(html as string),
+        3.5,
         'core',
         'filter'
     );

--- a/apps/web/src/lib/hooks/builtin/content-video.ts
+++ b/apps/web/src/lib/hooks/builtin/content-video.ts
@@ -7,7 +7,8 @@ import {
     transformVideos,
     transformCodeBlocks,
     transformOembed,
-    transformEscapedMedia
+    transformEscapedMedia,
+    transformSpoilers
 } from '$lib/utils/content-transform';
 
 /**
@@ -46,6 +47,15 @@ export function initContentVideo(): void {
         'post_content',
         (html: unknown) => transformCodeBlocks(html as string),
         3, // 동영상(5), auto-embed(10)보다 먼저 실행
+        'core',
+        'filter'
+    );
+
+    // [spoiler]...[/spoiler] BBCode → <details>
+    registerHook(
+        'post_content',
+        (html: unknown) => transformSpoilers(html as string),
+        3.5,
         'core',
         'filter'
     );

--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -12,6 +12,7 @@ const VIDEO_PATTERN = /\{(동영상|video)\s*:\s*([\s\S]*?)\}/gi;
 const CODE_BLOCK_PATTERN = /\[code(?:=([a-zA-Z0-9_+-]+))?\]([\s\S]*?)\[\/code\]/gi;
 const BACKTICK_CODE_BLOCK_PATTERN = /```([a-zA-Z0-9_+-]*)(?:\n|<br\s*\/?>)([\s\S]*?)```/gi;
 const INLINE_CODE_PATTERN = /`([^`\n]+)`/g;
+const SPOILER_PATTERN = /\[spoiler(?:=([^\]]*))?\]([\s\S]*?)\[\/spoiler\]/gi;
 const MAX_WIDTH = 200;
 const DEFAULT_WIDTH = 50;
 const ALLOWED_EXTENSIONS = ['.gif', '.png', '.jpg', '.jpeg', '.webp'];
@@ -251,4 +252,17 @@ export function transformEscapedMedia(html: string): string {
     );
 
     return result;
+}
+
+/**
+ * [spoiler]...[/spoiler] 또는 [spoiler=제목]...[/spoiler] BBCode를 <details> 태그로 변환
+ * 클릭하면 내용이 펼쳐지는 스포일러 블록
+ */
+export function transformSpoilers(html: string): string {
+    if (!html || !html.toLowerCase().includes('[spoiler')) return html;
+
+    return html.replace(SPOILER_PATTERN, (_match, title: string | undefined, content: string) => {
+        const label = title?.trim() || '스포일러';
+        return `<details class="spoiler-block"><summary>${label}</summary><div class="spoiler-content">${content}</div></details>`;
+    });
 }


### PR DESCRIPTION
## Summary
- `[spoiler]내용[/spoiler]` 또는 `[spoiler=제목]내용[/spoiler]` BBCode로 스포일러 블록 지원
- `<details>/<summary>` 태그 기반 — 클릭하면 펼쳐지는 접근성 있는 UI
- 게시글 본문 + 댓글 모두 적용
- DOMPurify에 `details`/`summary` 태그 허용 추가

## Test plan
- [ ] 게시글에서 `[spoiler]스포일러 내용입니다[/spoiler]` 입력 → 접힌 상태로 렌더링
- [ ] 클릭 시 내용 펼침/접힘 확인
- [ ] `[spoiler=커스텀 제목]` 사용 시 제목 표시 확인
- [ ] 댓글에서도 동일 동작 확인
- [ ] 스포일러 내부에 이미지/동영상/코드블록 포함 시 정상 렌더링