### PR TITLE
fix: promotion-inline-list.svelte 누락 — CI 빌드 실패 수정

### DIFF
--- a/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-list.svelte
+++ b/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-list.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import PromotionInlinePost from './promotion-inline-post.svelte';
+
+    interface Props {
+        posts?: any[];
+        variant?: 'default' | 'classic';
+    }
+
+    let { posts = [], variant = 'default' }: Props = $props();
+</script>
+
+{#if posts.length > 0}
+    {#each posts.slice(0, 2) as promo (promo.wrId)}
+        <PromotionInlinePost post={promo} {variant} />
+    {/each}
+{/if}


### PR DESCRIPTION
## Summary

- `promotion-inline-list.svelte`가 git에 추가되지 않아 CI 빌드 실패
- `slot-defaults.ts`에서 import하지만 untracked 상태였음