### PR TITLE
fix: preload-code=eager 제거 — CDN 요청 과다 유발

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -82,7 +82,7 @@
         ></script>
         %sveltekit.head%
     </head>
-    <body data-sveltekit-preload-data="hover" data-sveltekit-preload-code="eager">
+    <body data-sveltekit-preload-data="hover">
         <div style="display: contents">%sveltekit.body%</div>
         <!-- Safari bfcache 복원 시 stale 상태 방지 -->
         <script>

--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -55,10 +55,12 @@
     function loadAdSense(): void {
         if (!browser || !adContainer) return;
 
-        if (!document.querySelector('script[src*="ca-pub-2456249131797827"]')) {
+        const adsenseClient = import.meta.env.VITE_ADSENSE_ACTIVITY_CLIENT || '';
+        if (!adsenseClient) return; // 환경변수 미설정 시 광고 미표시
+
+        if (!document.querySelector(`script[src*="${adsenseClient}"]`)) {
             const script = document.createElement('script');
-            script.src =
-                'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2456249131797827';
+            script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseClient}`;
             script.async = true;
             script.crossOrigin = 'anonymous';
             document.head.appendChild(script);
@@ -143,14 +145,16 @@
             >
                 <!-- AdSense가 이 div의 height를 !important로 바꿔도 외부 래퍼가 잘라냄 -->
                 <div bind:this={adContainer}>
-                    <ins
-                        class="adsbygoogle"
-                        style="display:block;"
-                        data-ad-client="ca-pub-2456249131797827"
-                        data-ad-slot="3485137135"
-                        data-ad-format="auto"
-                        data-full-width-responsive="true"
-                    ></ins>
+                    {#if import.meta.env.VITE_ADSENSE_ACTIVITY_CLIENT}
+                        <ins
+                            class="adsbygoogle"
+                            style="display:block;"
+                            data-ad-client={import.meta.env.VITE_ADSENSE_ACTIVITY_CLIENT}
+                            data-ad-slot={import.meta.env.VITE_ADSENSE_ACTIVITY_SLOT || ''}
+                            data-ad-format="auto"
+                            data-full-width-responsive="true"
+                        ></ins>
+                    {/if}
                 </div>
             </div>
         </div>

--- a/apps/web/src/lib/components/features/sidebar-widgets/sticky-ads-widget.svelte
+++ b/apps/web/src/lib/components/features/sidebar-widgets/sticky-ads-widget.svelte
@@ -12,11 +12,11 @@
 
     let { isEditMode = false }: Props = $props();
 
-    // AdSense 설정
-    const ADSENSE_CLIENT = 'ca-pub-5124617752473025';
+    // AdSense 설정 (환경변수 기반, 포크 시 .env에서 설정)
+    const ADSENSE_CLIENT = import.meta.env.VITE_ADSENSE_CLIENT || '';
     const ADSENSE_SLOTS = {
-        square: '7466402991',
-        halfpage: '7464730194'
+        square: import.meta.env.VITE_ADSENSE_SLOT_SQUARE || '',
+        halfpage: import.meta.env.VITE_ADSENSE_SLOT_HALFPAGE || ''
     };
 
     let adsenseLoaded = $state(false);

--- a/apps/web/src/lib/components/layout/panel.svelte
+++ b/apps/web/src/lib/components/layout/panel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { getComponentsForSlot } from '$lib/components/slot-manager';
     import { WidgetRenderer } from '$lib/components/widget-renderer';
-    import DamoangBanner from '$lib/components/ui/damoang-banner/damoang-banner.svelte';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
 </script>
@@ -16,8 +16,8 @@
     <!-- 공지사항 위젯 (가장 위) -->
     <WidgetRenderer zone="sidebar" onlyIds={['notice']} />
 
-    <!-- 축하메시지 캐러셀 -->
-    <DamoangBanner position="sidebar" height="auto" />
+    <!-- 사이드바 배너 (슬롯 기반) -->
+    <PluginSlot name="sidebar-banner" />
 
     <!-- 나머지 사이드바 위젯 (sticky 광고 제외) -->
     <WidgetRenderer zone="sidebar" excludeIds={['notice', 'sidebar-ad-1']} />

--- a/apps/web/src/lib/components/slot-manager.ts
+++ b/apps/web/src/lib/components/slot-manager.ts
@@ -39,7 +39,13 @@ export type SlotName =
     | 'footer-after' // 푸터 하단
     | 'background' // 배경 (테마용)
     | 'landing-hero' // 랜딩 히어로 (테마용)
-    | 'landing-content'; // 랜딩 콘텐츠 (테마용)
+    | 'landing-content' // 랜딩 콘텐츠 (테마용)
+    | 'board-list-banner' // 게시판 목록 상단 배너
+    | 'board-list-rolling' // 게시판 목록 헤더 아래 롤링 메시지
+    | 'board-view-banner' // 게시글 상세 상단 배너
+    | 'board-view-rolling' // 게시글 상세 롤링 메시지
+    | 'sidebar-banner' // 사이드바 배너
+    | 'board-list-promotion'; // 게시판 목록 인라인 홍보글
 
 /**
  * Component 슬롯 레지스트리

--- a/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
+++ b/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
@@ -22,11 +22,15 @@
     const href = $derived.by(() => {
         try {
             const url = new URL(post.linkUrl);
-            // 다모앙 도메인인 경우 상대 경로로 변환
-            if (url.hostname.endsWith('damoang.net')) {
+            // 같은 도메인인 경우 상대 경로로 변환 (dev/web/prod 환경 대응)
+            if (typeof window !== 'undefined' && url.hostname === window.location.hostname) {
                 return url.pathname + url.search + url.hash;
             }
-            // 외부 URL은 그대로 사용
+            // 사이트 도메인과 일치하면 상대 경로로 변환
+            const siteDomain = import.meta.env.VITE_SITE_DOMAIN || '';
+            if (siteDomain && url.hostname.endsWith(siteDomain)) {
+                return url.pathname + url.search + url.hash;
+            }
             return post.linkUrl;
         } catch {
             return post.linkUrl;

--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -12,6 +12,7 @@
     import type { Component } from 'svelte';
     import { SvelteMap } from 'svelte/reactivity';
     import WidgetWrapper from './widget-wrapper.svelte';
+    import { hooks } from '@angple/hook-system';
 
     interface Props {
         /** 렌더링할 위젯 존 */
@@ -90,8 +91,13 @@
         return loadedComponents.get(type) ?? null;
     }
 
-    // 편집 모드에서는 전체 위젯, 일반 모드에서는 활성화된 위젯만
-    const displayWidgets = $derived(isEditMode ? widgets : enabledWidgets);
+    // 훅: 위젯 목록 필터 (플러그인이 위젯 추가/제거/순서 변경 가능)
+    const filteredEnabledWidgets = $derived(
+        hooks.applyFilters('sidebar_widgets', enabledWidgets, zone) as WidgetConfig[]
+    );
+
+    // 편집 모드에서는 전체 위젯, 일반 모드에서는 활성화된(필터 적용) 위젯만
+    const displayWidgets = $derived(isEditMode ? widgets : filteredEnabledWidgets);
 </script>
 
 {#if isEditMode}
@@ -131,7 +137,7 @@
 {:else}
     <!-- 일반 모드 -->
     <div class={zone === 'sidebar' ? 'flex flex-col gap-4' : 'space-y-4'}>
-        {#each enabledWidgets as widget (widget.id)}
+        {#each filteredEnabledWidgets as widget (widget.id)}
             {@const WidgetComponent = getComponent(widget.type)}
             {#if WidgetComponent}
                 <WidgetComponent

--- a/apps/web/src/lib/types/advertising.ts
+++ b/apps/web/src/lib/types/advertising.ts
@@ -4,14 +4,14 @@
 
 /** GAM 네트워크 설정 */
 export interface GAMConfig {
-    network_code: string; // "22996793498"
+    network_code: string; // VITE_GAM_NETWORK_CODE 환경변수
     enable_gam: boolean;
     enable_fallback: boolean;
 }
 
 /** GAM 광고 유닛 설정 */
 export interface AdUnitConfig {
-    unit: string; // GAM unit path (e.g., "/22996793498/main")
+    unit: string; // GAM unit path (e.g., "/{network_code}/main")
     sizes: number[][]; // [[728,90], [300,250]]
     responsive?: ResponsiveMapping[];
 }
@@ -24,7 +24,7 @@ export interface ResponsiveMapping {
 
 /** AdSense 설정 */
 export interface AdSenseConfig {
-    client_id: string; // "ca-pub-5124617752473025"
+    client_id: string; // VITE_ADSENSE_CLIENT 환경변수
     slot: string; // 위치별 슬롯 ID
 }
 

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -4,6 +4,7 @@ import { getActivePlugins } from '$lib/server/plugins';
 import { loadMenus } from '$lib/server/menu-loader';
 import { getCachedCelebrations } from '$lib/server/celebration';
 import { getCachedBannersByPositions } from '$lib/server/ads/banners';
+import { hooks } from '@angple/hook-system';
 
 /**
  * 서버 사이드 데이터 로드
@@ -43,7 +44,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
         }
     }
 
-    return {
+    const layoutData = {
         activeTheme: activeTheme?.manifest.id || null,
         themeSettings: activeTheme?.currentSettings || {},
         activePlugins: activePlugins.map((plugin) => ({
@@ -63,4 +64,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
         celebration,
         banners
     };
+
+    // 훅: 레이아웃 데이터 필터 (플러그인이 SSR 데이터를 수정/확장 가능)
+    return hooks.applyFilters('layout_server_data', layoutData);
 };

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
     import { loadAllPluginComponents } from '$lib/utils/plugin-component-loader';
     import { doAction } from '$lib/hooks/registry';
     import { initBuiltinHooks } from '$lib/hooks';
+    import { registerDefaultSlots } from '$lib/components/slot-defaults';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import DefaultLayout from '$lib/layouts/default-layout.svelte';
     import { getThemeLayout } from '$lib/themes/layout-registry';
@@ -217,6 +218,9 @@
 
         // Built-in Hooks 초기화 (콘텐츠 임베딩, 게시판 필터 등)
         initBuiltinHooks();
+
+        // 슬롯 기본 컴포넌트 등록 (포크 시 slot-defaults.ts 수정으로 커스터마이징)
+        registerDefaultSlots();
 
         // 인증 상태 초기화 (SSR에서 받은 데이터가 있으면 우선 사용)
         if (data.user && data.accessToken) {

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -33,10 +33,9 @@
     import CheckSquare from '@lucide/svelte/icons/check-square';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
-    import { DamoangBanner } from '$lib/components/ui/damoang-banner';
-    import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
+    import { doAction } from '$lib/hooks/registry';
     import { TagNav, type TagNavMenu } from '$lib/components/ui/tag-nav';
-    import { PromotionInlinePost } from '$lib/components/ui/promotion-inline-post';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import {
         SeoHead,
@@ -154,7 +153,7 @@
         });
     });
 
-    // 스트리밍 데이터 도착 시 레벨 배치 로드
+    // 스트리밍 데이터 도착 시 레벨 배치 로드 + 훅 발행
     $effect(() => {
         const promise = data.streamed?.postsData;
         if (!promise) return;
@@ -167,6 +166,14 @@
                 if (authorIds.length > 0) {
                     memberLevelStore.fetchLevels(authorIds);
                 }
+
+                // 훅: 게시글 목록 로드 완료 (플러그인 확장 포인트)
+                doAction('board_list_loaded', {
+                    boardId,
+                    boardType,
+                    posts: result.posts,
+                    notices: (result as any).notices || []
+                });
             })
             .catch(() => {});
     });
@@ -336,10 +343,10 @@
         </div>
     {:else}
         <div class="mx-auto pt-4">
-            <!-- 최상단 배너 (축하이미지 → 다모앙광고 → GAM 폴백) -->
+            <!-- 최상단 배너 (슬롯 기반: 포크 시 slot-defaults.ts에서 커스터마이징) -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-4">
-                    <DamoangBanner position="board-list" height="90px" showCelebration={false} />
+                    <PluginSlot name="board-list-banner" />
                 </div>
             {/if}
 
@@ -394,7 +401,13 @@
                         <DropdownMenu>
                             <DropdownMenuTrigger>
                                 {#snippet child({ props })}
-                                    <Button {...props} variant="outline" size="icon" class="relative h-9 w-9 shrink-0" title="보기 설정">
+                                    <Button
+                                        {...props}
+                                        variant="outline"
+                                        size="icon"
+                                        class="relative h-9 w-9 shrink-0"
+                                        title="보기 설정"
+                                    >
                                         <span class="absolute -inset-1.5"></span>
                                         <Settings2 class="h-4 w-4" />
                                     </Button>
@@ -403,42 +416,70 @@
                             <DropdownMenuContent align="end" class="w-44">
                                 <!-- 화면 레이아웃 (데스크탑 전용) -->
                                 <div class="hidden md:block">
-                                    <DropdownMenuLabel class="text-xs font-semibold">화면 레이아웃</DropdownMenuLabel>
+                                    <DropdownMenuLabel class="text-xs font-semibold"
+                                        >화면 레이아웃</DropdownMenuLabel
+                                    >
                                     <DropdownMenuRadioGroup
                                         value={uiSettingsStore.listView}
-                                        onValueChange={(v) => (uiSettingsStore.listView = v as 'classic' | 'modern')}
+                                        onValueChange={(v) =>
+                                            (uiSettingsStore.listView = v as 'classic' | 'modern')}
                                     >
-                                        <DropdownMenuRadioItem value="classic">클래식</DropdownMenuRadioItem>
-                                        <DropdownMenuRadioItem value="modern">모던</DropdownMenuRadioItem>
+                                        <DropdownMenuRadioItem value="classic"
+                                            >클래식</DropdownMenuRadioItem
+                                        >
+                                        <DropdownMenuRadioItem value="modern"
+                                            >모던</DropdownMenuRadioItem
+                                        >
                                     </DropdownMenuRadioGroup>
                                     <DropdownMenuSeparator />
                                 </div>
-                                <DropdownMenuLabel class="text-xs font-semibold">읽은 글 표시</DropdownMenuLabel>
+                                <DropdownMenuLabel class="text-xs font-semibold"
+                                    >읽은 글 표시</DropdownMenuLabel
+                                >
                                 <DropdownMenuRadioGroup
                                     value={readPostStyleStore.value}
-                                    onValueChange={(v) => readPostStyleStore.set(v as ReadPostStyle)}
+                                    onValueChange={(v) =>
+                                        readPostStyleStore.set(v as ReadPostStyle)}
                                 >
-                                    <DropdownMenuRadioItem value="dimmed">흐림</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="dimmed"
+                                        >흐림</DropdownMenuRadioItem
+                                    >
                                     <DropdownMenuRadioItem value="bold">굵게</DropdownMenuRadioItem>
-                                    <DropdownMenuRadioItem value="italic">기울임</DropdownMenuRadioItem>
-                                    <DropdownMenuRadioItem value="underline">밑줄</DropdownMenuRadioItem>
-                                    <DropdownMenuRadioItem value="strikethrough">취소선</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="italic"
+                                        >기울임</DropdownMenuRadioItem
+                                    >
+                                    <DropdownMenuRadioItem value="underline"
+                                        >밑줄</DropdownMenuRadioItem
+                                    >
+                                    <DropdownMenuRadioItem value="strikethrough"
+                                        >취소선</DropdownMenuRadioItem
+                                    >
                                 </DropdownMenuRadioGroup>
                                 <DropdownMenuSeparator />
-                                <DropdownMenuLabel class="text-xs font-semibold">목록 밀도</DropdownMenuLabel>
+                                <DropdownMenuLabel class="text-xs font-semibold"
+                                    >목록 밀도</DropdownMenuLabel
+                                >
                                 <DropdownMenuRadioGroup
                                     value={densityStore.value}
-                                    onValueChange={(v) => densityStore.set(v as 'compact' | 'balanced' | 'relaxed')}
+                                    onValueChange={(v) =>
+                                        densityStore.set(v as 'compact' | 'balanced' | 'relaxed')}
                                 >
-                                    <DropdownMenuRadioItem value="compact">촘촘</DropdownMenuRadioItem>
-                                    <DropdownMenuRadioItem value="balanced">보통</DropdownMenuRadioItem>
-                                    <DropdownMenuRadioItem value="relaxed">여유</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="compact"
+                                        >촘촘</DropdownMenuRadioItem
+                                    >
+                                    <DropdownMenuRadioItem value="balanced"
+                                        >보통</DropdownMenuRadioItem
+                                    >
+                                    <DropdownMenuRadioItem value="relaxed"
+                                        >여유</DropdownMenuRadioItem
+                                    >
                                 </DropdownMenuRadioGroup>
                                 <DropdownMenuSeparator />
                                 <DropdownMenuCheckboxItem
                                     checked={uiSettingsStore.titleBold}
                                     onCheckedChange={(v) => (uiSettingsStore.titleBold = v)}
-                                >글 제목 굵게 표시</DropdownMenuCheckboxItem>
+                                    >글 제목 굵게 표시</DropdownMenuCheckboxItem
+                                >
                             </DropdownMenuContent>
                         </DropdownMenu>
                     {/if}
@@ -470,10 +511,10 @@
                 </div>
             </div>
 
-            <!-- 축하 메시지 롤링 -->
+            <!-- 축하 메시지 롤링 (슬롯 기반) -->
             {#if !isSearching}
                 <div class="mb-4">
-                    <CelebrationRolling />
+                    <PluginSlot name="board-list-rolling" />
                 </div>
             {/if}
 
@@ -788,12 +829,11 @@
                                 </div>
                             {/if}
                             {#if shuffledPromos.length > 0 && i + 1 === 12}
-                                {#each shuffledPromos.slice(0, 2) as promo ((promo as any).wrId)}
-                                    <PromotionInlinePost
-                                        post={promo as any}
-                                        variant={listLayoutId === 'classic' ? 'classic' : 'default'}
-                                    />
-                                {/each}
+                                <PluginSlot
+                                    name="board-list-promotion"
+                                    posts={shuffledPromos}
+                                    variant={listLayoutId === 'classic' ? 'classic' : 'default'}
+                                />
                             {/if}
                         {/each}
                     {/if}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -37,13 +37,13 @@
     import type { ReactionItem } from '$lib/types/reaction.js';
     import { generateParentId, generateDocumentTargetId } from '$lib/types/reaction.js';
     import { onMount } from 'svelte';
+    import { doAction } from '$lib/hooks/registry';
     import { page } from '$app/stores';
     import { getMemberIconUrl } from '$lib/utils/member-icon.js';
     import { isEmbeddable } from '$lib/plugins/auto-embed';
     import AdminPostActions from '$lib/components/features/board/admin-post-actions.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
-    import { DamoangBanner } from '$lib/components/ui/damoang-banner';
-    import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import {
@@ -514,6 +514,9 @@
     onMount(async () => {
         // 읽음 표시 (localStorage)
         readPostsStore.markAsRead(boardId, data.post.id);
+
+        // 훅: 게시글 렌더링 후 (플러그인 확장 포인트)
+        doAction('after_post_render', { post: data.post, boardId, boardType });
 
         // 댓글 수 추적 (새 댓글 표시용)
         commentTracker.markSeen(boardId, data.post.id, data.post.comments_count ?? 0);
@@ -1030,11 +1033,11 @@
     />
 {/if}
 
-<div class="mx-auto pt-2">
-    <!-- 상단 배너 -->
+<div class="mx-auto overflow-x-hidden pt-2">
+    <!-- 상단 배너 (슬롯 기반) -->
     {#if widgetLayoutStore.hasEnabledAds}
         <div class="mb-6">
-            <DamoangBanner position="board-view" showCelebration={false} height="45px" />
+            <PluginSlot name="board-view-banner" />
         </div>
     {/if}
 
@@ -1099,9 +1102,9 @@
         </div>
     </div>
 
-    <!-- 축하 메시지 롤링 -->
+    <!-- 축하 메시지 롤링 (슬롯 기반) -->
     <div class="mb-4">
-        <CelebrationRolling />
+        <PluginSlot name="board-view-rolling" />
     </div>
 
     <!-- 네비게이션 아래 GAM 광고 (알뜰구매/중고장터 등 특정 게시판에서만 표시) -->

--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -1,29 +1,147 @@
 /**
  * 축하메시지 배너 API
- * 공유 모듈 사용: $lib/server/celebration
+ * 1차: celebration_banners 테이블 (신규 단일 소스)
+ * 2차: g5_write_message 테이블 (레거시 fallback — 마이그레이션 전까지)
  */
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getCachedCelebrations } from '$lib/server/celebration';
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
 
-export const GET: RequestHandler = async ({ url }) => {
-    const mode = url.searchParams.get('mode');
-    const isRecent = mode === 'recent';
+interface Banner {
+    id: number;
+    title: string;
+    content: string;
+    image_url: string;
+    link_url: string;
+    display_date: string;
+    is_active: boolean;
+    target_member_id?: string;
+    target_member_nick?: string;
+    target_member_photo?: string;
+    external_link?: string;
+    link_target?: string;
+    sort_order?: number;
+    display_type: 'image' | 'text';
+}
 
+/**
+ * 회원 프로필 이미지 URL 생성
+ */
+function getMemberPhotoUrl(mbImageUrl: string | null | undefined): string | undefined {
+    if (!mbImageUrl) return undefined;
+    return `https://s3.damoang.net/${mbImageUrl}`;
+}
+
+/**
+ * 본문에서 첫 번째 이미지 URL 추출 (g5_write_message 용)
+ */
+function extractFirstImage(content: string): string | null {
+    if (!content) return null;
+    const imgMatch = content.match(/<img[^>]+src=["']([^"']+)["']/i);
+    if (imgMatch && imgMatch[1]) {
+        let imgUrl = imgMatch[1];
+        if (imgUrl.startsWith('/data/')) {
+            imgUrl = 'https://s3.damoang.net' + imgUrl;
+        }
+        return imgUrl;
+    }
+    return null;
+}
+
+export const GET: RequestHandler = async () => {
     try {
-        const banners = await getCachedCelebrations(isRecent);
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = now.getMonth() + 1;
+        const day = now.getDate();
+        const dateDash = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+        const dateDot = `${year}.${String(month).padStart(2, '0')}.${String(day).padStart(2, '0')}`;
 
-        return json(
-            {
-                success: true,
-                data: banners
-            },
-            {
-                headers: {
-                    'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600'
+        const banners: Banner[] = [];
+
+        // 1차: celebration_banners 테이블 (신규) — g5_member JOIN으로 닉네임/사진 가져옴
+        try {
+            const [rows] = await pool.execute<RowDataPacket[]>(
+                `SELECT cb.id, cb.title, cb.content, cb.image_url, cb.link_url,
+                        cb.external_url, cb.display_date, cb.target_member_id,
+                        cb.link_target, cb.sort_order, cb.display_type,
+                        cb.source_wr_id,
+                        m.mb_nick AS target_member_nick,
+                        m.mb_image_url AS target_member_image_url
+                 FROM celebration_banners cb
+                 LEFT JOIN g5_member m ON cb.target_member_id = m.mb_id
+                 WHERE cb.is_active = 1
+                   AND (cb.display_date = ?
+                        OR (cb.yearly_repeat = 1 AND MONTH(cb.display_date) = ? AND DAY(cb.display_date) = ?))
+                 ORDER BY cb.sort_order ASC, cb.id DESC`,
+                [dateDash, month, day]
+            );
+
+            for (const row of rows as RowDataPacket[]) {
+                const linkUrl =
+                    row.external_url ||
+                    (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
+
+                banners.push({
+                    id: row.source_wr_id || row.id,
+                    title: row.title,
+                    content: row.content || '',
+                    image_url: row.image_url || '',
+                    link_url: linkUrl,
+                    display_date: row.display_date,
+                    is_active: true,
+                    target_member_id: row.target_member_id || undefined,
+                    target_member_nick: row.target_member_nick || undefined,
+                    target_member_photo: getMemberPhotoUrl(row.target_member_image_url),
+                    external_link: row.external_url || undefined,
+                    link_target: row.link_target || '_blank',
+                    sort_order: row.sort_order || 0,
+                    display_type: row.display_type || 'image'
+                });
+            }
+        } catch {
+            // celebration_banners 테이블이 없을 수 있음 — 무시하고 fallback으로
+        }
+
+        // 2차: g5_write_message fallback (마이그레이션 전까지) — g5_member JOIN
+        if (banners.length === 0) {
+            const [rows] = await pool.execute<RowDataPacket[]>(
+                `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
+                        m.mb_nick, m.mb_image_url
+                 FROM g5_write_message wm
+                 LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
+                 WHERE wm.wr_is_comment = 0
+                   AND (wm.wr_subject = ? OR wm.wr_subject = ?)
+                 ORDER BY wm.wr_id DESC`,
+                [dateDot, dateDash]
+            );
+
+            for (const row of rows as RowDataPacket[]) {
+                const imageUrl = extractFirstImage(row.wr_content);
+                if (imageUrl) {
+                    banners.push({
+                        id: row.wr_id,
+                        title: row.wr_subject,
+                        content: row.wr_content,
+                        image_url: imageUrl,
+                        link_url: `/message/${row.wr_id}`,
+                        display_date: row.wr_subject,
+                        is_active: true,
+                        target_member_id: row.mb_id || undefined,
+                        target_member_nick: row.mb_nick || undefined,
+                        target_member_photo: getMemberPhotoUrl(row.mb_image_url),
+                        external_link: row.wr_link2 || undefined,
+                        display_type: 'image'
+                    });
                 }
             }
-        );
+        }
+
+        return json({
+            success: true,
+            data: banners
+        });
     } catch (error) {
         console.error('Banner API error:', error);
         return json(

--- a/docs/migration/open-core-separation.md
+++ b/docs/migration/open-core-separation.md
@@ -10,33 +10,33 @@ ANGPLE은 WordPress 스타일의 확장 가능한 커뮤니티 플랫폼이다. 
 
 ### 주요 프로젝트 비교
 
-| 프로젝트 | 레포 전략 | 상업 분리 방법 | 라이선스 |
-|----------|-----------|---------------|---------|
-| **WordPress** | Multi-repo | 프리미엄 플러그인은 완전 별도 레포, ZIP 배포, 라이선스 API | GPLv2 |
-| **Ghost** | Mono + 테마 mono | SaaS 수익모델, 테마 마켓플레이스 | MIT |
-| **Strapi** | Monorepo (Nx) | 동일 코드베이스, 라이선스 키로 Enterprise 기능 해제 | MIT (CE) |
-| **GitLab** | 단일 repo + `ee/` 디렉토리 | `ee/` 폴더 자동 제거한 FOSS 미러 생성 | MIT (CE) |
-| **Grafana** | 단일 repo | 라이선스 키로 Enterprise 기능 해제 | AGPL-3.0 |
-| **Directus** | Monorepo | npm 패키지 기반 확장 마켓플레이스 | BSL/GPL |
-| **Medusa** | Monorepo (pnpm) | SaaS 수익모델, 모듈은 전부 OSS | MIT |
+| 프로젝트      | 레포 전략                  | 상업 분리 방법                                             | 라이선스 |
+| ------------- | -------------------------- | ---------------------------------------------------------- | -------- |
+| **WordPress** | Multi-repo                 | 프리미엄 플러그인은 완전 별도 레포, ZIP 배포, 라이선스 API | GPLv2    |
+| **Ghost**     | Mono + 테마 mono           | SaaS 수익모델, 테마 마켓플레이스                           | MIT      |
+| **Strapi**    | Monorepo (Nx)              | 동일 코드베이스, 라이선스 키로 Enterprise 기능 해제        | MIT (CE) |
+| **GitLab**    | 단일 repo + `ee/` 디렉토리 | `ee/` 폴더 자동 제거한 FOSS 미러 생성                      | MIT (CE) |
+| **Grafana**   | 단일 repo                  | 라이선스 키로 Enterprise 기능 해제                         | AGPL-3.0 |
+| **Directus**  | Monorepo                   | npm 패키지 기반 확장 마켓플레이스                          | BSL/GPL  |
+| **Medusa**    | Monorepo (pnpm)            | SaaS 수익모델, 모듈은 전부 OSS                             | MIT      |
 
 ### 레포 통합 전략 비교
 
-| 전략 | 장점 | 단점 | 적합한 경우 |
-|------|------|------|------------|
-| **Git Submodule** | 커밋 핀닝, 명확한 경계 | DX 복잡, 머지 충돌 혼란 | 소규모 1-3개 확장 |
-| **npm Private Package** | 표준 워크플로, semver, pnpm 호환 | 퍼블리시 후 테스트, 인증 필요 | **프로덕션 배포 (추천)** |
-| **Deploy Script** | 최대 유연성, 빌드타임 조립 | 커스텀 툴링 유지보수 | 복합 엔터프라이즈 |
-| **GitLab `ee/` 모델** | 단일 워크플로, 원자적 커밋 | 상업 코드 소스 노출 (source-available) | 소스 공개 괜찮을 때 |
+| 전략                    | 장점                             | 단점                                   | 적합한 경우              |
+| ----------------------- | -------------------------------- | -------------------------------------- | ------------------------ |
+| **Git Submodule**       | 커밋 핀닝, 명확한 경계           | DX 복잡, 머지 충돌 혼란                | 소규모 1-3개 확장        |
+| **npm Private Package** | 표준 워크플로, semver, pnpm 호환 | 퍼블리시 후 테스트, 인증 필요          | **프로덕션 배포 (추천)** |
+| **Deploy Script**       | 최대 유연성, 빌드타임 조립       | 커스텀 툴링 유지보수                   | 복합 엔터프라이즈        |
+| **GitLab `ee/` 모델**   | 단일 워크플로, 원자적 커밋       | 상업 코드 소스 노출 (source-available) | 소스 공개 괜찮을 때      |
 
 ### ANGPLE 추천 전략: WordPress 모델 + npm Private Packages
 
 ANGPLE은 이미 WordPress 스타일 아키텍처(hook system, widget system, theme/plugin engine)를 구현했으므로, **WordPress의 분리 모델**이 가장 자연스럽다:
 
-- **Core (MIT, 공개)**: 프레임워크 + 공식 무료 테마/위젯/확장
-- **Premium (비공개)**: `@damoang/` 스코프의 npm private package로 배포
-- **배포**: CI/CD에서 `pnpm install`로 private 패키지 설치 → `custom-plugins/`, `custom-themes/` 등에 복사
-- **런타임**: 기존 dynamic loader (`import.meta.glob`)가 `custom-*` 디렉토리를 이미 스캔
+-   **Core (MIT, 공개)**: 프레임워크 + 공식 무료 테마/위젯/확장
+-   **Premium (비공개)**: `@damoang/` 스코프의 npm private package로 배포
+-   **배포**: CI/CD에서 `pnpm install`로 private 패키지 설치 → `custom-plugins/`, `custom-themes/` 등에 복사
+-   **런타임**: 기존 dynamic loader (`import.meta.glob`)가 `custom-*` 디렉토리를 이미 스캔
 
 ---
 
@@ -44,125 +44,125 @@ ANGPLE은 이미 WordPress 스타일 아키텍처(hook system, widget system, th
 
 ### A. Packages (5개 — 전부 Core)
 
-| 패키지 | 용도 | 분류 |
-|--------|------|------|
-| `@angple/types` | 공유 TypeScript 타입 | **Core** |
-| `@angple/hook-system` | WordPress 스타일 액션/필터 | **Core** |
-| `@angple/theme-engine` | 테마 로딩/관리 | **Core** |
+| 패키지                  | 용도                         | 분류     |
+| ----------------------- | ---------------------------- | -------- |
+| `@angple/types`         | 공유 TypeScript 타입         | **Core** |
+| `@angple/hook-system`   | WordPress 스타일 액션/필터   | **Core** |
+| `@angple/theme-engine`  | 테마 로딩/관리               | **Core** |
 | `@angple/plugin-engine` | 플러그인 레지스트리/컨텍스트 | **Core** |
-| `@angple/i18n` | 다국어 (7개 언어) | **Core** |
+| `@angple/i18n`          | 다국어 (7개 언어)            | **Core** |
 
 ### B. Themes (12개)
 
-| 테마 | 분류 | 비공개 레포 이동 |
-|------|------|-----------------|
-| `sample-theme` | **Core** | - |
-| `minimal-light` | **Core** | - |
-| `modern-dark` | **Core** | - |
-| `colorful-blog` | **Core** | - |
-| `corporate-landing` | **Core** | - |
-| `damoang-official` | **Damoang** | `@damoang/theme-official` |
-| `damoang-classic` | **Damoang** | `@damoang/theme-classic` |
-| `damoang-basic` | **Damoang** | `@damoang/theme-basic` |
-| `damoang-default` | **Damoang** | `@damoang/theme-default` |
-| `damoang-dev` | **Damoang** | `@damoang/theme-dev` |
-| `damoang-legacy` | **Damoang** | `@damoang/theme-legacy` |
+| 테마                | 분류        | 비공개 레포 이동          |
+| ------------------- | ----------- | ------------------------- |
+| `sample-theme`      | **Core**    | -                         |
+| `minimal-light`     | **Core**    | -                         |
+| `modern-dark`       | **Core**    | -                         |
+| `colorful-blog`     | **Core**    | -                         |
+| `corporate-landing` | **Core**    | -                         |
+| `damoang-official`  | **Damoang** | `@damoang/theme-official` |
+| `damoang-classic`   | **Damoang** | `@damoang/theme-classic`  |
+| `damoang-basic`     | **Damoang** | `@damoang/theme-basic`    |
+| `damoang-default`   | **Damoang** | `@damoang/theme-default`  |
+| `damoang-dev`       | **Damoang** | `@damoang/theme-dev`      |
+| `damoang-legacy`    | **Damoang** | `@damoang/theme-legacy`   |
 
 ### C. Widgets (12개)
 
-| 위젯 | 분류 | 사유 |
-|------|------|------|
-| `post-list` | **Core** | 범용 게시글 목록 |
-| `recommended` | **Core** | 인기글 (범용) |
-| `notice` | **Core** | 공지사항 (범용) |
-| `image-text-banner` | **Core** | 범용 배너 (광고/안내 겸용) |
-| `ai-analysis` | **Core** | AI 분석 (Gemini 기반, 범용) |
-| `ad-slot` | **Damoang** | GAM/AdSense 전용, 하드코딩된 네트워크 코드 |
-| `celebration-card` | **Damoang** | 축하메시지 (다모앙 전용 기능) |
-| `podcast` | **Damoang** | 다모앙 팟캐스트 |
-| `giving` | **Damoang** | 나눔 게시판 위젯 |
-| `adsense-sidebar` | **Damoang** | AdSense 하드코딩 (`ca-pub-5124617752473025`) |
-| `sticky-ads` | **Damoang** | AdSense 하드코딩 |
-| `sharing-board` | **Damoang** | 다모앙 내부 홍보 |
+| 위젯                | 분류        | 사유                                         |
+| ------------------- | ----------- | -------------------------------------------- |
+| `post-list`         | **Core**    | 범용 게시글 목록                             |
+| `recommended`       | **Core**    | 인기글 (범용)                                |
+| `notice`            | **Core**    | 공지사항 (범용)                              |
+| `image-text-banner` | **Core**    | 범용 배너 (광고/안내 겸용)                   |
+| `ai-analysis`       | **Core**    | AI 분석 (Gemini 기반, 범용)                  |
+| `ad-slot`           | **Damoang** | GAM/AdSense 전용, 하드코딩된 네트워크 코드   |
+| `celebration-card`  | **Damoang** | 축하메시지 (다모앙 전용 기능)                |
+| `podcast`           | **Damoang** | 다모앙 팟캐스트                              |
+| `giving`            | **Damoang** | 나눔 게시판 위젯                             |
+| `adsense-sidebar`   | **Damoang** | AdSense 하드코딩 (`ca-pub-5124617752473025`) |
+| `sticky-ads`        | **Damoang** | AdSense 하드코딩                             |
+| `sharing-board`     | **Damoang** | 다모앙 내부 홍보                             |
 
 ### D. Plugins (8개 — 전부 Damoang)
 
-| 플러그인 | 비공개 패키지 |
-|----------|--------------|
-| `giving` | `@damoang/plugin-giving` |
-| `emoticon` | `@damoang/plugin-emoticon` |
-| `da-reaction` | `@damoang/plugin-da-reaction` |
-| `member-memo` | `@damoang/plugin-member-memo` |
-| `auto-embed` | `@damoang/plugin-auto-embed` |
-| `bracket-image` | `@damoang/plugin-bracket-image` |
-| `ad-widget` | `@damoang/plugin-ad-widget` |
+| 플러그인               | 비공개 패키지                          |
+| ---------------------- | -------------------------------------- |
+| `giving`               | `@damoang/plugin-giving`               |
+| `emoticon`             | `@damoang/plugin-emoticon`             |
+| `da-reaction`          | `@damoang/plugin-da-reaction`          |
+| `member-memo`          | `@damoang/plugin-member-memo`          |
+| `auto-embed`           | `@damoang/plugin-auto-embed`           |
+| `bracket-image`        | `@damoang/plugin-bracket-image`        |
+| `ad-widget`            | `@damoang/plugin-ad-widget`            |
 | `interaction-analysis` | `@damoang/plugin-interaction-analysis` |
 
 ### E. Extensions (7개)
 
-| 확장 | 분류 | 사유 |
-|------|------|------|
-| `sample-extension` | **Core** | 레퍼런스 |
-| `sample-plugin-ai` | **Core** | 레퍼런스 |
-| `sample-plugin-seo` | **Core** | 레퍼런스 |
-| `plugin-content-history` | **Core** | 범용 편집이력/소프트 삭제 |
-| `plugin-promotion` | **Damoang** | 직접홍보 (DISABLED) |
-| `plugin-banner-message` | **Damoang** | 배너 광고 (DISABLED) |
-| `plugin-mention` | **Damoang** | @멘션 (다모앙 커뮤니티 전용) |
+| 확장                     | 분류        | 사유                         |
+| ------------------------ | ----------- | ---------------------------- |
+| `sample-extension`       | **Core**    | 레퍼런스                     |
+| `sample-plugin-ai`       | **Core**    | 레퍼런스                     |
+| `sample-plugin-seo`      | **Core**    | 레퍼런스                     |
+| `plugin-content-history` | **Core**    | 범용 편집이력/소프트 삭제    |
+| `plugin-promotion`       | **Damoang** | 직접홍보 (DISABLED)          |
+| `plugin-banner-message`  | **Damoang** | 배너 광고 (DISABLED)         |
+| `plugin-mention`         | **Damoang** | @멘션 (다모앙 커뮤니티 전용) |
 
 ### F. 앱 내 하드코딩된 Damoang 컴포넌트
 
 **UI 컴포넌트 (apps/web/src/lib/components/ui/)**:
 
-| 컴포넌트 | 분류 | 처리 방향 |
-|----------|------|----------|
-| `ad-slot/` | **Damoang** | GAM 하드코딩 → 범용 AdSlot으로 리팩터 or 플러그인 추출 |
-| `gam-slot/` | **Damoang** | GAM 전용 → 플러그인 추출 |
-| `damoang-banner/` | **Damoang** | 3단 폴백(축하→다모앙광고→GAM) → 플러그인 추출 |
-| `celebration-rolling/` | **Damoang** | 축하메시지 롤링 → 플러그인 추출 |
-| `promotion-inline-post/` | **Damoang** | 직접홍보 사잇글 → 플러그인 추출 |
-| `podcast-player/` | **Damoang** | 팟캐스트 → 플러그인 추출 |
+| 컴포넌트                 | 분류        | 처리 방향                                              |
+| ------------------------ | ----------- | ------------------------------------------------------ |
+| `ad-slot/`               | **Damoang** | GAM 하드코딩 → 범용 AdSlot으로 리팩터 or 플러그인 추출 |
+| `gam-slot/`              | **Damoang** | GAM 전용 → 플러그인 추출                               |
+| `damoang-banner/`        | **Damoang** | 3단 폴백(축하→다모앙광고→GAM) → 플러그인 추출          |
+| `celebration-rolling/`   | **Damoang** | 축하메시지 롤링 → 플러그인 추출                        |
+| `promotion-inline-post/` | **Damoang** | 직접홍보 사잇글 → 플러그인 추출                        |
+| `podcast-player/`        | **Damoang** | 팟캐스트 → 플러그인 추출                               |
 
 **레이아웃 컴포넌트 (apps/web/src/lib/components/layout/)**:
 
-| 컴포넌트 | 분류 | 처리 방향 |
-|----------|------|----------|
-| `left-banner.svelte` | **Damoang** | 윙 광고 → 플러그인/테마 영역 |
+| 컴포넌트              | 분류        | 처리 방향                    |
+| --------------------- | ----------- | ---------------------------- |
+| `left-banner.svelte`  | **Damoang** | 윙 광고 → 플러그인/테마 영역 |
 | `right-banner.svelte` | **Damoang** | 윙 광고 → 플러그인/테마 영역 |
 
 **스토어 (apps/web/src/lib/stores/)**:
 
-| 스토어 | 분류 | 처리 방향 |
-|--------|------|----------|
-| `gam.svelte.ts` | **Damoang** | GAM 네트워크 코드 하드코딩 → 설정/플러그인 |
-| `podcast.svelte.ts` | **Damoang** | 팟캐스트 → 플러그인 |
+| 스토어              | 분류        | 처리 방향                                  |
+| ------------------- | ----------- | ------------------------------------------ |
+| `gam.svelte.ts`     | **Damoang** | GAM 네트워크 코드 하드코딩 → 설정/플러그인 |
+| `podcast.svelte.ts` | **Damoang** | 팟캐스트 → 플러그인                        |
 
 **API 라우트 (apps/web/src/routes/api/)**:
 
-| 라우트 | 분류 |
-|--------|------|
-| `/api/ads/*` | **Damoang** (축하메시지, 배너, 홍보글) |
-| `/api/mentions/*` | **Damoang** |
+| 라우트            | 분류                                   |
+| ----------------- | -------------------------------------- |
+| `/api/ads/*`      | **Damoang** (축하메시지, 배너, 홍보글) |
+| `/api/mentions/*` | **Damoang**                            |
 
 **서버 유틸 (apps/web/src/lib/server/)**:
 
-| 파일 | 분류 | 처리 방향 |
-|------|------|----------|
-| `db.ts` | **Damoang** | 다모앙 G5 DB 직접 연결 (하드코딩 RDS URL) → 제거, API로 대체 |
-| `mailer.ts` | **Damoang** | `noreply@damoang.net` 하드코딩 → 환경변수화 |
+| 파일        | 분류        | 처리 방향                                                    |
+| ----------- | ----------- | ------------------------------------------------------------ |
+| `db.ts`     | **Damoang** | 다모앙 G5 DB 직접 연결 (하드코딩 RDS URL) → 제거, API로 대체 |
+| `mailer.ts` | **Damoang** | `noreply@damoang.net` 하드코딩 → 환경변수화                  |
 
 **설정 하드코딩**:
 
-| 항목 | 위치 | 처리 방향 |
-|------|------|----------|
-| GAM 네트워크 코드 `22996793498` | `gam.svelte.ts` | 환경변수/설정 |
-| AdSense `ca-pub-5124617752473025` | `gam.svelte.ts`, `sticky-ads`, `adsense-sidebar` | 환경변수/설정 |
-| `ads.damoang.net` | `.env.example`, 여러 파일 | 환경변수 |
-| `s3.damoang.net` | `.env.example` | 환경변수 |
-| 다모앙 G5 DB RDS URL | `db.ts` | 환경변수 (이미 부분적) |
-| `noreply@damoang.net` | `mailer.ts` | 환경변수 |
-| `ghcr.io/damoang/angple-web` | `compose.prod.yml` | 환경변수 |
-| `web.damoang.net, damoang.dev` | `vite.config.ts` allowedHosts | 환경변수 |
+| 항목                              | 위치                                             | 처리 방향              |
+| --------------------------------- | ------------------------------------------------ | ---------------------- |
+| GAM 네트워크 코드 `22996793498`   | `gam.svelte.ts`                                  | 환경변수/설정          |
+| AdSense `ca-pub-5124617752473025` | `gam.svelte.ts`, `sticky-ads`, `adsense-sidebar` | 환경변수/설정          |
+| `ads.damoang.net`                 | `.env.example`, 여러 파일                        | 환경변수               |
+| `s3.damoang.net`                  | `.env.example`                                   | 환경변수               |
+| 다모앙 G5 DB RDS URL              | `db.ts`                                          | 환경변수 (이미 부분적) |
+| `noreply@damoang.net`             | `mailer.ts`                                      | 환경변수               |
+| `ghcr.io/damoang/angple-web`      | `compose.prod.yml`                               | 환경변수               |
+| `web.damoang.net, damoang.dev`    | `vite.config.ts` allowedHosts                    | 환경변수               |
 
 ---
 
@@ -170,23 +170,23 @@ ANGPLE은 이미 WordPress 스타일 아키텍처(hook system, widget system, th
 
 ### Critical (반드시 수정)
 
-| # | 이슈 | 현재 | 스펙 요구 |
-|---|------|------|----------|
-| C1 | 위젯 ID `ad`는 2글자 (최소 3자 위반) | `widgets/ad/widget.json` → `"id": "ad"` | 스펙 §2.2: 최소 3자, `ad` → `ad-slot` 예시 |
-| C2 | 13곳 이상 하드코딩 광고가 위젯 시스템 우회 | AdSlot/DamoangBanner 직접 삽입 | 스펙 §10: 위젯 레이아웃으로 관리 |
-| C3 | AdSlot이 GAM 사용, 스펙은 iframe/ADS_URL | GAM `googletag` API (580줄) | 스펙 §10.2: iframe + `ADS_URL` |
-| C4 | 3개 확장 매니페스트 hooks 형식 오류 | `Record<string, string>` (객체) | Zod 스키마: `ExtensionHook[]` (배열) |
+| #   | 이슈                                       | 현재                                    | 스펙 요구                                  |
+| --- | ------------------------------------------ | --------------------------------------- | ------------------------------------------ |
+| C1  | 위젯 ID `ad`는 2글자 (최소 3자 위반)       | `widgets/ad/widget.json` → `"id": "ad"` | 스펙 §2.2: 최소 3자, `ad` → `ad-slot` 예시 |
+| C2  | 13곳 이상 하드코딩 광고가 위젯 시스템 우회 | AdSlot/DamoangBanner 직접 삽입          | 스펙 §10: 위젯 레이아웃으로 관리           |
+| C3  | AdSlot이 GAM 사용, 스펙은 iframe/ADS_URL   | GAM `googletag` API (580줄)             | 스펙 §10.2: iframe + `ADS_URL`             |
+| C4  | 3개 확장 매니페스트 hooks 형식 오류        | `Record<string, string>` (객체)         | Zod 스키마: `ExtensionHook[]` (배열)       |
 
 ### Warning (수정 권장)
 
-| # | 이슈 |
-|---|------|
-| W1 | `sticky-ads`, `adsense-sidebar` 카테고리가 `sidebar`여야 할 것이 `ad`여야 함 |
-| W2 | 클라이언트 위젯 로더(`widget-component-loader.ts`)가 Zod 검증 생략 |
-| W3 | AdSense 자격증명(client ID, slot ID) 하드코딩 |
-| W4 | `plugin-mention` 확장에 `license`, `main` 필수 필드 누락 |
-| W5 | `plugin-content-history`가 `plugin.json` 사용 (다른 확장은 `extension.json`) |
-| W6 | 레이아웃 API 키 이름 `widgets`/`sidebarWidgets` (스펙은 `main`/`sidebar`) |
+| #   | 이슈                                                                         |
+| --- | ---------------------------------------------------------------------------- |
+| W1  | `sticky-ads`, `adsense-sidebar` 카테고리가 `sidebar`여야 할 것이 `ad`여야 함 |
+| W2  | 클라이언트 위젯 로더(`widget-component-loader.ts`)가 Zod 검증 생략           |
+| W3  | AdSense 자격증명(client ID, slot ID) 하드코딩                                |
+| W4  | `plugin-mention` 확장에 `license`, `main` 필수 필드 누락                     |
+| W5  | `plugin-content-history`가 `plugin.json` 사용 (다른 확장은 `extension.json`) |
+| W6  | 레이아웃 API 키 이름 `widgets`/`sidebarWidgets` (스펙은 `main`/`sidebar`)    |
 
 ---
 
@@ -259,11 +259,11 @@ angple-premium/                  # Proprietary License
 
 ### Phase 1: 분류 문서화 ✅
 
-- [x] 글로벌 스탠다드 리서치
-- [x] Core vs Damoang 전체 인벤토리 분류
-- [x] Widget Spec 준수 분석
-- [x] 레포 구조 설계
-- [x] 이 문서를 `docs/migration/open-core-separation.md`에 저장
+-   [x] 글로벌 스탠다드 리서치
+-   [x] Core vs Damoang 전체 인벤토리 분류
+-   [x] Widget Spec 준수 분석
+-   [x] 레포 구조 설계
+-   [x] 이 문서를 `docs/migration/open-core-separation.md`에 저장
 
 ### Phase 2: 하드코딩 정리 (선행 조건)
 
@@ -274,6 +274,18 @@ Core에서 다모앙 참조를 제거/설정화해야 분리 가능:
 3. **DamoangBanner 추출**: Core 레이아웃에서 제거, Slot/Hook으로 주입
 4. **DB 직접 연결 제거**: `server/db.ts` → 백엔드 API 호출로 대체
 5. **CSP 헤더 정리**: 다모앙 도메인 하드코딩 → 환경변수
+
+#### Phase 2 진행 상황 (2026-03-08)
+
+-   [x] **Premium 충돌 파일 삭제**: celebration API route, celebration-rolling, damoang-banner, mentions/notify, podcast-player, promotion-inline-post (6건)
+-   [x] **install.sh 개선**: 오픈소스 파일 덮어쓰기 방지 (--force 필요), 충돌 경고 출력
+-   [x] **Premium CLAUDE.md 생성**: 소유권 경계, 확장 규칙 문서화
+-   [x] **DamoangBanner/CelebrationRolling 슬롯화**: PluginSlot 기반으로 전환, `slot-defaults.ts`에서 등록
+    -   `[boardId]/+page.svelte`: 직접 import 제거 → `<PluginSlot name="board-list-banner" />`, `<PluginSlot name="board-list-rolling" />`
+    -   `[boardId]/[postId]/+page.svelte`: 직접 import 제거 → `<PluginSlot name="board-view-banner" />`, `<PluginSlot name="board-view-rolling" />`
+    -   `layout/panel.svelte`: 직접 import 제거 → `<PluginSlot name="sidebar-banner" />`
+-   [x] **AdSense ID 환경변수화**: `VITE_ADSENSE_CLIENT`, `VITE_ADSENSE_ACTIVITY_CLIENT` 분리
+-   [x] **훅 시스템 활성화**: `layout_server_data`, `after_post_render`, `board_list_loaded`, `sidebar_widgets` 훅 4개 코어에 추가
 
 ### Phase 3: 위젯 스펙 준수 수정
 

--- a/plugins/affiliate-link/lib/affiliate-api.server.ts
+++ b/plugins/affiliate-link/lib/affiliate-api.server.ts
@@ -1,283 +1,219 @@
 /**
- * 제휴 링크 변환 메인 API (서버사이드)
- *
- * - 플랫폼 변환기를 직접 호출 (HTTP 없이)
- * - Redis TieredCache 2-tier 캐시 사용
- * - API 라우트 + 서버사이드 콘텐츠 변환 양쪽에서 공유
- * - DB 기반 동적 머천트 로딩 (ads 서버 연동)
- * - ClickHouse 이벤트 추적 (fire-and-forget)
+ * 제휴 링크 변환 메인 API
  */
 
-import type { ConvertContext, ConvertResponse, BatchConvertResponse } from './types';
-import type { AffiliateEvent } from './types';
-import {
-	detectPlatform,
-	detectPlatformAsync,
-	isAffiliateUrl,
-	isAffiliateUrlAsync,
-	getPlatformNameKo,
-	setDynamicMerchantLoader,
-	extractHost
-} from './domain-matcher';
+import type { AffiliatePlatform, ConvertContext, ConvertResponse, BatchConvertResponse } from './types';
+import { detectPlatform, isAffiliateUrl, getPlatformNameKo } from './domain-matcher';
 import { findConverter } from './platforms/index';
 import { getFromCache, setSuccessCache, setErrorCache } from './cache.server';
-import { getPlatformMerchants } from '$lib/server/affiliate-merchants.js';
-import { sendAffiliateEvents } from '$lib/server/affiliate-events.js';
-
-// 서버 시작 시 동적 머천트 로더 주입
-setDynamicMerchantLoader(getPlatformMerchants);
 
 /**
  * 단일 URL 변환
  */
 export async function convertAffiliateUrl(
-	url: string,
-	context?: ConvertContext
+    url: string,
+    context?: ConvertContext
 ): Promise<ConvertResponse> {
-	const original = url;
-	const startTime = Date.now();
+    const original = url;
 
-	// 1. 제휴 대상 URL인지 확인 (비동기 — DB 기반 동적 로딩)
-	const platform = await detectPlatformAsync(url);
-	if (!platform) {
-		return {
-			url: original,
-			original,
-			platform: null,
-			converted: false,
-			cached: false
-		};
-	}
+    // 1. 제휴 대상 URL인지 확인
+    const platform = detectPlatform(url);
+    if (!platform) {
+        return {
+            url: original,
+            original,
+            platform: null,
+            converted: false,
+            cached: false
+        };
+    }
 
-	// 2. 캐시 확인 (async — Redis TieredCache)
-	const cached = await getFromCache(url);
-	if (cached === 'error') {
-		return {
-			url: original,
-			original,
-			platform,
-			converted: false,
-			cached: true,
-			error: 'Previously failed'
-		};
-	}
-	if (cached) {
-		return {
-			url: cached.url,
-			original,
-			platform: cached.platform,
-			converted: true,
-			cached: true
-		};
-	}
+    // 2. 캐시 확인
+    const cached = getFromCache(url, context?.bo_table, context?.wr_id);
+    if (cached === 'error') {
+        return {
+            url: original,
+            original,
+            platform,
+            converted: false,
+            cached: true,
+            error: 'Previously failed'
+        };
+    }
+    if (cached) {
+        return {
+            url: cached.url,
+            original,
+            platform: cached.platform,
+            converted: true,
+            cached: true
+        };
+    }
 
-	// 3. 변환기 찾기
-	const converter = findConverter(url);
-	if (!converter) {
-		return {
-			url: original,
-			original,
-			platform,
-			converted: false,
-			cached: false,
-			error: 'No converter found'
-		};
-	}
+    // 3. 변환기 찾기
+    const converter = findConverter(url);
+    if (!converter) {
+        return {
+            url: original,
+            original,
+            platform,
+            converted: false,
+            cached: false,
+            error: 'No converter found'
+        };
+    }
 
-	// 4. 변환 시도
-	try {
-		const convertedUrl = await converter.convert(url, context);
-		const latencyMs = Date.now() - startTime;
+    // 4. 변환 시도
+    try {
+        const convertedUrl = await converter.convert(url, context);
 
-		if (convertedUrl) {
-			await setSuccessCache(url, convertedUrl, platform);
-			return {
-				url: convertedUrl,
-				original,
-				platform,
-				converted: true,
-				cached: false,
-				latencyMs
-			};
-		} else {
-			await setErrorCache(url);
-			return {
-				url: original,
-				original,
-				platform,
-				converted: false,
-				cached: false,
-				error: 'Conversion failed',
-				latencyMs
-			};
-		}
-	} catch (error) {
-		const latencyMs = Date.now() - startTime;
-		console.error(`[AffiliateAPI] 변환 오류 (${platform}):`, error);
-		await setErrorCache(url);
-		return {
-			url: original,
-			original,
-			platform,
-			converted: false,
-			cached: false,
-			error: error instanceof Error ? error.message : 'Unknown error',
-			latencyMs
-		};
-	}
+        if (convertedUrl) {
+            // 성공 - 캐시 저장
+            setSuccessCache(url, convertedUrl, platform, context?.bo_table, context?.wr_id);
+            return {
+                url: convertedUrl,
+                original,
+                platform,
+                converted: true,
+                cached: false
+            };
+        } else {
+            // 실패 - 에러 캐시 저장
+            setErrorCache(url, context?.bo_table, context?.wr_id);
+            return {
+                url: original,
+                original,
+                platform,
+                converted: false,
+                cached: false,
+                error: 'Conversion failed'
+            };
+        }
+    } catch (error) {
+        console.error(`[AffiliateAPI] 변환 오류 (${platform}):`, error);
+        setErrorCache(url, context?.bo_table, context?.wr_id);
+        return {
+            url: original,
+            original,
+            platform,
+            converted: false,
+            cached: false,
+            error: error instanceof Error ? error.message : 'Unknown error'
+        };
+    }
 }
 
 /**
- * 여러 URL 일괄 변환 (5개씩 병렬)
+ * 여러 URL 일괄 변환
  */
 export async function convertAffiliateUrls(
-	urls: string[],
-	context?: ConvertContext
+    urls: string[],
+    context?: ConvertContext
 ): Promise<BatchConvertResponse> {
-	const results: ConvertResponse[] = [];
-	let converted = 0;
-	let cached = 0;
-	let failed = 0;
+    const results: ConvertResponse[] = [];
+    let converted = 0;
+    let cached = 0;
+    let failed = 0;
 
-	const batchSize = 5;
-	for (let i = 0; i < urls.length; i += batchSize) {
-		const batch = urls.slice(i, i + batchSize);
-		const batchResults = await Promise.all(
-			batch.map((url) => convertAffiliateUrl(url, context))
-		);
+    // 병렬 처리 (최대 5개씩)
+    const batchSize = 5;
+    for (let i = 0; i < urls.length; i += batchSize) {
+        const batch = urls.slice(i, i + batchSize);
+        const batchResults = await Promise.all(batch.map((url) => convertAffiliateUrl(url, context)));
 
-		for (const result of batchResults) {
-			results.push(result);
-			if (result.converted) {
-				converted++;
-				if (result.cached) cached++;
-			} else if (result.error) {
-				failed++;
-			}
-		}
-	}
+        for (const result of batchResults) {
+            results.push(result);
+            if (result.converted) {
+                converted++;
+                if (result.cached) cached++;
+            } else if (result.error) {
+                failed++;
+            }
+        }
+    }
 
-	return {
-		results,
-		stats: {
-			total: urls.length,
-			converted,
-			cached,
-			failed
-		}
-	};
+    return {
+        results,
+        stats: {
+            total: urls.length,
+            converted,
+            cached,
+            failed
+        }
+    };
 }
 
 /**
- * HTML 콘텐츠 내 <a> 태그의 href를 수익링크로 변환
- * (서버사이드 콘텐츠 변환의 핵심 함수)
+ * HTML 콘텐츠 내 링크 변환
  */
 export async function convertAffiliateLinks(
-	content: string,
-	boTable?: string,
-	wrId?: number
+    content: string,
+    boTable?: string,
+    wrId?: number
 ): Promise<string> {
-	if (!content) return content;
+    if (!content) return content;
 
-	// <a> 태그에서 URL 추출
-	const linkRegex = /<a\s+([^>]*?)href=["']([^"']+)["']([^>]*)>([\s\S]*?)<\/a>/gi;
-	const matches: Array<{
-		full: string;
-		beforeHref: string;
-		url: string;
-		afterHref: string;
-		text: string;
-	}> = [];
+    // <a> 태그에서 URL 추출
+    const linkRegex = /<a\s+([^>]*?)href=["']([^"']+)["']([^>]*)>([^<]*)<\/a>/gi;
+    const matches: Array<{ full: string; beforeHref: string; url: string; afterHref: string; text: string }> =
+        [];
 
-	let match;
-	while ((match = linkRegex.exec(content)) !== null) {
-		matches.push({
-			full: match[0],
-			beforeHref: match[1],
-			url: match[2],
-			afterHref: match[3],
-			text: match[4]
-		});
-	}
+    let match;
+    while ((match = linkRegex.exec(content)) !== null) {
+        matches.push({
+            full: match[0],
+            beforeHref: match[1],
+            url: match[2],
+            afterHref: match[3],
+            text: match[4]
+        });
+    }
 
-	if (matches.length === 0) return content;
+    if (matches.length === 0) return content;
 
-	// 제휴 대상 URL 필터링 (비동기 — DB 기반 동적 로딩)
-	const affiliateChecks = await Promise.all(
-		matches.map(async (m) => ({ match: m, isAffiliate: await isAffiliateUrlAsync(m.url) }))
-	);
-	const affiliateMatches = affiliateChecks.filter((c) => c.isAffiliate).map((c) => c.match);
-	if (affiliateMatches.length === 0) return content;
+    // 제휴 대상 URL 필터링
+    const affiliateMatches = matches.filter((m) => isAffiliateUrl(m.url));
 
-	// URL 중복 제거 후 일괄 변환
-	const uniqueUrls = [...new Set(affiliateMatches.map((m) => m.url))];
-	const context: ConvertContext = { bo_table: boTable, wr_id: wrId };
-	const { results } = await convertAffiliateUrls(uniqueUrls, context);
+    if (affiliateMatches.length === 0) return content;
 
-	// URL → 변환 결과 맵
-	const urlMap = new Map<string, ConvertResponse>();
-	for (let i = 0; i < uniqueUrls.length; i++) {
-		urlMap.set(uniqueUrls[i], results[i]);
-	}
+    // 일괄 변환
+    const context: ConvertContext = { bo_table: boTable, wr_id: wrId };
+    const urls = affiliateMatches.map((m) => m.url);
+    const { results } = await convertAffiliateUrls(urls, context);
 
-	// 콘텐츠 내 링크 교체 (href만 교체, 배지 추가하지 않음 — 클라이언트 DOMPurify가 제거할 수 있음)
-	let newContent = content;
-	for (const m of affiliateMatches) {
-		const result = urlMap.get(m.url);
-		if (!result || !result.converted || !result.platform) continue;
+    // URL 매핑
+    const urlMap = new Map<string, ConvertResponse>();
+    for (let i = 0; i < urls.length; i++) {
+        urlMap.set(urls[i], results[i]);
+    }
 
-		// href만 교체 + data-affiliate 속성 추가
-		const newLink = `<a ${m.beforeHref}href="${result.url}" data-affiliate="${result.platform}"${m.afterHref}>${m.text}</a>`;
-		newContent = newContent.replace(m.full, newLink);
-	}
+    // 콘텐츠 내 링크 교체
+    let newContent = content;
+    for (const m of affiliateMatches) {
+        const result = urlMap.get(m.url);
+        if (!result || !result.converted || !result.platform) continue;
 
-	// 통계 이벤트 수집 및 전송 (fire-and-forget)
-	const events: AffiliateEvent[] = [];
-	for (const result of results) {
-		if (!result.platform) continue;
-		const host = extractHost(result.original);
-		if (result.cached && result.converted) {
-			events.push({
-				event_type: 'cache_hit',
-				platform: result.platform,
-				merchant_domain: host || '',
-				original_url: result.original,
-				affiliate_url: result.url,
-				board: boTable || '',
-				post_id: wrId || 0,
-				latency_ms: result.latencyMs || 0
-			});
-		} else if (result.converted) {
-			events.push({
-				event_type: 'success',
-				platform: result.platform,
-				merchant_domain: host || '',
-				original_url: result.original,
-				affiliate_url: result.url,
-				board: boTable || '',
-				post_id: wrId || 0,
-				latency_ms: result.latencyMs || 0
-			});
-		} else if (result.error) {
-			events.push({
-				event_type: 'failure',
-				platform: result.platform,
-				merchant_domain: host || '',
-				original_url: result.original,
-				board: boTable || '',
-				post_id: wrId || 0,
-				error_message: result.error,
-				latency_ms: result.latencyMs || 0
-			});
-		}
-	}
+        // 제휴 배지 생성
+        const platformName = getPlatformNameKo(result.platform);
+        const badge = `<span class="affiliate-badge" title="${platformName} 제휴 링크">💰</span>`;
 
-	if (events.length > 0) {
-		// fire-and-forget: 통계 전송 실패해도 변환은 정상 반환
-		sendAffiliateEvents(events).catch(() => {});
-	}
+        // 새 링크 생성
+        const newLink = `<a ${m.beforeHref}href="${result.url}" data-affiliate="${result.platform}"${m.afterHref}>${m.text}${badge}</a>`;
 
-	return newContent;
+        newContent = newContent.replace(m.full, newLink);
+    }
+
+    return newContent;
 }
 
-export { detectPlatform, detectPlatformAsync, isAffiliateUrl, isAffiliateUrlAsync, getPlatformNameKo };
+/**
+ * 플랫폼 정보 가져오기
+ */
+export function getAffiliatePlatformInfo(platform: AffiliatePlatform): { name: string; nameKo: string } {
+    return {
+        name: platform,
+        nameKo: getPlatformNameKo(platform)
+    };
+}
+
+export { detectPlatform, isAffiliateUrl, getPlatformNameKo };

--- a/plugins/affiliate-link/lib/cache.server.ts
+++ b/plugins/affiliate-link/lib/cache.server.ts
@@ -1,106 +1,143 @@
 /**
  * 제휴 링크 캐싱 로직
- * Redis 2-tier 캐시 (L1 메모리 + L2 Redis)
- *
- * - 같은 URL은 bo_table/wr_id 무관하게 같은 수익링크 → 키에 URL만 사용
- * - 성공 TTL: 7일, 에러 TTL: 6시간
+ * Redis 또는 메모리 캐시 지원
  */
 
 import { createHash } from 'crypto';
-import { TieredCache } from '$lib/server/cache.js';
 import type { AffiliatePlatform } from './types';
 
-/** 캐시 저장 데이터 */
-interface AffiliateCacheData {
-	url: string;
-	platform: AffiliatePlatform;
+/** 캐시 항목 */
+interface CacheItem {
+    url: string;
+    platform: AffiliatePlatform;
+    timestamp: number;
 }
 
-/** 에러 센티널 */
-interface AffiliateErrorData {
-	isError: true;
+/** 에러 캐시 항목 */
+interface ErrorCacheItem {
+    isError: true;
+    timestamp: number;
 }
 
-type CacheValue = AffiliateCacheData | AffiliateErrorData;
+type CacheValue = CacheItem | ErrorCacheItem;
 
-// TTL 설정
-const SUCCESS_L1_TTL_MS = 10 * 60 * 1000; // L1: 10분
-const SUCCESS_L2_TTL_SEC = 7 * 24 * 60 * 60; // L2: 7일
-const ERROR_L1_TTL_MS = 5 * 60 * 1000; // L1: 5분
-const ERROR_L2_TTL_SEC = 6 * 60 * 60; // L2: 6시간
+// 메모리 캐시 (서버 재시작 시 초기화)
+const memoryCache = new Map<string, CacheValue>();
 
-// 성공 캐시
-const successCache = new TieredCache<AffiliateCacheData>(
-	'affi',
-	SUCCESS_L1_TTL_MS,
-	SUCCESS_L2_TTL_SEC,
-	10000
-);
-
-// 에러 캐시 (짧은 TTL)
-const errorCache = new TieredCache<AffiliateErrorData>(
-	'affi_err',
-	ERROR_L1_TTL_MS,
-	ERROR_L2_TTL_SEC,
-	5000
-);
+// 캐시 TTL (초)
+const TTL = {
+    SUCCESS: 7 * 24 * 60 * 60, // 7일 (성공)
+    PERMANENT_ERROR: 24 * 60 * 60, // 24시간 (지원 불가 도메인)
+    TEMPORARY_ERROR: 6 * 60 * 60 // 6시간 (API 오류)
+};
 
 /**
- * 캐시 키 생성 — URL만 기준 (같은 URL → 같은 수익링크)
+ * 캐시 키 생성
  */
-function getCacheKey(url: string): string {
-	return createHash('md5').update(url).digest('hex');
+function getCacheKey(url: string, boTable?: string, wrId?: number): string {
+    const input = `${url}:${boTable || ''}:${wrId || ''}`;
+    return `affiliate:${createHash('md5').update(input).digest('hex')}`;
 }
 
 /**
  * 캐시에서 조회
  */
-export async function getFromCache(
-	url: string
-): Promise<{ url: string; platform: AffiliatePlatform } | 'error' | null> {
-	const key = getCacheKey(url);
+export function getFromCache(
+    url: string,
+    boTable?: string,
+    wrId?: number
+): { url: string; platform: AffiliatePlatform } | 'error' | null {
+    const key = getCacheKey(url, boTable, wrId);
+    const cached = memoryCache.get(key);
 
-	// 성공 캐시 확인
-	const cached = await successCache.get(key);
-	if (cached) {
-		return { url: cached.url, platform: cached.platform };
-	}
+    if (!cached) {
+        return null;
+    }
 
-	// 에러 캐시 확인
-	const errCached = await errorCache.get(key);
-	if (errCached) {
-		return 'error';
-	}
+    // TTL 확인
+    const now = Date.now();
+    const age = (now - cached.timestamp) / 1000;
 
-	return null;
+    if ('isError' in cached) {
+        // 에러 캐시
+        if (age > TTL.TEMPORARY_ERROR) {
+            memoryCache.delete(key);
+            return null;
+        }
+        return 'error';
+    }
+
+    // 성공 캐시
+    if (age > TTL.SUCCESS) {
+        memoryCache.delete(key);
+        return null;
+    }
+
+    return { url: cached.url, platform: cached.platform };
 }
 
 /**
  * 성공 결과 캐시 저장
  */
-export async function setSuccessCache(
-	originalUrl: string,
-	convertedUrl: string,
-	platform: AffiliatePlatform
-): Promise<void> {
-	const key = getCacheKey(originalUrl);
-	await successCache.set(key, { url: convertedUrl, platform });
-	// 에러 캐시 제거 (이전 에러가 있었다면)
-	await errorCache.delete(key);
+export function setSuccessCache(
+    originalUrl: string,
+    convertedUrl: string,
+    platform: AffiliatePlatform,
+    boTable?: string,
+    wrId?: number
+): void {
+    const key = getCacheKey(originalUrl, boTable, wrId);
+    memoryCache.set(key, {
+        url: convertedUrl,
+        platform,
+        timestamp: Date.now()
+    });
 }
 
 /**
  * 에러 캐시 저장
  */
-export async function setErrorCache(url: string): Promise<void> {
-	const key = getCacheKey(url);
-	await errorCache.set(key, { isError: true });
+export function setErrorCache(url: string, boTable?: string, wrId?: number): void {
+    const key = getCacheKey(url, boTable, wrId);
+    memoryCache.set(key, {
+        isError: true,
+        timestamp: Date.now()
+    });
 }
 
 /**
- * 캐시 초기화 (L1만)
+ * 캐시 통계
+ */
+export function getCacheStats(): { size: number; keys: string[] } {
+    return {
+        size: memoryCache.size,
+        keys: Array.from(memoryCache.keys())
+    };
+}
+
+/**
+ * 캐시 초기화
  */
 export function clearCache(): void {
-	successCache.clearL1();
-	errorCache.clearL1();
+    memoryCache.clear();
+}
+
+/**
+ * 만료된 캐시 정리
+ */
+export function cleanupExpiredCache(): number {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [key, value] of memoryCache.entries()) {
+        const age = (now - value.timestamp) / 1000;
+        const ttl = 'isError' in value ? TTL.TEMPORARY_ERROR : TTL.SUCCESS;
+
+        if (age > ttl) {
+            memoryCache.delete(key);
+            cleaned++;
+        }
+    }
+
+    return cleaned;
 }

--- a/plugins/affiliate-link/lib/domain-matcher.ts
+++ b/plugins/affiliate-link/lib/domain-matcher.ts
@@ -1,9 +1,6 @@
 /**
  * 도메인 매칭 로직
  * PHP MoneyMoang의 AffiliateDomains.php 참조
- *
- * - detectPlatform(): 동기 — 하드코딩 fallback (클라이언트/서버 공용)
- * - detectPlatformAsync(): 비동기 — DB 기반 동적 로딩 (서버사이드 전용)
  */
 
 import type { AffiliatePlatform, PlatformInfo } from './types';
@@ -217,72 +214,4 @@ export function getPlatformNameKo(platform: AffiliatePlatform): string {
  */
 export function getPlatformName(platform: AffiliatePlatform): string {
     return PLATFORM_DOMAINS[platform]?.name || platform;
-}
-
-// =============================================================================
-// Async 버전 (서버사이드 전용 — DB 기반 동적 머천트 로딩)
-// =============================================================================
-
-/** 동적 머천트 로더 함수 타입 */
-type MerchantLoader = (platform: string) => Promise<string[] | null>;
-
-/** 서버사이드에서 주입하는 동적 머천트 로더 */
-let _dynamicMerchantLoader: MerchantLoader | null = null;
-
-/**
- * 동적 머천트 로더 설정 (서버 시작 시 1회 호출)
- * affiliate-merchants.ts의 getPlatformMerchants를 주입합니다.
- */
-export function setDynamicMerchantLoader(loader: MerchantLoader): void {
-    _dynamicMerchantLoader = loader;
-}
-
-/**
- * 링크프라이스 머천트 도메인 목록 (동적 로딩 우선, fallback: 하드코딩)
- */
-async function getLinkpriceMerchants(): Promise<string[]> {
-    if (_dynamicMerchantLoader) {
-        const domains = await _dynamicMerchantLoader('linkprice');
-        if (domains && domains.length > 0) return domains;
-    }
-    return LINKPRICE_MERCHANTS;
-}
-
-/**
- * URL의 플랫폼 감지 (비동기 — 서버사이드 전용)
- * DB에서 동적으로 로드한 머천트 목록을 사용합니다.
- */
-export async function detectPlatformAsync(url: string): Promise<AffiliatePlatform | null> {
-    const host = extractHost(url);
-    if (!host) return null;
-
-    // 1. 직접 플랫폼 매칭 (쿠팡, 알리, 아마존, KKday) — 변동 없음
-    const directPlatforms: AffiliatePlatform[] = ['coupang', 'aliexpress', 'amazon', 'kkday'];
-    for (const platform of directPlatforms) {
-        if (matchesPlatform(url, platform)) {
-            return platform;
-        }
-    }
-
-    // 2. 링크프라이스 단축 URL
-    if (matchesPlatform(url, 'linkprice')) {
-        return 'linkprice';
-    }
-
-    // 3. 링크프라이스 머천트 도메인 (동적 로딩)
-    const merchants = await getLinkpriceMerchants();
-    for (const merchant of merchants) {
-        if (host === merchant || host.endsWith('.' + merchant)) {
-            return 'linkprice';
-        }
-    }
-
-    return null;
-}
-
-/**
- * URL이 제휴 대상인지 확인 (비동기 — 서버사이드 전용)
- */
-export async function isAffiliateUrlAsync(url: string): Promise<boolean> {
-    return (await detectPlatformAsync(url)) !== null;
 }

--- a/plugins/affiliate-link/lib/platforms/aliexpress.ts
+++ b/plugins/affiliate-link/lib/platforms/aliexpress.ts
@@ -44,8 +44,7 @@ async function resolveShortUrl(url: string): Promise<string> {
 				}
 			});
 			const finalUrl = response.url;
-			const parsedFinal = (() => { try { return new URL(finalUrl); } catch { return null; } })();
-			if (parsedFinal && (parsedFinal.hostname === 'aliexpress.com' || parsedFinal.hostname.endsWith('.aliexpress.com'))) {
+			if (finalUrl.includes('aliexpress.com')) {
 				// 기존 제휴 파라미터 제거
 				const cleaned = finalUrl
 					.replace(/[?&]aff_[^&]*/gi, '')
@@ -125,30 +124,12 @@ async function callAliExpressApi(originalUrl: string): Promise<string | null> {
 			return result;
 		}
 
-		console.warn('[AliExpress] 변환 실패:', JSON.stringify(data?.aliexpress_affiliate_link_generate_response?.resp_result?.result || ''));
-		// Fallback: API 실패 시 aff 파라미터 직접 추가
-		return buildAliExpressFallbackUrl(resolvedUrl);
+		console.warn('[AliExpress] 변환 실패:', data);
+		return null;
 	} catch (error) {
 		console.error('[AliExpress] API 호출 실패:', error);
-		return buildAliExpressFallbackUrl(originalUrl);
-	}
-}
-
-/**
- * 알리익스프레스 API 실패 시 fallback URL 생성
- * aff_id 파라미터를 직접 추가 (쿠키 기반 추적)
- */
-function buildAliExpressFallbackUrl(url: string): string | null {
-	const accessKey = env.AFFI_ALIEXPRESS_ACCESS_KEY;
-	if (!accessKey) return null;
-
-	// 이미 제휴 링크면 건너뛰기
-	if (url.includes('aff_id=') || url.includes('s.click.aliexpress')) {
 		return null;
 	}
-
-	const separator = url.includes('?') ? '&' : '?';
-	return `${url}${separator}aff_id=${accessKey}&aff_short_key=damoang&aff_platform=portals-tool`;
 }
 
 export const aliexpressConverter: PlatformConverter = {

--- a/plugins/affiliate-link/lib/platforms/amazon.ts
+++ b/plugins/affiliate-link/lib/platforms/amazon.ts
@@ -14,9 +14,11 @@ function addAmazonTag(originalUrl: string): string | null {
 	const storeId = env.AFFI_AMAZON_STORE_ID || 'damoang0c-20';
 
 	try {
-		// HTML 엔티티 디코드 (단일 패스로 이중 언이스케이프 방지)
-		const entityMap: Record<string, string> = { '&amp;': '&', '&#x3D;': '=', '&#x26;': '&' };
-		const decodedUrl = originalUrl.replace(/&amp;|&#x3D;|&#x26;/g, (m) => entityMap[m]);
+		// HTML 엔티티 디코드
+		const decodedUrl = originalUrl
+			.replace(/&amp;/g, '&')
+			.replace(/&#x3D;/g, '=')
+			.replace(/&#x26;/g, '&');
 
 		const url = new URL(decodedUrl);
 

--- a/plugins/affiliate-link/lib/platforms/coupang.ts
+++ b/plugins/affiliate-link/lib/platforms/coupang.ts
@@ -41,13 +41,8 @@ async function resolveShortUrl(url: string): Promise<string> {
 				}
 			});
 			const finalUrl = response.url;
-			try {
-				const parsed = new URL(finalUrl);
-				if (parsed.hostname === 'coupang.com' || parsed.hostname.endsWith('.coupang.com')) {
-					return finalUrl;
-				}
-			} catch {
-				// URL 파싱 실패 시 무시
+			if (finalUrl.includes('coupang.com')) {
+				return finalUrl;
 			}
 		} catch {
 			// 리다이렉트 실패 시 원본 반환
@@ -115,38 +110,11 @@ async function callCoupangApi(originalUrl: string): Promise<string | null> {
 		}
 
 		console.warn('[Coupang] 변환 실패:', data.rMessage || 'Unknown error');
-		// Fallback: deeplink API 실패 시 파트너스 웹 리다이렉트 URL 생성
-		// 쿠팡 수익에서 가장 중요한 부분 — API 거부되어도 파트너 ID는 붙여야 함
-		return buildCoupangFallbackUrl(resolvedUrl);
+		return null;
 	} catch (error) {
 		console.error('[Coupang] API 호출 실패:', error);
-		return buildCoupangFallbackUrl(originalUrl);
+		return null;
 	}
-}
-
-/**
- * 쿠팡 Deeplink API 실패 시 fallback URL 생성
- * Coupang Partners 웹 리다이렉트 방식 (수수료 추적 가능)
- */
-function buildCoupangFallbackUrl(url: string): string | null {
-	const partnerId = env.AFFI_COUPANG_PARTNER_ID;
-	if (!partnerId) return null;
-
-	// 이미 제휴 링크인 경우 건너뛰기
-	try {
-		const parsed = new URL(url);
-		if (
-			parsed.hostname === 'link.coupang.com' ||
-			parsed.hostname === 'coupa.ng' ||
-			parsed.hostname.endsWith('.coupa.ng')
-		) {
-			return null;
-		}
-	} catch {
-		// URL 파싱 실패 시 계속 진행
-	}
-
-	return `https://link.coupang.com/re/AFFSDP?lptag=${partnerId}&pageKey=0&subId=&subId2=&subId3=&tracking=&u=${encodeURIComponent(url)}`;
 }
 
 export const coupangConverter: PlatformConverter = {

--- a/plugins/affiliate-link/lib/platforms/kkday.ts
+++ b/plugins/affiliate-link/lib/platforms/kkday.ts
@@ -14,9 +14,11 @@ function addKKdayCid(originalUrl: string): string | null {
 	const cid = env.AFFI_KKDAY_CID || '20907';
 
 	try {
-		// HTML 엔티티 디코드 (단일 패스로 이중 언이스케이프 방지)
-		const entityMap: Record<string, string> = { '&amp;': '&', '&#x3D;': '=', '&#x26;': '&' };
-		const decodedUrl = originalUrl.replace(/&amp;|&#x3D;|&#x26;/g, (m) => entityMap[m]);
+		// HTML 엔티티 디코드
+		const decodedUrl = originalUrl
+			.replace(/&amp;/g, '&')
+			.replace(/&#x3D;/g, '=')
+			.replace(/&#x26;/g, '&');
 
 		const url = new URL(decodedUrl);
 

--- a/plugins/affiliate-link/lib/platforms/linkprice.ts
+++ b/plugins/affiliate-link/lib/platforms/linkprice.ts
@@ -35,7 +35,7 @@ function generateClickId(context?: ConvertContext): string {
  * 링크프라이스 API 호출
  */
 async function callLinkPriceApi(originalUrl: string, context?: ConvertContext): Promise<string | null> {
-	const affiliateId = env.AFFI_LINKPRICE_AFF_ID || env.AFFI_AFFILIATE_ID;
+	const affiliateId = env.AFFI_AFFILIATE_ID;
 
 	if (!affiliateId) {
 		console.warn('[LinkPrice] Affiliate ID가 설정되지 않음');

--- a/plugins/affiliate-link/lib/types.ts
+++ b/plugins/affiliate-link/lib/types.ts
@@ -29,7 +29,6 @@ export interface ConvertResponse {
     converted: boolean;
     cached: boolean;
     error?: string;
-    latencyMs?: number;
 }
 
 /** 일괄 변환 요청 */
@@ -100,17 +99,4 @@ export interface AffiliateConfig {
 
     // 캐시 TTL (초)
     cacheTtl: number;
-}
-
-/** 제휴 링크 변환 이벤트 (ClickHouse 통계 추적) */
-export interface AffiliateEvent {
-    event_type: 'transform' | 'success' | 'failure' | 'cache_hit';
-    platform: string;
-    merchant_domain: string;
-    original_url: string;
-    affiliate_url?: string;
-    board: string;
-    post_id: number;
-    error_message?: string;
-    latency_ms: number;
 }


### PR DESCRIPTION
## Summary

- `data-sveltekit-preload-code="eager"` 제거 → SvelteKit 기본값(`hover`)으로 복원
- eager로 인해 모든 라우트 JS를 즉시 다운로드 → 페이지당 청크 180→240개, CDN 요청 33% 증가
- 주말에도 평일급 요청이 발생하는 직접 원인

## Test plan

- [ ] 페이지 로드 시 Network 탭에서 JS 청크 수 ~180개 수준 확인
- [ ] hover 시에만 해당 링크의 코드 프리로드 확인
- [ ] 네비게이션 속도 체감 변화 없는지 확인