### PR TITLE
fix: 글자 크기 A-/A/A+ 버튼 동작 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -28,7 +28,7 @@
     import Flag from '@lucide/svelte/icons/flag';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
-    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
+    import { uiSettingsStore, type ContentFontSize } from '$lib/stores/ui-settings.svelte.js';
     import { getMemberIconUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
@@ -45,13 +45,14 @@
     import type { CommentReportInfo } from '$lib/api/types.js';
     import { apiClient } from '$lib/api/index.js';
 
-    type FontSizeKey = 'small' | 'base' | 'large' | 'xlarge';
-    const FONT_SIZES: Record<FontSizeKey, string> = {
+    const FONT_SIZES: Record<ContentFontSize, string> = {
         small: '14px',
         base: '16px',
         large: '18px',
         xlarge: '20px'
     };
+
+    const currentFontSize = $derived(uiSettingsStore.contentFontSize);
 
     let {
         post,
@@ -318,21 +319,21 @@
             <button
                 type="button"
                 class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
-                disabled={fontSize === 'small'}
-                onclick={() => onChangeFontSize(-1)}
+                disabled={currentFontSize === 'small'}
+                onclick={() => uiSettingsStore.changeContentFontSize(-1)}
                 aria-label="글자 작게">A-</button
             >
             <button
                 type="button"
                 class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors"
-                onclick={() => onChangeFontSize(0)}
+                onclick={() => uiSettingsStore.changeContentFontSize(0)}
                 aria-label="글자 기본">A</button
             >
             <button
                 type="button"
                 class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
-                disabled={fontSize === 'xlarge'}
-                onclick={() => onChangeFontSize(1)}
+                disabled={currentFontSize === 'xlarge'}
+                onclick={() => uiSettingsStore.changeContentFontSize(1)}
                 aria-label="글자 크게">A+</button
             >
         </div>
@@ -342,10 +343,7 @@
             <AdultBlur
                 isAdult={(post.is_adult ?? false) || uiSettingsStore.shouldBlurContent(post.title)}
             >
-                <div
-                    id="economy-post-content"
-                    style="font-size: {FONT_SIZES[fontSize as FontSizeKey]}"
-                >
+                <div id="economy-post-content" style="font-size: {FONT_SIZES[currentFontSize]}">
                     <Markdown content={postContent} />
                 </div>
 

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -39,7 +39,7 @@
     import CalendarDays from '@lucide/svelte/icons/calendar-days';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
-    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
+    import { uiSettingsStore, type ContentFontSize } from '$lib/stores/ui-settings.svelte.js';
     import { getMemberIconUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
@@ -53,13 +53,14 @@
     import Info from '@lucide/svelte/icons/info';
     import type { ViewLayoutProps } from '../types.js';
 
-    type FontSizeKey = 'small' | 'base' | 'large' | 'xlarge';
-    const FONT_SIZES: Record<FontSizeKey, string> = {
+    const FONT_SIZES: Record<ContentFontSize, string> = {
         small: '14px',
         base: '16px',
         large: '18px',
         xlarge: '20px'
     };
+
+    const currentFontSize = $derived(uiSettingsStore.contentFontSize);
 
     let {
         post,
@@ -381,21 +382,21 @@
             <button
                 type="button"
                 class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
-                disabled={fontSize === 'small'}
-                onclick={() => onChangeFontSize(-1)}
+                disabled={currentFontSize === 'small'}
+                onclick={() => uiSettingsStore.changeContentFontSize(-1)}
                 aria-label="글자 작게">A-</button
             >
             <button
                 type="button"
                 class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors"
-                onclick={() => onChangeFontSize(0)}
+                onclick={() => uiSettingsStore.changeContentFontSize(0)}
                 aria-label="글자 기본">A</button
             >
             <button
                 type="button"
                 class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"
-                disabled={fontSize === 'xlarge'}
-                onclick={() => onChangeFontSize(1)}
+                disabled={currentFontSize === 'xlarge'}
+                onclick={() => uiSettingsStore.changeContentFontSize(1)}
                 aria-label="글자 크게">A+</button
             >
         </div>
@@ -405,10 +406,7 @@
             <AdultBlur
                 isAdult={(post.is_adult ?? false) || uiSettingsStore.shouldBlurContent(post.title)}
             >
-                <div
-                    id="economy-post-content"
-                    style="font-size: {FONT_SIZES[fontSize as FontSizeKey]}"
-                >
+                <div id="economy-post-content" style="font-size: {FONT_SIZES[currentFontSize]}">
                     <Markdown content={postContent} />
                 </div>
 


### PR DESCRIPTION
## Summary
- prop 전달 체인 대신 뷰 레이아웃에서 uiSettingsStore 직접 호출
- basic.svelte, report.svelte 모두 수정

## Test plan
- [ ] A+ 클릭 → 본문 글자 커지는지 확인
- [ ] A- 클릭 → 본문 글자 작아지는지 확인
- [ ] A 클릭 → 기본 크기(16px)로 복원 확인