### PR TITLE
광고 배너 프록시 타임아웃 단축

### DIFF
--- a/apps/web/src/lib/server/ads/banners.ts
+++ b/apps/web/src/lib/server/ads/banners.ts
@@ -9,6 +9,7 @@ import { getAdsServerUrl } from './config';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const bannerCache = createCache<Record<string, any[]>>({ ttl: 60_000, maxSize: 10 });
+const ADS_BANNER_TIMEOUT_MS = 1_200;
 
 /** ads 서버에서 배너 데이터 조회 (60초 캐시, singleflight) */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,7 +27,8 @@ export async function getCachedBannersByPositions(
             positions.map(async (position) => {
                 try {
                     const response = await fetch(
-                        `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=10`
+                        `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=10`,
+                        { signal: AbortSignal.timeout(ADS_BANNER_TIMEOUT_MS) }
                     );
                     if (response.ok) {
                         const data = await response.json();

--- a/apps/web/src/routes/api/ads/banners/+server.ts
+++ b/apps/web/src/routes/api/ads/banners/+server.ts
@@ -6,6 +6,7 @@ import type { RequestHandler } from './$types';
 // 인메모리 캐시 (60초 TTL, singleflight 내장)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const bannerProxyCache = createCache<any>({ ttl: 60_000, maxSize: 50 });
+const ADS_BANNER_TIMEOUT_MS = 1_200;
 
 // GET /api/ads/banners?position=board-head&limit=1
 // ads.damoang.net 프록시 (Cloudflare 우회, 60초 singleflight 캐시)
@@ -18,7 +19,8 @@ export const GET: RequestHandler = async ({ url }) => {
         const data = await bannerProxyCache.getOrSet(cacheKey, async () => {
             const adsServerUrl = getAdsServerUrl();
             const response = await fetch(
-                `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`
+                `${adsServerUrl}/api/v1/serve/banners?position=${encodeURIComponent(position)}&limit=${limit}`,
+                { signal: AbortSignal.timeout(ADS_BANNER_TIMEOUT_MS) }
             );
             if (!response.ok) {
                 return { success: false, data: { banners: [], count: 0 } };


### PR DESCRIPTION
## 요약
- /api/ads/banners 프록시에 1.2초 타임아웃을 추가합니다.
- 서버측 배너 prefetch에도 같은 타임아웃을 적용합니다.
- ads 서버가 느릴 때 빈 응답으로 빠르게 fail-open 하도록 조정합니다.

## 목적
- side-image-text-banner 504로 본문 체감을 끌어내리지 않도록 긴급 완화합니다.