### PR TITLE
perf: 페이지 이동 속도 개선

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -82,7 +82,7 @@
         ></script>
         %sveltekit.head%
     </head>
-    <body data-sveltekit-preload-data="tap">
+    <body data-sveltekit-preload-data="hover">
         <div style="display: contents">%sveltekit.body%</div>
         <!-- Safari bfcache 복원 시 stale 상태 방지 -->
         <script>

--- a/apps/web/src/lib/api/retry.ts
+++ b/apps/web/src/lib/api/retry.ts
@@ -14,9 +14,9 @@ export interface RetryConfig {
 }
 
 export const DEFAULT_RETRY_CONFIG: RetryConfig = {
-    maxRetries: 2,
-    baseDelay: 1000,
-    timeout: 15000
+    maxRetries: 1,
+    baseDelay: 500,
+    timeout: 8000
 };
 
 /** 지수 백오프 딜레이 계산 */

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -207,7 +207,6 @@
             </button>
             <a
                 href="/"
-                data-sveltekit-reload
                 class="flex items-center ps-1 md:ps-0"
                 onclick={(e: MouseEvent) => {
                     if (window.location.pathname === '/') {
@@ -231,7 +230,6 @@
                         href={headerMenu.url}
                         target={headerMenu.target === '_blank' ? '_blank' : undefined}
                         rel={headerMenu.target === '_blank' || isExternal ? 'noopener' : undefined}
-                        data-sveltekit-reload={isHome ? '' : undefined}
                         class="text-foreground hover:text-primary flex items-center transition-all duration-200 ease-out"
                         onclick={isHome
                             ? (e: MouseEvent) => {
@@ -250,7 +248,6 @@
                 <!-- headerMenus가 비어있으면 홈 링크만 기본 표시 -->
                 <a
                     href="/"
-                    data-sveltekit-reload
                     class="text-foreground hover:text-primary flex items-center transition-all duration-200 ease-out"
                     onclick={(e: MouseEvent) => {
                         if (window.location.pathname === '/') {

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -192,21 +192,27 @@
     // - LCP/FCP 개선, invisible 대기 시간 0ms
     const ThemeLayout = $derived(getThemeLayout(data.activeTheme));
 
-    // 테마 Hook 및 Component 로드 (레이아웃과 별개로 동작)
+    // 테마 Hook 및 Component 로드 (변경 시에만)
+    let prevThemeId = '';
     $effect(() => {
         const theme = data.activeTheme;
-        if (theme) {
+        if (theme && theme !== prevThemeId) {
+            prevThemeId = theme;
             loadThemeHooks(theme);
             loadThemeComponents(theme);
         }
     });
 
-    // activePlugins 변경 시 플러그인 Hook 및 Component 로드
+    // activePlugins 변경 시 플러그인 Hook 및 Component 로드 (ID 변경 시에만)
+    let prevPluginIds = '';
     $effect(() => {
-        if (activePlugins.length > 0) {
+        const plugins = activePlugins;
+        const pluginIds = plugins.map((p) => p.id).join(',');
+        if (plugins.length > 0 && pluginIds !== prevPluginIds) {
+            prevPluginIds = pluginIds;
             // 플러그인 Hook 로드 후 액션 실행
             loadAllPluginHooks(
-                activePlugins.map((p) => ({
+                plugins.map((p) => ({
                     id: p.id,
                     manifest: {
                         id: p.id,
@@ -223,7 +229,7 @@
 
             // 플러그인 Component 로드
             loadAllPluginComponents(
-                activePlugins.map((p) => ({
+                plugins.map((p) => ({
                     id: p.id,
                     manifest: {
                         id: p.id,


### PR DESCRIPTION
## Summary
- preload 전략 `tap` → `hover` 변경 (hover 시 ~200ms 데이터 선점)
- 홈 링크 `data-sveltekit-reload` 제거 (풀 리로드 → SPA 네비게이션)
- 클라이언트 API retry timeout 15초→8초, maxRetries 2→1, baseDelay 1초→0.5초
- 테마/플러그인 Hook `$effect` 중복 실행 방지 (ID 비교 후 스킵)

## Test plan
- [x] dev.damoang.net에서 페이지 이동 속도 개선 확인
- [ ] 홈 → 게시판: SPA 네비게이션 (풀 리로드 아님)
- [ ] 게시글 → 목록: hover 시 preload → 클릭 시 즉시 전환
- [ ] 연속 네비게이션: 플러그인/테마 불필요한 재로드 없음