### PR TITLE
fix: 모든 게시판 목록 레이아웃에 formatDateCompact 적용

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
@@ -4,7 +4,7 @@
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { formatCommentCountBadge } from '$lib/utils/comment-count.js';
-    import { formatDate, isToday } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, isToday } from '$lib/utils/format-date.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     import { formatCompactNumber } from '$lib/utils/format-number.js';
     import { readPostStyleStore } from '$lib/stores/read-post-style.svelte.js';
@@ -153,7 +153,7 @@
                         ? 'date-today'
                         : ''}"
                 >
-                    {formatDate(post.created_at)}
+                    {formatDateCompact(post.created_at)}
                 </span>
 
                 <!-- 조회수 (col 5, 데스크톱) -->
@@ -182,7 +182,7 @@
                         />
                     </span>
                     <span class="mobile-meta-sep {isToday(post.created_at) ? 'date-today' : ''}">
-                        {formatDate(post.created_at)}
+                        {formatDateCompact(post.created_at)}
                     </span>
                     <span class="mobile-meta-sep">{formatCompactNumber(post.views)}</span>
                     {#if isReportLock && sourceBoard}

--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -7,7 +7,7 @@
     import type { Component } from 'svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { highlightQuery } from '$lib/utils/highlight.js';

--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -7,7 +7,7 @@
     import type { Component } from 'svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
@@ -126,7 +126,7 @@
                                         <MemoBadge memberId={post.author_id} />
                                     {/if}
                                     <span>•</span>
-                                    <span>{formatDate(post.created_at)}</span>
+                                    <span>{formatDateCompact(post.created_at)}</span>
                                     <span>•</span>
                                     <span>조회 {post.views.toLocaleString()}</span>
                                 </div>

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -8,7 +8,7 @@
     import Heart from '@lucide/svelte/icons/heart';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate, isToday } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, isToday } from '$lib/utils/format-date.js';
     import { formatCompactNumber } from '$lib/utils/format-number.js';
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { readPostStyleStore } from '$lib/stores/read-post-style.svelte.js';
@@ -284,7 +284,7 @@
                         ? 'hidden'
                         : `post-meta-text hidden md:inline md:w-[70px] md:pl-1 md:text-center ${isToday(post.created_at) ? 'date-today' : ''}`}
                 >
-                    {formatDate(post.created_at)}
+                    {formatDateCompact(post.created_at)}
                 </span>
 
                 <!-- 조회수 (col 5, 데스크톱만) -->
@@ -308,7 +308,7 @@
                         >
                     {/if}
                     <span class="mobile-meta-sep {isToday(post.created_at) ? 'date-today' : ''}">
-                        {formatDate(post.created_at)}
+                        {formatDateCompact(post.created_at)}
                     </span>
                     <span class="mobile-meta-sep">{formatCompactNumber(post.views)}</span>
                     <span class="mobile-meta-sep inline-flex items-center gap-0.5">

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -4,7 +4,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
     import ImageIcon from '@lucide/svelte/icons/image';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     // Props

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -4,7 +4,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
     import ImageIcon from '@lucide/svelte/icons/image';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     // Props
@@ -111,7 +111,7 @@
                         /></span
                     >
                     <span>•</span>
-                    <span>{formatDate(post.created_at)}</span>
+                    <span>{formatDateCompact(post.created_at)}</span>
                     <span>•</span>
                     <span>조회 {post.views.toLocaleString()}</span>
                 </div>

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -4,7 +4,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     // Props
@@ -86,7 +86,7 @@
                                 /></span
                             >
                             <span>•</span>
-                            <span>{formatDate(post.created_at)}</span>
+                            <span>{formatDateCompact(post.created_at)}</span>
                             <span>•</span>
                             <span>조회 {post.views.toLocaleString()}</span>
                         </div>

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -4,7 +4,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     // Props

--- a/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
@@ -3,7 +3,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     // Props (동일 인터페이스)
     let {

--- a/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
@@ -3,7 +3,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     // Props (동일 인터페이스)
     let {
@@ -110,7 +110,7 @@
                     /></span
                 >
                 <span>·</span>
-                <span>{formatDate(post.created_at)}</span>
+                <span>{formatDateCompact(post.created_at)}</span>
             </div>
         </div>
     </a>

--- a/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
@@ -11,7 +11,7 @@
     import ImageIcon from '@lucide/svelte/icons/image';
     import MapPin from '@lucide/svelte/icons/map-pin';
     import Truck from '@lucide/svelte/icons/truck';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     let {
         post,
         displaySettings,
@@ -149,7 +149,7 @@
                     </span>
                     <span>·</span>
                 {/if}
-                <span>{formatDate(post.created_at)}</span>
+                <span>{formatDateCompact(post.created_at)}</span>
             </div>
 
             <!-- 작성자 + 댓글/좋아요 -->

--- a/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
@@ -11,7 +11,7 @@
     import ImageIcon from '@lucide/svelte/icons/image';
     import MapPin from '@lucide/svelte/icons/map-pin';
     import Truck from '@lucide/svelte/icons/truck';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     let {
         post,
         displaySettings,

--- a/apps/web/src/lib/components/features/board/layouts/list/message.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/message.svelte
@@ -12,7 +12,7 @@
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     let {
         post,
         displaySettings,

--- a/apps/web/src/lib/components/features/board/layouts/list/message.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/message.svelte
@@ -12,7 +12,7 @@
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     let {
         post,
         displaySettings,
@@ -137,7 +137,7 @@
             </span>
             {#if post.created_at}
                 <span class="text-muted-foreground/60 ml-auto shrink-0 text-xs">
-                    {formatDate(post.created_at)}
+                    {formatDateCompact(post.created_at)}
                 </span>
             {/if}
         </div>

--- a/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
@@ -5,7 +5,7 @@
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import Pin from '@lucide/svelte/icons/pin';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     let {
         post,
@@ -70,7 +70,7 @@
                         authorName={post.author}
                         isWithdrawn={!!post.is_left}
                     />
-                    <span>{formatDate(post.created_at)}</span>
+                    <span>{formatDateCompact(post.created_at)}</span>
                     <span class="flex items-center gap-1">
                         <Eye class="h-3.5 w-3.5" />
                         {post.views.toLocaleString()}

--- a/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
@@ -5,7 +5,7 @@
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import Pin from '@lucide/svelte/icons/pin';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     let {
         post,

--- a/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
@@ -3,7 +3,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     let {
         post,

--- a/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
@@ -3,7 +3,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     let {
         post,
@@ -84,7 +84,7 @@
                         />
                     </span>
                     <span>·</span>
-                    <span>{formatDate(post.created_at)}</span>
+                    <span>{formatDateCompact(post.created_at)}</span>
                 </div>
             </div>
 

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -4,7 +4,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import Lock from '@lucide/svelte/icons/lock';
-    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     // Props (동일 인터페이스)
     let {

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -4,7 +4,7 @@
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import Lock from '@lucide/svelte/icons/lock';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDate, formatDateCompact, formatDateCompact } from '$lib/utils/format-date.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
     // Props (동일 인터페이스)
     let {
@@ -125,7 +125,7 @@
                             isWithdrawn={!!post.is_left}
                         /></span
                     >
-                    <span>{formatDate(post.created_at)}</span>
+                    <span>{formatDateCompact(post.created_at)}</span>
                     <span>조회 {post.views.toLocaleString()}</span>
 
                     {#if post.tags && post.tags.length > 0}

--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -16,6 +16,7 @@
     import UserWidget from './user-widget.svelte';
     import { getComponentsForSlot } from '$lib/components/slot-manager';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
+    import AdfitSlot from '$lib/components/ui/adfit-slot/adfit-slot.svelte';
     import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
     import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
@@ -363,6 +364,13 @@
         <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
             {#if compact}{:else}
                 <AdSlot position="sidebar" height="250px" slotKey="sidebar-main" />
+                <!-- 애드핏 심사용 (GAM 아래 배치) -->
+                <div class="mt-2">
+                    <AdfitSlot
+                        unit={{ unitId: 'DAN-eAXFNdHYsuiUQoFs', width: 300, height: 250 }}
+                        id="sidebar-adfit-review"
+                    />
+                </div>
             {/if}
         </div>
         {#if compact}


### PR DESCRIPTION
## Summary
PR #1158에서 skins/ 3개만 수정했으나, 실제 운영에서 사용하는 layouts/list/ 12개 파일이 누락됨.

11개 레이아웃에 formatDateCompact (MM.DD HH:MM) 적용:
archive, card, classic, compact, detailed, gallery, market-card, message, notice, poster-gallery, webzine

trade.svelte 제외 (상대 시간 "3분 전" 방식 유지)

## Test plan
- [ ] 자유게시판 목록 → MM.DD HH:MM 형식
- [ ] 검색 결과 → 동일 형식
- [ ] 소모임/갤러리 등 다른 레이아웃도 동일 형식