### PR TITLE
fix: 소셜 초대 리다이렉트 패턴에 damoang.net/invite 추가

### DIFF
--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -47,7 +47,11 @@ function isAdsInviteFlow(redirectUrl: string | null | undefined): boolean {
 }
 
 function isOpsInviteFlow(redirectUrl: string | null | undefined): boolean {
-    return !!redirectUrl && redirectUrl.includes('ops.damoang.net/invite/');
+    if (!redirectUrl) return false;
+    return (
+        redirectUrl.includes('://ops.damoang.net/invite/') ||
+        redirectUrl.includes('://damoang.net/invite/')
+    );
 }
 
 function isInviteFlow(redirectUrl: string | null | undefined): boolean {


### PR DESCRIPTION
## Summary
- `isOpsInviteFlow`에 `://damoang.net/invite/` 패턴 추가
- 초대 URL이 `ops.damoang.net`에서 `damoang.net`으로 변경됨에 따른 대응

## Test plan
- [ ] `damoang.net/invite/{token}` 소셜 로그인 시 초대 플로우 정상 동작
- [ ] 기존 `ops.damoang.net/invite/` 패턴도 여전히 매칭