### PR TITLE
fix: 글 작성 후 목록 미반영 — SSR 캐시 무효화 + TTL 단축

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -14,12 +14,14 @@ const JWT_CACHE_TTL = 5 * 60 * 1000; // 5분
 const MAX_JWT_CACHE_SIZE = 50000;
 
 // --- SSR 응답 캐시 (비로그인: 홈 + 게시판 목록 + 글 상세) ---
-const ssrCache = new Map<string, { body: string; timestamp: number }>();
-const SSR_CACHE_TTL_HOME = 60_000; // 홈 60초
-const SSR_CACHE_TTL_BOARD = 120_000; // 게시판 목록 120초
-const SSR_CACHE_TTL_POST = 60_000; // 글 상세 60초
-const MAX_SSR_CACHE_SIZE = 500; // 캐시할 최대 페이지 수
-const ssrCachePending = new Map<string, Promise<Response>>();
+import {
+    ssrCache,
+    ssrCachePending,
+    SSR_CACHE_TTL_HOME,
+    SSR_CACHE_TTL_BOARD,
+    SSR_CACHE_TTL_POST,
+    MAX_SSR_CACHE_SIZE
+} from '$lib/server/ssr-cache.js';
 
 /**
  * SvelteKit Server Hooks

--- a/apps/web/src/lib/server/ssr-cache.ts
+++ b/apps/web/src/lib/server/ssr-cache.ts
@@ -1,0 +1,32 @@
+/**
+ * SSR 응답 캐시 (비로그인 사용자 전용)
+ *
+ * hooks.server.ts에서 사용하며, 글 작성/수정/삭제 시
+ * 해당 게시판 캐시를 무효화하기 위해 별도 모듈로 분리.
+ */
+
+/** 키: pathname → { body, timestamp } */
+export const ssrCache = new Map<string, { body: string; timestamp: number }>();
+
+/** Singleflight 중복 요청 방지용 */
+export const ssrCachePending = new Map<string, Promise<Response>>();
+
+export const SSR_CACHE_TTL_HOME = 60_000; // 홈 60초
+export const SSR_CACHE_TTL_BOARD = 30_000; // 게시판 목록 30초 (120초 → 30초 단축)
+export const SSR_CACHE_TTL_POST = 60_000; // 글 상세 60초
+export const MAX_SSR_CACHE_SIZE = 500;
+
+/**
+ * 게시판 관련 캐시 무효화
+ * 글 작성/수정/삭제 시 호출하여 해당 게시판 목록 + 홈 캐시를 즉시 제거
+ */
+export function invalidateBoardCache(boardId: string, postId?: number): void {
+    // 게시판 목록 캐시 제거
+    ssrCache.delete(`/${boardId}`);
+    // 홈 캐시 제거 (새 글이 홈에도 표시되므로)
+    ssrCache.delete('/');
+    // 글 상세 캐시 제거
+    if (postId) {
+        ssrCache.delete(`/${boardId}/${postId}`);
+    }
+}

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -3,6 +3,7 @@ import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import pool from '$lib/server/db';
 import type { RowDataPacket } from 'mysql2';
+import { invalidateBoardCache } from '$lib/server/ssr-cache.js';
 
 /**
  * API v1 프록시 핸들러
@@ -337,6 +338,22 @@ async function proxyRequest(
             syncCelebrationBanner(path).catch((err) => {
                 console.error('[API Proxy] celebration sync error:', err);
             });
+        }
+
+        // 글/댓글 작성·수정·삭제 성공 시 SSR 캐시 무효화 (비로그인 사용자도 즉시 반영)
+        if (
+            (method === 'POST' || method === 'PUT' || method === 'DELETE') &&
+            response.status >= 200 &&
+            response.status < 300
+        ) {
+            const boardMatch = path.match(/^boards\/([a-zA-Z0-9_-]+)\/posts/);
+            if (boardMatch) {
+                const postIdMatch = path.match(/^boards\/[a-zA-Z0-9_-]+\/posts\/(\d+)/);
+                invalidateBoardCache(
+                    boardMatch[1],
+                    postIdMatch ? parseInt(postIdMatch[1], 10) : undefined
+                );
+            }
         }
 
         return new Response(response.body, {


### PR DESCRIPTION
## Summary
- SSR 캐시를 별도 모듈(`$lib/server/ssr-cache.ts`)로 분리
- 글/댓글 작성·수정·삭제 성공 시 해당 게시판 + 홈 SSR 캐시 즉시 무효화
- 게시판 목록 캐시 TTL: 120초 → 30초 단축
- 비로그인 사용자도 새 글을 빠르게 확인 가능

## Test plan
- [x] `pnpm build` 성공
- [ ] 글 작성 후 게시판 목록에 즉시 반영 확인
- [ ] 비로그인 사용자가 새 글을 30초 이내 확인 가능