### PR TITLE
fix: 알림 뱃지 auth 타이밍 수정 (200ms)

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -264,8 +264,9 @@
 
     onMount(() => {
         // 페이지 로드 시 자동 prime (hover 없이도 알림 수 표시)
+        // auth 초기화(layout onMount)가 완료된 후 호출해야 하므로 200ms 대기
         if (!unreadPrimed && document.visibilityState === 'visible') {
-            primeUnreadCount();
+            setTimeout(() => primeUnreadCount(), 200);
         }
 
         let interval: ReturnType<typeof setInterval> | null = null;


### PR DESCRIPTION
## 근본 원인
PR #1154에서 setTimeout 제거 → notification onMount가 layout onMount(auth 초기화)보다 먼저 실행 → authStore.isAuthenticated=false → primeUnreadCount() 즉시 return

## 수정
setTimeout 200ms 복원 (원래 1000ms → 200ms로 줄임)

## Sprint Contract
- [ ] 페이지 로드 시 알림 뱃지 자동 표시 (클릭 없이)
- [ ] 200ms 내에 뱃지 표시
- [ ] 로그인/비로그인 전환 시 정상 동작