### PR TITLE
feat(seo): OG 캐시버스팅 + RSS 이미지 + sitemap image

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1294,6 +1294,11 @@
         const authorUrl = data.post.author_id
             ? `${siteUrl}/member/${data.post.author_id}`
             : undefined;
+        // OG 이미지: 캐시버스팅으로 소셜 미디어 stale preview 방지
+        const rawOgImage = data.post.thumbnail || data.post.images?.[0];
+        const ogImageUrl = rawOgImage
+            ? `${rawOgImage}${rawOgImage.includes('?') ? '&' : '?'}v=${new Date(data.post.updated_at || data.post.created_at).getTime()}`
+            : undefined;
 
         return {
             meta: {
@@ -1307,16 +1312,13 @@
                 description: postDescription,
                 type: 'article',
                 url: postUrl,
-                image: data.post.thumbnail || data.post.images?.[0]
+                image: ogImageUrl
             },
             twitter: {
-                card:
-                    data.post.thumbnail || data.post.images?.[0]
-                        ? 'summary_large_image'
-                        : 'summary',
+                card: rawOgImage ? 'summary_large_image' : 'summary',
                 title: data.post.title,
                 description: postDescription,
-                image: data.post.thumbnail || data.post.images?.[0]
+                image: ogImageUrl
             },
             jsonLd: [
                 // DiscussionForumPosting - 커뮤니티 게시글에 최적화된 구조화 데이터
@@ -1330,7 +1332,7 @@
                     url: postUrl,
                     commentCount: comments.length,
                     upvoteCount: data.post.likes || 0,
-                    image: data.post.thumbnail || data.post.images?.[0]
+                    image: ogImageUrl
                 }),
                 // Article - 일반 검색 결과용 (폴백)
                 createArticleJsonLd({
@@ -1338,7 +1340,7 @@
                     author: data.post.deleted_at ? '' : data.post.author,
                     datePublished: data.post.created_at,
                     dateModified: data.post.updated_at || data.post.created_at,
-                    image: data.post.thumbnail || data.post.images?.[0],
+                    image: ogImageUrl,
                     description: postDescription
                 }),
                 // Breadcrumb

--- a/apps/web/src/routes/rss/+server.ts
+++ b/apps/web/src/routes/rss/+server.ts
@@ -26,6 +26,7 @@ export const GET: RequestHandler = async ({ url }) => {
             author: string;
             pubDate: string;
             boardSubject: string;
+            imageUrl: string;
         }> = [];
 
         for (const board of boards as Array<{ bo_table: string; bo_subject: string }>) {
@@ -52,7 +53,8 @@ export const GET: RequestHandler = async ({ url }) => {
                         description: escapeXml(stripHtmlTags(post.wr_content).slice(0, 200)),
                         author: escapeXml(post.wr_name),
                         pubDate: new Date(post.wr_datetime).toUTCString(),
-                        boardSubject: escapeXml(board.bo_subject)
+                        boardSubject: escapeXml(board.bo_subject),
+                        imageUrl: extractFirstImage(post.wr_content) || ''
                     });
                 }
             } catch {
@@ -73,8 +75,7 @@ export const GET: RequestHandler = async ({ url }) => {
       <author>${post.author}</author>
       <pubDate>${post.pubDate}</pubDate>
       <category>${post.boardSubject}</category>
-      <guid isPermaLink="true">${post.link}</guid>
-    </item>`
+      <guid isPermaLink="true">${post.link}</guid>${post.imageUrl ? `\n      <media:content url="${escapeXml(post.imageUrl)}" medium="image" />` : ''}`
             )
             .join('\n');
     } catch (err) {
@@ -82,7 +83,7 @@ export const GET: RequestHandler = async ({ url }) => {
     }
 
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
   <channel>
     <title>${siteTitle}</title>
     <link>${siteUrl}</link>
@@ -111,6 +112,18 @@ function stripHtmlTags(str: string): string {
         result = result.replace(/<[^>]+>/g, '');
     } while (result !== prev);
     return result;
+}
+
+const CDN_BASE = 'https://s3.damoang.net';
+
+/** 본문 HTML에서 첫 번째 이미지 URL 추출 */
+function extractFirstImage(content: string): string | null {
+    if (!content) return null;
+    const match = content.match(/<img[^>]+src=["']([^"']+)["']/i);
+    if (!match?.[1]) return null;
+    let url = match[1];
+    if (url.startsWith('/data/')) url = CDN_BASE + url;
+    return url;
 }
 
 function escapeXml(str: string): string {

--- a/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
+++ b/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
@@ -51,7 +51,8 @@ export const GET: RequestHandler = async ({ params, url }) => {
                 }
 
                 const [posts] = await pool.query<RowDataPacket[]>(
-                    `SELECT wr_id, wr_datetime, wr_last FROM g5_write_${boTable}
+                    `SELECT wr_id, wr_datetime, wr_last, LEFT(wr_content, 1000) AS content_head
+                     FROM g5_write_${boTable}
 					 WHERE wr_is_comment = 0
 					 ORDER BY wr_id DESC
 					 LIMIT ? OFFSET ?`,
@@ -62,16 +63,20 @@ export const GET: RequestHandler = async ({ params, url }) => {
                     wr_id: number;
                     wr_datetime: string;
                     wr_last: string;
+                    content_head: string;
                 }>) {
-                    // lastmod: 수정일(wr_last)이 있으면 수정일, 없으면 작성일
                     const lastmod = post.wr_last || post.wr_datetime;
                     const lastmodDate = new Date(lastmod).toISOString().split('T')[0];
+                    const imageUrl = extractFirstImage(post.content_head);
+                    const imageTag = imageUrl
+                        ? `\n    <image:image>\n      <image:loc>${escapeXml(imageUrl)}</image:loc>\n    </image:image>`
+                        : '';
 
                     postUrls.push(`  <url>
     <loc>${siteUrl}/${boTable}/${post.wr_id}</loc>
     <lastmod>${lastmodDate}</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <priority>0.5</priority>${imageTag}
   </url>`);
                     totalCollected++;
                 }
@@ -87,7 +92,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
     }
 
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
 ${postUrls.join('\n')}
 </urlset>`;
 
@@ -98,3 +103,23 @@ ${postUrls.join('\n')}
         }
     });
 };
+
+const CDN_BASE = 'https://s3.damoang.net';
+
+function extractFirstImage(content: string | null): string | null {
+    if (!content) return null;
+    const match = content.match(/<img[^>]+src=["']([^"']+)["']/i);
+    if (!match?.[1]) return null;
+    let url = match[1];
+    if (url.startsWith('/data/')) url = CDN_BASE + url;
+    return url;
+}
+
+function escapeXml(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}


### PR DESCRIPTION
## Summary
이미지 최적화 프로젝트 최종 마무리 — SEO/소셜 공유 개선 3건.

### 변경 내용
1. **OG 이미지 캐시버스팅** — `og:image`, `twitter:image`, jsonLd에 `?v=updated_at` 추가. 소셜 공유 시 stale preview 방지.
2. **RSS `<media:content>` 이미지** — 피드 아이템에 첫 번째 이미지 포함. RSS 리더에서 미리보기 가능.
3. **Sitemap `<image:image>`** — Google Images 인덱싱 향상. `LEFT(wr_content, 1000)`으로 경량 추출.

### 수정 파일
- `routes/[boardId]/[postId]/+page.svelte` — OG/Twitter/jsonLd 이미지 URL
- `routes/rss/+server.ts` — RSS 피드 media:content
- `routes/sitemap-posts-[page].xml/+server.ts` — 사이트맵 image 태그

## Test plan
- [ ] 게시글 페이지 → `<meta property="og:image">` 에 `?v=` 파라미터 확인
- [ ] `/rss` → XML 응답에 `<media:content url="..." medium="image" />` 존재
- [ ] `/sitemap-posts-1.xml` → `<image:image><image:loc>` 존재
- [ ] Facebook Debugger로 OG preview 갱신 테스트
- [ ] `pnpm check` 통과 (0 errors)