### PR TITLE
fix: SSR singleflight Response.clone() 버그 수정 (JSON raw output)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -402,8 +402,26 @@ export const handle: Handle = async ({ event, resolve }) => {
         const pending = ssrCachePending.get(cacheKey);
         if (pending) {
             try {
-                const result = await pending;
-                return result.clone();
+                await pending;
+                // Response.clone() 대신 캐시된 body로 새 Response 생성
+                // (원본 Response body가 이미 소비되어 clone() 실패하는 버그 방지)
+                const freshCached = ssrCache.get(cacheKey);
+                if (freshCached) {
+                    return new Response(freshCached.body, {
+                        status: 200,
+                        headers: {
+                            'Content-Type': 'text/html; charset=utf-8',
+                            'Cache-Control': 'private, no-store, no-cache, must-revalidate',
+                            Vary: 'Cookie',
+                            'X-Content-Type-Options': 'nosniff',
+                            'X-Frame-Options': 'SAMEORIGIN',
+                            'Referrer-Policy': 'strict-origin-when-cross-origin',
+                            'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+                            ...(!dev ? { 'Content-Security-Policy': cspHeader } : {}),
+                            'X-SSR-Cache': 'HIT'
+                        }
+                    });
+                }
             } catch {
                 // pending 실패 시 아래에서 직접 렌더링
             }


### PR DESCRIPTION
## Summary
- 비로그인 사용자가 동시에 같은 페이지를 요청할 때, singleflight 패턴에서 `Response.clone()` 실패로 JSON raw output이 노출되던 버그 수정
- 원인: 첫 번째 caller가 Response를 반환하면 SvelteKit이 body를 소비 → 두 번째 caller의 `clone()`이 실패
- 수정: `clone()` 대신 ssrCache에 이미 저장된 body string으로 새 Response 생성

## Test plan
- [x] `pnpm build` 성공
- [ ] 운영 배포 후 JSON raw output 재현 모니터링