### PR TITLE
fix: View Transitions API 비활성화 (SPA 깜빡임 제거)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -352,51 +352,7 @@
     }
 }
 
-/* View Transitions API — 부드러운 페이지 전환 애니메이션 */
-@keyframes fade-in {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-@keyframes fade-out {
-    to {
-        opacity: 0;
-    }
-}
-
-/* 기존 root 전환 — 이름 없는 요소의 fallback */
-::view-transition-old(root) {
-    animation: 90ms fade-out ease-out;
-}
-
-::view-transition-new(root) {
-    animation: 210ms fade-in ease-in;
-}
-
-/* 헤더/사이드바/패널/푸터 — 전환 없음 (안정적 유지) */
-::view-transition-old(header),
-::view-transition-new(header),
-::view-transition-old(sidebar),
-::view-transition-new(sidebar),
-::view-transition-old(panel),
-::view-transition-new(panel),
-::view-transition-old(footer),
-::view-transition-new(footer) {
-    animation: none;
-}
-
-/* 콘텐츠 영역만 부드러운 전환 */
-::view-transition-old(content) {
-    animation: 80ms fade-out ease-out;
-}
-
-::view-transition-new(content) {
-    animation: 120ms fade-in ease-in;
-}
+/* View Transitions API — 비활성화됨 (SPA 네비게이션 깜빡임/쪼그라듦 유발) */
 
 /* 네비게이션 프로그레스바 */
 @keyframes nav-progress {

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -142,17 +142,17 @@
         }
     });
 
-    // View Transitions API — 부드러운 페이지 전환 (지원 브라우저에서만, 모션 감소 설정 존중)
-    onNavigate((navigation) => {
-        if (!document.startViewTransition || matchMedia('(prefers-reduced-motion: reduce)').matches)
-            return;
-        return new Promise((resolve) => {
-            document.startViewTransition(async () => {
-                resolve();
-                await navigation.complete;
-            });
-        });
-    });
+    // View Transitions API — 비활성화 (SPA 네비게이션 깜빡임 유발)
+    // onNavigate((navigation) => {
+    //     if (!document.startViewTransition || matchMedia('(prefers-reduced-motion: reduce)').matches)
+    //         return;
+    //     return new Promise((resolve) => {
+    //         document.startViewTransition(async () => {
+    //             resolve();
+    //             await navigation.complete;
+    //         });
+    //     });
+    // });
 
     // 새 버전 감지 시 다음 네비게이션에서 풀 리로드 (최대 2회, 무한 루프 방지)
     const UPDATED_RELOAD_KEY = '__angple_updated_reload__';


### PR DESCRIPTION
## Summary
- View Transitions API의 onNavigate 훅 비활성화
- View Transition CSS 규칙 전부 제거
- SPA 네비게이션 시 헤더/사이드바/광고 영역 깜빡임 및 레이아웃 쪼그라듦 해소

## Test plan
- [x] dev.damoang.net에서 목록→본문, 본문→목록 이동 확인
- [x] 헤더/사이드바/윙 배너 고정 유지 확인
- [x] GAM 광고 정상 표시 확인