### PR TITLE
fix: 앙티콘 hover 확대를 피커 내 제자리 확대로 변경

### DIFF
--- a/apps/web/src/lib/components/features/board/emoticon-picker.svelte
+++ b/apps/web/src/lib/components/features/board/emoticon-picker.svelte
@@ -242,14 +242,8 @@
                                     <img
                                         src={thumbUrl(item)}
                                         alt={item.file}
-                                        class="size-10 object-contain"
+                                        class="size-10 object-contain transition-transform group-hover/emo:scale-[3]"
                                         loading="lazy"
-                                    />
-                                    <!-- 호버 확대 미리보기 -->
-                                    <img
-                                        src={thumbUrl(item)}
-                                        alt={item.file}
-                                        class="pointer-events-none absolute -top-20 left-1/2 hidden size-16 -translate-x-1/2 rounded-lg border bg-white object-contain p-1 shadow-lg group-hover/emo:block dark:bg-zinc-800"
                                     />
                                 </button>
                             {/each}

--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -167,7 +167,7 @@
                 <img
                     src={display.url}
                     alt={display.label}
-                    class="h-5 w-5 object-scale-down transition-transform group-hover:scale-[100]"
+                    class="h-5 w-5 object-scale-down transition-transform group-hover:scale-[2.5]"
                 />
             {:else}
                 <span class="text-base leading-none">{display.emoji}</span>
@@ -249,13 +249,7 @@
                             <img
                                 src={emo.url}
                                 alt={emo.reaction}
-                                class="h-7 w-7 object-scale-down"
-                            />
-                            <!-- 호버 확대 미리보기 -->
-                            <img
-                                src={emo.url}
-                                alt={emo.reaction}
-                                class="pointer-events-none absolute -top-16 left-1/2 hidden h-14 w-14 -translate-x-1/2 rounded-lg border bg-white object-scale-down p-1 shadow-lg group-hover/emo:block dark:bg-zinc-800"
+                                class="h-7 w-7 object-scale-down transition-transform group-hover/emo:scale-[4]"
                             />
                         {:else}
                             <span class="text-xl leading-none">{emo.emoji}</span>


### PR DESCRIPTION
## Summary
- 리액션 바 뱃지 `scale-[100]` → 원래 `scale-[2.5]`로 복원
- 리액션 피커: 별도 미리보기 이미지 제거 → 제자리 `scale-[4]` 확대
- 이모티콘 피커: 별도 미리보기 이미지 제거 → 제자리 `scale-[3]` 확대