### PR TITLE
소셜 아이디와 회원 탈퇴 처리를 정리

### DIFF
--- a/apps/web/src/lib/server/auth/member-leave.test.ts
+++ b/apps/web/src/lib/server/auth/member-leave.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatLeaveDate, prependLeaveMemo } from './member-leave';
+
+describe('member leave helpers', () => {
+    it('formats leave date as YYYYMMDD', () => {
+        expect(formatLeaveDate(new Date('2026-03-12T01:02:03+09:00'))).toBe('20260312');
+    });
+
+    it('prepends leave memo before existing memo', () => {
+        expect(prependLeaveMemo('기존 메모', '20260312')).toBe('20260312 탈퇴함\n기존 메모');
+        expect(prependLeaveMemo('', '20260312')).toBe('20260312 탈퇴함');
+    });
+});

--- a/apps/web/src/lib/server/auth/member-leave.ts
+++ b/apps/web/src/lib/server/auth/member-leave.ts
@@ -5,28 +5,52 @@
 import pool from '$lib/server/db.js';
 import type { ResultSetHeader, RowDataPacket } from 'mysql2';
 
+function formatLeaveDate(date: Date = new Date()): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}${month}${day}`;
+}
+
+function prependLeaveMemo(existingMemo: string, leaveDate: string): string {
+    const leaveMemo = `${leaveDate} 탈퇴함`;
+    return existingMemo ? `${leaveMemo}\n${existingMemo}` : leaveMemo;
+}
+
 /**
  * 회원 탈퇴 처리 (소프트 삭제)
- * 1. mb_leave_date = CURDATE()
- * 2. 소셜 프로필 삭제
+ * 1. mb_leave_date = YYYYMMDD
+ * 2. mb_memo 앞에 "YYYYMMDD 탈퇴함" 기록
+ * 3. 본인인증/중복가입 관련 값 초기화
+ * 4. 소셜 프로필 삭제
  */
 export async function processMemberLeave(
     mbId: string
 ): Promise<{ success: boolean; error?: string }> {
     // 회원 존재 확인
     const [rows] = await pool.query<RowDataPacket[]>(
-        "SELECT mb_id, mb_leave_date FROM g5_member WHERE mb_id = ? AND mb_leave_date = '' LIMIT 1",
+        "SELECT mb_id, mb_leave_date, COALESCE(mb_memo, '') AS mb_memo FROM g5_member WHERE mb_id = ? AND mb_leave_date = '' LIMIT 1",
         [mbId]
     );
 
-    if (!rows[0]) {
+    const member = rows[0];
+    if (!member) {
         return { success: false, error: '회원 정보를 찾을 수 없거나 이미 탈퇴한 회원입니다.' };
     }
 
-    // 소프트 삭제: mb_leave_date 설정
+    const leaveDate = formatLeaveDate();
+    const nextMemo = prependLeaveMemo(member.mb_memo ?? '', leaveDate);
+
+    // 소프트 삭제: PHP member_leave.php 호환 필드 반영
     await pool.query<ResultSetHeader>(
-        'UPDATE g5_member SET mb_leave_date = CURDATE() WHERE mb_id = ?',
-        [mbId]
+        `UPDATE g5_member
+            SET mb_leave_date = ?,
+                mb_memo = ?,
+                mb_certify = '',
+                mb_adult = 0,
+                mb_dupinfo = ''
+          WHERE mb_id = ?`,
+        [leaveDate, nextMemo, mbId]
     );
 
     // 소셜 프로필 삭제
@@ -36,3 +60,5 @@ export async function processMemberLeave(
 
     return { success: true };
 }
+
+export { formatLeaveDate, prependLeaveMemo };

--- a/apps/web/src/lib/server/auth/register.test.ts
+++ b/apps/web/src/lib/server/auth/register.test.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'crypto';
+import { describe, expect, it } from 'vitest';
+
+import { adler32, generateSocialMbId } from './register';
+
+describe('generateSocialMbId', () => {
+    it('keeps the provider prefix and never emits a negative hash marker', () => {
+        expect(generateSocialMbId('google', '108692925130582663034')).toMatch(
+            /^google_[0-9a-f]{8}$/
+        );
+        expect(generateSocialMbId('naver', 'XUj7e3kQ0mJ4sYw2P9')).toMatch(/^naver_[0-9a-f]{8}$/);
+    });
+
+    it('normalizes signed adler32 outputs to unsigned hex', () => {
+        const identifier = 'case-0';
+        const md5Hash = createHash('md5').update(identifier).digest('hex');
+        const signedValue = adler32(Buffer.from(md5Hash, 'utf-8'));
+
+        expect(signedValue).toBeLessThan(0);
+        expect(generateSocialMbId('google', identifier)).toBe(
+            `google_${(signedValue >>> 0).toString(16).padStart(8, '0')}`
+        );
+    });
+});

--- a/apps/web/src/lib/server/auth/register.ts
+++ b/apps/web/src/lib/server/auth/register.ts
@@ -30,7 +30,7 @@ export function adler32(buf: Buffer): number {
  */
 export function generateSocialMbId(provider: string, identifier: string): string {
     const md5Hash = createHash('md5').update(identifier).digest('hex');
-    const adlerValue = adler32(Buffer.from(md5Hash, 'utf-8'));
+    const adlerValue = adler32(Buffer.from(md5Hash, 'utf-8')) >>> 0;
     return `${provider.toLowerCase()}_${adlerValue.toString(16).padStart(8, '0')}`;
 }
 


### PR DESCRIPTION
## 요약
- 소셜 가입 mb_id 생성 시 음수 해시 표기가 나오지 않도록 수정했습니다.
- 회원 탈퇴 시 PHP 운영 로직과 동일하게 탈퇴일자, 메모, 인증 관련 필드를 정리하도록 맞췄습니다.
- 두 로직에 대한 단위 테스트를 추가했습니다.

## 테스트
- 대상 단위 테스트 통과

## 참고
- 기존 잘못 생성된 google_- 패턴, naver_- 패턴 계정은 운영 DB에서 백업 후 일괄 정리했습니다.
- 정리 후 g5_member, g5_write_hello 에 남은 잘못된 패턴은 0건입니다.