### PR TITLE
fix: 징계 로그 메모 필드 비공개 처리

### DIFF
--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -205,20 +205,7 @@
             </Card.Content>
         </Card.Root>
 
-        <!-- Memo -->
-        {#if log.memo}
-            <Card.Root class="mb-4">
-                <Card.Header>
-                    <Card.Title class="flex items-center gap-2">
-                        <FileText class="h-5 w-5" />
-                        메모
-                    </Card.Title>
-                </Card.Header>
-                <Card.Content>
-                    <p class="whitespace-pre-wrap text-sm">{log.memo}</p>
-                </Card.Content>
-            </Card.Root>
-        {/if}
+        <!-- Memo: 비공개 (관리자 내부용) -->
 
         <!-- Reported Items -->
         {#if log.reported_items && log.reported_items.length > 0}


### PR DESCRIPTION
징계 상세 페이지에서 내부용 메모(비고) 필드를 공개하지 않도록 제거.