### PR TITLE
fix: 한글 IME 활성 시 키보드 단축키 미작동 문제 수정

### DIFF
--- a/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
+++ b/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
@@ -6,6 +6,9 @@
  *
  * event.code 기반으로 한영 전환과 무관하게 동작.
  * (예: 한글 'ㄹ' 입력 → event.code = 'KeyF' → 자유게시판)
+ *
+ * keyup 이벤트 사용: Linux IME(ibus/fcitx)에서 한글 입력 시
+ * keydown의 event.code가 비정상(빈 문자열, keyCode=229)이 되는 문제 회피.
  */
 
 import { goto } from '$app/navigation';
@@ -147,9 +150,9 @@ class KeyboardShortcutService {
     }
 
     /**
-     * 글로벌 keydown 이벤트 핸들러
+     * 글로벌 keyup 이벤트 핸들러
      */
-    handleKeydown = (event: KeyboardEvent) => {
+    handleKeyup = (event: KeyboardEvent) => {
         // 입력 필드 안에서는 무시
         if (isInputElement(event.target)) return;
         // contentEditable 요소 안에서는 무시

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -338,7 +338,7 @@
     });
 </script>
 
-<svelte:window onkeydown={(e) => keyboardShortcutsMod?.keyboardShortcuts.handleKeydown(e)} />
+<svelte:window onkeyup={(e) => keyboardShortcutsMod?.keyboardShortcuts.handleKeyup(e)} />
 
 <svelte:head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary
- Linux IME(ibus/fcitx)에서 한글 입력 모드일 때 키보드 단축키(F, R 등)가 간헐적으로 작동하지 않는 문제 수정
- `keydown` → `keyup` 이벤트로 전환하여 IME가 `event.code`를 가로채는 문제 회피
- 네비게이션 단축키 특성상 `keyup` 전환에 따른 부작용 없음

## Test plan
- [ ] staging에서 한글 IME 활성 상태로 단축키(F, R, H 등) 테스트
- [ ] 영문 IME 상태에서 기존 단축키 정상 동작 확인
- [ ] Shift+숫자 즐겨찾기 단축키 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)