### PR TITLE
fix: SSR 인증 상태 공유 버그 긴급 수정

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -21,19 +21,33 @@
     import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon';
     import { menuStore } from '$lib/stores/menu.svelte';
     import { getIcon } from '$lib/utils/icon-map';
+    import { page } from '$app/stores';
+
+    // SSR 안전한 인증 상태: authStore.isLoading(SSR) 시 $page.data.user 사용
+    // authStore의 $state는 모듈 레벨이라 SSR에서 요청간 공유 → $page.data는 요청별 안전
+    const ssrUser = $derived(
+        $page.data.user
+            ? {
+                  mb_id: $page.data.user.id ?? '',
+                  mb_name: $page.data.user.nickname ?? '',
+                  mb_level: $page.data.user.level ?? 0,
+                  mb_image: $page.data.user.mb_image
+              }
+            : null
+    );
+    const effectiveUser = $derived(authStore.isLoading ? ssrUser : authStore.user);
+    const isEffectivelyLoggedIn = $derived(effectiveUser !== null && effectiveUser !== undefined);
 
     let headerAvatarUrl = $derived(
-        authStore.user
-            ? getAvatarUrl(authStore.user.mb_image) ||
-                  getMemberIconUrl(authStore.user.mb_id) ||
-                  null
+        effectiveUser
+            ? getAvatarUrl(effectiveUser.mb_image) || getMemberIconUrl(effectiveUser.mb_id) || null
             : null
     );
     let headerAvatarFailed = $state(false);
 
     // user 변경 시 실패 상태 리셋
     $effect(() => {
-        if (authStore.user) untrack(() => (headerAvatarFailed = false));
+        if (effectiveUser) untrack(() => (headerAvatarFailed = false));
     });
 
     // 스크롤 상태 관리
@@ -286,7 +300,7 @@
             </button>
 
             <!-- 사용자 아이콘 (로그인/프로필) -->
-            {#if authStore.isAuthenticated && authStore.user}
+            {#if isEffectivelyLoggedIn && effectiveUser}
                 <a
                     href="/my"
                     class="hover:bg-accent flex items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all duration-200 ease-out"
@@ -300,7 +314,7 @@
                         {#if headerAvatarUrl && !headerAvatarFailed}
                             <img
                                 src={headerAvatarUrl}
-                                alt={authStore.user.mb_name}
+                                alt={effectiveUser.mb_name}
                                 class="h-full w-full object-cover"
                                 onerror={() => {
                                     headerAvatarFailed = true;
@@ -308,12 +322,12 @@
                             />
                         {:else}
                             <span class="text-primary text-xs font-bold"
-                                >{authStore.user.mb_name.charAt(0).toUpperCase()}</span
+                                >{effectiveUser.mb_name.charAt(0).toUpperCase()}</span
                             >
                         {/if}
                     </div>
                     <span class="text-foreground hidden text-sm font-medium md:inline">
-                        {authStore.user.mb_name}
+                        {effectiveUser.mb_name}
                     </span>
                 </a>
             {:else}
@@ -327,7 +341,7 @@
                 </button>
             {/if}
 
-            {#if authStore.isAuthenticated}
+            {#if isEffectivelyLoggedIn}
                 <!-- 쪽지 아이콘 -->
                 <button
                     onclick={() => goto('/messages')}

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -52,10 +52,7 @@ function initFromSSR(
         mb_level: ssrUser.level,
         mb_email: ''
     };
-    // accessToken은 클라이언트에서만 설정 (SSR에서 글로벌 상태 오염 방지)
-    if (typeof window !== 'undefined') {
-        apiClient.setAccessToken(accessToken);
-    }
+    apiClient.setAccessToken(accessToken);
     isLoading = false;
 }
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -39,7 +39,7 @@
 
     const { children, data } = $props(); // Svelte 5: SSR 데이터 받기
 
-    // 인증 상태 동기화 — SSR + 클라이언트 모두에서 즉시 실행
+    // 인증 상태 동기화 (클라이언트 전용 — 모듈 레벨 $state는 SSR에서 요청간 공유되므로)
     function syncAuth(d: typeof data) {
         if (d.user && d.accessToken) {
             authActions.initFromSSR(
@@ -56,14 +56,14 @@
         }
     }
 
-    // 즉시 실행: SSR에서도 인증 상태 반영 (로그인 버튼 깜빡임 방지)
-    syncAuth(data);
-
-    // $effect: data.user 변경 시 인증 상태 자동 동기화 (SPA 네비게이션 시)
+    // $effect: SPA 네비게이션 시 data.user 변경 감지 → 인증 상태 동기화
+    let authInitialized = false;
     $effect(() => {
         const u = data.user;
         const t = data.accessToken;
-        untrack(() => syncAuth(data));
+        if (authInitialized) {
+            untrack(() => syncAuth(data));
+        }
     });
 
     // /admin, /install 경로 여부 확인 (테마 레이아웃 적용 안함)
@@ -264,6 +264,10 @@
 
         // 슬롯 기본 컴포넌트 등록 (포크 시 slot-defaults.ts 수정으로 커스터마이징)
         registerDefaultSlots();
+
+        // 인증 상태 초기화 (클라이언트 전용 — SSR에서는 data.user를 직접 사용)
+        syncAuth(data);
+        authInitialized = true;
 
         // postMessage 리스너 (Admin에서 테마 변경 시 리로드)
         function handleMessage(event: MessageEvent) {


### PR DESCRIPTION
## Summary
- `syncAuth()`를 `onMount`로 되돌림 (모듈 레벨 `$state`는 SSR에서 요청간 공유됨)
- 헤더: SSR 시 `$page.data.user` 사용, 클라이언트에서 `authStore` 사용
- `effectiveUser` 패턴으로 SSR/클라이언트 모두 올바른 사용자 표시

## 원인
- PR #469에서 `syncAuth()`를 스크립트 최상위에서 실행하도록 변경
- `auth.svelte.ts`의 `$state`가 모듈 레벨 → SSR에서 모든 요청이 같은 상태 공유
- 유저 A 요청이 `user = A` 설정 → 유저 B 요청의 SSR HTML에 유저 A가 렌더링

## Test plan
- [ ] 새로고침 시 올바른 사용자 표시 확인
- [ ] 다른 브라우저에서 동시 접속 시 각자 올바른 사용자 표시
- [ ] 비로그인 → 로그인 후 프로필 아이콘 정상 표시