### PR TITLE
feat: 댓글 경량 Tiptap 에디터 도입

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-editor.svelte
+++ b/apps/web/src/lib/components/features/board/comment-editor.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+    import { onMount, onDestroy } from 'svelte';
+    import { Editor } from '@tiptap/core';
+    import StarterKit from '@tiptap/starter-kit';
+    import Image from '@tiptap/extension-image';
+    import Link from '@tiptap/extension-link';
+    import Placeholder from '@tiptap/extension-placeholder';
+    import Mention from '@tiptap/extension-mention';
+    import { mentionSuggestion } from '$lib/components/features/editor/mention-suggestion';
+    import Bold from '@lucide/svelte/icons/bold';
+    import Italic from '@lucide/svelte/icons/italic';
+
+    interface Props {
+        content?: string;
+        placeholder?: string;
+        disabled?: boolean;
+        onUpdate?: (html: string) => void;
+        onImagePaste?: (file: File) => void;
+        onSubmitShortcut?: () => void;
+        class?: string;
+    }
+
+    let {
+        content = '',
+        placeholder = '댓글을 입력하세요...',
+        disabled = false,
+        onUpdate,
+        onImagePaste,
+        onSubmitShortcut,
+        class: className = ''
+    }: Props = $props();
+
+    let editorElement = $state<HTMLDivElement | null>(null);
+    let editor: Editor | null = null;
+    let isBold = $state(false);
+    let isItalic = $state(false);
+
+    onMount(() => {
+        if (!editorElement) return;
+
+        editor = new Editor({
+            element: editorElement,
+            extensions: [
+                StarterKit.configure({
+                    heading: false,
+                    bulletList: false,
+                    orderedList: false,
+                    blockquote: false,
+                    codeBlock: false,
+                    code: false,
+                    strike: false,
+                    horizontalRule: false,
+                    dropcursor: false,
+                    gapcursor: false
+                }),
+                Image.configure({ inline: true, allowBase64: false }),
+                Link.configure({ openOnClick: false }),
+                Placeholder.configure({ placeholder }),
+                Mention.configure({
+                    HTMLAttributes: { class: 'mention' },
+                    suggestion: mentionSuggestion
+                })
+            ],
+            content: content || '',
+            editable: !disabled,
+            editorProps: {
+                attributes: {
+                    class: 'prose-sm'
+                },
+                handleKeyDown: (_view, event) => {
+                    if ((event.altKey || event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+                        event.preventDefault();
+                        onSubmitShortcut?.();
+                        return true;
+                    }
+                    return false;
+                },
+                handlePaste: (_view, event) => {
+                    const items = event.clipboardData?.items;
+                    if (items) {
+                        for (const item of items) {
+                            if (item.type.startsWith('image/')) {
+                                event.preventDefault();
+                                const file = item.getAsFile();
+                                if (file) onImagePaste?.(file);
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+            },
+            onUpdate: ({ editor: e }) => {
+                onUpdate?.(e.getHTML());
+            },
+            onTransaction: ({ editor: e }) => {
+                isBold = e.isActive('bold');
+                isItalic = e.isActive('italic');
+            }
+        });
+    });
+
+    $effect(() => {
+        editor?.setEditable(!disabled);
+    });
+
+    onDestroy(() => {
+        editor?.destroy();
+    });
+
+    function toggleBold(): void {
+        editor?.chain().focus().toggleBold().run();
+    }
+
+    function toggleItalic(): void {
+        editor?.chain().focus().toggleItalic().run();
+    }
+
+    export function insertContent(text: string): void {
+        if (!editor) return;
+        editor.chain().focus().insertContent(text).run();
+    }
+
+    export function insertImage(src: string, alt?: string): void {
+        if (!editor) return;
+        editor
+            .chain()
+            .focus()
+            .setImage({ src, alt: alt || '' })
+            .run();
+    }
+
+    export function getHTML(): string {
+        return editor?.getHTML() ?? '';
+    }
+
+    export function clear(): void {
+        editor?.commands.clearContent(true);
+    }
+
+    export function focus(): void {
+        editor?.commands.focus();
+    }
+
+    export function getImageCount(): number {
+        if (!editor) return 0;
+        let count = 0;
+        editor.state.doc.descendants((node) => {
+            if (node.type.name === 'image') count++;
+        });
+        return count;
+    }
+</script>
+
+<div
+    class="comment-editor border-border bg-background focus-within:border-primary focus-within:ring-primary rounded-lg border focus-within:ring-1 {className}"
+>
+    <div class="border-border flex items-center gap-0.5 border-b px-1.5 py-1">
+        <button
+            type="button"
+            class="hover:bg-accent rounded p-1 transition-colors {isBold
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground'}"
+            onclick={toggleBold}
+            title="굵게 (Ctrl+B)"
+            {disabled}
+        >
+            <Bold class="size-3.5" />
+        </button>
+        <button
+            type="button"
+            class="hover:bg-accent rounded p-1 transition-colors {isItalic
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground'}"
+            onclick={toggleItalic}
+            title="기울임 (Ctrl+I)"
+            {disabled}
+        >
+            <Italic class="size-3.5" />
+        </button>
+    </div>
+    <div bind:this={editorElement}></div>
+</div>
+
+<style>
+    .comment-editor :global(.tiptap) {
+        outline: none;
+        padding: 0.5rem 0.75rem;
+        min-height: 5rem;
+        max-height: 40vh;
+        overflow-y: auto;
+        font-size: 0.875rem;
+        line-height: 1.5;
+    }
+</style>

--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { untrack } from 'svelte';
     import { Button } from '$lib/components/ui/button/index.js';
-    import { Textarea } from '$lib/components/ui/textarea/index.js';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon.js';
@@ -13,7 +12,7 @@
     import CornerDownRight from '@lucide/svelte/icons/corner-down-right';
     import Lock from '@lucide/svelte/icons/lock';
     import Loader2 from '@lucide/svelte/icons/loader-2';
-    import { MentionAutocomplete } from '$lib/components/features/mention/index.js';
+    import type { Component } from 'svelte';
     import CommentToolbar from './comment-toolbar.svelte';
 
     interface Props {
@@ -29,16 +28,11 @@
         parentId?: string | number;
         parentAuthor?: string;
         isReplyMode?: boolean;
-        showSecretOption?: boolean; // deprecated: 관리자 레벨 기반으로 자동 판단
-        /** 게시판 권한 정보 (서버에서 계산) */
+        showSecretOption?: boolean;
         permissions?: BoardPermissions;
-        /** 댓글 작성에 필요한 레벨 (하위호환용) */
         requiredCommentLevel?: number;
-        /** 게시판 ID (이미지 업로드용) */
         boardId?: string;
-        /** 댓글 새로고침 콜백 */
         onRefresh?: () => void;
-        /** 새로고침 중 여부 */
         isRefreshing?: boolean;
     }
 
@@ -58,20 +52,15 @@
         isRefreshing = false
     }: Props = $props();
 
-    // 댓글/답글 작성 권한 체크
     const canComment = $derived.by(() => {
         if (!authStore.isAuthenticated) return false;
-        // 서버에서 계산된 권한 정보가 있으면 사용
         if (permissions) {
-            // 대댓글 모드면 can_reply, 일반 댓글이면 can_comment
             return isReplyMode ? permissions.can_reply : permissions.can_comment;
         }
-        // 하위호환: 클라이언트에서 레벨 비교
         const userLevel = authStore.user?.mb_level ?? 1;
         return userLevel >= requiredCommentLevel;
     });
 
-    // 권한 부족 시 표시할 메시지
     const permissionMessage = $derived(`레벨 ${requiredCommentLevel} 이상 작성 가능`);
 
     let commentAvatarUrl = $derived(
@@ -86,8 +75,26 @@
     let content = $state('');
     let isSecret = $state(false);
     let error = $state<string | null>(null);
-    let textareaRef = $state<HTMLTextAreaElement | null>(null);
+    let editorRef = $state<any>(null);
     let fileInputRef = $state<HTMLInputElement | null>(null);
+
+    // === CommentEditor 동적 로드 ===
+    let LazyCommentEditor = $state<Component | null>(null);
+    let editorLoading = $state(false);
+
+    function loadEditor(): void {
+        if (LazyCommentEditor || editorLoading) return;
+        editorLoading = true;
+        import('./comment-editor.svelte').then((m) => {
+            LazyCommentEditor = m.default;
+            editorLoading = false;
+        });
+    }
+
+    // 대댓글: 폼이 마운트되면 바로 에디터 로드 시작
+    $effect(() => {
+        if (isReplyMode && canComment) loadEditor();
+    });
 
     // 이미지 업로드 상태
     let isUploading = $state(false);
@@ -95,19 +102,27 @@
     const MAX_IMAGES = 3;
     const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
 
-    // 대댓글 모드일 때 플레이스홀더 변경
     const actualPlaceholder = $derived(
         isReplyMode && parentAuthor ? `@${parentAuthor}님에게 답글 작성...` : placeholder
     );
 
-    // 제출 가능 여부
-    const canSubmit = $derived(content.trim().length > 0);
+    // 제출 가능 여부 — Tiptap 빈 상태 <p></p> 대응
+    const canSubmit = $derived(
+        content.replace(/<[^>]*>/g, '').trim().length > 0 || content.includes('<img ')
+    );
 
-    // 제출 핸들러
+    // 앙티콘 이미지를 {emo:filename} 텍스트로 복원
+    function convertEmoticonImages(html: string): string {
+        return html.replace(
+            /<img[^>]+src="\/emoticons\/([^"]+)"[^>]*>/g,
+            (_match, filename) => `{emo:${filename}}`
+        );
+    }
+
     async function handleSubmit(e: Event): Promise<void> {
         e.preventDefault();
 
-        if (!content.trim()) {
+        if (!canSubmit) {
             error = '댓글 내용을 입력해주세요.';
             return;
         }
@@ -115,15 +130,16 @@
         error = null;
 
         try {
-            await onSubmit(content.trim(), parentId, isSecret);
+            const submitContent = convertEmoticonImages(content.trim());
+            await onSubmit(submitContent, parentId, isSecret);
             content = '';
+            editorRef?.clear();
             isSecret = false;
         } catch (err) {
             error = err instanceof Error ? err.message : '댓글 작성에 실패했습니다.';
         }
     }
 
-    // 취소 핸들러
     function handleCancel(): void {
         content = '';
         isSecret = false;
@@ -131,35 +147,17 @@
         onCancel?.();
     }
 
-    // 툴바에서 텍스트 삽입
     function insertText(text: string): void {
-        if (textareaRef) {
-            const start = textareaRef.selectionStart;
-            const end = textareaRef.selectionEnd;
-            content = content.substring(0, start) + text + content.substring(end);
-            // 커서를 삽입된 텍스트 뒤로 이동
-            requestAnimationFrame(() => {
-                if (textareaRef) {
-                    const newPos = start + text.length;
-                    textareaRef.selectionStart = newPos;
-                    textareaRef.selectionEnd = newPos;
-                    textareaRef.focus();
-                }
-            });
-        } else {
-            content += text;
-        }
+        editorRef?.insertContent(text);
     }
 
-    // 파일 선택 트리거
     function triggerFileSelect(): void {
         fileInputRef?.click();
     }
 
-    // 이미지 파일 처리 — 업로드 후 커서 위치에 img 태그 삽입
     async function handleFiles(files: FileList | File[]): Promise<void> {
         const fileArray = Array.from(files);
-        const insertedImageCount = (content.match(/<img\s/g) || []).length;
+        const insertedImageCount = editorRef?.getImageCount() ?? 0;
         const remaining = MAX_IMAGES - insertedImageCount;
         if (remaining <= 0) {
             error = `이미지는 최대 ${MAX_IMAGES}개까지 첨부할 수 있습니다.`;
@@ -186,9 +184,7 @@
                     error = '이미지 URL을 받지 못했습니다.';
                     continue;
                 }
-                // 커서 위치에 img 태그 삽입
-                const imgTag = `<img src="${result.url}" alt="첨부 이미지" loading="lazy">`;
-                insertText(imgTag);
+                editorRef?.insertImage(result.url, '첨부 이미지');
             } catch (err) {
                 error = err instanceof Error ? err.message : '이미지 업로드에 실패했습니다.';
             } finally {
@@ -197,31 +193,11 @@
         }
     }
 
-    // 파일 input 변경
     function handleFileChange(e: Event): void {
         const input = e.currentTarget as HTMLInputElement;
         if (input.files && input.files.length > 0) {
             handleFiles(input.files);
-            input.value = ''; // 리셋하여 같은 파일 재선택 허용
-        }
-    }
-
-    // 클립보드 붙여넣기 이미지 처리
-    function handlePaste(e: ClipboardEvent): void {
-        const items = e.clipboardData?.items;
-        if (!items) return;
-
-        const imageFiles: File[] = [];
-        for (const item of items) {
-            if (item.type.startsWith('image/')) {
-                const file = item.getAsFile();
-                if (file) imageFiles.push(file);
-            }
-        }
-
-        if (imageFiles.length > 0) {
-            e.preventDefault();
-            handleFiles(imageFiles);
+            input.value = '';
         }
     }
 </script>
@@ -229,7 +205,6 @@
 {#if canComment}
     <form onsubmit={handleSubmit} class="space-y-2">
         {#if isReplyMode}
-            <!-- 대댓글 모드 표시 -->
             <div class="text-muted-foreground flex items-center gap-2 text-sm">
                 <CornerDownRight class="h-4 w-4" />
                 <span>
@@ -239,7 +214,6 @@
         {/if}
 
         <div class="flex items-start gap-3">
-            <!-- 사용자 아바타 (답글 모드에서는 모바일 숨김) -->
             <div
                 class="flex size-10 shrink-0 items-center justify-center rounded-full {isReplyMode
                     ? 'hidden sm:flex'
@@ -262,24 +236,37 @@
             </div>
 
             <div class="relative flex-1 space-y-2">
-                <Textarea
-                    bind:ref={textareaRef}
-                    bind:value={content}
-                    placeholder={actualPlaceholder}
-                    rows={isReplyMode ? 1 : 2}
-                    class="{error ? 'border-destructive' : ''} max-h-[40vh] overflow-y-auto"
-                    disabled={isLoading}
-                    onpaste={handlePaste}
-                    onkeydown={(e: KeyboardEvent) => {
-                        if ((e.altKey || e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                            e.preventDefault();
-                            if (canSubmit && !isLoading) {
-                                handleSubmit(e);
-                            }
-                        }
-                    }}
-                />
-                <MentionAutocomplete textarea={textareaRef} />
+                {#if LazyCommentEditor}
+                    <LazyCommentEditor
+                        bind:this={editorRef}
+                        placeholder={actualPlaceholder}
+                        disabled={isLoading}
+                        onUpdate={(html) => {
+                            content = html;
+                        }}
+                        onImagePaste={(file) => handleFiles([file])}
+                        onSubmitShortcut={() => {
+                            if (canSubmit && !isLoading) handleSubmit(new Event('submit'));
+                        }}
+                        class={error ? 'border-destructive' : ''}
+                    />
+                {:else}
+                    <!-- 에디터 로드 전 플레이스홀더 — hover로 preload, click으로 활성화 -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <div
+                        class="border-border bg-background text-muted-foreground min-h-20 cursor-text rounded-lg border p-3 text-sm"
+                        onmouseenter={loadEditor}
+                        onfocusin={loadEditor}
+                        onclick={loadEditor}
+                        onkeydown={loadEditor}
+                    >
+                        {#if editorLoading}
+                            <span class="animate-pulse">에디터 로딩 중...</span>
+                        {:else}
+                            {actualPlaceholder}
+                        {/if}
+                    </div>
+                {/if}
 
                 {#if isUploading}
                     <div class="text-muted-foreground flex items-center gap-2 text-sm">
@@ -293,12 +280,14 @@
                     <CommentToolbar
                         onInsertText={insertText}
                         onSelectImage={triggerFileSelect}
+                        onInsertEmoticon={(filename) => {
+                            editorRef?.insertImage(`/emoticons/${filename}`, filename);
+                        }}
                         disabled={isLoading}
                         {boardId}
                     />
 
                     <div class="ml-auto flex items-center gap-2">
-                        <!-- 비밀댓글 옵션 (관리자만) -->
                         {#if authStore.user?.mb_level != null && authStore.user.mb_level >= 10}
                             <label
                                 class="text-muted-foreground flex cursor-pointer items-center gap-2 text-sm"
@@ -348,7 +337,6 @@
             </div>
         </div>
 
-        <!-- 숨겨진 파일 input -->
         <input
             bind:this={fileInputRef}
             type="file"
@@ -359,7 +347,6 @@
         />
     </form>
 {:else if authStore.isAuthenticated}
-    <!-- 로그인했지만 권한 부족 -->
     <div class="bg-muted/50 rounded-md p-4 text-center">
         <p class="text-muted-foreground flex items-center justify-center gap-2">
             <Lock class="h-4 w-4" />

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -135,6 +135,7 @@
     let editingCommentId = $state<string | null>(null);
     let editContent = $state('');
     let isUpdating = $state(false);
+    let LazyCommentEditor = $state<Component | null>(null);
     let isDeleting = $state<string | null>(null);
     let isRestoring = $state<string | null>(null);
 
@@ -313,11 +314,15 @@
 
     // 수정 모드 시작
     function startEdit(comment: FreeComment): void {
-        // commentTree에서 ID로 명시적 조회 (클로저 안전)
         const target = commentTree.find((c) => c.id === comment.id) ?? comment;
         editingCommentId = String(target.id);
         editContent = target.content;
-        replyingToCommentId = null; // 답글 모드 해제
+        replyingToCommentId = null;
+        if (!LazyCommentEditor) {
+            import('./comment-editor.svelte').then((m) => {
+                LazyCommentEditor = m.default;
+            });
+        }
     }
 
     // 수정 취소
@@ -552,6 +557,7 @@
                     comment.id,
                     DOMPurify.sanitize(withLinks, {
                         ALLOWED_TAGS: [
+                            'p',
                             'img',
                             'br',
                             'div',
@@ -1102,12 +1108,20 @@
                     {:else if isEditing}
                         <!-- 댓글 수정 폼 -->
                         <div class="mt-2 space-y-3">
-                            <textarea
-                                bind:value={editContent}
-                                class="border-border bg-background text-foreground focus:border-primary focus:ring-primary min-h-24 w-full resize-y rounded-lg border p-3 text-sm focus:outline-none focus:ring-1"
-                                placeholder="댓글을 입력하세요..."
-                                disabled={isUpdating}
-                            ></textarea>
+                            {#if LazyCommentEditor}
+                                <LazyCommentEditor
+                                    content={editContent}
+                                    onUpdate={(html) => {
+                                        editContent = html;
+                                    }}
+                                    placeholder="댓글을 입력하세요..."
+                                    disabled={isUpdating}
+                                />
+                            {:else}
+                                <div
+                                    class="border-border bg-background min-h-24 animate-pulse rounded-lg border p-3"
+                                ></div>
+                            {/if}
                             <div class="flex justify-end gap-2">
                                 <Button
                                     type="button"

--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -4,27 +4,69 @@
     import ImageIcon from '@lucide/svelte/icons/image';
     import Film from '@lucide/svelte/icons/film';
     import Space from '@lucide/svelte/icons/space';
-    import EmoticonPicker from './emoticon-picker.svelte';
-    import TenorGifPicker from './tenor-gif-picker.svelte';
+    import type { Component } from 'svelte';
 
     interface Props {
         onInsertText: (text: string) => void;
         onSelectImage: () => void;
+        onInsertEmoticon?: (filename: string) => void;
         disabled?: boolean;
         boardId?: string;
     }
 
-    let { onInsertText, onSelectImage, disabled = false, boardId }: Props = $props();
+    let {
+        onInsertText,
+        onSelectImage,
+        onInsertEmoticon,
+        disabled = false,
+        boardId
+    }: Props = $props();
 
     let showEmoticonPicker = $state(false);
     let showGifPicker = $state(false);
 
+    // 동적 로드 — 버튼 클릭 시에만 import
+    let LazyEmoticonPicker = $state<Component | null>(null);
+    let LazyTenorGifPicker = $state<Component | null>(null);
+
+    function toggleEmoticonPicker(): void {
+        if (showEmoticonPicker) {
+            showEmoticonPicker = false;
+            return;
+        }
+        if (!LazyEmoticonPicker) {
+            import('./emoticon-picker.svelte').then((m) => {
+                LazyEmoticonPicker = m.default;
+                showEmoticonPicker = true;
+            });
+        } else {
+            showEmoticonPicker = true;
+        }
+    }
+
+    function openGifPicker(): void {
+        if (!LazyTenorGifPicker) {
+            import('./tenor-gif-picker.svelte').then((m) => {
+                LazyTenorGifPicker = m.default;
+                showGifPicker = true;
+            });
+        } else {
+            showGifPicker = true;
+        }
+    }
+
     function insertBlankComment(): void {
-        // U+2800 Braille Pattern Blank - 시각적으로 빈 문자
         onInsertText('\u2800');
     }
 
     function handleInsertEmoticon(text: string): void {
+        if (onInsertEmoticon) {
+            const match = text.match(/^\{emo:([^}]+)\}$/);
+            if (match) {
+                onInsertEmoticon(match[1]);
+                return;
+            }
+        }
         onInsertText(text);
     }
 
@@ -40,7 +82,7 @@
             type="button"
             variant="ghost"
             size="sm"
-            onclick={() => (showEmoticonPicker = !showEmoticonPicker)}
+            onclick={toggleEmoticonPicker}
             {disabled}
             class="h-8 px-2"
             title="이모티콘"
@@ -48,19 +90,17 @@
             <Smile class="h-4 w-4" />
             <span class="ml-1 hidden text-xs sm:inline">이모티콘</span>
         </Button>
-        {#if showEmoticonPicker}
-            <!-- 외부 클릭으로 닫기 -->
+        {#if showEmoticonPicker && LazyEmoticonPicker}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
                 class="fixed inset-0 z-40 bg-black/20 sm:bg-transparent"
                 onclick={() => (showEmoticonPicker = false)}
                 onkeydown={(e) => e.key === 'Escape' && (showEmoticonPicker = false)}
             ></div>
-            <!-- 모바일: 화면 하단 고정, PC: 버튼 위에 팝업 -->
             <div
                 class="fixed inset-x-0 bottom-0 z-50 sm:absolute sm:inset-auto sm:bottom-full sm:left-0 sm:mb-1"
             >
-                <EmoticonPicker
+                <LazyEmoticonPicker
                     onInsertEmoticon={handleInsertEmoticon}
                     onClose={() => (showEmoticonPicker = false)}
                 />
@@ -73,7 +113,7 @@
         type="button"
         variant="ghost"
         size="sm"
-        onclick={() => (showGifPicker = true)}
+        onclick={openGifPicker}
         {disabled}
         class="h-8 px-2"
         title="GIF"
@@ -112,8 +152,10 @@
 </div>
 
 <!-- Tenor GIF 다이얼로그 -->
-<TenorGifPicker
-    bind:open={showGifPicker}
-    onInsertGif={handleInsertGif}
-    onClose={() => (showGifPicker = false)}
-/>
+{#if LazyTenorGifPicker}
+    <LazyTenorGifPicker
+        bind:open={showGifPicker}
+        onInsertGif={handleInsertGif}
+        onClose={() => (showGifPicker = false)}
+    />
+{/if}

--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -339,6 +339,38 @@ pre:hover .hljs-copy-btn {
     border-radius: 4px;
 }
 
+/* 댓글 에디터 */
+.comment-editor .tiptap {
+    outline: none;
+    min-height: 5rem;
+    max-height: 40vh;
+    overflow-y: auto;
+}
+
+.comment-editor .tiptap p {
+    margin: 0;
+}
+
+.comment-editor .tiptap p.is-editor-empty:first-child::before {
+    content: attr(data-placeholder);
+    color: var(--color-muted-foreground);
+    float: left;
+    height: 0;
+    pointer-events: none;
+}
+
+.comment-editor .tiptap img {
+    max-width: 100%;
+    border-radius: 0.5rem;
+    margin: 0.25rem 0;
+    display: inline;
+}
+
+.comment-editor .tiptap img.ProseMirror-selectednode {
+    outline: 2px solid oklch(0.62 0.15 250);
+    outline-offset: 2px;
+}
+
 /* 댓글 이모티콘 overflow 방지 */
 .comment-body img {
     display: inline;


### PR DESCRIPTION
## Summary
- 댓글 textarea를 경량 Tiptap 에디터로 교체
- 이미지 인라인 미리보기 + 앙티콘 실시간 표시 + 굵게/기울임 서식 + @멘션
- 전체 동적 import로 초기 페이지 로드 영향 0 (hover preload 방식)

## 변경 파일
| 파일 | 변경 |
|------|------|
| `comment-editor.svelte` | **신규** — Tiptap 래퍼 (B/I 툴바, 인라인 이미지, 멘션) |
| `comment-form.svelte` | Textarea → 동적 CommentEditor + 앙티콘 이미지 삽입 |
| `comment-toolbar.svelte` | EmoticonPicker/GifPicker 동적 import + onInsertEmoticon |
| `comment-list.svelte` | DOMPurify `p` 태그 허용 + 수정 폼 에디터 적용 |
| `components.css` | 댓글 에디터 ProseMirror 스타일 |

## 로딩 최적화
- 페이지 진입 → Tiptap/EmoticonPicker/GifPicker JS 로드 0
- 댓글 입력 영역 hover → Tiptap preload
- 이모티콘/GIF 버튼 클릭 시에만 피커 로드
- 대댓글/수정 버튼 클릭 시에만 에디터 로드

## Test plan
- [ ] 댓글 작성: 이미지 업로드 → 인라인 미리보기
- [ ] 앙티콘 선택 → 에디터에서 실시간 이미지 표시
- [ ] 앙티콘 옆에 텍스트 입력 (인라인 동작)
- [ ] 제출 후 {emo:filename} 텍스트로 정상 저장
- [ ] @멘션 자동완성
- [ ] 굵게(Ctrl+B) / 기울임(Ctrl+I) 서식
- [ ] 대댓글 폼 정상 동작
- [ ] 댓글 수정 폼 정상 동작
- [ ] 기존 plain text 댓글 렌더링 깨짐 없음
- [ ] Alt/Ctrl+Enter 단축키 제출
- [ ] 클립보드 이미지 붙여넣기