### PR TITLE
메인 CI lint 실행 조건 정리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,12 @@ env:
   NODE_VERSION: "24.11.1"
 
 jobs:
-  # Lint 검사 (push only - PR은 prettier-suggester + eslint-review 사용)
+  # 전체 lint는 수동 실행만 허용한다.
+  # PR에서는 eslint-review/prettier-suggester가 이미 같은 역할을 맡고,
+  # main push에서는 빌드/테스트/배포 경로를 막지 않도록 분리한다.
   lint:
     name: Lint (${{ matrix.app }})
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## 변경 내용
- 전체 lint job을 수동 실행 전용으로 변경
- PR 품질 검사는 기존 eslint-review / prettier-suggester 유지
- main push에서는 build/test/deploy 중심으로 파이프라인 단순화

## 이유
- PR에서 이미 동일 계열 검사를 수행하고 있어 main push full lint는 중복
- 레거시 lint debt 때문에 main 배포 경로가 막히는 문제 해소
