### PR TITLE
업데이트 감지 리로드를 캐시 버스터 방식으로 조정

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -136,6 +136,43 @@
                     );
                 }
 
+                function reloadWithCacheBust(clearCaches) {
+                    function replaceNow() {
+                        var url = new URL(location.href);
+                        url.searchParams.set('_v', String(Date.now()));
+                        location.replace(url.toString());
+                    }
+
+                    if (!clearCaches) {
+                        replaceNow();
+                        return;
+                    }
+
+                    var tasks = [];
+                    if (navigator.serviceWorker) {
+                        tasks.push(
+                            navigator.serviceWorker.getRegistrations().then(function (regs) {
+                                regs.forEach(function (r) {
+                                    r.unregister();
+                                });
+                            })
+                        );
+                    }
+                    if (window.caches) {
+                        tasks.push(
+                            caches.keys().then(function (names) {
+                                return Promise.all(
+                                    names.map(function (name) {
+                                        return caches.delete(name);
+                                    })
+                                );
+                            })
+                        );
+                    }
+
+                    Promise.all(tasks).finally(replaceNow);
+                }
+
                 function handle() {
                     var s = getState();
                     var now = Date.now();
@@ -147,7 +184,7 @@
                     s.ts = now;
                     if (s.count <= MAX_RELOADS) {
                         setState(s);
-                        location.reload();
+                        reloadWithCacheBust(s.count > 1);
                     } else {
                         s.exhausted = true;
                         setState(s);

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -157,14 +157,18 @@
     // afterNavigate 통합: 버전 감지 리로드 + GA4 페이지뷰 + 광고 observer 재설정
     const UPDATED_RELOAD_KEY = '__angple_updated_reload__';
     afterNavigate(({ type, to }) => {
-        // 새 버전 감지 시 풀 리로드 (최대 2회, 무한 루프 방지)
+        // 새 버전 감지 시 캐시 버스터로 1회만 재요청
         if ($updated && type !== 'enter') {
             const count = Number(sessionStorage.getItem(UPDATED_RELOAD_KEY) || '0');
-            if (count < 2) {
+            if (count < 1) {
                 sessionStorage.setItem(UPDATED_RELOAD_KEY, String(count + 1));
-                location.reload();
+                const url = new URL(location.href);
+                url.searchParams.set('_v', String(Date.now()));
+                location.replace(url.toString());
                 return;
             }
+        } else if (!$updated) {
+            sessionStorage.removeItem(UPDATED_RELOAD_KEY);
         }
         // GA4 페이지뷰 추적
         if (to?.url) {


### PR DESCRIPTION
## 요약
- chunk error 자동 복구 시 cache-busting reload를 사용하도록 변경했습니다.
- 두 번째 자동 복구 시에는 service worker와 cache storage까지 정리한 뒤 재요청합니다.
- `$updated` 감지 리로드는 1회만 실행하고 정상 상태에서 카운터를 초기화합니다.

## 테스트
- 코드 diff 확인
- `svelte-check` 는 임시 worktree에 의존성이 없어 PR 체크에서 검증 예정