### PR TITLE
fix: 축하메시지 타임존 버그 수정 + 모바일 드로워 배너 추가

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -13,7 +13,6 @@
     import AlignJustify from '@lucide/svelte/icons/align-justify';
     import Mail from '@lucide/svelte/icons/mail';
     import Sidebar from './sidebar.svelte';
-    import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
     import {
         NotificationDropdown,
         LevelupCelebration
@@ -398,29 +397,21 @@
     class:md:translate-x-full={!isDrawerOpen}
     class:translate-x-0={isDrawerOpen}
 >
-    <div class="flex h-full min-w-0 flex-col p-6">
-        <div class="mb-8 flex shrink-0 items-center justify-between">
-            <h2 class="text-foreground text-xl font-bold">추가 메뉴</h2>
+    <div class="flex h-full min-w-0 flex-col px-3 py-2">
+        <div class="mb-1 flex shrink-0 items-center justify-between">
+            <h2 class="text-foreground text-base font-bold">추가 메뉴</h2>
             <button
                 onclick={toggleDrawer}
-                class="hover:bg-accent rounded-lg p-2 transition-all duration-200 ease-out"
+                class="hover:bg-accent rounded-lg p-1 transition-all duration-200 ease-out"
                 aria-label="메뉴 닫기"
             >
-                <X class="text-muted-foreground h-6 w-6" />
+                <X class="text-muted-foreground h-5 w-5" />
             </button>
-        </div>
-
-        <!-- 사이드바 이미지텍스트 배너 (메뉴 바로 아래) -->
-        <div class="shrink-0 pb-4">
-            <div class="mb-2 flex items-center justify-between">
-                <span class="text-xs font-medium text-slate-500">AD</span>
-            </div>
-            <ImageTextBanner position="side-image-text-banner" />
         </div>
 
         <!-- 사이드바 메뉴 -->
         <div class="min-h-0 flex-1 overflow-y-auto">
-            <Sidebar />
+            <Sidebar compact />
         </div>
     </div>
 </div>

--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -16,8 +16,15 @@
     import UserWidget from './user-widget.svelte';
     import { getComponentsForSlot } from '$lib/components/slot-manager';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
+    import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { boardFavoritesStore, slotLabel } from '$lib/stores/board-favorites.svelte';
+
+    interface Props {
+        compact?: boolean;
+    }
+
+    let { compact = false }: Props = $props();
 
     let isCollapsed = $state(false);
 
@@ -79,7 +86,10 @@
 
 <div
     data-collapsed={isCollapsed}
-    class="group flex flex-col gap-4 py-2 pe-3 data-[collapsed=true]:py-2"
+    class={cn(
+        'group flex flex-col pe-3 data-[collapsed=true]:py-2',
+        compact ? 'gap-1 py-0 pe-1' : 'gap-4 py-2'
+    )}
 >
     <!-- Slot: sidebar-left-top -->
     {#each getComponentsForSlot('sidebar-left-top') as slotComp (slotComp.id)}
@@ -87,13 +97,13 @@
         <Component {...slotComp.props || {}} />
     {/each}
 
-    <div class="px-2">
-        <UserWidget />
+    <div class={compact ? 'px-1' : 'px-2'}>
+        <UserWidget {compact} />
     </div>
 
     <!-- 즐겨찾기 단축키 메뉴 (2열 그리드) -->
     {#if boardFavoritesStore.normalSlots.length > 0 || boardFavoritesStore.shiftSlots.length > 0}
-        <div class="px-2">
+        <div class={compact ? 'px-1' : 'px-2'}>
             <div class="text-muted-foreground mb-1.5 text-xs font-semibold">즐겨찾기</div>
             <!-- 일반 슬롯 (1-0): 2열 -->
             <div class="grid grid-cols-2 gap-0.5">
@@ -164,7 +174,10 @@
     {/if}
 
     <nav
-        class="grid gap-1 px-2 group-[[data-collapsed=true]]:justify-center group-[[data-collapsed=true]]:px-2"
+        class={cn(
+            'grid group-[[data-collapsed=true]]:justify-center group-[[data-collapsed=true]]:px-2',
+            compact ? 'gap-0 px-1' : 'gap-1 px-2'
+        )}
     >
         {#if loading}
             <div class="text-muted-foreground text-center text-sm">메뉴 로딩 중...</div>
@@ -181,6 +194,7 @@
                                 class={cn(
                                     'cursor-pointer',
                                     'hover:no-underline',
+                                    compact && 'py-2.5',
                                     isCollapsed &&
                                         'flex justify-center [&[data-state=open]>div>svg.lucide-chevron-down]:hidden'
                                 )}
@@ -343,15 +357,31 @@
         {/if}
     </nav>
 
-    <!-- 사이드바 메뉴 아래 GAM 광고 -->
-    <div class="space-y-2 px-2">
+    <!-- 사이드바 메뉴 아래 광고 -->
+    <div class={compact ? 'space-y-2 px-1' : 'space-y-2 px-2'}>
         <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
-            <AdSlot position="sidebar" height="250px" />
+            {#if compact}
+                <div class="flex justify-center">
+                    <AdSlot position="sidebar-drawer" height="100px" />
+                </div>
+            {:else}
+                <AdSlot position="sidebar" height="250px" />
+            {/if}
         </div>
-        <!-- Slot: sidebar-left-bottom -->
-        {#each getComponentsForSlot('sidebar-left-bottom') as slotComp (slotComp.id)}
-            {@const Component = slotComp.component}
-            <Component {...slotComp.props || {}} />
-        {/each}
+        {#if compact}
+            <!-- 드로워: 이미지텍스트 배너 -->
+            <div>
+                <div class="mb-1 flex items-center justify-between">
+                    <span class="text-xs font-medium text-slate-500">AD</span>
+                </div>
+                <ImageTextBanner position="side-image-text-banner" />
+            </div>
+        {:else}
+            <!-- Slot: sidebar-left-bottom -->
+            {#each getComponentsForSlot('sidebar-left-bottom') as slotComp (slotComp.id)}
+                {@const Component = slotComp.component}
+                <Component {...slotComp.props || {}} />
+            {/each}
+        {/if}
     </div>
 </div>

--- a/apps/web/src/lib/components/layout/user-widget.svelte
+++ b/apps/web/src/lib/components/layout/user-widget.svelte
@@ -12,6 +12,12 @@
     import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon';
     import { getGradeName } from '$lib/utils/grade';
 
+    interface Props {
+        compact?: boolean;
+    }
+
+    let { compact = false }: Props = $props();
+
     let isLoggingOut = $state(false);
 
     async function handleLogout() {
@@ -67,7 +73,7 @@
     );
 </script>
 
-<div class="bg-card mb-3 rounded-lg border p-3">
+<div class={compact ? 'bg-card mb-1 rounded-lg border p-2' : 'bg-card mb-3 rounded-lg border p-3'}>
     {#if isLoading}
         <!-- 로딩 상태 -->
         <div class="flex items-center gap-2">
@@ -126,7 +132,7 @@
 
         <!-- 레벨 게이지 -->
         {#if user.as_level !== undefined}
-            <a href="/my/exp" class="group mt-2 block">
+            <a href="/my/exp" class={compact ? 'group mt-1 block' : 'group mt-2 block'}>
                 <div class="text-muted-foreground flex items-center justify-between text-[10px]">
                     <span>Lv.{user.as_level}</span>
                     {#if user.as_max && user.as_max > 0}
@@ -149,7 +155,7 @@
         {/if}
 
         <!-- 내글 / 내댓글 / 전체 + 포인트 -->
-        <div class="mt-2 space-y-1 text-xs">
+        <div class={compact ? 'mt-1 space-y-0.5 text-xs' : 'mt-2 space-y-1 text-xs'}>
             <div class="text-muted-foreground flex items-center justify-center gap-1.5">
                 <a href="/my?tab=posts" class="hover:text-primary transition-colors">내글</a>
                 <span class="text-border">·</span>

--- a/apps/web/src/lib/config/ad-config.ts
+++ b/apps/web/src/lib/config/ad-config.ts
@@ -161,6 +161,11 @@ export const AD_CONFIGS: Record<string, AdConfig> = {
         sizes: [[300, 250]],
         responsive: null
     },
+    'banner-square-small': {
+        unit: AD_UNIT_PATHS.sub,
+        sizes: [[320, 100]],
+        responsive: null
+    },
     'banner-halfpage': {
         unit: AD_UNIT_PATHS.sub,
         sizes: [
@@ -323,6 +328,7 @@ export const POSITION_MAP: Record<string, string> = {
     // 사이드바 — sub 유닛 (소형)
     'sidebar-sticky': 'banner-halfpage',
     sidebar: 'banner-square',
+    'sidebar-drawer': 'banner-square-small',
     'sidebar-1': 'banner-square',
     'sidebar-b2b': 'banner-square',
 

--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -54,9 +54,7 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
 
     // 1차: celebration_banners 테이블 (신규)
     try {
-        const dateFilter = isRecent
-            ? ''
-            : "AND cb.display_date = DATE(CONVERT_TZ(NOW(), '+00:00', '+09:00'))";
+        const dateFilter = isRecent ? '' : 'AND cb.display_date = CURDATE()';
         const [rows] = await pool.execute<RowDataPacket[]>(
             `SELECT cb.id, cb.title, cb.content, cb.image_url, cb.link_url,
 					cb.external_url, cb.display_date, cb.target_member_id,
@@ -101,7 +99,7 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
     if (banners.length === 0) {
         const legacyDateFilter = isRecent
             ? ''
-            : "AND (wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(),'+00:00','+09:00'),'%Y.%m.%d') OR wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(),'+00:00','+09:00'),'%Y-%m-%d'))";
+            : "AND (wm.wr_subject = DATE_FORMAT(NOW(),'%Y.%m.%d') OR wm.wr_subject = DATE_FORMAT(NOW(),'%Y-%m-%d'))";
         const [rows] = await pool.execute<RowDataPacket[]>(
             `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
 					m.mb_nick, m.mb_image_url

--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -66,10 +66,10 @@ export const GET: RequestHandler = async () => {
                  FROM celebration_banners cb
                  LEFT JOIN g5_member m ON cb.target_member_id = m.mb_id
                  WHERE cb.is_active = 1
-                   AND (cb.display_date = DATE(CONVERT_TZ(NOW(), '+00:00', '+09:00'))
+                   AND (cb.display_date = CURDATE()
                         OR (cb.yearly_repeat = 1
-                            AND MONTH(cb.display_date) = MONTH(CONVERT_TZ(NOW(), '+00:00', '+09:00'))
-                            AND DAY(cb.display_date) = DAY(CONVERT_TZ(NOW(), '+00:00', '+09:00'))))
+                            AND MONTH(cb.display_date) = MONTH(CURDATE())
+                            AND DAY(cb.display_date) = DAY(CURDATE())))
                  ORDER BY cb.sort_order ASC, cb.id DESC`
             );
 
@@ -107,8 +107,8 @@ export const GET: RequestHandler = async () => {
                  FROM g5_write_message wm
                  LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
                  WHERE wm.wr_is_comment = 0
-                   AND (wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(), '+00:00', '+09:00'), '%Y.%m.%d')
-                        OR wm.wr_subject = DATE_FORMAT(CONVERT_TZ(NOW(), '+00:00', '+09:00'), '%Y-%m-%d'))
+                   AND (wm.wr_subject = DATE_FORMAT(NOW(), '%Y.%m.%d')
+                        OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y-%m-%d'))
                  ORDER BY wm.wr_id DESC`
             );
 


### PR DESCRIPTION
## Summary
- 축하메시지 API/SSR에서 CONVERT_TZ 이중 변환 버그 수정 (MySQL 세션이 이미 KST → CURDATE()/NOW() 직접 사용)
- 모바일 드로워 compact 모드 추가 (여백 축소, 배너 가시성 확보)
- 드로워에 GAM 320x100 배너 + ImageTextBanner(2x2 그리드) 추가

## Test plan
- [ ] 축하메시지 API가 KST 기준 올바른 날짜 필터링
- [ ] 모바일 드로워에서 메뉴 + 배너 정상 표시
- [ ] 추가 성능 저하 없음 확인