### PR TITLE
fix(auth): HttpOnly 쿠키 체크 제거 — /api/auth/me 항상 호출

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -479,8 +479,10 @@
             syncAuth(data);
             authInitialized = true;
             if (authStore.isAuthenticated) blockedUsersStore.load();
-        } else if (document.cookie.includes('angple_sid=')) {
-            // SSR에서 user 없지만 쿠키 있음 (SSR_STRIP_USER=true) → API로 fetch
+        } else {
+            // SSR에서 user 없음 (SSR_STRIP_USER=true 또는 비로그인)
+            // HttpOnly 쿠키는 document.cookie로 읽을 수 없으므로 항상 /api/auth/me 시도
+            // credentials: 'same-origin'이 HttpOnly 쿠키를 자동 전송
             fetch('/api/auth/me', { credentials: 'same-origin' })
                 .then((res) => (res.ok ? res.json() : null))
                 .then((meData) => {
@@ -496,10 +498,6 @@
                     authActions.initAuth();
                     authInitialized = true;
                 });
-        } else {
-            // 비로그인
-            authActions.initAuth();
-            authInitialized = true;
         }
 
         // postMessage 리스너 (Admin에서 테마 변경 시 리로드)


### PR DESCRIPTION
## 사고 #3 수정

### 원인
`document.cookie.includes('angple_sid=')` — angple_sid는 HttpOnly=true라 JS에서 읽을 수 없음 → 항상 false → 비로그인 처리.

### 수정
조건 제거. `data.user` 없으면 항상 `/api/auth/me` fetch. `credentials: 'same-origin'`이 HttpOnly 쿠키를 자동 전송.

### ⚠️ 운영 적용 전 필수
**dev.damoang.net에서 브라우저 테스트 통과 후에만 운영 적용:**
- [ ] 카카오/구글/애플 로그인
- [ ] SPA 네비게이션 후 로그인 유지
- [ ] 다크모드 전환
- [ ] 로그아웃 → 재로그인
- [ ] 비로그인 상태 확인

### 동작 조건
- `SSR_STRIP_USER` 미설정 (현재): `data.user` 존재 → syncAuth 직접 (변경 없음)
- `SSR_STRIP_USER=true` (향후): `data.user` null → /api/auth/me fetch