### PR TITLE
카나리 스모크 테스트 SSM 명령 이스케이프 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,7 +182,7 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --parameters "{
               \"commands\": [
-                \"for i in {1..10}; do STATUS=\\$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:30082/); [ \\\"\\$STATUS\\\" = \\\"200\\\" ] && echo 'OK' && exit 0; sleep 2; done; exit 1\"
+                \"for i in {1..10}; do curl -I -s http://127.0.0.1:30082/ | head -n 1 | grep -q ' 200 ' && echo 'OK' && exit 0; sleep 2; done; exit 1\"
               ]
             }" \
             --timeout-seconds 60 \


### PR DESCRIPTION
## 요약
- canary smoke test SSM 명령의 JSON escape 문제를 수정했습니다.
- `%{http_code}` 포맷 문자열 대신 HTTP 상태줄 검사 방식으로 변경했습니다.

## 테스트
- workflow YAML 파싱 확인
- 실패 로그 원인 확인