### PR TITLE
fix/게시판 상단 툴바 및 보기설정 개선

### DIFF
--- a/apps/web/src/lib/components/features/board/board-favorite-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-favorite-button.svelte
@@ -49,9 +49,10 @@
     title={isFavorite
         ? `즐겨찾기 '${slotLabel(registeredSlot!)}' (클릭하여 해제)`
         : '이 게시판을 즐겨찾기에 등록'}
-    class="h-8 w-8 {isFavorite
+    class="relative h-8 w-8 {isFavorite
         ? 'text-yellow-500 hover:text-yellow-600'
         : 'text-muted-foreground hover:text-yellow-500'}"
 >
+    <span class="absolute -inset-2"></span>
     <Star class="h-4 w-4" fill={isFavorite ? 'currentColor' : 'none'} />
 </Button>

--- a/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
@@ -80,10 +80,11 @@
         title={isSubscribed
             ? `'${boardTitle}' 구독 중 (${subscriberCount}명) — 클릭하여 해제`
             : `'${boardTitle}' 구독하기 — 새 글 알림 받기${subscriberCount > 0 ? ` (${subscriberCount}명 구독 중)` : ''}`}
-        class="h-8 w-8 {isSubscribed
+        class="relative h-8 w-8 {isSubscribed
             ? 'text-primary hover:text-primary/80'
             : 'text-muted-foreground hover:text-primary'}"
     >
+        <span class="absolute -inset-2"></span>
         {#if isSubscribed}
             <Bell class="h-4 w-4" fill="currentColor" />
         {:else}

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -107,6 +107,9 @@
 
     // 모바일 10+ 추천 시 pill 배지 스타일
     const mobileLikesPill = $derived(post.likes >= 10);
+
+    // 모던 보기: 데스크탑에서도 모바일 레이아웃 강제 적용
+    const isMobileView = $derived(uiSettingsStore.listView === 'modern');
 </script>
 
 <!-- Classic 스킨: 데스크톱 CSS Grid 5컬럼 (추천|제목|이름|날짜|조회) -->
@@ -135,10 +138,12 @@
         data-sveltekit-preload-data="hover"
     >
         <div
-            class="flex items-center gap-2 md:grid md:grid-cols-[60px_1fr_auto_auto_auto] md:items-center md:gap-0"
+            class={isMobileView
+                ? 'flex items-center gap-2'
+                : 'flex items-center gap-2 md:grid md:grid-cols-[60px_1fr_auto_auto_auto] md:items-center md:gap-0'}
         >
             <!-- 추천 박스 (col 1, 데스크톱만) — legacy: rcmd-box 40×20 rounded-lg -->
-            <div class="hidden md:flex md:items-center md:justify-center">
+            <div class={isMobileView ? 'hidden' : 'hidden md:flex md:items-center md:justify-center'}>
                 {#if post.is_notice}
                     <div
                         class="flex h-5 w-10 items-center justify-center rounded-lg"
@@ -157,11 +162,11 @@
             </div>
 
             <!-- 콘텐츠 (모바일: block, 데스크톱: contents → 그리드 col 2~5 참여) -->
-            <div class="min-w-0 flex-1 space-y-1 md:contents md:space-y-0">
+            <div class={isMobileView ? 'min-w-0 flex-1 space-y-1' : 'min-w-0 flex-1 space-y-1 md:contents md:space-y-0'}>
                 <!-- 제목 줄 (col 2) -->
                 <div class="flex min-w-0 items-center gap-1">
                     {#if post.is_notice}
-                        <span class="mobile-only" style="display:none"
+                        <span class="mobile-only" class:modern-view={isMobileView}
                             ><Pin class="text-liked h-3.5 w-3.5 shrink-0" /></span
                         >
                     {/if}
@@ -180,7 +185,7 @@
                             {post.category}
                         </span>
                     {/if}
-                    <span class="truncate {readClass}" class:font-bold={uiSettingsStore.titleBold}>
+                    <span class="truncate {readClass}" class:font-semibold={uiSettingsStore.titleBold}>
                         {post.title}
                     </span>
                     <!-- 부가 아이콘: N, 이미지, 동영상, 댓글 -->
@@ -204,7 +209,7 @@
 
                 <!-- 이름 (col 3, 데스크톱만) — legacy: 13px, 100px wide -->
                 <span
-                    class="post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:pl-1"
+                    class={isMobileView ? 'hidden' : 'post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:pl-1'}
                 >
                     {#if iconUrl}
                         <img
@@ -219,22 +224,18 @@
 
                 <!-- 날짜 (col 4, 데스크톱만) -->
                 <span
-                    class="post-meta-text hidden md:inline md:w-[70px] md:pl-1 md:text-center {isToday(
-                        post.created_at
-                    )
-                        ? 'date-today'
-                        : ''}"
+                    class={isMobileView ? 'hidden' : `post-meta-text hidden md:inline md:w-[70px] md:pl-1 md:text-center ${isToday(post.created_at) ? 'date-today' : ''}`}
                 >
                     {formatDate(post.created_at)}
                 </span>
 
                 <!-- 조회수 (col 5, 데스크톱만) -->
-                <span class="post-meta-text hidden md:inline md:w-[50px] md:pl-1 md:text-center">
+                <span class={isMobileView ? 'hidden' : 'post-meta-text hidden md:inline md:w-[50px] md:pl-1 md:text-center'}>
                     {formatCompactNumber(post.views)}
                 </span>
 
                 <!-- 모바일 메타 (Line 2: 👍likes · Author · Date · 조회) -->
-                <div class="mobile-meta" style="display:none">
+                <div class="mobile-meta" class:modern-view={isMobileView}>
                     {#if mobileLikesPill}
                         <span class="mobile-likes-pill">👍{post.likes}</span>
                     {:else}
@@ -353,6 +354,17 @@
             align-items: center;
             gap: 0.25rem;
         }
+    }
+
+    /* 모던 보기: 데스크탑에서 모바일 레이아웃 강제 적용 */
+    .mobile-only.modern-view {
+        display: inline-flex !important;
+    }
+
+    .mobile-meta.modern-view {
+        display: flex !important;
+        align-items: center;
+        gap: 0.25rem;
     }
 
     /* 모바일 메타 구분자: CSS-only (HTML에 · 없음 → FOUC 시 점 미노출) */

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -12,10 +12,12 @@ const STORAGE_KEY = 'angple_ui_settings';
 export type FontFamily = 'default' | 'pretendard' | 'nanum-gothic' | 'noto-sans';
 export type LineHeight = 'compact' | 'normal' | 'relaxed' | 'loose';
 export type ShortcutButtonSize = 'small' | 'medium' | 'large';
+export type ListViewMode = 'classic' | 'modern';
 
 interface UiSettings {
     // 레이아웃
     titleBold: boolean;
+    listView: ListViewMode;
     lineHeight: LineHeight;
     fontFamily: FontFamily;
     hideMyProfile: boolean;
@@ -40,6 +42,7 @@ interface UiSettings {
 
 const DEFAULTS: UiSettings = {
     titleBold: false,
+    listView: 'classic',
     lineHeight: 'normal',
     fontFamily: 'default',
     hideMyProfile: false,
@@ -127,6 +130,13 @@ function createUiSettingsStore() {
         },
         set titleBold(v: boolean) {
             settings.titleBold = v;
+            save();
+        },
+        get listView() {
+            return settings.listView;
+        },
+        set listView(v: ListViewMode) {
+            settings.listView = v;
             save();
         },
         get lineHeight() {

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -52,6 +52,17 @@
     import { readPostStyleStore, type ReadPostStyle } from '$lib/stores/read-post-style.svelte.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import BoardListSkeleton from '$lib/components/features/board/board-list-skeleton.svelte';
+    import {
+        DropdownMenu,
+        DropdownMenuContent,
+        DropdownMenuTrigger,
+        DropdownMenuLabel,
+        DropdownMenuSeparator,
+        DropdownMenuRadioGroup,
+        DropdownMenuRadioItem,
+        DropdownMenuCheckboxItem
+    } from '$lib/components/ui/dropdown-menu/index.js';
+    import Settings2 from '@lucide/svelte/icons/settings-2';
 
     // 특수 게시판 컴포넌트 (플러그인 레지스트리 기반)
     import { boardTypeRegistry } from '$lib/components/features/board/board-type-registry.js';
@@ -352,9 +363,9 @@
             {/if}
 
             <!-- 헤더 -->
-            <div class="mb-4 flex items-center gap-3">
+            <div class="mb-4 flex items-center justify-between">
                 <div class="flex shrink-0 items-center gap-2">
-                    <h1 class="text-xl font-bold sm:text-3xl">
+                    <h1 class="text-2xl font-bold sm:text-3xl">
                         <a
                             href="/{boardId}"
                             class="text-foreground hover:text-primary transition-colors"
@@ -378,31 +389,85 @@
                     {/if}
                 </div>
 
-                <Button
-                    variant="outline"
-                    size="icon"
-                    class="h-9 w-9 shrink-0"
-                    onclick={() => (showSearch = !showSearch)}
-                    title="검색"
-                >
-                    <Search class="h-4 w-4" />
-                </Button>
-                {#if canWrite()}
-                    <Button onclick={goToWrite} class="shrink-0">
-                        <Pencil class="mr-2 h-4 w-4" />
-                        글쓰기
-                    </Button>
-                {:else if authStore.isAuthenticated}
-                    <!-- 로그인했지만 권한 부족 -->
+                <div class="flex items-center gap-2">
+                    {#if listLayoutId === 'classic'}
+                        <DropdownMenu>
+                            <DropdownMenuTrigger>
+                                {#snippet child({ props })}
+                                    <Button {...props} variant="outline" size="icon" class="relative h-9 w-9 shrink-0" title="보기 설정">
+                                        <span class="absolute -inset-1.5"></span>
+                                        <Settings2 class="h-4 w-4" />
+                                    </Button>
+                                {/snippet}
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" class="w-44">
+                                <!-- 화면 레이아웃 (데스크탑 전용) -->
+                                <div class="hidden md:block">
+                                    <DropdownMenuLabel class="text-xs font-semibold">화면 레이아웃</DropdownMenuLabel>
+                                    <DropdownMenuRadioGroup
+                                        value={uiSettingsStore.listView}
+                                        onValueChange={(v) => (uiSettingsStore.listView = v as 'classic' | 'modern')}
+                                    >
+                                        <DropdownMenuRadioItem value="classic">클래식</DropdownMenuRadioItem>
+                                        <DropdownMenuRadioItem value="modern">모던</DropdownMenuRadioItem>
+                                    </DropdownMenuRadioGroup>
+                                    <DropdownMenuSeparator />
+                                </div>
+                                <DropdownMenuLabel class="text-xs font-semibold">읽은 글 표시</DropdownMenuLabel>
+                                <DropdownMenuRadioGroup
+                                    value={readPostStyleStore.value}
+                                    onValueChange={(v) => readPostStyleStore.set(v as ReadPostStyle)}
+                                >
+                                    <DropdownMenuRadioItem value="dimmed">흐림</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="bold">굵게</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="italic">기울임</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="underline">밑줄</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="strikethrough">취소선</DropdownMenuRadioItem>
+                                </DropdownMenuRadioGroup>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuLabel class="text-xs font-semibold">목록 밀도</DropdownMenuLabel>
+                                <DropdownMenuRadioGroup
+                                    value={densityStore.value}
+                                    onValueChange={(v) => densityStore.set(v as 'compact' | 'balanced' | 'relaxed')}
+                                >
+                                    <DropdownMenuRadioItem value="compact">촘촘</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="balanced">보통</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="relaxed">여유</DropdownMenuRadioItem>
+                                </DropdownMenuRadioGroup>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuCheckboxItem
+                                    checked={uiSettingsStore.titleBold}
+                                    onCheckedChange={(v) => (uiSettingsStore.titleBold = v)}
+                                >글 제목 굵게 표시</DropdownMenuCheckboxItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    {/if}
                     <Button
-                        disabled
-                        class="shrink-0 cursor-not-allowed opacity-60"
-                        title={writePermissionMessage()}
+                        variant="outline"
+                        size="icon"
+                        class="relative h-9 w-9 shrink-0"
+                        onclick={() => (showSearch = !showSearch)}
+                        title="검색"
                     >
-                        <Lock class="mr-2 h-4 w-4" />
-                        글쓰기
+                        <span class="absolute -inset-1.5"></span>
+                        <Search class="h-4 w-4" />
                     </Button>
-                {/if}
+                    {#if canWrite()}
+                        <Button onclick={goToWrite} class="shrink-0">
+                            <Pencil class="mr-2 h-4 w-4" />
+                            글쓰기
+                        </Button>
+                    {:else if authStore.isAuthenticated}
+                        <Button
+                            disabled
+                            class="shrink-0 cursor-not-allowed opacity-60"
+                            title={writePermissionMessage()}
+                        >
+                            <Lock class="mr-2 h-4 w-4" />
+                            글쓰기
+                        </Button>
+                    {/if}
+                </div>
             </div>
 
             <!-- 축하 메시지 롤링 -->
@@ -520,61 +585,7 @@
 
                 <!-- 게시글 목록 -->
                 <div class={wrapperClass}>
-                    {#if listLayoutId === 'classic'}
-                        <div class="hidden justify-end px-4 pb-1 md:flex">
-                            <div class="flex items-center gap-3">
-                                <!-- 읽은 글 스타일 -->
-                                <div class="flex items-center gap-0.5">
-                                    <span class="text-muted-foreground mr-0.5 text-[10px]"
-                                        >읽은글</span
-                                    >
-                                    {#each [{ value: 'dimmed', label: '흐림' }, { value: 'bold', label: '굵게' }, { value: 'italic', label: '기울임' }, { value: 'underline', label: '밑줄' }, { value: 'strikethrough', label: '취소선' }] as opt (opt.value)}
-                                        <button
-                                            class="rounded px-1.5 py-0.5 text-[10px] transition-colors {readPostStyleStore.value ===
-                                            opt.value
-                                                ? 'bg-foreground/10 text-foreground'
-                                                : 'text-muted-foreground hover:text-foreground'}"
-                                            onclick={() =>
-                                                readPostStyleStore.set(opt.value as ReadPostStyle)}
-                                            >{opt.label}</button
-                                        >
-                                    {/each}
-                                </div>
-                                <!-- 밀도 -->
-                                <div class="flex items-center gap-0.5">
-                                    <button
-                                        class="rounded px-1.5 py-0.5 text-[10px] transition-colors {densityStore.value ===
-                                        'compact'
-                                            ? 'bg-foreground/10 text-foreground'
-                                            : 'text-muted-foreground hover:text-foreground'}"
-                                        onclick={() => densityStore.set('compact')}>촘촘</button
-                                    >
-                                    <button
-                                        class="rounded px-1.5 py-0.5 text-[10px] transition-colors {densityStore.value ===
-                                        'balanced'
-                                            ? 'bg-foreground/10 text-foreground'
-                                            : 'text-muted-foreground hover:text-foreground'}"
-                                        onclick={() => densityStore.set('balanced')}>보통</button
-                                    >
-                                    <button
-                                        class="rounded px-1.5 py-0.5 text-[10px] transition-colors {densityStore.value ===
-                                        'relaxed'
-                                            ? 'bg-foreground/10 text-foreground'
-                                            : 'text-muted-foreground hover:text-foreground'}"
-                                        onclick={() => densityStore.set('relaxed')}>여유</button
-                                    >
-                                </div>
-                                <!-- 제목 굵게 -->
-                                <button
-                                    class="rounded px-1.5 py-0.5 text-[10px] transition-colors {uiSettingsStore.titleBold
-                                        ? 'bg-foreground/10 text-foreground'
-                                        : 'text-muted-foreground hover:text-foreground'}"
-                                    onclick={() =>
-                                        (uiSettingsStore.titleBold = !uiSettingsStore.titleBold)}
-                                    >제목 굵게</button
-                                >
-                            </div>
-                        </div>
+                    {#if listLayoutId === 'classic' && uiSettingsStore.listView !== 'modern'}
                         <div
                             class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium md:block"
                         >


### PR DESCRIPTION
모바일 h1 크기가 너무 작아서 (20에서 pc 갑자기 30으로 점프) 24로 조절하였습니다.
게시판 헤더 버튼들이 36px로 피츠의 법칙을 위반하여 터치영역만 늘렸습니다.
게시판 상단에 작은 글자로 펼쳐져 있던 보기 설정 툴바를 드롭다운 형식으로 헤더에 넣었습니다.
보기 설정 중 pc에서 게시판 글만 모바일 뷰로 바꿀 수 있는 토글 기능을 넣었습니다. (클래식 <-> 모던)

헤더 버튼이 너무 빼곡해서 장기적으로는 정리가 필요하겠으나 일단 툴바 형식으로 펼쳐놓는것보다는 인지부하가 줄 것 같아서 일시적으로 개선했습니다.