### PR TITLE
fix: 에셋 인라인화 안하게 변경

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => {
     return {
         plugins: [tailwindcss(), sveltekit()],
         build: {
-            assetsInlineLimit: 8192,
+            assetsInlineLimit: 0,
             chunkSizeWarningLimit: 1120
         },
         ssr: {


### PR DESCRIPTION
* 로고,파비콘 등이 인라인되어 base64로 전송되고있습니다.
브라우저캐시로 남게 인라인옵션을 끕니다.