### PR TITLE
fix: 직접홍보 카테고리 필터 + 이모티콘 팝업 가려짐 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -95,12 +95,12 @@
         {#if showEmoticonPicker && LazyEmoticonPicker}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
-                class="fixed inset-0 z-40 bg-black/20 sm:bg-transparent"
+                class="fixed inset-0 z-[9998] bg-black/20 sm:bg-transparent"
                 onclick={() => (showEmoticonPicker = false)}
                 onkeydown={(e) => e.key === 'Escape' && (showEmoticonPicker = false)}
             ></div>
             <div
-                class="fixed inset-x-0 bottom-0 z-50 sm:absolute sm:inset-auto sm:bottom-full sm:left-0 sm:mb-1"
+                class="fixed inset-x-0 bottom-0 z-[9999] sm:absolute sm:inset-auto sm:bottom-full sm:left-0 sm:mb-1"
             >
                 <LazyEmoticonPicker
                     onInsertEmoticon={handleInsertEmoticon}

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -107,7 +107,8 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
     };
 
     // 프로모션 게시판 전용: 광고주별 post_count 제한 적용 (검색/태그 필터 없을 때만)
-    const isPromotionBoard = boardId === 'promotion' && !isSearching && !isTagFiltering;
+    const isPromotionBoard =
+        boardId === 'promotion' && !isSearching && !isTagFiltering && !category;
     const isHotBoard = boardId === 'free' || boardId === 'hello';
 
     // 비로그인 + 검색/태그 필터 없는 경우: 게시글 목록 캐시 사용 (15초)


### PR DESCRIPTION
## Summary
- 직접홍보(promotion) 게시판에서 카테고리 필터 시 ads 서버 대신 일반 API 사용하여 필터링 정상 동작
- 댓글 이모티콘 피커 z-index를 9998/9999로 상향하여 헤더 등에 가려지지 않도록 수정

## Test plan
- [ ] 직접홍보 게시판에서 카테고리 탭 클릭 시 해당 카테고리 게시글만 표시
- [ ] 댓글 작성 시 이모티콘 피커가 헤더에 가려지지 않는지 확인
- [ ] 모바일에서 이모티콘 피커 하단 시트 정상 동작 확인