### PR TITLE
feat: 관리자에게 삭제된 댓글 내용 표시

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1056,6 +1056,14 @@
                                 </span>
                             {/if}
                         </div>
+                        {#if isSuperAdmin() && comment.content}
+                            <!-- 관리자: 삭제된 댓글 원문 표시 -->
+                            <div
+                                class="mt-1 rounded border border-red-200 bg-red-50/50 p-2 text-sm opacity-70 dark:border-red-800 dark:bg-red-950/20"
+                            >
+                                {@html comment.content}
+                            </div>
+                        {/if}
                     {:else if isEditing}
                         <!-- 댓글 수정 폼 -->
                         <div class="mt-2 space-y-3">


### PR DESCRIPTION
## Summary
- 삭제된 댓글에서 관리자(super_admin)에게만 원본 내용을 빨간 테두리 박스로 표시
- 백엔드 PR #193 (angple-backend)과 함께 동작

## Test plan
- [ ] 관리자로 삭제된 댓글이 있는 게시물 접근 → 삭제된 댓글 내용 빨간 박스로 표시
- [ ] 일반 유저로 같은 게시물 → 삭제된 댓글 내용 미표시