### PR TITLE
알림 UI에 쪽지(memo) 타입 지원 추가

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -12,6 +12,7 @@
     import AtSign from '@lucide/svelte/icons/at-sign';
     import Heart from '@lucide/svelte/icons/heart';
     import Star from '@lucide/svelte/icons/star';
+    import Mail from '@lucide/svelte/icons/mail';
     import Info from '@lucide/svelte/icons/info';
     import Check from '@lucide/svelte/icons/check';
     import Loader2 from '@lucide/svelte/icons/loader-2';
@@ -32,6 +33,8 @@
                 return AtSign;
             case 'like':
                 return Heart;
+            case 'memo':
+                return Mail;
             case 'levelup':
                 return Star;
             default:
@@ -49,6 +52,8 @@
                 return 'text-purple-500';
             case 'like':
                 return 'text-red-500';
+            case 'memo':
+                return 'text-orange-500';
             case 'levelup':
                 return 'text-yellow-500';
             default:

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -12,6 +12,7 @@
     import AtSign from '@lucide/svelte/icons/at-sign';
     import Heart from '@lucide/svelte/icons/heart';
     import Star from '@lucide/svelte/icons/star';
+    import Mail from '@lucide/svelte/icons/mail';
     import Info from '@lucide/svelte/icons/info';
     import Check from '@lucide/svelte/icons/check';
     import Trash2 from '@lucide/svelte/icons/trash-2';
@@ -33,6 +34,7 @@
         { key: 'comment', label: '댓글' },
         { key: 'like', label: '추천' },
         { key: 'mention', label: '멘션' },
+        { key: 'memo', label: '쪽지' },
         { key: 'system', label: '시스템' }
     ];
 
@@ -46,6 +48,8 @@
                 return AtSign;
             case 'like':
                 return Heart;
+            case 'memo':
+                return Mail;
             case 'levelup':
                 return Star;
             default:
@@ -63,6 +67,8 @@
                 return 'text-purple-500';
             case 'like':
                 return 'text-red-500';
+            case 'memo':
+                return 'text-orange-500';
             case 'levelup':
                 return 'text-yellow-500';
             default:


### PR DESCRIPTION
## Summary
- 알림 드롭다운/페이지에 쪽지(memo) 타입 아이콘(Mail, orange) 추가
- 알림 전체 페이지에 쪽지 필터 탭 추가

## 관련 버그
- #8045 쪽지 알림이 "새 알림"으로만 표시되는 문제

## Test plan
- [ ] 쪽지 알림 시 Mail 아이콘(주황색) 표시 확인
- [ ] 알림 페이지에서 쪽지 필터 탭 동작 확인