### PR TITLE
fix: SSR 인증 상태 오염 근본 수정

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -22,9 +22,12 @@
     import { menuStore } from '$lib/stores/menu.svelte';
     import { getIcon } from '$lib/utils/icon-map';
     import { page } from '$app/stores';
+    import { browser } from '$app/environment';
 
-    // SSR 안전한 인증 상태: authStore.isLoading(SSR) 시 $page.data.user 사용
-    // authStore의 $state는 모듈 레벨이라 SSR에서 요청간 공유 → $page.data는 요청별 안전
+    // SSR 안전한 인증 상태:
+    // - 서버(SSR): $page.data.user 사용 (요청별 안전, 모듈 레벨 상태 오염 없음)
+    // - 클라이언트(hydration 전): $page.data.user 사용 (authStore.isLoading = true)
+    // - 클라이언트(onMount 후): authStore.user 사용 (syncAuth로 초기화됨)
     const ssrUser = $derived(
         $page.data.user
             ? {
@@ -35,7 +38,7 @@
               }
             : null
     );
-    const effectiveUser = $derived(authStore.isLoading ? ssrUser : authStore.user);
+    const effectiveUser = $derived(browser && !authStore.isLoading ? authStore.user : ssrUser);
     const isEffectivelyLoggedIn = $derived(effectiveUser !== null && effectiveUser !== undefined);
 
     let headerAvatarUrl = $derived(


### PR DESCRIPTION
## Summary
- 헤더에서 `browser` 플래그로 SSR/클라이언트 분기
- 서버에서는 항상 `$page.data.user` 사용 (요청별 안전)
- `authStore.isLoading`도 모듈 레벨 `$state`라 SSR에서 오염 가능했음

## 원인
- PR #471에서 `authStore.isLoading`으로 SSR/클라이언트 분기했으나
- `isLoading`도 모듈 레벨 `$state` → 이전 요청에서 `false`로 설정되면 다음 SSR 요청에서도 `false`
- → 이전 요청의 `authStore.user`가 노출

## Test plan
- [ ] 여러 사용자 동시 접속 시 각자 올바른 사용자 표시
- [ ] 새로고침 시 올바른 사용자 유지
- [ ] 비로그인 → 로그인 → 프로필 아이콘 정상 표시