### PR TITLE
fix: 사이드바 sticky 광고 레이아웃 개선

### DIFF
--- a/apps/web/src/lib/components/layout/panel.svelte
+++ b/apps/web/src/lib/components/layout/panel.svelte
@@ -6,7 +6,7 @@
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
 </script>
 
-<div class="flex min-h-full flex-col gap-4 p-4">
+<div class="flex flex-1 flex-col gap-4 p-4">
     <!-- Slot: sidebar-right-top -->
     {#each getComponentsForSlot('sidebar-right-top') as slotComp (slotComp.id)}
         {@const Component = slotComp.component}
@@ -29,9 +29,11 @@
     {/each}
 
     <!-- sidebar-sticky (GAM 300x600) -->
-    <div class="sticky top-[64px]">
-        <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
-            <AdSlot position="sidebar-sticky" height="600px" />
+    <div class="flex-1">
+        <div class="sticky top-[64px]">
+            <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
+                <AdSlot position="sidebar-sticky" height="600px" />
+            </div>
         </div>
     </div>
 </div>

--- a/apps/web/src/lib/layouts/default-layout.svelte
+++ b/apps/web/src/lib/layouts/default-layout.svelte
@@ -37,7 +37,7 @@
         <div class="mx-auto flex w-full flex-1">
             {#if snbPosition === 'right'}
                 <aside
-                    class="bg-subtle border-border my-5 hidden w-[320px] flex-shrink-0 rounded-md border lg:block"
+                    class="bg-subtle border-border my-5 hidden w-[320px] flex-shrink-0 rounded-md border lg:flex lg:flex-col"
                 >
                     <!-- 여기에 오른쪽 사이드바 내용 추가 -->
                     <Panel />
@@ -62,7 +62,7 @@
 
             {#if snbPosition === 'left'}
                 <aside
-                    class="bg-subtle border-border my-5 hidden w-[320px] flex-shrink-0 rounded-md border lg:block"
+                    class="bg-subtle border-border my-5 hidden w-[320px] flex-shrink-0 rounded-md border lg:flex lg:flex-col"
                 >
                     <!-- 여기에 오른쪽 사이드바 내용 추가 -->
                     <Panel />

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -1,6 +1,6 @@
 /* 모바일 좌우 스크롤 방지 (긴 URL, 광고 등으로 인한 레이아웃 밀림 차단) */
 html {
-    overflow-x: hidden;
+    overflow-x: clip;
     overflow-y: scroll;
     max-width: 100vw;
     /* 스크롤바 공간 예약 — 드롭다운/모달 열릴 때 콘텐츠 밀림 방지 */
@@ -8,7 +8,7 @@ html {
 }
 
 body {
-    overflow-x: hidden;
+    overflow-x: clip;
     max-width: 100vw;
 }
 


### PR DESCRIPTION
## Summary
- 사이드바 sticky 광고가 패널 하단까지 정상적으로 고정되도록 flex 레이아웃 구조 개선
- `overflow-x: hidden` → `clip`으로 변경하여 sticky 요소 동작 보장

## Changes
- `panel.svelte`: `min-h-full` → `flex-1`, sticky 광고 wrapper에 `flex-1` 추가
- `default-layout.svelte`: aside를 `lg:block` → `lg:flex lg:flex-col`로 변경
- `layout.css`: `overflow-x: hidden` → `overflow-x: clip`

## Test plan
- [ ] 사이드바 sticky 광고가 스크롤 시 정상 고정되는지 확인
- [ ] 모바일에서 좌우 스크롤 여전히 차단되는지 확인
- [ ] 사이드바 left/right 양쪽 레이아웃 정상 동작 확인