### PR TITLE
ci: 빌드 시간 최적화 — ARM64 네이티브 + GHCR 통합

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -11,12 +11,13 @@ on:
 permissions:
   id-token: write
   contents: write
+  packages: write
 
 env:
   NODE_VERSION: '22'
   AWS_REGION: ap-northeast-2
-  ECR_REPOSITORY: angple-web
-  ECR_REGISTRY: 891376997084.dkr.ecr.ap-northeast-2.amazonaws.com
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/damoang/angple-web
 
 jobs:
   build-and-deploy:
@@ -83,15 +84,12 @@ jobs:
             exit 1
           fi
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Login to GHCR
+        uses: docker/login-action@v3
         with:
-          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -126,8 +124,8 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}:sha-${{ github.sha }}"
-          LATEST_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          FULL_IMAGE="${IMAGE_NAME}:sha-${{ github.sha }}"
+          LATEST_IMAGE="${IMAGE_NAME}:latest"
 
           echo "Building ARM64 image: ${FULL_IMAGE}"
 
@@ -151,6 +149,12 @@ jobs:
             .
 
           echo "Image pushed: ${FULL_IMAGE}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy via SSM
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   build-and-deploy:
     name: Build & Deploy to Staging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -56,6 +56,41 @@ jobs:
         run: |
           mkdir -p custom-themes custom-widgets extensions plugins widgets
 
+      # --- 네이티브 빌드 (ARM64 러너에서 직접) ---
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages & web
+        env:
+          VITE_USE_MOCK: 'false'
+          VITE_GAM_NETWORK_CODE: '23338387889'
+          VITE_GAM_SITE_NAME: 'damoang'
+        run: |
+          pnpm --filter "./packages/*" build
+          echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
+          echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
+          pnpm --filter web build
+
+      - name: Prepare deploy package
+        run: |
+          pnpm --filter web deploy --prod --legacy apps/web/deploy
+          cp -r apps/web/build apps/web/deploy/
+          rm -rf apps/web/deploy/plugins apps/web/deploy/widgets apps/web/deploy/themes
+          rm -rf apps/web/deploy/custom-themes apps/web/deploy/custom-widgets apps/web/deploy/extensions
+          for dir in plugins widgets themes custom-themes custom-widgets extensions; do
+            cp -r "$dir" "apps/web/deploy/" 2>/dev/null || mkdir -p "apps/web/deploy/$dir"
+          done
+
+      # --- Docker 이미지 빌드 + push ---
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -77,18 +112,13 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: apps/web/Dockerfile
-          target: production
+          context: apps/web/deploy
+          file: apps/web/Dockerfile.prod
           push: true
           platforms: linux/arm64
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=staging
-          cache-to: type=gha,mode=max,scope=staging
-          build-args: |
-            VITE_USE_MOCK=false
-            VITE_GAM_NETWORK_CODE=23338387889
-            VITE_GAM_SITE_NAME=damoang
+          cache-to: type=gha,mode=min,scope=staging
 
       - name: Deploy to staging server
         uses: appleboy/ssh-action@v1.2.4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,19 +9,16 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/angple-web
-  ECR_REGISTRY: 891376997084.dkr.ecr.ap-northeast-2.amazonaws.com
-  ECR_REPOSITORY: angple-web
   AWS_REGION: ap-northeast-2
 
 jobs:
   # ──────────────────────────────────────────────
-  # 1단계: 빌드 → GHCR + ECR push (자동)
+  # 1단계: 빌드 → GHCR push (자동)
   # ──────────────────────────────────────────────
   build:
     name: Build & Push
     runs-on: ubuntu-24.04-arm
     permissions:
-      id-token: write
       contents: read
       packages: write
     outputs:
@@ -106,22 +103,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Set image tags
         id: tags
         run: |
           SHA_TAG="sha-${GITHUB_SHA}"
           echo "sha_tag=${SHA_TAG}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push to GHCR + ECR
+      - name: Build and push to GHCR
         uses: docker/build-push-action@v5
         with:
           context: apps/web/deploy
@@ -131,14 +119,13 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.sha_tag }}
             ${{ env.IMAGE_NAME }}:latest
-            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.sha_tag }}
-            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
+          cache-from: type=gha,scope=prod
+          cache-to: type=gha,mode=min,scope=prod
 
       - name: Build summary
         run: |
           echo "### Build Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "- GHCR: \`${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.sha_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ECR: \`${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.sha_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   # ──────────────────────────────────────────────
   # 2단계: 카나리 배포 + 스모크 테스트 (자동)


### PR DESCRIPTION
## Summary
- **deploy-staging**: ARM64 네이티브 빌드 전환 (QEMU 에뮬레이션 제거)
  - 러너에서 직접 `pnpm build` → 경량 `Dockerfile.prod`로 패키징
  - 예상 빌드 시간: **22분 → 3분**
- **deploy-binary**: ECR → GHCR 마이그레이션 (레지스트리 통합)
- **docker-publish**: ECR 듀얼 푸시 제거 + GHA 캐시 추가

## 변경 원리
기존: QEMU로 x86 러너에서 ARM64 에뮬레이션 → Docker 내부에서 pnpm install + build (매우 느림)
변경: ARM64 네이티브 러너(`ubuntu-24.04-arm`)에서 직접 빌드 → 빌드 결과물만 Docker에 COPY

## Test plan
- [ ] staging 배포 트리거 → 빌드 시간 3분 이내 확인
- [ ] 배포된 staging 사이트 정상 동작 확인
- [ ] deploy-binary 워크플로우 정상 동작 확인