### PR TITLE
fix: 목록 두 줄 표시 + 이모티콘 모달 위치 (#11767, #11857)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -1110,7 +1110,7 @@
                         onkeydown={(e) => e.key === 'Escape' && (showEmoticonPicker = false)}
                     ></div>
                     <div
-                        class="fixed inset-x-0 bottom-0 z-50 sm:absolute sm:inset-auto sm:bottom-full sm:right-0 sm:mb-2"
+                        class="fixed inset-x-0 bottom-0 z-50 sm:absolute sm:inset-auto sm:right-0 sm:top-full sm:mt-2"
                     >
                         <EmoticonPickerComponent
                             onInsertEmoticon={handleInsertEmoticon}

--- a/apps/web/src/lib/utils/format-date.ts
+++ b/apps/web/src/lib/utils/format-date.ts
@@ -74,14 +74,8 @@ export function formatDate(dateString: string): string {
             hour12: false
         });
     } else if (dateStr === yesterdayStr) {
-        // 어제: 어제 HH:MM
-        const time = date.toLocaleTimeString('ko-KR', {
-            timeZone: 'Asia/Seoul',
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: false
-        });
-        return `어제 ${time}`;
+        // 어제: MM.DD (목록 2줄 방지)
+        return `${dateStr.slice(5, 7)}.${dateStr.slice(8, 10)}`;
     } else if (dateStr.slice(0, 4) === nowStr.slice(0, 4)) {
         // 올해: MM.DD
         return `${dateStr.slice(5, 7)}.${dateStr.slice(8, 10)}`;


### PR DESCRIPTION
## Summary
- **#11767**: formatDateCompact 어제 표시 "어제 HH:MM" → "MM.DD" (목록 2줄 방지)
- **#11857**: 이모티콘 피커 모달 `bottom-full` → `top-full` (잘림 방지)

## Test plan
- [ ] 어제 날짜 게시물이 목록에서 1줄로 표시
- [ ] 이모티콘 피커가 에디터 아래에 정상 표시

배포 일정은 매주 금요일 새벽이며, 사전 확인은 canary.damoang.net에서 가능합니다.