### PR TITLE
feat: admin 쪽지 차단 + 모바일 목록 카드 스타일 + disciplinelog 해제 표시

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -68,6 +68,7 @@ export interface DisciplineLogListItem {
     member_nickname: string;
     penalty_period: number; // -1: permanent, 0: warning, >0: days
     penalty_date_from: string;
+    penalty_date_to?: string;
     violation_types: number[];
     violation_titles: string[];
     memo?: string;
@@ -107,17 +108,33 @@ export interface DisciplineLogDetailResponse {
 /**
  * Get penalty period display text and color
  */
-export function getPenaltyDisplay(period: number): {
+export function getPenaltyDisplay(
+    period: number,
+    penaltyDateTo?: string
+): {
     text: string;
-    color: 'magenta' | 'orange' | 'red';
+    color: 'magenta' | 'orange' | 'red' | 'green';
+    released: boolean;
 } {
-    if (period === -1) {
-        return { text: '영구', color: 'magenta' };
-    } else if (period === 0) {
-        return { text: '주의', color: 'orange' };
-    } else {
-        return { text: `${period}일`, color: 'red' };
+    // 경고는 해제 개념 없음
+    if (period === 0) {
+        return { text: '주의', color: 'orange', released: false };
     }
+    // 영구 제재는 해제되지 않음
+    if (period === -1) {
+        return { text: '영구', color: 'magenta', released: false };
+    }
+    // 종료일이 있고 현재 날짜보다 과거이면 해제됨
+    if (penaltyDateTo) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const toDate = new Date(penaltyDateTo);
+        toDate.setHours(0, 0, 0, 0);
+        if (toDate < today) {
+            return { text: '해제됨', color: 'green', released: true };
+        }
+    }
+    return { text: `${period}일`, color: 'red', released: false };
 }
 
 /**

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -625,7 +625,9 @@
                 {/if}
 
                 <!-- 게시글 목록 -->
-                <div class={wrapperClass}>
+                <div
+                    class="{wrapperClass} bg-card rounded-xl px-1 py-2 md:rounded-none md:bg-transparent md:px-0 md:py-0"
+                >
                     {#if listLayoutId === 'classic' && uiSettingsStore.listView !== 'modern'}
                         <div
                             class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium md:block"

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -28,8 +28,10 @@
     }
 
     function getPenaltyBadgeVariant(
-        period: number
+        period: number,
+        released: boolean
     ): 'default' | 'secondary' | 'destructive' | 'outline' {
+        if (released) return 'secondary';
         if (period === -1) return 'destructive';
         if (period === 0) return 'secondary';
         return 'destructive';
@@ -78,7 +80,10 @@
                         </thead>
                         <tbody>
                             {#each logs as log (log.id)}
-                                {@const penalty = getPenaltyDisplay(log.penalty_period)}
+                                {@const penalty = getPenaltyDisplay(
+                                    log.penalty_period,
+                                    log.penalty_date_to
+                                )}
                                 <tr
                                     class="hover:bg-muted/50 border-b transition-all duration-200 ease-out"
                                 >
@@ -97,7 +102,12 @@
                                         >{log.penalty_date_from}</td
                                     >
                                     <td class="p-3 text-center">
-                                        <Badge variant={getPenaltyBadgeVariant(log.penalty_period)}>
+                                        <Badge
+                                            variant={getPenaltyBadgeVariant(
+                                                log.penalty_period,
+                                                penalty.released
+                                            )}
+                                        >
                                             {penalty.text}
                                         </Badge>
                                     </td>
@@ -129,7 +139,10 @@
                 <!-- Mobile cards -->
                 <div class="space-y-3 md:hidden">
                     {#each logs as log (log.id)}
-                        {@const penalty = getPenaltyDisplay(log.penalty_period)}
+                        {@const penalty = getPenaltyDisplay(
+                            log.penalty_period,
+                            log.penalty_date_to
+                        )}
                         <a href="/disciplinelog/{log.id}" class="block">
                             <div
                                 class="hover:bg-muted/50 rounded-lg border p-4 transition-all duration-200 ease-out"
@@ -140,7 +153,12 @@
                                             ? 'text-red-500'
                                             : ''}">{log.member_nickname}</span
                                     >
-                                    <Badge variant={getPenaltyBadgeVariant(log.penalty_period)}>
+                                    <Badge
+                                        variant={getPenaltyBadgeVariant(
+                                            log.penalty_period,
+                                            penalty.released
+                                        )}
+                                    >
                                         {penalty.text}
                                     </Badge>
                                 </div>

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -58,8 +58,10 @@
     }
 
     function getPenaltyBadgeVariant(
-        period: number
+        period: number,
+        released: boolean = false
     ): 'default' | 'secondary' | 'destructive' | 'outline' {
+        if (released) return 'secondary';
         if (period === 0) return 'secondary';
         return 'destructive';
     }
@@ -143,7 +145,7 @@
             </Card.Content>
         </Card.Root>
     {:else}
-        {@const penalty = getPenaltyDisplay(log.penalty_period)}
+        {@const penalty = getPenaltyDisplay(log.penalty_period, log.penalty_date_to)}
 
         <!-- Basic Info -->
         <Card.Root class="mb-4">
@@ -167,7 +169,9 @@
                 <div>
                     <div class="text-muted-foreground mb-1 text-sm">제재 기간</div>
                     <div class="flex items-center gap-2">
-                        <Badge variant={getPenaltyBadgeVariant(log.penalty_period)}>
+                        <Badge
+                            variant={getPenaltyBadgeVariant(log.penalty_period, penalty.released)}
+                        >
                             {penalty.text}
                         </Badge>
                         <span class="text-muted-foreground text-sm">
@@ -281,7 +285,10 @@
                 <Card.Content>
                     <div class="space-y-2">
                         {#each memberHistory as item}
-                            {@const itemPenalty = getPenaltyDisplay(item.penalty_period)}
+                            {@const itemPenalty = getPenaltyDisplay(
+                                item.penalty_period,
+                                item.penalty_date_to
+                            )}
                             <a
                                 href="/disciplinelog/{item.id}"
                                 class="hover:bg-muted/50 flex items-center justify-between rounded p-2 text-sm transition-all duration-200 ease-out"
@@ -290,7 +297,12 @@
                                     <span class="text-muted-foreground"
                                         >{item.penalty_date_from}</span
                                     >
-                                    <Badge variant={getPenaltyBadgeVariant(item.penalty_period)}>
+                                    <Badge
+                                        variant={getPenaltyBadgeVariant(
+                                            item.penalty_period,
+                                            itemPenalty.released
+                                        )}
+                                    >
                                         {itemPenalty.text}
                                     </Badge>
                                 </div>

--- a/apps/web/src/routes/messages/+page.svelte
+++ b/apps/web/src/routes/messages/+page.svelte
@@ -127,6 +127,11 @@
             return;
         }
 
+        if (sendTo.trim().toLowerCase() === 'admin') {
+            sendError = '관리자에게는 쪽지를 보낼 수 없습니다.';
+            return;
+        }
+
         isSending = true;
         sendError = null;
 


### PR DESCRIPTION
## Summary
- admin에게 쪽지 발신 프론트엔드 차단 (에러 메시지 표시)
- 모바일 게시판 목록에 `bg-card rounded-xl` 카드 스타일 적용 (상세 하단 목록과 통일)
- `getPenaltyDisplay`에 `penalty_date_to` 기반 해제 판단 로직 추가
- 목록/상세 페이지에서 종료일 지난 제재는 '해제됨' Badge 표시

## Test plan
- [ ] admin에게 쪽지 보내기 시도 → 에러 메시지 확인
- [ ] 모바일에서 게시판 목록 카드 스타일 확인
- [ ] /disciplinelog에서 종료일 지난 제재가 '해제됨'으로 표시되는지 확인