### PR TITLE
fix: 공지 게시글에서 공지해제 버튼 표시 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -706,7 +706,7 @@
     // 공지 상태
     let noticeType = $state<'normal' | 'important' | null>(null);
     $effect(() => {
-        noticeType = data.post.notice_type ?? null;
+        noticeType = data.post.notice_type ?? (data.post.is_notice ? 'important' : null);
     });
     let isTogglingNotice = $state(false);
 


### PR DESCRIPTION
## Summary
- 백엔드 API가 `notice_type` 없이 `is_notice: true`만 반환하는 경우, 프론트에서 `noticeType`이 null로 설정되어 "공지 고정" 버튼이 잘못 표시되던 문제 수정
- `is_notice` fallback 추가: `notice_type`이 없으면 `is_notice`로 판단

## Test plan
- [ ] 공지 고정된 글 (예: /free/5946880)에서 "공지 해제" 버튼 표시 확인
- [ ] 일반 글에서 "공지 고정" 버튼 표시 확인