### PR TITLE
fix: 앙티콘 hover 확대 시 z-index 최상위로 표시

### DIFF
--- a/apps/web/src/lib/components/features/board/emoticon-picker.svelte
+++ b/apps/web/src/lib/components/features/board/emoticon-picker.svelte
@@ -242,7 +242,7 @@
                                     <img
                                         src={thumbUrl(item)}
                                         alt={item.file}
-                                        class="size-10 object-contain transition-transform group-hover/emo:scale-[3]"
+                                        class="size-10 object-contain transition-transform group-hover/emo:z-50 group-hover/emo:scale-[3]"
                                         loading="lazy"
                                     />
                                 </button>

--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -249,7 +249,7 @@
                             <img
                                 src={emo.url}
                                 alt={emo.reaction}
-                                class="h-7 w-7 object-scale-down transition-transform group-hover/emo:scale-[4]"
+                                class="h-7 w-7 object-scale-down transition-transform group-hover/emo:z-50 group-hover/emo:scale-[4]"
                             />
                         {:else}
                             <span class="text-xl leading-none">{emo.emoji}</span>


### PR DESCRIPTION
## Summary
- 리액션 피커, 이모티콘 피커에서 hover 확대 시 `z-50` 적용하여 다른 요소에 가리지 않도록 수정