### PR TITLE
사이드바 브레이크포인트와 코드 하이라이트를 안정화

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -199,7 +199,7 @@
         <div class="flex items-center">
             <button
                 onclick={toggleDrawer}
-                class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out md:hidden"
+                class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out 2xl:hidden"
                 aria-label="메뉴"
             >
                 <span class="absolute -inset-1"></span>

--- a/apps/web/src/lib/utils/code-highlight.ts
+++ b/apps/web/src/lib/utils/code-highlight.ts
@@ -6,6 +6,16 @@
  */
 import hljs from 'highlight.js/lib/common';
 
+function getLanguageClass(codeEl: HTMLElement): string | null {
+    for (const cls of Array.from(codeEl.classList)) {
+        if (cls.startsWith('language-')) {
+            return cls.slice('language-'.length);
+        }
+    }
+
+    return null;
+}
+
 /**
  * 줄번호 테이블 생성
  * highlight.js 처리 후의 <code> 내부 HTML을 줄 단위 테이블로 변환
@@ -78,7 +88,16 @@ export function highlightAllCodeBlocks(container: HTMLElement): void {
         // 이미 처리된 블록은 건너뜀
         if (code.dataset.highlighted === 'yes') continue;
 
-        hljs.highlightElement(code);
+        const source = code.textContent || '';
+        const language = getLanguageClass(code);
+
+        if (language && hljs.getLanguage(language)) {
+            code.innerHTML = hljs.highlight(source, { language, ignoreIllegals: true }).value;
+        } else {
+            code.innerHTML = hljs.highlightAuto(source).value;
+        }
+        code.dataset.highlighted = 'yes';
+
         addLineNumbers(code);
         addCopyButton(pre);
     }


### PR DESCRIPTION
요약: 좌측 사이드바가 사라지는 2xl 아래 구간에서도 햄버거 메뉴를 노출하고, 코드 블록 하이라이팅을 textContent 기반으로 바꿔 highlight 경고를 줄입니다.