### PR TITLE
feat: 사이드바에 애드핏 광고 추가 (심사용)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -16,6 +16,7 @@
     import UserWidget from './user-widget.svelte';
     import { getComponentsForSlot } from '$lib/components/slot-manager';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
+    import AdfitSlot from '$lib/components/ui/adfit-slot/adfit-slot.svelte';
     import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
     import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
@@ -363,6 +364,13 @@
         <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
             {#if compact}{:else}
                 <AdSlot position="sidebar" height="250px" slotKey="sidebar-main" />
+                <!-- 애드핏 심사용 (GAM 아래 배치) -->
+                <div class="mt-2">
+                    <AdfitSlot
+                        unit={{ unitId: 'DAN-eAXFNdHYsuiUQoFs', width: 300, height: 250 }}
+                        id="sidebar-adfit-review"
+                    />
+                </div>
             {/if}
         </div>
         {#if compact}


### PR DESCRIPTION
## Summary
- 카카오 애드핏 매체 심사 통과를 위해 좌측 사이드바 GAM 광고 아래에 애드핏 300x250 배너 임시 배치
- 데스크톱 전용 (모바일 드로워에서는 미표시)
- 심사 통과 후 제거 또는 폴백 전용으로 전환 예정

## Test plan
- [ ] dev.damoang.net 좌측 사이드바에서 애드핏 광고 노출 확인
- [ ] 모바일 드로워에서는 미노출 확인