### PR TITLE
버그 트래커/제보 플로팅 버튼 제거

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -374,64 +374,6 @@
     <LazyToaster />
 {/if}
 
-<!-- 버그 제보 + 트래커 FAB (admin/install 제외) -->
-{#if !isAdminRoute && !isInstallRoute}
-    <div class="fixed bottom-24 right-6 z-50 flex flex-col items-end gap-2">
-        <a
-            href="https://docs.google.com/spreadsheets/d/1zqUv_vKVqEeZhxpxrw2OVIUmUEAS8qONUUPVpNthYOU"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-600 text-white shadow-lg transition-all hover:scale-105 hover:bg-emerald-700"
-            title="버그 트래커 (Google Sheets)"
-        >
-            <!-- FileSpreadsheet icon (inline SVG — lucide 의존성 제거) -->
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                ><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /><path
-                    d="M14 2v4a2 2 0 0 0 2 2h4"
-                /><path d="M8 13h2" /><path d="M14 13h2" /><path d="M8 17h2" /><path
-                    d="M14 17h2"
-                /></svg
-            >
-        </a>
-        <a
-            href="/bug"
-            class="flex h-10 w-10 items-center justify-center rounded-full bg-red-600 text-white shadow-lg transition-all hover:scale-105 hover:bg-red-700"
-            title="버그 제보"
-        >
-            <!-- Bug icon (inline SVG — lucide 의존성 제거) -->
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                ><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path
-                    d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1"
-                /><path
-                    d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6"
-                /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path
-                    d="M6 13H2"
-                /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path
-                    d="M20.97 5c0 2.1-1.6 3.8-3.5 4"
-                /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg
-            >
-        </a>
-    </div>
-{/if}
-
 <!-- 단축 버튼 (지연 로딩, admin/install 제외) -->
 {#if !isAdminRoute && !isInstallRoute && LazyShortcutButtons}
     <LazyShortcutButtons />


### PR DESCRIPTION
## Summary
- 버그 트래커(Google Sheets 링크) 및 버그 제보(/bug) 플로팅 버튼(FAB)을 `+layout.svelte`에서 제거

## Test plan
- [ ] admin/install 외 일반 페이지에서 우하단 플로팅 버튼이 더 이상 표시되지 않는지 확인
- [ ] 단축 버튼 등 기존 FAB 기능 정상 동작 확인