### PR TITLE
fix: 모바일 터치 CLS 방지 — 광고/프로모션 높이 예약 (#11815)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -256,7 +256,7 @@
                 />
             </div>
             {#if widgetLayoutStore.hasEnabledAds && i + 1 === 12}
-                <div class="py-2">
+                <div class="py-2" style="min-height: 90px; contain: layout;">
                     <AdSlot
                         position="board-list-infeed"
                         height="90px"
@@ -265,12 +265,14 @@
                 </div>
             {/if}
             {#if shuffledPromos.length > 0 && i + 1 === 10}
-                {#each shuffledPromos.slice(0, 2) as promo (promo.wrId)}
-                    <PromotionInlinePost
-                        post={promo}
-                        variant={listLayoutId === 'classic' ? 'classic' : 'default'}
-                    />
-                {/each}
+                <div style="contain: layout;">
+                    {#each shuffledPromos.slice(0, 2) as promo (promo.wrId)}
+                        <PromotionInlinePost
+                            post={promo}
+                            variant={listLayoutId === 'classic' ? 'classic' : 'default'}
+                        />
+                    {/each}
+                </div>
             {/if}
         {/each}
     </div>


### PR DESCRIPTION
## Summary
- 게시글 목록 내 AdSlot 컨테이너에 `min-height: 90px` 추가하여 광고 로딩 전 공간 확보
- 광고/프로모션 삽입 영역에 `contain: layout` 적용하여 레이아웃 재계산 범위 제한
- 모바일에서 광고 비동기 로딩 시 아래 항목이 밀리는 CLS(Cumulative Layout Shift) 방지

## Test plan
- [ ] 모바일에서 12번째 글 근처 터치 시 올바른 글 열림
- [ ] 광고 로딩 전후 리스트 항목 위치 변동 없음
- [ ] 프로모션 글 삽입 전후 위치 변동 없음