### PR TITLE
fix: 리비전 단일 선택 시 삭제 전 내용 표시

### DIFF
--- a/apps/web/src/lib/components/post/revision-history.svelte
+++ b/apps/web/src/lib/components/post/revision-history.svelte
@@ -169,7 +169,11 @@
                                     onclick={() => toggleVersion(rev.version)}
                                     class="h-7 text-xs"
                                 >
-                                    {isSelected ? '닫기' : '비교'}
+                                    {isSelected
+                                        ? '닫기'
+                                        : sortedRevisions.length > 1
+                                          ? '비교'
+                                          : '보기'}
                                 </Button>
                                 {#if canRestore && rev.change_type !== 'create'}
                                     <Button
@@ -215,6 +219,33 @@
                                 newLabel="v{selectedRevision.version}"
                             />
                         </div>
+                    </div>
+                {:else if selectedRevision && !compareRevision}
+                    <!-- 단일 리비전 보기 (비교 대상 없음) -->
+                    <div class="mt-4 space-y-3">
+                        <h4 class="text-sm font-medium">
+                            v{selectedRevision.version} — {getLabel(selectedRevision.change_type)} 내용
+                        </h4>
+                        {#if selectedRevision.title}
+                            <div>
+                                <p class="text-muted-foreground mb-1 text-xs font-medium">제목</p>
+                                <div
+                                    class="rounded-md border px-3 py-2 text-sm dark:border-neutral-700"
+                                >
+                                    {selectedRevision.title}
+                                </div>
+                            </div>
+                        {/if}
+                        {#if selectedRevision.content}
+                            <div>
+                                <p class="text-muted-foreground mb-1 text-xs font-medium">본문</p>
+                                <div
+                                    class="max-h-80 overflow-y-auto rounded-md border px-3 py-2 text-xs dark:border-neutral-700"
+                                >
+                                    {@html selectedRevision.content}
+                                </div>
+                            </div>
+                        {/if}
                     </div>
                 {/if}
             </div>


### PR DESCRIPTION
## Summary
- 비교 대상이 없는 리비전(1개만 있을 때) 클릭 시 제목+본문 직접 표시
- 버튼 텍스트: 리비전 여러개면 '비교', 1개면 '보기'

## Test plan
- [ ] 삭제된 글 상세 → 수정 이력 1개 → '보기' 클릭 → 삭제 전 제목+본문 표시 확인
- [ ] 수정 이력 여러 개 → '비교' 클릭 → 기존 diff 비교 정상 동작 확인