### PR TITLE
fix: P1 버그 Round 3 - UI/UX 일괄 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -100,7 +100,7 @@
                 onkeydown={(e) => e.key === 'Escape' && (showEmoticonPicker = false)}
             ></div>
             <div
-                class="fixed inset-x-0 bottom-0 z-[9999] sm:absolute sm:inset-auto sm:bottom-full sm:left-0 sm:mb-1"
+                class="fixed inset-x-0 bottom-0 z-[9999] sm:fixed sm:inset-x-auto sm:bottom-4 sm:left-1/2 sm:-translate-x-1/2"
             >
                 <LazyEmoticonPicker
                     onInsertEmoticon={handleInsertEmoticon}

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -332,9 +332,11 @@
                                 >
                             {/if}
                         </div>
-                        <span class="text-foreground hidden text-sm font-medium md:inline">
-                            {effectiveUser.mb_name}
-                        </span>
+                        {#if !uiSettingsStore.hideMyProfile}
+                            <span class="text-foreground hidden text-sm font-medium md:inline">
+                                {effectiveUser.mb_name}
+                            </span>
+                        {/if}
                     {/if}
                 </a>
             {:else}

--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -17,11 +17,18 @@
     interface Props {
         authorId: string;
         authorName: string;
+        isWithdrawn?: boolean;
         class?: string;
         children?: Snippet;
     }
 
-    let { authorId, authorName, class: className = '', children }: Props = $props();
+    let {
+        authorId,
+        authorName,
+        isWithdrawn = false,
+        class: className = '',
+        children
+    }: Props = $props();
 
     const isOwnProfile = $derived(authStore.user?.mb_id === authorId);
 
@@ -101,7 +108,7 @@
 </script>
 
 {#if !authorId}
-    <span class={className}>
+    <span class="{className} {isWithdrawn ? 'line-through opacity-60' : ''}">
         {#if children}
             {@render children()}
         {:else}
@@ -117,7 +124,9 @@
             }}
         >
             <DropdownMenu.Trigger
-                class="cursor-pointer text-left hover:underline focus:outline-none {className}"
+                class="cursor-pointer text-left hover:underline focus:outline-none {className} {isWithdrawn
+                    ? 'line-through opacity-60'
+                    : ''}"
             >
                 {#if children}
                     {@render children()}

--- a/apps/web/src/lib/utils/format-date.ts
+++ b/apps/web/src/lib/utils/format-date.ts
@@ -16,7 +16,12 @@ export function isToday(dateString: string): boolean {
 }
 
 export function formatDate(dateString: string): string {
-    const date = new Date(dateString);
+    // Gnuboard YYYYMMDD 형식 (mb_leave_date 등) → ISO 변환
+    let normalized = dateString;
+    if (/^\d{8}$/.test(dateString)) {
+        normalized = `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
+    }
+    const date = new Date(normalized);
     const now = new Date();
 
     // 서울 시간 기준 YYYY-MM-DD 문자열 추출

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1165,7 +1165,8 @@
 
     <!-- 상단 네비게이션 -->
     <div class="-mx-5 mb-2 flex items-center gap-3 px-5 py-2 md:mx-0 md:px-0">
-        <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">← 목록으로</Button>
+        <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
+        <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
 
         <div class="flex-1"></div>
 
@@ -1465,8 +1466,10 @@
 
         <!-- 댓글 아래 네비게이션 -->
         <div class="-mx-5 mt-4 flex items-center gap-3 px-5 py-2 md:mx-0 md:px-0">
-            <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">← 목록으로</Button
+            <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0"
+                >←</Button
             >
+            <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
             <div class="flex-1"></div>
             {#if authStore.isAuthenticated && checkPermission(data.board, 'can_write', authStore.user ?? null)}
                 <Button

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -441,7 +441,11 @@
 
                     <div class="min-w-0 flex-1">
                         <div class="flex items-center gap-2">
-                            <h1 class="text-foreground truncate text-xl font-bold">
+                            <h1
+                                class="text-foreground truncate text-xl font-bold {p.is_left
+                                    ? 'line-through opacity-60'
+                                    : ''}"
+                            >
                                 {p.mb_name}
                             </h1>
                             {#if p.mb_certify}

--- a/apps/web/src/routes/messages/+page.svelte
+++ b/apps/web/src/routes/messages/+page.svelte
@@ -351,7 +351,7 @@
 
 <!-- 쪽지 보내기 다이얼로그 -->
 <Dialog.Root bind:open={showSendDialog}>
-    <Dialog.Content class="sm:max-w-md">
+    <Dialog.Content class="flex max-h-[90vh] flex-col sm:max-w-md">
         <Dialog.Header>
             <Dialog.Title class="flex items-center gap-2">
                 <PenSquare class="h-5 w-5" />
@@ -360,7 +360,7 @@
             <Dialog.Description>회원에게 쪽지를 보냅니다.</Dialog.Description>
         </Dialog.Header>
 
-        <div class="space-y-4 py-4">
+        <div class="flex-1 space-y-4 overflow-y-auto py-4">
             <div class="space-y-2">
                 <Label for="send-to">받는 사람</Label>
                 <Input

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -42,6 +42,16 @@
     }
 
     // 날짜 포맷
+    function stripHtml(html: string): string {
+        return html
+            .replace(/<[^>]*>/g, '')
+            .replace(/&nbsp;/g, ' ')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&')
+            .trim();
+    }
+
     function formatDate(dateString: string): string {
         const date = new Date(dateString);
         return date.toLocaleDateString('ko-KR', {
@@ -254,7 +264,7 @@
                                                 </p>
                                             {/if}
                                             <p class="text-foreground mb-2 line-clamp-2">
-                                                {comment.content}
+                                                {stripHtml(comment.content)}
                                             </p>
                                             <div
                                                 class="text-muted-foreground flex items-center gap-2 text-xs"


### PR DESCRIPTION
## Summary
- 글 상세 뒤로가기 버튼 추가 (톺아보기/피드 등 다양한 진입점 지원)
- #8020 쪽지 보내기 모바일 버튼 접근 불가 (Dialog max-height + scroll)
- #8028 프로필 가리기 설정 시 헤더 닉네임도 숨기기
- #8031 마이페이지 댓글 `<p>` 태그 노출 (HTML strip 처리)
- #7936 탈퇴 회원 날짜 깨짐 (YYYYMMDD 파싱) + 닉네임 취소선
- #8027 이모티콘 피커 상단 가려짐 (fixed 위치 통일)

## Test plan
- [ ] 톺아보기/피드에서 글 상세 진입 → ← 뒤로가기 → 이전 페이지 복귀
- [ ] 모바일에서 긴 쪽지 작성 → 보내기 버튼 접근 가능
- [ ] 프로필 가리기 ON → 헤더 닉네임 숨김 확인
- [ ] 마이페이지 > 내가 쓴 댓글 → `<p>` 태그 미노출
- [ ] 탈퇴 회원 프로필 → 날짜 정상 표시 + 닉네임 취소선
- [ ] 첫 번째 댓글 답글 → 이모티콘 팩 탭 접근 가능