### PR TITLE
게시판 UI 개선: 빠른이동 네비, 브레드크럼, 중복배너 제거

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -71,6 +71,7 @@
     import { boardTypeRegistry } from '$lib/components/features/board/board-type-registry.js';
     import BoardMapHeader from '$lib/components/features/board/board-map-header.svelte';
     import EconomyShoppingBanner from '$lib/components/features/board/economy-shopping-banner.svelte';
+    import TagNav from '$lib/components/ui/tag-nav/tag-nav.svelte';
     import QAPostList from '$lib/components/features/board/qa-post-list.svelte';
     import BoardFavoriteButton from '$lib/components/features/board/board-favorite-button.svelte';
     import BoardSubscribeButton from '$lib/components/features/board/board-subscribe-button.svelte';
@@ -392,6 +393,11 @@
         </div>
     {:else}
         <div class="mx-auto pt-4">
+            <!-- 빠른 이동 네비게이션 -->
+            <div class="mb-4">
+                <TagNav />
+            </div>
+
             <!-- 최상단 배너 (슬롯 기반: 포크 시 slot-defaults.ts에서 커스터마이징) -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-4">
@@ -416,6 +422,13 @@
                         <a
                             href="/{boardId}"
                             class="text-foreground hover:text-primary transition-colors"
+                            onclick={(e) => {
+                                if ($page.url.pathname === `/${boardId}` && !$page.url.search) {
+                                    e.preventDefault();
+                                    invalidateAll();
+                                    window.scrollTo(0, 0);
+                                }
+                            }}
                         >
                             {boardTitle}
                         </a>
@@ -569,11 +582,6 @@
                 <div class="mb-3" transition:slide={{ duration: 200 }}>
                     <SearchForm boardPath={`/${boardId}`} />
                 </div>
-            {/if}
-
-            <!-- 알뜰구매 쇼핑 바로가기 (검색 → GAM → 여기) -->
-            {#if boardId === 'economy'}
-                <EconomyShoppingBanner />
             {/if}
 
             <!-- 카테고리 탭 -->

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1141,6 +1141,20 @@
         </div>
     {/if}
 
+    <!-- 브레드크럼 -->
+    <nav
+        class="text-muted-foreground -mx-5 mb-1 flex items-center gap-1 px-5 text-sm md:mx-0 md:px-0"
+        aria-label="breadcrumb"
+    >
+        <a href="/" class="hover:text-foreground transition-colors">홈</a>
+        <span class="text-muted-foreground/50">/</span>
+        <a href="/{data.boardId}" class="hover:text-foreground transition-colors">{boardTitle}</a>
+        <span class="text-muted-foreground/50">/</span>
+        <span class="text-foreground max-w-[200px] truncate sm:max-w-[400px]"
+            >{data.post.title}</span
+        >
+    </nav>
+
     <!-- 상단 네비게이션 -->
     <div class="-mx-5 mb-2 flex items-center gap-3 px-5 py-2 md:mx-0 md:px-0">
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">← 목록으로</Button>


### PR DESCRIPTION
## Summary
- 게시판 목록 상단에 빠른 이동 네비게이션(TagNav) 추가
- 게시글 상세 페이지에 브레드크럼 UI 추가 (홈 > 게시판 > 글제목)
- 알뜰구매 쇼핑 배너 중복 렌더링 제거 (상단 하나만 유지)
- 게시판 제목 클릭 시 현재 게시판이면 데이터 새로고침

## Test plan
- [ ] 게시판 목록에서 TagNav 표시 확인
- [ ] 현재 게시판이 하이라이트되는지 확인
- [ ] 게시글 상세에서 브레드크럼 표시 확인
- [ ] 알뜰구매 게시판에서 쇼핑 배너가 한 번만 표시되는지 확인
- [ ] 게시판 제목 클릭 시 목록 새로고침 확인