### PR TITLE
fix: 메모 UI 설정 전 컴포넌트에 적용 (#7791)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
+++ b/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
@@ -9,6 +9,7 @@
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { formatDate } from '$lib/utils/format-date.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     // 동적 플러그인 임포트: member-memo
     let MemoBadge = $state<Component | null>(null);
@@ -135,10 +136,11 @@
                                         >
                                             {liker.mb_nick || liker.mb_name}
                                         </a>
-                                        {#if memoPluginActive && MemoBadge}
+                                        {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                                             <MemoBadge
                                                 memberId={liker.mb_id}
                                                 showIcon={true}
+                                                blur={uiSettingsStore.blurMemo}
                                                 onclick={() => {
                                                     editingMemoFor =
                                                         editingMemoFor === liker.mb_id

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -27,6 +27,7 @@
     import RevisionHistory from '$lib/components/post/revision-history.svelte';
     import type { PostRevision } from '$lib/api/types.js';
     import History from '@lucide/svelte/icons/history';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     // 동적 플러그인 임포트: member-memo
     let MemoBadge = $state<Component | null>(null);
@@ -748,11 +749,11 @@
                         class="text-foreground mb-1 ml-1 flex items-center gap-1 text-xs font-semibold"
                     >
                         <AuthorLink authorId={comment.author_id} authorName={comment.author} />
-                        {#if memoPluginActive && MemoBadge}
+                        {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                             <MemoBadge
                                 memberId={comment.author_id}
                                 showIcon={true}
-                                ip={comment.author_ip}
+                                blur={uiSettingsStore.blurMemo}
                             />
                         {/if}
                     </p>
@@ -817,11 +818,11 @@
                                         authorId={comment.author_id}
                                         authorName={comment.author}
                                     />
-                                    {#if !isDeleted && memoPluginActive && MemoBadge}
+                                    {#if !isDeleted && memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                                         <MemoBadge
                                             memberId={comment.author_id}
                                             showIcon={true}
-                                            ip={comment.author_ip}
+                                            blur={uiSettingsStore.blurMemo}
                                         />
                                     {/if}
                                     {#if comment.is_secret}

--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -10,6 +10,7 @@
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { formatDate } from '$lib/utils/format-date.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
 
@@ -106,7 +107,7 @@
                                             authorName={post.author}
                                         /></span
                                     >
-                                    {#if memoPluginActive && MemoBadge}
+                                    {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemoInList}
                                         <MemoBadge memberId={post.author_id} />
                                     {/if}
                                     <span>•</span>

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -208,7 +208,7 @@
                     {#if post.comments_count > 0}
                         <span class="comment-count shrink-0">+{post.comments_count}</span>
                     {/if}
-                    {#if memoPluginActive && MemoBadge}
+                    {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemoInList}
                         <span class="ml-auto shrink-0">
                             <MemoBadge memberId={post.author_id} />
                         </span>

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -91,7 +91,7 @@
 </script>
 
 <!-- 게시글 카드 -->
-<Card class="bg-background mb-6 pt-0 pb-5">
+<Card class="bg-background mb-6 pb-5 pt-0">
     <CardHeader class="space-y-3">
         <!-- 관리자 본문 레이아웃 스위처 -->
         <div class="flex items-center justify-end">
@@ -166,7 +166,6 @@
                                 memberId={post.author_id}
                                 showIcon={true}
                                 blur={uiSettingsStore.blurMemo}
-                                ip={post.author_ip}
                             />
                         {/if}
                         {#if post.author_ip}

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -274,7 +274,6 @@
                                 memberId={post.author_id}
                                 showIcon={true}
                                 blur={uiSettingsStore.blurMemo}
-                                ip={post.author_ip}
                             />
                         {/if}
                     </p>

--- a/apps/web/src/lib/components/features/board/skins/card.svelte
+++ b/apps/web/src/lib/components/features/board/skins/card.svelte
@@ -7,6 +7,7 @@
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { formatDate } from '$lib/utils/format-date.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
 
@@ -78,7 +79,7 @@
                             class="text-secondary-foreground flex flex-wrap items-center gap-2 text-sm"
                         >
                             <span>{post.author}</span>
-                            {#if memoPluginActive && MemoBadge}
+                            {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemoInList}
                                 <MemoBadge memberId={post.author_id} />
                             {/if}
                             <span>•</span>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1441,10 +1441,11 @@
                                         >
                                             {liker.mb_nick || liker.mb_name}
                                         </a>
-                                        {#if memoPluginActive && MemoBadge}
+                                        {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                                             <MemoBadge
                                                 memberId={liker.mb_id}
                                                 showIcon={true}
+                                                blur={uiSettingsStore.blurMemo}
                                                 onclick={() => {
                                                     editingMemoFor =
                                                         editingMemoFor === liker.mb_id

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -31,6 +31,7 @@
     import type { Component } from 'svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import {
         getMemberMemos,
         createMemberMemo,
@@ -354,8 +355,12 @@
                                     aria-label="본인확인 완료"
                                 />
                             {/if}
-                            {#if memoPluginActive && MemoBadge}
-                                <MemoBadge memberId={p.mb_id} showIcon={true} />
+                            {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
+                                <MemoBadge
+                                    memberId={p.mb_id}
+                                    showIcon={true}
+                                    blur={uiSettingsStore.blurMemo}
+                                />
                             {/if}
                         </div>
                         <p class="text-muted-foreground text-sm">{p.mb_id}</p>


### PR DESCRIPTION
## Summary
- `hideMemoInList` 설정이 리스트 컴포넌트(classic, card, skins/card)에 적용되지 않던 버그 수정
- `hideMemo` 설정이 댓글 목록, 추천자 목록, 프로필 페이지에 적용되지 않던 버그 수정
- `blurMemo` 설정 prop을 MemoBadge 컴포넌트에 전달 (hover 시 블러 해제)
- 미사용 `ip` prop 제거 (memo-badge Props에 없는 prop 전달)

## 변경 내역
| 파일 | 변경 |
|------|------|
| classic.svelte, card.svelte, skins/card.svelte | `hideMemoInList` 체크 추가 |
| comment-list.svelte | `hideMemo` + `blurMemo` 적용 |
| comment-likers-dialog.svelte | `hideMemo` + `blurMemo` 적용 |
| [postId]/+page.svelte | 추천자 목록 `hideMemo` + `blurMemo` 적용 |
| member/[id]/+page.svelte | 프로필 `hideMemo` + `blurMemo` 적용 |
| basic.svelte, report.svelte | 미사용 `ip` prop 제거 |

## 참고
- `plugins/member-memo/components/memo-badge.svelte`에 `blur` prop + CSS 추가 (gitignore 대상, premium으로 별도 반영 필요)

## Test plan
- [ ] UI 설정 `/member/settings/ui`에서 메모 가리기 ON → 게시글 상세, 댓글, 프로필에서 메모 배지 숨김 확인
- [ ] 목록 메모 배지 가리기 ON → 게시판 리스트에서 메모 배지 숨김 확인
- [ ] 메모 내용 흐리게 ON → 메모 배지 내용이 블러 처리, 호버 시 표시 확인
- [ ] 모든 설정 OFF → 메모 배지 정상 표시 확인