### PR TITLE
fix: svelte-check 타입 에러 수정 + tar 보안 패치

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -110,7 +110,7 @@
         "svelte-dnd-action": "^0.9.54",
         "svelte-sonner": "^1.0.7",
         "svelte-tiptap": "^3.0.1",
-        "tar": "^7.5.10",
+        "tar": "^7.5.11",
         "turndown": "^7.2.2",
         "zod": "^4.2.1"
     }

--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -241,10 +241,10 @@
                         bind:this={editorRef}
                         placeholder={actualPlaceholder}
                         disabled={isLoading}
-                        onUpdate={(html) => {
+                        onUpdate={(html: string) => {
                             content = html;
                         }}
-                        onImagePaste={(file) => handleFiles([file])}
+                        onImagePaste={(file: File) => handleFiles([file])}
                         onSubmitShortcut={() => {
                             if (canSubmit && !isLoading) handleSubmit(new Event('submit'));
                         }}

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -718,7 +718,8 @@
         {@const isReply = depth > 0}
         {@const iconUrl = isDeleted
             ? null
-            : getAvatarUrl(comment.author_image) || getMemberIconUrl(comment.author_id)}
+            : getAvatarUrl((comment as FreeComment & { author_image?: string }).author_image) ||
+              getMemberIconUrl(comment.author_id)}
 
         <!-- 댓글 5개마다 GAM 인피드 광고 (루트 댓글 기준, 첫 번째 제외) -->
         {#if widgetLayoutStore.hasEnabledAds && commentIndex > 0 && commentIndex % 5 === 0 && depth === 0}
@@ -1111,7 +1112,7 @@
                             {#if LazyCommentEditor}
                                 <LazyCommentEditor
                                     content={editContent}
-                                    onUpdate={(html) => {
+                                    onUpdate={(html: string) => {
                                         editContent = html;
                                     }}
                                     placeholder="댓글을 입력하세요..."

--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -26,8 +26,10 @@
     let showGifPicker = $state(false);
 
     // 동적 로드 — 버튼 클릭 시에만 import
-    let LazyEmoticonPicker = $state<Component | null>(null);
-    let LazyTenorGifPicker = $state<Component | null>(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let LazyEmoticonPicker = $state<Component<any> | null>(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let LazyTenorGifPicker = $state<Component<any> | null>(null);
 
     function toggleEmoticonPicker(): void {
         if (showEmoticonPicker) {

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -20,7 +20,7 @@
     import CompactLayout from './layouts/list/compact.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
-    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
+    import { uiSettingsStore, type ListViewMode } from '$lib/stores/ui-settings.svelte.js';
 
     // 코어 레이아웃 초기화 (중복 호출 안전)
     initCoreLayouts();
@@ -175,7 +175,12 @@
         <!-- 보기 옵션 -->
         <DropdownMenu>
             <DropdownMenuTrigger>
-                <Button variant="ghost" size="icon" class="h-8 w-8 hover:bg-accent-foreground/5 dark:hover:bg-primary-foreground/50" title="보기 옵션">
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    class="hover:bg-accent-foreground/5 dark:hover:bg-primary-foreground/50 h-8 w-8"
+                    title="보기 옵션"
+                >
                     <SlidersHorizontal class="h-4 w-4" />
                 </Button>
             </DropdownMenuTrigger>
@@ -183,7 +188,7 @@
                 <DropdownMenuRadioGroup
                     value={uiSettingsStore.listView}
                     onValueChange={(v) => {
-                        if (v) uiSettingsStore.listView = v;
+                        if (v) uiSettingsStore.listView = v as ListViewMode;
                     }}
                 >
                     <DropdownMenuRadioItem value="classic">클래식</DropdownMenuRadioItem>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -78,7 +78,7 @@ export const load: PageServerLoad = async ({
 
         // 삭제된 게시글: 관리자는 본문+리비전 유지, 일반 유저는 본문 숨김
         if (post.deleted_at) {
-            const isAdmin = (locals.user?.mb_level ?? 0) >= 10;
+            const isAdmin = (locals.user?.level ?? 0) >= 10;
             if (!isAdmin) {
                 post.content = '';
             }

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -506,7 +506,7 @@
     // 초기 추천 상태 + 읽음 표시
     // 조회수: SSR에서 처리 (CDN 요청 제거)
     // 레벨/리액션/추천자 아바타: SSR 스트리밍에서 로드 (CDN 요청 제거)
-    onMount(async () => {
+    onMount(() => {
         // 읽음 표시 (localStorage)
         readPostsStore.markAsRead(boardId, data.post.id);
 
@@ -528,15 +528,17 @@
         window.addEventListener('comment-refresh', handleCommentRefresh);
 
         // 추천 상태 조회 (사용자별 데이터 — 클라이언트 전용)
-        try {
-            const status = await apiClient.getPostLikeStatus(boardId, String(data.post.id));
-            isLiked = status.user_liked;
-            isDisliked = status.user_disliked ?? false;
-            likeCount = status.likes;
-            dislikeCount = status.dislikes ?? 0;
-        } catch (err) {
-            console.error('Failed to load like status:', err);
-        }
+        (async () => {
+            try {
+                const status = await apiClient.getPostLikeStatus(boardId, String(data.post.id));
+                isLiked = status.user_liked;
+                isDisliked = status.user_disliked ?? false;
+                likeCount = status.likes;
+                dislikeCount = status.dislikes ?? 0;
+            } catch (err) {
+                console.error('Failed to load like status:', err);
+            }
+        })();
 
         return () => {
             window.removeEventListener('comment-refresh', handleCommentRefresh);

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
@@ -102,6 +102,7 @@ export const GET: RequestHandler = async ({ params, url, cookies }) => {
                     mb_id: string;
                     mb_name: string;
                     mb_nick: string;
+                    mb_image: string;
                     bg_ip: string;
                     liked_at: string;
                 }>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(@floating-ui/dom@1.7.4)(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/extension-bubble-menu@3.17.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/extension-floating-menu@3.17.1(@floating-ui/dom@1.7.4)(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(svelte@5.53.6)
       tar:
-        specifier: '>=7.5.8'
-        version: 7.5.9
+        specifier: ^7.5.11
+        version: 7.5.11
       turndown:
         specifier: ^7.2.2
         version: 7.2.2
@@ -4463,8 +4463,8 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar@7.5.9:
-    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+  tar@7.5.11:
+    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
 
   term-size@2.2.1:
@@ -9531,7 +9531,7 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar@7.5.9:
+  tar@7.5.11:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## Summary
- svelte-check에서 발생하던 기존 타입 에러 10건 수정 (Component 제네릭, 콜백 파라미터 타입 등)
- tar 7.5.9 → 7.5.10 보안 취약점 패치

## Test plan
- [ ] `pnpm check` (svelte-check) 통과 확인
- [ ] `pnpm audit --audit-level=high` 취약점 없음 확인
- [ ] 댓글 폼/목록/툴바 정상 동작 확인