### PR TITLE
fix: 키보드 단축키로 같은 페이지 이동 시 데이터 새로고침

### DIFF
--- a/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
+++ b/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
@@ -218,7 +218,7 @@ class KeyboardShortcutService {
         if (url.startsWith('http://') || url.startsWith('https://')) {
             window.location.href = url;
         } else {
-            goto(url);
+            goto(url, { invalidateAll: true });
         }
     }
 }


### PR DESCRIPTION
## Summary
- 같은 게시판에서 단축키(예: F=자유게시판)를 누르면 `goto()`가 동일 URL을 무시하여 아무 반응이 없던 문제 수정
- `goto(url, { invalidateAll: true })`로 변경하여 같은 페이지여도 서버 데이터를 다시 로드

## Test plan
- [ ] 자유게시판에서 F 키를 눌러 데이터가 새로고침되는지 확인
- [ ] 다른 게시판에서 단축키로 이동이 정상 동작하는지 확인
- [ ] 숫자 단축키(1~9)도 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)