### PR TITLE
fix: allow Inicis form POST in CSP

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -277,7 +277,7 @@ function buildCsp(): string {
         "frame-src 'self' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com https://player.vimeo.com https://clips.twitch.tv https://player.twitch.tv https://www.tiktok.com https://www.instagram.com https://www.redditmedia.com https://embed.bsky.app https://googleads.g.doubleclick.net https://securepubads.g.doubleclick.net https://tpc.googlesyndication.com https://www.google.com https://*.googlesyndication.com https://*.doubleclick.net https://*.adtrafficquality.google",
         "frame-ancestors 'self'",
         "base-uri 'self'",
-        "form-action 'self' https://appleid.apple.com"
+        "form-action 'self' https://appleid.apple.com https://sa.inicis.com"
     ];
 
     return directives.join('; ');


### PR DESCRIPTION
## Summary
- allow POST form submission to https://sa.inicis.com in CSP
- fix /cert/inicis redirect to KG Inicis auth page in production

## Review
- reviewed diff against origin/main
- removed unrelated deploy workflow change by rebasing onto latest main