### PR TITLE
feat: chat 레이아웃에 신고 버튼 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1342,6 +1342,19 @@
                                 <Trash2 class="h-3.5 w-3.5" />
                             </Button>
                         {/if}
+
+                        <!-- 신고 버튼 (본인이 아닌 경우) -->
+                        {#if !isAuthor && authStore.isAuthenticated}
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onclick={() => startReport(comment)}
+                                class="text-muted-foreground hover:text-destructive h-6 px-1.5"
+                                title="신고"
+                            >
+                                <Flag class="h-3.5 w-3.5" />
+                            </Button>
+                        {/if}
                     </div>
                 {/if}
 


### PR DESCRIPTION
채팅형 레이아웃에도 신고 버튼 추가

- 타인 댓글에만 표시
- 로그인 사용자만 표시
- 수정/삭제 버튼 다음에 배치

Fixes: https://damoang.net/hello/26435#c_26456