### PR TITLE
카나리 승인 링크를 배포 알림에 포함

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,13 +124,14 @@ jobs:
       - name: Deploy canary via SSM
         env:
           IMAGE_TAG: ${{ needs.build.outputs.sha_tag }}
+          APPROVAL_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "i-038a1d1f00798d94b" \
             --document-name "AWS-RunShellScript" \
             --parameters "{
               \"commands\": [
-                \"export GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' TELEGRAM_BOT_TOKEN='${{ secrets.TELEGRAM_BOT_TOKEN }}' TELEGRAM_DEPLOY_CHAT_ID='${{ secrets.TELEGRAM_DEPLOY_CHAT_ID }}' DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/1435940653375815730/${{ secrets.DISCORD_WEBHOOK_TOKEN_WEB }}' && /home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --canary-only\"
+                \"export GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' TELEGRAM_BOT_TOKEN='${{ secrets.TELEGRAM_BOT_TOKEN }}' TELEGRAM_DEPLOY_CHAT_ID='${{ secrets.TELEGRAM_DEPLOY_CHAT_ID }}' DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/1435940653375815730/${{ secrets.DISCORD_WEBHOOK_TOKEN_WEB }}' APPROVAL_URL='${APPROVAL_URL}' && /home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --canary-only\"
               ]
             }" \
             --timeout-seconds 600 \


### PR DESCRIPTION
## 요약
- 카나리 배포 SSM 실행 시 승인 URL을 함께 전달하도록 변경했습니다.
- 서버 배포 알림에서 승인 대기 메시지에 승인 주소가 함께 노출되도록 맞췄습니다.

## 테스트
- workflow YAML 파싱 확인
- deploy.sh 문법 확인