### PR TITLE
fix: 회원 드롭다운 게시판 내 검색 + 공유 버튼 수정

### DIFF
--- a/apps/web/src/lib/components/post/share-button.svelte
+++ b/apps/web/src/lib/components/post/share-button.svelte
@@ -10,9 +10,7 @@
         shareToNaver,
         shareToPinterest,
         shareToTumblr,
-        copyUrl,
-        nativeShare,
-        canNativeShare
+        copyUrl
     } from '$lib/utils/share.js';
 
     interface Props {
@@ -30,13 +28,8 @@
         return `${window.location.origin}/${boardId}/${postId}`;
     }
 
-    async function handleShare() {
-        // 모바일: 네이티브 공유 시트, 데스크탑: 드롭다운
-        if (canNativeShare()) {
-            await nativeShare(title, getShareUrl());
-        } else {
-            open = !open;
-        }
+    function handleShare() {
+        open = !open;
     }
 
     function handleClickOutside(e: MouseEvent) {

--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -2,9 +2,11 @@
     import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { goto } from '$app/navigation';
+    import { page } from '$app/stores';
     import { apiClient } from '$lib/api/index.js';
     import User from '@lucide/svelte/icons/user';
     import FileText from '@lucide/svelte/icons/file-text';
+    import Search from '@lucide/svelte/icons/search';
     import Mail from '@lucide/svelte/icons/mail';
     import Ban from '@lucide/svelte/icons/ban';
     import UserPlus from '@lucide/svelte/icons/user-plus';
@@ -138,6 +140,18 @@
                     <FileText class="h-3.5 w-3.5" />
                     전체 게시물
                 </DropdownMenu.Item>
+                {#if $page.params.boardId}
+                    <DropdownMenu.Item
+                        class="cursor-pointer gap-2"
+                        onclick={() =>
+                            goto(
+                                `/${$page.params.boardId}?sfl=author&stx=${encodeURIComponent(authorName)}&page=1`
+                            )}
+                    >
+                        <Search class="h-3.5 w-3.5" />
+                        게시판 내 검색
+                    </DropdownMenu.Item>
+                {/if}
 
                 {#if authStore.isAuthenticated && !isOwnProfile}
                     <DropdownMenu.Separator />


### PR DESCRIPTION
## Summary
- 회원 드롭다운에 현재 게시판 내 작성자 검색 메뉴 추가
- 공유 버튼: iOS/macOS 네이티브 공유 팝업 대신 항상 커스텀 드롭다운 표시 (URL 복사, 카카오톡 등)

## Test plan
- [ ] 게시판 내에서 회원 닉네임 클릭 → "게시판 내 검색" 메뉴 확인
- [ ] 홈/프로필 등 게시판 외부에서는 해당 메뉴 미표시 확인
- [ ] iOS/macOS에서 공유 버튼 클릭 → 드롭다운 표시 확인
- [ ] URL 복사, 카카오톡 공유 정상 동작 확인