### PR TITLE
fix(board): market-card 썸네일 적용 + gallery priority

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
@@ -10,12 +10,14 @@
         post,
         displaySettings,
         href,
-        isRead = false
+        isRead = false,
+        isPriority = false
     }: {
         post: FreePost;
         displaySettings?: BoardDisplaySettings;
         href: string;
         isRead?: boolean;
+        isPriority?: boolean;
     } = $props();
 
     // 삭제된 글
@@ -50,7 +52,8 @@
                     src={thumbnailUrl}
                     alt=""
                     class="h-full w-full object-cover transition-transform group-hover:scale-105"
-                    loading="lazy"
+                    loading={isPriority ? 'eager' : 'lazy'}
+                    fetchpriority={isPriority ? 'high' : 'auto'}
                     decoding="async"
                     width="400"
                     height="225"

--- a/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
@@ -12,6 +12,7 @@
     import MapPin from '@lucide/svelte/icons/map-pin';
     import Truck from '@lucide/svelte/icons/truck';
     import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
+    import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     let {
         post,
         displaySettings,
@@ -28,7 +29,9 @@
     const isDeleted = $derived(!!post.deleted_at);
 
     const market = $derived(parseMarketInfo(post));
-    const thumbnailUrl = $derived(post.thumbnail || post.images?.[0] || '');
+    // market card는 aspect-square, 화면에서 200~400px 크기로 표시 → 400x225 썸네일 충분
+    const rawImageUrl = $derived(post.thumbnail || post.images?.[0] || '');
+    const thumbnailUrl = $derived(toThumbnailUrl(rawImageUrl, '400x225'));
     const hasImage = $derived(Boolean(thumbnailUrl));
     const isSold = $derived(market.status === 'sold');
 
@@ -85,9 +88,15 @@
                     alt=""
                     class="h-full w-full object-cover transition-transform group-hover:scale-105"
                     loading="lazy"
+                    decoding="async"
                     onerror={(e) => {
+                        // 썸네일 없으면 원본으로 폴백, 원본도 실패하면 숨김
                         const target = e.target as HTMLImageElement;
-                        target.style.display = 'none';
+                        if (rawImageUrl && target.src !== rawImageUrl) {
+                            target.src = rawImageUrl;
+                        } else {
+                            target.style.display = 'none';
+                        }
                     }}
                 />
             {:else}

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -252,6 +252,7 @@
                     {displaySettings}
                     href="/{boardId}/{post.id}{currentPage > 1 ? `?page=${currentPage}` : ''}"
                     isRead={showReadState && readPostsStore.isRead(boardId, post.id)}
+                    isPriority={i === 0}
                 />
             </div>
             {#if widgetLayoutStore.hasEnabledAds && i + 1 === 12}


### PR DESCRIPTION
## Summary
- market-card.svelte가 원본 JPG (5~10MB) 로드 중이던 버그 수정 → `toThumbnailUrl()` 래핑으로 400x225.webp (~60KB) 서빙 (~95% 용량 감소)
- gallery.svelte에 `isPriority` prop 추가, recent-posts.svelte에서 첫 카드에 priority 전달 → LCP 개선
- 썸네일 없는 레거시 파일 대비 onerror 폴백 체인 유지

## 검증
- [x] `pnpm check` 통과 (0 errors)
- [ ] 마켓 보드 DevTools로 이미지 URL이 `.webp`로 바뀌는지 확인 (배포 후)
- [ ] 갤러리 레이아웃 첫 카드에 `fetchpriority="high"` 렌더링 확인

## 배포 정책
- 운영 배포는 다음 새벽 4시 사용자 승인 후

## Test plan
- [ ] 마켓 보드 (`/used`, `/market`) 접속 → 카드 이미지 URL이 `-400x225.webp` 포함
- [ ] 갤러리 레이아웃 (`/humor`, `/free` 등 gallery 설정) → 첫 카드 `<img>`에 `fetchpriority="high" loading="eager"`
- [ ] 썸네일 없는 옛날 이미지 → onerror → 원본 JPG 폴백 표시
- [ ] 리액션/댓글 기능 정상 동작 (무관 영역)