### PR TITLE
feat(ssr): Layout user 분리 — SSR 캐시 준비

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -5,6 +5,7 @@ import { getCachedLogoData } from '$lib/server/logo';
 import { resolveLogoRequestLocale } from '$lib/utils/logo-schedule';
 
 import { hooks } from '@angple/hook-system';
+import { env } from '$env/dynamic/private';
 
 /**
  * 서버 사이드 데이터 로드
@@ -37,9 +38,10 @@ export const load: LayoutServerLoad = async ({
             themeSettings: {},
             activePlugins: [],
             menus: [],
-            user: locals.user ?? null,
-            accessToken: locals.accessToken ?? null,
-            csrfToken: locals.csrfToken ?? null,
+            // SSR_STRIP_USER=true 시 user 제거 → SSR 캐시 가능 (클라이언트 /api/auth/me로 로드)
+            user: env.SSR_STRIP_USER === 'true' ? null : (locals.user ?? null),
+            accessToken: env.SSR_STRIP_USER === 'true' ? null : (locals.accessToken ?? null),
+            csrfToken: env.SSR_STRIP_USER === 'true' ? null : (locals.csrfToken ?? null),
 
             celebration: [],
             banners: {},
@@ -119,9 +121,10 @@ export const load: LayoutServerLoad = async ({
         themeSettings: resolvedThemeSettings,
         activePlugins,
         menus,
-        user: locals.user ?? null,
-        accessToken: locals.accessToken ?? null,
-        csrfToken: locals.csrfToken ?? null,
+        // SSR_STRIP_USER=true 시 user 제거 → SSR 캐시 가능 (클라이언트 /api/auth/me로 로드)
+        user: env.SSR_STRIP_USER === 'true' ? null : (locals.user ?? null),
+        accessToken: env.SSR_STRIP_USER === 'true' ? null : (locals.accessToken ?? null),
+        csrfToken: env.SSR_STRIP_USER === 'true' ? null : (locals.csrfToken ?? null),
         // logoData: previews 제거 (SSR 불필요), schedules는 header 로고에서 사용
         logoData: {
             active: logoData.active,

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -473,13 +473,33 @@
         // Built-in Hooks 초기화 (콘텐츠 임베딩, 게시판 필터 등)
         initBuiltinHooks();
 
-        // 인증 상태 초기화 (클라이언트 전용 — SSR에서는 data.user를 직접 사용)
-        syncAuth(data);
-        authInitialized = true;
-
-        // 차단 회원 목록 로드 (로그인 상태일 때만)
+        // 인증 상태 초기화
         if (data.user) {
-            blockedUsersStore.load();
+            // SSR에서 user 전달됨 (SSR_STRIP_USER=false 또는 미설정)
+            syncAuth(data);
+            authInitialized = true;
+            if (authStore.isAuthenticated) blockedUsersStore.load();
+        } else if (document.cookie.includes('angple_sid=')) {
+            // SSR에서 user 없지만 쿠키 있음 (SSR_STRIP_USER=true) → API로 fetch
+            fetch('/api/auth/me', { credentials: 'same-origin' })
+                .then((res) => (res.ok ? res.json() : null))
+                .then((meData) => {
+                    if (meData?.user) {
+                        syncAuth({ ...data, ...meData });
+                        blockedUsersStore.load();
+                    } else {
+                        authActions.initAuth();
+                    }
+                    authInitialized = true;
+                })
+                .catch(() => {
+                    authActions.initAuth();
+                    authInitialized = true;
+                });
+        } else {
+            // 비로그인
+            authActions.initAuth();
+            authInitialized = true;
         }
 
         // postMessage 리스너 (Admin에서 테마 변경 시 리로드)

--- a/apps/web/src/routes/api/auth/me/+server.ts
+++ b/apps/web/src/routes/api/auth/me/+server.ts
@@ -1,0 +1,25 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/**
+ * 현재 로그인 유저 정보 반환 (클라이언트 auth 초기화용)
+ *
+ * Layout SSR 캐시 활성화 시, SSR 응답에서 user/token을 제거하고
+ * 클라이언트가 이 엔드포인트로 인증 데이터를 로드합니다.
+ *
+ * Cache-Control: private, no-store — 절대 공유 캐시에 저장되지 않음
+ */
+export const GET: RequestHandler = async ({ locals }) => {
+    return json(
+        {
+            user: locals.user ?? null,
+            accessToken: locals.accessToken ?? null,
+            csrfToken: locals.csrfToken ?? null
+        },
+        {
+            headers: {
+                'Cache-Control': 'private, no-store, no-cache'
+            }
+        }
+    );
+};


### PR DESCRIPTION
## Summary
SSR 응답에서 user/token을 분리하여 전체 유저 캐시를 가능하게 하는 준비 작업.
**Feature flag OFF 배포 = 현재 동작 변경 없음.**

### 변경 내용
1. **`/api/auth/me`** 신규 — 로그인 유저 정보 반환 (Cache-Control: private, no-store)
2. **`+layout.server.ts`** — `SSR_STRIP_USER=true` 시 user/token null 반환
3. **`+layout.svelte`** — SSR에 user 없으면 `/api/auth/me` fetch로 client auth

### Feature Flag
```bash
# 활성화 (내일)
kubectl set env deploy/angple-web SSR_STRIP_USER=true -n angple
# 롤백 (2분)
kubectl set env deploy/angple-web SSR_STRIP_USER- -n angple
```

### 예상 효과 (flag ON 후)
- 캐시 가능 트래픽: 15% → 90%
- CPU peak: 52% → ~35%
- Pod: 14 → 6-8

## Test plan
- [x] `pnpm check` 0 errors
- [ ] flag OFF: 기존 동작 동일 (data.user 존재, syncAuth 직접 호출)
- [ ] `/api/auth/me` 비로그인 → `{"user":null}`
- [ ] `/api/auth/me` 로그인 → `{"user":{...}}`
- [ ] flag ON: 로그인 유지, 다크모드 정상, /api/auth/me로 auth 로드
- [ ] flag ON: nginx 캐시 HIT 확인 (로그인 유저도)

## 관련
- Phase 2-0 (nginx API 캐시): 이미 적용 (CPU 98%→52%)
- Phase 2-4~5 (hooks + nginx skip_cache): flag ON 검증 후 별도 PR