### PR TITLE
feat: AdFit 심사용 모바일+PC 광고 슬롯 추가

### DIFF
--- a/apps/web/src/lib/components/ui/adfit-slot/adfit-responsive-slot.svelte
+++ b/apps/web/src/lib/components/ui/adfit-slot/adfit-responsive-slot.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import AdfitSlot from './adfit-slot.svelte';
+
+    interface AdfitUnit {
+        unitId: string;
+        width: number;
+        height: number;
+    }
+
+    interface Props {
+        desktop: AdfitUnit;
+        mobile: AdfitUnit;
+        id: string;
+        breakpoint?: number;
+    }
+
+    let { desktop, mobile, id, breakpoint = 728 }: Props = $props();
+    let unit = $state<AdfitUnit | null>(null);
+
+    onMount(() => {
+        unit = window.innerWidth >= breakpoint ? desktop : mobile;
+    });
+</script>
+
+{#if unit}
+    <AdfitSlot {unit} {id} />
+{/if}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -40,6 +40,7 @@
     import BulkActionsToolbar from '$lib/components/features/board/bulk-actions-toolbar.svelte';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
+    import AdfitResponsiveSlot from '$lib/components/ui/adfit-slot/adfit-responsive-slot.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import { doAction } from '$lib/hooks/registry';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
@@ -1122,6 +1123,14 @@
                             position="board-list-bottom"
                             height="90px"
                             slotKey="board-list-bottom"
+                        />
+                    </div>
+                    <!-- AdFit 전용 슬롯 (모바일+PC) -->
+                    <div class="mt-2">
+                        <AdfitResponsiveSlot
+                            desktop={{ unitId: 'DAN-9qdD2GVgW3AXbClR', width: 728, height: 90 }}
+                            mobile={{ unitId: 'DAN-ry6MhSvNcdUCMwtP', width: 320, height: 100 }}
+                            id="board-list-bottom-adfit"
                         />
                     </div>
                 {/if}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -54,6 +54,7 @@
     import { isEmbeddable } from '$lib/plugins/auto-embed';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import AdsenseMultiplex from '$lib/components/ui/adsense-multiplex/adsense-multiplex.svelte';
+    import AdfitResponsiveSlot from '$lib/components/ui/adfit-slot/adfit-responsive-slot.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
@@ -1824,6 +1825,14 @@
             </div>
             <div class="mt-2 hidden md:block">
                 <AdsenseMultiplex />
+            </div>
+            <!-- AdFit 전용 슬롯 (모바일+PC) -->
+            <div class="mt-2">
+                <AdfitResponsiveSlot
+                    desktop={{ unitId: 'DAN-9qdD2GVgW3AXbClR', width: 728, height: 90 }}
+                    mobile={{ unitId: 'DAN-ry6MhSvNcdUCMwtP', width: 320, height: 100 }}
+                    id="post-after-comments-adfit"
+                />
             </div>
         {/if}
 


### PR DESCRIPTION
## Summary
AdFit 심사 보류 대응 — 모바일+PC 모두에서 보이는 AdFit 전용 슬롯 추가

- 게시글 상세: 댓글 하단에 AdFit (PC 728x90, 모바일 320x100)
- 게시판 목록: 하단에 AdFit (PC 728x90, 모바일 320x100)
- 신규 AdfitResponsiveSlot 컴포넌트 (반응형 unit 선택)
- 기존 사이드바 AdFit + GAM 광고와 독립

## Test plan
- [ ] 모바일: 게시글 댓글 아래 AdFit 표시
- [ ] 모바일: 게시판 목록 하단 AdFit 표시
- [ ] PC: 동일 위치에 728x90 표시
- [ ] 기존 GAM 광고 정상