### PR TITLE
ci: 카나리 통과 시 텔레그램 승인 알림

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -194,6 +194,28 @@ jobs:
           echo "Timed out"
           exit 1
 
+      - name: Notify Telegram (승인 요청)
+        if: success()
+        env:
+          IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
+        run: |
+          COMMIT_MSG=$(echo "${{ github.event.head_commit.message }}" | head -1)
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          MSG="✅ 카나리 배포 통과 — 승인 대기 중
+
+          ${COMMIT_MSG}
+          Tag: ${IMAGE_TAG}
+
+          👉 승인하기: ${RUN_URL}"
+
+          # 들여쓰기 제거
+          MSG=$(echo "$MSG" | sed 's/^          //')
+
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
+            --data-urlencode "text=${MSG}" >/dev/null 2>&1 || true
+
       - name: Canary summary
         run: |
           echo "### Canary Passed" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- 카나리 배포 + 스모크 테스트 통과 후 텔레그램으로 알림 전송
- 커밋 메시지 + 이미지 태그 + 승인 링크 포함
- GitHub Secrets에 TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID 등록 완료

## 알림 예시
```
✅ 카나리 배포 통과 — 승인 대기 중

fix: 버그 수정 (#410)
Tag: sha-abc1234...

👉 승인하기: https://github.com/damoang/angple/actions/runs/12345
```