### PR TITLE
댓글과 광고 로딩 경로를 분리

### DIFF
--- a/apps/web/src/lib/server/ads/promotion.ts
+++ b/apps/web/src/lib/server/ads/promotion.ts
@@ -9,6 +9,8 @@
 import { getAdsServerUrl } from './config';
 
 const PROMOTION_CACHE_TTL = 30_000; // 30초
+const PROMOTION_POSTS_TIMEOUT_MS = 500;
+const PROMOTION_BOARD_TIMEOUT_MS = 1_500;
 
 let promotionCache: { data: unknown; expiresAt: number } | null = null;
 
@@ -54,7 +56,7 @@ export async function fetchPromotionBoardPosts(): Promise<PromotionBoardPostsRes
     }
     try {
         const res = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-board-posts`, {
-            signal: AbortSignal.timeout(5_000)
+            signal: AbortSignal.timeout(PROMOTION_BOARD_TIMEOUT_MS)
         });
         if (!res.ok) return EMPTY_BOARD_RESPONSE;
         const data = await res.json();
@@ -74,7 +76,7 @@ export async function fetchPromotionPosts(): Promise<unknown> {
     }
     try {
         const res = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-posts`, {
-            signal: AbortSignal.timeout(3_000)
+            signal: AbortSignal.timeout(PROMOTION_POSTS_TIMEOUT_MS)
         });
         if (!res.ok) return EMPTY_RESPONSE;
         const data = await res.json();

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -11,7 +11,6 @@ import { getCachedBoard } from '$lib/server/board-cache.js';
 interface PostsCacheData {
     posts: FreePost[];
     notices: FreePost[];
-    promotionPosts: unknown[];
     pagination: { total: number; page: number; limit: number; totalPages: number };
     error: string | null;
 }
@@ -166,7 +165,7 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
                 totalPages: 1
             };
 
-            const result = { posts, notices, promotionPosts: [] as unknown[], pagination, error };
+            const result = { posts, notices, pagination, error };
 
             // 비로그인 + 에러 없는 경우만 캐시 저장
             if (usePostsCache && !error) {
@@ -177,7 +176,7 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         }
 
         // 일반 게시판 (또는 프로모션 게시판 검색/태그 필터)
-        const [postsResult, noticesResult, promotionResult] = await Promise.allSettled([
+        const [postsResult, noticesResult] = await Promise.allSettled([
             bFetch(buildPostsUrl(), { headers }).then(async (res) => {
                 if (!res.ok) throw new Error(`Posts API error: ${res.status}`);
                 return res.json();
@@ -190,8 +189,7 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
                           const json = await res.json();
                           return (json.data as FreePost[]) || [];
                       }
-                  ),
-            fetchPromotionPosts()
+                  )
         ]);
 
         // 게시글
@@ -221,20 +219,7 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
 
         const notices = noticesResult.status === 'fulfilled' ? noticesResult.value : [];
 
-        // 프로모션 사잇광고: board_exception에 포함된 게시판은 제외
-        let promotionPosts: unknown[] = [];
-        if (promotionResult.status === 'fulfilled') {
-            const promoData = (promotionResult.value as Record<string, unknown>)?.data as
-                | Record<string, unknown>
-                | undefined;
-            const boardException = (promoData?.board_exception || '') as string;
-            const excludedBoards = boardException.split(',').map((s: string) => s.trim());
-            if (!excludedBoards.includes(boardId)) {
-                promotionPosts = (promoData?.posts as unknown[]) || [];
-            }
-        }
-
-        const result = { posts, notices, promotionPosts, pagination, error };
+        const result = { posts, notices, pagination, error };
 
         // 비로그인 + 에러 없는 경우만 캐시 저장
         if (usePostsCache && !error) {
@@ -244,6 +229,27 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         return result;
     })();
 
+    const promotionDataPromise = (async () => {
+        if (isSearching || isPromotionBoard) {
+            return [] as unknown[];
+        }
+
+        try {
+            const promotionResult = await fetchPromotionPosts();
+            const promoData = (promotionResult as Record<string, unknown>)?.data as
+                | Record<string, unknown>
+                | undefined;
+            const boardException = (promoData?.board_exception || '') as string;
+            const excludedBoards = boardException.split(',').map((s: string) => s.trim());
+            if (excludedBoards.includes(boardId)) {
+                return [] as unknown[];
+            }
+            return (promoData?.posts as unknown[]) || [];
+        } catch {
+            return [] as unknown[];
+        }
+    })();
+
     return {
         boardId,
         board,
@@ -251,7 +257,8 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         activeTag: tag,
         /** 스트리밍: Promise로 반환 → 클라이언트에서 {#await} 사용 */
         streamed: {
-            postsData: postsDataPromise
+            postsData: postsDataPromise,
+            promotionData: promotionDataPromise
         }
     };
 };

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -89,6 +89,7 @@
     }
 
     let { data }: { data: PageData } = $props();
+    let promotionPosts = $state<unknown[]>([]);
 
     // 게시판 정보
     const boardId = $derived(data.boardId);
@@ -180,6 +181,31 @@
                 });
             })
             .catch(() => {});
+    });
+
+    $effect(() => {
+        const promise = data.streamed?.promotionData;
+        if (!promise) {
+            promotionPosts = [];
+            return;
+        }
+
+        let cancelled = false;
+        promotionPosts = [];
+
+        promise
+            .then((result: unknown[]) => {
+                if (cancelled) return;
+                promotionPosts = result || [];
+            })
+            .catch(() => {
+                if (cancelled) return;
+                promotionPosts = [];
+            });
+
+        return () => {
+            cancelled = true;
+        };
     });
 
     // 활성 태그 필터
@@ -580,7 +606,6 @@
             {:then result}
                 {@const posts = result.posts}
                 {@const notices = result.notices || []}
-                {@const promotionPosts = result.promotionPosts || []}
                 {@const pagination = result.pagination}
                 {@const filteredPosts =
                     selectedCategory === '전체'

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -178,10 +178,97 @@ export const load: PageServerLoad = async ({
             }
         }
 
-        // --- 2단계: 보조 데이터 스트리밍 (await 안 함 → 스켈레톤 먼저 표시) ---
-        const secondaryDataPromise = (async () => {
+        // --- 2단계: 핵심/보조 데이터를 분리해 스트리밍 ---
+        const commentsDataPromise = (async () => {
+            const commentsResult = await svelteKitFetch(
+                `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=200`
+            ).then(async (res) => {
+                if (!res.ok) return { items: [], total: 0, page: 1, limit: 200, total_pages: 0 };
+                const json = await res.json();
+                if (!json.success)
+                    return { items: [], total: 0, page: 1, limit: 200, total_pages: 0 };
+                const data = json.data;
+                return {
+                    items: data.comments || [],
+                    total: data.total || 0,
+                    page: data.page || 1,
+                    limit: data.limit || 200,
+                    total_pages: data.total_pages || 1
+                };
+            });
+
+            const comments = commentsResult;
+
+            // 댓글 제휴 링크 서버사이드 변환
+            if (comments.items?.length) {
+                try {
+                    const transformPromises: Promise<void>[] = [];
+                    for (const comment of comments.items) {
+                        if (comment.content) {
+                            transformPromises.push(
+                                transformAffiliateContent(comment.content, affiliateContext).then(
+                                    (html) => {
+                                        comment.content = html;
+                                    }
+                                )
+                            );
+                        }
+                    }
+                    if (transformPromises.length > 0) {
+                        await Promise.race([
+                            Promise.allSettled(transformPromises),
+                            new Promise((resolve) => setTimeout(resolve, 3000))
+                        ]);
+                    }
+                } catch {
+                    // 변환 실패 시 원본 유지
+                }
+            }
+
+            // 회원 레벨 배치 조회 (작성자 + 댓글 작성자, DB 직접 — CDN 요청 제거)
+            let memberLevels: Record<string, number> = {};
+            try {
+                const authorIds = new Set<string>();
+                if (post.author_id) authorIds.add(post.author_id);
+                for (const c of comments.items || []) {
+                    if (c.author_id) authorIds.add(c.author_id);
+                }
+                if (authorIds.size > 0) {
+                    memberLevels = await fetchMemberLevels([...authorIds]);
+                }
+            } catch {
+                // 레벨 조회 실패 시 빈 맵 (클라이언트에서 fallback)
+            }
+
+            // 댓글 좋아요/비추천 상태 배치 조회 (로그인 시만)
+            let commentLikeStatuses: { likedIds: number[]; dislikedIds: number[] } = {
+                likedIds: [],
+                dislikedIds: []
+            };
+            if (locals.user?.id && comments.items?.length) {
+                try {
+                    const commentIds = comments.items
+                        .map((c: { id: number | string }) => Number(c.id))
+                        .filter((id: number) => !isNaN(id));
+                    commentLikeStatuses = await fetchCommentLikeStatuses(
+                        boardId,
+                        commentIds,
+                        locals.user.id
+                    );
+                } catch {
+                    // 실패 시 빈 상태 (클라이언트에서 fallback)
+                }
+            }
+
+            return {
+                comments,
+                memberLevels,
+                commentLikeStatuses
+            };
+        })();
+
+        const auxiliaryDataPromise = (async () => {
             const [
-                commentsResult,
                 promotionResult,
                 revisionsResult,
                 reactionsResult,
@@ -190,24 +277,6 @@ export const load: PageServerLoad = async ({
                 scrapResult,
                 postReportCountResult
             ] = await Promise.allSettled([
-                // 댓글 (SvelteKit 내부 라우트 → svelteKitFetch)
-                svelteKitFetch(
-                    `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=200`
-                ).then(async (res) => {
-                    if (!res.ok)
-                        return { items: [], total: 0, page: 1, limit: 200, total_pages: 0 };
-                    const json = await res.json();
-                    if (!json.success)
-                        return { items: [], total: 0, page: 1, limit: 200, total_pages: 0 };
-                    const data = json.data;
-                    return {
-                        items: data.comments || [],
-                        total: data.total || 0,
-                        page: data.page || 1,
-                        limit: data.limit || 200,
-                        total_pages: data.total_pages || 1
-                    };
-                }),
                 // 직접홍보 사잇광고 (ads 서버 직접 호출 + 캐시)
                 fetchPromotionPosts(),
                 // 리비전 히스토리 (관리자 level ≥ 10일 때만)
@@ -256,37 +325,6 @@ export const load: PageServerLoad = async ({
                     : Promise.resolve(null)
             ]);
 
-            const comments =
-                commentsResult.status === 'fulfilled'
-                    ? commentsResult.value
-                    : { items: [], total: 0, page: 1, limit: 200, total_pages: 0 };
-
-            // 댓글 제휴 링크 서버사이드 변환
-            if (comments.items?.length) {
-                try {
-                    const transformPromises: Promise<void>[] = [];
-                    for (const comment of comments.items) {
-                        if (comment.content) {
-                            transformPromises.push(
-                                transformAffiliateContent(comment.content, affiliateContext).then(
-                                    (html) => {
-                                        comment.content = html;
-                                    }
-                                )
-                            );
-                        }
-                    }
-                    if (transformPromises.length > 0) {
-                        await Promise.race([
-                            Promise.allSettled(transformPromises),
-                            new Promise((resolve) => setTimeout(resolve, 3000))
-                        ]);
-                    }
-                } catch {
-                    // 변환 실패 시 원본 유지
-                }
-            }
-
             // 프로모션 사잇광고: board_exception에 포함된 게시판은 제외
             let promotionPosts: unknown[] = [];
             if (promotionResult.status === 'fulfilled') {
@@ -311,41 +349,6 @@ export const load: PageServerLoad = async ({
                     ? likersResult.value || { likers: [], total: 0 }
                     : { likers: [], total: 0 };
 
-            // 회원 레벨 배치 조회 (작성자 + 댓글 작성자, DB 직접 — CDN 요청 제거)
-            let memberLevels: Record<string, number> = {};
-            try {
-                const authorIds = new Set<string>();
-                if (post.author_id) authorIds.add(post.author_id);
-                for (const c of comments.items || []) {
-                    if (c.author_id) authorIds.add(c.author_id);
-                }
-                if (authorIds.size > 0) {
-                    memberLevels = await fetchMemberLevels([...authorIds]);
-                }
-            } catch {
-                // 레벨 조회 실패 시 빈 맵 (클라이언트에서 fallback)
-            }
-
-            // 댓글 좋아요/비추천 상태 배치 조회 (로그인 시만)
-            let commentLikeStatuses: { likedIds: number[]; dislikedIds: number[] } = {
-                likedIds: [],
-                dislikedIds: []
-            };
-            if (locals.user?.id && comments.items?.length) {
-                try {
-                    const commentIds = comments.items
-                        .map((c: { id: number | string }) => Number(c.id))
-                        .filter((id: number) => !isNaN(id));
-                    commentLikeStatuses = await fetchCommentLikeStatuses(
-                        boardId,
-                        commentIds,
-                        locals.user.id
-                    );
-                } catch {
-                    // 실패 시 빈 상태 (클라이언트에서 fallback)
-                }
-            }
-
             // 본문 제휴 링크 변환 결과
             const transformedPostContent =
                 postContentResult.status === 'fulfilled' ? postContentResult.value : null;
@@ -356,13 +359,10 @@ export const load: PageServerLoad = async ({
                 postReportCountResult.status === 'fulfilled' ? postReportCountResult.value : null;
 
             return {
-                comments,
                 promotionPosts,
                 revisions,
                 reactions,
                 likersData,
-                memberLevels,
-                commentLikeStatuses,
                 transformedPostContent,
                 isScrapped,
                 postReportCount
@@ -394,7 +394,8 @@ export const load: PageServerLoad = async ({
             watermark,
             /** 스트리밍: Promise로 반환 → 클라이언트에서 $effect로 수신 */
             streamed: {
-                secondaryData: secondaryDataPromise
+                commentsData: commentsDataPromise,
+                auxiliaryData: auxiliaryDataPromise
             }
         };
     } catch (err) {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -251,23 +251,24 @@
     let revisions = $state<PostRevision[]>([]);
     let initialLikedCommentIds = $state<number[]>([]);
     let initialDislikedCommentIds = $state<number[]>([]);
-    let secondaryLoaded = $state(false);
-    let secondaryError = $state(false);
+    let commentsLoaded = $state(false);
+    let commentsError = $state(false);
+    let auxiliaryLoaded = $state(false);
     let isScrapped = $state(false);
     let postReportCount = $state<number | string | null>(null);
 
     $effect(() => {
-        const promise = data.streamed?.secondaryData;
+        const promise = data.streamed?.commentsData;
         if (!promise) return;
 
         let cancelled = false;
 
         // 네비게이션 시 초기화
         comments = [];
-        promotionPosts = [];
-        revisions = [];
-        secondaryLoaded = false;
-        secondaryError = false;
+        initialLikedCommentIds = [];
+        initialDislikedCommentIds = [];
+        commentsLoaded = false;
+        commentsError = false;
 
         promise
             .then(
@@ -279,43 +280,15 @@
                         limit: number;
                         total_pages: number;
                     };
-                    promotionPosts: unknown[];
-                    revisions: PostRevision[];
-                    reactions?: Record<string, unknown>;
-                    likersData?: { likers: LikerInfo[]; total: number };
                     memberLevels?: Record<string, number>;
                     commentLikeStatuses?: { likedIds: number[]; dislikedIds: number[] };
-                    transformedPostContent?: string | null;
-                    isScrapped?: boolean;
-                    postReportCount?: number | string | null;
                 }) => {
                     if (cancelled) return;
                     comments = result.comments.items || [];
-                    promotionPosts = result.promotionPosts || [];
-                    revisions = result.revisions || [];
-
-                    // SSR 리액션 데이터 적용
-                    if (result.reactions && Object.keys(result.reactions).length > 0) {
-                        reactionsMap = result.reactions as Record<string, ReactionItem[]>;
-                        const docTargetId = generateDocumentTargetId(boardId, data.post.id);
-                        postReactions =
-                            (result.reactions as Record<string, ReactionItem[]>)[docTargetId] || [];
-                    }
-
-                    // SSR 추천자 아바타 적용
-                    if (result.likersData) {
-                        likers = result.likersData.likers || [];
-                        likersTotal = result.likersData.total || 0;
-                    }
 
                     // SSR 회원 레벨 적용
                     if (result.memberLevels && Object.keys(result.memberLevels).length > 0) {
                         memberLevelStore.initFromSSR(result.memberLevels);
-                    }
-
-                    // 본문 제휴 링크 변환 적용 (스트리밍)
-                    if (result.transformedPostContent) {
-                        data.post.content = result.transformedPostContent;
                     }
 
                     // SSR 댓글 좋아요 상태 적용
@@ -323,18 +296,7 @@
                         initialLikedCommentIds = result.commentLikeStatuses.likedIds || [];
                         initialDislikedCommentIds = result.commentLikeStatuses.dislikedIds || [];
                     }
-
-                    // 스크랩 상태 적용 (스트리밍)
-                    if (result.isScrapped) {
-                        isScrapped = result.isScrapped;
-                    }
-
-                    // 게시글 신고 횟수 (관리자만)
-                    if (result.postReportCount != null) {
-                        postReportCount = result.postReportCount;
-                    }
-
-                    secondaryLoaded = true;
+                    commentsLoaded = true;
                 }
             )
             .catch(async () => {
@@ -349,7 +311,7 @@
                             const json = await res.json();
                             if (json.success && json.data) {
                                 comments = json.data.comments || [];
-                                secondaryLoaded = true;
+                                commentsLoaded = true;
                                 return;
                             }
                         }
@@ -357,8 +319,70 @@
                         // 재시도도 실패
                     }
                 }
-                secondaryError = true;
-                secondaryLoaded = true;
+                commentsError = true;
+                commentsLoaded = true;
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    });
+
+    $effect(() => {
+        const promise = data.streamed?.auxiliaryData;
+        if (!promise) return;
+
+        let cancelled = false;
+
+        promotionPosts = [];
+        revisions = [];
+        auxiliaryLoaded = false;
+
+        promise
+            .then(
+                (result: {
+                    promotionPosts: unknown[];
+                    revisions: PostRevision[];
+                    reactions?: Record<string, unknown>;
+                    likersData?: { likers: LikerInfo[]; total: number };
+                    transformedPostContent?: string | null;
+                    isScrapped?: boolean;
+                    postReportCount?: number | string | null;
+                }) => {
+                    if (cancelled) return;
+                    promotionPosts = result.promotionPosts || [];
+                    revisions = result.revisions || [];
+
+                    if (result.reactions && Object.keys(result.reactions).length > 0) {
+                        reactionsMap = result.reactions as Record<string, ReactionItem[]>;
+                        const docTargetId = generateDocumentTargetId(boardId, data.post.id);
+                        postReactions =
+                            (result.reactions as Record<string, ReactionItem[]>)[docTargetId] || [];
+                    }
+
+                    if (result.likersData) {
+                        likers = result.likersData.likers || [];
+                        likersTotal = result.likersData.total || 0;
+                    }
+
+                    if (result.transformedPostContent) {
+                        data.post.content = result.transformedPostContent;
+                    }
+
+                    if (result.isScrapped) {
+                        isScrapped = result.isScrapped;
+                    }
+
+                    if (result.postReportCount != null) {
+                        postReportCount = result.postReportCount;
+                    }
+
+                    auxiliaryLoaded = true;
+                }
+            )
+            .catch(() => {
+                if (cancelled) return;
+                auxiliaryLoaded = true;
             });
 
         return () => {
@@ -579,7 +603,7 @@
 
     // 앵커 스크롤 (#c_댓글ID, #comment_댓글ID, #likes) — 스트리밍 완료 후 실행
     $effect(() => {
-        if (secondaryLoaded && browser) {
+        if (commentsLoaded && browser) {
             const hash = window.location.hash;
             if (!hash) return;
 
@@ -1300,7 +1324,7 @@
         -->
 
         <!-- 수정 이력 (리비전 히스토리) - 관리자 전용 (스트리밍 완료 후) -->
-        {#if isAdmin && secondaryLoaded && revisions.length > 0}
+        {#if isAdmin && auxiliaryLoaded && revisions.length > 0}
             <div class="mb-6">
                 <RevisionHistory
                     {revisions}
@@ -1312,7 +1336,7 @@
         {/if}
 
         <!-- 댓글 섹션 (비밀글 열람 가능 + 스트리밍 완료 시 표시) -->
-        {#if canViewSecret && !secondaryLoaded}
+        {#if canViewSecret && !commentsLoaded}
             <Card class="bg-background">
                 <CardContent class="space-y-4 py-6">
                     <!-- 댓글 스켈레톤 -->
@@ -1331,7 +1355,7 @@
                     {/each}
                 </CardContent>
             </Card>
-        {:else if canViewSecret && secondaryError}
+        {:else if canViewSecret && commentsError}
             <Card class="bg-background">
                 <CardContent class="py-8 text-center">
                     <p class="text-destructive text-sm">댓글을 불러오지 못했습니다.</p>


### PR DESCRIPTION
## 요약
- 게시글 상세에서 댓글 로딩과 광고/보조 데이터를 분리했습니다.
- 게시판 목록에서 프로모션 광고 fetch를 글 목록 렌더와 분리했습니다.
- promotion ads timeout을 줄여 느린 광고 서버가 본문과 목록을 3초씩 막지 않게 했습니다.

## 기대 효과
- 댓글 스켈레톤이 광고 timeout에 같이 묶이지 않습니다.
- 목록 진입 시 프로모션 광고 지연이 글 목록 렌더를 막지 않습니다.
- ads 서버가 느려도 본문과 목록 핵심 데이터가 먼저 보입니다.

## 확인
- 최신 main 기준으로 리베이스 후 반영
- 워크트리에는 node_modules가 없어 로컬 svelte-check는 못 돌렸고 CI에서 확인합니다.