### PR TITLE
fix: pnpm-lock.yaml specifier 불일치 수정

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(@floating-ui/dom@1.7.4)(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/extension-bubble-menu@3.17.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/extension-floating-menu@3.17.1(@floating-ui/dom@1.7.4)(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(svelte@5.53.6)
       tar:
-        specifier: ^7.5.11
+        specifier: '>=7.5.8'
         version: 7.5.11
       turndown:
         specifier: ^7.2.2


### PR DESCRIPTION
## Summary
- lockfile의 tar specifier `^7.5.11` → `>=7.5.8`로 수정 (package.json과 일치)
- CI `frozen-lockfile` 에러 해결

## Test plan
- [ ] CI `pnpm install --frozen-lockfile` 통과 확인