### PR TITLE
실명인증 상태를 클라이언트에 전달

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -43,12 +43,22 @@
     function syncAuth(d: typeof data) {
         if (d.user && d.accessToken) {
             authActions.initFromSSR(
-                { id: d.user.id, nickname: d.user.nickname ?? '', level: d.user.level },
+                {
+                    id: d.user.id,
+                    nickname: d.user.nickname ?? '',
+                    level: d.user.level,
+                    mb_certify: d.user.mb_certify ?? ''
+                },
                 d.accessToken
             );
         } else if (d.user) {
             authActions.initFromSSR(
-                { id: d.user.id, nickname: d.user.nickname ?? '', level: d.user.level },
+                {
+                    id: d.user.id,
+                    nickname: d.user.nickname ?? '',
+                    level: d.user.level,
+                    mb_certify: d.user.mb_certify ?? ''
+                },
                 ''
             );
         } else {


### PR DESCRIPTION
## 요약
- SSR 사용자 데이터의 mb_certify 값을 auth store 초기화에 함께 전달합니다.
- 실명인증한 사용자가 게시판에서 글쓰기 버튼을 정상적으로 보도록 맞춥니다.