### PR TITLE
revert: 키보드 단축키 keyup 전환 되돌림 (#538)

### DIFF
--- a/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
+++ b/apps/web/src/lib/services/keyboard-shortcuts.svelte.ts
@@ -6,9 +6,6 @@
  *
  * event.code 기반으로 한영 전환과 무관하게 동작.
  * (예: 한글 'ㄹ' 입력 → event.code = 'KeyF' → 자유게시판)
- *
- * keyup 이벤트 사용: Linux IME(ibus/fcitx)에서 한글 입력 시
- * keydown의 event.code가 비정상(빈 문자열, keyCode=229)이 되는 문제 회피.
  */
 
 import { goto } from '$app/navigation';
@@ -150,9 +147,9 @@ class KeyboardShortcutService {
     }
 
     /**
-     * 글로벌 keyup 이벤트 핸들러
+     * 글로벌 keydown 이벤트 핸들러
      */
-    handleKeyup = (event: KeyboardEvent) => {
+    handleKeydown = (event: KeyboardEvent) => {
         // 입력 필드 안에서는 무시
         if (isInputElement(event.target)) return;
         // contentEditable 요소 안에서는 무시

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -352,7 +352,7 @@
     });
 </script>
 
-<svelte:window onkeyup={(e) => keyboardShortcutsMod?.keyboardShortcuts.handleKeyup(e)} />
+<svelte:window onkeydown={(e) => keyboardShortcutsMod?.keyboardShortcuts.handleKeydown(e)} />
 
 <svelte:head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary
- #538 에서 Linux IME 문제 해결을 위해 `keydown` → `keyup`으로 전환했으나 부작용 발생
- `Ctrl+W`로 탭을 닫을 때 `keyup` 이벤트가 남은 다른 탭에서 발생하여 단축키가 오작동
- Linux IME 문제도 완전히 해결되지 않음
- `keydown` 이벤트로 복원

## Test plan
- [ ] `Ctrl+W`로 탭 닫은 후 다른 탭에서 단축키 오작동 없는지 확인
- [ ] 단축키(F, R, H 등) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)