### PR TITLE
feat: 게시글 수정/삭제 시간 표시 — 4가지 케이스

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -603,6 +603,30 @@
         });
     }
 
+    // 시간만 표시 (같은 날이면 HH:MM, 다른 날이면 MM.DD HH:MM)
+    function formatTimeShort(dateString: string, refDateString?: string): string {
+        const date = new Date(dateString);
+        const ref = refDateString ? new Date(refDateString) : new Date();
+        const opts: Intl.DateTimeFormatOptions = {
+            timeZone: 'Asia/Seoul',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false
+        };
+        const sameDay =
+            date.toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' }) ===
+            ref.toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' });
+        if (sameDay) {
+            return date.toLocaleTimeString('ko-KR', opts);
+        }
+        return date.toLocaleDateString('ko-KR', {
+            timeZone: 'Asia/Seoul',
+            month: '2-digit',
+            day: '2-digit',
+            ...opts
+        });
+    }
+
     // 파일 크기 포맷
     function formatFileSize(bytes: number): string {
         if (!bytes) return '';
@@ -1195,12 +1219,29 @@
             </div>
         {/if}
 
-        <!-- 수정/삭제 시간 표시 -->
-        {#if data.post.updated_at && data.post.updated_at !== data.post.created_at}
+        <!-- 수정/삭제 시간 표시 (4가지 케이스) -->
+        {@const hasEdits = data.post.updated_at && data.post.updated_at !== data.post.created_at}
+        {@const isDeletedPost = !!data.post.deleted_at}
+        {@const editCount = revisions.filter((r) => r.change_type === 'update').length}
+        {#if hasEdits || isDeletedPost}
             <p class="text-muted-foreground mt-4 text-center text-[15px]">
-                마지막 수정: {formatDate(data.post.updated_at)}
-                {#if revisions.length > 0}
-                    <span class="text-muted-foreground/70">· 수정됨 ({revisions.length}회)</span>
+                {formatDate(data.post.created_at)}
+                {#if hasEdits && editCount > 0}
+                    <span class="text-muted-foreground/70">
+                        · 수정 {editCount}회({formatTimeShort(
+                            data.post.updated_at,
+                            data.post.created_at
+                        )})
+                    </span>
+                {:else if hasEdits}
+                    <span class="text-muted-foreground/70">
+                        · 수정됨({formatTimeShort(data.post.updated_at, data.post.created_at)})
+                    </span>
+                {/if}
+                {#if isDeletedPost}
+                    <span class="text-red-500/70">
+                        · 삭제됨 {formatTimeShort(data.post.deleted_at, data.post.created_at)}
+                    </span>
                 {/if}
             </p>
         {/if}


### PR DESCRIPTION
## Summary
- 수정 없음: 작성일만 표시
- 수정 있음: `2026.03.09 00:10 · 수정 2회(04:00)`
- 삭제됨: `2026.03.09 00:10 · 삭제됨 04:20`
- 수정+삭제: `2026.03.09 00:10 · 수정 2회(04:00) · 삭제됨 04:20`
- 같은 날이면 시간만, 다른 날이면 월.일 시간 표시

## Test plan
- [ ] 수정 안 한 글 → 작성일만 표시
- [ ] 수정한 글 → 수정 N회(시간) 표시
- [ ] 삭제된 글 → 삭제됨 시간 빨간색 표시
- [ ] 수정+삭제된 글 → 두 정보 모두 표시