### PR TITLE
fix: PC 댓글~목록 사이 광고 영역 높이 축소

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -868,7 +868,7 @@
                         중 {pagination.page} / {pagination.totalPages} 페이지
                     </p>
                     {#if widgetLayoutStore.hasEnabledAds}
-                        <div class="mt-6">
+                        <div class="mt-3">
                             <AdSlot position="board-list-bottom" height="90px" />
                         </div>
                     {/if}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1377,15 +1377,8 @@
 
         <!-- 댓글~목록 사이 GAM 광고 -->
         {#if widgetLayoutStore.hasEnabledAds}
-            <div class="my-6">
+            <div class="my-3 md:my-4">
                 <AdSlot position="board-after-comments" height="90px" />
-            </div>
-        {/if}
-
-        <!-- 댓글 섹션 하단 광고 (푸터 위, PC만) -->
-        {#if widgetLayoutStore.hasEnabledAds}
-            <div class="mt-6 hidden md:block">
-                <AdSlot position="board-footer" height="90px" />
             </div>
         {/if}
     {/if}
@@ -1394,7 +1387,7 @@
 
 <!-- 게시판 최근글 목록 -->
 {#if canRead}
-    <div class="bg-card mx-auto mt-6 rounded-xl px-3 py-3 md:px-5">
+    <div class="bg-card mx-auto mt-3 rounded-xl px-3 py-3 md:mt-4 md:px-5">
         <RecentPosts
             {boardId}
             {boardTitle}


### PR DESCRIPTION
## Summary
- PC에서 댓글 아래~목록 사이 `board-footer` 광고 제거 (`board-after-comments`와 중복)
- 댓글~목록 사이 마진 축소 (my-6 → my-3/md:my-4)
- 게시판 목록 하단 광고 마진 축소 (mt-6 → mt-3)

## Test plan
- [ ] PC에서 글 상세 페이지 댓글~목록 사이 광고 영역 높이 확인
- [ ] 모바일에서 광고 정상 표시 확인