### PR TITLE
fix: 팔로워/팔로잉 목록 collation 에러 수정

### DIFF
--- a/apps/web/src/routes/api/members/[id]/followers/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/followers/+server.ts
@@ -37,7 +37,7 @@ export const GET: RequestHandler = async ({ params }) => {
         const [rows] = await readPool.query<FollowerRow[]>(
             `SELECT f.mb_id, m.mb_nick, m.mb_image_url, m.mb_image_updated_at, m.mb_level, f.created_at as followed_at
 			 FROM g5_member_follow f
-			 JOIN g5_member m ON f.mb_id = m.mb_id
+			 JOIN g5_member m ON f.mb_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
 			 WHERE f.target_id = ?
 			 ORDER BY f.created_at DESC
 			 LIMIT 50`,

--- a/apps/web/src/routes/api/members/[id]/following/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/following/+server.ts
@@ -37,7 +37,7 @@ export const GET: RequestHandler = async ({ params }) => {
         const [rows] = await readPool.query<FollowingRow[]>(
             `SELECT f.target_id as mb_id, m.mb_nick, m.mb_image_url, m.mb_image_updated_at, m.mb_level, f.created_at as followed_at
 			 FROM g5_member_follow f
-			 JOIN g5_member m ON f.target_id = m.mb_id
+			 JOIN g5_member m ON f.target_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
 			 WHERE f.mb_id = ?
 			 ORDER BY f.created_at DESC
 			 LIMIT 50`,


### PR DESCRIPTION
## Summary
g5_member_follow (utf8mb4_0900_ai_ci)와 g5_member (utf8mb4_unicode_ci)의 collation 불일치로 JOIN 실패.
COLLATE 명시 추가.

Fixes #11765

## Test plan
- [ ] 프로필 → 팔로워 클릭 → 목록 표시
- [ ] 프로필 → 팔로잉 클릭 → 목록 표시