### PR TITLE
fix: TypeScript 빌드 에러 및 deprecated CSRF 설정 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1256,7 +1256,7 @@
                                     신고잠금
                                 </span>
                             {/if}
-                        {:else if comment.report_count && comment.report_count > 0}
+                        {:else if comment.report_count && typeof comment.report_count === 'number' && comment.report_count > 0}
                             <button
                                 type="button"
                                 onclick={() => toggleCommentReportDetails(String(comment.id))}

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -35,8 +35,8 @@ const config = {
         },
         csrf: {
             // 자체 CSRF 보호 사용 (세션 기반 double-submit cookie, hooks.server.ts)
-            // Apple Sign In form_post 등 cross-origin POST 허용을 위해 비활성화
-            checkOrigin: false
+            // Apple Sign In form_post 등 cross-origin POST 허용을 위해 모든 origin 허용
+            trustedOrigins: ['*']
         },
         output: {
             // 청크 수를 줄이기 위해 단일 번들 전략 사용


### PR DESCRIPTION
## Summary
- `comment.report_count` 비교 시 `typeof` 체크 추가 (string | number 타입 처리)
- `csrf.checkOrigin` → `csrf.trustedOrigins` 마이그레이션 (deprecated 경고 해결)

## 수정 내용

### 1. TypeScript 에러 수정
```
Error: Operator '>' cannot be applied to types 'string | number' and 'number'
```
`report_count`가 `"lock"` 문자열일 수 있어서 숫자 비교 전에 `typeof` 체크 추가

### 2. SvelteKit CSRF 설정 마이그레이션
```
`config.kit.csrf.checkOrigin` has been deprecated in favour of `csrf.trustedOrigins`
```
- Before: `checkOrigin: false`
- After: `trustedOrigins: ['*']`

## Test plan
- [ ] CI 빌드 통과 확인
- [ ] svelte-check 에러 없음
- [ ] deprecation 경고 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)