### PR TITLE
fix: 중복된 head 태그 제거로 SEO 메타 태그를 덮어쓰는 문제 방지

### DIFF
--- a/apps/web/src/lib/layouts/default-layout.svelte
+++ b/apps/web/src/lib/layouts/default-layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import '../../app.css';
-    import favicon from '$lib/assets/favicon.png';
     import { onMount } from 'svelte';
     import Header from '$lib/components/layout/header.svelte';
     import Sidebar from '$lib/components/layout/sidebar.svelte';
@@ -23,12 +22,6 @@
         authActions.initAuth();
     });
 </script>
-
-<svelte:head>
-    <title>{import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href={favicon} />
-</svelte:head>
 
 <div class="relative flex min-h-screen flex-col items-center">
     <!-- 배경 박스 -->

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -340,7 +340,6 @@
 <svelte:window onkeydown={(e) => keyboardShortcutsMod?.keyboardShortcuts.handleKeydown(e)} />
 
 <svelte:head>
-    <title>{import.meta.env.VITE_SITE_NAME || '다모앙'} - 종합 커뮤니티</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href={favicon} />
 </svelte:head>


### PR DESCRIPTION
중복 태그로 인해 SSR에서 SEO 메타 태그가 덮어쓰어져 검색 엔진에 사이트 제목이 잘못 표시되는 문제 발생
기본 레이아웃(default-layout.svelte) 및 추가 레이아웃(layout.svelte)에서 중복된 `<svelte:head>` 섹션 제거