### PR TITLE
fix: CI/CD 플러그인 deploy 패키지 누락 수정

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -100,12 +100,21 @@ jobs:
 
           cp -r apps/web/build apps/web/deploy/
 
+          # 기존 부분 복사 방지 — 깨끗한 상태에서 복사
+          rm -rf apps/web/deploy/plugins apps/web/deploy/widgets apps/web/deploy/themes
+          rm -rf apps/web/deploy/custom-themes apps/web/deploy/custom-widgets apps/web/deploy/extensions
+
           cp -r plugins apps/web/deploy/ 2>/dev/null || mkdir -p apps/web/deploy/plugins
           cp -r widgets apps/web/deploy/ 2>/dev/null || mkdir -p apps/web/deploy/widgets
           cp -r themes apps/web/deploy/ 2>/dev/null || mkdir -p apps/web/deploy/themes
           cp -r custom-themes apps/web/deploy/ 2>/dev/null || mkdir -p apps/web/deploy/custom-themes
           cp -r custom-widgets apps/web/deploy/ 2>/dev/null || mkdir -p apps/web/deploy/custom-widgets
           cp -r extensions apps/web/deploy/ 2>/dev/null || mkdir -p apps/web/deploy/extensions
+
+          # 검증 로그
+          echo "=== Plugin verification ==="
+          ls -la apps/web/deploy/plugins/ || echo "WARNING: plugins directory empty!"
+          ls apps/web/deploy/plugins/*/plugin.json 2>/dev/null | wc -l | xargs -I{} echo "Plugins with manifest: {}"
 
       - name: Build and push Docker image
         run: |


### PR DESCRIPTION
## Summary
- deploy 디렉토리 `rm -rf` 후 깨끗한 상태에서 plugins/widgets/themes 복사하도록 변경
- 복사 후 plugin.json 매니페스트 수 검증 로그 추가
- 운영 pod에 플러그인 누락되던 근본 원인 수정

## Test plan
- [ ] CI 로그에서 "Plugin verification" 섹션 확인
- [ ] `Plugins with manifest: 9` (또는 그에 준하는 수) 출력 확인
- [ ] 배포 후 `/admin/plugins`에서 플러그인 목록 정상 표시 확인