### PR TITLE
fix: 메인 페이지 폰트 크기 통일 및 앙티콘 hover 확대

### DIFF
--- a/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
+++ b/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
@@ -38,7 +38,7 @@
                 >
                     <div class="flex items-center gap-2">
                         <div
-                            class="min-w-0 flex-1 truncate text-sm leading-relaxed {getReadPostClasses(
+                            class="min-w-0 flex-1 truncate text-base leading-relaxed {getReadPostClasses(
                                 showReadState &&
                                     readPostsStore.isRead(getBoardId(post.url), post.id)
                             )}"

--- a/apps/web/src/lib/components/features/economy/economy-tabs.svelte
+++ b/apps/web/src/lib/components/features/economy/economy-tabs.svelte
@@ -30,7 +30,7 @@
             >
                 <ShoppingCart class="h-4 w-4 text-green-500" />
             </div>
-            <h3 class="text-foreground text-base font-semibold">알뜰구매</h3>
+            <h3 class="text-foreground text-lg font-semibold">알뜰구매</h3>
         </div>
         <EconomyTabs bind:activeTab onTabChange={handleTabChange} />
     </CardHeader>

--- a/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
+++ b/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
@@ -22,7 +22,7 @@
             >
                 <Images class="h-4 w-4 text-purple-500" />
             </div>
-            <h3 class="text-foreground text-base font-semibold">갤러리</h3>
+            <h3 class="text-foreground text-lg font-semibold">갤러리</h3>
         </div>
         <a
             href="/gallery"

--- a/apps/web/src/lib/components/features/group/components/header/group-header.svelte
+++ b/apps/web/src/lib/components/features/group/components/header/group-header.svelte
@@ -8,5 +8,5 @@
     >
         <Users class="h-4 w-4 text-orange-500" />
     </div>
-    <h3 class="text-foreground text-base font-semibold">소모임 추천글</h3>
+    <h3 class="text-foreground text-lg font-semibold">소모임 추천글</h3>
 </div>

--- a/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
+++ b/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
@@ -46,7 +46,7 @@
                             {formatNumber(post.recommend_count)}
                         </span>
                         <div
-                            class="min-w-0 flex-1 truncate text-sm leading-relaxed {getReadPostClasses(
+                            class="min-w-0 flex-1 truncate text-base leading-relaxed {getReadPostClasses(
                                 showReadState &&
                                     readPostsStore.isRead(getBoardId(post.url), post.id)
                             )}"

--- a/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
@@ -32,7 +32,7 @@
                 >
                     <div class="flex items-center gap-2">
                         <div
-                            class="min-w-0 flex-1 truncate text-sm leading-relaxed {getReadPostClasses(
+                            class="min-w-0 flex-1 truncate text-base leading-relaxed {getReadPostClasses(
                                 showReadState && readPostsStore.isRead(post.board, post.id)
                             )}"
                         >

--- a/apps/web/src/lib/components/features/new-board/new-board.svelte
+++ b/apps/web/src/lib/components/features/new-board/new-board.svelte
@@ -30,7 +30,7 @@
             >
                 <Newspaper class="h-4 w-4 text-blue-500" />
             </div>
-            <h3 class="text-foreground text-base font-semibold">새로운 소식</h3>
+            <h3 class="text-foreground text-lg font-semibold">새로운 소식</h3>
         </div>
         <NewsTabs bind:activeTab onTabChange={handleTabChange} />
     </CardHeader>

--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -167,7 +167,7 @@
                 <img
                     src={display.url}
                     alt={display.label}
-                    class="h-5 w-5 object-scale-down transition-transform group-hover:scale-[25]"
+                    class="h-5 w-5 object-scale-down transition-transform group-hover:scale-[100]"
                 />
             {:else}
                 <span class="text-base leading-none">{display.emoji}</span>

--- a/apps/web/src/lib/components/features/recommended/components/header/recommended-header.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/header/recommended-header.svelte
@@ -8,5 +8,5 @@
     >
         <Flame class="h-4 w-4 text-orange-500" />
     </div>
-    <h3 class="text-foreground text-base font-semibold">추천 글</h3>
+    <h3 class="text-foreground text-lg font-semibold">추천 글</h3>
 </div>

--- a/apps/web/src/lib/components/ui/post-card/post-card.svelte
+++ b/apps/web/src/lib/components/ui/post-card/post-card.svelte
@@ -43,7 +43,7 @@
             </span>
             <!-- text-truncate -->
             <div
-                class="min-w-0 flex-1 truncate text-sm leading-relaxed {getReadPostClasses(
+                class="min-w-0 flex-1 truncate text-base leading-relaxed {getReadPostClasses(
                     showReadState && readPostsStore.isRead(getBoardId(post.url), post.id)
                 )}"
             >


### PR DESCRIPTION
## Summary
- 메인 페이지 위젯 글 목록 폰트 크기를 `text-base`(16px)로 통일
- 위젯 헤더 폰트 크기를 `text-lg`(18px)로 통일
- 앙티콘(리액션) hover 시 확대 효과를 `scale-[100]`으로 변경

## 변경 내역
- 추천글, 새로운 소식, 알뜰구매, 소모임 추천글, 갤러리 위젯의 글 목록 텍스트: `text-sm` → `text-base`
- 각 위젯 헤더: `text-base` → `text-lg`
- 리액션 바 앙티콘 hover scale: `scale-[2.5]` → `scale-[100]`

## Test plan
- [ ] dev.damoang.net 메인 페이지에서 모든 위젯 글 목록 폰트 크기 동일 확인
- [ ] 각 위젯 헤더 크기 확인
- [ ] 앙티콘 hover 시 확대 효과 확인