### PR TITLE
feat: /my/following 팔로잉 목록 페이지 추가

### DIFF
--- a/apps/web/src/lib/components/features/my/my-nav.svelte
+++ b/apps/web/src/lib/components/features/my/my-nav.svelte
@@ -7,6 +7,7 @@
     import Ban from '@lucide/svelte/icons/ban';
     import Bookmark from '@lucide/svelte/icons/bookmark';
     import NotepadText from '@lucide/svelte/icons/notepad-text';
+    import Users from '@lucide/svelte/icons/users';
     import Palette from '@lucide/svelte/icons/palette';
     import Settings from '@lucide/svelte/icons/settings';
     import type { Component } from 'svelte';
@@ -42,13 +43,19 @@
             label: '활동내역',
             icon: Bookmark,
             match: (pathname) =>
-                ['/my/points', '/my/exp', '/my/blocked', '/my/scraps', '/my/memos'].some((href) =>
-                    pathname.startsWith(href)
-                ),
+                [
+                    '/my/points',
+                    '/my/exp',
+                    '/my/blocked',
+                    '/my/scraps',
+                    '/my/memos',
+                    '/my/following'
+                ].some((href) => pathname.startsWith(href)),
             children: [
                 { href: '/my/points', label: '포인트', icon: Coins, exact: false },
                 { href: '/my/exp', label: '경험치', icon: Star, exact: false },
                 { href: '/my/scraps', label: '스크랩', icon: Bookmark, exact: false },
+                { href: '/my/following', label: '팔로잉', icon: Users, exact: false },
                 { href: '/my/blocked', label: '차단목록', icon: Ban, exact: false },
                 { href: '/my/memos', label: '회원메모', icon: NotepadText, exact: false }
             ]

--- a/apps/web/src/routes/my/following/+page.server.ts
+++ b/apps/web/src/routes/my/following/+page.server.ts
@@ -23,7 +23,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 			   ON f.target_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
 			 WHERE f.mb_id COLLATE utf8mb4_unicode_ci = CAST(? AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_unicode_ci
 			 ORDER BY f.created_at DESC`,
-            [user.mb_id]
+            [user.id]
         );
 
         return {

--- a/apps/web/src/routes/my/following/+page.server.ts
+++ b/apps/web/src/routes/my/following/+page.server.ts
@@ -1,0 +1,45 @@
+import type { PageServerLoad } from './$types';
+import type { RowDataPacket } from 'mysql2';
+import { readPool } from '$lib/server/db.js';
+
+interface FollowingRow extends RowDataPacket {
+    mb_id: string;
+    mb_nick: string;
+    mb_level: number;
+    mb_image: string;
+    followed_at: string;
+}
+
+export const load: PageServerLoad = async ({ parent }) => {
+    const { user } = await parent();
+
+    try {
+        const [rows] = await readPool.query<FollowingRow[]>(
+            `SELECT f.target_id AS mb_id, m.mb_nick, m.mb_level,
+					COALESCE(m.mb_image, '') AS mb_image,
+					f.created_at AS followed_at
+			 FROM g5_member_follow f
+			 JOIN g5_member m
+			   ON f.target_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
+			 WHERE f.mb_id COLLATE utf8mb4_unicode_ci = CAST(? AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_unicode_ci
+			 ORDER BY f.created_at DESC`,
+            [user.mb_id]
+        );
+
+        return {
+            following: rows.map((r) => ({
+                mb_id: r.mb_id,
+                mb_nick: r.mb_nick,
+                mb_level: r.mb_level,
+                mb_image: r.mb_image,
+                followed_at: r.followed_at
+            }))
+        };
+    } catch (error) {
+        console.error('[My Following] load error:', error);
+        return {
+            following: [],
+            error: '팔로잉 목록을 불러오지 못했습니다.'
+        };
+    }
+};

--- a/apps/web/src/routes/my/following/+page.svelte
+++ b/apps/web/src/routes/my/following/+page.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+    import { goto } from '$app/navigation';
+    import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import type { PageData } from './$types.js';
+    import Users from '@lucide/svelte/icons/users';
+    import User from '@lucide/svelte/icons/user';
+    import UserMinus from '@lucide/svelte/icons/user-minus';
+
+    let { data }: { data: PageData } = $props();
+
+    let followingList = $state<typeof data.following>([]);
+    let unfollowingId = $state<string | null>(null);
+
+    $effect(() => {
+        followingList = data.following || [];
+    });
+
+    function formatDate(dateString: string): string {
+        const date = new Date(dateString);
+        return date.toLocaleDateString('ko-KR', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
+        });
+    }
+
+    async function handleUnfollow(memberId: string, memberNick: string): Promise<void> {
+        if (!confirm(`${memberNick}님의 팔로우를 해제하시겠습니까?`)) return;
+
+        unfollowingId = memberId;
+        try {
+            await fetch(`/api/members/${memberId}/follow`, { method: 'DELETE' });
+            followingList = followingList.filter((m) => m.mb_id !== memberId);
+        } catch (err) {
+            console.error('팔로우 해제 실패:', err);
+            alert('팔로우 해제에 실패했습니다.');
+        } finally {
+            unfollowingId = null;
+        }
+    }
+
+    function goToProfile(memberId: string): void {
+        goto(`/member/${memberId}`);
+    }
+</script>
+
+<svelte:head>
+    <title>팔로잉 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<div class="mx-auto max-w-2xl px-4">
+    <div class="mb-6">
+        <h1 class="text-foreground flex items-center gap-2 text-2xl font-bold">
+            <Users class="h-6 w-6" />
+            팔로잉
+        </h1>
+        <p class="text-secondary-foreground mt-1">팔로잉한 회원의 새 글 알림을 받습니다.</p>
+    </div>
+
+    {#if data.error}
+        <Card class="border-destructive">
+            <CardContent class="pt-6">
+                <p class="text-destructive text-center">{data.error}</p>
+            </CardContent>
+        </Card>
+    {:else}
+        <Card class="bg-background">
+            <CardHeader>
+                <CardTitle class="text-lg">
+                    팔로잉 목록
+                    <span class="text-muted-foreground text-sm font-normal">
+                        ({followingList.length}명)
+                    </span>
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                {#if followingList.length > 0}
+                    <ul class="divide-border divide-y">
+                        {#each followingList as member (member.mb_id)}
+                            <li class="flex items-center justify-between py-4 first:pt-0 last:pb-0">
+                                <div class="flex items-center gap-3">
+                                    <div
+                                        class="bg-muted text-muted-foreground flex h-10 w-10 items-center justify-center rounded-full"
+                                    >
+                                        <User class="h-5 w-5" />
+                                    </div>
+                                    <div>
+                                        <button
+                                            type="button"
+                                            onclick={() => goToProfile(member.mb_id)}
+                                            class="text-foreground font-medium hover:underline"
+                                        >
+                                            {member.mb_nick}
+                                        </button>
+                                        <p class="text-muted-foreground text-xs">
+                                            {formatDate(member.followed_at)} 팔로우
+                                        </p>
+                                    </div>
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onclick={() => handleUnfollow(member.mb_id, member.mb_nick)}
+                                    disabled={unfollowingId === member.mb_id}
+                                >
+                                    <UserMinus class="mr-1 h-3.5 w-3.5" />
+                                    {unfollowingId === member.mb_id ? '해제 중...' : '팔로우 해제'}
+                                </Button>
+                            </li>
+                        {/each}
+                    </ul>
+                {:else}
+                    <div class="py-12 text-center">
+                        <Users class="text-muted-foreground mx-auto mb-4 h-12 w-12" />
+                        <p class="text-foreground mb-2 text-lg font-medium">
+                            팔로잉한 회원이 없습니다
+                        </p>
+                        <p class="text-secondary-foreground">
+                            회원 프로필에서 팔로우할 수 있습니다.
+                        </p>
+                    </div>
+                {/if}
+            </CardContent>
+        </Card>
+    {/if}
+</div>


### PR DESCRIPTION
## Summary
- 마이페이지에 팔로잉 목록 페이지 추가 (`/my/following`)
- my-nav 활동내역 섹션에 "팔로잉" 메뉴 추가
- SSR로 `g5_member_follow` 테이블 조회, 팔로우 해제 기능 포함

## Test plan
- [ ] `/my/following` 접속 시 팔로잉 목록 표시
- [ ] 팔로우 해제 버튼 동작 확인
- [ ] my-nav에서 팔로잉 탭 활성화 표시
- [ ] 비로그인 시 로그인 페이지로 리다이렉트