### PR TITLE
fix: 목록 날짜 한국 표준 (오늘=HH:MM, 이전=MM.DD)

### DIFF
--- a/apps/web/src/lib/utils/format-date.ts
+++ b/apps/web/src/lib/utils/format-date.ts
@@ -22,19 +22,20 @@ export function formatDateCompact(dateString: string): string {
     const dateStr = toSeoulDateStr(date);
     const nowStr = toSeoulDateStr(now);
 
-    const time = date.toLocaleTimeString('ko-KR', {
-        timeZone: 'Asia/Seoul',
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false
-    });
-
-    if (dateStr.slice(0, 4) === nowStr.slice(0, 4)) {
-        // 올해: MM.DD HH:MM
-        return `${dateStr.slice(5, 7)}.${dateStr.slice(8, 10)} ${time}`;
+    if (dateStr === nowStr) {
+        // 오늘: HH:MM
+        return date.toLocaleTimeString('ko-KR', {
+            timeZone: 'Asia/Seoul',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false
+        });
+    } else if (dateStr.slice(0, 4) === nowStr.slice(0, 4)) {
+        // 올해: MM.DD
+        return `${dateStr.slice(5, 7)}.${dateStr.slice(8, 10)}`;
     } else {
-        // 작년 이전: YY.MM.DD HH:MM
-        return `${dateStr.slice(2, 4)}.${dateStr.slice(5, 7)}.${dateStr.slice(8, 10)} ${time}`;
+        // 작년 이전: YY.MM.DD
+        return `${dateStr.slice(2, 4)}.${dateStr.slice(5, 7)}.${dateStr.slice(8, 10)}`;
     }
 }
 /**


### PR DESCRIPTION
## Summary
formatDateCompact가 MM.DD HH:MM (2줄)으로 남아있던 문제.
한국 커뮤니티 표준으로 수정: 오늘=HH:MM, 이전=MM.DD, 항상 1줄.

## Test plan
- [ ] 오늘 글: 14:30
- [ ] 어제 글: 04.09
- [ ] 작년 글: 25.12.03