### PR TITLE
fix: $derived.by 값을 함수 호출하던 버그 일괄 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -59,7 +59,7 @@
     }: Props = $props();
 
     // 댓글/답글 작성 권한 체크
-    const canComment = $derived(() => {
+    const canComment = $derived.by(() => {
         if (!authStore.isAuthenticated) return false;
         // 서버에서 계산된 권한 정보가 있으면 사용
         if (permissions) {

--- a/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
@@ -35,7 +35,7 @@
     const isSold = $derived(market.status === 'sold');
 
     // 상태 배지 스타일
-    const statusBadge = $derived(() => {
+    const statusBadge = $derived.by(() => {
         const s = market.status;
         switch (s) {
             case 'selling':

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -27,7 +27,7 @@
     const hasImage = $derived(Boolean(thumbnailUrl));
 
     // HTML 태그 제거하여 미리보기 텍스트 생성
-    const previewText = $derived(() => {
+    const previewText = $derived.by(() => {
         if (!post.content) return '';
         const maxLen = displaySettings?.preview_length || 200;
         const stripped = post.content

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -148,7 +148,7 @@
     });
 
     // 페이지 번호 배열 계산
-    const pageNumbers = $derived(() => {
+    const pageNumbers = $derived.by(() => {
         const pages: number[] = [];
         const startPage = Math.max(1, currentPage - 2);
         const endPage = Math.min(totalPages, startPage + 4);

--- a/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
+++ b/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
@@ -115,7 +115,7 @@
     }
 
     // 4칸 슬롯 배열 생성 (side-image-text-banner용)
-    const slots = $derived(() => {
+    const slots = $derived.by(() => {
         if (position !== 'side-image-text-banner') return null;
         const result: (BannerItem | null)[] = [null, null, null, null];
         banners.slice(0, 4).forEach((b, i) => {

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -111,7 +111,7 @@
     const boardTypeComponent = $derived(boardTypeRegistry.resolve(boardType));
 
     // 목록 보기 권한 체크 (list_level이 0보다 크고 인증된 경우에만 체크)
-    const canList = $derived(() => {
+    const canList = $derived.by(() => {
         if (!authStore.isAuthenticated) {
             // 비회원 레벨=1, list_level<=1이면 공개 게시판
             const requiredLevel = data.board?.list_level ?? 1;
@@ -124,13 +124,13 @@
     );
 
     // 글쓰기 권한 체크 (서버 permissions 우선, 클라이언트 레벨 비교 폴백)
-    const canWrite = $derived(() => {
+    const canWrite = $derived.by(() => {
         if (!authStore.isAuthenticated) return false;
         return checkPermission(data.board, 'can_write', authStore.user ?? null);
     });
 
     // 권한 부족 시 표시할 메시지
-    const writePermissionMessage = $derived(() => {
+    const writePermissionMessage = $derived.by(() => {
         if (!authStore.isAuthenticated) return '로그인이 필요합니다';
         return getPermissionMessage(data.board, 'can_write', authStore.user ?? null);
     });

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -41,7 +41,7 @@
 
     // 글쓰기 권한 체크
     const requiredLevel = $derived(data.board?.write_level ?? 3);
-    const canWrite = $derived(() => {
+    const canWrite = $derived.by(() => {
         if (!authStore.isAuthenticated) return false;
         if (isRestricted) return false;
         return checkPermission(data.board, 'can_write', authStore.user ?? null);

--- a/apps/web/src/routes/admin/plugins/marketplace/+page.svelte
+++ b/apps/web/src/routes/admin/plugins/marketplace/+page.svelte
@@ -125,7 +125,7 @@
     });
 
     /** 검색 필터링 */
-    const filteredPlugins = $derived(() => {
+    const filteredPlugins = $derived.by(() => {
         let result = plugins;
 
         if (activeCategory !== 'all') {

--- a/apps/web/src/routes/admin/themes/marketplace/+page.svelte
+++ b/apps/web/src/routes/admin/themes/marketplace/+page.svelte
@@ -274,7 +274,7 @@
     });
 
     /** 검색 + 카테고리 필터링 */
-    const filteredThemes = $derived(() => {
+    const filteredThemes = $derived.by(() => {
         let result = themes;
 
         if (activeCategory !== 'all') {

--- a/apps/web/src/routes/my/exp/+page.svelte
+++ b/apps/web/src/routes/my/exp/+page.svelte
@@ -26,7 +26,7 @@
     ];
 
     // 필터링된 아이템
-    let filteredItems = $derived(() => {
+    let filteredItems = $derived.by(() => {
         if (!expHistory) return [];
         if (data.filter === 'earned') return expHistory.items.filter((item) => item.exp_point > 0);
         if (data.filter === 'used') return expHistory.items.filter((item) => item.exp_point < 0);

--- a/apps/web/src/routes/my/points/+page.svelte
+++ b/apps/web/src/routes/my/points/+page.svelte
@@ -23,7 +23,7 @@
     ];
 
     // 필터링된 아이템
-    let filteredItems = $derived(() => {
+    let filteredItems = $derived.by(() => {
         if (!pointData) return [];
         if (data.filter === 'earned') return pointData.items.filter((item) => item.po_point > 0);
         if (data.filter === 'used') return pointData.items.filter((item) => item.po_point < 0);


### PR DESCRIPTION
## Summary
- `$derived(() => {})` → `$derived.by(() => {})` 변환 (13건)
- 호출부 `variable()` → `variable` 수정 (27건)
- 500 에러 및 스켈레톤 멈춤 현상 해결

## Test plan
- [x] dev 환경에서 /free, /free/detail, /economy, /car, /bug 모두 200 확인
- [x] 서버 에러 0건 확인