### PR TITLE
chore: ads.txt, robots.txt gitignore 추가

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -23,6 +23,10 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# Site-specific
+/static/ads.txt
+/static/robots.txt
+
 # Theme System
 /custom-themes
 /data/settings.json


### PR DESCRIPTION
## Summary
- `static/ads.txt`, `static/robots.txt`를 gitignore에 추가
- 사이트별 고유 파일(애드센스 퍼블리셔 ID)이 오픈소스 레포에 포함되지 않도록 처리