### PR TITLE
fix: 앙티콘 hover 확대 크기 증가

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -167,7 +167,7 @@
                 <img
                     src={display.url}
                     alt={display.label}
-                    class="h-5 w-5 object-scale-down transition-transform group-hover:scale-[2.5]"
+                    class="h-5 w-5 object-scale-down transition-transform group-hover:scale-[25]"
                 />
             {:else}
                 <span class="text-base leading-none">{display.emoji}</span>


### PR DESCRIPTION
## Summary
- 앙티콘(리액션 이모티콘) hover 시 확대 크기를 2.5x → 25x로 변경
- 작은 앙티콘을 hover했을 때 더 크게 미리보기 가능

## Test plan
- [x] dev 환경에서 리액션 앙티콘에 마우스 올려서 확대 크기 확인