### PR TITLE
fix: 모바일 댓글 이미지 오버플로우 + 폰트 크기 버튼 (#7790, #7782, #7784)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -267,7 +267,7 @@
                     bind:value={content}
                     placeholder={actualPlaceholder}
                     rows={isReplyMode ? 1 : 2}
-                    class={error ? 'border-destructive' : ''}
+                    class="{error ? 'border-destructive' : ''} max-h-[40vh] overflow-y-auto"
                     disabled={isLoading}
                     onpaste={handlePaste}
                     onkeydown={(e: KeyboardEvent) => {

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -215,20 +215,20 @@
         <div class="mb-1 flex justify-end gap-1">
             <button
                 type="button"
-                class="text-muted-foreground hover:text-foreground border-border hover:bg-muted rounded border px-2 py-0.5 text-xs transition-colors disabled:opacity-30"
+                class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
                 disabled={fontSize === 'small'}
                 onclick={() => onChangeFontSize(-1)}
                 aria-label="글자 작게">A-</button
             >
             <button
                 type="button"
-                class="text-muted-foreground hover:text-foreground border-border hover:bg-muted rounded border px-2 py-0.5 text-xs transition-colors"
+                class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors"
                 onclick={() => onChangeFontSize(0)}
                 aria-label="글자 기본">A</button
             >
             <button
                 type="button"
-                class="text-muted-foreground hover:text-foreground border-border hover:bg-muted rounded border px-2 py-0.5 text-xs transition-colors disabled:opacity-30"
+                class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
                 disabled={fontSize === 'xlarge'}
                 onclick={() => onChangeFontSize(1)}
                 aria-label="글자 크게">A+</button

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -356,20 +356,20 @@
         <div class="mb-1 flex justify-end gap-1">
             <button
                 type="button"
-                class="text-muted-foreground hover:text-foreground border-border hover:bg-muted rounded border px-2 py-0.5 text-xs transition-colors disabled:opacity-30"
+                class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
                 disabled={fontSize === 'small'}
                 onclick={() => onChangeFontSize(-1)}
                 aria-label="글자 작게">A-</button
             >
             <button
                 type="button"
-                class="text-muted-foreground hover:text-foreground border-border hover:bg-muted rounded border px-2 py-0.5 text-xs transition-colors"
+                class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors"
                 onclick={() => onChangeFontSize(0)}
                 aria-label="글자 기본">A</button
             >
             <button
                 type="button"
-                class="text-muted-foreground hover:text-foreground border-border hover:bg-muted rounded border px-2 py-0.5 text-xs transition-colors disabled:opacity-30"
+                class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
                 disabled={fontSize === 'xlarge'}
                 onclick={() => onChangeFontSize(1)}
                 aria-label="글자 크게">A+</button


### PR DESCRIPTION
## Summary
- **댓글 이미지 삽입 시 버튼 밀림 (#7790, #7782)**: textarea에 `max-h-[40vh] overflow-y-auto` 추가하여 이미지 삽입 시 무한 확장 방지. 내용이 넘치면 스크롤되고, 작성완료 버튼은 항상 화면 내에 유지됨.
- **폰트 크기 변경 미작동 (#7784)**: 버튼 터치 영역 확대 (`px-2 py-0.5` → `px-3 py-1.5`, `text-xs` → `text-sm`), `active:bg-muted`로 모바일 터치 피드백 추가.

## Test plan
- [ ] 모바일에서 댓글에 이미지 3개 이상 첨부 → textarea가 40vh 이내로 제한되고 스크롤 가능, 작성완료 버튼 화면 내 유지
- [ ] 모바일에서 글자 크기 A-/A/A+ 버튼 터치 → 터치 영역 충분하고 피드백 있음
- [ ] 글자 크기 변경 후 본문 폰트 사이즈 실제 반영 확인