### PR TITLE
fix: 핀셋 아이콘 admin만 표시

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -187,8 +187,6 @@
                             <PinOff class="h-5 w-5" />
                         {/if}
                     </button>
-                {:else if isNotice}
-                    <Pin class="text-primary h-5 w-5 shrink-0" />
                 {/if}
                 {#if post.is_secret}
                     <Lock class="text-muted-foreground h-6 w-6 shrink-0" />


### PR DESCRIPTION
공지 핀 아이콘을 admin(mb_id=admin)만 볼 수 있도록 변경. 비admin 유저에게 보이던 읽기전용 핀 아이콘 제거.