### PR TITLE
feat: 수정/삭제 시간을 상단 작성자 영역으로 이동

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/types.ts
+++ b/apps/web/src/lib/components/features/board/layouts/types.ts
@@ -103,8 +103,14 @@ export interface ViewLayoutProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     afterContentSlots: any[];
 
+    // 수정/삭제 메타
+    /** 수정 횟수 (update 타입 리비전 수) */
+    editCount?: number;
+
     // 유틸
     formatDate: (date: string) => string;
+    /** 시간만 짧게 표시 (같은 날: HH:MM, 다른 날: MM.DD HH:MM) */
+    formatTimeShort?: (date: string, refDate?: string) => string;
     formatFileSize: (bytes: number) => string;
     /** 본문 HTML (link1 동영상 URL 포함) */
     postContent: string;

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -81,7 +81,9 @@
         MemoBadge,
         beforeContentSlots,
         afterContentSlots,
+        editCount = 0,
         formatDate,
+        formatTimeShort,
         formatFileSize,
         postContent,
         pageData,
@@ -254,6 +256,28 @@
                     </p>
                     <p class="text-secondary-foreground text-[15px]">
                         {formatDate(post.created_at)}
+                        {#if post.updated_at && post.updated_at !== post.created_at && formatTimeShort}
+                            {#if editCount > 0}
+                                <span class="text-muted-foreground/70"
+                                    >· 수정 {editCount}회({formatTimeShort(
+                                        post.updated_at,
+                                        post.created_at
+                                    )})</span
+                                >
+                            {:else}
+                                <span class="text-muted-foreground/70"
+                                    >· 수정됨({formatTimeShort(
+                                        post.updated_at,
+                                        post.created_at
+                                    )})</span
+                                >
+                            {/if}
+                        {/if}
+                        {#if post.deleted_at && formatTimeShort}
+                            <span class="text-red-500/70"
+                                >· 삭제됨 {formatTimeShort(post.deleted_at, post.created_at)}</span
+                            >
+                        {/if}
                     </p>
                 </div>
             </div>

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -89,7 +89,9 @@
         MemoBadge,
         beforeContentSlots,
         afterContentSlots,
+        editCount = 0,
         formatDate,
+        formatTimeShort,
         formatFileSize,
         postContent,
         pageData,
@@ -279,6 +281,28 @@
                     </p>
                     <p class="text-secondary-foreground text-[15px]">
                         {formatDate(post.created_at)}
+                        {#if post.updated_at && post.updated_at !== post.created_at && formatTimeShort}
+                            {#if editCount > 0}
+                                <span class="text-muted-foreground/70"
+                                    >· 수정 {editCount}회({formatTimeShort(
+                                        post.updated_at,
+                                        post.created_at
+                                    )})</span
+                                >
+                            {:else}
+                                <span class="text-muted-foreground/70"
+                                    >· 수정됨({formatTimeShort(
+                                        post.updated_at,
+                                        post.created_at
+                                    )})</span
+                                >
+                            {/if}
+                        {/if}
+                        {#if post.deleted_at && formatTimeShort}
+                            <span class="text-red-500/70"
+                                >· 삭제됨 {formatTimeShort(post.deleted_at, post.created_at)}</span
+                            >
+                        {/if}
                     </p>
                 </div>
             </div>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1206,6 +1206,8 @@
                 {beforeContentSlots}
                 {afterContentSlots}
                 {formatDate}
+                {formatTimeShort}
+                editCount={revisions.filter((r) => r.change_type === 'update').length}
                 {formatFileSize}
                 postContent={postContent()}
                 pageData={data}
@@ -1217,33 +1219,6 @@
             <div class="text-muted-foreground py-12 text-center">
                 레이아웃을 불러올 수 없습니다.
             </div>
-        {/if}
-
-        <!-- 수정/삭제 시간 표시 (4가지 케이스) -->
-        {@const hasEdits = data.post.updated_at && data.post.updated_at !== data.post.created_at}
-        {@const isDeletedPost = !!data.post.deleted_at}
-        {@const editCount = revisions.filter((r) => r.change_type === 'update').length}
-        {#if hasEdits || isDeletedPost}
-            <p class="text-muted-foreground mt-4 text-center text-[15px]">
-                {formatDate(data.post.created_at)}
-                {#if hasEdits && editCount > 0}
-                    <span class="text-muted-foreground/70">
-                        · 수정 {editCount}회({formatTimeShort(
-                            data.post.updated_at,
-                            data.post.created_at
-                        )})
-                    </span>
-                {:else if hasEdits}
-                    <span class="text-muted-foreground/70">
-                        · 수정됨({formatTimeShort(data.post.updated_at, data.post.created_at)})
-                    </span>
-                {/if}
-                {#if isDeletedPost}
-                    <span class="text-red-500/70">
-                        · 삭제됨 {formatTimeShort(data.post.deleted_at, data.post.created_at)}
-                    </span>
-                {/if}
-            </p>
         {/if}
 
         <!-- 중고게시판 상태 변경 (작성자/관리자만) -->


### PR DESCRIPTION
## Summary
- 하단 중복 표시 제거, 작성일 옆에 수정/삭제 시간 통합 표시
- basic, report 뷰 레이아웃 모두 적용
- ViewLayoutProps에 editCount, formatTimeShort 추가

## Test plan
- [ ] 수정 안 한 글 → 작성일만 표시
- [ ] 수정한 글 → `작성일 · 수정 2회(04:00)` 상단 표시
- [ ] 삭제된 글 → `작성일 · 삭제됨 04:20` 빨간색 표시
- [ ] 하단에 중복 표시 없는지 확인