### PR TITLE
fix: SSM 배포 타임아웃 근본 원인 수정

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -162,37 +162,45 @@ jobs:
             --parameters 'commands=[
               "/home/angple/k8s/prod/deploy.sh web '"$IMAGE_TAG"'"
             ]' \
-            --timeout-seconds 300 \
+            --timeout-seconds 900 \
             --query "Command.CommandId" \
             --output text)
 
           echo "Command ID: $COMMAND_ID"
 
+          # 커스텀 폴링 (15초 간격, 최대 60회 = 15분)
           echo "Waiting for deployment..."
-          aws ssm wait command-executed \
-            --command-id "$COMMAND_ID" \
-            --instance-id "i-038a1d1f00798d94b" || true
+          for i in $(seq 1 60); do
+            sleep 15
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "i-038a1d1f00798d94b" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
 
-          STATUS=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "i-038a1d1f00798d94b" \
-            --query "Status" \
-            --output text)
+            echo "  [$i/60] Status: $STATUS"
 
-          echo "Status: $STATUS"
+            if [ "$STATUS" = "Success" ]; then
+              break
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+              echo "Deployment failed with status: $STATUS"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardErrorContent" \
+                --output text
+              exit 1
+            fi
+          done
 
+          if [ "$STATUS" != "Success" ]; then
+            echo "Deployment timed out (still $STATUS after 15 minutes)"
+            exit 1
+          fi
+
+          # 성공 시 출력 표시
           aws ssm get-command-invocation \
             --command-id "$COMMAND_ID" \
             --instance-id "i-038a1d1f00798d94b" \
             --query "StandardOutputContent" \
             --output text
-
-          if [ "$STATUS" != "Success" ]; then
-            echo "Error:"
-            aws ssm get-command-invocation \
-              --command-id "$COMMAND_ID" \
-              --instance-id "i-038a1d1f00798d94b" \
-              --query "StandardErrorContent" \
-              --output text
-            exit 1
-          fi


### PR DESCRIPTION
## Summary
- SSM `--timeout-seconds`: 300 → 900 (15분)으로 증가
- `aws ssm wait` (100초 하드 리밋) 제거 → 15초 간격 커스텀 폴링 루프 (최대 60회 = 15분)
- 상태별 분기 처리 (Success/Failed/Cancelled/TimedOut) — `|| true`로 에러 무시하던 패턴 제거
- deploy.sh `kubectl rollout --timeout`: 본 배포 300s→600s, 롤백 180s→300s

## 근본 원인
1. SSM `--timeout-seconds 300` — deploy.sh 실제 소요시간(500-700s)보다 짧음
2. `aws ssm wait` 기본 100s — 20회 × 5s 폴링 후 타임아웃 (커스텀 불가)
3. `|| true`로 에러 무시 — 타임아웃 후 상태 InProgress → exit 1
4. `kubectl rollout --timeout=300s` — 5개 pod × 90s/pod = 450s+ 소요

## Test plan
- [x] 수동 배포 (`deploy.sh web sha-8d1db22...`) 실행 → 플러그인 9개 확인 완료
- [ ] 워크플로우 배포 테스트 → CI 로그에서 폴링 진행 + Success 확인