### PR TITLE
메인 페이지 톺아보기 미리보기 위젯 + 레이아웃 개선

### DIFF
--- a/apps/web/src/lib/components/features/explore/explore-preview.svelte
+++ b/apps/web/src/lib/components/features/explore/explore-preview.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
+    import Compass from '@lucide/svelte/icons/compass';
+    import ChevronRight from '@lucide/svelte/icons/chevron-right';
+    import MessageSquare from '@lucide/svelte/icons/message-square';
+    import {
+        formatNumber,
+        getRecommendBadgeClass
+    } from '$lib/components/features/recommended/utils/index.js';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { getReadPostClasses } from '$lib/stores/read-post-style.svelte.js';
+    import type { ExploreData, ExplorePost } from '$lib/api/types.js';
+
+    interface Props {
+        prefetchData?: { data: ExploreData } | unknown;
+    }
+
+    const { prefetchData }: Props = $props();
+
+    const ssrData = prefetchData as { data: ExploreData } | undefined;
+    let exploreData = $state<ExploreData | null>(ssrData?.data ?? null);
+    let loading = $state(!ssrData?.data);
+    let showReadState = $state(false);
+
+    const PREVIEW_COUNT = 10;
+
+    const hotPosts = $derived<ExplorePost[]>(
+        exploreData?.modes?.hot?.posts?.slice(0, PREVIEW_COUNT) ?? []
+    );
+
+    onMount(async () => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                showReadState = true;
+            });
+        });
+
+        if (!exploreData) {
+            try {
+                const res = await fetch('/api/widgets/explore/data');
+                if (res.ok) {
+                    exploreData = await res.json();
+                }
+            } catch {
+                // silent fail
+            } finally {
+                loading = false;
+            }
+        }
+    });
+
+    function getBoardId(url: string): string {
+        const parts = url.split('/').filter(Boolean);
+        return parts[0] || '';
+    }
+</script>
+
+<Card class="gap-0">
+    <CardHeader class="flex flex-row items-center justify-between gap-2 space-y-0 py-3">
+        <div class="flex shrink-0 items-center gap-2">
+            <div
+                class="flex h-7 w-7 items-center justify-center rounded-lg bg-teal-100 dark:bg-teal-900/30"
+            >
+                <Compass class="h-4 w-4 text-teal-500" />
+            </div>
+            <h3 class="text-foreground text-lg font-semibold">톺아보기</h3>
+            <span class="text-muted-foreground text-xs">핫</span>
+        </div>
+        <a
+            href="/explore"
+            class="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-xs transition-colors"
+        >
+            더보기
+            <ChevronRight class="h-3.5 w-3.5" />
+        </a>
+    </CardHeader>
+
+    <CardContent class="">
+        {#if loading}
+            <div class="space-y-2">
+                {#each Array(5) as _}
+                    <div class="flex items-center gap-2 py-1">
+                        <div class="bg-muted h-5 w-10 animate-pulse rounded-full"></div>
+                        <div class="bg-muted h-4 flex-1 animate-pulse rounded"></div>
+                    </div>
+                {/each}
+            </div>
+        {:else if hotPosts.length === 0}
+            <div class="text-muted-foreground py-6 text-center text-sm">
+                데이터를 준비하고 있습니다...
+            </div>
+        {:else}
+            <ul>
+                {#each hotPosts as post (post.board + '-' + post.id)}
+                    <li>
+                        <a
+                            href={post.url}
+                            rel="external"
+                            class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
+                        >
+                            <div class="flex items-center gap-2">
+                                <!-- 추천수 배지 -->
+                                <span
+                                    class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-bold {getRecommendBadgeClass(
+                                        post.recommend_count
+                                    )}"
+                                >
+                                    <img alt="공감" class="size-3" src="/images/thumbup.png?v=2" />
+                                    {formatNumber(post.recommend_count)}
+                                </span>
+
+                                <!-- 게시판 뱃지 -->
+                                <span
+                                    class="bg-muted text-muted-foreground hidden shrink-0 rounded px-1.5 py-0.5 text-xs sm:inline-block"
+                                >
+                                    {post.board_name}
+                                </span>
+
+                                <!-- 제목 -->
+                                <span
+                                    class="min-w-0 flex-1 truncate leading-relaxed {getReadPostClasses(
+                                        showReadState &&
+                                            readPostsStore.isRead(getBoardId(post.url), post.id)
+                                    )}"
+                                >
+                                    {post.title}
+                                </span>
+
+                                <!-- 댓글 수 -->
+                                {#if post.comment_count > 0}
+                                    <span
+                                        class="text-primary flex shrink-0 items-center gap-0.5 text-xs"
+                                    >
+                                        <MessageSquare class="h-3 w-3" />
+                                        {post.comment_count}
+                                    </span>
+                                {/if}
+                            </div>
+                        </a>
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+    </CardContent>
+</Card>

--- a/apps/web/src/lib/components/features/explore/index.ts
+++ b/apps/web/src/lib/components/features/explore/index.ts
@@ -1,0 +1,1 @@
+export { default as ExplorePreview } from './explore-preview.svelte';

--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -20,38 +20,39 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
     },
     { id: 'tag-nav', type: 'tag-nav', position: 1, enabled: true },
     { id: 'recommended', type: 'recommended', position: 2, enabled: true },
+    { id: 'explore', type: 'explore', position: 3, enabled: true },
     {
         id: 'ad-top',
         type: 'ad-slot',
-        position: 3,
+        position: 4,
         enabled: true,
         settings: { position: 'index-top' }
     },
     {
         id: 'new-board',
         type: 'post-list',
-        position: 4,
+        position: 5,
         enabled: true,
         settings: { boardId: 'notice', layout: 'list', sortBy: 'date', count: 10, showTitle: true }
     },
     {
         id: 'economy',
         type: 'post-list',
-        position: 5,
+        position: 6,
         enabled: true,
         settings: { boardId: 'economy', layout: 'list', sortBy: 'date', count: 10, showTitle: true }
     },
     {
         id: 'ad-middle-1',
         type: 'ad-slot',
-        position: 6,
+        position: 7,
         enabled: true,
         settings: { position: 'index-middle-1' }
     },
     {
         id: 'gallery',
         type: 'post-list',
-        position: 7,
+        position: 8,
         enabled: true,
         settings: {
             boardId: 'gallery',
@@ -64,22 +65,22 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
     {
         id: 'group',
         type: 'post-list',
-        position: 8,
-        enabled: true,
-        settings: { boardId: 'group', layout: 'grid', sortBy: 'date', count: 10, showTitle: true }
-    },
-    {
-        id: 'ad-bottom',
-        type: 'ad-slot',
         position: 9,
         enabled: true,
-        settings: { position: 'index-bottom' }
+        settings: { boardId: 'group', layout: 'grid', sortBy: 'date', count: 10, showTitle: true }
     },
     {
         id: 'celebration',
         type: 'celebration',
         position: 10,
         enabled: true
+    },
+    {
+        id: 'ad-bottom',
+        type: 'ad-slot',
+        position: 11,
+        enabled: true,
+        settings: { position: 'index-bottom' }
     }
 ];
 

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -3,6 +3,7 @@ import { getWidgetLayout, getSidebarWidgetLayout } from '$lib/server/settings/in
 import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default-widgets';
 import { buildIndexWidgets } from '$lib/server/index-widgets-builder';
 import { getDefaultPeriod, loadRecommendedData } from '$lib/server/recommended-loader';
+import { loadExploreData } from '$lib/server/explore-loader';
 import { getCachedCelebrations } from '$lib/server/celebration';
 import { env } from '$env/dynamic/private';
 
@@ -10,7 +11,7 @@ const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
 
 export const load: PageServerLoad = async () => {
     // 위젯 데이터, 레이아웃, 추천글, 축하메시지를 병렬로 로드
-    const [indexWidgetsResult, layoutResult, recommendedResult, celebrationResult] =
+    const [indexWidgetsResult, layoutResult, recommendedResult, exploreResult, celebrationResult] =
         await Promise.allSettled([
             buildIndexWidgets(BACKEND_URL),
             (async () => {
@@ -25,6 +26,8 @@ export const load: PageServerLoad = async () => {
             })(),
             // 추천글 기본 탭 SSR 프리페치 (로딩 없이 즉시 표시)
             loadRecommendedData(getDefaultPeriod()),
+            // 톺아보기 SSR 프리페치
+            loadExploreData(),
             // 인덱스 전용: 최근 축하메시지 (오늘뿐 아니라 최근 8건)
             getCachedCelebrations(true)
         ]);
@@ -37,6 +40,7 @@ export const load: PageServerLoad = async () => {
             : { widgetLayout: DEFAULT_WIDGETS, sidebarWidgetLayout: DEFAULT_SIDEBAR_WIDGETS };
     const recommendedData =
         recommendedResult.status === 'fulfilled' ? recommendedResult.value : null;
+    const exploreData = exploreResult.status === 'fulfilled' ? exploreResult.value : null;
     const celebrationRecent =
         celebrationResult.status === 'fulfilled' ? celebrationResult.value : null;
 
@@ -50,6 +54,7 @@ export const load: PageServerLoad = async () => {
         sidebarWidgetLayout: layoutData.sidebarWidgetLayout,
         recommendedData,
         recommendedPeriod: getDefaultPeriod(),
+        exploreData,
         celebrationRecent
     };
 };

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -69,6 +69,7 @@
         recommended: data.recommendedData
             ? { data: data.recommendedData, period: data.recommendedPeriod }
             : undefined,
+        explore: data.exploreData ? { data: data.exploreData } : undefined,
         celebration: (data.celebrationRecent ?? data.celebration)?.length
             ? { data: data.celebrationRecent ?? data.celebration }
             : undefined

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -175,10 +175,11 @@
                             >
                                 <!-- 추천수 배지 (기존 추천글 패턴) -->
                                 <span
-                                    class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center rounded-full px-2 py-0.5 text-xs font-bold {getRecommendBadgeClass(
+                                    class="inline-flex min-w-[2.5rem] flex-shrink-0 items-center justify-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-bold {getRecommendBadgeClass(
                                         post.recommend_count
                                     )}"
                                 >
+                                    <img alt="공감" class="size-3" src="/images/thumbup.png?v=2" />
                                     {formatNumber(post.recommend_count)}
                                 </span>
 

--- a/widgets/explore/index.svelte
+++ b/widgets/explore/index.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    /**
+     * 톺아보기 위젯 (메인 페이지용)
+     * 핫 모드 상위 10건 표시 + 더보기 → /explore
+     */
+    import type { WidgetProps } from '$lib/types/widget-props';
+    import ExplorePreview from '$lib/components/features/explore/explore-preview.svelte';
+
+    let { config, slot, isEditMode = false, prefetchData }: WidgetProps = $props();
+</script>
+
+<ExplorePreview {prefetchData} />

--- a/widgets/explore/widget.json
+++ b/widgets/explore/widget.json
@@ -1,0 +1,12 @@
+{
+    "id": "explore",
+    "name": "톺아보기",
+    "version": "1.0.0",
+    "description": "전체 게시판 통합 피드 (핫 상위 10건)",
+    "author": { "name": "Angple" },
+    "category": "content",
+    "slots": ["main"],
+    "icon": "Compass",
+    "allowMultiple": false,
+    "main": "index.svelte"
+}


### PR DESCRIPTION
## Summary
- 메인 페이지에 톺아보기 미리보기 위젯 추가 (공감글 바로 아래)
- 핫 모드 상위 10건 표시 + "더보기" → /explore 링크
- SSR prefetch로 로딩 없이 즉시 표시
- 추천수 배지에 따봉 아이콘(thumbup.png) 적용
- 광고(ad-bottom) 최하단으로 이동 (콘텐츠 흐름 개선)

## 변경 파일
- `widgets/explore/` — 톺아보기 위젯 (widget.json + index.svelte)
- `src/lib/components/features/explore/` — 미리보기 컴포넌트
- `src/lib/constants/default-widgets.ts` — 위젯 순서 조정
- `src/routes/+page.server.ts` — SSR prefetch에 explore 추가
- `src/routes/+page.svelte` — prefetchDataMap에 explore 전달
- `src/routes/explore/+page.svelte` — 따봉 아이콘 적용

## Test plan
- [ ] 메인 페이지에 톺아보기 위젯 표시 확인
- [ ] 공감글 아래, 광고 위에 위치 확인
- [ ] 핫 상위 10건 + 따봉 아이콘 + 게시판 뱃지 정상 표시
- [ ] "더보기" 클릭 → /explore 이동
- [ ] /explore 페이지에도 따봉 아이콘 적용 확인