### PR TITLE
feat: 내 회원 메모 목록 페이지 추가

### DIFF
--- a/apps/web/src/lib/components/features/my/my-nav.svelte
+++ b/apps/web/src/lib/components/features/my/my-nav.svelte
@@ -6,6 +6,7 @@
     import Star from '@lucide/svelte/icons/star';
     import Ban from '@lucide/svelte/icons/ban';
     import Bookmark from '@lucide/svelte/icons/bookmark';
+    import NotepadText from '@lucide/svelte/icons/notepad-text';
     import Palette from '@lucide/svelte/icons/palette';
     import Settings from '@lucide/svelte/icons/settings';
 
@@ -15,6 +16,7 @@
         { href: '/my/exp', label: '경험치', icon: Star, exact: false },
         { href: '/my/blocked', label: '차단 목록', icon: Ban, exact: false },
         { href: '/my/scraps', label: '스크랩', icon: Bookmark, exact: false },
+        { href: '/my/memos', label: '회원 메모', icon: NotepadText, exact: false },
         { href: '/member/settings/ui', label: 'UI 설정', icon: Palette, exact: false },
         { href: '/member/settings', label: '설정', icon: Settings, exact: true }
     ];

--- a/apps/web/src/lib/server/member-memo.ts
+++ b/apps/web/src/lib/server/member-memo.ts
@@ -1,0 +1,90 @@
+/**
+ * g5_member_memo 테이블 조회
+ * 회원이 다른 회원에 대해 남긴 메모 목록 조회
+ */
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+
+interface MemoRow extends RowDataPacket {
+    id: number;
+    member_id: string;
+    target_member_id: string;
+    memo: string;
+    memo_detail: string;
+    color: string;
+    created_at: string;
+    updated_at: string;
+    target_mb_nick: string;
+    target_mb_level: number;
+    target_mb_leave_date: string;
+}
+
+interface CountRow extends RowDataPacket {
+    cnt: number;
+}
+
+export interface MemberMemoItem {
+    id: number;
+    target_member_id: string;
+    target_member_nickname: string;
+    target_member_level: number;
+    target_member_left: boolean;
+    memo: string;
+    memo_detail: string;
+    color: string;
+    created_at: string;
+}
+
+export interface MemberMemoListResult {
+    items: MemberMemoItem[];
+    total: number;
+    page: number;
+    totalPages: number;
+}
+
+export async function getMyMemos(
+    memberId: string,
+    page: number,
+    limit: number
+): Promise<MemberMemoListResult> {
+    const offset = (page - 1) * limit;
+
+    const [[countResult], [rows]] = await Promise.all([
+        readPool.query<CountRow[]>(
+            `SELECT COUNT(*) AS cnt FROM g5_member_memo WHERE member_id = ?`,
+            [memberId]
+        ),
+        readPool.query<MemoRow[]>(
+            `SELECT m.id, m.target_member_id, m.memo, m.memo_detail, m.color,
+                    m.created_at, m.updated_at,
+                    g.mb_nick AS target_mb_nick,
+                    g.mb_level AS target_mb_level,
+                    g.mb_leave_date AS target_mb_leave_date
+             FROM g5_member_memo m
+             LEFT JOIN g5_member g ON g.mb_id = m.target_member_id
+             WHERE m.member_id = ?
+             ORDER BY m.updated_at DESC
+             LIMIT ? OFFSET ?`,
+            [memberId, limit, offset]
+        )
+    ]);
+
+    const total = countResult[0]?.cnt ?? 0;
+
+    return {
+        items: rows.map((r) => ({
+            id: r.id,
+            target_member_id: r.target_member_id,
+            target_member_nickname: r.target_mb_nick || r.target_member_id,
+            target_member_level: r.target_mb_level ?? 0,
+            target_member_left: !!r.target_mb_leave_date,
+            memo: r.memo ?? '',
+            memo_detail: r.memo_detail ?? '',
+            color: r.color || 'yellow',
+            created_at: r.created_at
+        })),
+        total,
+        page,
+        totalPages: Math.max(1, Math.ceil(total / limit))
+    };
+}

--- a/apps/web/src/routes/my/memos/+page.server.ts
+++ b/apps/web/src/routes/my/memos/+page.server.ts
@@ -1,0 +1,20 @@
+import type { PageServerLoad } from './$types.js';
+import { getMyMemos } from '$lib/server/member-memo.js';
+
+export const load: PageServerLoad = async ({ url, locals, depends }) => {
+    depends('app:memos');
+    const page = Number(url.searchParams.get('page')) || 1;
+    const limit = 20;
+
+    if (!locals.user?.id) {
+        return { memos: [], total: 0, page, totalPages: 1 };
+    }
+
+    const result = await getMyMemos(locals.user.id, page, limit);
+    return {
+        memos: result.items,
+        total: result.total,
+        page: result.page,
+        totalPages: result.totalPages
+    };
+};

--- a/apps/web/src/routes/my/memos/+page.svelte
+++ b/apps/web/src/routes/my/memos/+page.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+    /**
+     * 내 회원 메모 목록 페이지
+     * 내가 다른 회원에 대해 남긴 메모를 모아보는 페이지
+     */
+    import { goto, invalidate } from '$app/navigation';
+    import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { Badge } from '$lib/components/ui/badge/index.js';
+    import NotepadText from '@lucide/svelte/icons/notepad-text';
+    import Pencil from '@lucide/svelte/icons/pencil';
+    import Trash2 from '@lucide/svelte/icons/trash-2';
+    import LogOut from '@lucide/svelte/icons/log-out';
+    import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+    import ChevronRight from '@lucide/svelte/icons/chevron-right';
+    import { deleteMemberMemo } from '$lib/api/admin-members.js';
+    import { getGradeName } from '$lib/utils/grade.js';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    let deletingId = $state<number | null>(null);
+
+    const memoColorMap: Record<string, { bg: string; text: string }> = {
+        yellow: { bg: '#ffe69c', text: '#664d03' },
+        green: { bg: '#d1e7dd', text: '#0f5132' },
+        purple: { bg: '#e2d9f3', text: '#432874' },
+        red: { bg: '#f8d7da', text: '#dc3545' },
+        blue: { bg: '#cfe2ff', text: '#084298' }
+    };
+
+    async function handleDelete(memoId: number) {
+        if (!confirm('이 메모를 삭제하시겠습니까?')) return;
+        deletingId = memoId;
+        try {
+            await deleteMemberMemo(memoId);
+            await invalidate('app:memos');
+        } catch (err) {
+            console.error('메모 삭제 실패:', err);
+        } finally {
+            deletingId = null;
+        }
+    }
+
+    function formatDate(dateStr: string): string {
+        return new Date(dateStr).toLocaleDateString('ko-KR', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+        });
+    }
+
+    function goToPage(pageNum: number): void {
+        if (pageNum < 1 || pageNum > data.totalPages) return;
+        goto(`/my/memos?page=${pageNum}`);
+    }
+
+    function getPageNumbers(current: number, total: number): (number | '...')[] {
+        if (total <= 5) {
+            return Array.from({ length: total }, (_, i) => i + 1);
+        }
+        const pages: (number | '...')[] = [];
+        if (current <= 3) {
+            for (let i = 1; i <= 4; i++) pages.push(i);
+            pages.push('...');
+            pages.push(total);
+        } else if (current >= total - 2) {
+            pages.push(1);
+            pages.push('...');
+            for (let i = total - 3; i <= total; i++) pages.push(i);
+        } else {
+            pages.push(1);
+            pages.push('...');
+            for (let i = current - 1; i <= current + 1; i++) pages.push(i);
+            pages.push('...');
+            pages.push(total);
+        }
+        return pages;
+    }
+</script>
+
+<svelte:head>
+    <title>내 회원 메모 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<div class="mx-auto max-w-4xl px-4">
+    <div class="mb-6">
+        <h1 class="text-foreground text-2xl font-bold">내 회원 메모</h1>
+        <p class="text-muted-foreground mt-1 text-sm">
+            다른 회원에 대해 남긴 메모 {data.total}건
+        </p>
+    </div>
+
+    <Card class="bg-background">
+        <CardHeader>
+            <CardTitle class="flex items-center gap-2">
+                <NotepadText class="h-5 w-5" />
+                메모 목록
+                <span class="text-muted-foreground text-sm font-normal">
+                    ({data.total}건)
+                </span>
+            </CardTitle>
+        </CardHeader>
+        <CardContent>
+            {#if data.memos.length > 0}
+                <!-- Desktop table -->
+                <div class="hidden overflow-x-auto md:block">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="bg-muted/50 border-b">
+                                <th class="p-3 text-left font-medium">닉네임</th>
+                                <th class="p-3 text-left font-medium">아이디</th>
+                                <th class="p-3 text-center font-medium">등급</th>
+                                <th class="p-3 text-left font-medium">메모</th>
+                                <th class="w-24 p-3 text-center font-medium">관리</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {#each data.memos as memo (memo.id)}
+                                {@const colors = memoColorMap[memo.color] || memoColorMap.yellow}
+                                {@const isDeleting = deletingId === memo.id}
+                                <tr
+                                    class="border-b transition-opacity"
+                                    class:opacity-50={isDeleting}
+                                >
+                                    <td class="p-3">
+                                        <a
+                                            href="/member/{memo.target_member_id}"
+                                            class="text-foreground font-medium hover:underline"
+                                        >
+                                            {memo.target_member_nickname}
+                                        </a>
+                                    </td>
+                                    <td class="text-muted-foreground p-3">
+                                        {memo.target_member_id}
+                                    </td>
+                                    <td class="p-3 text-center">
+                                        <a
+                                            href="/disciplinelog?sfl=wr_subject%7C%7Cwr_content%2C1&sop=and&stx={encodeURIComponent(
+                                                memo.target_member_id
+                                            )}"
+                                            target="_blank"
+                                            title="{memo.target_member_nickname}님 이용제한 이력 조회"
+                                        >
+                                            {#if memo.target_member_left}
+                                                <LogOut class="mx-auto h-4 w-4 opacity-50" />
+                                            {:else}
+                                                <Badge variant="outline"
+                                                    >{getGradeName(memo.target_member_level)}</Badge
+                                                >
+                                            {/if}
+                                        </a>
+                                    </td>
+                                    <td class="p-3">
+                                        <span
+                                            class="inline-block max-w-xs truncate rounded px-2 py-0.5 text-sm"
+                                            style="background-color: {colors.bg}; color: {colors.text}"
+                                            title={memo.memo_detail || memo.memo}
+                                        >
+                                            {memo.memo}
+                                        </span>
+                                    </td>
+                                    <td class="p-3 text-center">
+                                        <div class="flex items-center justify-center gap-1">
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                class="h-8 w-8"
+                                                onclick={() =>
+                                                    goto(`/member/${memo.target_member_id}`)}
+                                                aria-label="수정"
+                                            >
+                                                <Pencil class="h-4 w-4" />
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                class="text-muted-foreground hover:text-destructive h-8 w-8"
+                                                onclick={() => handleDelete(memo.id)}
+                                                disabled={isDeleting}
+                                                aria-label="삭제"
+                                            >
+                                                <Trash2 class="h-4 w-4" />
+                                            </Button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {/each}
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Mobile cards -->
+                <div class="space-y-3 md:hidden">
+                    {#each data.memos as memo (memo.id)}
+                        {@const colors = memoColorMap[memo.color] || memoColorMap.yellow}
+                        {@const isDeleting = deletingId === memo.id}
+                        <div
+                            class="rounded-lg border p-4 transition-opacity"
+                            class:opacity-50={isDeleting}
+                        >
+                            <div class="mb-2 flex items-center justify-between">
+                                <a
+                                    href="/member/{memo.target_member_id}"
+                                    class="text-foreground font-medium hover:underline"
+                                >
+                                    {memo.target_member_nickname}
+                                </a>
+                                <a
+                                    href="/disciplinelog?sfl=wr_subject%7C%7Cwr_content%2C1&sop=and&stx={encodeURIComponent(
+                                        memo.target_member_id
+                                    )}"
+                                    target="_blank"
+                                    title="{memo.target_member_nickname}님 이용제한 이력 조회"
+                                >
+                                    {#if memo.target_member_left}
+                                        <LogOut class="h-4 w-4 opacity-50" />
+                                    {:else}
+                                        <Badge variant="outline"
+                                            >{getGradeName(memo.target_member_level)}</Badge
+                                        >
+                                    {/if}
+                                </a>
+                            </div>
+                            <div class="text-muted-foreground mb-2 text-sm">
+                                {memo.target_member_id} · {formatDate(memo.created_at)}
+                            </div>
+                            <div class="mb-3">
+                                <span
+                                    class="inline-block rounded px-2 py-0.5 text-sm"
+                                    style="background-color: {colors.bg}; color: {colors.text}"
+                                >
+                                    {memo.memo}
+                                </span>
+                                {#if memo.memo_detail}
+                                    <p class="text-muted-foreground mt-1 text-xs">
+                                        {memo.memo_detail}
+                                    </p>
+                                {/if}
+                            </div>
+                            <div class="flex justify-end gap-1">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onclick={() => goto(`/member/${memo.target_member_id}`)}
+                                >
+                                    <Pencil class="mr-1 h-3 w-3" />
+                                    수정
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    class="text-destructive hover:bg-destructive hover:text-destructive-foreground"
+                                    onclick={() => handleDelete(memo.id)}
+                                    disabled={isDeleting}
+                                >
+                                    <Trash2 class="mr-1 h-3 w-3" />
+                                    삭제
+                                </Button>
+                            </div>
+                        </div>
+                    {/each}
+                </div>
+            {:else}
+                <div class="flex flex-col items-center justify-center py-12">
+                    <div class="bg-muted mb-4 rounded-full p-4">
+                        <NotepadText class="text-muted-foreground h-8 w-8" />
+                    </div>
+                    <p class="text-foreground mb-1 font-medium">아직 메모가 없어요</p>
+                    <p class="text-muted-foreground text-sm">회원 프로필에서 메모를 남겨보세요.</p>
+                </div>
+            {/if}
+        </CardContent>
+    </Card>
+
+    <!-- 페이지네이션 -->
+    {#if data.totalPages > 1}
+        <div class="mt-6 flex items-center justify-center gap-1">
+            <Button
+                variant="outline"
+                size="sm"
+                disabled={data.page === 1}
+                onclick={() => goToPage(data.page - 1)}
+            >
+                <ChevronLeft class="h-4 w-4" />
+                이전
+            </Button>
+
+            {#each getPageNumbers(data.page, data.totalPages) as pageNum}
+                {#if pageNum === '...'}
+                    <span class="text-muted-foreground px-2 text-sm">...</span>
+                {:else}
+                    <Button
+                        variant={data.page === pageNum ? 'default' : 'outline'}
+                        size="sm"
+                        class="min-w-9"
+                        onclick={() => goToPage(pageNum)}
+                    >
+                        {pageNum}
+                    </Button>
+                {/if}
+            {/each}
+
+            <Button
+                variant="outline"
+                size="sm"
+                disabled={data.page === data.totalPages}
+                onclick={() => goToPage(data.page + 1)}
+            >
+                다음
+                <ChevronRight class="h-4 w-4" />
+            </Button>
+        </div>
+    {/if}
+</div>


### PR DESCRIPTION
> [!IMPORTANT]
> 아직 구현 중입니다. 메모 편집 모달과 메모 상세 표시 기능은 `plugins/member-memo` submodule 추가 후 진행 예정입니다.

## Summary
- `/my/memos` 페이지: 내가 다른 회원에 대해 남긴 메모를 모아보는 리스트
- SSR 데이터 로드 + 페이지네이션 (20건 단위)
- 데스크톱 테이블 / 모바일 카드 반응형 레이아웃
- 등급명 표시, 탈퇴 회원 아이콘, 이용제한 이력 링크
- 메모 색상 배지 (5색), 삭제 기능
- 마이페이지 네비게이션에 "회원 메모" 탭 추가

## TODO
- [ ] 메모 편집 모달 (plugins/member-memo submodule 연동)
- [ ] 메모 상세(memo_detail) hover/popover 표시

## Test plan
- [ ] `/my/memos` 접속 시 본인 메모 리스트 정상 표시
- [ ] 페이지네이션 동작 확인 (20건 초과 시)
- [ ] 삭제 버튼 클릭 시 메모 삭제 및 리스트 갱신
- [ ] 모바일 카드 레이아웃 확인
- [ ] 비로그인 시 로그인 페이지로 리다이렉트

🤖 Generated with [Claude Code](https://claude.com/claude-code)