### PR TITLE
Block restricted reactions and likes

### DIFF
--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -18,6 +18,12 @@ export interface AuthUser {
     mb_nick: string;
     mb_level: number;
     mb_email: string;
+    mb_intercept_date?: string;
+}
+
+export function isRestrictedUser(user: AuthUser | null): boolean {
+    if (!user?.mb_intercept_date) return false;
+    return user.mb_intercept_date !== '0000-00-00' && user.mb_intercept_date !== '00000000';
 }
 
 /**
@@ -37,7 +43,8 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
                         mb_name: member.mb_nick || member.mb_name,
                         mb_nick: member.mb_nick || '',
                         mb_level: member.mb_level ?? 0,
-                        mb_email: member.mb_email || ''
+                        mb_email: member.mb_email || '',
+                        mb_intercept_date: member.mb_intercept_date || ''
                     };
                 }
             }
@@ -51,12 +58,14 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
     if (accessToken) {
         const payload = await verifyToken(accessToken);
         if (payload) {
+            const member = payload.sub ? await getMemberById(payload.sub) : null;
             return {
                 mb_id: payload.sub,
-                mb_name: payload.nickname,
-                mb_nick: payload.nickname,
-                mb_level: payload.level,
-                mb_email: payload.email
+                mb_name: member?.mb_nick || member?.mb_name || payload.nickname,
+                mb_nick: member?.mb_nick || payload.nickname,
+                mb_level: member?.mb_level ?? payload.level,
+                mb_email: member?.mb_email || payload.email,
+                mb_intercept_date: member?.mb_intercept_date || ''
             };
         }
     }
@@ -74,7 +83,8 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
                         mb_name: member.mb_nick || member.mb_name,
                         mb_nick: member.mb_nick || '',
                         mb_level: member.mb_level ?? 0,
-                        mb_email: member.mb_email || ''
+                        mb_email: member.mb_email || '',
+                        mb_intercept_date: member.mb_intercept_date || ''
                     };
                 }
             }
@@ -89,12 +99,14 @@ export async function getAuthUser(cookies: Cookies): Promise<AuthUser | null> {
         try {
             const payload = await verifyTokenLax(legacyJwt);
             if (payload?.sub) {
+                const member = await getMemberById(payload.sub);
                 return {
                     mb_id: payload.sub,
-                    mb_name: payload.nickname,
-                    mb_nick: payload.nickname,
-                    mb_level: payload.level,
-                    mb_email: payload.email
+                    mb_name: member?.mb_nick || member?.mb_name || payload.nickname,
+                    mb_nick: member?.mb_nick || payload.nickname,
+                    mb_level: member?.mb_level ?? payload.level,
+                    mb_email: member?.mb_email || payload.email,
+                    mb_intercept_date: member?.mb_intercept_date || ''
                 };
             }
         } catch {

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -9,7 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
-import { getAuthUser } from '$lib/server/auth';
+import { getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 
 interface GoodRow extends RowDataPacket {
@@ -95,6 +95,13 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
     const user = await getAuthUser(cookies);
     if (!user) {
         return json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    if (isRestrictedUser(user)) {
+        return json(
+            { success: false, message: '이용제한 중에는 추천/비추천을 할 수 없습니다.' },
+            { status: 403 }
+        );
     }
 
     if ((user.mb_level ?? 0) < 3) {

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -9,7 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import pool from '$lib/server/db';
-import { getAuthUser } from '$lib/server/auth';
+import { getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 
 interface GoodRow extends RowDataPacket {
@@ -101,6 +101,13 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
     const user = await getAuthUser(cookies);
     if (!user) {
         return json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    if (isRestrictedUser(user)) {
+        return json(
+            { success: false, message: '이용제한 중에는 추천/비추천을 할 수 없습니다.' },
+            { status: 403 }
+        );
     }
 
     // 레벨 체크 (레벨 3 미만은 추천/비추천 불가)

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -9,7 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
-import { getAuthUser } from '$lib/server/auth';
+import { getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 import { fetchReactionsByParentId } from '$lib/server/reactions';
 
@@ -134,6 +134,13 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
     const user = await getAuthUser(cookies);
     if (!user) {
         return json({ status: 'error', message: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    if (isRestrictedUser(user)) {
+        return json(
+            { status: 'error', message: '이용제한 중에는 리액션을 할 수 없습니다.' },
+            { status: 403 }
+        );
     }
 
     try {


### PR DESCRIPTION
## Summary
- block likes and reactions for restricted users
- reuse cached member auth state to avoid extra hot-path queries

## Test
- not run