### PR TITLE
fix: 모바일 게시판 헤더 overflow 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -604,8 +604,8 @@
             {/if}
 
             <!-- 헤더 -->
-            <div class="mb-4 flex items-center justify-between">
-                <div class="flex shrink-0 items-center gap-2">
+            <div class="mb-4 flex min-w-0 flex-wrap items-center justify-between gap-2">
+                <div class="flex min-w-0 shrink items-center gap-2">
                     <h1 class="text-2xl font-bold sm:text-3xl">
                         <a
                             href="/{boardId}"


### PR DESCRIPTION
## Summary
로그인 시 글쓰기/검색/설정 버튼이 뷰포트를 초과하여 가로 스크롤 발생.
헤더 flex 컨테이너에 flex-wrap + min-w-0 추가.

Fixes #11773

## Test plan
- [ ] 모바일에서 로그인 상태로 게시판 목록 → 가로 스크롤 없음
- [ ] 데스크톱 레이아웃 변화 없음