### PR TITLE
Block restricted likes and reactions outside promotion

### DIFF
--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -21,6 +21,8 @@ export interface AuthUser {
     mb_intercept_date?: string;
 }
 
+const RESTRICTED_WRITE_ALLOWED_BOARDS = new Set(['promotion']);
+
 function parseInterceptDate(value: string): Date | null {
     if (!value || value === '0000-00-00' || value === '00000000') {
         return null;
@@ -50,6 +52,18 @@ export function isRestrictedUser(user: AuthUser | null): boolean {
     const banEnd = parseInterceptDate(user.mb_intercept_date);
     if (!banEnd) return false;
     return Date.now() <= banEnd.getTime();
+}
+
+function normalizeBoardId(boardId: string | null | undefined): string {
+    return (boardId || '').replace(/[^a-zA-Z0-9_-]/g, '');
+}
+
+export function canRestrictedUserWriteToBoard(boardId: string | null | undefined): boolean {
+    return RESTRICTED_WRITE_ALLOWED_BOARDS.has(normalizeBoardId(boardId));
+}
+
+export function canRestrictedUserReactToBoard(_boardId: string | null | undefined): boolean {
+    return false;
 }
 
 /**

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -9,7 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
-import { getAuthUser, isRestrictedUser } from '$lib/server/auth';
+import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 
 interface GoodRow extends RowDataPacket {
@@ -97,7 +97,7 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
         return json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 });
     }
 
-    if (isRestrictedUser(user)) {
+    if (isRestrictedUser(user) && !canRestrictedUserReactToBoard(boardId)) {
         return json(
             { success: false, message: '이용제한 중에는 추천/비추천을 할 수 없습니다.' },
             { status: 403 }

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -9,7 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import pool from '$lib/server/db';
-import { getAuthUser, isRestrictedUser } from '$lib/server/auth';
+import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 
 interface GoodRow extends RowDataPacket {
@@ -103,7 +103,7 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
         return json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 });
     }
 
-    if (isRestrictedUser(user)) {
+    if (isRestrictedUser(user) && !canRestrictedUserReactToBoard(boardId)) {
         return json(
             { success: false, message: '이용제한 중에는 추천/비추천을 할 수 없습니다.' },
             { status: 403 }

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -9,7 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
-import { getAuthUser, isRestrictedUser } from '$lib/server/auth';
+import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 import { fetchReactionsByParentId } from '$lib/server/reactions';
 
@@ -136,13 +136,6 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         return json({ status: 'error', message: '로그인이 필요합니다.' }, { status: 401 });
     }
 
-    if (isRestrictedUser(user)) {
-        return json(
-            { status: 'error', message: '이용제한 중에는 리액션을 할 수 없습니다.' },
-            { status: 403 }
-        );
-    }
-
     try {
         const body = await request.json();
         const { reaction, targetId, parentId, reactionMode = 'add' } = body;
@@ -170,8 +163,17 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
             );
         }
 
+        const targetParts = safeTargetId.split(':');
+        const restrictedBoardId = targetParts.length >= 2 ? targetParts[1] : '';
+        if (isRestrictedUser(user) && !canRestrictedUserReactToBoard(restrictedBoardId)) {
+            return json(
+                { status: 'error', message: '이용제한 중에는 리액션을 할 수 없습니다.' },
+                { status: 403 }
+            );
+        }
+
         // 실명인증 체크 (targetId에서 boardId 추출)
-        const certTargetParts = safeTargetId.split(':');
+        const certTargetParts = targetParts;
         if (certTargetParts.length >= 2) {
             const certBoardId = certTargetParts[1].replace(/[^a-zA-Z0-9_-]/g, '');
             const certError = await checkCertification(certBoardId, user.mb_id);
@@ -181,7 +183,6 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         }
 
         // 작성자 리액션 방지 (PHP preventWriterReaction과 동일: wr_is_comment=1로 댓글만 체크)
-        const targetParts = safeTargetId.split(':');
         if (targetParts.length >= 3) {
             const boardTable = targetParts[1].replace(/[^a-zA-Z0-9_]/g, '');
             const wrId = targetParts[2];


### PR DESCRIPTION
## Summary
- keep restricted-member likes and reactions blocked across boards
- centralize board restriction helpers for promotion-only write exceptions

## Verification
- prettier --check on changed files
- svelte-check is blocked in this environment because .svelte-kit is not writable