### PR TITLE
fix: 모바일 드로워 축하메시지 배너 복원

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -17,6 +17,7 @@
     import { getComponentsForSlot } from '$lib/components/slot-manager';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
+    import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { boardFavoritesStore, slotLabel } from '$lib/stores/board-favorites.svelte';
 
@@ -376,6 +377,8 @@
                 </div>
                 <ImageTextBanner position="side-image-text-banner" />
             </div>
+            <!-- 드로워: 축하메시지 -->
+            <CelebrationRolling />
         {:else}
             <!-- Slot: sidebar-left-bottom -->
             {#each getComponentsForSlot('sidebar-left-bottom') as slotComp (slotComp.id)}


### PR DESCRIPTION
## Summary
- 모바일 햄버거 메뉴에서 ImageTextBanner 아래에 축하메시지(CelebrationRolling) 다시 추가

## Test plan
- [ ] 모바일 드로워 열기 → 하단에 축하메시지 롤링 표시 확인