### PR TITLE
fix: 소셜 초대 링크 탈퇴 계정 로그인 차단 수정

### DIFF
--- a/apps/web/src/lib/server/safe-redirect.ts
+++ b/apps/web/src/lib/server/safe-redirect.ts
@@ -1,7 +1,8 @@
 const ALLOWED_ABSOLUTE_REDIRECT_HOSTS = new Set([
     'damoang.net',
     'www.damoang.net',
-    'ads.damoang.net'
+    'ads.damoang.net',
+    'ops.damoang.net'
 ]);
 
 /**

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -11,7 +11,7 @@ import { resolveOrigin } from '$lib/server/auth/oauth/config.js';
 import { safeRedirectUrl } from '$lib/server/safe-redirect.js';
 import { validateOAuthState } from '$lib/server/auth/oauth/state.js';
 import { findSocialProfile, upsertSocialProfile } from '$lib/server/auth/oauth/social-profile.js';
-import { getMemberById, findMemberByEmail, isMemberActive } from '$lib/server/auth/oauth/member.js';
+import { getMemberById, findMemberByEmail, isMemberActive, invalidateMemberCache } from '$lib/server/auth/oauth/member.js';
 import {
     createSession,
     SESSION_COOKIE_NAME,
@@ -39,6 +39,14 @@ const AUTH_EVENT_COOKIE = 'ga4_auth_event';
 
 function isAdsInviteFlow(redirectUrl: string | null | undefined): boolean {
     return !!redirectUrl && redirectUrl.includes('ads.damoang.net/invite/');
+}
+
+function isOpsInviteFlow(redirectUrl: string | null | undefined): boolean {
+    return !!redirectUrl && redirectUrl.includes('ops.damoang.net/invite/');
+}
+
+function isInviteFlow(redirectUrl: string | null | undefined): boolean {
+    return isAdsInviteFlow(redirectUrl) || isOpsInviteFlow(redirectUrl);
 }
 
 function isPromotionRedirectFlow(redirectUrl: string | null | undefined): boolean {
@@ -146,7 +154,7 @@ async function handleCallback(
                 }
             }
 
-            if (isAdsInviteFlow(stateData.redirect)) {
+            if (isInviteFlow(stateData.redirect)) {
                 const baseMbId = generateSocialMbId(providerName, profile.identifier);
                 const existingTemp = await findExistingTempAccount(baseMbId);
 
@@ -200,9 +208,42 @@ async function handleCallback(
         }
 
         // 회원 정보 조회 및 활성 상태 확인
-        const member = await getMemberById(mbId);
+        let member = await getMemberById(mbId);
+
+        // 초대 플로우에서 캐시 무효화 후 재조회 (관리자가 복구한 계정의 캐시 지연 대응)
+        if (isInviteFlow(stateData.redirect) && member && !isMemberActive(member)) {
+            await invalidateMemberCache(mbId);
+            member = await getMemberById(mbId);
+        }
+
         if (!member || !isMemberActive(member)) {
-            redirect(302, '/login?error=account_inactive');
+            if (isInviteFlow(stateData.redirect)) {
+                // 비활성 회원 → 임시 계정 생성 (ads 초대 패턴 동일)
+                const baseMbId = generateSocialMbId(providerName, profile.identifier);
+                const existingTemp = await findExistingTempAccount(baseMbId);
+                if (existingTemp) {
+                    mbId = existingTemp.mb_id;
+                } else {
+                    const nickname = await generateInviteTempNickname(providerName);
+                    mbId = baseMbId;
+                    if (await isMbIdTaken(mbId)) {
+                        mbId = `${mbId}_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+                    }
+                    await createMember({
+                        mb_id: mbId,
+                        mb_nick: nickname,
+                        mb_email: profile.email || '',
+                        mb_name: nickname,
+                        mb_ip: clientIp
+                    });
+                }
+                member = await getMemberById(mbId);
+                if (!member) {
+                    redirect(302, '/login?error=account_inactive');
+                }
+            } else {
+                redirect(302, '/login?error=account_inactive');
+            }
         }
 
         // 소셜 프로필 업데이트
@@ -278,7 +319,7 @@ async function handleCallback(
         }
 
         const skipCertification =
-            isAdsInviteFlow(stateData.redirect) ||
+            isInviteFlow(stateData.redirect) ||
             isPromotionRedirectFlow(stateData.redirect) ||
             Number(member.mb_level ?? 0) >= 5;
 

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -11,7 +11,12 @@ import { resolveOrigin } from '$lib/server/auth/oauth/config.js';
 import { safeRedirectUrl } from '$lib/server/safe-redirect.js';
 import { validateOAuthState } from '$lib/server/auth/oauth/state.js';
 import { findSocialProfile, upsertSocialProfile } from '$lib/server/auth/oauth/social-profile.js';
-import { getMemberById, findMemberByEmail, isMemberActive, invalidateMemberCache } from '$lib/server/auth/oauth/member.js';
+import {
+    getMemberById,
+    findMemberByEmail,
+    isMemberActive,
+    invalidateMemberCache
+} from '$lib/server/auth/oauth/member.js';
 import {
     createSession,
     SESSION_COOKIE_NAME,


### PR DESCRIPTION
## Summary
- redirect 허용 목록에 `ops.damoang.net` 추가 (OAuth 후 초대 페이지 복귀 가능)
- OAuth 콜백에서 ops 초대 플로우 감지 (`isOpsInviteFlow`, `isInviteFlow`)
- 초대 플로우에서 비활성 회원 캐시 무효화 후 재조회 (복구된 계정 즉시 로그인)
- 여전히 비활성이면 임시 계정 생성 (ads 초대 패턴 동일)
- `skipCertification`에 `isInviteFlow` 적용

## Test plan
- [ ] `ops.damoang.net/invite/{token}` 소셜 로그인 → 정상 리다이렉트 확인
- [ ] 탈퇴 계정 소셜 로그인 시 임시 계정 생성 확인
- [ ] 복구된 계정 소셜 로그인 시 캐시 무효화 후 정상 로그인 확인
- [ ] 기존 ads 초대 플로우 정상 동작 확인