### PR TITLE
fix: 축하메시지 이미지 원본 게시글 동기화

### DIFF
--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -68,10 +68,13 @@ export const GET: RequestHandler = async () => {
                         cb.link_target, cb.sort_order, cb.display_type,
                         cb.source_wr_id, cb.updated_at AS cb_updated_at,
                         m.mb_nick AS target_member_nick,
-                        m.mb_image_url AS target_member_image_url
+                        m.mb_image_url AS target_member_image_url,
+                        wm.wr_content AS source_content
                  FROM celebration_banners cb
                  LEFT JOIN g5_member m
                    ON cb.target_member_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
+                 LEFT JOIN g5_write_message wm
+                   ON cb.source_wr_id = wm.wr_id AND wm.wr_is_comment = 0
                  WHERE cb.is_active = 1
                    AND (cb.display_date = CURDATE()
                         OR (cb.yearly_repeat = 1
@@ -85,13 +88,23 @@ export const GET: RequestHandler = async () => {
                     row.external_url ||
                     (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
 
+                // source_wr_id가 있으면 원본 게시글에서 최신 이미지 추출 (동기화)
+                let imageUrl = row.image_url || '';
+                if (row.source_content) {
+                    const freshImage = extractFirstImage(row.source_content);
+                    if (freshImage) imageUrl = freshImage;
+                }
+                // 캐시버스팅: updated_at 타임스탬프 추가
+                if (imageUrl) {
+                    const ts = new Date(row.cb_updated_at || 0).getTime();
+                    imageUrl += `${imageUrl.includes('?') ? '&' : '?'}t=${ts}`;
+                }
+
                 banners.push({
                     id: row.source_wr_id || row.id,
                     title: row.title,
                     content: row.content || '',
-                    image_url: row.image_url
-                        ? `${row.image_url}${row.image_url.includes('?') ? '&' : '?'}t=${new Date(row.cb_updated_at || 0).getTime()}`
-                        : '',
+                    image_url: imageUrl,
                     link_url: linkUrl,
                     display_date: row.display_date,
                     is_active: true,


### PR DESCRIPTION
## Summary
축하메시지 이미지를 수정해도 `celebration_banners` 테이블의 `image_url`이 갱신 안 되는 문제.

- `source_wr_id`가 있으면 `g5_write_message` 원본에서 최신 이미지 추출
- 캐시버스팅 타임스탬프 포함 (PR #1169)

## Test plan
- [ ] 축하메시지 이미지 수정 → 홈 배너에 최신 이미지 표시
- [ ] message 페이지와 홈 배너 이미지 동일