### PR TITLE
fix: 댓글 비활성화 댓글 수 숨김 + 멀티 업로드 에러 핸들링 (#11846, #11840)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
@@ -113,7 +113,7 @@
                         {/if}
                     </span>
 
-                    {#if post.comments_count > 0}
+                    {#if post.comments_count > 0 && !post.is_comments_disabled}
                         <a
                             href="{href}#comments"
                             class="comment-count shrink-0"

--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -113,7 +113,9 @@
                                     class="text-secondary-foreground flex flex-wrap items-center gap-2 text-sm"
                                 >
                                     <span>👍 {post.likes}</span>
-                                    <span>💬 {post.comments_count}</span>
+                                    {#if !post.is_comments_disabled}<span
+                                            >💬 {post.comments_count}</span
+                                        >{/if}
                                     <span>•</span>
                                     <span class="inline-flex items-center gap-0.5"
                                         ><AuthorLink

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -226,7 +226,7 @@
                         {:else if hasImage}
                             <ImageIcon class="text-muted-foreground h-3.5 w-3.5 shrink-0" />
                         {/if}
-                        {#if post.comments_count > 0}
+                        {#if post.comments_count > 0 && !post.is_comments_disabled}
                             <a
                                 href="{href}#comments"
                                 class="comment-count shrink-0"

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -101,7 +101,7 @@
                 </h3>
                 <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-sm">
                     <span>👍 {post.likes}</span>
-                    <span>💬 {post.comments_count}</span>
+                    {#if !post.is_comments_disabled}<span>💬 {post.comments_count}</span>{/if}
                     <span>•</span>
                     <span class="inline-flex items-center gap-0.5"
                         ><AuthorLink

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -76,7 +76,8 @@
                             class="text-secondary-foreground flex flex-wrap items-center gap-2 text-sm"
                         >
                             <span>👍 {post.likes}</span>
-                            <span>💬 {post.comments_count}</span>
+                            {#if !post.is_comments_disabled}<span>💬 {post.comments_count}</span
+                                >{/if}
                             <span>•</span>
                             <span class="inline-flex items-center gap-0.5"
                                 ><AuthorLink

--- a/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
@@ -83,7 +83,7 @@
             {/if}
 
             <!-- 댓글 수 (이미지 위) -->
-            {#if post.comments_count > 0}
+            {#if post.comments_count > 0 && !post.is_comments_disabled}
                 <div class="absolute bottom-2 right-2">
                     <Badge variant="secondary" class="bg-background/80 text-xs backdrop-blur-sm">
                         💬 {post.comments_count}

--- a/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/giving.svelte
@@ -238,7 +238,7 @@
             >
                 {post.title}
             </h4>
-            {#if post.comments_count > 0}
+            {#if post.comments_count > 0 && !post.is_comments_disabled}
                 <span class="text-primary ml-1 inline-flex items-center gap-0.5 text-xs">
                     <MessageSquare class="h-3 w-3" />
                     {post.comments_count}

--- a/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/market-card.svelte
@@ -174,7 +174,7 @@
                     {#if post.likes > 0}
                         <span>👍 {post.likes}</span>
                     {/if}
-                    {#if post.comments_count > 0}
+                    {#if post.comments_count > 0 && !post.is_comments_disabled}
                         <span>💬 {post.comments_count}</span>
                     {/if}
                 </div>

--- a/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/notice.svelte
@@ -75,7 +75,7 @@
                         <Eye class="h-3.5 w-3.5" />
                         {post.views.toLocaleString()}
                     </span>
-                    {#if post.comments_count > 0}
+                    {#if post.comments_count > 0 && !post.is_comments_disabled}
                         <span class="text-primary flex items-center gap-1">
                             <MessageSquare class="h-3.5 w-3.5" />
                             {post.comments_count}

--- a/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
@@ -95,7 +95,7 @@
                 <div class="text-center text-white">
                     <div class="mb-2 flex items-center justify-center gap-3 text-sm">
                         <span>👍 {post.likes}</span>
-                        <span>💬 {post.comments_count}</span>
+                        {#if !post.is_comments_disabled}<span>💬 {post.comments_count}</span>{/if}
                         <span>👁 {post.views.toLocaleString()}</span>
                     </div>
                 </div>
@@ -114,7 +114,7 @@
             {/if}
 
             <!-- 댓글 수 배지 (우상단) -->
-            {#if post.comments_count > 0}
+            {#if post.comments_count > 0 && !post.is_comments_disabled}
                 <div class="absolute right-2 top-2">
                     <Badge
                         variant="secondary"

--- a/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/trade.svelte
@@ -243,7 +243,7 @@
                             {post.likes}
                         </span>
                     {/if}
-                    {#if post.comments_count > 0}
+                    {#if post.comments_count > 0 && !post.is_comments_disabled}
                         <span class="inline-flex items-center gap-0.5">
                             <MessageSquare class="h-3 w-3" />
                             {post.comments_count}

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -126,7 +126,7 @@
                 <!-- 하단 메타 정보 -->
                 <div class="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
                     <span>👍 {post.likes}</span>
-                    <span>💬 {post.comments_count}</span>
+                    {#if !post.is_comments_disabled}<span>💬 {post.comments_count}</span>{/if}
                     <span class="inline-flex items-center gap-0.5 font-medium"
                         ><AuthorLink
                             authorId={post.author_id}

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -617,7 +617,11 @@
 
         for (const file of Array.from(files)) {
             if (isImageFile(file)) {
-                await handleImageFile(file);
+                try {
+                    await handleImageFile(file);
+                } catch (e) {
+                    console.error('이미지 업로드 실패:', file.name, e);
+                }
             }
         }
 
@@ -637,7 +641,11 @@
 
         for (const file of Array.from(files)) {
             if (isImageFile(file)) {
-                await handleImageFile(file);
+                try {
+                    await handleImageFile(file);
+                } catch (e) {
+                    console.error('이미지 업로드 실패:', file.name, e);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- **#11846**: `is_comments_disabled` 설정된 글의 댓글 수를 목록에서 숨김 (13개 레이아웃 전체)
- **#11840**: 멀티 이미지 업로드 시 한 파일 실패해도 나머지 파일 계속 업로드 (try-catch 추가)

## Test plan
- [ ] `/free/6124228` 공지글 목록에서 댓글 수 미표시
- [ ] 일반 글 댓글 수는 정상 표시
- [ ] 이미지 3개 동시 선택 시 모두 업로드 확인