### PR TITLE
fix: 삭제된 댓글 관리자 원문 표시 및 복구 기능

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -716,6 +716,13 @@ class ApiClient {
         });
     }
 
+    async restoreComment(boardId: string, postId: string, commentId: string): Promise<void> {
+        await this.request<void>(
+            `/boards/${boardId}/posts/${postId}/comments/${commentId}/restore`,
+            { method: 'POST' }
+        );
+    }
+
     // ========================================
     // 스크랩 (Scrap/Bookmark)
     // ========================================

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -9,6 +9,7 @@
     import Link2 from '@lucide/svelte/icons/link-2';
     import Pencil from '@lucide/svelte/icons/pencil';
     import Trash2 from '@lucide/svelte/icons/trash-2';
+    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
     import CommentForm from './comment-form.svelte';
     import { ReportDialog } from '$lib/components/features/report/index.js';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
@@ -67,6 +68,7 @@
         ) => Promise<void>;
         onLike?: (commentId: string) => Promise<{ likes: number; user_liked: boolean }>;
         onDislike?: (commentId: string) => Promise<{ dislikes: number; user_disliked: boolean }>;
+        onRestore?: (commentId: string) => Promise<void>;
         postAuthorId?: string; // 게시글 작성자 ID (비밀댓글 열람 권한 체크용)
         boardId?: string; // 신고 기능용
         postId?: number; // 신고 기능용
@@ -84,6 +86,7 @@
         onReply,
         onLike,
         onDislike,
+        onRestore,
         postAuthorId,
         boardId = 'free',
         postId = 0,
@@ -133,6 +136,7 @@
     let editContent = $state('');
     let isUpdating = $state(false);
     let isDeleting = $state<string | null>(null);
+    let isRestoring = $state<string | null>(null);
 
     // 댓글 리비전 이력 상태 (관리자 전용)
     let revisionCommentId = $state<string | null>(null);
@@ -350,6 +354,22 @@
             alert('댓글 삭제에 실패했습니다.');
         } finally {
             isDeleting = null;
+        }
+    }
+
+    async function handleRestore(commentId: string): Promise<void> {
+        if (!onRestore) return;
+        if (!confirm('이 댓글을 복구하시겠습니까?')) return;
+
+        isRestoring = commentId;
+        try {
+            await onRestore(commentId);
+            toast.success('댓글이 복구되었습니다.');
+        } catch (err) {
+            console.error('Failed to restore comment:', err);
+            toast.error('댓글 복구에 실패했습니다.');
+        } finally {
+            isRestoring = null;
         }
     }
 
@@ -1065,6 +1085,18 @@
                             >
                                 {@html comment.content}
                             </div>
+                        {/if}
+                        {#if isSuperAdmin() && onRestore}
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                class="mt-1"
+                                disabled={isRestoring === String(comment.id)}
+                                onclick={() => handleRestore(String(comment.id))}
+                            >
+                                <RotateCcw class="mr-1 h-3 w-3" />
+                                {isRestoring === String(comment.id) ? '복구 중...' : '복구'}
+                            </Button>
                         {/if}
                     {:else if isEditing}
                         <!-- 댓글 수정 폼 -->

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -976,6 +976,11 @@
         await refetchComments();
     }
 
+    async function handleRestoreComment(commentId: string): Promise<void> {
+        await apiClient.restoreComment(boardId, String(data.post.id), commentId);
+        await refetchComments();
+    }
+
     // 댓글 추천
     async function handleLikeComment(
         commentId: string
@@ -1336,6 +1341,7 @@
                         {comments}
                         onUpdate={handleUpdateComment}
                         onDelete={handleDeleteComment}
+                        onRestore={handleRestoreComment}
                         onReply={handleReplyComment}
                         onLike={handleLikeComment}
                         onDislike={handleDislikeComment}

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -118,11 +118,25 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 
         const comments = rows.map((row) => ({
             id: row.wr_id,
-            content: row.wr_deleted_at ? '' : row.wr_content, // 삭제된 댓글은 내용 숨김
-            author: row.wr_deleted_at ? '' : nickMap.get(row.mb_id) || row.wr_name || row.mb_id,
-            author_id: row.wr_deleted_at ? '' : row.mb_id,
-            author_image: row.wr_deleted_at ? '' : imageMap.get(row.mb_id) || '',
-            author_ip: row.wr_deleted_at ? '' : isAdmin ? row.wr_ip : maskIp(row.wr_ip),
+            content: row.wr_deleted_at ? (isAdmin ? row.wr_content : '') : row.wr_content,
+            author: row.wr_deleted_at
+                ? isAdmin
+                    ? nickMap.get(row.mb_id) || row.wr_name || row.mb_id
+                    : ''
+                : nickMap.get(row.mb_id) || row.wr_name || row.mb_id,
+            author_id: row.wr_deleted_at ? (isAdmin ? row.mb_id : '') : row.mb_id,
+            author_image: row.wr_deleted_at
+                ? isAdmin
+                    ? imageMap.get(row.mb_id) || ''
+                    : ''
+                : imageMap.get(row.mb_id) || '',
+            author_ip: row.wr_deleted_at
+                ? isAdmin
+                    ? row.wr_ip
+                    : ''
+                : isAdmin
+                  ? row.wr_ip
+                  : maskIp(row.wr_ip),
             likes: row.wr_good,
             dislikes: row.wr_nogood,
             depth: row.wr_comment_reply.length,


### PR DESCRIPTION
## Summary
- 관리자에게 삭제된 댓글의 원문/작성자 정보 표시
- 관리자용 댓글 복구 버튼 추가
- restoreComment API 클라이언트 메서드 추가

## Test plan
- [ ] 관리자 로그인 시 삭제된 댓글 원문이 보이는지 확인
- [ ] 복구 버튼 클릭 시 댓글 복구되는지 확인