### PR TITLE
fix: 댓글 리액션 개별 API 호출 제거 — SSR 일괄 조회만 사용

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -136,15 +136,14 @@
         }
     }
 
-    // initialReactions가 제공되면 fetch 스킵 (일괄 조회 최적화)
-    if (initialReactions) {
-        reactions = initialReactions;
-    }
+    // initialReactions 반응적 감시 (SSR 스트리밍 데이터 도착 시 자동 적용)
+    $effect(() => {
+        if (initialReactions !== undefined) {
+            reactions = initialReactions;
+        }
+    });
 
     onMount(() => {
-        if (!initialReactions) {
-            loadReactions();
-        }
         document.addEventListener('click', handleClickOutside);
         return () => document.removeEventListener('click', handleClickOutside);
     });


### PR DESCRIPTION
## 문제

댓글이 100개인 게시글 열람 시 `/api/reactions` 개별 호출이 100+건 발생.
10명 동접 시 1,000건의 서버 요청 → CloudFront 요청 비용 증가.

전체 API 요청의 약 10%를 차지하는 문제.

## 원인

`reaction-bar.svelte`의 `onMount`에서 `initialReactions`가 `undefined`이면 개별 fetch 실행.
SSR 스트리밍 데이터(`reactionsMap`)가 도착하기 전에 `onMount`가 먼저 실행되어 개별 호출 발생.

## 수정

- `onMount` 개별 fetch 제거
- `$effect`로 `initialReactions` 반응적 감시 → SSR 스트리밍 데이터 도착 시 자동 적용
- 이미 `+page.server.ts`에서 `parentId` 기반 일괄 조회 구현되어 있으므로 개별 호출 불필요

## 효과

- 댓글 100개 게시글: 100+건 → 0건 클라이언트 API 호출
- CloudFront 요청 약 10% 감소 예상