### PR TITLE
feat: 회원 설정 페이지에 실명인증 섹션 추가

### DIFF
--- a/apps/web/src/lib/server/auth/member-update.ts
+++ b/apps/web/src/lib/server/auth/member-update.ts
@@ -29,6 +29,7 @@ export interface MemberFullProfile {
     mb_intercept_date: string;
     mb_level: number;
     mb_image_url: string;
+    mb_certify: string;
 }
 
 /** 프로필 전체 정보 조회 */
@@ -36,7 +37,7 @@ export async function getMemberFullProfile(mbId: string): Promise<MemberFullProf
     const [rows] = await pool.query<RowDataPacket[]>(
         `SELECT mb_id, mb_nick, mb_email, mb_homepage, mb_signature,
 		        mb_open, mb_mailling, mb_nick_date, mb_hp, mb_password,
-		        mb_leave_date, mb_intercept_date, mb_level, mb_image_url
+		        mb_leave_date, mb_intercept_date, mb_level, mb_image_url, mb_certify
 		 FROM g5_member WHERE mb_id = ? LIMIT 1`,
         [mbId]
     );

--- a/apps/web/src/routes/member/settings/+page.server.ts
+++ b/apps/web/src/routes/member/settings/+page.server.ts
@@ -46,7 +46,8 @@ export const load: PageServerLoad = async ({ locals }) => {
                   mb_open: memberProfile.mb_open,
                   mb_mailling: memberProfile.mb_mailling,
                   mb_level: memberProfile.mb_level,
-                  mb_image_url: memberProfile.mb_image_url || ''
+                  mb_image_url: memberProfile.mb_image_url || '',
+                  mb_certify: memberProfile.mb_certify || ''
               }
             : null,
         nickChangeDaysLeft,

--- a/apps/web/src/routes/member/settings/+page.svelte
+++ b/apps/web/src/routes/member/settings/+page.svelte
@@ -24,6 +24,9 @@
     import Camera from '@lucide/svelte/icons/camera';
     import CircleCheck from '@lucide/svelte/icons/circle-check';
     import CircleAlert from '@lucide/svelte/icons/circle-alert';
+    import ShieldCheck from '@lucide/svelte/icons/shield-check';
+    import ShieldAlert from '@lucide/svelte/icons/shield-alert';
+    import ExternalLink from '@lucide/svelte/icons/external-link';
     import type { PageData } from './$types.js';
     import { enhance } from '$app/forms';
     import { getAvatarUrl } from '$lib/utils/member-icon';
@@ -171,6 +174,64 @@
             day: 'numeric'
         });
     }
+
+    // 실명인증 관련
+    function openCertPopup() {
+        const width = 500;
+        const height = 600;
+        const left = (screen.width - width) / 2;
+        const top = (screen.height - height) / 2;
+        window.open(
+            '/cert/inicis?pageType=settings',
+            'cert_popup',
+            `width=${width},height=${height},left=${left},top=${top},scrollbars=yes`
+        );
+    }
+
+    function handleCertMessage(e: MessageEvent) {
+        if (e.data?.type === 'cert_complete' && e.data?.success) {
+            location.reload();
+        }
+    }
+
+    function handleCertStorage(e: StorageEvent) {
+        if (e.key === 'cert_result') {
+            try {
+                const result = JSON.parse(e.newValue || '');
+                if (result.success) {
+                    localStorage.removeItem('cert_result');
+                    location.reload();
+                }
+            } catch {
+                // ignore
+            }
+        }
+    }
+
+    let certPollTimer: ReturnType<typeof setInterval> | undefined;
+
+    $effect(() => {
+        window.addEventListener('message', handleCertMessage);
+        window.addEventListener('storage', handleCertStorage);
+        certPollTimer = setInterval(() => {
+            try {
+                const raw = localStorage.getItem('cert_result');
+                if (raw) {
+                    const result = JSON.parse(raw);
+                    if (result.success) {
+                        localStorage.removeItem('cert_result');
+                        clearInterval(certPollTimer);
+                        location.reload();
+                    }
+                }
+            } catch {}
+        }, 1000);
+        return () => {
+            window.removeEventListener('message', handleCertMessage);
+            window.removeEventListener('storage', handleCertStorage);
+            if (certPollTimer) clearInterval(certPollTimer);
+        };
+    });
 </script>
 
 <svelte:head>
@@ -592,7 +653,74 @@
             </Card>
         {/if}
 
-        <!-- 4. 소셜 계정 관리 -->
+        <!-- 4. 실명인증 -->
+        {#if data.profile}
+            <Card>
+                <CardHeader>
+                    <CardTitle class="flex items-center gap-2">
+                        {#if data.profile.mb_certify}
+                            <ShieldCheck class="h-5 w-5 text-green-600" />
+                        {:else}
+                            <ShieldAlert class="h-5 w-5 text-yellow-600" />
+                        {/if}
+                        실명인증
+                    </CardTitle>
+                    <CardDescription>
+                        {#if data.profile.mb_certify}
+                            본인확인이 완료되었습니다.
+                        {:else}
+                            일부 게시판 이용 시 본인확인이 필요할 수 있습니다.
+                        {/if}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {#if data.profile.mb_certify}
+                        <div
+                            class="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950"
+                        >
+                            <ShieldCheck class="h-6 w-6 shrink-0 text-green-600 dark:text-green-400" />
+                            <div>
+                                <p class="font-medium text-green-800 dark:text-green-200">인증 완료</p>
+                                <p class="text-sm text-green-600 dark:text-green-400">
+                                    본인확인이 정상적으로 완료되었습니다.
+                                </p>
+                            </div>
+                        </div>
+                    {:else}
+                        <div
+                            class="flex items-center gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-950"
+                        >
+                            <ShieldAlert class="h-6 w-6 shrink-0 text-yellow-600 dark:text-yellow-400" />
+                            <div>
+                                <p class="font-medium text-yellow-800 dark:text-yellow-200">인증 필요</p>
+                                <p class="text-sm text-yellow-600 dark:text-yellow-400">
+                                    일부 게시판 이용 시 본인확인이 필요할 수 있습니다.
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="mt-4 space-y-3">
+                            <Button class="w-full" onclick={openCertPopup}>
+                                <ShieldCheck class="mr-2 h-4 w-4" />
+                                간편인증 하기
+                            </Button>
+
+                            <a
+                                href="https://damoang.net/verification/45"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-muted-foreground hover:text-foreground flex items-center justify-center gap-1 text-sm underline-offset-4 hover:underline"
+                            >
+                                해외 거주자 실명인증 안내
+                                <ExternalLink class="h-3 w-3" />
+                            </a>
+                        </div>
+                    {/if}
+                </CardContent>
+            </Card>
+        {/if}
+
+        <!-- 5. 소셜 계정 관리 -->
         <Card>
             <CardHeader>
                 <CardTitle class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- 회원 설정 페이지(/member/settings)에 실명인증 카드 추가
- 실명인증 상태 표시 (인증 완료/미완료)
- 미인증 회원도 설정 페이지에서 간편인증 가능

## Changes
- `MemberFullProfile`에 `mb_certify` 필드 추가
- 회원 설정 페이지 서버 로드에서 인증 상태 전달
- 실명인증 UI 카드 추가 (간편인증 버튼, 해외 거주자 안내 링크)

## Test plan
- [ ] 실명인증 완료 회원: 인증 완료 상태 표시 확인
- [ ] 실명인증 미완료 회원: 간편인증 버튼 표시 및 팝업 동작 확인
- [ ] 인증 완료 후 페이지 자동 새로고침 확인