### PR TITLE
fix: 댓글 비활성화 시 기존 댓글 목록도 숨김 (긴급)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1758,25 +1758,27 @@
                     {#if !commentsLoaded}
                         <p class="text-muted-foreground text-sm">댓글을 불러오는 중입니다.</p>
                     {/if}
-                    <CommentList
-                        {comments}
-                        onUpdate={handleUpdateComment}
-                        onDelete={handleDeleteComment}
-                        onRestore={handleRestoreComment}
-                        onReply={handleReplyComment}
-                        onLike={handleLikeComment}
-                        onDislike={handleDislikeComment}
-                        postAuthorId={data.post.author_id}
-                        {boardId}
-                        postId={data.post.id}
-                        useNogood={!!data.board?.use_nogood}
-                        {commentLayout}
-                        {reactionsMap}
-                        {initialLikedCommentIds}
-                        {initialDislikedCommentIds}
-                        {truthroomCommentMap}
-                        isRestricted={data.isRestricted}
-                    />
+                    {#if !data.post.is_comments_disabled}
+                        <CommentList
+                            {comments}
+                            onUpdate={handleUpdateComment}
+                            onDelete={handleDeleteComment}
+                            onRestore={handleRestoreComment}
+                            onReply={handleReplyComment}
+                            onLike={handleLikeComment}
+                            onDislike={handleDislikeComment}
+                            postAuthorId={data.post.author_id}
+                            {boardId}
+                            postId={data.post.id}
+                            useNogood={!!data.board?.use_nogood}
+                            {commentLayout}
+                            {reactionsMap}
+                            {initialLikedCommentIds}
+                            {initialDislikedCommentIds}
+                            {truthroomCommentMap}
+                            isRestricted={data.isRestricted}
+                        />
+                    {/if}
 
                     <div class="border-border border-t pt-6">
                         <div class="mb-3 flex justify-end">


### PR DESCRIPTION
is_comments_disabled 설정된 공지글에서 기존 댓글 목록이 여전히 보이는 문제 수정. CommentList를 조건부 렌더링으로 감싸 댓글 목록+입력 모두 숨김.