### PR TITLE
chore: 취약한 전이 의존성 override

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,10 +74,12 @@
             "rollup": ">=4.59.0",
             "cookie": ">=0.7.0",
             "markdown-it": ">=14.1.1",
-            "fast-xml-parser": ">=5.3.8",
-            "tar": ">=7.5.8",
-            "svelte": ">=5.53.5",
-            "@sveltejs/kit": ">=2.53.3"
-        }
+        "fast-xml-parser": ">=5.3.8",
+        "tar": ">=7.5.8",
+        "svelte": ">=5.53.5",
+        "@sveltejs/kit": ">=2.53.3",
+        "flatted": ">=3.4.0",
+        "undici": ">=7.24.0"
     }
+}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,8 @@ overrides:
   tar: '>=7.5.8'
   svelte: '>=5.53.5'
   '@sveltejs/kit': '>=2.53.3'
+  flatted: '>=3.4.0'
+  undici: '>=7.24.0'
 
 importers:
 
@@ -3009,8 +3011,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -4617,8 +4619,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.21.0:
-    resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
+  undici@7.24.1:
+    resolution: {integrity: sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==}
     engines: {node: '>=20.18.1'}
 
   universal-github-app-jwt@1.2.0:
@@ -8115,16 +8117,16 @@ snapshots:
 
   flat-cache@3.2.0:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.1
       keyv: 4.5.4
       rimraf: 3.0.2
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.1: {}
 
   follow-redirects@1.15.11: {}
 
@@ -8465,7 +8467,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.21.0
+      undici: 7.24.1
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9672,7 +9674,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.21.0: {}
+  undici@7.24.1: {}
 
   universal-github-app-jwt@1.2.0:
     dependencies:


### PR DESCRIPTION
## 요약
- web 보안 audit에서 잡히던 high 취약점을 루트 override로 정리했습니다.
- 코드 변경 없이 lockfile과 override만 조정했습니다.

## 변경 내용
- 루트  overrides 추가
  - 
  - 
-  갱신

## 배경
- 기존 PR 검증에서  이 다음 전이 의존성 때문에 실패했습니다.
  -  via 
  -  via 
- 기능 PR과 분리해서 별도 의존성 정리 PR로 관리합니다.

## 검증
-  ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /home/ec2-user
-  ERR_PNPM_AUDIT_NO_LOCKFILE  No pnpm-lock.yaml found: Cannot audit a project without a lockfile
  - high 취약점 0건
