### PR TITLE
feat: 본문 글자 크기를 UI 설정과 연동

### DIFF
--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -13,6 +13,7 @@ export type FontFamily = 'default' | 'pretendard' | 'nanum-gothic' | 'noto-sans'
 export type LineHeight = 'compact' | 'normal' | 'relaxed' | 'loose';
 export type ShortcutButtonSize = 'small' | 'medium' | 'large';
 export type ListViewMode = 'classic' | 'modern';
+export type ContentFontSize = 'small' | 'base' | 'large' | 'xlarge';
 
 interface UiSettings {
     // 레이아웃
@@ -20,6 +21,7 @@ interface UiSettings {
     listView: ListViewMode;
     lineHeight: LineHeight;
     fontFamily: FontFamily;
+    contentFontSize: ContentFontSize;
     hideMyProfile: boolean;
     // 게시판
     contentBlur: boolean;
@@ -45,6 +47,7 @@ const DEFAULTS: UiSettings = {
     listView: 'classic',
     lineHeight: 'normal',
     fontFamily: 'default',
+    contentFontSize: 'base',
     hideMyProfile: false,
     contentBlur: true,
     hidePostList: false,
@@ -144,6 +147,27 @@ function createUiSettingsStore() {
         },
         get fontFamily() {
             return settings.fontFamily;
+        },
+        get contentFontSize() {
+            return settings.contentFontSize;
+        },
+        setContentFontSize(v: ContentFontSize) {
+            settings.contentFontSize = v;
+            save();
+        },
+        /** A-/A/A+ 버튼용: -1=작게, 0=기본, 1=크게 */
+        changeContentFontSize(direction: -1 | 0 | 1) {
+            const order: ContentFontSize[] = ['small', 'base', 'large', 'xlarge'];
+            if (direction === 0) {
+                settings.contentFontSize = 'base';
+            } else {
+                const idx = order.indexOf(settings.contentFontSize);
+                const next = idx + direction;
+                if (next >= 0 && next < order.length) {
+                    settings.contentFontSize = order[next];
+                }
+            }
+            save();
         },
         get hideMyProfile() {
             return settings.hideMyProfile;

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -134,30 +134,20 @@
     const viewEntry = $derived(layoutRegistry.resolveView(viewLayoutId));
     const ViewComponent = $derived(viewEntry?.component);
 
-    // 글자 크기 조절
-    type FontSizeKey = 'small' | 'base' | 'large' | 'xlarge';
-    const FONT_SIZES: Record<FontSizeKey, string> = {
-        small: '14px',
-        base: '16px',
-        large: '18px',
-        xlarge: '20px'
-    };
-    const FONT_SIZE_ORDER: FontSizeKey[] = ['small', 'base', 'large', 'xlarge'];
-    let fontSize = $state<FontSizeKey>(
-        browser ? (localStorage.getItem('damoang_font_size') as FontSizeKey) || 'base' : 'base'
-    );
+    // 글자 크기 조절 (uiSettingsStore 연동)
+    const fontSize = $derived(uiSettingsStore.contentFontSize);
 
     function changeFontSize(direction: -1 | 0 | 1) {
-        if (direction === 0) {
-            fontSize = 'base';
-        } else {
-            const idx = FONT_SIZE_ORDER.indexOf(fontSize);
-            const next = idx + direction;
-            if (next >= 0 && next < FONT_SIZE_ORDER.length) {
-                fontSize = FONT_SIZE_ORDER[next];
-            }
+        uiSettingsStore.changeContentFontSize(direction);
+    }
+
+    // 기존 damoang_font_size localStorage → uiSettingsStore 마이그레이션
+    if (browser) {
+        const legacy = localStorage.getItem('damoang_font_size');
+        if (legacy && ['small', 'base', 'large', 'xlarge'].includes(legacy)) {
+            uiSettingsStore.setContentFontSize(legacy as 'small' | 'base' | 'large' | 'xlarge');
+            localStorage.removeItem('damoang_font_size');
         }
-        if (browser) localStorage.setItem('damoang_font_size', fontSize);
     }
 
     // 글 읽기 권한 체크
@@ -1192,7 +1182,7 @@
                 {likers}
                 {likersTotal}
                 {fontSize}
-                fontSizeLabel={FONT_SIZE_ORDER[FONT_SIZE_ORDER.indexOf(fontSize)]}
+                fontSizeLabel={fontSize}
                 onLike={handleLike}
                 onDislike={handleDislike}
                 onLoadLikers={loadLikers}

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -37,6 +37,7 @@
         BLUR_KEYWORDS,
         type FontFamily,
         type LineHeight,
+        type ContentFontSize,
         type ShortcutButtonSize
     } from '$lib/stores/ui-settings.svelte.js';
     import { densityStore } from '$lib/stores/density.svelte.js';
@@ -85,6 +86,13 @@
         { value: 'normal', label: '보통 (1.6)' },
         { value: 'relaxed', label: '여유 (1.8)' },
         { value: 'loose', label: '넓게 (2.0)' }
+    ];
+
+    const contentFontSizeOptions: { value: ContentFontSize; label: string }[] = [
+        { value: 'small', label: '작게 (14px)' },
+        { value: 'base', label: '보통 (16px)' },
+        { value: 'large', label: '크게 (18px)' },
+        { value: 'xlarge', label: '아주 크게 (20px)' }
     ];
 
     const readStyleOptions: { value: ReadPostStyle; label: string }[] = [
@@ -300,6 +308,34 @@
                                     ? 'border-primary bg-primary/10 text-foreground'
                                     : 'border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground'}"
                                 onclick={() => uiSettingsStore.setLineHeight(opt.value)}
+                            >
+                                {opt.label}
+                            </button>
+                        {/each}
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle class="flex items-center gap-2">
+                        <Type class="h-5 w-5" />
+                        본문 글자 크기
+                    </CardTitle>
+                    <CardDescription
+                        >게시글 본문의 글자 크기를 조정합니다. 게시글 상세 페이지의 A-/A/A+ 버튼과
+                        연동됩니다.</CardDescription
+                    >
+                </CardHeader>
+                <CardContent>
+                    <div class="flex flex-wrap gap-2">
+                        {#each contentFontSizeOptions as opt (opt.value)}
+                            <button
+                                class="rounded-lg border px-4 py-2 text-sm transition-colors {uiSettingsStore.contentFontSize ===
+                                opt.value
+                                    ? 'border-primary bg-primary/10 text-foreground'
+                                    : 'border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground'}"
+                                onclick={() => uiSettingsStore.setContentFontSize(opt.value)}
                             >
                                 {opt.label}
                             </button>


### PR DESCRIPTION
## Summary
- uiSettingsStore에 contentFontSize 추가 (A-/A/A+ 버튼과 UI 설정 페이지 연동)
- /member/settings/ui 레이아웃 탭에 "본문 글자 크기" 옵션 추가
- 기존 localStorage(damoang_font_size) → uiSettingsStore 자동 마이그레이션

## Test plan
- [ ] 게시글 상세 A+/A- 버튼 → 글자 크기 변경 확인
- [ ] /member/settings/ui → 본문 글자 크기 변경 → 게시글에 반영 확인
- [ ] 양쪽 설정이 동기화되는지 확인