### PR TITLE
fix(board): webzine/giving/trade 카드 썸네일 적용

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
@@ -25,6 +25,7 @@
     import Timer from '@lucide/svelte/icons/timer';
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import { resolveGivingMeta, type GivingStatus } from '$lib/features/giving/model.js';
+    import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     let {
         post,
         displaySettings,
@@ -40,9 +41,12 @@
     // 삭제된 글
     const isDeleted = $derived(!!post.deleted_at);
 
-    // 썸네일 표시
-    const thumbnailUrl = $derived(post.thumbnail || post.images?.[0] || '');
-    const hasImage = $derived(Boolean(thumbnailUrl));
+    // 썸네일 표시 (원본 대신 400x225.webp 로드 → 대역폭 절감)
+    const rawThumbnailUrl = $derived(
+        post.thumbnail_raw || post.thumbnail || post.images?.[0] || ''
+    );
+    const thumbnailUrl = $derived(toThumbnailUrl(rawThumbnailUrl, '400x225'));
+    const hasImage = $derived(Boolean(rawThumbnailUrl));
 
     const givingMeta = $derived(resolveGivingMeta(post));
     const givingStart = $derived(post.giving_start ?? givingMeta.givingStart);
@@ -176,6 +180,15 @@
                         ? ''
                         : 'group-hover:scale-105'}"
                     loading="lazy"
+                    decoding="async"
+                    onerror={(e) => {
+                        const target = e.target as HTMLImageElement;
+                        if (rawThumbnailUrl && target.src !== rawThumbnailUrl) {
+                            target.src = rawThumbnailUrl;
+                        } else {
+                            target.style.display = 'none';
+                        }
+                    }}
                 />
             {:else}
                 <div class="text-muted-foreground flex h-full w-full items-center justify-center">

--- a/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
@@ -27,6 +27,7 @@
     import CheckCircle from '@lucide/svelte/icons/check-circle';
     import Tag from '@lucide/svelte/icons/tag';
     import MessageSquare from '@lucide/svelte/icons/message-square';
+    import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     let {
         post,
         displaySettings,
@@ -42,9 +43,12 @@
     // 삭제된 글
     const isDeleted = $derived(!!post.deleted_at);
 
-    // 썸네일 표시
-    const thumbnailUrl = $derived(post.thumbnail || post.images?.[0] || '');
-    const hasImage = $derived(Boolean(thumbnailUrl));
+    // 썸네일 표시 (원본 대신 400x225.webp 로드 → 대역폭 절감)
+    const rawThumbnailUrl = $derived(
+        post.thumbnail_raw || post.thumbnail || post.images?.[0] || ''
+    );
+    const thumbnailUrl = $derived(toThumbnailUrl(rawThumbnailUrl, '400x225'));
+    const hasImage = $derived(Boolean(rawThumbnailUrl));
 
     // 중고 마켓 정보 파싱
     const market = $derived(parseMarketInfo(post));
@@ -116,6 +120,15 @@
                         ? 'grayscale'
                         : 'group-hover:scale-105'}"
                     loading="lazy"
+                    decoding="async"
+                    onerror={(e) => {
+                        const target = e.target as HTMLImageElement;
+                        if (rawThumbnailUrl && target.src !== rawThumbnailUrl) {
+                            target.src = rawThumbnailUrl;
+                        } else {
+                            target.style.display = 'none';
+                        }
+                    }}
                 />
             {:else}
                 <div class="text-muted-foreground flex h-full w-full items-center justify-center">

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -6,6 +6,7 @@
     import Lock from '@lucide/svelte/icons/lock';
     import { formatDate, formatDateCompact } from '$lib/utils/format-date.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
+    import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     // Props (동일 인터페이스)
     let {
         post,
@@ -24,8 +25,11 @@
     // 삭제된 글
     const isDeleted = $derived(!!post.deleted_at);
 
-    const thumbnailUrl = $derived(post.thumbnail || post.images?.[0] || '');
-    const hasImage = $derived(Boolean(thumbnailUrl));
+    const rawThumbnailUrl = $derived(
+        post.thumbnail_raw || post.thumbnail || post.images?.[0] || ''
+    );
+    const thumbnailUrl = $derived(toThumbnailUrl(rawThumbnailUrl, '835x626'));
+    const hasImage = $derived(Boolean(rawThumbnailUrl));
 
     // HTML 태그 제거하여 미리보기 텍스트 생성
     const previewText = $derived.by(() => {
@@ -61,9 +65,14 @@
                         alt=""
                         class="h-full w-full object-cover"
                         loading="lazy"
+                        decoding="async"
                         onerror={(e) => {
                             const target = e.target as HTMLImageElement;
-                            target.style.display = 'none';
+                            if (rawThumbnailUrl && target.src !== rawThumbnailUrl) {
+                                target.src = rawThumbnailUrl;
+                            } else {
+                                target.style.display = 'none';
+                            }
                         }}
                     />
                 </div>


### PR DESCRIPTION
## Summary
PR #1188과 동일 버그 3개 추가 발견 및 수정.

### 수정 내용
- **webzine.svelte**: 웹진 레이아웃, 큰 이미지 (835x626)
- **giving.svelte**: 나눔 보드, 카드 이미지 (400x225)
- **trade.svelte**: 거래 보드, 카드 이미지 (400x225)

각 파일에:
1. `toThumbnailUrl()` import 추가
2. `rawThumbnailUrl → thumbnailUrl` 래핑 패턴 적용
3. `onerror` 폴백 체인 추가 (썸네일 실패 → 원본 → 숨김)
4. `decoding="async"` 속성 추가

## 효과
웹진/나눔/거래 보드 카드 이미지 ~95% 대역폭 절감

## Test plan
- [ ] `/used`, `/market` 등 거래 보드 → 카드 img src `-400x225.webp` 확인
- [ ] 나눔 보드 (`/giving`) → 카드 img src `-400x225.webp` 확인
- [ ] 웹진 레이아웃 설정 보드 → 카드 img src `-835x626.webp` 확인
- [ ] 레거시 이미지 (사이드카 없음) → onerror → 원본 JPG 폴백
- [ ] 검색 결과, 목록 페이징 정상 동작

## 관련
- PR #1188 (market-card/gallery) 이후 후속 감사에서 발견