### PR TITLE
fix: SSR 캐시 __data.json 오염으로 JSON raw output 노출 수정

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -444,7 +444,10 @@ export const handle: Handle = async ({ event, resolve }) => {
                 }
             });
 
-            if (response.status === 200) {
+            const contentType = response.headers.get('Content-Type') || '';
+            const isHtml = contentType.includes('text/html');
+
+            if (response.status === 200 && isHtml) {
                 const body = await response.text();
 
                 // 캐시 크기 제한: 오래된 항목 정리


### PR DESCRIPTION
## Summary
- 비로그인 SSR 캐시에서 `resolve()` 응답의 `Content-Type`을 확인하지 않아, 클라이언트 네비게이션(`__data.json`) JSON 응답이 HTML 캐시를 덮어쓰는 버그 수정
- 캐시 만료 직후 클라이언트 네비게이션 요청이 먼저 도착하면 JSON이 캐시에 저장 → 다음 풀페이지 요청 시 JSON 텍스트가 `text/html`로 그대로 렌더링
- `Content-Type: text/html` 응답만 캐시에 저장하도록 조건 추가 (1줄 변경)

## 원인
1. 캐시 TTL 만료
2. SvelteKit 클라이언트 네비게이션 요청 도착 (같은 pathname, JSON 응답)
3. `resolve()` → JSON 반환 → 캐시에 HTML 대신 JSON 저장
4. 다음 풀페이지 요청 → 캐시 HIT → JSON이 `Content-Type: text/html`로 반환

## Test plan
- [ ] 운영 배포 후 JSON raw output 재현 모니터링
- [ ] 비로그인 상태에서 게시판 목록/글 상세 정상 렌더링 확인
- [ ] 클라이언트 네비게이션 후 새로고침 시 HTML 정상 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)