### PR TITLE
fix/게시글 post 레이아웃 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -91,7 +91,7 @@
 </script>
 
 <!-- 게시글 카드 -->
-<Card class="bg-background mb-6">
+<Card class="bg-background mb-6 pt-0 pb-5">
     <CardHeader class="space-y-3">
         <!-- 관리자 본문 레이아웃 스위처 -->
         <div class="flex items-center justify-end">

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1030,7 +1030,7 @@
     />
 {/if}
 
-<div class="mx-auto overflow-x-hidden pt-2">
+<div class="mx-auto pt-2">
     <!-- 상단 배너 -->
     {#if widgetLayoutStore.hasEnabledAds}
         <div class="mb-6">
@@ -1039,7 +1039,7 @@
     {/if}
 
     <!-- 상단 네비게이션 -->
-    <div class="-mx-1 mb-2 flex items-center gap-3 py-2">
+    <div class="-mx-5 mb-2 flex items-center gap-3 px-5 py-2 md:mx-0 md:px-0">
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">← 목록으로</Button>
 
         <div class="flex-1"></div>


### PR DESCRIPTION
이전 PR의 레이아웃과 같은 방향으로 POST에서는 음수마진이 적용되지 않았던 문제를 수정하였습니다.

그리고 게시글 카드의 상하좌우 패딩을 비슷하게 보이도록 조절하였고,

게시글 카드 위의 요소가 잘못된 크기로 잘려 나오던것을 수정하였습니다.