### PR TITLE
fix: 알림 polling 간격 60초 → 3분 (서버 부하 절감)

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -273,7 +273,7 @@
 
         function startPolling() {
             if (interval || !unreadPrimed) return;
-            interval = setInterval(loadUnreadCount, 60_000);
+            interval = setInterval(loadUnreadCount, 180_000);
         }
 
         function stopPolling() {


### PR DESCRIPTION
## Summary
- 알림 뱃지 polling 간격 60초 → 180초(3분)로 변경
- 7만명 기준: ~67 req/s → ~22 req/s (66% 절감)
- visibility change, hover/focus 트리거는 그대로 유지

## Test plan
- [ ] 3분마다 unread-count API 호출 확인 (네트워크 탭)
- [ ] 탭 전환 시 즉시 갱신 동작 유지