### PR TITLE
feat: 삭제된 게시물 모든 사용자 클릭 가능 + 관리자 본문 열람

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -11,7 +11,6 @@
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { formatDate } from '$lib/utils/format-date.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
-
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
 
     // 동적 플러그인 임포트: member-memo
@@ -48,11 +47,13 @@
 
 <!-- Card 스킨: 제목 + 본문 미리보기 2줄 + 메타데이터 + 태그 -->
 {#if isDeleted}
-    <Card class="bg-background opacity-50">
-        <CardContent class="py-4">
-            <span class="text-muted-foreground">[삭제된 게시물입니다]</span>
-        </CardContent>
-    </Card>
+    <a {href} class="block cursor-pointer no-underline">
+        <Card class="bg-background opacity-50 transition-shadow hover:shadow-md">
+            <CardContent class="py-4">
+                <span class="text-muted-foreground">[삭제된 게시물입니다]</span>
+            </CardContent>
+        </Card>
+    </a>
 {:else}
     <a {href} class="block no-underline">
         <Card class="bg-background overflow-hidden transition-shadow hover:shadow-md">

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -14,7 +14,6 @@
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { readPostStyleStore } from '$lib/stores/read-post-style.svelte.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
-
     // 메모 플러그인
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
     let MemoBadge = $state<Component | null>(null);
@@ -114,7 +113,10 @@
 
 <!-- Classic 스킨: 데스크톱 CSS Grid 5컬럼 (추천|제목|이름|날짜|조회) -->
 {#if isDeleted}
-    <div class="bg-background px-4 py-1.5 opacity-50">
+    <a
+        {href}
+        class="bg-background hover:bg-accent block cursor-pointer px-4 py-1.5 no-underline opacity-50"
+    >
         <div class="flex items-center gap-2 md:gap-3">
             <div class="hidden shrink-0 md:block">
                 <div
@@ -128,7 +130,7 @@
                 <span class="text-muted-foreground text-[15px]">[삭제된 게시물입니다]</span>
             </div>
         </div>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -7,7 +7,6 @@
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
-
     // Props
     let {
         post,
@@ -33,9 +32,12 @@
 
 <!-- Compact 스킨: 제목 + 메타데이터 + 태그만 (심플) -->
 {#if isDeleted}
-    <div class="bg-background border-border rounded-lg border px-4 py-3 opacity-50">
+    <a
+        {href}
+        class="bg-background border-border hover:bg-accent block cursor-pointer rounded-lg border px-4 py-3 no-underline opacity-50 transition-all"
+    >
         <span class="text-muted-foreground">[삭제된 게시물입니다]</span>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -7,7 +7,6 @@
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
-
     // Props
     let {
         post,
@@ -30,11 +29,13 @@
 
 <!-- Detailed 스킨: 제목 + 본문 미리보기 4-5줄 + 썸네일 + 메타데이터 + 태그 (뉴스 스타일) -->
 {#if isDeleted}
-    <Card class="bg-background opacity-50">
-        <CardContent class="py-4">
-            <span class="text-muted-foreground">[삭제된 게시물입니다]</span>
-        </CardContent>
-    </Card>
+    <a {href} class="block cursor-pointer no-underline">
+        <Card class="bg-background opacity-50 transition-shadow hover:shadow-md">
+            <CardContent class="py-4">
+                <span class="text-muted-foreground">[삭제된 게시물입니다]</span>
+            </CardContent>
+        </Card>
+    </a>
 {:else}
     <a {href} class="block no-underline">
         <Card class="bg-background transition-shadow hover:shadow-md">

--- a/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
@@ -6,7 +6,6 @@
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
-
     // Props (동일 인터페이스)
     let {
         post,
@@ -29,11 +28,14 @@
 
 <!-- Gallery 레이아웃: 썸네일 중심 카드 (그리드 아이템) -->
 {#if isDeleted}
-    <div class="bg-background border-border overflow-hidden rounded-lg border opacity-50">
+    <a
+        {href}
+        class="bg-background border-border block cursor-pointer overflow-hidden rounded-lg border no-underline opacity-50 transition-shadow hover:shadow-md"
+    >
         <div class="bg-muted flex aspect-video items-center justify-center">
             <span class="text-muted-foreground text-sm">[삭제됨]</span>
         </div>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
@@ -24,7 +24,6 @@
     import PlayCircle from '@lucide/svelte/icons/play-circle';
     import Timer from '@lucide/svelte/icons/timer';
     import MessageSquare from '@lucide/svelte/icons/message-square';
-
     let {
         post,
         displaySettings,
@@ -158,13 +157,14 @@
 
 <!-- 나눔 카드 -->
 {#if isDeleted}
-    <div
-        class="border-border bg-background flex flex-col overflow-hidden rounded-xl border opacity-50"
+    <a
+        {href}
+        class="border-border bg-background flex cursor-pointer flex-col overflow-hidden rounded-xl border no-underline opacity-50 transition-shadow hover:shadow-md"
     >
         <div class="bg-muted flex aspect-[4/3] items-center justify-center">
             <span class="text-muted-foreground text-sm">[삭제됨]</span>
         </div>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
@@ -14,7 +14,6 @@
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
-
     let {
         post,
         displaySettings,
@@ -65,11 +64,14 @@
 
 <!-- 마켓 카드 레이아웃 -->
 {#if isDeleted}
-    <div class="bg-background border-border overflow-hidden rounded-lg border opacity-50">
+    <a
+        {href}
+        class="bg-background border-border block cursor-pointer overflow-hidden rounded-lg border no-underline opacity-50 transition-shadow hover:shadow-md"
+    >
         <div class="bg-muted flex aspect-square items-center justify-center">
             <span class="text-muted-foreground text-sm">[삭제됨]</span>
         </div>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/message.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/message.svelte
@@ -12,7 +12,6 @@
     import { getMemberIconUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { formatDate } from '$lib/utils/format-date.js';
-
     let {
         post,
         displaySettings,
@@ -57,13 +56,14 @@
 </script>
 
 {#if isDeleted}
-    <div
-        class="border-border bg-background flex h-full flex-col overflow-hidden rounded-lg border opacity-50"
+    <a
+        {href}
+        class="border-border bg-background flex h-full cursor-pointer flex-col overflow-hidden rounded-lg border no-underline opacity-50 transition-shadow hover:shadow-md"
     >
         <div class="flex flex-1 items-center justify-center p-4">
             <span class="text-muted-foreground text-sm">[삭제된 게시물입니다]</span>
         </div>
-    </div>
+    </a>
 {:else}
     <div
         class="border-border bg-background group flex h-full flex-col overflow-hidden rounded-lg border border-l-[3px] shadow-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md {accent}"

--- a/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
@@ -6,7 +6,6 @@
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import Pin from '@lucide/svelte/icons/pin';
     import { formatDate } from '$lib/utils/format-date.js';
-
     let {
         post,
         displaySettings,
@@ -24,9 +23,12 @@
 
 <!-- Notice 스킨: 카드형 공지사항 스타일 (배지 + 깔끔한 메타데이터) -->
 {#if isDeleted}
-    <div class="border-border bg-background rounded-lg border px-4 py-3 opacity-50">
+    <a
+        {href}
+        class="border-border bg-background hover:border-primary/30 hover:bg-muted/30 block cursor-pointer rounded-lg border px-4 py-3 no-underline opacity-50 transition-all"
+    >
         <span class="text-muted-foreground">[삭제된 게시물입니다]</span>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
@@ -6,7 +6,6 @@
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
-
     let {
         post,
         displaySettings,
@@ -28,11 +27,14 @@
 
 <!-- 포스터 갤러리 레이아웃: 2:3 비율 포스터 카드 -->
 {#if isDeleted}
-    <div class="overflow-hidden rounded-lg opacity-50">
+    <a
+        {href}
+        class="block cursor-pointer overflow-hidden rounded-lg no-underline opacity-50 transition-shadow hover:shadow-lg"
+    >
         <div class="bg-muted flex items-center justify-center" style="aspect-ratio: 2/3">
             <span class="text-muted-foreground text-sm">[삭제됨]</span>
         </div>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
@@ -27,7 +27,6 @@
     import CheckCircle from '@lucide/svelte/icons/check-circle';
     import Tag from '@lucide/svelte/icons/tag';
     import MessageSquare from '@lucide/svelte/icons/message-square';
-
     let {
         post,
         displaySettings,
@@ -92,13 +91,14 @@
 
 <!-- 거래 카드 -->
 {#if isDeleted}
-    <div
-        class="border-border bg-background flex flex-col overflow-hidden rounded-xl border opacity-50"
+    <a
+        {href}
+        class="border-border bg-background flex cursor-pointer flex-col overflow-hidden rounded-xl border no-underline opacity-50 transition-shadow hover:shadow-md"
     >
         <div class="bg-muted flex aspect-square items-center justify-center">
             <span class="text-muted-foreground text-sm">[삭제됨]</span>
         </div>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -7,7 +7,6 @@
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
-
     // Props (동일 인터페이스)
     let {
         post,
@@ -41,9 +40,12 @@
 
 <!-- Webzine 레이아웃: 큰 이미지 + 제목 + 본문 미리보기 (블로그/뉴스 스타일) -->
 {#if isDeleted}
-    <div class="bg-background border-border rounded-lg border px-4 py-3 opacity-50">
+    <a
+        {href}
+        class="bg-background border-border hover:border-primary/30 block cursor-pointer rounded-lg border px-4 py-3 no-underline opacity-50"
+    >
         <span class="text-muted-foreground">[삭제된 게시물입니다]</span>
-    </div>
+    </a>
 {:else}
     <a
         {href}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -76,9 +76,12 @@ export const load: PageServerLoad = async ({
             throw error(404, '게시글을 찾을 수 없습니다.');
         }
 
-        // 삭제된 게시글: 에러 대신 데이터 전달 (PHP 호환: "삭제된 게시물입니다" 표시)
+        // 삭제된 게시글: 관리자는 본문+리비전 유지, 일반 유저는 본문 숨김
         if (post.deleted_at) {
-            post.content = '';
+            const isAdmin = (locals.user?.mb_level ?? 0) >= 10;
+            if (!isAdmin) {
+                post.content = '';
+            }
         }
 
         let board = null;


### PR DESCRIPTION
## Summary
- 12개 목록 레이아웃에서 삭제된 글을 모든 사용자가 클릭 가능 (댓글 확인용)
- SSR에서 관리자는 삭제된 글 본문 유지, 일반 유저는 본문 숨김
- 기존 관리자 전용 클릭 제한 제거 (authStore/isAdmin 의존성 제거)

## Test plan
- [ ] 일반 유저로 삭제된 글 목록에서 클릭 → 상세 페이지 진입 확인
- [ ] 일반 유저: 본문 비어있고 댓글은 표시되는지 확인
- [ ] 관리자: 삭제된 글 본문 + 리비전 이력 표시 확인