### PR TITLE
fix: 회원 프로필 이미지를 DB 기반으로 통합

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -21,6 +21,7 @@ export interface FreePost {
     content: string;
     author: string;
     author_id: string;
+    author_image?: string; // 프로필 이미지 URL (mb_image_url)
     board_id?: string;
     author_ip?: string; // 작성자 IP (마스킹된 형태, 예: 123.456.*.*)
     views: number;
@@ -62,6 +63,7 @@ export interface FreeComment {
     content: string;
     author: string;
     author_id: string;
+    author_image?: string; // 프로필 이미지 URL (mb_image_url)
     author_ip?: string; // 작성자 IP (마스킹된 형태, 예: 123.456.*.*)
     likes?: number;
     dislikes?: number; // 비추천 수

--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -8,7 +8,7 @@
         getCertificationBlockedMessage,
         goToCertification
     } from '$lib/utils/certification-gate.js';
-    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import type { BoardPermissions } from '$lib/api/types.js';
     import { apiClient } from '$lib/api/index.js';
     import Send from '@lucide/svelte/icons/send';
@@ -68,9 +68,7 @@
 
     const permissionMessage = $derived(`레벨 ${requiredCommentLevel} 이상 작성 가능`);
 
-    let commentAvatarUrl = $derived(
-        getAvatarUrl(authStore.user?.mb_image) || getMemberIconUrl(authStore.user?.mb_id) || null
-    );
+    let commentAvatarUrl = $derived(getAvatarUrl(authStore.user?.mb_image) || null);
     let commentAvatarFailed = $state(false);
 
     $effect(() => {

--- a/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
+++ b/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import * as Dialog from '$lib/components/ui/dialog/index.js';
     import type { LikerInfo } from '$lib/api/types.js';
-    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
@@ -97,8 +97,7 @@
             {:else}
                 <ul class="divide-border divide-y">
                     {#each likers as liker (liker.mb_id)}
-                        {@const likerIcon =
-                            getAvatarUrl(liker.mb_image) || getMemberIconUrl(liker.mb_id)}
+                        {@const likerIcon = getAvatarUrl(liker.mb_image)}
                         <li class="py-3">
                             <div class="flex items-center gap-3">
                                 {#if likerIcon}

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -19,7 +19,7 @@
     import { getHookVersion } from '$lib/hooks/hook-state.svelte';
     import { tick } from 'svelte';
     import { highlightAllCodeBlocks } from '$lib/utils/code-highlight';
-    import { getAvatarUrl, getMemberIconUrl, handleIconError } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { SvelteMap, SvelteSet } from 'svelte/reactivity';
     import type { Component } from 'svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
@@ -768,8 +768,7 @@
         {@const isReply = depth > 0}
         {@const iconUrl = isDeleted
             ? null
-            : getAvatarUrl((comment as FreeComment & { author_image?: string }).author_image) ||
-              getMemberIconUrl(comment.author_id)}
+            : getAvatarUrl((comment as FreeComment & { author_image?: string }).author_image)}
 
         <!-- 댓글 5개마다 GAM 인피드 광고 (루트 댓글 기준, 첫 번째 제외) -->
         {#if widgetLayoutStore.hasEnabledAds && commentIndex > 0 && commentIndex % 5 === 0 && depth === 0}
@@ -814,7 +813,10 @@
                         src={iconUrl}
                         alt=""
                         class="size-8 shrink-0 rounded-full object-cover"
-                        onerror={handleIconError}
+                        onerror={(e) => {
+                            const img = e.currentTarget as HTMLImageElement;
+                            img.style.display = 'none';
+                        }}
                     />
                 {:else}
                     <div

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -6,7 +6,7 @@
     import ImageIcon from '@lucide/svelte/icons/image';
     import Play from '@lucide/svelte/icons/play';
     import Pin from '@lucide/svelte/icons/pin';
-    import { getMemberIconUrl, handleIconError } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { formatDate, isToday } from '$lib/utils/format-date.js';
     import { formatCompactNumber } from '$lib/utils/format-number.js';
@@ -38,7 +38,7 @@
     } = $props();
 
     // 회원 아이콘 URL
-    const iconUrl = $derived(getMemberIconUrl(post.author_id));
+    const iconUrl = $derived(getAvatarUrl(post.author_image));
 
     /**
      * 추천 색상 단계 — 레거시 rcmd-box 기반
@@ -228,7 +228,10 @@
                             src={iconUrl}
                             alt=""
                             class="h-5 w-5 shrink-0 rounded-full object-cover"
-                            onerror={handleIconError}
+                            onerror={(e) => {
+                                const img = e.currentTarget as HTMLImageElement;
+                                img.style.display = 'none';
+                            }}
                         />
                     {/if}
                     <AuthorLink authorId={post.author_id} authorName={post.author} />
@@ -260,7 +263,10 @@
                                 src={iconUrl}
                                 alt=""
                                 class="h-5 w-5 shrink-0 rounded-full object-cover"
-                                onerror={handleIconError}
+                                onerror={(e) => {
+                                    const img = e.currentTarget as HTMLImageElement;
+                                    img.style.display = 'none';
+                                }}
                             />
                         {/if}
                         <AuthorLink authorId={post.author_id} authorName={post.author} />

--- a/apps/web/src/lib/components/features/board/layouts/list/message.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/message.svelte
@@ -9,7 +9,7 @@
      */
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Heart from '@lucide/svelte/icons/heart';
-    import { getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { formatDate } from '$lib/utils/format-date.js';
     let {
@@ -25,7 +25,7 @@
     } = $props();
 
     let showIcon = $state(true);
-    const iconUrl = $derived(showIcon ? getMemberIconUrl(post.author_id) : null);
+    const iconUrl = $derived(showIcon ? getAvatarUrl(post.author_image) : null);
     const initial = $derived((post.author || '?').charAt(0).toUpperCase());
 
     const isDeleted = $derived(!!post.deleted_at);

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -30,7 +30,7 @@
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
     import { uiSettingsStore, type ContentFontSize } from '$lib/stores/ui-settings.svelte.js';
-    import { getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
@@ -225,9 +225,9 @@
 
         <div class="border-border flex flex-wrap items-center gap-4 border-t pt-4">
             <div class="flex items-center gap-2">
-                {#if getMemberIconUrl(post.author_id)}
+                {#if getAvatarUrl(post.author_image)}
                     <img
-                        src={getMemberIconUrl(post.author_id)}
+                        src={getAvatarUrl(post.author_image)}
                         alt={post.author}
                         class="size-10 rounded-full object-cover"
                         onerror={(e) => {

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -40,7 +40,7 @@
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
     import { uiSettingsStore, type ContentFontSize } from '$lib/stores/ui-settings.svelte.js';
-    import { getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
@@ -246,9 +246,9 @@
 
         <div class="border-border flex flex-wrap items-center gap-4 border-t pt-4">
             <div class="flex items-center gap-2">
-                {#if getMemberIconUrl(post.author_id)}
+                {#if getAvatarUrl(post.author_image)}
                     <img
-                        src={getMemberIconUrl(post.author_id)}
+                        src={getAvatarUrl(post.author_image)}
                         alt={post.author}
                         class="size-10 rounded-full object-cover"
                         onerror={(e) => {

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -19,7 +19,7 @@
     } from '$lib/components/features/notification/index.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
-    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon';
+    import { getAvatarUrl } from '$lib/utils/member-icon';
     import { menuStore } from '$lib/stores/menu.svelte';
     import { getIcon } from '$lib/utils/icon-map';
     import { page } from '$app/stores';
@@ -43,9 +43,7 @@
     const isEffectivelyLoggedIn = $derived(effectiveUser !== null && effectiveUser !== undefined);
 
     let headerAvatarUrl = $derived(
-        effectiveUser
-            ? getAvatarUrl(effectiveUser.mb_image) || getMemberIconUrl(effectiveUser.mb_id) || null
-            : null
+        effectiveUser ? getAvatarUrl(effectiveUser.mb_image) || null : null
     );
     let headerAvatarFailed = $state(false);
 

--- a/apps/web/src/lib/components/layout/user-widget.svelte
+++ b/apps/web/src/lib/components/layout/user-widget.svelte
@@ -9,7 +9,7 @@
     import Coins from '@lucide/svelte/icons/coins';
     import Star from '@lucide/svelte/icons/star';
     import { getUser, getIsLoggedIn, getIsLoading, authActions } from '$lib/stores/auth.svelte';
-    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon';
+    import { getAvatarUrl } from '$lib/utils/member-icon';
     import { getGradeName } from '$lib/utils/grade';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
@@ -60,7 +60,7 @@
     );
 
     // 아바타 URL (mb_image 우선 → avatar_url → member_image 경로 폴백)
-    let avatarUrl = $derived(getAvatarUrl(user?.mb_image) || getMemberIconUrl(user?.mb_id) || null);
+    let avatarUrl = $derived(getAvatarUrl(user?.mb_image) || null);
     let avatarFailed = $state(false);
 
     // user 변경 시 실패 상태 리셋

--- a/apps/web/src/lib/components/ui/avatar-stack/avatar-stack.svelte
+++ b/apps/web/src/lib/components/ui/avatar-stack/avatar-stack.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getAvatarUrl, getMemberIconUrl, handleIconError } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
 
     interface AvatarItem {
         mb_id: string;
@@ -32,7 +32,7 @@
 >
     <div class="flex items-center -space-x-1.5">
         {#each visibleItems as item (item.mb_id)}
-            {@const iconUrl = getAvatarUrl(item.mb_image) || getMemberIconUrl(item.mb_id)}
+            {@const iconUrl = getAvatarUrl(item.mb_image)}
             {@const nick = item.mb_nick || item.mb_name || item.mb_id}
             {#if iconUrl}
                 <img
@@ -41,9 +41,9 @@
                     title={nick}
                     class="{sizeClass} ring-background rounded-full object-cover ring-2"
                     onerror={(e) => {
-                        handleIconError(e);
-                        const fallback = (e.currentTarget as HTMLElement)
-                            .nextElementSibling as HTMLElement;
+                        const img = e.currentTarget as HTMLImageElement;
+                        img.style.display = 'none';
+                        const fallback = img.nextElementSibling as HTMLElement;
                         if (fallback) fallback.style.display = 'flex';
                     }}
                 />

--- a/apps/web/src/lib/server/member-images.ts
+++ b/apps/web/src/lib/server/member-images.ts
@@ -1,0 +1,35 @@
+/**
+ * 회원 프로필 이미지 서버사이드 배치 조회 (SSR용)
+ *
+ * mb_id 배열로 g5_member.mb_image_url을 배치 조회.
+ * 게시글 목록/상세에서 author_image를 enrichment할 때 사용.
+ */
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+const MAX_IDS = 200;
+
+/**
+ * 회원 프로필 이미지 URL 배치 조회
+ * @param ids mb_id 배열
+ * @returns { [mb_id]: mb_image_url } 맵 (이미지 없는 회원은 포함 안 됨)
+ */
+export async function fetchMemberImages(ids: string[]): Promise<Record<string, string>> {
+    const validIds = ids.filter((id) => id && /^[a-zA-Z0-9_]+$/.test(id)).slice(0, MAX_IDS);
+
+    if (validIds.length === 0) return {};
+
+    const placeholders = validIds.map(() => '?').join(',');
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT mb_id, mb_image_url FROM g5_member WHERE mb_id IN (${placeholders}) AND mb_image_url != ''`,
+        validIds
+    );
+
+    const images: Record<string, string> = {};
+    for (const row of rows) {
+        if (row.mb_image_url) {
+            images[row.mb_id] = row.mb_image_url;
+        }
+    }
+    return images;
+}

--- a/apps/web/src/lib/utils/member-icon.ts
+++ b/apps/web/src/lib/utils/member-icon.ts
@@ -1,58 +1,23 @@
 /**
- * 회원 아이콘 URL 생성 유틸리티
- * 1순위: API에서 받은 avatar_url (mb_image_url)
- * 2순위: S3 경로 기반 폴백 (data/member_image/{prefix}/{mb_id}.gif)
+ * 회원 프로필 이미지 URL 유틸리티
+ * DB(mb_image_url)에 저장된 S3 경로만 사용. 추측 경로 없음.
  */
 
 const CDN_BASE_URL = 'https://s3.damoang.net';
 
 /**
- * 이미지 로드 실패한 mb_id 캐시 (세션 내 재요청 방지)
- */
-const failedIconCache = new Set<string>();
-
-/**
- * avatar_url 또는 mb_image_url로 전체 URL 생성
- * @param avatarUrl API에서 받은 avatar_url (예: data/member_image/ad/admin_1760156943.webp)
+ * mb_image_url(DB)로 전체 URL 생성
+ * @param imageUrl API에서 받은 mb_image / author_image (예: data/member_image/ad/admin_1760156943.webp)
  * @returns 전체 URL 또는 null
  */
-export function getAvatarUrl(avatarUrl: string | null | undefined): string | null {
-    if (!avatarUrl) return null;
+export function getAvatarUrl(imageUrl: string | null | undefined): string | null {
+    if (!imageUrl) return null;
 
     // 이미 전체 URL이면 그대로 반환
-    if (avatarUrl.startsWith('http://') || avatarUrl.startsWith('https://')) {
-        return avatarUrl;
+    if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
+        return imageUrl;
     }
 
     // 상대 경로면 CDN 베이스 추가
-    return `${CDN_BASE_URL}/${avatarUrl}`;
-}
-
-/**
- * 회원 ID로 아이콘 URL 생성 (폴백용)
- * 이전에 로드 실패한 ID는 null 반환 (불필요한 403 요청 방지)
- * @param mbId 회원 ID (예: google_78ca0772, naver_889808c8)
- * @returns 아이콘 URL 또는 null
- */
-export function getMemberIconUrl(mbId: string | null | undefined): string | null {
-    if (!mbId || mbId.length < 2) return null;
-    if (failedIconCache.has(mbId)) return null;
-
-    const prefix = mbId.substring(0, 2).toLowerCase();
-    return `${CDN_BASE_URL}/data/member_image/${prefix}/${mbId}.gif`;
-}
-
-/**
- * 아이콘 이미지 로드 실패 시 폴백 처리
- * @param event 이미지 에러 이벤트
- */
-export function handleIconError(event: Event): void {
-    const img = event.target as HTMLImageElement;
-    if (img) {
-        const match = img.src.match(/\/member_image\/\w+\/([^.]+)\.\w+/);
-        if (match) {
-            failedIconCache.add(match[1]);
-        }
-        img.style.display = 'none';
-    }
+    return `${CDN_BASE_URL}/${imageUrl}`;
 }

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -4,6 +4,7 @@ import type { FreePost, Board, SearchField } from '$lib/api/types.js';
 import { fetchPromotionPosts, fetchPromotionBoardPosts } from '$lib/server/ads/promotion.js';
 import type { PromotionBoardPost } from '$lib/server/ads/promotion.js';
 import { backendFetch as bFetch, createAuthHeaders } from '$lib/server/backend-fetch.js';
+import { fetchMemberImages } from '$lib/server/member-images.js';
 import { createCache } from '$lib/server/cache.js';
 import { getCachedBoard } from '$lib/server/board-cache.js';
 
@@ -163,6 +164,23 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
             }
 
             const notices = noticesResult.status === 'fulfilled' ? noticesResult.value : [];
+
+            // 프로필 이미지 enrichment
+            const allPosts = [...posts, ...notices];
+            if (allPosts.length > 0) {
+                const mbIds = [...new Set(allPosts.map((p) => p.author_id).filter(Boolean))];
+                try {
+                    const imageMap = await fetchMemberImages(mbIds);
+                    for (const p of allPosts) {
+                        if (p.author_id && imageMap[p.author_id]) {
+                            p.author_image = imageMap[p.author_id];
+                        }
+                    }
+                } catch {
+                    // ignore
+                }
+            }
+
             const pagination = {
                 total: posts.length,
                 page: 1,
@@ -226,6 +244,22 @@ export const load: PageServerLoad = async ({ url, params, locals }) => {
         }
 
         const notices = noticesResult.status === 'fulfilled' ? noticesResult.value : [];
+
+        // 프로필 이미지 enrichment (DB mb_image_url 배치 조회)
+        const allPosts = [...posts, ...notices];
+        if (allPosts.length > 0) {
+            const mbIds = [...new Set(allPosts.map((p) => p.author_id).filter(Boolean))];
+            try {
+                const imageMap = await fetchMemberImages(mbIds);
+                for (const p of allPosts) {
+                    if (p.author_id && imageMap[p.author_id]) {
+                        p.author_image = imageMap[p.author_id];
+                    }
+                }
+            } catch {
+                // 이미지 조회 실패해도 게시글 표시는 정상 진행
+            }
+        }
 
         const result = { posts, notices, pagination, error };
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -14,6 +14,7 @@ import {
 } from '$lib/server/viewcount.js';
 import { fetchReactionsByParentId } from '$lib/server/reactions.js';
 import { fetchMemberLevels } from '$lib/server/member-levels.js';
+import { fetchMemberImages } from '$lib/server/member-images.js';
 import { fetchCommentLikeStatuses } from '$lib/server/comment-likes.js';
 import { fetchPostReportCount } from '$lib/server/report-count.js';
 
@@ -281,6 +282,28 @@ export const load: PageServerLoad = async ({
                 }
             } catch {
                 // 레벨 조회 실패 시 빈 맵 (클라이언트에서 fallback)
+            }
+
+            // 프로필 이미지 배치 조회 (DB mb_image_url)
+            try {
+                const imgIds = new Set<string>();
+                if (post.author_id) imgIds.add(post.author_id);
+                for (const c of comments.items || []) {
+                    if (c.author_id) imgIds.add(c.author_id);
+                }
+                if (imgIds.size > 0) {
+                    const imageMap = await fetchMemberImages([...imgIds]);
+                    if (post.author_id && imageMap[post.author_id]) {
+                        post.author_image = imageMap[post.author_id];
+                    }
+                    for (const c of comments.items || []) {
+                        if (c.author_id && imageMap[c.author_id]) {
+                            c.author_image = imageMap[c.author_id];
+                        }
+                    }
+                }
+            } catch {
+                // 이미지 조회 실패해도 정상 진행
             }
 
             // 댓글 좋아요/비추천 상태 배치 조회 (로그인 시만)

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -44,7 +44,7 @@
     import { onMount } from 'svelte';
     import { doAction } from '$lib/hooks/registry';
     import { page } from '$app/stores';
-    import { getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { isEmbeddable } from '$lib/plugins/auto-embed';
     import AdminPostActions from '$lib/components/features/board/admin-post-actions.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
@@ -1537,9 +1537,9 @@
                         <li class="py-3">
                             <div class="flex items-center gap-3">
                                 <!-- 프로필 이미지 -->
-                                {#if getMemberIconUrl(liker.mb_id)}
+                                {#if getAvatarUrl(liker.mb_image)}
                                     <img
-                                        src={getMemberIconUrl(liker.mb_id)}
+                                        src={getAvatarUrl(liker.mb_image)}
                                         alt={liker.mb_nick || liker.mb_name}
                                         class="size-8 rounded-full object-cover"
                                         onerror={(e) => {

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -6,7 +6,7 @@
     import * as Tabs from '$lib/components/ui/tabs/index.js';
     import type { PageData } from './$types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
-    import { getAvatarUrl, getMemberIconUrl, handleIconError } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { apiClient } from '$lib/api/index.js';
     import { goto } from '$app/navigation';
     import { onMount } from 'svelte';
@@ -66,9 +66,7 @@
     const p = $derived(data.profile);
 
     let overrideImageUrl = $state<string | null>(null);
-    const profileIconUrl = $derived(
-        overrideImageUrl || getAvatarUrl(p?.mb_image) || getMemberIconUrl(p?.mb_id)
-    );
+    const profileIconUrl = $derived(overrideImageUrl || getAvatarUrl(p?.mb_image));
     let profileIconFailed = $state(false);
     $effect(() => {
         if (p) profileIconFailed = false;
@@ -387,8 +385,7 @@
                                 class="size-16 rounded-full object-cover"
                                 class:cursor-pointer={isOwnProfile}
                                 onclick={handleImageClick}
-                                onerror={(e) => {
-                                    handleIconError(e);
+                                onerror={() => {
                                     profileIconFailed = true;
                                 }}
                             />

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -6,7 +6,7 @@
     import type { PageData } from './$types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { getGradeName } from '$lib/utils/grade.js';
-    import { getAvatarUrl, getMemberIconUrl } from '$lib/utils/member-icon.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import MySkeleton from '$lib/components/features/my/my-skeleton.svelte';
     import FileText from '@lucide/svelte/icons/file-text';
     import MessageSquare from '@lucide/svelte/icons/message-square';
@@ -16,9 +16,7 @@
 
     let { data }: { data: PageData } = $props();
 
-    let myAvatarUrl = $derived(
-        getAvatarUrl(authStore.user?.mb_image) || getMemberIconUrl(authStore.user?.mb_id) || null
-    );
+    let myAvatarUrl = $derived(getAvatarUrl(authStore.user?.mb_image) || null);
     let myAvatarFailed = $state(false);
 
     $effect(() => {


### PR DESCRIPTION
## Summary
- `getMemberIconUrl()`/`handleIconError()` 추측 방식 제거, `getAvatarUrl()` 하나로 통일
- SSR에서 `g5_member.mb_image_url` DB 배치 조회로 `author_image` enrichment (게시판 목록 + 게시글 상세)
- `FreePost`/`FreeComment` 타입에 `author_image` 필드 추가
- 13개 컴포넌트에서 삭제된 함수 참조 제거 및 `getAvatarUrl(author_image)` 사용으로 전환

## Test plan
- [ ] dev.damoang.net에서 게시판 목록 프로필 이미지 정상 표시 확인
- [ ] 게시글 상세 페이지 본문 작성자 + 댓글 작성자 프로필 이미지 확인
- [ ] 프로필 이미지 없는 회원은 기본 아이콘 표시 확인
- [ ] 헤더/마이페이지/회원 프로필 페이지 이미지 정상 표시 확인