### PR TITLE
fix: 인덱스 축하메시지 최근 것 모두 표시

### DIFF
--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -3,28 +3,31 @@ import { getWidgetLayout, getSidebarWidgetLayout } from '$lib/server/settings/in
 import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default-widgets';
 import { buildIndexWidgets } from '$lib/server/index-widgets-builder';
 import { getDefaultPeriod, loadRecommendedData } from '$lib/server/recommended-loader';
+import { getCachedCelebrations } from '$lib/server/celebration';
 import { env } from '$env/dynamic/private';
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
 
 export const load: PageServerLoad = async () => {
     // 위젯 데이터, 레이아웃, 추천글, 축하메시지를 병렬로 로드
-    const [indexWidgetsResult, layoutResult, recommendedResult] = await Promise.allSettled([
-        buildIndexWidgets(BACKEND_URL),
-        (async () => {
-            const [widgetLayout, sidebarWidgetLayout] = await Promise.all([
-                getWidgetLayout(),
-                getSidebarWidgetLayout()
-            ]);
-            return {
-                widgetLayout: widgetLayout ?? DEFAULT_WIDGETS,
-                sidebarWidgetLayout: sidebarWidgetLayout ?? DEFAULT_SIDEBAR_WIDGETS
-            };
-        })(),
-        // 추천글 기본 탭 SSR 프리페치 (로딩 없이 즉시 표시)
-        loadRecommendedData(getDefaultPeriod())
-        // 축하메시지는 +layout.server.ts에서 로드 (celebration) — 중복 제거
-    ]);
+    const [indexWidgetsResult, layoutResult, recommendedResult, celebrationResult] =
+        await Promise.allSettled([
+            buildIndexWidgets(BACKEND_URL),
+            (async () => {
+                const [widgetLayout, sidebarWidgetLayout] = await Promise.all([
+                    getWidgetLayout(),
+                    getSidebarWidgetLayout()
+                ]);
+                return {
+                    widgetLayout: widgetLayout ?? DEFAULT_WIDGETS,
+                    sidebarWidgetLayout: sidebarWidgetLayout ?? DEFAULT_SIDEBAR_WIDGETS
+                };
+            })(),
+            // 추천글 기본 탭 SSR 프리페치 (로딩 없이 즉시 표시)
+            loadRecommendedData(getDefaultPeriod()),
+            // 인덱스 전용: 최근 축하메시지 (오늘뿐 아니라 최근 8건)
+            getCachedCelebrations(true)
+        ]);
 
     const indexWidgets =
         indexWidgetsResult.status === 'fulfilled' ? indexWidgetsResult.value : null;
@@ -34,6 +37,8 @@ export const load: PageServerLoad = async () => {
             : { widgetLayout: DEFAULT_WIDGETS, sidebarWidgetLayout: DEFAULT_SIDEBAR_WIDGETS };
     const recommendedData =
         recommendedResult.status === 'fulfilled' ? recommendedResult.value : null;
+    const celebrationRecent =
+        celebrationResult.status === 'fulfilled' ? celebrationResult.value : null;
 
     if (indexWidgetsResult.status === 'rejected') {
         console.error('[SSR] Failed to load index widgets:', indexWidgetsResult.reason);
@@ -44,6 +49,7 @@ export const load: PageServerLoad = async () => {
         widgetLayout: layoutData.widgetLayout,
         sidebarWidgetLayout: layoutData.sidebarWidgetLayout,
         recommendedData,
-        recommendedPeriod: getDefaultPeriod()
+        recommendedPeriod: getDefaultPeriod(),
+        celebrationRecent
     };
 };

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -56,7 +56,9 @@
         recommended: data.recommendedData
             ? { data: data.recommendedData, period: data.recommendedPeriod }
             : undefined,
-        celebration: data.celebration?.length ? { data: data.celebration } : undefined
+        celebration: (data.celebrationRecent ?? data.celebration)?.length
+            ? { data: data.celebrationRecent ?? data.celebration }
+            : undefined
     }}
 />
 


### PR DESCRIPTION
## Summary
- 인덱스 페이지 축하메시지: 오늘 것만 → 최근 8건으로 변경
- `+page.server.ts`에서 `getCachedCelebrations(true)` 별도 조회
- 다른 페이지의 축하메시지는 기존대로 오늘 것만 표시 (layout 변경 없음)

## Test plan
- [ ] 인덱스 축하메시지 영역에 최근 것 다 나오는지 확인
- [ ] 다른 페이지 축하메시지가 영향 없는지 확인
- [ ] `pnpm build` 성공