### PR TITLE
프론트 정적 자산 배포 안정화와 R2 릴리스 경로 정리

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,6 +17,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/angple-web
+  STATIC_ASSET_BASE_ROOT: https://static.damoang.net/releases
 
 concurrency:
   group: staging-deploy
@@ -109,8 +110,31 @@ jobs:
         run: |
           SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           SHORT_SHA="${SHA:0:7}"
-          echo "sha_tag=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=staging-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "tags=${{ env.IMAGE_NAME }}:staging,${{ env.IMAGE_NAME }}:staging-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable assets to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
+          SHA_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY R2_ACCOUNT_ID R2_BUCKET SHA_TAG; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required R2 variable: $name"
+              exit 1
+            fi
+          done
+
+          aws s3 sync apps/web/build/client/_app/immutable/ \
+            "s3://${R2_BUCKET}/releases/${SHA_TAG}/_app/immutable/" \
+            --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -138,7 +162,7 @@ jobs:
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             # 이미지 pull
-            docker pull ${{ env.IMAGE_NAME }}:staging
+            docker pull ${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.image_tag }}
 
             # 기존 컨테이너 강제 제거
             docker rm -f angple-staging 2>/dev/null || true
@@ -159,8 +183,10 @@ jobs:
               -v /home/damoang/angple-deploy/data-staging:/app/data \
               -e NODE_ENV=production \
               -e PORT=3011 \
+              -e ASSET_RELEASE_ID=${{ steps.tags.outputs.sha_tag }} \
+              -e ASSET_BASE_URL=${{ env.STATIC_ASSET_BASE_ROOT }}/${{ steps.tags.outputs.sha_tag }} \
               $ENV_FLAG \
-              ${{ env.IMAGE_NAME }}:staging
+              ${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.image_tag }}
 
             # 헬스체크 대기
             echo "Waiting for health check..."
@@ -192,7 +218,8 @@ jobs:
               '### Staging 배포 완료',
               '',
               `**URL**: https://dev.damoang.net`,
-              `**이미지**: \`staging-${sha}\``,
+              `**이미지**: \`${{ steps.tags.outputs.image_tag }}\``,
+              `**Static Release**: \`${sha}\``,
               `**커밋**: ${context.payload.pull_request.head.sha}`,
               '',
               '> 변경사항을 dev.damoang.net에서 확인하세요.'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/damoang/angple-web
+  STATIC_ASSET_BASE_ROOT: https://static.damoang.net/releases
 
 concurrency:
   group: deploy-main-web
@@ -67,6 +68,32 @@ jobs:
           echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
           pnpm --filter web build
 
+      - name: Set image tags
+        id: tags
+        run: echo "sha_tag=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable assets to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
+          SHA_TAG: ${{ steps.tags.outputs.sha_tag }}
+        run: |
+          for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY R2_ACCOUNT_ID R2_BUCKET SHA_TAG; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required R2 variable: $name"
+              exit 1
+            fi
+          done
+
+          aws s3 sync apps/web/build/client/_app/immutable/ \
+            "s3://${R2_BUCKET}/releases/${SHA_TAG}/_app/immutable/" \
+            --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress
+
       - name: Prepare deploy package
         run: |
           pnpm --filter web deploy --prod --legacy apps/web/deploy
@@ -85,10 +112,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set image tags
-        id: tags
-        run: echo "sha_tag=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         id: build_image
@@ -125,13 +148,14 @@ jobs:
         env:
           IMAGE_TAG: ${{ needs.build.outputs.sha_tag }}
           APPROVAL_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ASSET_BASE_URL: ${{ env.STATIC_ASSET_BASE_ROOT }}/${{ needs.build.outputs.sha_tag }}
         run: |
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "i-038a1d1f00798d94b" \
             --document-name "AWS-RunShellScript" \
             --parameters "{
               \"commands\": [
-                \"export GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' TELEGRAM_BOT_TOKEN='${{ secrets.TELEGRAM_BOT_TOKEN }}' TELEGRAM_DEPLOY_CHAT_ID='${{ secrets.TELEGRAM_DEPLOY_CHAT_ID }}' DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/1435940653375815730/${{ secrets.DISCORD_WEBHOOK_TOKEN_WEB }}' APPROVAL_URL='${APPROVAL_URL}' && /home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --canary-only\"
+                \"export GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' TELEGRAM_BOT_TOKEN='${{ secrets.TELEGRAM_BOT_TOKEN }}' TELEGRAM_DEPLOY_CHAT_ID='${{ secrets.TELEGRAM_DEPLOY_CHAT_ID }}' DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/1435940653375815730/${{ secrets.DISCORD_WEBHOOK_TOKEN_WEB }}' APPROVAL_URL='${APPROVAL_URL}' ASSET_BASE_URL='${ASSET_BASE_URL}' && /home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --canary-only\"
               ]
             }" \
             --timeout-seconds 600 \
@@ -263,13 +287,14 @@ jobs:
       - name: Deploy production via SSM
         env:
           IMAGE_TAG: ${{ needs.build.outputs.sha_tag }}
+          ASSET_BASE_URL: ${{ env.STATIC_ASSET_BASE_ROOT }}/${{ needs.build.outputs.sha_tag }}
         run: |
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "i-038a1d1f00798d94b" \
             --document-name "AWS-RunShellScript" \
             --parameters "{
               \"commands\": [
-                \"export GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' TELEGRAM_BOT_TOKEN='${{ secrets.TELEGRAM_BOT_TOKEN }}' TELEGRAM_DEPLOY_CHAT_ID='${{ secrets.TELEGRAM_DEPLOY_CHAT_ID }}' DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/1435940653375815730/${{ secrets.DISCORD_WEBHOOK_TOKEN_WEB }}' && /home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --skip-canary\"
+                \"export GHCR_TOKEN='${{ secrets.GITHUB_TOKEN }}' TELEGRAM_BOT_TOKEN='${{ secrets.TELEGRAM_BOT_TOKEN }}' TELEGRAM_DEPLOY_CHAT_ID='${{ secrets.TELEGRAM_DEPLOY_CHAT_ID }}' DISCORD_WEBHOOK_URL='https://discord.com/api/webhooks/1435940653375815730/${{ secrets.DISCORD_WEBHOOK_TOKEN_WEB }}' ASSET_BASE_URL='${ASSET_BASE_URL}' && /home/angple/k8s/prod/deploy.sh web $IMAGE_TAG --skip-canary\"
               ]
             }" \
             --timeout-seconds 600 \

--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -196,51 +196,38 @@ function clearCachesAndReload(): void {
     });
 }
 
-function showUpdateNotice(): void {
-    if (document.getElementById('__angple_update_banner__')) return;
-    const banner = document.createElement('div');
-    banner.id = '__angple_update_banner__';
-    banner.setAttribute(
-        'style',
-        'position:fixed;top:0;left:0;right:0;z-index:99999;display:flex;flex-direction:column;align-items:center;padding:0;background:#2563eb;color:white;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;font-size:14px;box-shadow:0 2px 8px rgba(0,0,0,0.15)'
-    );
-    banner.innerHTML = `
-        <div style="display:flex;align-items:center;justify-content:center;gap:12px;padding:10px 16px;width:100%;flex-wrap:wrap">
-            <span>새 버전이 배포되었습니다.</span>
-            <button id="__angple_update_reload__" style="padding:5px 16px;font-size:13px;cursor:pointer;border-radius:4px;border:1px solid rgba(255,255,255,0.4);background:transparent;color:white;font-weight:500;white-space:nowrap">새로고침</button>
-            <button id="__angple_update_force_clear__" style="padding:5px 16px;font-size:13px;cursor:pointer;border-radius:4px;border:none;background:rgba(255,255,255,0.25);color:white;font-weight:600;white-space:nowrap">강력 캐시 삭제</button>
-            <button id="__angple_update_close__" style="padding:2px 6px;font-size:18px;cursor:pointer;border:none;background:transparent;color:white;line-height:1" aria-label="닫기">&times;</button>
-        </div>`;
-    document.body.prepend(banner);
-    document.getElementById('__angple_update_reload__')?.addEventListener('click', () => {
-        clearCachesAndReload();
-    });
-    document.getElementById('__angple_update_force_clear__')?.addEventListener('click', () => {
-        forceClearAllAndReload();
-    });
-    document.getElementById('__angple_update_close__')?.addEventListener('click', () => {
-        banner.remove();
-    });
+const CHUNK_FORCE_CLEAR_KEY = '__angple_chunk_force_clear__';
+
+function recoverChunkErrorSilently(): boolean {
+    try {
+        const count = Number(sessionStorage.getItem(CHUNK_FORCE_CLEAR_KEY) || '0');
+        if (count >= 1) return false;
+        sessionStorage.setItem(CHUNK_FORCE_CLEAR_KEY, String(count + 1));
+    } catch {
+        return false;
+    }
+    forceClearAllAndReload();
+    return true;
 }
 
-// app.html 통합 핸들러와 연동: exhausted 상태면 배너 표시
+// app.html 통합 핸들러와 연동: exhausted 상태면 상단 배너 대신 1회 강력 새로고침
 if (typeof window !== 'undefined') {
-    // 페이지 로드 시 exhausted 체크
     const chunkError = (window as any).__angpleChunkError;
     if (chunkError) {
         const state = chunkError.getState();
         if (state.exhausted) {
-            // DOM 준비 후 배너 표시
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', () => showUpdateNotice());
-            } else {
-                showUpdateNotice();
-            }
+            recoverChunkErrorSilently();
         }
     }
-    // 리로드 한도 초과 이벤트 수신
     window.addEventListener('angple:chunk-error-exhausted', () => {
-        showUpdateNotice();
+        if (!recoverChunkErrorSilently()) {
+            guardedSend({
+                type: 'chunk_error_exhausted',
+                message: 'Chunk error recovery exhausted after forced clear reload',
+                url: window.location.href,
+                userAgent: navigator.userAgent
+            });
+        }
     });
 }
 

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -62,6 +62,7 @@ const COOKIE_DOMAIN = env.COOKIE_DOMAIN || '';
 // CSP에 추가할 사이트별 도메인 (런타임 환경변수)
 const ADS_URL = env.ADS_URL || '';
 const LEGACY_URL = env.LEGACY_URL || '';
+const ASSET_BASE_URL = (env.ASSET_BASE_URL || '').replace(/\/+$/, '');
 
 /** CDN 캐시 가능한 공개 경로 (비로그인 시만 적용) */
 const PUBLIC_CACHEABLE_PATHS = ['/feed', '/games', '/info'];
@@ -112,6 +113,14 @@ function isBoardListPath(pathname: string, searchParams: URLSearchParams): boole
 const POST_DETAIL_REGEX = /^\/[a-z][a-z0-9_-]{1,20}\/\d+$/;
 function isPostDetailPath(pathname: string): boolean {
     return POST_DETAIL_REGEX.test(pathname);
+}
+
+function rewriteImmutableAssetUrls(html: string): string {
+    if (!ASSET_BASE_URL) return html;
+    return html.replace(
+        /(["'(])(?:\.\/|\/)?_app\/immutable\//g,
+        `$1${ASSET_BASE_URL}/_app/immutable/`
+    );
 }
 
 /**
@@ -264,16 +273,17 @@ function buildCsp(): string {
     // 사이트별 도메인을 CSP에 동적 추가
     const adsHost = ADS_URL ? ` ${ADS_URL}` : '';
     const legacyHost = LEGACY_URL ? ` ${LEGACY_URL}` : '';
+    const assetOrigin = ASSET_BASE_URL ? ` ${new URL(ASSET_BASE_URL).origin}` : '';
 
     const directives: string[] = [
         "default-src 'self' https://damoang.net https://*.damoang.net",
         // SvelteKit + GAM(GPT) + AdSense + Turnstile 스크립트 허용
-        `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com https://securepubads.g.doubleclick.net https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com${adsHost} https://www.googletagservices.com https://www.googletagmanager.com https://adservice.google.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://www.google.com https://fundingchoicesmessages.google.com https://*.googlesyndication.com https://*.doubleclick.net https://*.gstatic.com https://*.adtrafficquality.google https://cdn.ampproject.org`,
-        `style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com${adsHost}`,
-        "font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com",
-        "img-src 'self' data: blob: https:",
+        `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com https://securepubads.g.doubleclick.net https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com${adsHost}${assetOrigin} https://www.googletagservices.com https://www.googletagmanager.com https://adservice.google.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://www.google.com https://fundingchoicesmessages.google.com https://*.googlesyndication.com https://*.doubleclick.net https://*.gstatic.com https://*.adtrafficquality.google https://cdn.ampproject.org`,
+        `style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com${adsHost}${assetOrigin}`,
+        `font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com${assetOrigin}`,
+        `img-src 'self' data: blob: https:${assetOrigin}`,
         // API 및 광고 서버 연결 허용
-        `connect-src 'self' http://localhost:* ws://localhost:* https://*.damoang.net https://damoang.net${legacyHost}${adsHost} https://pagead2.googlesyndication.com https://securepubads.g.doubleclick.net https://www.google-analytics.com https://cdn.jsdelivr.net https://*.google.com https://*.googlesyndication.com https://*.doubleclick.net https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://*.adtrafficquality.google https://*.gstatic.com https://cdn.ampproject.org`,
+        `connect-src 'self' http://localhost:* ws://localhost:* https://*.damoang.net https://damoang.net${legacyHost}${adsHost}${assetOrigin} https://pagead2.googlesyndication.com https://securepubads.g.doubleclick.net https://www.google-analytics.com https://cdn.jsdelivr.net https://*.google.com https://*.googlesyndication.com https://*.doubleclick.net https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://*.adtrafficquality.google https://*.gstatic.com https://cdn.ampproject.org`,
         // YouTube, 임베드 플랫폼, Google 광고, Turnstile iframe 허용
         "frame-src 'self' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube-nocookie.com https://platform.twitter.com https://player.vimeo.com https://clips.twitch.tv https://player.twitch.tv https://www.tiktok.com https://www.instagram.com https://www.redditmedia.com https://embed.bsky.app https://googleads.g.doubleclick.net https://securepubads.g.doubleclick.net https://tpc.googlesyndication.com https://www.google.com https://*.googlesyndication.com https://*.doubleclick.net https://*.adtrafficquality.google",
         "frame-ancestors 'self'",
@@ -414,7 +424,6 @@ export const handle: Handle = async ({ event, resolve }) => {
                 csrfFormValue = null;
             }
         }
-
         if (csrfHeader !== event.locals.csrfToken && csrfFormValue !== event.locals.csrfToken) {
             return new Response(JSON.stringify({ error: 'CSRF 토큰이 유효하지 않습니다.' }), {
                 status: 403,
@@ -515,7 +524,9 @@ export const handle: Handle = async ({ event, resolve }) => {
                 transformPageChunk: ({ html }) => {
                     const cls = htmlClass ? ` class="${htmlClass}"` : '';
                     const sty = ` style="--row-pad-extra:${dPad};--comment-pad-extra:${dPad}"`;
-                    return html.replace('<html lang="ko">', `<html lang="ko"${cls}${sty}>`);
+                    return rewriteImmutableAssetUrls(
+                        html.replace('<html lang="ko">', `<html lang="ko"${cls}${sty}>`)
+                    );
                 }
             });
 
@@ -580,7 +591,9 @@ export const handle: Handle = async ({ event, resolve }) => {
         transformPageChunk: ({ html }) => {
             const cls = htmlClass ? ` class="${htmlClass}"` : '';
             const sty = ` style="--row-pad-extra:${dPad};--comment-pad-extra:${dPad}"`;
-            return html.replace('<html lang="ko">', `<html lang="ko"${cls}${sty}>`);
+            return rewriteImmutableAssetUrls(
+                html.replace('<html lang="ko">', `<html lang="ko"${cls}${sty}>`)
+            );
         }
     });
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -5,7 +5,7 @@
     import type { Component } from 'svelte';
     import { afterNavigate, onNavigate } from '$app/navigation';
     import { navigating } from '$app/state';
-    import { page, updated } from '$app/stores';
+    import { page } from '$app/stores';
     import { configureSeo } from '$lib/seo';
     import { authActions, authStore } from '$lib/stores/auth.svelte';
     import { themeStore } from '$lib/stores/theme.svelte';
@@ -164,22 +164,8 @@
     //     });
     // });
 
-    // afterNavigate 통합: 버전 감지 리로드 + GA4 페이지뷰 + 광고 observer 재설정
-    const UPDATED_RELOAD_KEY = '__angple_updated_reload__';
+    // afterNavigate 통합: GA4 페이지뷰 + 광고 observer 재설정
     afterNavigate(({ type, to }) => {
-        // 새 버전 감지 시 캐시 버스터로 1회만 재요청
-        if ($updated && type !== 'enter') {
-            const count = Number(sessionStorage.getItem(UPDATED_RELOAD_KEY) || '0');
-            if (count < 1) {
-                sessionStorage.setItem(UPDATED_RELOAD_KEY, String(count + 1));
-                const url = new URL(location.href);
-                url.searchParams.set('_v', String(Date.now()));
-                location.replace(url.toString());
-                return;
-            }
-        } else if (!$updated) {
-            sessionStorage.removeItem(UPDATED_RELOAD_KEY);
-        }
         // GA4 페이지뷰 추적
         if (to?.url) {
             trackPageView(to.url.pathname + to.url.search);
@@ -270,9 +256,6 @@
         if (data.ga4MeasurementId) {
             initGA4(data.ga4MeasurementId);
         }
-
-        // $updated 리로드 카운터 리셋 (정상 로드 확인 후)
-        setTimeout(() => sessionStorage.removeItem(UPDATED_RELOAD_KEY), 10000);
 
         // Built-in Hooks 초기화 (콘텐츠 임베딩, 게시판 필터 등)
         initBuiltinHooks();

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -45,8 +45,8 @@ const config = {
             preloadStrategy: 'modulepreload'
         },
         version: {
-            // 빌드 시 자동 생성되는 버전 해시로 새 배포 감지
-            pollInterval: 60000 // 60초마다 서버 버전 확인
+            // 주기적 버전 폴링은 배포 직후 불필요한 새로고침 UX를 유발할 수 있으므로 비활성화.
+            pollInterval: 0
         }
     },
     compilerOptions: {

--- a/docs/deployment/frontend-404-cache-incident.md
+++ b/docs/deployment/frontend-404-cache-incident.md
@@ -1,0 +1,91 @@
+# 프론트엔드 404 캐시 장애 대응
+
+## 현상
+
+- 브라우저 콘솔에서 `/_app/immutable/bundle.*.js` 또는 `entry/app.*.js` 가 `404` 로 실패한다.
+- 화면이 하얗게 보이거나 레이아웃이 깨진다.
+- 사용자에게 "새 버전이 배포되었습니다" 배너가 반복 노출된다.
+
+예시:
+
+```text
+GET https://damoang.net/_app/immutable/bundle.CcgrH9TJ.js net::ERR_ABORTED 404
+Uncaught (in promise) TypeError: Failed to fetch dynamically imported module
+```
+
+## 1차 확인
+
+문제 번들 URL을 직접 확인한다.
+
+```bash
+curl -I -s https://damoang.net/_app/immutable/bundle.CcgrH9TJ.js
+```
+
+아래 조건이면 Cloudflare가 오래된 `404` 를 캐시 중일 가능성이 높다.
+
+- `cf-cache-status: HIT`
+- `age: 0` 보다 큰 값
+- 상태 코드가 `404`
+
+## 원인
+
+배포 전환 중 아주 짧은 시점에 HTML이 새 번들을 참조했는데, 해당 파일이 아직 원본에 없어서 `404` 가 발생할 수 있다.
+
+이 `404` 응답을 Cloudflare가 캐시하면, 이후 원본에 파일이 생겨도 CDN이 계속 `404` 를 반환할 수 있다.
+
+즉 문제는 "원본 파일 없음"이 아니라 "CDN이 오래된 404를 계속 서빙"하는 경우가 많다.
+
+## 긴급 조치
+
+HTML과 문제 번들을 핀셋 purge 한다.
+
+대상 예시:
+
+- `https://damoang.net/free`
+- `https://damoang.net/_app/immutable/bundle.CcgrH9TJ.js`
+
+Cloudflare API 예시:
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/purge_cache" \
+  -H "Authorization: Bearer <API_TOKEN>" \
+  -H "Content-Type: application/json" \
+  --data '{"files":["https://damoang.net/free","https://damoang.net/_app/immutable/bundle.CcgrH9TJ.js"]}'
+```
+
+또는 대시보드에서 `Custom Purge` 로 동일 URL을 purge 한다.
+
+## 운영 체크리스트
+
+1. 공개 도메인 HTML이 어떤 bundle명을 참조하는지 확인
+2. 해당 bundle URL이 `200` 인지 확인
+3. `404 HIT` 이면 HTML + bundle URL 핀셋 purge
+4. 새 탭/프라이빗탭에서 재확인
+
+## 재발 방지
+
+- `/_app/immutable/*` 의 `200` 응답은 장기 캐시 유지
+- `/_app/immutable/*` 의 `404` 응답은 Cloudflare에서 캐시하지 않도록 규칙 적용
+- HTML(`/`, `/free`) 은 짧게 캐시하거나 배포 직후 핀셋 purge
+- 배포 후 origin smoke test로 HTML이 참조한 bundle `200` 확인
+
+## 적용 완료 사항
+
+2026-03-12 기준 Cloudflare `http_request_cache_settings` ruleset에 아래 규칙을 추가했다.
+
+- 경로: `/_app/immutable/*`
+- 동작: `set_cache_settings`
+- 정책:
+  - 일반 응답: origin cache control 존중
+  - `404`: 캐시하지 않음
+
+규칙 목적:
+
+- 배포 전환 중 잠깐 발생한 immutable `404` 가 CDN에 `HIT` 로 오래 남는 문제 방지
+- 이후 원본에 파일이 생겼을 때 CDN이 오래된 `404` 를 계속 반환하지 않도록 함
+
+## 관련 구성
+
+- 배포 스크립트: `/home/angple/k8s/prod/deploy.sh`
+- 프론트 스모크 테스트: `/home/ec2-user/angple/scripts/smoke-test.sh`
+- Cloudflare purge: `/home/ec2-user/angple/scripts/cloudflare-purge.sh`

--- a/docs/deployment/frontend-release-runbook.md
+++ b/docs/deployment/frontend-release-runbook.md
@@ -1,0 +1,102 @@
+# Frontend Release Runbook
+
+## 목표
+
+프론트 배포를 항상 같은 절차로 수행해서 `/_app/immutable/*` 404, CSP 차단, 배포 중 흰 화면 장애를 방지한다.
+
+## 운영 원칙
+
+1. `canary -> 검증 -> production` 순서만 사용한다.
+2. 이미지와 static asset은 같은 release SHA를 사용한다.
+3. mutable `latest`를 운영 기준으로 믿지 않는다.
+4. HTML이 참조하는 immutable asset은 항상 `https://static.damoang.net/releases/<sha>/...` 형식이어야 한다.
+5. `/_app/immutable/*` 404는 경미한 오류가 아니라 장애로 본다.
+
+## 배포 전 확인
+
+1. GitHub Actions secrets 존재
+    - `CLOUDFLARE_R2_ACCESS_KEY_ID`
+    - `CLOUDFLARE_R2_SECRET_ACCESS_KEY`
+    - `CLOUDFLARE_R2_ACCOUNT_ID`
+    - `CLOUDFLARE_R2_BUCKET`
+2. `static.damoang.net` 정상 응답
+3. canary/prod ingress 및 service 정상
+4. backend 주요 API 장애 없음
+
+## 정식 배포 절차
+
+1. 웹을 빌드한다.
+2. `apps/web/build/client/_app/immutable/`를 R2 `releases/<sha>/_app/immutable/`로 업로드한다.
+3. canary에 같은 `<sha>` 이미지와 `ASSET_BASE_URL=https://static.damoang.net/releases/<sha>`를 배포한다.
+4. canary 검증을 통과하면 prod에 같은 `<sha>`를 승격한다.
+
+## canary 검증
+
+필수 확인:
+
+1. `https://canary.damoang.net` 또는 내부 NodePort `/` 가 `200`
+2. `/health` 가 `200`
+3. HTML 안에 `https://static.damoang.net/releases/<sha>/_app/immutable/...` 가 보인다
+4. HTML이 참조한 JS/CSS URL이 실제로 `200`
+5. CSP 헤더에 `https://static.damoang.net` 이 포함된다
+6. 브라우저 콘솔에 CSP/CORS 오류가 없다
+
+예시:
+
+```bash
+curl -sS http://127.0.0.1:30082/ | tr "\"'" "\n\n\n" | grep 'https://static.damoang.net/releases/.*/_app/immutable' | head
+curl -I -sS https://static.damoang.net/releases/<sha>/_app/immutable/bundle.<hash>.js
+```
+
+## production 검증
+
+필수 확인:
+
+1. `/` 와 `/health` 가 `200`
+2. HTML이 새 release SHA를 참조한다
+3. HTML이 참조한 bundle JS/CSS가 `200`
+4. CSP 헤더에 `https://static.damoang.net` 이 포함된다
+5. 브라우저 콘솔에 `Failed to fetch dynamically imported module`, CSP 차단, stylesheet 차단이 없다
+
+## 장애 대응
+
+증상:
+
+1. 흰 화면
+2. 콘솔에 immutable JS/CSS `404`
+3. `Failed to fetch dynamically imported module`
+4. `Loading the script/style ... violates Content Security Policy`
+
+즉시 확인:
+
+1. HTML이 어떤 release SHA를 참조하는지 확인
+2. 해당 JS/CSS 파일이 R2에 존재하는지 확인
+3. CSP 헤더에 `static.damoang.net` 이 들어있는지 확인
+4. R2 CORS가 대상 origin을 허용하는지 확인
+
+즉시 조치:
+
+1. HTML + 문제 asset URL targeted purge
+2. 필요 시 직전 정상 release SHA로 롤백
+
+## 롤백
+
+롤백 원칙:
+
+1. 직전 정상 `<sha>` 를 다시 배포한다
+2. old asset은 이미 R2 `releases/<sha>/...` 에 남아 있어야 한다
+3. 개별 파일 복구나 pod 내부 복사는 하지 않는다
+
+## 금지 사항
+
+1. 배포 중 임의로 `latest` 태그 재사용
+2. pod 시작 시 immutable asset 복사로 문제를 덮는 방식
+3. 사용자에게 새 버전 배너/강제 새로고침으로 복구를 맡기는 방식
+4. canary 검증 없이 바로 production 반영
+
+## 관련 파일
+
+1. `/home/angple/web/.github/workflows/deploy.yml`
+2. `/home/angple/web/apps/web/src/hooks.server.ts`
+3. `/home/angple/web/scripts/cloudflare-purge.sh`
+4. `/home/angple/k8s/prod/deploy.sh`

--- a/docs/deployment/production-checklist.md
+++ b/docs/deployment/production-checklist.md
@@ -1,35 +1,37 @@
 # Angple Production Deployment Checklist
 
+운영 프론트 배포 절차는 [frontend-release-runbook.md](/home/angple/web/docs/deployment/frontend-release-runbook.md) 를 기준으로 진행한다.
+
 ## Pre-deployment
 
 ### Environment Variables
 
-- [ ] Copy `.env.example` to `.env.local` and fill in all production values
-- [ ] `NODE_ENV=production`
-- [ ] `INTERNAL_API_URL` points to the Go backend (e.g. `http://angple-api:8081/api/v2`)
-- [ ] `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` configured for production database
-- [ ] `GITHUB_TOKEN_ENCRYPTION_KEY` generated (`node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`)
-- [ ] `PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` set if CAPTCHA is enabled
-- [ ] `VITE_SITE_NAME` set to the desired site branding name
-- [ ] Run env validation: `node --import tsx apps/web/scripts/validate-env.ts`
+-   [ ] Copy `.env.example` to `.env.local` and fill in all production values
+-   [ ] `NODE_ENV=production`
+-   [ ] `INTERNAL_API_URL` points to the Go backend (e.g. `http://angple-api:8081/api/v2`)
+-   [ ] `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` configured for production database
+-   [ ] `GITHUB_TOKEN_ENCRYPTION_KEY` generated (`node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`)
+-   [ ] `PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` set if CAPTCHA is enabled
+-   [ ] `VITE_SITE_NAME` set to the desired site branding name
+-   [ ] Run env validation: `node --import tsx apps/web/scripts/validate-env.ts`
 
 ### Secrets
 
-- [ ] Database credentials are not hardcoded; they come from `.env.local` or Docker secrets
-- [ ] `.env.local` is in `.gitignore` and never committed
-- [ ] SMTP credentials configured if email features are required
+-   [ ] Database credentials are not hardcoded; they come from `.env.local` or Docker secrets
+-   [ ] `.env.local` is in `.gitignore` and never committed
+-   [ ] SMTP credentials configured if email features are required
 
 ### Docker Build
 
-- [ ] Docker image builds successfully: `docker build -t angple-web -f apps/web/Dockerfile .`
-- [ ] Or use pre-built image: `ANGPLE_WEB_IMAGE=ghcr.io/angple/angple-web:<tag>`
-- [ ] Verify image size is reasonable (should be under 500 MB)
+-   [ ] Docker image builds successfully: `docker build -t angple-web -f apps/web/Dockerfile .`
+-   [ ] Or use pre-built image: `ANGPLE_WEB_IMAGE=ghcr.io/angple/angple-web:<tag>`
+-   [ ] Verify image size is reasonable (should be under 500 MB)
 
 ### Database
 
-- [ ] Production database is accessible from the Docker network
-- [ ] Database user has appropriate permissions (read/write on the application database)
-- [ ] Database backups are configured and tested
+-   [ ] Production database is accessible from the Docker network
+-   [ ] Database user has appropriate permissions (read/write on the application database)
+-   [ ] Database backups are configured and tested
 
 ---
 
@@ -86,8 +88,8 @@ curl -f http://localhost:3010/health
 
 ### Admin Access
 
-- [ ] Navigate to `https://<domain>/admin` and verify the admin login page loads
-- [ ] Log in with admin credentials and verify the dashboard is accessible
+-   [ ] Navigate to `https://<domain>/admin` and verify the admin login page loads
+-   [ ] Log in with admin credentials and verify the dashboard is accessible
 
 ### API Connectivity
 
@@ -96,15 +98,15 @@ curl -f http://localhost:3010/health
 docker exec angple-web wget -qO- http://angple-api:8081/api/v2/health
 ```
 
-- [ ] Boards load correctly on the homepage
-- [ ] Posts can be created and read
-- [ ] User authentication (login/logout) works
+-   [ ] Boards load correctly on the homepage
+-   [ ] Posts can be created and read
+-   [ ] User authentication (login/logout) works
 
 ### SSL / Reverse Proxy
 
-- [ ] HTTPS is properly configured via reverse proxy (Nginx, Traefik, Caddy, etc.)
-- [ ] HTTP redirects to HTTPS
-- [ ] HSTS headers are present
+-   [ ] HTTPS is properly configured via reverse proxy (Nginx, Traefik, Caddy, etc.)
+-   [ ] HTTP redirects to HTTPS
+-   [ ] HSTS headers are present
 
 ---
 
@@ -146,9 +148,9 @@ If a deployment includes database schema changes:
 
 ## Monitoring Endpoints
 
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/health` | GET | Application health check (used by Docker HEALTHCHECK) |
+| Endpoint  | Method | Purpose                                               |
+| --------- | ------ | ----------------------------------------------------- |
+| `/health` | GET    | Application health check (used by Docker HEALTHCHECK) |
 
 ### Docker Health Status
 

--- a/docs/deployment/r2-release-immutable-architecture.md
+++ b/docs/deployment/r2-release-immutable-architecture.md
@@ -1,0 +1,284 @@
+# R2 Release-Prefixed Immutable Asset Architecture
+
+## Goal
+
+Reduce `/_app/immutable/*` 404s to near-zero by separating immutable frontend assets from pod lifecycle.
+
+Target outcomes:
+
+-   HTML and immutable JS/CSS are always referenced as one release set.
+-   Old HTML can continue loading old immutable assets for days after deployment.
+-   Pod rollout, autoscaling, restart, and canary/prod separation no longer affect asset availability.
+-   Users do not need to see a top-of-page "new version deployed" refresh banner.
+
+## Recommendation
+
+Adopt a hybrid architecture:
+
+1. Keep SSR HTML and API responses on the existing app deployment.
+2. Move only `/_app/immutable/*` to Cloudflare R2 behind a custom domain.
+3. Publish immutable assets under a release-prefixed path:
+
+```text
+https://static.damoang.net/releases/sha-<gitsha>/_app/immutable/...
+```
+
+4. Ensure each HTML release references only its own release-prefixed asset URLs.
+
+This matches the common large-service pattern: release-versioned immutable assets on object storage + CDN, dynamic HTML on app servers.
+
+## Why This Fixes the Current Failure Mode
+
+Current failures happen when HTML and the immutable file set are not guaranteed to stay together during rollout.
+
+With release-prefixed assets:
+
+-   old HTML references old release paths
+-   new HTML references new release paths
+-   both asset sets can coexist safely
+-   CDN and browsers can cache immutable files for a long time
+-   deployment timing no longer decides whether the referenced file exists
+
+## Target Request Flow
+
+### HTML / SSR
+
+```text
+User -> Cloudflare -> angple-web Service -> SvelteKit SSR
+```
+
+### Immutable Assets
+
+```text
+User -> Cloudflare (static.damoang.net) -> R2 custom domain
+```
+
+Example:
+
+```html
+<script
+    type="module"
+    src="https://static.damoang.net/releases/sha-abc123/_app/immutable/bundle.xyz.js"
+></script>
+```
+
+## Naming Rules
+
+### Release ID
+
+Use the same immutable identifier already used for deployment:
+
+```text
+sha-<gitsha>
+```
+
+### R2 Object Layout
+
+```text
+releases/
+  sha-abc123/
+    _app/
+      immutable/
+        bundle.xyz.js
+        bundle.xyz.js.gz
+        bundle.xyz.js.br
+        assets/...
+```
+
+### Domain Layout
+
+```text
+https://static.damoang.net/releases/sha-abc123/_app/immutable/...
+```
+
+## Deployment Model
+
+### Build
+
+GitHub Actions should:
+
+1. Build the SvelteKit app.
+2. Build the container image tagged with `sha-<gitsha>`.
+3. Upload `apps/web/build/client/_app/immutable/` to R2 under `releases/<sha>/`.
+4. Deploy app pods with the same release SHA.
+
+### Runtime
+
+The app deployment should expose the active release ID to SSR.
+
+Recommended environment variable:
+
+```text
+ASSET_RELEASE_ID=sha-<gitsha>
+ASSET_BASE_URL=https://static.damoang.net/releases/sha-<gitsha>
+```
+
+SSR should build immutable asset URLs from `ASSET_BASE_URL`.
+
+## Required App Changes
+
+### 1. Asset URL Rewriting
+
+SvelteKit-generated immutable URLs currently assume same-origin `/_app/immutable/...`.
+
+We need one of these approaches:
+
+1. preferred: configure generated asset base URL so build output already points to `https://static.damoang.net/releases/<sha>/`
+2. fallback: rewrite immutable asset URLs in SSR HTML before response
+
+Preferred behavior:
+
+-   local/dev: same-origin
+-   production: release-prefixed static domain
+
+### 2. Remove Runtime Immutable Copy Dependence
+
+Once R2 serves immutable assets, app pods no longer need to copy immutable files into `emptyDir` for public delivery.
+
+That means the long-term target is:
+
+-   remove `copy-immutable-assets` initContainer
+-   remove `immutable-assets` emptyDir
+-   remove nginx alias dependency for public `/_app/immutable/*`
+
+Short term, these can stay while the static domain migration is introduced.
+
+### 3. Keep Error Recovery, But Stop User Banner UX
+
+Client behavior should remain:
+
+-   one silent forced reload on chunk exhaustion
+-   no top update banner
+
+This is already aligned with the recent frontend changes.
+
+## Cloudflare / R2 Rules
+
+### Cache Rules
+
+For `static.damoang.net/releases/*/_app/immutable/*`:
+
+-   `200`: cache long, immutable
+-   `404`: do not cache
+
+For HTML on `damoang.net`:
+
+-   short cache or bypass
+-   targeted purge on deployment if needed
+
+### Security / Access
+
+Use an R2 custom domain, not `r2.dev`, for production delivery.
+
+## Retention Policy
+
+Keep previous release asset sets for at least 7 days.
+
+Recommended progression:
+
+-   phase 1: 7 days
+-   phase 2: 14 days
+-   phase 3: 30 days if storage cost remains acceptable
+
+Delete only whole release prefixes, never individual files from an active release.
+
+## Rollback Model
+
+Rollback becomes simple:
+
+1. redeploy app pods with previous `sha-<gitsha>`
+2. HTML again points to previous release prefix
+3. old immutable assets already exist in R2
+
+No asset recopy or shared-volume repair is needed.
+
+## Canary / Production Model
+
+Both canary and production can use the same immutable asset upload model.
+
+Recommended rule:
+
+-   canary HTML references canary release SHA paths
+-   production HTML references production release SHA paths
+
+Do not use mutable `latest` tags anywhere in deploy or storage naming.
+
+## Monitoring and Auto-Recovery
+
+Keep the current health-check strategy and adapt it to the static domain:
+
+1. fetch production HTML
+2. extract referenced immutable bundle URL
+3. verify bundle returns `200`
+4. if external returns `404` but origin HTML is healthy:
+    - targeted purge the HTML page and the broken immutable URL
+    - alert Telegram
+
+Once migrated, this check should validate `static.damoang.net/...` instead of same-origin `/_app/immutable/...`.
+
+## Migration Plan
+
+### Phase 0: Already in Progress
+
+-   SHA-pinned deployment
+-   top update banner removed
+-   immutable 404 detection and targeted purge support
+
+### Phase 1: Introduce Static Domain Without Removing Existing Delivery
+
+1. Create R2 bucket for immutable assets.
+2. Attach `static.damoang.net` custom domain.
+3. Upload each release's immutable assets to `releases/<sha>/`.
+4. Add app config for:
+    - `ASSET_BASE_URL`
+    - `ASSET_RELEASE_ID`
+5. Update SSR/build output so immutable URLs point to the static domain.
+6. Validate production HTML references `static.damoang.net/releases/<sha>/...`.
+
+### Phase 2: Dual Safety Window
+
+For a limited time:
+
+-   keep existing pod-local immutable serving available
+-   serve new HTML with static-domain immutable URLs
+
+This reduces migration risk.
+
+### Phase 3: Remove Pod-Local Immutable Delivery
+
+After stable verification:
+
+-   remove initContainer copy
+-   remove public immutable serving from nginx sidecar
+-   simplify `angple-web` deployment
+
+## Concrete Repo Changes Expected Next
+
+### GitHub Actions
+
+-   upload immutable assets to R2 after build
+-   pass release SHA into deploy
+
+### Web App
+
+-   production asset base URL configuration
+-   SSR or build-time immutable URL rewrite
+
+### Kubernetes
+
+-   add env vars for active release and static asset base
+-   later remove immutable copy container and volume
+
+### Health Check
+
+-   switch bundle validation target to `static.damoang.net`
+
+## Success Criteria
+
+The migration is successful when all of the following are true:
+
+1. production HTML references only `static.damoang.net/releases/<sha>/...`
+2. referenced immutable bundle returns `200`
+3. canary/prod rollout no longer changes public immutable file availability
+4. users no longer report white screen after deploy
+5. immutable 404 alerts become rare or zero

--- a/docs/deployment/r2-release-immutable-implementation-plan.md
+++ b/docs/deployment/r2-release-immutable-implementation-plan.md
@@ -1,0 +1,285 @@
+# R2 Release-Prefixed Immutable Asset Implementation Plan
+
+## Scope
+
+This plan turns the target architecture into an incremental implementation sequence for the current Angple web stack.
+
+Goals:
+
+-   move `/_app/immutable/*` delivery to `static.damoang.net`
+-   version immutable assets by release SHA
+-   keep SSR HTML/API on the existing app deployment
+-   preserve safe rollback and canary flow
+
+## Current Constraints
+
+Observed in the current repo and runtime:
+
+1. frontend builds are produced in `apps/web/build`
+2. deploy image is built from `apps/web/deploy`
+3. deploy workflow already emits `sha-<gitsha>` tags
+4. current runtime still assumes same-origin `/_app/immutable/*`
+5. health checks already know how to extract the referenced bundle from HTML
+
+This means the migration does not need a new release identifier format. It only needs:
+
+-   a static asset publishing step
+-   a way for HTML to reference the static domain
+-   post-deploy validation against the static domain
+
+## Proposed Release Variables
+
+Add these production environment variables:
+
+```text
+ASSET_RELEASE_ID=sha-<gitsha>
+PUBLIC_ASSET_BASE_URL=https://static.damoang.net/releases/sha-<gitsha>
+```
+
+Recommended behavior:
+
+-   local/dev: `PUBLIC_ASSET_BASE_URL` unset
+-   production/canary: `PUBLIC_ASSET_BASE_URL` set per release
+
+## Implementation Strategy
+
+Use a 3-step migration.
+
+### Step 1: Publish Assets to R2
+
+Add a workflow step after `pnpm --filter web build`:
+
+1. collect `apps/web/build/client/_app/immutable/`
+2. upload to:
+
+```text
+releases/${SHA_TAG}/_app/immutable/
+```
+
+3. keep brotli and gzip artifacts
+
+Expected upload set:
+
+```text
+bundle.*.js
+bundle.*.js.br
+bundle.*.js.gz
+assets/*
+entry/*
+nodes/*
+chunks/*
+```
+
+### Step 2: Make HTML Reference Static Asset Base
+
+The current app still emits same-origin immutable paths.
+
+Implementation options:
+
+1. build-time asset base using SvelteKit config
+2. SSR HTML rewrite using `transformPageChunk`
+
+Recommended first implementation:
+
+-   use server-side HTML rewrite in `hooks.server.ts`
+-   replace only same-origin immutable references in HTML:
+
+```text
+/_app/immutable/... -> ${PUBLIC_ASSET_BASE_URL}/_app/immutable/...
+```
+
+Why start here:
+
+-   lowest migration risk
+-   no need to deeply change build assumptions first
+-   easy to guard with `if (PUBLIC_ASSET_BASE_URL)`
+
+Rewrite targets:
+
+-   `<script src="/_app/immutable/...">`
+-   `<link href="/_app/immutable/...">`
+-   `modulepreload` tags in rendered head
+
+Do not rewrite:
+
+-   API paths
+-   non-immutable static paths
+-   local/dev requests
+
+### Step 3: Switch Monitoring and Deployment Validation
+
+After HTML rewrite is enabled:
+
+1. health checks should validate bundle URLs on `static.damoang.net`
+2. deploy smoke test should:
+    - fetch production HTML
+    - extract referenced bundle URL
+    - assert `200`
+
+This step makes deployment fail fast before users encounter a broken release.
+
+## Detailed Repo Changes
+
+### A. GitHub Actions: `web/.github/workflows/deploy.yml`
+
+Add:
+
+1. R2 credentials configuration
+2. upload step for immutable assets
+3. deploy-time env propagation of:
+    - `ASSET_RELEASE_ID`
+    - `PUBLIC_ASSET_BASE_URL`
+
+Suggested secret/env names:
+
+```text
+CLOUDFLARE_ACCOUNT_ID
+R2_ACCESS_KEY_ID
+R2_SECRET_ACCESS_KEY
+R2_BUCKET
+STATIC_ASSET_BASE_URL=https://static.damoang.net/releases
+```
+
+Expected per-release asset URL:
+
+```text
+${STATIC_ASSET_BASE_URL}/${SHA_TAG}
+```
+
+### B. Web App: `apps/web/src/hooks.server.ts`
+
+Add a small HTML transform only in production when `PUBLIC_ASSET_BASE_URL` is set.
+
+Pseudo-behavior:
+
+1. call existing `resolve(event, { transformPageChunk })`
+2. inside transform:
+    - rewrite `"/_app/immutable/..."`
+    - rewrite `'/_app/immutable/...'`
+3. leave HTML untouched if env var is absent
+
+Important:
+
+-   only rewrite exact immutable path prefixes
+-   preserve quotes and relative markup structure
+
+### C. Runtime Config
+
+Inject per-release env values into the deployed web container:
+
+```text
+ASSET_RELEASE_ID=sha-abc123
+PUBLIC_ASSET_BASE_URL=https://static.damoang.net/releases/sha-abc123
+```
+
+Canary and production must each receive their own release value.
+
+### D. Health Check
+
+Update the existing auto-heal/health-check logic later to:
+
+-   accept `static.damoang.net` bundle URLs directly
+-   targeted purge those URLs if HTML points to a cached 404
+
+### E. Deploy Smoke Test
+
+Update `k8s/prod/deploy.sh`:
+
+1. fetch HTML from canary/prod
+2. extract first immutable JS URL
+3. if the extracted URL is relative, prefix with host
+4. if absolute, test as-is
+
+This keeps the test compatible across migration phases.
+
+## Cloudflare / R2 Setup Tasks
+
+Required one-time tasks outside the repo:
+
+1. create R2 bucket for immutable assets
+2. attach custom domain `static.damoang.net`
+3. set cache rule:
+    - `200`: long cache
+    - `404`: do not cache
+4. confirm `br` and `gz` objects are served with correct content headers
+
+## Retention and Cleanup
+
+Do not delete files by age at the object level.
+
+Delete by whole release prefix only:
+
+```text
+releases/sha-old-1/
+releases/sha-old-2/
+```
+
+Recommended cleanup policy:
+
+-   keep latest 20 releases, or
+-   keep releases newer than 14 days
+
+Prefer keeping both:
+
+-   minimum 14 days
+-   always keep last 20 releases
+
+## Rollback Procedure
+
+Rollback should become:
+
+1. select previous release SHA
+2. deploy app pods with that SHA
+3. set `PUBLIC_ASSET_BASE_URL` to that SHA path
+4. rollout
+
+No asset copy is needed because R2 already holds the previous immutable set.
+
+## Canary Procedure
+
+Canary remains useful.
+
+Canary sequence:
+
+1. upload `sha-x` immutable assets to R2
+2. deploy canary with:
+    - `ASSET_RELEASE_ID=sha-x`
+    - `PUBLIC_ASSET_BASE_URL=https://static.damoang.net/releases/sha-x`
+3. validate canary HTML and bundle URL
+4. promote the same SHA to production
+
+## Success Gates
+
+Before removing pod-local immutable delivery, confirm:
+
+1. production HTML references `static.damoang.net/releases/<sha>/...`
+2. bundle URL returns `200`
+3. gzip/brotli responses are correct
+4. rollback to a previous SHA works without missing asset errors
+5. 404 alerts for immutable assets stay near zero across several deployments
+
+## Recommended Build Order
+
+Implement in this exact order:
+
+1. add R2 upload in GitHub Actions
+2. add env-driven HTML rewrite in `hooks.server.ts`
+3. add deploy env propagation for release asset base URL
+4. update smoke tests for absolute bundle URLs
+5. verify canary
+6. verify production
+7. only then consider removing pod-local immutable serving
+
+## Next Patch Set
+
+The next code patch should include:
+
+1. `web/.github/workflows/deploy.yml`
+    - R2 upload step
+    - deploy env propagation
+2. `web/apps/web/src/hooks.server.ts`
+    - immutable asset URL rewrite
+3. `k8s/prod/deploy.sh`
+    - smoke test support for absolute bundle URLs
+
+After that lands, we can run canary with real release-prefixed static asset URLs.

--- a/scripts/cloudflare-purge.sh
+++ b/scripts/cloudflare-purge.sh
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+DEFAULT_ENV_FILE="/home/angple/.cloudflare.env"
+
+if { [ -z "${CF_API_TOKEN:-}" ] || [ -z "${CF_ZONE_ID:-}" ]; } && [ -f "$DEFAULT_ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$DEFAULT_ENV_FILE"
+    set +a
+fi
+
 SITE_URL="${DEPLOY_SITE_URL:-https://damoang.net}"
 DEFAULT_PATHS="/,/free"
 

--- a/scripts/cloudflare-r2-bootstrap.sh
+++ b/scripts/cloudflare-r2-bootstrap.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Cloudflare R2 bootstrap helper
+# Usage:
+#   bash cloudflare-r2-bootstrap.sh
+#   R2_BUCKET_NAME=my-bucket bash cloudflare-r2-bootstrap.sh
+
+set -euo pipefail
+
+DEFAULT_ENV_FILE="/home/angple/.cloudflare.env"
+R2_BUCKET_NAME="${R2_BUCKET_NAME:-damoang-web-assets}"
+
+if [ -f "$DEFAULT_ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$DEFAULT_ENV_FILE"
+    set +a
+fi
+
+for name in CF_API_TOKEN CF_ACCOUNT_ID; do
+    if [ -z "${!name:-}" ]; then
+        echo "Error: ${name} is not set"
+        exit 1
+    fi
+done
+
+api() {
+    local method=$1
+    local path=$2
+    local data=${3:-}
+
+    if [ -n "$data" ]; then
+        curl -sS -X "$method" "https://api.cloudflare.com/client/v4${path}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data "$data"
+    else
+        curl -sS -X "$method" "https://api.cloudflare.com/client/v4${path}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json"
+    fi
+}
+
+echo "== Verify token =="
+api GET "/user/tokens/verify"
+echo
+echo
+
+echo "== Existing R2 buckets =="
+api GET "/accounts/${CF_ACCOUNT_ID}/r2/buckets"
+echo
+echo
+
+echo "== Create bucket: ${R2_BUCKET_NAME} =="
+api POST "/accounts/${CF_ACCOUNT_ID}/r2/buckets" "{\"name\":\"${R2_BUCKET_NAME}\"}"
+echo
+echo
+
+cat <<EOF
+If bucket creation succeeded, the next manual step is creating S3-compatible R2 credentials
+with object-read/object-write access for bucket: ${R2_BUCKET_NAME}.
+
+GitHub Secrets to set afterwards:
+  CLOUDFLARE_R2_ACCOUNT_ID=${CF_ACCOUNT_ID}
+  CLOUDFLARE_R2_BUCKET=${R2_BUCKET_NAME}
+  CLOUDFLARE_R2_ACCESS_KEY_ID=<R2 S3 access key id>
+  CLOUDFLARE_R2_SECRET_ACCESS_KEY=<R2 S3 secret access key>
+EOF


### PR DESCRIPTION
## 배경
- 프론트 배포 시 `/_app/immutable/*` 404, CSP 차단, 흰 화면 장애가 반복되었습니다.
- HTML이 참조하는 JS/CSS와 실제 배포 자산 세트가 어긋나면서 카나리/운영 전환 중 장애가 발생했습니다.

## 변경 사항
- immutable 정적 자산을 `static.damoang.net/releases/<sha>/...` 경로로 참조하도록 정리했습니다.
- main/staging 배포 workflow에 R2 업로드와 `ASSET_BASE_URL` 주입을 추가했습니다.
- SSR HTML에서 immutable 자산 경로를 static domain 기준으로 rewrite 하도록 반영했습니다.
- CSP에 `static.damoang.net` 허용을 추가했습니다.
- 클라이언트의 새 버전 감지 배너/자동 리로드 의존을 줄이고, chunk 오류 시 1회 강력 새로고침만 시도하도록 정리했습니다.
- Cloudflare targeted purge 스크립트와 R2 bootstrap 스크립트를 추가했습니다.
- 프론트 배포 runbook, 장애 대응 문서, R2 아키텍처/구현 계획 문서를 추가했습니다.

## 기대 효과
- HTML과 immutable asset이 같은 release SHA를 기준으로 움직이게 됩니다.
- 카나리/운영 롤아웃 중 JS/CSS 404가 날 가능성이 크게 줄어듭니다.
- 배포 시 사용자에게 상단 새 버전 배너를 띄우지 않아도 되는 구조로 갑니다.

## 검증
- 카나리/운영에서 `static.damoang.net/releases/<sha>/_app/immutable/...` 참조를 확인했습니다.
- CSP와 R2 CORS 반영 후 JS/CSS가 정상 `200` 응답하는 것을 확인했습니다.
- 운영 배포 전략과 runbook을 실제 live 환경 기준으로 정리했습니다.

## 운영 메모
- 머지 후에는 기존 원칙대로 `canary -> 검증 -> production` 순서로 확인합니다.
- `/_app/immutable/*` 404는 경미한 이슈가 아니라 장애로 보고 대응합니다.
