### PR TITLE
fix: playonly님 모바일 레이아웃 복원

### DIFF
--- a/apps/web/src/lib/components/ui/card/card.svelte
+++ b/apps/web/src/lib/components/ui/card/card.svelte
@@ -14,7 +14,7 @@
     bind:this={ref}
     data-slot="card"
     class={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border-none px-5 py-3 shadow-none md:shadow-sm',
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-none border-none px-5 py-3 shadow-none md:rounded-xl md:shadow-sm',
         className
     )}
     {...restProps}

--- a/apps/web/src/lib/layouts/default-layout.svelte
+++ b/apps/web/src/lib/layouts/default-layout.svelte
@@ -57,7 +57,7 @@
             {/if}
 
             <main
-                class="box-content min-w-0 flex-1 px-2 pt-1 md:px-0 md:py-5 lg:pe-6 2xl:!px-9 md:[&_[data-slot='card']]:mx-0"
+                class="box-content min-w-0 flex-1 px-5 pt-1 md:px-0 md:py-5 lg:pe-6 2xl:!px-9 [&_[data-slot='card']]:-mx-5 md:[&_[data-slot='card']]:mx-0"
             >
                 {@render children()}
             </main>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -625,226 +625,214 @@
                 {/if}
 
                 <!-- 게시글 목록 -->
-                <div
-                    class="bg-card overflow-hidden rounded-xl py-3 md:overflow-visible md:rounded-none md:bg-transparent md:py-0"
-                >
-                    <div class="{wrapperClass} max-md:!-mx-0 max-md:!rounded-xl max-md:!border-y-0">
-                        {#if listLayoutId === 'classic' && uiSettingsStore.listView !== 'modern'}
+                <div class={wrapperClass}>
+                    {#if listLayoutId === 'classic' && uiSettingsStore.listView !== 'modern'}
+                        <div
+                            class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium md:block"
+                        >
                             <div
-                                class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium md:block"
+                                class="grid grid-cols-[60px_1fr_auto_auto_auto] items-center gap-0"
                             >
-                                <div
-                                    class="grid grid-cols-[60px_1fr_auto_auto_auto] items-center gap-0"
-                                >
-                                    <div class="text-center">추천</div>
-                                    <div>제목</div>
-                                    <div class="w-[120px] pl-1">이름</div>
-                                    <div class="w-[70px] pl-1 text-center">날짜</div>
-                                    <div class="w-[50px] pl-1 text-center">조회</div>
-                                </div>
+                                <div class="text-center">추천</div>
+                                <div>제목</div>
+                                <div class="w-[120px] pl-1">이름</div>
+                                <div class="w-[70px] pl-1 text-center">날짜</div>
+                                <div class="w-[50px] pl-1 text-center">조회</div>
                             </div>
-                        {/if}
-                        <!-- 공지사항 (목록 내부) -->
-                        {#if hasNotices && !isSearching}
-                            {#if listLayoutId === 'classic'}
-                                {#each importantNotices as notice (notice.id)}
-                                    <a
-                                        href="/{boardId}/{notice.id}"
-                                        class="hover:bg-destructive/10 block px-4 py-1.5 no-underline transition-colors"
-                                        style="background: rgba(239, 68, 68, 0.04);"
-                                    >
-                                        <div class="flex items-center gap-2 md:gap-3">
+                        </div>
+                    {/if}
+                    <!-- 공지사항 (목록 내부) -->
+                    {#if hasNotices && !isSearching}
+                        {#if listLayoutId === 'classic'}
+                            {#each importantNotices as notice (notice.id)}
+                                <a
+                                    href="/{boardId}/{notice.id}"
+                                    class="hover:bg-destructive/10 block px-4 py-1.5 no-underline transition-colors"
+                                    style="background: rgba(239, 68, 68, 0.04);"
+                                >
+                                    <div class="flex items-center gap-2 md:gap-3">
+                                        <div class="hidden shrink-0 md:block" style="width: 60px;">
                                             <div
-                                                class="hidden shrink-0 md:block"
-                                                style="width: 60px;"
+                                                class="mx-auto flex h-5 w-10 items-center justify-center rounded-lg"
+                                                style="background: rgba(239,68,68,0.1);"
                                             >
-                                                <div
-                                                    class="mx-auto flex h-5 w-10 items-center justify-center rounded-lg"
-                                                    style="background: rgba(239,68,68,0.1);"
-                                                >
-                                                    <Megaphone
-                                                        class="h-3.5 w-3.5"
-                                                        style="color: orangered;"
-                                                    />
-                                                </div>
+                                                <Megaphone
+                                                    class="h-3.5 w-3.5"
+                                                    style="color: orangered;"
+                                                />
                                             </div>
-                                            <div class="min-w-0 flex-1">
-                                                <div class="flex items-center gap-1">
-                                                    <Megaphone
-                                                        class="text-destructive h-3.5 w-3.5 shrink-0 md:hidden"
-                                                    /><Badge
-                                                        variant="destructive"
-                                                        class="shrink-0 text-[10px]">필수</Badge
-                                                    >
-                                                    <h3
-                                                        class="text-foreground truncate font-medium"
-                                                        style="font-size: 0.9375rem;"
-                                                    >
-                                                        {notice.title}
-                                                    </h3>
-                                                </div>
-                                            </div>
-                                            <span
-                                                class="text-muted-foreground hidden shrink-0 md:inline"
-                                                style="font-size: 13px;">{notice.author}</span
-                                            >
-                                        </div>
-                                    </a>
-                                {/each}
-                                {#each normalNotices as notice (notice.id)}
-                                    <a
-                                        href="/{boardId}/{notice.id}"
-                                        class="hover:bg-accent block px-4 py-1.5 no-underline transition-colors"
-                                        style="background: rgba(255, 255, 255, 0.03);"
-                                    >
-                                        <div class="flex items-center gap-2 md:gap-3">
-                                            <div
-                                                class="hidden shrink-0 md:block"
-                                                style="width: 60px;"
-                                            >
-                                                <div
-                                                    class="mx-auto flex h-5 w-10 items-center justify-center rounded-lg"
-                                                    style="background: rgba(239,68,68,0.1);"
-                                                >
-                                                    <Pin
-                                                        class="h-3.5 w-3.5"
-                                                        style="color: orangered;"
-                                                    />
-                                                </div>
-                                            </div>
-                                            <div class="min-w-0 flex-1">
-                                                <div class="flex items-center gap-1">
-                                                    <Pin
-                                                        class="text-liked h-3.5 w-3.5 shrink-0 md:hidden"
-                                                    /><Badge
-                                                        class="shrink-0 text-[10px] font-semibold"
-                                                        style="background: rgba(239, 68, 68, 0.15); color: rgb(239, 68, 68); border: 1px solid rgba(239, 68, 68, 0.2);"
-                                                        >공지</Badge
-                                                    >
-                                                    <h3
-                                                        class="text-foreground truncate font-medium"
-                                                        style="font-size: 0.9375rem;"
-                                                    >
-                                                        {notice.title}
-                                                    </h3>
-                                                </div>
-                                            </div>
-                                            <span
-                                                class="text-muted-foreground hidden shrink-0 md:inline"
-                                                style="font-size: 13px;">{notice.author}</span
-                                            >
-                                        </div>
-                                    </a>
-                                {/each}
-                            {:else}
-                                {#each importantNotices as notice (notice.id)}
-                                    <a
-                                        href="/{boardId}/{notice.id}"
-                                        class="bg-destructive/5 border-destructive/20 hover:bg-destructive/10 block rounded-lg border px-4 py-3 no-underline transition-colors"
-                                    >
-                                        <div class="flex items-center gap-3">
-                                            <div class="flex shrink-0 items-center gap-1.5">
-                                                <Megaphone class="text-destructive h-4 w-4" /><Badge
-                                                    variant="destructive"
-                                                    class="text-xs">필수</Badge
-                                                >
-                                            </div>
-                                            <h3 class="text-foreground flex-1 truncate font-medium">
-                                                {notice.title}
-                                            </h3>
-                                            <span class="text-muted-foreground shrink-0 text-xs"
-                                                >{notice.author}</span
-                                            >
-                                        </div>
-                                    </a>
-                                {/each}
-                                {#each normalNotices as notice (notice.id)}
-                                    <a
-                                        href="/{boardId}/{notice.id}"
-                                        class="bg-muted/50 border-border hover:bg-muted block rounded-lg border px-4 py-3 no-underline transition-colors"
-                                    >
-                                        <div class="flex items-center gap-3">
-                                            <div class="flex shrink-0 items-center gap-1.5">
-                                                <Pin class="text-muted-foreground h-4 w-4" /><Badge
-                                                    variant="secondary"
-                                                    class="text-xs">공지</Badge
-                                                >
-                                            </div>
-                                            <h3 class="text-foreground flex-1 truncate font-medium">
-                                                {notice.title}
-                                            </h3>
-                                            <span class="text-muted-foreground shrink-0 text-xs"
-                                                >{notice.author}</span
-                                            >
-                                        </div>
-                                    </a>
-                                {/each}
-                            {/if}
-                        {/if}
-                        {#if filteredPosts.length === 0}
-                            <Card
-                                class="bg-background {listLayoutId === 'gallery'
-                                    ? 'col-span-full'
-                                    : ''}"
-                            >
-                                <CardContent class="py-12 text-center">
-                                    {#if isSearching}
-                                        <p class="text-secondary-foreground">
-                                            검색 결과가 없습니다.
-                                        </p>
-                                    {:else}
-                                        <p class="text-secondary-foreground">게시글이 없습니다.</p>
-                                    {/if}
-                                </CardContent>
-                            </Card>
-                        {:else if LayoutComponent}
-                            {#each filteredPosts as post, i (post.id)}
-                                {#if bulkSelectMode}
-                                    <div class="flex items-start gap-2">
-                                        <div class="flex shrink-0 items-center pt-3">
-                                            <Checkbox
-                                                checked={selectedPostIds.includes(post.id)}
-                                                onCheckedChange={() => togglePostSelection(post.id)}
-                                            />
                                         </div>
                                         <div class="min-w-0 flex-1">
-                                            <LayoutComponent
-                                                {post}
-                                                displaySettings={data.board?.display_settings}
-                                                href="/{boardId}/{post.id}{listPage > 1
-                                                    ? `?page=${listPage}`
-                                                    : ''}"
-                                                isRead={showReadState &&
-                                                    readPostsStore.isRead(boardId, post.id)}
-                                            />
+                                            <div class="flex items-center gap-1">
+                                                <Megaphone
+                                                    class="text-destructive h-3.5 w-3.5 shrink-0 md:hidden"
+                                                /><Badge
+                                                    variant="destructive"
+                                                    class="shrink-0 text-[10px]">필수</Badge
+                                                >
+                                                <h3
+                                                    class="text-foreground truncate font-medium"
+                                                    style="font-size: 0.9375rem;"
+                                                >
+                                                    {notice.title}
+                                                </h3>
+                                            </div>
                                         </div>
+                                        <span
+                                            class="text-muted-foreground hidden shrink-0 md:inline"
+                                            style="font-size: 13px;">{notice.author}</span
+                                        >
                                     </div>
-                                {:else}
-                                    <LayoutComponent
-                                        {post}
-                                        displaySettings={data.board?.display_settings}
-                                        href="/{boardId}/{post.id}{listPage > 1
-                                            ? `?page=${listPage}`
-                                            : ''}"
-                                        isRead={showReadState &&
-                                            readPostsStore.isRead(boardId, post.id)}
-                                    />
-                                {/if}
-                                {#if widgetLayoutStore.hasEnabledAds && i + 1 === 7}
-                                    <div class="py-2">
-                                        <AdSlot position="board-list-infeed" height="90px" />
+                                </a>
+                            {/each}
+                            {#each normalNotices as notice (notice.id)}
+                                <a
+                                    href="/{boardId}/{notice.id}"
+                                    class="hover:bg-accent block px-4 py-1.5 no-underline transition-colors"
+                                    style="background: rgba(255, 255, 255, 0.03);"
+                                >
+                                    <div class="flex items-center gap-2 md:gap-3">
+                                        <div class="hidden shrink-0 md:block" style="width: 60px;">
+                                            <div
+                                                class="mx-auto flex h-5 w-10 items-center justify-center rounded-lg"
+                                                style="background: rgba(239,68,68,0.1);"
+                                            >
+                                                <Pin
+                                                    class="h-3.5 w-3.5"
+                                                    style="color: orangered;"
+                                                />
+                                            </div>
+                                        </div>
+                                        <div class="min-w-0 flex-1">
+                                            <div class="flex items-center gap-1">
+                                                <Pin
+                                                    class="text-liked h-3.5 w-3.5 shrink-0 md:hidden"
+                                                /><Badge
+                                                    class="shrink-0 text-[10px] font-semibold"
+                                                    style="background: rgba(239, 68, 68, 0.15); color: rgb(239, 68, 68); border: 1px solid rgba(239, 68, 68, 0.2);"
+                                                    >공지</Badge
+                                                >
+                                                <h3
+                                                    class="text-foreground truncate font-medium"
+                                                    style="font-size: 0.9375rem;"
+                                                >
+                                                    {notice.title}
+                                                </h3>
+                                            </div>
+                                        </div>
+                                        <span
+                                            class="text-muted-foreground hidden shrink-0 md:inline"
+                                            style="font-size: 13px;">{notice.author}</span
+                                        >
                                     </div>
-                                {/if}
-                                {#if shuffledPromos.length > 0 && i + 1 === 12}
-                                    <PluginSlot
-                                        name="board-list-promotion"
-                                        posts={shuffledPromos}
-                                        variant={listLayoutId === 'classic' ? 'classic' : 'default'}
-                                    />
-                                {/if}
+                                </a>
+                            {/each}
+                        {:else}
+                            {#each importantNotices as notice (notice.id)}
+                                <a
+                                    href="/{boardId}/{notice.id}"
+                                    class="bg-destructive/5 border-destructive/20 hover:bg-destructive/10 block rounded-lg border px-4 py-3 no-underline transition-colors"
+                                >
+                                    <div class="flex items-center gap-3">
+                                        <div class="flex shrink-0 items-center gap-1.5">
+                                            <Megaphone class="text-destructive h-4 w-4" /><Badge
+                                                variant="destructive"
+                                                class="text-xs">필수</Badge
+                                            >
+                                        </div>
+                                        <h3 class="text-foreground flex-1 truncate font-medium">
+                                            {notice.title}
+                                        </h3>
+                                        <span class="text-muted-foreground shrink-0 text-xs"
+                                            >{notice.author}</span
+                                        >
+                                    </div>
+                                </a>
+                            {/each}
+                            {#each normalNotices as notice (notice.id)}
+                                <a
+                                    href="/{boardId}/{notice.id}"
+                                    class="bg-muted/50 border-border hover:bg-muted block rounded-lg border px-4 py-3 no-underline transition-colors"
+                                >
+                                    <div class="flex items-center gap-3">
+                                        <div class="flex shrink-0 items-center gap-1.5">
+                                            <Pin class="text-muted-foreground h-4 w-4" /><Badge
+                                                variant="secondary"
+                                                class="text-xs">공지</Badge
+                                            >
+                                        </div>
+                                        <h3 class="text-foreground flex-1 truncate font-medium">
+                                            {notice.title}
+                                        </h3>
+                                        <span class="text-muted-foreground shrink-0 text-xs"
+                                            >{notice.author}</span
+                                        >
+                                    </div>
+                                </a>
                             {/each}
                         {/if}
-                    </div>
+                    {/if}
+                    {#if filteredPosts.length === 0}
+                        <Card
+                            class="bg-background {listLayoutId === 'gallery'
+                                ? 'col-span-full'
+                                : ''}"
+                        >
+                            <CardContent class="py-12 text-center">
+                                {#if isSearching}
+                                    <p class="text-secondary-foreground">검색 결과가 없습니다.</p>
+                                {:else}
+                                    <p class="text-secondary-foreground">게시글이 없습니다.</p>
+                                {/if}
+                            </CardContent>
+                        </Card>
+                    {:else if LayoutComponent}
+                        {#each filteredPosts as post, i (post.id)}
+                            {#if bulkSelectMode}
+                                <div class="flex items-start gap-2">
+                                    <div class="flex shrink-0 items-center pt-3">
+                                        <Checkbox
+                                            checked={selectedPostIds.includes(post.id)}
+                                            onCheckedChange={() => togglePostSelection(post.id)}
+                                        />
+                                    </div>
+                                    <div class="min-w-0 flex-1">
+                                        <LayoutComponent
+                                            {post}
+                                            displaySettings={data.board?.display_settings}
+                                            href="/{boardId}/{post.id}{listPage > 1
+                                                ? `?page=${listPage}`
+                                                : ''}"
+                                            isRead={showReadState &&
+                                                readPostsStore.isRead(boardId, post.id)}
+                                        />
+                                    </div>
+                                </div>
+                            {:else}
+                                <LayoutComponent
+                                    {post}
+                                    displaySettings={data.board?.display_settings}
+                                    href="/{boardId}/{post.id}{listPage > 1
+                                        ? `?page=${listPage}`
+                                        : ''}"
+                                    isRead={showReadState &&
+                                        readPostsStore.isRead(boardId, post.id)}
+                                />
+                            {/if}
+                            {#if widgetLayoutStore.hasEnabledAds && i + 1 === 7}
+                                <div class="py-2">
+                                    <AdSlot position="board-list-infeed" height="90px" />
+                                </div>
+                            {/if}
+                            {#if shuffledPromos.length > 0 && i + 1 === 12}
+                                <PluginSlot
+                                    name="board-list-promotion"
+                                    posts={shuffledPromos}
+                                    variant={listLayoutId === 'classic' ? 'classic' : 'default'}
+                                />
+                            {/if}
+                        {/each}
+                    {/if}
                 </div>
 
                 <!-- 페이지네이션 -->


### PR DESCRIPTION
## Summary
- 모바일에서 카드 스타일을 화면 폭 양끝까지 채워서 라운딩 없이 지면공간을 효율적으로 사용하도록 복원
- #452/#453에서 의도치 않게 덮어쓴 playonly(토비)님의 모바일 레이아웃 원복

## Changes
- `card.svelte`: `rounded-xl` → `rounded-none md:rounded-xl` (모바일 라운딩 제거)
- `default-layout.svelte`: `px-2` → `px-5` + `[&_[data-slot='card']]:-mx-5 md:[&_[data-slot='card']]:mx-0` (카드가 모바일에서 좌우 끝까지 확장)
- `[boardId]/+page.svelte`: 외부 `bg-card overflow-hidden rounded-xl` wrapper div 제거 (playonly 디자인과 충돌)

## Test plan
- [ ] 모바일에서 카드가 화면 양끝까지 채워지는지 확인
- [ ] 데스크탑에서 카드 라운딩 정상 표시 확인
- [ ] 게시판 목록/상세 페이지 레이아웃 확인