### PR TITLE
perf: Docker 빌드 속도 최적화 (~70% 단축)

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build & Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm  # ARM64 네이티브 (QEMU 불필요)
     if: inputs.confirm == 'deploy'
 
     steps:
@@ -90,9 +90,6 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
   # main push 시 Docker 이미지 빌드 + GHCR push
   build-and-push:
     name: Build & Push Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm  # ARM64 네이티브 러너 (QEMU 불필요)
     permissions:
       contents: read
       packages: write
@@ -55,9 +55,6 @@ jobs:
         run: |
           mkdir -p custom-themes custom-widgets extensions plugins widgets
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -84,11 +81,11 @@ jobs:
           file: apps/web/Dockerfile
           target: production
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=production
-          cache-to: type=gha,mode=max,scope=production
+          cache-from: type=gha,scope=production-arm64
+          cache-to: type=gha,mode=max,scope=production-arm64
           build-args: |
             VITE_USE_MOCK=false
             VITE_GAM_NETWORK_CODE=23338387889

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -46,6 +46,24 @@ ENV DEV_PORT=$DEV_PORT
 CMD ["sh", "-c", "pnpm dev --host 0.0.0.0 --port $DEV_PORT"]
 
 # -----------------------------
+# Dependencies stage (캐시 최적화)
+# -----------------------------
+FROM base AS deps
+
+WORKDIR /app
+
+# 의존성 파일만 먼저 복사 (소스 변경 시에도 이 레이어 캐시 유지)
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
+COPY packages/types/package.json ./packages/types/
+COPY packages/i18n/package.json ./packages/i18n/
+COPY packages/hook-system/package.json ./packages/hook-system/
+COPY packages/theme-engine/package.json ./packages/theme-engine/
+COPY apps/web/package.json ./apps/web/
+
+# Install dependencies (lock 파일 변경 시에만 재실행)
+RUN pnpm install --frozen-lockfile --filter web...
+
+# -----------------------------
 # Build stage
 # -----------------------------
 FROM base AS builder
@@ -60,36 +78,33 @@ ENV VITE_SSR=$VITE_SSR
 ENV VITE_GAM_NETWORK_CODE=$VITE_GAM_NETWORK_CODE
 ENV VITE_GAM_SITE_NAME=$VITE_GAM_SITE_NAME
 
-# Set working directory
 WORKDIR /app
 
-# Copy workspace configuration files
+# 캐시된 node_modules 복사
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/types/node_modules ./packages/types/node_modules
+COPY --from=deps /app/packages/i18n/node_modules ./packages/i18n/node_modules
+COPY --from=deps /app/packages/hook-system/node_modules ./packages/hook-system/node_modules
+COPY --from=deps /app/packages/theme-engine/node_modules ./packages/theme-engine/node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+
+# 소스 코드 복사
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
-
-# Copy workspace packages (workspace:* dependencies)
 COPY packages ./packages
-
-# Copy themes/plugins/widgets before install (needed for build)
 COPY themes ./themes
 COPY plugins ./plugins
 COPY widgets ./widgets
-
-# Premium 에셋 (빌드 전 mkdir -p로 빈 디렉토리라도 보장)
 COPY custom-themes ./custom-themes
 COPY custom-widgets ./custom-widgets
 COPY extensions ./extensions
-
-# Copy application source
 COPY apps/web ./apps/web
 
-# Install dependencies (with .npmrc hoisting for plugins)
-RUN pnpm install --frozen-lockfile --filter web...
 # 워크스페이스 패키지 먼저 빌드 (의존성 순서대로)
-RUN pnpm --filter @angple/types run build
-RUN pnpm --filter @angple/i18n run build
-RUN pnpm --filter @angple/hook-system run build
-RUN pnpm --filter @angple/theme-engine run build
-RUN pnpm --filter web run build
+RUN pnpm --filter @angple/types run build \
+    && pnpm --filter @angple/i18n run build \
+    && pnpm --filter @angple/hook-system run build \
+    && pnpm --filter @angple/theme-engine run build \
+    && pnpm --filter web run build
 
 # Deploy as standalone package (resolves workspace:* dependencies)
 # --legacy: pnpm v10에서 inject-workspace-packages 없이 deploy 허용


### PR DESCRIPTION
## Summary
- ARM64 전용 빌드로 변경 (amd64 제거 — K8s 단일 ARM64 노드이므로 불필요)
- `ubuntu-24.04-arm` 네이티브 러너 사용 (QEMU 에뮬레이션 완전 제거)
- Dockerfile에 `deps` stage 분리하여 레이어 캐시 최적화 (소스만 변경 시 pnpm install 스킵)
- 빌드 RUN 명령어 체이닝으로 레이어 수 감소

### 예상 효과
| 항목 | Before | After |
|---|---|---|
| 아키텍처 | amd64 + arm64 | arm64만 |
| 빌드 방식 | QEMU 에뮬레이션 | 네이티브 ARM64 |
| 의존성 캐시 | 소스 변경 시 재설치 | lock 파일 변경 시에만 |
| 예상 빌드 시간 | ~8분 | ~2-3분 |

## Test plan
- [ ] Docker Build & Deploy 워크플로우가 ARM64 네이티브 러너에서 정상 실행
- [ ] 빌드된 이미지로 K8s pod 정상 기동 확인
- [ ] 의존성 미변경 시 deps 레이어 캐시 히트 확인