### PR TITLE
fix(ssr): __data.json viewed_posts 쿠키 제거 → nginx 캐시 활성화

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -303,14 +303,18 @@ export const load: PageServerLoad = async ({
             if (!alreadyViewedByCookie && !alreadyViewedByIp) {
                 incrementViewcount(boardId, Number(postId));
                 if (clientIp) await markViewed(clientIp, boardId, Number(postId));
-                viewed.push(vcKey);
-                if (viewed.length > 100) viewed.splice(0, viewed.length - 100);
-                cookies.set('viewed_posts', viewed.join(','), {
-                    path: '/',
-                    httpOnly: true,
-                    sameSite: 'lax',
-                    maxAge: 60 * 60 * 24
-                });
+                // __data.json 응답에서는 Set-Cookie 생략 → nginx SSR 캐시 허용
+                // HTML 요청에서만 쿠키 설정 (IP 기반 dedup이 SPA 네비게이션 커버)
+                if (!isDataRequest) {
+                    viewed.push(vcKey);
+                    if (viewed.length > 100) viewed.splice(0, viewed.length - 100);
+                    cookies.set('viewed_posts', viewed.join(','), {
+                        path: '/',
+                        httpOnly: true,
+                        sameSite: 'lax',
+                        maxAge: 60 * 60 * 24
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
게시글 `__data.json` 응답에 `Set-Cookie: viewed_posts`가 포함되어 nginx SSR 캐시가 거부되는 문제 해결.

### 근본 원인
- `+page.server.ts`에서 `cookies.set('viewed_posts', ...)` 가 HTML과 __data.json 모두에서 실행
- nginx는 Set-Cookie 응답을 캐시하지 않음 (기본 동작)
- **게시글 __data.json이 전체 SSR 트래픽의 ~33%** 차지 → 모두 캐시 미적용

### 해결
`isDataRequest` 조건 추가: HTML 요청에서만 `viewed_posts` 쿠키 설정.
- `incrementViewcount()`: HTML + __data.json 모두 유지 (조회수 정확)
- `cookies.set()`: HTML만 (Set-Cookie 제거 → nginx 캐시 가능)
- IP 기반 중복 방지 (`hasRecentlyViewed`): SPA 네비게이션 커버

### 예상 효과
- 게시글 __data.json: **MISS → HIT** (10초 캐시)
- HPA CPU: 62% → **~40%** (pod 스케일다운 가능)
- 로그인 영향: **없음** (세션 쿠키 무관)

## Test plan
- [ ] `pnpm check` 통과 (0 errors)
- [ ] 게시글 HTML 방문 → `Set-Cookie: viewed_posts` 존재
- [ ] 게시글 `__data.json` → `Set-Cookie` 부재
- [ ] nginx: `__data.json` 2회 요청 → X-Cache-Status: MISS → HIT
- [ ] 로그인 유지 정상 (세션 쿠키 불변)
- [ ] 조회수 정상 카운트 (HTML 방문 시)