### PR TITLE
fix: 초대 플로우 개선 — angple에서 한번에 처리

### DIFF
--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -294,10 +294,11 @@ export const actions: Actions = {
 
             if (inviteToken) {
                 try {
+                    const inviteMember = await getMemberById(mbId);
                     const jwtToken = await generateDamoangJWT({
                         mb_id: mbId,
-                        mb_level: member?.mb_level ?? 0,
-                        mb_name: member?.mb_name || nickname,
+                        mb_level: inviteMember?.mb_level ?? 0,
+                        mb_name: inviteMember?.mb_name || nickname,
                         mb_email: socialProfile.email
                     });
 

--- a/apps/web/src/routes/register/invite-complete/+page.svelte
+++ b/apps/web/src/routes/register/invite-complete/+page.svelte
@@ -19,7 +19,9 @@
 <div class="mx-auto flex min-h-[60vh] max-w-md items-center justify-center px-4 py-12">
     <Card class="w-full">
         <CardHeader class="items-center text-center">
-            <div class="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
+            <div
+                class="mb-2 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30"
+            >
                 <CircleCheck class="h-8 w-8 text-green-600 dark:text-green-400" />
             </div>
             <CardTitle class="text-xl">가입이 완료되었습니다</CardTitle>


### PR DESCRIPTION
## Summary

- 초대(create_account) 플로우에서 angple 가입 완료 후 ads API를 서버사이드에서 호출하여 한번에 처리
- 가입 완료 후 /register/invite-complete 안내 페이지로 리다이렉트
- ads에서 다시 mb_id/닉네임 입력하는 2중 단계 제거

## 변경 내역

- +page.server.ts: 초대 플로우 가입 시 ads /api/v1/invite/{token}/confirm 서버사이드 호출 추가
- invite-complete/+page.svelte: 완료 안내 페이지 신규 (프로모션 관리 이동 버튼)

## 연관 변경

- damoang-ads invite_service.go: ExecuteCreateAccount에서 이미 존재하는 회원(angple에서 생성) 처리 (0fe7cc8, main 반영 완료)

## Test plan

- [ ] 초대 링크(create_account) → angple 소셜 가입 → 완료 페이지 표시 확인
- [ ] 완료 페이지에서 프로모션 관리로 이동 버튼 동작 확인
- [ ] 광고주 레코드 + 프로모션 정상 생성 확인
- [ ] link_social 타입 초대는 기존 동작 유지 확인