### PR TITLE
광고 슬롯 생명주기를 registry 기반으로 안정화

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -736,7 +736,11 @@
         <!-- 댓글 5개마다 GAM 인피드 광고 (루트 댓글 기준, 첫 번째 제외) -->
         {#if widgetLayoutStore.hasEnabledAds && commentIndex > 0 && commentIndex % 5 === 0 && depth === 0}
             <li class="list-none py-2">
-                <AdSlot position="comment-infeed" height="90px" />
+                <AdSlot
+                    position="comment-infeed"
+                    height="90px"
+                    slotKey={`comment-infeed-${comment.id}`}
+                />
             </li>
         {/if}
         <li

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -313,7 +313,7 @@
 
         <!-- GAM 광고 -->
         {#if widgetLayoutStore.hasEnabledAds && (postContent?.length ?? 0) >= 500}
-            <AdSlot position="board-content" height="90px" />
+            <AdSlot position="board-content" height="90px" slotKey="board-content" />
         {/if}
 
         <!-- 알뜰구매 모든 링크열기 (GAM 바로 아래) -->

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -368,7 +368,7 @@
 
         <!-- GAM 광고 -->
         {#if widgetLayoutStore.hasEnabledAds}
-            <AdSlot position="board-content" height="90px" />
+            <AdSlot position="board-content" height="90px" slotKey="board-content" />
         {/if}
 
         <!-- 알뜰구매 모든 링크열기 (GAM 바로 아래) -->

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -257,7 +257,11 @@
             </div>
             {#if widgetLayoutStore.hasEnabledAds && i + 1 === 7}
                 <div class="py-2">
-                    <AdSlot position="board-list-infeed" height="90px" />
+                    <AdSlot
+                        position="board-list-infeed"
+                        height="90px"
+                        slotKey={`recent-posts-infeed-${i}`}
+                    />
                 </div>
             {/if}
             {#if shuffledPromos.length > 0 && i + 1 === 10}
@@ -311,7 +315,7 @@
     <!-- 페이징 아래 GAM 광고 (모바일만) -->
     {#if widgetLayoutStore.hasEnabledAds}
         <div class="mt-4 md:hidden">
-            <AdSlot position="board-footer" height="90px" />
+            <AdSlot position="board-footer" height="90px" slotKey="recent-posts-footer" />
         </div>
     {/if}
 {/if}

--- a/apps/web/src/lib/components/features/widget-editor/widget-editor.svelte
+++ b/apps/web/src/lib/components/features/widget-editor/widget-editor.svelte
@@ -68,7 +68,11 @@
                 <div animate:flip={{ duration: flipDurationMs }}>
                     <WidgetWrapper {widget}>
                         {#if widget.type === 'ad'}
-                            <AdSlot position={getAdPosition(widget)} height={getAdHeight(widget)} />
+                            <AdSlot
+                                position={getAdPosition(widget)}
+                                height={getAdHeight(widget)}
+                                slotKey={`widget-${widget.id}`}
+                            />
                         {:else if widget.type === 'recommended'}
                             <RecommendedPosts />
                         {:else if widget.type === 'new-board'}
@@ -97,7 +101,11 @@
         <!-- 일반 모드: 드래그 비활성화 -->
         {#each widgets.filter((w) => w.enabled) as widget (widget.id)}
             {#if widget.type === 'ad'}
-                <AdSlot position={getAdPosition(widget)} height={getAdHeight(widget)} />
+                <AdSlot
+                    position={getAdPosition(widget)}
+                    height={getAdHeight(widget)}
+                    slotKey={`widget-${widget.id}`}
+                />
             {:else if widget.type === 'recommended'}
                 <RecommendedPosts />
             {:else if widget.type === 'new-board'}

--- a/apps/web/src/lib/components/layout/left-banner.svelte
+++ b/apps/web/src/lib/components/layout/left-banner.svelte
@@ -8,5 +8,5 @@
     class="flex w-[160px] flex-col items-center justify-center gap-2"
     class:hidden={!widgetLayoutStore.hasEnabledAds}
 >
-    <AdSlot position="wing-left" height="600px" />
+    <AdSlot position="wing-left" height="600px" slotKey="wing-left" />
 </div>

--- a/apps/web/src/lib/components/layout/panel.svelte
+++ b/apps/web/src/lib/components/layout/panel.svelte
@@ -32,7 +32,7 @@
     <div class="flex-1">
         <div class="sticky top-[64px]">
             <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
-                <AdSlot position="sidebar-sticky" height="600px" />
+                <AdSlot position="sidebar-sticky" height="600px" slotKey="sidebar-sticky" />
             </div>
         </div>
     </div>

--- a/apps/web/src/lib/components/layout/right-banner.svelte
+++ b/apps/web/src/lib/components/layout/right-banner.svelte
@@ -31,7 +31,7 @@
     class="flex w-[160px] flex-col items-center justify-center gap-2"
     class:hidden={!widgetLayoutStore.hasEnabledAds}
 >
-    <AdSlot position="wing-right" height="600px" />
+    <AdSlot position="wing-right" height="600px" slotKey="wing-right" />
 </div>
 
 <!-- TOP 버튼 - 오른쪽 하단 -->

--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -363,10 +363,10 @@
         <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
             {#if compact}
                 <div class="flex justify-center">
-                    <AdSlot position="sidebar-drawer" height="100px" />
+                    <AdSlot position="sidebar-drawer" height="100px" slotKey="sidebar-drawer" />
                 </div>
             {:else}
-                <AdSlot position="sidebar" height="250px" />
+                <AdSlot position="sidebar" height="250px" slotKey="sidebar-main" />
             {/if}
         </div>
         {#if compact}

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
@@ -1,0 +1,352 @@
+import { browser } from '$app/environment';
+import { GAM_SITE_NAME, type AdConfig } from '$lib/config/ad-config.js';
+
+const REGISTRY_KEY = '__gam_slot_registry__';
+const DESTROY_DELAY_MS = 1500;
+
+type SlotSizes = Array<[number, number]> | 'fluid';
+
+type SlotState = {
+    key: string;
+    slotId: string;
+    slot: googletag.Slot | null;
+    config: AdConfig;
+    sizes: SlotSizes;
+    mountCount: number;
+    empty: boolean;
+    loaded: boolean;
+    refreshTimer: ReturnType<typeof setInterval> | null;
+    emptyRetryTimer: ReturnType<typeof setTimeout> | null;
+    emptyRetryCount: number;
+    destroyTimer: ReturnType<typeof setTimeout> | null;
+    visible: boolean;
+};
+
+type SlotAttachOptions = {
+    key: string;
+    position: string;
+    sizes: SlotSizes;
+    config: AdConfig;
+    refreshIntervalMs: number;
+    emptyRetryDelayMs: number;
+    maxEmptyRetries: number;
+    onRender: (isEmpty: boolean) => void;
+};
+
+type Registry = {
+    slots: Map<string, SlotState>;
+    callbacks: Map<string, Set<(isEmpty: boolean) => void>>;
+    servicesEnabled: boolean;
+    listenerRegistered: boolean;
+    gptReadyPromise: Promise<void> | null;
+};
+
+function createRegistry(): Registry {
+    return {
+        slots: new Map(),
+        callbacks: new Map(),
+        servicesEnabled: false,
+        listenerRegistered: false,
+        gptReadyPromise: null
+    };
+}
+
+function getRegistry(): Registry {
+    if (!browser) return createRegistry();
+    const win = window as Window & { [REGISTRY_KEY]?: Registry };
+    if (!win[REGISTRY_KEY]) {
+        win[REGISTRY_KEY] = createRegistry();
+    }
+    return win[REGISTRY_KEY]!;
+}
+
+function emitRender(slotId: string, isEmpty: boolean) {
+    const registry = getRegistry();
+    const callbacks = registry.callbacks.get(slotId);
+    if (!callbacks) return;
+    callbacks.forEach((callback) => callback(isEmpty));
+}
+
+function ensureSlotListener() {
+    const registry = getRegistry();
+    if (registry.listenerRegistered) return;
+
+    googletag.pubads().addEventListener('slotRenderEnded', (event) => {
+        const slotId = event.slot.getSlotElementId();
+        const state = registry.slots.get(slotId);
+        if (!state) return;
+
+        state.loaded = true;
+        state.empty = event.isEmpty;
+        emitRender(slotId, event.isEmpty);
+    });
+
+    registry.listenerRegistered = true;
+}
+
+function ensureServices() {
+    const registry = getRegistry();
+    if (registry.servicesEnabled) return;
+
+    googletag.pubads().collapseEmptyDivs();
+    googletag.pubads().enableLazyLoad({
+        fetchMarginPercent: 200,
+        renderMarginPercent: 100,
+        mobileScaling: 2
+    });
+    googletag.pubads().setCentering(true);
+    googletag.pubads().setTargeting('site', GAM_SITE_NAME);
+    const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+    googletag.pubads().setTargeting('theme', theme);
+    googletag.enableServices();
+    registry.servicesEnabled = true;
+}
+
+function defineSlot(slotId: string, config: AdConfig, sizes: SlotSizes): googletag.Slot | null {
+    let slot: googletag.Slot | null;
+
+    if (sizes === 'fluid') {
+        slot = googletag.defineSlot(config.unit, ['fluid'], slotId);
+    } else {
+        slot = googletag.defineSlot(config.unit, sizes as googletag.GeneralSize, slotId);
+    }
+
+    if (!slot) return null;
+
+    if (config.responsive) {
+        const mapping = googletag.sizeMapping();
+        for (const [viewport, slotSizes] of config.responsive) {
+            mapping.addSize([viewport, 0], slotSizes as googletag.GeneralSize);
+        }
+        const built = mapping.build();
+        if (built) {
+            slot.defineSizeMapping(built);
+        }
+    }
+
+    slot.addService(googletag.pubads());
+    return slot;
+}
+
+async function ensureGPTReady() {
+    if (!browser) return;
+
+    const registry = getRegistry();
+    if (window.googletag?.apiReady) return;
+
+    if (!registry.gptReadyPromise) {
+        registry.gptReadyPromise = new Promise<void>((resolve) => {
+            if (window.googletag?.apiReady) {
+                resolve();
+                return;
+            }
+
+            const existingScript = document.querySelector(
+                'script[src*="securepubads.g.doubleclick.net"]'
+            );
+            if (existingScript) {
+                const readyCheck = setInterval(() => {
+                    if (window.googletag?.apiReady) {
+                        clearInterval(readyCheck);
+                        resolve();
+                    }
+                }, 100);
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
+            script.async = true;
+            script.onload = () => {
+                const readyCheck = setInterval(() => {
+                    if (window.googletag?.apiReady) {
+                        clearInterval(readyCheck);
+                        resolve();
+                    }
+                }, 100);
+            };
+            document.head.appendChild(script);
+        });
+    }
+
+    await registry.gptReadyPromise;
+}
+
+function scheduleAutoRefresh(state: SlotState, intervalMs: number) {
+    if (state.refreshTimer || intervalMs <= 0) return;
+
+    state.refreshTimer = setInterval(() => {
+        googletag.cmd.push(() => {
+            if (!state.slot || state.empty || state.mountCount <= 0 || !state.visible) return;
+            googletag.pubads().refresh([state.slot], { changeCorrelator: false });
+        });
+    }, intervalMs);
+}
+
+function clearSlotTimers(state: SlotState) {
+    if (state.refreshTimer) {
+        clearInterval(state.refreshTimer);
+        state.refreshTimer = null;
+    }
+    if (state.emptyRetryTimer) {
+        clearTimeout(state.emptyRetryTimer);
+        state.emptyRetryTimer = null;
+    }
+    if (state.destroyTimer) {
+        clearTimeout(state.destroyTimer);
+        state.destroyTimer = null;
+    }
+}
+
+function scheduleEmptyRetry(state: SlotState, delayMs: number, maxRetries: number) {
+    if (state.emptyRetryTimer || state.emptyRetryCount >= maxRetries) return;
+
+    state.emptyRetryTimer = setTimeout(() => {
+        state.emptyRetryTimer = null;
+        state.emptyRetryCount += 1;
+
+        googletag.cmd.push(() => {
+            if (!state.slot || state.mountCount <= 0) return;
+            googletag.pubads().refresh([state.slot], { changeCorrelator: false });
+        });
+    }, delayMs);
+}
+
+export function buildSlotId(position: string, slotKey: string) {
+    return `gam-${position}-${slotKey}`;
+}
+
+export async function attachSlot(options: SlotAttachOptions) {
+    if (!browser) return null;
+
+    await ensureGPTReady();
+
+    window.googletag = window.googletag || { cmd: [] };
+    const registry = getRegistry();
+    const slotId = buildSlotId(options.position, options.key);
+
+    let state = registry.slots.get(slotId);
+    if (!state) {
+        state = {
+            key: options.key,
+            slotId,
+            slot: null,
+            config: options.config,
+            sizes: options.sizes,
+            mountCount: 0,
+            empty: false,
+            loaded: false,
+            refreshTimer: null,
+            emptyRetryTimer: null,
+            emptyRetryCount: 0,
+            destroyTimer: null,
+            visible: false
+        };
+        registry.slots.set(slotId, state);
+    }
+
+    state.mountCount += 1;
+    state.config = options.config;
+    state.sizes = options.sizes;
+
+    if (!registry.callbacks.has(slotId)) {
+        registry.callbacks.set(slotId, new Set());
+    }
+    registry.callbacks.get(slotId)!.add(options.onRender);
+
+    if (state.destroyTimer) {
+        clearTimeout(state.destroyTimer);
+        state.destroyTimer = null;
+    }
+
+    googletag.cmd.push(() => {
+        ensureSlotListener();
+        ensureServices();
+
+        if (!state!.slot) {
+            state!.slot = defineSlot(slotId, options.config, options.sizes);
+            if (!state!.slot) return;
+            googletag.display(slotId);
+        } else if (state!.loaded || state!.mountCount > 1) {
+            googletag.pubads().refresh([state!.slot], { changeCorrelator: false });
+        }
+
+        scheduleAutoRefresh(state!, options.refreshIntervalMs);
+        if (state!.loaded) {
+            emitRender(slotId, state!.empty);
+        }
+        if (state!.loaded && state!.empty) {
+            scheduleEmptyRetry(state!, options.emptyRetryDelayMs, options.maxEmptyRetries);
+        }
+    });
+
+    return {
+        slotId,
+        state
+    };
+}
+
+export function onSlotRendered(
+    slotId: string,
+    isEmpty: boolean,
+    emptyRetryDelayMs: number,
+    maxRetries: number
+) {
+    const registry = getRegistry();
+    const state = registry.slots.get(slotId);
+    if (!state) return;
+
+    state.loaded = true;
+    state.empty = isEmpty;
+    if (isEmpty) {
+        scheduleEmptyRetry(state, emptyRetryDelayMs, maxRetries);
+        return;
+    }
+
+    if (state.emptyRetryTimer) {
+        clearTimeout(state.emptyRetryTimer);
+        state.emptyRetryTimer = null;
+    }
+    state.emptyRetryCount = 0;
+}
+
+export function detachSlot(slotId: string, onRender: (isEmpty: boolean) => void) {
+    if (!browser) return;
+
+    const registry = getRegistry();
+    const callbacks = registry.callbacks.get(slotId);
+    callbacks?.delete(onRender);
+    if (callbacks && callbacks.size === 0) {
+        registry.callbacks.delete(slotId);
+    }
+
+    const state = registry.slots.get(slotId);
+    if (!state) return;
+
+    state.mountCount = Math.max(0, state.mountCount - 1);
+    if (state.mountCount > 0) return;
+
+    if (state.destroyTimer) {
+        clearTimeout(state.destroyTimer);
+    }
+
+    state.destroyTimer = setTimeout(() => {
+        googletag.cmd.push(() => {
+            if (!state.slot || state.mountCount > 0) return;
+
+            clearSlotTimers(state);
+            googletag.destroySlots([state.slot]);
+            registry.slots.delete(slotId);
+            registry.callbacks.delete(slotId);
+        });
+    }, DESTROY_DELAY_MS);
+}
+
+export function updateSlotVisibility(slotId: string, visible: boolean) {
+    if (!browser) return;
+
+    const registry = getRegistry();
+    const state = registry.slots.get(slotId);
+    if (!state) return;
+    state.visible = visible;
+}

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -1,225 +1,46 @@
 <script lang="ts">
-    import { onMount, onDestroy, tick } from 'svelte';
-    import { browser } from '$app/environment';
+    import { onDestroy, onMount, tick } from 'svelte';
     import {
-        GAM_SITE_NAME,
-        GAM_AD_REFRESH_INTERVAL,
-        GAM_AD_EMPTY_RETRY_DELAY,
-        AD_UNIT_PATHS,
         AD_CONFIGS,
-        POSITION_MAP,
+        AD_UNIT_PATHS,
+        GAM_AD_EMPTY_RETRY_DELAY,
+        GAM_AD_REFRESH_INTERVAL,
         POSITION_LABELS,
+        POSITION_MAP,
         type AdConfig
     } from '$lib/config/ad-config.js';
+    import {
+        attachSlot,
+        buildSlotId,
+        detachSlot,
+        onSlotRendered,
+        updateSlotVisibility
+    } from './ad-slot-registry.js';
 
     interface Props {
         position: string;
         height?: string;
         class?: string;
         sizes?: Array<[number, number]> | 'fluid';
+        slotKey?: string;
     }
 
-    let { position, height = '90px', class: className = '', sizes }: Props = $props();
+    let { position, height = '90px', class: className = '', sizes, slotKey }: Props = $props();
 
     let isLoaded = $state(false);
     let hasAd = $state(false);
     let slotId = $state('');
     let computedHeight = $state(height);
-    let slot: googletag.Slot | null = null;
-    let refreshInterval: ReturnType<typeof setInterval> | null = null;
-    let emptyRetryTimeout: ReturnType<typeof setTimeout> | null = null;
-    let emptyRetryCount = 0;
-    let destroyed = false;
-    let isVisible = false;
-    let visibilityObserver: IntersectionObserver | null = null;
+    let detached = false;
     let containerEl: HTMLDivElement | null = null;
+    let visibilityObserver: IntersectionObserver | null = null;
 
-    // ========================================
-    // 배치 슬롯 매니저 (전역 싱글톤)
-    // ========================================
-    const BATCH_KEY = '__gam_batch_manager__';
-
-    interface BatchManager {
-        queue: Array<{
-            divId: string;
-            config: AdConfig;
-            adSizes: Array<[number, number]> | 'fluid';
-            onRender: (isEmpty: boolean) => void;
-        }>;
-        timer: ReturnType<typeof setTimeout> | null;
-        servicesEnabled: boolean;
-        slotsMap: Map<string, googletag.Slot>;
-        renderCallbacks: Map<string, (isEmpty: boolean) => void>;
-        slotRenderListenerRegistered: boolean;
-    }
-
-    function getBatchManager(): BatchManager {
-        if (!browser)
-            return {
-                queue: [],
-                timer: null,
-                servicesEnabled: false,
-                slotsMap: new Map(),
-                renderCallbacks: new Map(),
-                slotRenderListenerRegistered: false
-            };
-        if (!(window as any)[BATCH_KEY]) {
-            (window as any)[BATCH_KEY] = {
-                queue: [],
-                timer: null,
-                servicesEnabled: false,
-                slotsMap: new Map(),
-                renderCallbacks: new Map(),
-                slotRenderListenerRegistered: false
-            };
-        }
-        return (window as any)[BATCH_KEY];
-    }
-
-    function processBatch() {
-        const mgr = getBatchManager();
-        if (mgr.queue.length === 0) return;
-
-        const batch = mgr.queue.splice(0);
-
-        googletag.cmd.push(() => {
-            const newSlots: googletag.Slot[] = [];
-
-            if (!mgr.slotRenderListenerRegistered) {
-                googletag
-                    .pubads()
-                    .addEventListener(
-                        'slotRenderEnded',
-                        (event: googletag.events.SlotRenderEndedEvent) => {
-                            const divId = event.slot.getSlotElementId();
-                            const onRender = mgr.renderCallbacks.get(divId);
-                            if (onRender) {
-                                onRender(event.isEmpty);
-                            }
-                        }
-                    );
-                mgr.slotRenderListenerRegistered = true;
-            }
-
-            for (const item of batch) {
-                if (!document.getElementById(item.divId)) continue;
-                if (mgr.slotsMap.has(item.divId)) continue;
-
-                let s: googletag.Slot | null;
-                if (item.adSizes === 'fluid') {
-                    s = googletag.defineSlot(item.config.unit, ['fluid'], item.divId);
-                } else {
-                    s = googletag.defineSlot(
-                        item.config.unit,
-                        item.adSizes as googletag.GeneralSize,
-                        item.divId
-                    );
-                }
-
-                if (!s) continue;
-
-                if (item.config.responsive) {
-                    const mapping = googletag.sizeMapping();
-                    for (const [viewport, slotSizes] of item.config.responsive) {
-                        mapping.addSize([viewport, 0], slotSizes as googletag.GeneralSize);
-                    }
-                    const builtMapping = mapping.build();
-                    if (builtMapping) {
-                        s.defineSizeMapping(builtMapping);
-                    }
-                }
-
-                s.addService(googletag.pubads());
-                mgr.slotsMap.set(item.divId, s);
-                mgr.renderCallbacks.set(item.divId, item.onRender);
-                newSlots.push(s);
-            }
-
-            if (!mgr.servicesEnabled) {
-                googletag.pubads().collapseEmptyDivs();
-                googletag.pubads().enableLazyLoad({
-                    fetchMarginPercent: 200,
-                    renderMarginPercent: 100,
-                    mobileScaling: 2.0
-                });
-                googletag.pubads().setCentering(true);
-                googletag.pubads().setTargeting('site', GAM_SITE_NAME);
-                const theme = document.documentElement.classList.contains('dark')
-                    ? 'dark'
-                    : 'light';
-                googletag.pubads().setTargeting('theme', theme);
-                googletag.enableServices();
-                mgr.servicesEnabled = true;
-            }
-
-            // display 호출로 초기 광고 요청이 시작됨
-            for (const s of newSlots) {
-                googletag.display(s.getSlotElementId());
-            }
-        });
-    }
-
-    function enqueueSlot(
-        divId: string,
-        config: AdConfig,
-        adSizes: Array<[number, number]> | 'fluid',
-        onRender: (isEmpty: boolean) => void
-    ) {
-        const mgr = getBatchManager();
-        mgr.queue.push({ divId, config, adSizes, onRender });
-
-        // 50ms 디바운스로 같은 틱에 마운트되는 슬롯들을 배치 처리
-        if (mgr.timer) clearTimeout(mgr.timer);
-        mgr.timer = setTimeout(() => {
-            mgr.timer = null;
-            processBatch();
-        }, 50);
-    }
-
-    // GPT 스크립트 로드
-    function loadGPT(): Promise<void> {
-        return new Promise((resolve) => {
-            if (!browser) return resolve();
-
-            if (window.googletag?.apiReady) {
-                resolve();
-                return;
-            }
-
-            const existingScript = document.querySelector(
-                'script[src*="securepubads.g.doubleclick.net"]'
-            );
-            if (existingScript) {
-                const checkReady = setInterval(() => {
-                    if (window.googletag?.apiReady) {
-                        clearInterval(checkReady);
-                        resolve();
-                    }
-                }, 100);
-                return;
-            }
-
-            const script = document.createElement('script');
-            script.src = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
-            script.async = true;
-            script.onload = () => {
-                const checkReady = setInterval(() => {
-                    if (window.googletag?.apiReady) {
-                        clearInterval(checkReady);
-                        resolve();
-                    }
-                }, 100);
-            };
-            document.head.appendChild(script);
-        });
-    }
-
-    // 광고 설정 가져오기
     function getAdConfig(): AdConfig {
         const configKey = POSITION_MAP[position];
         if (configKey && AD_CONFIGS[configKey]) {
             return AD_CONFIGS[configKey];
         }
+
         return {
             unit: AD_UNIT_PATHS.sub,
             sizes: (sizes as Array<[number, number]>) || [
@@ -233,125 +54,79 @@
         };
     }
 
-    // 반응형 높이 자동 계산
     function getResponsiveHeight(config: AdConfig): string {
         if (typeof window === 'undefined') return height;
         const width = window.innerWidth;
+
         if (config.responsive) {
             for (const [viewport, viewportSizes] of config.responsive) {
                 if (width >= viewport && viewportSizes.length > 0) {
-                    const maxHeight = Math.max(...viewportSizes.map((s) => s[1]));
-                    return `${maxHeight}px`;
+                    return `${Math.max(...viewportSizes.map((size) => size[1]))}px`;
                 }
             }
         }
-        // fallback: 기본 sizes에서 최대 높이
+
         if (config.sizes.length > 0) {
-            const maxHeight = Math.max(...config.sizes.map((s) => s[1]));
-            return `${maxHeight}px`;
+            return `${Math.max(...config.sizes.map((size) => size[1]))}px`;
         }
+
         return height;
     }
 
-    // 광고 슬롯 초기화
-    async function initAdSlot() {
-        if (!browser) return;
+    function handleRender(isEmpty: boolean) {
+        if (detached) return;
+        isLoaded = true;
+        hasAd = !isEmpty;
+        onSlotRendered(slotId, isEmpty, GAM_AD_EMPTY_RETRY_DELAY * 1000, 3);
+    }
 
-        await loadGPT();
+    async function initAdSlot() {
+        detached = false;
 
         const config = getAdConfig();
         const adSizes = sizes || config.sizes;
-        slotId = `gam-${position}-${Math.random().toString(36).substr(2, 9)}`;
+        const resolvedSlotKey = slotKey || position;
 
-        // 반응형 높이 자동 계산 (CLS 방지)
+        slotId = buildSlotId(position, resolvedSlotKey);
         computedHeight = getResponsiveHeight(config);
 
         await tick();
 
-        window.googletag = window.googletag || { cmd: [] };
-
-        // IntersectionObserver로 viewability 추적
-        const slotEl = document.getElementById(slotId);
-        if (slotEl) {
+        if (containerEl && typeof IntersectionObserver !== 'undefined') {
+            visibilityObserver?.disconnect();
             visibilityObserver = new IntersectionObserver(
                 ([entry]) => {
-                    isVisible = entry.isIntersecting;
+                    updateSlotVisibility(slotId, entry.isIntersecting);
                 },
                 { threshold: 0.5 }
             );
-            visibilityObserver.observe(slotEl);
+            visibilityObserver.observe(containerEl);
+        } else {
+            updateSlotVisibility(slotId, true);
         }
 
-        enqueueSlot(slotId, config, adSizes, (isEmpty: boolean) => {
-            isLoaded = true;
-            hasAd = !isEmpty;
-
-            // 슬롯 참조 저장
-            const mgr = getBatchManager();
-            slot = mgr.slotsMap.get(slotId) || null;
-            const maxRetryLimit = 3;
-            // 빈 광고면 delay ms 마다 최대 3회까지만 재시도하고, 중복 타이머는 만들지 않음
-            if (!isEmpty) {
-                if (emptyRetryTimeout) {
-                    clearTimeout(emptyRetryTimeout);
-                    emptyRetryTimeout = null;
-                }
-            } else if (slot && emptyRetryCount < maxRetryLimit && !emptyRetryTimeout) {
-                const delayMilliseconds =
-                    emptyRetryCount === 0 ? 10_000 : GAM_AD_EMPTY_RETRY_DELAY * 1000;
-                emptyRetryTimeout = setTimeout(() => {
-                    emptyRetryTimeout = null;
-                    if (slot && !destroyed && hasAd === false) {
-                        emptyRetryCount += 1;
-                        googletag.cmd.push(() => {
-                            if (slot && !destroyed) {
-                                googletag.pubads().refresh([slot], { changeCorrelator: false });
-                            }
-                        });
-                    }
-                }, delayMilliseconds);
-            }
-
-            // 자동 새로고침 설정 (viewability 체크)
-            if (!isEmpty && !refreshInterval) {
-                refreshInterval = setInterval(() => {
-                    if (slot && hasAd && !destroyed && isVisible) {
-                        googletag.pubads().refresh([slot], { changeCorrelator: false });
-                    }
-                }, GAM_AD_REFRESH_INTERVAL * 1000);
-            }
+        await attachSlot({
+            key: resolvedSlotKey,
+            position,
+            sizes: adSizes,
+            config,
+            refreshIntervalMs: GAM_AD_REFRESH_INTERVAL * 1000,
+            emptyRetryDelayMs: GAM_AD_EMPTY_RETRY_DELAY * 1000,
+            maxEmptyRetries: 3,
+            onRender: handleRender
         });
     }
 
     onMount(() => {
-        initAdSlot();
+        void initAdSlot();
     });
 
     onDestroy(() => {
-        destroyed = true;
-
-        if (visibilityObserver) {
-            visibilityObserver.disconnect();
-        }
-
-        if (refreshInterval) {
-            clearInterval(refreshInterval);
-        }
-
-        if (emptyRetryTimeout) {
-            clearTimeout(emptyRetryTimeout);
-        }
-
-        if (slot && browser && window.googletag) {
-            googletag.cmd.push(() => {
-                if (slot) {
-                    googletag.destroySlots([slot]);
-                    const mgr = getBatchManager();
-                    mgr.slotsMap.delete(slotId);
-                    mgr.renderCallbacks.delete(slotId);
-                }
-            });
-        }
+        detached = true;
+        visibilityObserver?.disconnect();
+        if (!slotId) return;
+        updateSlotVisibility(slotId, false);
+        detachSlot(slotId, handleRender);
     });
 </script>
 
@@ -363,12 +138,10 @@
     style:min-height={computedHeight}
 >
     {#if slotId}
-        <!-- GAM 광고 슬롯 -->
         <div id={slotId} class="gam-ad-slot w-full" style="min-height: {computedHeight};"></div>
     {/if}
 
     {#if !isLoaded}
-        <!-- 로딩 중 플레이스홀더 -->
         <div
             class="absolute inset-0 flex items-center justify-center rounded-lg border-2 border-dashed border-slate-300 bg-slate-50/50 dark:border-slate-600 dark:bg-slate-800/50"
         >

--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -241,7 +241,7 @@
             </div>
         {:else}
             <!-- GAM 폴백 -->
-            <AdSlot position={gamPosition} {height} />
+            <AdSlot position={gamPosition} {height} slotKey={`damoang-banner-${position}`} />
         {/if}
     {/if}
 </div>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -866,7 +866,11 @@
                             {/if}
                             {#if widgetLayoutStore.hasEnabledAds && i + 1 === 7}
                                 <div class="py-2">
-                                    <AdSlot position="board-list-infeed" height="90px" />
+                                    <AdSlot
+                                        position="board-list-infeed"
+                                        height="90px"
+                                        slotKey={`board-list-infeed-${i}`}
+                                    />
                                 </div>
                             {/if}
                             {#if shuffledPromos.length > 0 && i + 1 === 12}
@@ -914,7 +918,11 @@
                     </p>
                     {#if widgetLayoutStore.hasEnabledAds}
                         <div class="mt-3">
-                            <AdSlot position="board-list-bottom" height="90px" />
+                            <AdSlot
+                                position="board-list-bottom"
+                                height="90px"
+                                slotKey="board-list-bottom"
+                            />
                         </div>
                     {/if}
                 {/if}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1210,7 +1210,7 @@
     <!-- 네비게이션 아래 GAM 광고 (알뜰구매/중고장터 등 특정 게시판에서만 표시) -->
     {#if widgetLayoutStore.hasEnabledAds && (boardType === 'economy' || boardType === 'used-market')}
         <div class="mb-6">
-            <AdSlot position="board-view-top" height="45px" />
+            <AdSlot position="board-view-top" height="45px" slotKey="board-view-top" />
         </div>
     {/if}
 
@@ -1319,7 +1319,11 @@
         <!-- 작성자 활동 패널 아래 GAM 광고 (비활성화: 본문 영역 광고 과다 방지)
         {#if widgetLayoutStore.hasEnabledAds}
             <div class="my-6">
-                <AdSlot position="board-before-comments" height="90px" />
+                <AdSlot
+                    position="board-before-comments"
+                    height="90px"
+                    slotKey="board-before-comments"
+                />
             </div>
         {/if}
         -->
@@ -1468,7 +1472,11 @@
         <!-- 댓글~목록 사이 GAM 광고 -->
         {#if widgetLayoutStore.hasEnabledAds}
             <div class="my-3 md:my-4">
-                <AdSlot position="board-after-comments" height="90px" />
+                <AdSlot
+                    position="board-after-comments"
+                    height="90px"
+                    slotKey="board-after-comments"
+                />
             </div>
         {/if}
     {/if}


### PR DESCRIPTION
요약\n- GPT 광고 슬롯을 전역 registry가 관리하도록 구조를 정리했습니다.\n- 고정 슬롯과 주요 반복 슬롯에 stable slot key를 부여했습니다.\n- 즉시 destroy 대신 지연 정리를 적용해 SPA 이동 중 슬롯 재사용률을 높였습니다.\n- 보이는 슬롯만 자동 새로고침하도록 viewability 상태를 registry에서 관리합니다.\n\n기대 효과\n- slotDestroyed 로그 빈도 감소\n- 광고 슬롯 재생성 감소\n- 레이아웃 점프 감소\n- SPA 전환 시 광고 안정성 및 수익 회복 기반 강화