### PR TITLE
ci: 배포 승인 게이트 도입 (카나리→승인→본배포)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,19 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      environment:
-        description: '배포 환경'
-        required: true
-        default: 'build-only'
-        type: choice
-        options:
-          - build-only
-          - prod
-      confirm:
-        description: '프로덕션 배포 확인 (prod 선택 시 "deploy" 입력)'
-        required: false
-        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -27,14 +14,18 @@ env:
   AWS_REGION: ap-northeast-2
 
 jobs:
-  # main push 시 Docker 이미지 빌드 + GHCR push
-  build-and-push:
-    name: Build & Push Image
-    runs-on: ubuntu-24.04-arm  # ARM64 네이티브 러너 (QEMU 불필요)
+  # ──────────────────────────────────────────────
+  # 1단계: 빌드 → GHCR + ECR push (자동)
+  # ──────────────────────────────────────────────
+  build:
+    name: Build & Push
+    runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write
       contents: read
       packages: write
+    outputs:
+      image-tag: ${{ steps.tags.outputs.sha_tag }}
 
     steps:
       - name: Checkout angple
@@ -56,10 +47,9 @@ jobs:
           echo "Premium assets installed"
 
       - name: Ensure premium directories exist
-        run: |
-          mkdir -p custom-themes custom-widgets extensions plugins widgets
+        run: mkdir -p custom-themes custom-widgets extensions plugins widgets
 
-      # --- 네이티브 빌드 (Docker 밖에서 빌드 → 최소 이미지만 생성) ---
+      # --- 네이티브 빌드 ---
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -91,87 +81,90 @@ jobs:
             cp -r "$dir" "apps/web/deploy/" 2>/dev/null || mkdir -p "apps/web/deploy/$dir"
           done
 
-      # --- 최소 Docker 이미지 생성 (COPY만) ---
+      # --- Docker 이미지 빌드 + push ---
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha,prefix=
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: apps/web/deploy
-          file: apps/web/Dockerfile.prod
-          push: true
-          platforms: linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Image digest
-        run: echo "Image pushed to GHCR with tags ${{ steps.meta.outputs.tags }}"
-
-      # --- ECR push + K8s 배포 (main push 시 자동) ---
       - name: Configure AWS credentials
-        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
-        if: github.ref == 'refs/heads/main'
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Push to ECR
-        if: github.ref == 'refs/heads/main'
+      - name: Set image tags
+        id: tags
         run: |
-          ECR_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}"
-          SHA_TAG="sha-${{ github.sha }}"
+          SHA_TAG="sha-${GITHUB_SHA}"
+          echo "sha_tag=${SHA_TAG}" >> "$GITHUB_OUTPUT"
 
-          # Buildx로 빌드된 이미지를 ECR에도 push
-          docker buildx build \
-            --platform linux/arm64 \
-            -t "${ECR_IMAGE}:${SHA_TAG}" \
-            -t "${ECR_IMAGE}:latest" \
-            --push \
-            -f apps/web/Dockerfile.prod \
-            apps/web/deploy
+      - name: Build and push to GHCR + ECR
+        uses: docker/build-push-action@v5
+        with:
+          context: apps/web/deploy
+          file: apps/web/Dockerfile.prod
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.sha_tag }}
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.sha_tag }}
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
 
-          echo "ECR push complete: ${ECR_IMAGE}:${SHA_TAG}"
+      - name: Build summary
+        run: |
+          echo "### Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "- GHCR: \`${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.sha_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ECR: \`${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.sha_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Deploy to K8s via SSM
-        if: github.ref == 'refs/heads/main'
+  # ──────────────────────────────────────────────
+  # 2단계: 카나리 배포 + 스모크 테스트 (자동)
+  # ──────────────────────────────────────────────
+  deploy-canary:
+    name: Canary Deploy & Smoke Test
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy canary via SSM
         env:
-          IMAGE_TAG: sha-${{ github.sha }}
+          IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
         run: |
+          echo "Deploying canary with tag: $IMAGE_TAG"
+
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "i-038a1d1f00798d94b" \
             --document-name "AWS-RunShellScript" \
-            --parameters 'commands=[
-              "/home/angple/k8s/prod/deploy.sh web '"$IMAGE_TAG"'"
-            ]' \
-            --timeout-seconds 600 \
+            --parameters "commands=[
+              \"/home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --canary-only\"
+            ]" \
+            --timeout-seconds 300 \
             --query "Command.CommandId" \
             --output text)
 
-          echo "Command ID: $COMMAND_ID"
-          echo "Waiting for deployment..."
+          echo "SSM Command: $COMMAND_ID"
 
-          for i in $(seq 1 60); do
+          for i in $(seq 1 30); do
             STATUS=$(aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
               --instance-id "i-038a1d1f00798d94b" \
@@ -179,7 +172,7 @@ jobs:
               --output text 2>/dev/null || echo "Pending")
 
             if [ "$STATUS" = "Success" ]; then
-              echo "Deploy successful!"
+              echo "Canary deploy + smoke test passed!"
               aws ssm get-command-invocation \
                 --command-id "$COMMAND_ID" \
                 --instance-id "i-038a1d1f00798d94b" \
@@ -187,7 +180,7 @@ jobs:
                 --output text
               exit 0
             elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
-              echo "Deploy failed with status: $STATUS"
+              echo "Canary failed: $STATUS"
               aws ssm get-command-invocation \
                 --command-id "$COMMAND_ID" \
                 --instance-id "i-038a1d1f00798d94b" \
@@ -198,76 +191,85 @@ jobs:
 
             sleep 10
           done
-
-          echo "Deploy timed out waiting for SSM response"
+          echo "Timed out"
           exit 1
 
-  # 프로덕션 배포 (수동 트리거 전용)
-  deploy-prod:
-    name: Deploy to Production
-    needs: build-and-push
+      - name: Canary summary
+        run: |
+          echo "### Canary Passed" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag: \`${{ needs.build.outputs.image-tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- 스모크 테스트 통과 → 본배포 승인 대기 중" >> "$GITHUB_STEP_SUMMARY"
+
+  # ──────────────────────────────────────────────
+  # 3단계: 본배포 (수동 승인 후)
+  # ──────────────────────────────────────────────
+  deploy-production:
+    name: Production Deploy
+    needs: [build, deploy-canary]
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      && github.event.inputs.environment == 'prod'
-      && github.event.inputs.confirm == 'deploy'
+    environment: production  # ← 승인 게이트
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2.4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.DEV_SERVER_HOST }}
-          username: ${{ secrets.DEV_SERVER_USER }}
-          key: ${{ secrets.DEV_SERVER_SSH_KEY }}
-          script: |
-            set -e
+          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
+          aws-region: ${{ env.AWS_REGION }}
 
-            echo "=== Production Deploy Start ==="
+      - name: Deploy to production via SSM
+        env:
+          IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
+        run: |
+          echo "Production deploy with tag: $IMAGE_TAG"
 
-            # GHCR 로그인
-            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "i-038a1d1f00798d94b" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[
+              \"/home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --skip-canary\"
+            ]" \
+            --timeout-seconds 600 \
+            --query "Command.CommandId" \
+            --output text)
 
-            # 최신 이미지 pull
-            docker pull ${{ env.IMAGE_NAME }}:latest
+          echo "SSM Command: $COMMAND_ID"
 
-            # 기존 컨테이너 강제 제거
-            docker rm -f angple-web 2>/dev/null || true
-            sleep 3
+          for i in $(seq 1 60); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "i-038a1d1f00798d94b" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
 
-            # 환경 변수 파일 확인
-            ENV_FILE="/home/damoang/angple-deploy/.env.prod"
-            ENV_FLAG=""
-            if [ -f "$ENV_FILE" ]; then
-              ENV_FLAG="--env-file $ENV_FILE"
+            if [ "$STATUS" = "Success" ]; then
+              echo "Production deploy complete!"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardOutputContent" \
+                --output text
+              exit 0
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+              echo "Production deploy failed: $STATUS"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardErrorContent" \
+                --output text
+              exit 1
             fi
 
-            # 새 컨테이너 시작 (host 네트워크 — 포트 바인딩 충돌 방지)
-            docker run -d \
-              --name angple-web \
-              --restart unless-stopped \
-              --network host \
-              -v /home/damoang/angple-deploy/data-prod:/app/data \
-              -e NODE_ENV=production \
-              -e PORT=3010 \
-              $ENV_FLAG \
-              ${{ env.IMAGE_NAME }}:latest
+            sleep 10
+          done
+          echo "Timed out"
+          exit 1
 
-            # 헬스체크 대기
-            echo "Waiting for health check..."
-            for i in $(seq 1 30); do
-              if docker exec angple-web wget -q -O /dev/null http://127.0.0.1:3010/health 2>/dev/null; then
-                echo "Health check passed!"
-                break
-              fi
-              if [ "$i" -eq 30 ]; then
-                echo "Health check failed after 30 attempts"
-                docker logs --tail 50 angple-web
-                exit 1
-              fi
-              sleep 2
-            done
-
-            # 이전 이미지 정리
-            docker image prune -f
-
-            echo "=== Production Deploy Complete ==="
+      - name: Deploy summary
+        run: |
+          echo "### Production Deploy Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag: \`${{ needs.build.outputs.image-tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- 전체 Pod 롤링 업데이트 완료" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- main push 시 자동 운영 배포 → 승인 게이트 추가로 안전성 확보
- 3단계 파이프라인: 빌드(자동) → 카나리+스모크(자동) → 본배포(승인 후)
- GitHub Environment `production`에 sdk-kr 승인 필수 설정 완료
- deploy.sh에 `--canary-only` 모드 추가

## 배포 흐름
```
main push → 빌드+ECR push (자동, ~3분)
         → 카나리 1 pod + 스모크 테스트 (자동)
         → ✅ 통과 시 GitHub에서 승인 요청 알림
         → 👤 승인 클릭 → 전체 pod 롤링 업데이트
```

## Test plan
- [ ] main push 시 빌드 → ECR+GHCR push 확인
- [ ] 카나리 배포 + 스모크 테스트 자동 실행 확인
- [ ] production 승인 대기 상태 확인
- [ ] 승인 후 본배포 실행 확인