### PR TITLE
fix: 알림 뱃지 polling 간격 30분 → 60초 (#11795)

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -273,7 +273,7 @@
 
         function startPolling() {
             if (interval || !unreadPrimed) return;
-            interval = setInterval(loadUnreadCount, 1800000);
+            interval = setInterval(loadUnreadCount, 60_000);
         }
 
         function stopPolling() {


### PR DESCRIPTION
## Summary
- 알림 뱃지 polling 간격을 30분(1,800,000ms) → 60초(60,000ms)로 단축
- 새 알림 수신 시 최대 1분 이내 뱃지에 반영
- unread count API는 `idx_mb_readed` 인덱스를 사용하는 경량 쿼리로 서버 부하 미미

## Test plan
- [ ] 알림 뱃지가 60초 이내에 자동 갱신되는지 확인
- [ ] 다른 사용자가 댓글/쪽지 발송 → 1분 이내 뱃지에 반영
- [ ] 네트워크 탭에서 60초마다 unread-count API 호출 확인