### PR TITLE
ci: main push 시 ECR + K8s 자동 배포

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/angple-web
+  ECR_REGISTRY: 891376997084.dkr.ecr.ap-northeast-2.amazonaws.com
+  ECR_REPOSITORY: angple-web
+  AWS_REGION: ap-northeast-2
 
 jobs:
   # main push 시 Docker 이미지 빌드 + GHCR push
@@ -29,6 +32,7 @@ jobs:
     name: Build & Push Image
     runs-on: ubuntu-24.04-arm  # ARM64 네이티브 러너 (QEMU 불필요)
     permissions:
+      id-token: write
       contents: read
       packages: write
 
@@ -118,7 +122,85 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Image digest
-        run: echo "Image pushed with tags ${{ steps.meta.outputs.tags }}"
+        run: echo "Image pushed to GHCR with tags ${{ steps.meta.outputs.tags }}"
+
+      # --- ECR push + K8s 배포 (main push 시 자동) ---
+      - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/main'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        if: github.ref == 'refs/heads/main'
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Push to ECR
+        if: github.ref == 'refs/heads/main'
+        run: |
+          ECR_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}"
+          SHA_TAG="sha-${{ github.sha }}"
+
+          # Buildx로 빌드된 이미지를 ECR에도 push
+          docker buildx build \
+            --platform linux/arm64 \
+            -t "${ECR_IMAGE}:${SHA_TAG}" \
+            -t "${ECR_IMAGE}:latest" \
+            --push \
+            -f apps/web/Dockerfile.prod \
+            apps/web/deploy
+
+          echo "ECR push complete: ${ECR_IMAGE}:${SHA_TAG}"
+
+      - name: Deploy to K8s via SSM
+        if: github.ref == 'refs/heads/main'
+        env:
+          IMAGE_TAG: sha-${{ github.sha }}
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "i-038a1d1f00798d94b" \
+            --document-name "AWS-RunShellScript" \
+            --parameters 'commands=[
+              "/home/angple/k8s/prod/deploy.sh web '"$IMAGE_TAG"'"
+            ]' \
+            --timeout-seconds 600 \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "Command ID: $COMMAND_ID"
+          echo "Waiting for deployment..."
+
+          for i in $(seq 1 60); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "i-038a1d1f00798d94b" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+
+            if [ "$STATUS" = "Success" ]; then
+              echo "Deploy successful!"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardOutputContent" \
+                --output text
+              exit 0
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+              echo "Deploy failed with status: $STATUS"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardErrorContent" \
+                --output text
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Deploy timed out waiting for SSM response"
+          exit 1
 
   # 프로덕션 배포 (수동 트리거 전용)
   deploy-prod:


### PR DESCRIPTION
## Summary
- main push 시 GHCR뿐만 아니라 ECR에도 자동 push
- SSM을 통해 K8s deploy.sh 자동 실행 (카나리 → 본배포)
- `deploy-binary.yml` 수동 실행 없이도 운영 반영 가능

## 변경 이유
기존에는 main 머지 → GHCR push만 되고, ECR/K8s 배포는 `deploy-binary.yml`을 수동 실행해야 했음.
이로 인해 머지했는데 운영에 반영 안 되는 문제가 반복 발생.

## Test plan
- [ ] main push 시 GHCR + ECR 양쪽에 이미지 push 확인
- [ ] SSM deploy.sh 자동 실행 및 K8s pod 업데이트 확인