### PR TITLE
fix: $derived.by 값을 함수 호출하던 버그 일괄 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -493,7 +493,7 @@
                         <span class="absolute -inset-1.5"></span>
                         <Search class="h-4 w-4" />
                     </Button>
-                    {#if canWrite()}
+                    {#if canWrite}
                         <Button onclick={goToWrite} class="shrink-0">
                             <Pencil class="mr-2 h-4 w-4" />
                             글쓰기
@@ -502,7 +502,7 @@
                         <Button
                             disabled
                             class="shrink-0 cursor-not-allowed opacity-60"
-                            title={writePermissionMessage()}
+                            title={writePermissionMessage}
                         >
                             <Lock class="mr-2 h-4 w-4" />
                             글쓰기
@@ -892,7 +892,7 @@
 {/if}
 
 <!-- 모바일 글쓰기 FAB -->
-{#if canWrite()}
+{#if canWrite}
     <button
         onclick={goToWrite}
         class="bg-primary text-primary-foreground fixed bottom-4 right-4 z-50 flex h-10 w-10 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95 md:hidden"

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -122,7 +122,7 @@
         <div class="py-12 text-center">
             <p class="text-muted-foreground">로그인이 필요합니다. 로그인 페이지로 이동합니다...</p>
         </div>
-    {:else if !canWrite()}
+    {:else if !canWrite}
         <div class="py-12 text-center">
             <div class="bg-muted/50 mx-auto max-w-md rounded-lg p-8">
                 <p class="text-muted-foreground text-lg font-medium">글쓰기 권한이 없습니다</p>

--- a/apps/web/src/routes/admin/plugins/marketplace/+page.svelte
+++ b/apps/web/src/routes/admin/plugins/marketplace/+page.svelte
@@ -202,7 +202,7 @@
                 <p class="text-muted-foreground">잠시만 기다려주세요.</p>
             </CardContent>
         </Card>
-    {:else if filteredPlugins().length === 0}
+    {:else if filteredPlugins.length === 0}
         <Card>
             <CardContent class="py-12 text-center">
                 <Package class="text-muted-foreground mx-auto mb-4 h-12 w-12" />
@@ -212,7 +212,7 @@
         </Card>
     {:else}
         <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {#each filteredPlugins() as plugin (plugin.id)}
+            {#each filteredPlugins as plugin (plugin.id)}
                 <Card class="overflow-hidden transition-shadow hover:shadow-lg">
                     {#if plugin.screenshot}
                         <div class="bg-muted aspect-video">

--- a/apps/web/src/routes/admin/themes/marketplace/+page.svelte
+++ b/apps/web/src/routes/admin/themes/marketplace/+page.svelte
@@ -368,7 +368,7 @@
                 <p class="text-muted-foreground">잠시만 기다려주세요.</p>
             </CardContent>
         </Card>
-    {:else if filteredThemes().length === 0}
+    {:else if filteredThemes.length === 0}
         <Card>
             <CardContent class="py-12 text-center">
                 <Package class="text-muted-foreground mx-auto mb-4 h-12 w-12" />
@@ -378,7 +378,7 @@
         </Card>
     {:else}
         <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {#each filteredThemes() as theme (theme.id)}
+            {#each filteredThemes as theme (theme.id)}
                 <Card class="overflow-hidden transition-shadow hover:shadow-lg">
                     {#if theme.screenshot}
                         <div class="bg-muted aspect-video">

--- a/apps/web/src/routes/my/exp/+page.svelte
+++ b/apps/web/src/routes/my/exp/+page.svelte
@@ -228,14 +228,14 @@
                 <CardTitle class="flex items-center gap-2">
                     경험치 내역
                     <span class="text-muted-foreground text-sm font-normal">
-                        ({filteredItems().length}건)
+                        ({filteredItems.length}건)
                     </span>
                 </CardTitle>
             </CardHeader>
             <CardContent>
-                {#if filteredItems().length > 0}
+                {#if filteredItems.length > 0}
                     <ul class="divide-border divide-y">
-                        {#each filteredItems() as history (history.id)}
+                        {#each filteredItems as history (history.id)}
                             <li class="flex items-center justify-between py-3 first:pt-0 last:pb-0">
                                 <div class="flex items-center gap-3">
                                     <!-- 증감 아이콘 -->

--- a/apps/web/src/routes/my/points/+page.svelte
+++ b/apps/web/src/routes/my/points/+page.svelte
@@ -178,14 +178,14 @@
                 <CardTitle class="flex items-center gap-2">
                     포인트 내역
                     <span class="text-muted-foreground text-sm font-normal">
-                        ({filteredItems().length}건)
+                        ({filteredItems.length}건)
                     </span>
                 </CardTitle>
             </CardHeader>
             <CardContent>
-                {#if filteredItems().length > 0}
+                {#if filteredItems.length > 0}
                     <ul class="divide-border divide-y">
-                        {#each filteredItems() as item (item.id)}
+                        {#each filteredItems as item (item.id)}
                             <li class="py-3 first:pt-0 last:pb-0">
                                 <div class="flex items-center justify-between gap-4">
                                     <div class="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- `$derived.by`로 정의된 값을 `()`로 함수 호출하던 500 에러 일괄 수정
- 6개 파일, 12곳 수정

## 수정 대상
| 파일 | 변수 | 수정 |
|------|------|------|
| `[boardId]/+page.svelte` | `canWrite`, `writePermissionMessage` | 3곳 |
| `[boardId]/write/+page.svelte` | `canWrite` | 1곳 |
| `admin/themes/marketplace` | `filteredThemes` | 2곳 |
| `admin/plugins/marketplace` | `filteredPlugins` | 2곳 |
| `my/exp` | `filteredItems` | 3곳 |
| `my/points` | `filteredItems` | 3곳 |

## Test plan
- [x] `pnpm build` 성공
- [ ] /free 게시판 목록 500 에러 해소 확인
- [ ] /free/write 글쓰기 페이지 정상 확인
- [ ] /my/exp, /my/points 페이지 정상 확인