### PR TITLE
fix: P1 버그 Round 4 - 공감글 UI + 뒤로가기 + 이미지 캐시

### DIFF
--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -21,6 +21,7 @@ declare global {
                 level: number;
                 mb_certify?: string;
                 mb_image?: string;
+                mb_image_updated_at?: string;
             } | null;
             accessToken: string | null;
             /** 서버사이드 세션 ID (angple_sid 쿠키 원본값) */

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -179,7 +179,8 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                         nickname: member.mb_nick || member.mb_name,
                         level: member.mb_level ?? 0,
                         mb_certify: member.mb_certify || '',
-                        mb_image: member.mb_image_url || undefined
+                        mb_image: member.mb_image_url || undefined,
+                        mb_image_updated_at: member.mb_image_updated_at || undefined
                     };
                     event.locals.sessionId = sessionId;
                     event.locals.csrfToken = session.csrfToken;

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -364,6 +364,7 @@ export interface DamoangUser {
     mb_point?: number; // 보유 포인트
     mb_exp?: number; // 경험치
     mb_image?: string; // 프로필 이미지 URL
+    mb_image_updated_at?: string; // 프로필 이미지 갱신 시각
     as_level?: number; // 나리야 경험치 레벨
     as_max?: number; // 현재 레벨 최대 경험치
 }

--- a/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
+++ b/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
@@ -33,7 +33,6 @@
             <li>
                 <a
                     href={post.url}
-                    rel="external"
                     class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
                 >
                     <div class="flex items-center gap-2">

--- a/apps/web/src/lib/components/features/explore/explore-preview.svelte
+++ b/apps/web/src/lib/components/features/explore/explore-preview.svelte
@@ -96,7 +96,6 @@
                     <li>
                         <a
                             href={post.url}
-                            rel="external"
                             class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
                         >
                             <div class="flex items-center gap-2">

--- a/apps/web/src/lib/components/features/gallery/components/gallery-card.svelte
+++ b/apps/web/src/lib/components/features/gallery/components/gallery-card.svelte
@@ -20,7 +20,6 @@
 
 <a
     href={post.url}
-    rel="external"
     class="bg-card border-border group flex h-full flex-col overflow-hidden rounded-xl border shadow-sm transition-all duration-200 ease-out hover:shadow-md"
 >
     <!-- 16:9 이미지 -->

--- a/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
+++ b/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
@@ -26,7 +26,6 @@
         </div>
         <a
             href="/gallery"
-            rel="external"
             class="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1 text-[15px] transition-all duration-200 ease-out"
         >
             더보기

--- a/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
+++ b/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
@@ -34,7 +34,6 @@
             <li>
                 <a
                     href={post.url}
-                    rel="external"
                     class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
                 >
                     <div class="flex items-center gap-2">

--- a/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
@@ -27,7 +27,6 @@
             <li>
                 <a
                     href={post.url}
-                    rel="external"
                     class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
                 >
                     <div class="flex items-center gap-2">

--- a/apps/web/src/lib/components/ui/post-card/post-card.svelte
+++ b/apps/web/src/lib/components/ui/post-card/post-card.svelte
@@ -29,7 +29,6 @@
 <li>
     <a
         href={post.url}
-        rel="external"
         class="hover:bg-muted block rounded px-2 py-1.5 transition-all duration-200 ease-out"
     >
         <div class="flex items-center gap-2">

--- a/apps/web/src/lib/server/auth/oauth/member.ts
+++ b/apps/web/src/lib/server/auth/oauth/member.ts
@@ -25,7 +25,8 @@ export async function getMemberById(mbId: string): Promise<MemberRow | null> {
     const [rows] = await pool.query<RowDataPacket[]>(
         `SELECT mb_id, mb_name, mb_nick, mb_email, mb_level, mb_point,
 		        mb_today_login, mb_login_ip, mb_leave_date, mb_intercept_date, mb_certify,
-		        COALESCE(mb_image_url, '') AS mb_image_url
+		        COALESCE(mb_image_url, '') AS mb_image_url,
+		        mb_image_updated_at
 		 FROM g5_member
 		 WHERE mb_id = ? LIMIT 1`,
         [mbId]
@@ -44,7 +45,8 @@ export async function findMemberByEmail(email: string): Promise<MemberRow | null
     const [rows] = await pool.query<RowDataPacket[]>(
         `SELECT mb_id, mb_name, mb_nick, mb_email, mb_level, mb_point,
 		        mb_today_login, mb_login_ip, mb_leave_date, mb_intercept_date, mb_certify,
-		        COALESCE(mb_image_url, '') AS mb_image_url
+		        COALESCE(mb_image_url, '') AS mb_image_url,
+		        mb_image_updated_at
 		 FROM g5_member
 		 WHERE mb_email = ? AND mb_leave_date = ''
 		 LIMIT 1`,

--- a/apps/web/src/lib/server/auth/oauth/types.ts
+++ b/apps/web/src/lib/server/auth/oauth/types.ts
@@ -69,6 +69,7 @@ export interface MemberRow {
     mb_intercept_date: string;
     mb_certify: string;
     mb_image_url: string;
+    mb_image_updated_at: string | null;
 }
 
 /** OAuth state 쿠키에 저장되는 데이터 */

--- a/apps/web/src/lib/server/member-images.ts
+++ b/apps/web/src/lib/server/member-images.ts
@@ -9,6 +9,11 @@ import pool from '$lib/server/db';
 
 const MAX_IDS = 200;
 
+export interface MemberImageInfo {
+    url: string;
+    updated_at?: string;
+}
+
 /**
  * 회원 프로필 이미지 URL 배치 조회
  * @param ids mb_id 배열
@@ -29,6 +34,36 @@ export async function fetchMemberImages(ids: string[]): Promise<Record<string, s
     for (const row of rows) {
         if (row.mb_image_url) {
             images[row.mb_id] = row.mb_image_url;
+        }
+    }
+    return images;
+}
+
+/**
+ * 회원 프로필 이미지 URL + updated_at 배치 조회
+ * @param ids mb_id 배열
+ * @returns { [mb_id]: { url, updated_at } } 맵
+ */
+export async function fetchMemberImagesWithTimestamp(
+    ids: string[]
+): Promise<Record<string, MemberImageInfo>> {
+    const validIds = ids.filter((id) => id && /^[a-zA-Z0-9_]+$/.test(id)).slice(0, MAX_IDS);
+
+    if (validIds.length === 0) return {};
+
+    const placeholders = validIds.map(() => '?').join(',');
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT mb_id, mb_image_url, mb_image_updated_at FROM g5_member WHERE mb_id IN (${placeholders}) AND mb_image_url != ''`,
+        validIds
+    );
+
+    const images: Record<string, MemberImageInfo> = {};
+    for (const row of rows) {
+        if (row.mb_image_url) {
+            images[row.mb_id] = {
+                url: row.mb_image_url,
+                updated_at: row.mb_image_updated_at ? String(row.mb_image_updated_at) : undefined
+            };
         }
     }
     return images;

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -49,6 +49,7 @@ function initFromSSR(
         level: number;
         mb_certify?: string;
         mb_image?: string;
+        mb_image_updated_at?: string;
     },
     accessToken: string
 ): void {
@@ -57,6 +58,7 @@ function initFromSSR(
     if (user && user.mb_id === mbId) {
         if (ssrUser.mb_image && user.mb_image !== ssrUser.mb_image) {
             user.mb_image = ssrUser.mb_image;
+            user.mb_image_updated_at = ssrUser.mb_image_updated_at;
         }
         isLoading = false;
         return;
@@ -67,7 +69,8 @@ function initFromSSR(
         mb_level: ssrUser.level,
         mb_email: '',
         mb_certify: ssrUser.mb_certify || '',
-        mb_image: ssrUser.mb_image
+        mb_image: ssrUser.mb_image,
+        mb_image_updated_at: ssrUser.mb_image_updated_at
     };
     apiClient.setAccessToken(accessToken);
     isLoading = false;

--- a/apps/web/src/lib/utils/member-icon.ts
+++ b/apps/web/src/lib/utils/member-icon.ts
@@ -8,16 +8,35 @@ const CDN_BASE_URL = 'https://s3.damoang.net';
 /**
  * mb_image_url(DB)로 전체 URL 생성
  * @param imageUrl API에서 받은 mb_image / author_image (예: data/member_image/ad/admin_1760156943.webp)
+ * @param updatedAt mb_image_updated_at (Unix timestamp 또는 ISO 문자열) — 캐시 버스팅용
  * @returns 전체 URL 또는 null
  */
-export function getAvatarUrl(imageUrl: string | null | undefined): string | null {
+export function getAvatarUrl(
+    imageUrl: string | null | undefined,
+    updatedAt?: number | string | null
+): string | null {
     if (!imageUrl) return null;
 
-    // 이미 전체 URL이면 그대로 반환
+    let url: string;
+
+    // 이미 전체 URL이면 그대로 사용
     if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
-        return imageUrl;
+        url = imageUrl;
+    } else {
+        // 상대 경로면 CDN 베이스 추가
+        url = `${CDN_BASE_URL}/${imageUrl}`;
     }
 
-    // 상대 경로면 CDN 베이스 추가
-    return `${CDN_BASE_URL}/${imageUrl}`;
+    // 캐시 버스팅: ?v=timestamp 추가
+    if (updatedAt) {
+        const v =
+            typeof updatedAt === 'number'
+                ? updatedAt
+                : Math.floor(new Date(updatedAt).getTime() / 1000);
+        if (v > 0) {
+            url += `${url.includes('?') ? '&' : '?'}v=${v}`;
+        }
+    }
+
+    return url;
 }

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -48,7 +48,8 @@
                     nickname: d.user.nickname ?? '',
                     level: d.user.level,
                     mb_certify: d.user.mb_certify ?? '',
-                    mb_image: d.user.mb_image
+                    mb_image: d.user.mb_image,
+                    mb_image_updated_at: d.user.mb_image_updated_at
                 },
                 d.accessToken
             );
@@ -59,7 +60,8 @@
                     nickname: d.user.nickname ?? '',
                     level: d.user.level,
                     mb_certify: d.user.mb_certify ?? '',
-                    mb_image: d.user.mb_image
+                    mb_image: d.user.mb_image,
+                    mb_image_updated_at: d.user.mb_image_updated_at
                 },
                 ''
             );

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -175,7 +175,6 @@
                         <li>
                             <a
                                 href={post.url}
-                                rel="external"
                                 class="hover:bg-muted flex items-center gap-2.5 px-4 py-2 transition-all duration-200 ease-out"
                             >
                                 <!-- 추천수 배지 (기존 추천글 패턴) -->

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -875,17 +875,25 @@
                     {:else}
                         <ul class="divide-border divide-y">
                             {#each likedPosts as liked (liked.wr_id)}
-                                <li class="py-2">
+                                <li>
                                     <a
                                         href={liked.href}
-                                        class="text-foreground hover:text-primary block text-sm transition-colors"
+                                        class="hover:bg-muted flex items-center gap-2.5 px-4 py-2 no-underline transition-all duration-200 ease-out"
                                     >
-                                        {liked.wr_subject}
+                                        <span
+                                            class="bg-muted text-muted-foreground hidden shrink-0 rounded px-1.5 py-0.5 text-xs sm:inline-block"
+                                        >
+                                            {liked.bo_subject}
+                                        </span>
+                                        <span class="min-w-0 flex-1 truncate leading-relaxed">
+                                            {liked.wr_subject}
+                                        </span>
+                                        <span
+                                            class="text-muted-foreground hidden shrink-0 text-xs sm:inline-block"
+                                        >
+                                            {formatDate(liked.bg_datetime)}
+                                        </span>
                                     </a>
-                                    <div class="text-muted-foreground mt-0.5 flex gap-2 text-xs">
-                                        <span class="text-primary/70">{liked.bo_subject}</span>
-                                        <span>{formatDate(liked.bg_datetime)}</span>
-                                    </div>
                                 </li>
                             {/each}
                         </ul>

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -331,25 +331,25 @@
                         {#if result.likedPosts && result.likedPosts.items.length > 0}
                             <ul class="divide-border divide-y">
                                 {#each result.likedPosts.items as post (post.id)}
-                                    <li class="py-3 first:pt-0 last:pb-0">
+                                    <li>
                                         <a
                                             href="/{post.board_id || 'free'}/{post.id}"
-                                            class="hover:bg-accent -m-2 block w-full rounded-md p-2 no-underline transition-colors"
+                                            class="hover:bg-muted flex items-center gap-2.5 px-4 py-2 no-underline transition-all duration-200 ease-out"
                                         >
-                                            <h3
-                                                class="text-foreground mb-1 line-clamp-1 font-medium"
+                                            <span
+                                                class="bg-muted text-muted-foreground hidden shrink-0 rounded px-1.5 py-0.5 text-xs sm:inline-block"
                                             >
+                                                {post.board_name || post.board_id || 'free'}
+                                            </span>
+                                            <span class="min-w-0 flex-1 truncate leading-relaxed">
                                                 {post.title}
-                                            </h3>
-                                            <div
-                                                class="text-muted-foreground flex items-center gap-2 text-xs"
+                                            </span>
+                                            <span
+                                                class="text-muted-foreground hidden shrink-0 items-center gap-3 text-xs sm:flex"
                                             >
                                                 <span>{post.author}</span>
-                                                <span>·</span>
                                                 <span>{formatDate(post.created_at)}</span>
-                                                <span>·</span>
-                                                <span>공감 {post.likes}</span>
-                                            </div>
+                                            </span>
                                         </a>
                                     </li>
                                 {/each}


### PR DESCRIPTION
## Summary
- 공감글(마이페이지/회원프로필) 폰트/레이아웃을 톺아보기 스타일로 통일
- 위젯/탐색 링크에서 rel="external" 제거 → SvelteKit 클라이언트 라우팅으로 전환 (뒤로가기 두 번 이슈 해결)
- mb_image_updated_at 캐시 버스팅: SSR 파이프라인 + getAvatarUrl()에 ?v=timestamp 지원

## Test plan
- [ ] 마이페이지 > 공감한 글 탭에서 폰트/레이아웃이 톺아보기와 동일한지 확인
- [ ] 회원 프로필 > 공감 내역 탭에서 동일 확인
- [ ] 톺아보기/메인에서 게시글 클릭 후 뒤로가기 한 번으로 이전 페이지 복귀 확인
- [ ] 프로필 이미지 변경 시 캐시 없이 즉시 반영되는지 확인