### PR TITLE
인기 게시판 목록 SSR 백프레셔를 완화

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -15,6 +15,10 @@ interface PostsCacheData {
     error: string | null;
 }
 const postsCache = createCache<PostsCacheData>({ ttl: 15_000, maxSize: 100 });
+const inFlightPostsLoads = new Map<string, Promise<PostsCacheData>>();
+
+const DEFAULT_POSTS_TIMEOUT_MS = 3_000;
+const HOT_BOARD_POSTS_TIMEOUT_MS = 1_500;
 
 /**
  * 게시판 목록 페이지 — Streaming SSR
@@ -104,6 +108,7 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
 
     // 프로모션 게시판 전용: 광고주별 post_count 제한 적용 (검색/태그 필터 없을 때만)
     const isPromotionBoard = boardId === 'promotion' && !isSearching && !isTagFiltering;
+    const isHotBoard = boardId === 'free' || boardId === 'hello';
 
     // 비로그인 + 검색/태그 필터 없는 경우: 게시글 목록 캐시 사용 (15초)
     const usePostsCache = !locals.user && !isSearching && !isTagFiltering;
@@ -122,8 +127,7 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         }
     }
 
-    // Promise (await 하지 않음 → SvelteKit이 스트리밍)
-    const postsDataPromise = (async () => {
+    const buildPostsData = async (): Promise<PostsCacheData> => {
         if (isPromotionBoard) {
             // 프로모션 게시판: ads 서버에서 광고주별 제한된 게시글 조회
             const [promoBoardResult, noticesResult] = await Promise.allSettled([
@@ -177,7 +181,10 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
 
         // 일반 게시판 (또는 프로모션 게시판 검색/태그 필터)
         const [postsResult, noticesResult] = await Promise.allSettled([
-            bFetch(buildPostsUrl(), { headers }).then(async (res) => {
+            bFetch(buildPostsUrl(), {
+                headers,
+                timeout: isHotBoard ? HOT_BOARD_POSTS_TIMEOUT_MS : DEFAULT_POSTS_TIMEOUT_MS
+            }).then(async (res) => {
                 if (!res.ok) throw new Error(`Posts API error: ${res.status}`);
                 return res.json();
             }),
@@ -227,7 +234,23 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         }
 
         return result;
-    })();
+    };
+
+    // Promise (await 하지 않음 → SvelteKit이 스트리밍)
+    let postsDataPromise: Promise<PostsCacheData>;
+    if (usePostsCache) {
+        const inFlight = inFlightPostsLoads.get(postsCacheKey);
+        if (inFlight) {
+            postsDataPromise = inFlight;
+        } else {
+            postsDataPromise = buildPostsData().finally(() => {
+                inFlightPostsLoads.delete(postsCacheKey);
+            });
+            inFlightPostsLoads.set(postsCacheKey, postsDataPromise);
+        }
+    } else {
+        postsDataPromise = buildPostsData();
+    }
 
     const promotionDataPromise = (async () => {
         if (isSearching || isPromotionBoard) {


### PR DESCRIPTION
## 요약
- 인기 게시판 목록 SSR에 in-flight dedupe를 추가했습니다.
- 같은 페이지 요청이 몰릴 때 동일한 백엔드 fetch를 공유합니다.
- free/hello 게시판 목록 API timeout을 더 짧게 조정했습니다.
- 비로그인 목록 요청은 stale 캐시 fallback을 더 빠르게 활용합니다.

## 기대 효과
- 백엔드 지연 시 web 프로세스에 타임아웃 요청이 대량 적체되는 현상 완화
- Node heap OOM 및 502 재발 가능성 감소
- free/hello 인기 목록 페이지의 과부하 내성 향상
