### PR TITLE
fix: 댓글 추천 상태 표시 + 글 수정 시 링크 삭제

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -97,15 +97,31 @@
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
     let reactionPluginActive = $derived(pluginStore.isPluginActive('da-reaction'));
 
-    // 댓글별 좋아요 상태 관리 (SSR 데이터로 초기화)
-    let likedComments = new SvelteSet<string>(initialLikedCommentIds.map((id) => String(id)));
+    // 댓글별 좋아요 상태 관리 (SSR 스트리밍 데이터 반영)
+    let likedComments = new SvelteSet<string>();
     let commentLikes = new SvelteMap<string, number>();
     let likingComment = $state<string | null>(null);
 
-    // 댓글별 비추천 상태 관리 (SSR 데이터로 초기화)
-    let dislikedComments = new SvelteSet<string>(initialDislikedCommentIds.map((id) => String(id)));
+    // 댓글별 비추천 상태 관리 (SSR 스트리밍 데이터 반영)
+    let dislikedComments = new SvelteSet<string>();
     let commentDislikes = new SvelteMap<string, number>();
     let dislikingComment = $state<string | null>(null);
+
+    // SSR 스트리밍으로 좋아요/비추천 상태가 나중에 도착할 때 SvelteSet 업데이트
+    $effect(() => {
+        if (initialLikedCommentIds.length > 0) {
+            for (const id of initialLikedCommentIds) {
+                likedComments.add(String(id));
+            }
+        }
+    });
+    $effect(() => {
+        if (initialDislikedCommentIds.length > 0) {
+            for (const id of initialDislikedCommentIds) {
+                dislikedComments.add(String(id));
+            }
+        }
+    });
 
     // 댓글별 추천자 아바타 캐시
     let commentLikersList = new SvelteMap<string, LikerInfo[]>();

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -333,8 +333,8 @@
                       content: finalContent,
                       category: category || undefined,
                       tags: tags.length > 0 ? tags : undefined,
-                      link1: link1.trim() || undefined,
-                      link2: link2.trim() || undefined
+                      link1: link1.trim(),
+                      link2: link2.trim()
                   };
 
         try {


### PR DESCRIPTION
## Summary
- **댓글 추천 표시 (7760)**: SSR 스트리밍 데이터가 SvelteSet 초기화 이후에 도착하여 반영 안 됨. `$effect`로 스트리밍 도착 시 Set 업데이트
- **링크 삭제 (7765)**: 글 수정 시 link1/link2 빈 문자열을 `undefined` 대신 `""`로 전송하여 백엔드에서 삭제 처리 가능

## Test plan
- [x] `pnpm build` 성공
- [ ] 댓글 추천 후 페이지 이동 → 재진입 시 추천 색상 유지 확인
- [ ] 글 수정 시 링크 삭제 후 저장 → 링크 제거 확인