### PR TITLE
fix: 공감글 탭 복원 시 데이터도 동기화

### DIFF
--- a/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
+++ b/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
@@ -138,6 +138,9 @@
     onMount(() => {
         if (!canUseSSR) {
             loadData(activeTab, true);
+        } else if (savedTab && savedTab !== ssrData?.period) {
+            // SSR 데이터와 복원된 탭이 다르면 해당 탭 데이터 fetch
+            loadData(savedTab);
         }
     });
 </script>


### PR DESCRIPTION
탭 UI는 3h로 복원되지만 데이터는 SSR의 1h. savedTab !== ssrPeriod일 때 데이터 fetch 추가. Fixes #11821