### PR TITLE
fix: 메인 페이지 폰트 통일 + 댓글 인피드 광고 축소

### DIFF
--- a/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
+++ b/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
@@ -38,7 +38,7 @@
                 >
                     <div class="flex items-center gap-2">
                         <div
-                            class="min-w-0 flex-1 truncate text-[17px] font-medium {getReadPostClasses(
+                            class="min-w-0 flex-1 truncate text-sm leading-relaxed {getReadPostClasses(
                                 showReadState &&
                                     readPostsStore.isRead(getBoardId(post.url), post.id)
                             )}"

--- a/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
+++ b/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
@@ -46,7 +46,7 @@
                             {formatNumber(post.recommend_count)}
                         </span>
                         <div
-                            class="min-w-0 flex-1 truncate text-[17px] font-medium {getReadPostClasses(
+                            class="min-w-0 flex-1 truncate text-sm leading-relaxed {getReadPostClasses(
                                 showReadState &&
                                     readPostsStore.isRead(getBoardId(post.url), post.id)
                             )}"

--- a/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
@@ -32,7 +32,7 @@
                 >
                     <div class="flex items-center gap-2">
                         <div
-                            class="min-w-0 flex-1 truncate text-[17px] font-medium {getReadPostClasses(
+                            class="min-w-0 flex-1 truncate text-sm leading-relaxed {getReadPostClasses(
                                 showReadState && readPostsStore.isRead(post.board, post.id)
                             )}"
                         >

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -311,7 +311,7 @@
         'index-bottom': 'banner-large',
         'header-after': 'banner-horizontal',
         'board-list-infeed': 'infeed-compact',
-        'comment-infeed': 'infeed',
+        'comment-infeed': 'infeed-compact',
         'comment-top': 'banner-compact',
         'sidebar-sticky': 'banner-halfpage',
         sidebar: 'banner-square',


### PR DESCRIPTION
## Summary
- 새로운 소식/알뜰구매/소모임 게시글 폰트 text-[17px] → text-sm (추천글 기준 통일)
- 댓글 인피드 광고 모바일 300x250 제거, 320x100만 허용

## Test plan
- [ ] 메인 페이지 각 섹션 폰트 크기 일관성 확인
- [ ] 모바일 댓글 인피드 광고 높이 축소 확인