### PR TITLE
fix: 축하메시지 이미지 캐시버스팅 + Cache-Control

### DIFF
--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -66,7 +66,7 @@ export const GET: RequestHandler = async () => {
                 `SELECT cb.id, cb.title, cb.content, cb.image_url, cb.link_url,
                         cb.external_url, cb.display_date, cb.target_member_id,
                         cb.link_target, cb.sort_order, cb.display_type,
-                        cb.source_wr_id,
+                        cb.source_wr_id, cb.updated_at AS cb_updated_at,
                         m.mb_nick AS target_member_nick,
                         m.mb_image_url AS target_member_image_url
                  FROM celebration_banners cb
@@ -89,7 +89,9 @@ export const GET: RequestHandler = async () => {
                     id: row.source_wr_id || row.id,
                     title: row.title,
                     content: row.content || '',
-                    image_url: row.image_url || '',
+                    image_url: row.image_url
+                        ? `${row.image_url}${row.image_url.includes('?') ? '&' : '?'}t=${new Date(row.cb_updated_at || 0).getTime()}`
+                        : '',
                     link_url: linkUrl,
                     display_date: row.display_date,
                     is_active: true,
@@ -140,10 +142,10 @@ export const GET: RequestHandler = async () => {
             }
         }
 
-        return json({
-            success: true,
-            data: banners
-        });
+        return json(
+            { success: true, data: banners },
+            { headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' } }
+        );
     } catch (error) {
         console.error('Banner API error:', error);
         return json(


### PR DESCRIPTION
## Summary
축하메시지 이미지 업데이트 후 이전 이미지가 계속 표시되는 문제 수정

- image_url에 `?t=updated_at_timestamp` 추가 → CDN/브라우저 캐시 우회
- API 응답에 `Cache-Control: max-age=60` 헤더 추가

## Test plan
- [ ] 축하메시지 이미지 변경 후 새 이미지 즉시 표시
- [ ] API 응답의 image_url에 `?t=` 파라미터 포함