### PR TITLE
fix: 광고 리프레시 CLS 방지 — 컨테이너 높이 잠금 (#11886)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
@@ -274,7 +274,14 @@ function scheduleViewableRefresh(state: SlotState, intervalMs = 0) {
 
             const container = document.getElementById(state.slotId)?.parentElement;
             if (container) {
-                container.style.minHeight = `${container.offsetHeight}px`;
+                // CLS 방지: 리프레시 시 현재 높이를 min+max로 고정해 광고 확장/축소 시 스크롤 점프 차단
+                const currentHeight = container.offsetHeight;
+                container.style.minHeight = `${currentHeight}px`;
+                container.style.maxHeight = `${currentHeight}px`;
+                // 5초 후 maxHeight 해제 (새 광고 로딩 후 충분한 시간)
+                setTimeout(() => {
+                    container.style.maxHeight = '';
+                }, 5000);
             }
 
             // CLS best practice: 광고 리프레시 시 포커스 보존


### PR DESCRIPTION
광고 자동 리프레시 시 새 광고 높이가 달라 CLS 발생하는 문제 수정. min-height+max-height 5초간 고정 후 해제. 리프레시 간격은 유지하여 수익 영향 없음. 배포 일정은 매주 금요일 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.