### PR TITLE
perf: Docker 빌드를 네이티브 빌드로 전환 (~3분 목표)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,6 +55,39 @@ jobs:
         run: |
           mkdir -p custom-themes custom-widgets extensions plugins widgets
 
+      # --- 네이티브 빌드 (Docker 밖에서 빌드 → 최소 이미지만 생성) ---
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages & web
+        env:
+          VITE_USE_MOCK: 'false'
+          VITE_GAM_NETWORK_CODE: '23338387889'
+          VITE_GAM_SITE_NAME: 'damoang'
+        run: |
+          pnpm --filter "./packages/*" build
+          echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
+          echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
+          pnpm --filter web build
+
+      - name: Prepare deploy package
+        run: |
+          pnpm --filter web deploy --prod --legacy apps/web/deploy
+          cp -r apps/web/build apps/web/deploy/
+          for dir in plugins widgets themes custom-themes custom-widgets extensions; do
+            cp -r "$dir" "apps/web/deploy/" 2>/dev/null || mkdir -p "apps/web/deploy/$dir"
+          done
+
+      # --- 최소 Docker 이미지 생성 (COPY만) ---
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -77,19 +110,12 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: apps/web/Dockerfile
-          target: production
+          context: apps/web/deploy
+          file: apps/web/Dockerfile.prod
           push: true
           platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=production-arm64
-          cache-to: type=gha,mode=max,scope=production-arm64
-          build-args: |
-            VITE_USE_MOCK=false
-            VITE_GAM_NETWORK_CODE=23338387889
-            VITE_GAM_SITE_NAME=damoang
 
       - name: Image digest
         run: echo "Image pushed with tags ${{ steps.meta.outputs.tags }}"

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -1,0 +1,21 @@
+FROM node:22-alpine
+
+RUN adduser -D -u 1001 -s /bin/sh nodeuser
+
+WORKDIR /app
+
+COPY --chown=nodeuser:nodeuser . .
+
+RUN mkdir -p /app/data && chown nodeuser:nodeuser /app/data
+
+USER nodeuser
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -q -O /dev/null http://127.0.0.1:${PORT}/health || exit 1
+
+CMD ["node", "build/index.js"]


### PR DESCRIPTION
## Summary
- pnpm install + build를 Docker 밖에서 네이티브 실행 (GitHub Actions pnpm 캐시 활용)
- Docker는 빌드 결과물을 COPY만 하는 최소 이미지 생성 (`Dockerfile.prod`)
- 기존 멀티스테이지 Dockerfile은 로컬 개발용으로 유지

### 빌드 시간 변화
| 버전 | 방식 | 소요 시간 |
|---|---|---|
| v1 | QEMU + amd64/arm64 | ~22분 |
| v2 (현재) | ARM64 네이티브 러너 + Docker 내 빌드 | ~8분 |
| **v3 (이 PR)** | **네이티브 빌드 + 최소 Docker** | **~3분 (목표)** |

### 왜 빨라지나?
1. `pnpm install` — GitHub Actions 캐시 히트 시 ~5초 (Docker 레이어 캐시보다 훨씬 안정적)
2. `pnpm build` — 네이티브 실행 (Docker BuildKit 오버헤드 없음)
3. Docker build — `COPY . .` + 베이스 이미지만 (수초)

## Test plan
- [ ] 워크플로우 정상 실행 확인
- [ ] GHCR 이미지 push 확인
- [ ] K8s pod에서 새 이미지로 정상 기동
- [ ] GAM 광고 코드 번들에 포함 확인