### PR TITLE
feat: 검색창 고정(핀) 기능 + 첨부파일 표시 수정

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -33,6 +33,7 @@ export interface FreePost {
     tags?: string[];
     images?: string[];
     videos?: { url: string; filename: string; size: number }[];
+    files?: { url: string; filename: string; size: number }[]; // 일반 첨부파일 (PDF, ZIP 등)
     is_secret?: boolean; // 비밀글 여부
     is_notice?: boolean; // 공지사항 여부
     notice_type?: 'normal' | 'important'; // 공지 타입 (일반/필수)

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -20,6 +20,7 @@
     import { Markdown } from '$lib/components/ui/markdown/index.js';
     import ExternalLink from '@lucide/svelte/icons/external-link';
     import Download from '@lucide/svelte/icons/download';
+    import Paperclip from '@lucide/svelte/icons/paperclip';
     import Video from '@lucide/svelte/icons/video';
     import Heart from '@lucide/svelte/icons/heart';
     import ThumbsDown from '@lucide/svelte/icons/thumbs-down';
@@ -412,6 +413,34 @@
                                 class="max-w-full rounded-lg border"
                                 loading="lazy"
                             />
+                        {/each}
+                    </div>
+                {/if}
+
+                {#if post.files && post.files.length > 0}
+                    <div class="mt-6 space-y-2">
+                        <p
+                            class="text-muted-foreground flex items-center gap-1.5 text-sm font-medium"
+                        >
+                            <Paperclip class="h-4 w-4" />
+                            첨부파일
+                        </p>
+                        {#each post.files as file, i (i)}
+                            <a
+                                href={file.url}
+                                download={file.filename}
+                                class="bg-muted/50 hover:bg-muted flex items-center gap-3 rounded-lg border px-4 py-2.5 transition-colors"
+                            >
+                                <Download class="text-muted-foreground h-4 w-4 shrink-0" />
+                                <span class="text-foreground min-w-0 truncate text-sm">
+                                    {file.filename}
+                                </span>
+                                {#if file.size}
+                                    <span class="text-muted-foreground ml-auto shrink-0 text-xs">
+                                        {formatFileSize(file.size)}
+                                    </span>
+                                {/if}
+                            </a>
                         {/each}
                     </div>
                 {/if}

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -40,6 +40,8 @@ interface UiSettings {
     // 글씨 크기
     listFontSize: ListFontSize;
     recommendFontSize: ListFontSize;
+    // 검색
+    pinSearch: boolean;
     // 기타 (메모)
     hideMemo: boolean;
     hideMemoInList: boolean;
@@ -62,6 +64,7 @@ const DEFAULTS: UiSettings = {
     shortcutButtonSize: 'medium',
     listFontSize: 'base',
     recommendFontSize: 'base',
+    pinSearch: false,
     enableTouchGestures: false,
     swipeThreshold: 50,
     doubleTapInterval: 300,
@@ -229,6 +232,14 @@ function createUiSettingsStore() {
         },
         setShowNewComments(v: boolean) {
             settings.showNewComments = v;
+            save();
+        },
+        // 검색
+        get pinSearch() {
+            return settings.pinSearch;
+        },
+        setPinSearch(v: boolean) {
+            settings.pinSearch = v;
             save();
         },
         // 단축키

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -150,7 +150,7 @@
 
     // 읽은 글 표시 지연 — SSR에서는 모든 글이 "안읽음"으로 렌더링되므로,
     // 하이드레이션 직후 즉시 변경하면 깜빡임 발생. 2프레임 대기 후 부드럽게 전환.
-    let showSearch = $state(false);
+    let showSearch = $state(uiSettingsStore.pinSearch);
     let showReadState = $state(false);
     function scheduleAuthorLevelFetch(authorIds: string[]) {
         const uniqueAuthorIds = [...new Set(authorIds)];
@@ -536,16 +536,41 @@
                             </DropdownMenuContent>
                         </DropdownMenu>
                     {/if}
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        class="relative h-9 w-9 shrink-0"
-                        onclick={() => (showSearch = !showSearch)}
-                        title="검색"
-                    >
-                        <span class="absolute -inset-1.5"></span>
-                        <Search class="h-4 w-4" />
-                    </Button>
+                    <div class="relative flex shrink-0">
+                        <Button
+                            variant="outline"
+                            size="icon"
+                            class="h-9 w-9 {uiSettingsStore.pinSearch
+                                ? 'rounded-r-none border-r-0'
+                                : ''}"
+                            onclick={() => (showSearch = !showSearch)}
+                            title="검색"
+                        >
+                            <Search class="h-4 w-4" />
+                        </Button>
+                        {#if showSearch || isSearching}
+                            <Button
+                                variant="outline"
+                                size="icon"
+                                class="h-9 w-7 rounded-l-none px-0 {uiSettingsStore.pinSearch
+                                    ? 'bg-primary/10 text-primary'
+                                    : ''}"
+                                onclick={() => {
+                                    uiSettingsStore.setPinSearch(!uiSettingsStore.pinSearch);
+                                    if (uiSettingsStore.pinSearch) showSearch = true;
+                                }}
+                                title={uiSettingsStore.pinSearch
+                                    ? '검색창 고정 해제'
+                                    : '검색창 고정'}
+                            >
+                                <Pin
+                                    class="h-3 w-3 {uiSettingsStore.pinSearch
+                                        ? 'fill-current'
+                                        : ''}"
+                                />
+                            </Button>
+                        {/if}
+                    </div>
                     {#if canWrite}
                         <Button
                             onclick={goToWrite}
@@ -577,8 +602,8 @@
                 </div>
             {/if}
 
-            <!-- 검색 폼 (토글 or 검색 중) -->
-            {#if showSearch || isSearching}
+            <!-- 검색 폼 (토글 or 검색 중 or 핀 고정) -->
+            {#if showSearch || isSearching || uiSettingsStore.pinSearch}
                 <div class="mb-3" transition:slide={{ duration: 200 }}>
                     <SearchForm boardPath={`/${boardId}`} />
                 </div>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -123,6 +123,9 @@ export const load: PageServerLoad = async ({
             if (filesData.videos?.length) {
                 post.videos = filesData.videos;
             }
+            if (filesData.files?.length) {
+                post.files = filesData.files;
+            }
         }
 
         // 본문 제휴 링크 변환은 2단계 스트리밍으로 이동 (초기 렌더 블로킹 방지)

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/files/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/files/+server.ts
@@ -4,7 +4,8 @@
  * GET /api/boards/[boardId]/posts/[postId]/files
  * → {
  *     images: ["https://s3.damoang.net/data/file/free/xxx.jpg", ...],
- *     videos: [{ url: "...", filename: "원본파일명.mp4", size: 0 }, ...]
+ *     videos: [{ url: "...", filename: "원본파일명.mp4", size: 0 }, ...],
+ *     files: [{ url: "...", filename: "원본파일명.pdf", size: 12345 }, ...]
  *   }
  *
  * Go 백엔드 API가 images 필드를 반환하지 않아
@@ -33,14 +34,14 @@ export const GET: RequestHandler = async ({ params }) => {
     const { boardId, postId } = params;
 
     if (!boardId || !postId) {
-        return json({ images: [], videos: [] });
+        return json({ images: [], videos: [], files: [] });
     }
 
     const safeBoardId = boardId.replace(/[^a-zA-Z0-9_-]/g, '');
     const safePostId = parseInt(postId, 10);
 
     if (isNaN(safePostId)) {
-        return json({ images: [], videos: [] });
+        return json({ images: [], videos: [], files: [] });
     }
 
     try {
@@ -64,9 +65,23 @@ export const GET: RequestHandler = async ({ params }) => {
                 size: row.bf_filesize || 0
             }));
 
-        return json({ images, videos });
+        // 일반 첨부파일 (이미지/영상 제외, bf_type=0 첨부만)
+        const files = rows
+            .filter(
+                (row) =>
+                    !IMAGE_EXTENSIONS.test(row.bf_file) &&
+                    !VIDEO_EXTENSIONS.test(row.bf_file) &&
+                    row.bf_type === 0
+            )
+            .map((row) => ({
+                url: `${S3_BASE}/${safeBoardId}/${row.bf_file}`,
+                filename: row.bf_source || row.bf_file,
+                size: row.bf_filesize || 0
+            }));
+
+        return json({ images, videos, files });
     } catch (error) {
         console.error('Board files GET error:', error);
-        return json({ images: [], videos: [] });
+        return json({ images: [], videos: [], files: [] });
     }
 };

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -23,6 +23,7 @@
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import XIcon from '@lucide/svelte/icons/x';
     import Plus from '@lucide/svelte/icons/plus';
+    import Search from '@lucide/svelte/icons/search';
     import Keyboard from '@lucide/svelte/icons/keyboard';
     import Smartphone from '@lucide/svelte/icons/smartphone';
     import Hand from '@lucide/svelte/icons/hand';
@@ -434,6 +435,29 @@
 
         <!-- ========== 게시판 탭 ========== -->
         {#if activeTab === 'board'}
+            <Card>
+                <CardHeader>
+                    <CardTitle class="flex items-center gap-2">
+                        <Search class="h-5 w-5" />
+                        검색
+                    </CardTitle>
+                </CardHeader>
+                <CardContent class="space-y-4">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <Label>검색창 고정</Label>
+                            <p class="text-muted-foreground text-xs">
+                                게시판 목록에서 검색창을 항상 열어둡니다
+                            </p>
+                        </div>
+                        <Switch
+                            checked={uiSettingsStore.pinSearch}
+                            onCheckedChange={(v) => uiSettingsStore.setPinSearch(v)}
+                        />
+                    </div>
+                </CardContent>
+            </Card>
+
             <Card>
                 <CardHeader>
                     <CardTitle class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- 게시판 목록 검색 버튼 옆에 핀(고정) 버튼 추가 — 검색창을 항상 열어둘 수 있음
- UI 설정 > 게시판 탭에 "검색창 고정" 스위치 추가
- 첨부파일 API에서 일반 파일(PDF, ZIP 등) 누락 수정 (#8030)
- 게시글 상세 페이지에 첨부파일 다운로드 UI 추가

## Test plan
- [ ] 게시판 목록에서 검색 버튼 클릭 → 핀 버튼 표시 확인
- [ ] 핀 버튼 클릭 → 검색창 고정, 페이지 이동 후에도 유지
- [ ] UI 설정 > 게시판 탭에서 검색창 고정 스위치 동작 확인
- [ ] 첨부파일(PDF, ZIP 등)이 있는 게시글에서 파일 표시 확인
- [ ] 첨부파일 다운로드 링크 정상 동작