### PR TITLE
fix: $derived.by 값을 함수 호출로 사용하던 500 에러 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -321,7 +321,7 @@
 {:else}
     <SeoHead config={seoConfig} />
 
-    {#if !canList()}
+    {#if !canList}
         <div class="mx-auto pt-4">
             <div class="bg-muted/50 mx-auto mt-12 max-w-md rounded-lg p-8 text-center">
                 <Lock class="text-muted-foreground mx-auto mb-4 h-12 w-12" />

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1214,7 +1214,7 @@
                 {formatTimeShort}
                 editCount={revisions.filter((r) => r.change_type === 'update').length}
                 {formatFileSize}
-                postContent={postContent()}
+                {postContent}
                 pageData={data}
                 {postReactions}
                 {postReportCount}


### PR DESCRIPTION
## Summary
- `canList`와 `postContent`가 `$derived.by()`로 정의된 값인데 `canList()`, `postContent()`로 함수 호출하여 500 에러 발생
- `$derived.by`는 값을 반환하므로 괄호 없이 참조해야 함

## 원인
PR #454 머지 시 prettier 포맷팅 과정에서 발생한 것으로 추정

## Test plan
- [x] dev.damoang.net /free 200 확인
- [x] dev.damoang.net /free/{postId} 200 확인