### PR TITLE
fix: 소모임 더보기 링크를 SvelteKit 라우트로 수정

### DIFF
--- a/apps/web/src/lib/components/features/group/group-tabs.svelte
+++ b/apps/web/src/lib/components/features/group/group-tabs.svelte
@@ -29,8 +29,7 @@
         <div class="flex items-center gap-2">
             <GroupTabs bind:activeTab onTabChange={handleTabChange} />
             <a
-                href="/bbs/group.php?gr_id=group"
-                rel="external"
+                href="/groups"
                 class="text-muted-foreground hover:text-foreground flex items-center gap-1 text-[15px] transition-all duration-200 ease-out"
             >
                 더보기


### PR DESCRIPTION
## Summary
- 소모임 "더보기" 링크를 레거시 PHP URL(`/bbs/group.php?gr_id=group`)에서 SvelteKit 라우트(`/groups`)로 변경
- 불필요한 `rel="external"` 속성 제거

## Test plan
- [ ] 메인 페이지 소모임 섹션에서 "더보기" 클릭 시 `/groups` 페이지로 정상 이동 확인
- [ ] SvelteKit 클라이언트 사이드 네비게이션 정상 동작 확인