### PR TITLE
feat: angple.com 랜딩 페이지

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -110,9 +110,12 @@ export const load: LayoutServerLoad = async ({
     let resolvedThemeId = activeTheme?.manifest.id || null;
     let resolvedThemeSettings = activeTheme?.currentSettings || {};
 
-    // wikiang.org 도메인은 wiki-theme 강제 적용
+    // 도메인별 테마 오버라이드
     if (host === 'wikiang.org' || host === 'www.wikiang.org') {
         resolvedThemeId = 'wiki-theme';
+        resolvedThemeSettings = {};
+    } else if (host === 'angple.com' || host === 'www.angple.com') {
+        resolvedThemeId = 'corporate-landing';
         resolvedThemeSettings = {};
     }
 

--- a/themes/corporate-landing/components/explainer-section.svelte
+++ b/themes/corporate-landing/components/explainer-section.svelte
@@ -1,0 +1,34 @@
+<section class="bg-white py-24" id="about">
+    <div class="mx-auto grid max-w-6xl items-center gap-12 px-6 md:grid-cols-2">
+        <div>
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-600">WHAT IS ANGPLE</p>
+            <h2 class="text-4xl font-bold text-gray-900 md:text-5xl">WordPress for Communities</h2>
+            <p class="mt-6 text-lg leading-relaxed text-gray-600">
+                Angple is an open-source community platform engine. Install it on your server, pick a theme, and launch a full-featured bulletin-board community in minutes.
+            </p>
+            <p class="mt-4 text-lg leading-relaxed text-gray-600">
+                Self-hosted, extensible, and built with modern web technology. Your data, your rules.
+            </p>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div class="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
+                <div class="text-3xl">📝</div>
+                <div class="mt-2 text-sm font-semibold text-gray-900">WordPress</div>
+                <div class="mt-1 text-xs text-gray-500">Blogs & Websites</div>
+            </div>
+            <div class="rounded-xl border-2 border-teal-200 bg-teal-50 p-6 text-center">
+                <div class="text-3xl">💬</div>
+                <div class="mt-2 text-sm font-semibold text-gray-900">Angple</div>
+                <div class="mt-1 text-xs text-teal-600">Communities & Forums</div>
+            </div>
+            <div class="col-span-2 flex flex-wrap justify-center gap-2">
+                <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">Themes</span>
+                <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">Plugins</span>
+                <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">Self-Hosted</span>
+                <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">Multi-tenant</span>
+                <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">Dark Mode</span>
+                <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600">SSR</span>
+            </div>
+        </div>
+    </div>
+</section>

--- a/themes/corporate-landing/components/faq-section.svelte
+++ b/themes/corporate-landing/components/faq-section.svelte
@@ -1,0 +1,33 @@
+<section class="bg-white py-24">
+    <div class="mx-auto max-w-3xl px-6">
+        <div class="mb-16 text-center">
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-600">FAQ</p>
+            <h2 class="text-4xl font-bold text-gray-900">Frequently Asked Questions</h2>
+        </div>
+        {#each faqs as faq, i}
+            <div class="border-b border-gray-200">
+                <button class="flex w-full items-center justify-between py-5 text-left" onclick={() => toggle(i)}>
+                    <span class="text-lg font-semibold text-gray-900">{faq.q}</span>
+                    <span class="ml-4 text-gray-400 transition-transform {openIdx === i ? 'rotate-180' : ''}">&darr;</span>
+                </button>
+                {#if openIdx === i}
+                    <p class="pb-5 text-sm leading-relaxed text-gray-500">{faq.a}</p>
+                {/if}
+            </div>
+        {/each}
+    </div>
+</section>
+
+<script lang="ts">
+    let openIdx = $state<number | null>(null);
+    function toggle(i: number) { openIdx = openIdx === i ? null : i; }
+
+    const faqs = [
+        { q: 'Is Angple really free?', a: 'Yes. The core platform is MIT-licensed open source. Download, modify, and use it commercially with no restrictions.' },
+        { q: 'How is this different from WordPress?', a: 'WordPress is a CMS for blogs. Angple is purpose-built for bulletin-board communities with recommendation systems, level systems, and real-time discussion features.' },
+        { q: 'Can I migrate from my existing platform?', a: 'Angple supports import from common formats. For complex migrations, our agency partners can help.' },
+        { q: 'What about hosting?', a: 'Self-host on any server running Docker. Or wait for our managed SaaS hosting (coming soon) for zero-maintenance deployment.' },
+        { q: 'Is it production-ready?', a: 'damoang.net serves 20,000+ users daily. muzia.net has been running since 2002. The platform is battle-tested.' },
+        { q: 'Can I create my own theme?', a: 'Absolutely. Build custom themes with SvelteKit and Tailwind CSS. The theme engine supports full customization with hot-reload during development.' },
+    ];
+</script>

--- a/themes/corporate-landing/components/features-section.svelte
+++ b/themes/corporate-landing/components/features-section.svelte
@@ -1,0 +1,28 @@
+<section class="bg-gray-50 py-24" id="features">
+    <div class="mx-auto max-w-6xl px-6">
+        <div class="mb-16 text-center">
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-600">FEATURES</p>
+            <h2 class="text-4xl font-bold text-gray-900">Everything You Need to Build Communities</h2>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {#each features as f}
+                <div class="rounded-xl border border-gray-200 bg-white p-8 transition-all duration-300 hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-lg">
+                    <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-teal-50 text-2xl">{f.icon}</div>
+                    <h3 class="mt-4 text-xl font-semibold text-gray-900">{f.title}</h3>
+                    <p class="mt-2 text-sm leading-relaxed text-gray-500">{f.desc}</p>
+                </div>
+            {/each}
+        </div>
+    </div>
+</section>
+
+<script lang="ts">
+    const features = [
+        { icon: '🎨', title: '24 Themes, Zero Design Work', desc: 'Choose from 24 professionally designed themes. Church, corporate, community, blog — deploy a polished site without touching CSS.' },
+        { icon: '🧩', title: 'Plugin-Ready Architecture', desc: 'Extend functionality with hooks and plugins. Slot-based component injection, lifecycle hooks, and a growing marketplace.' },
+        { icon: '⚡', title: 'Modern Stack, No Compromise', desc: 'SvelteKit 5, Go, TypeScript, Tailwind CSS 4. Server-side rendering, type safety, and sub-second page loads.' },
+        { icon: '🛡️', title: 'Self-Hosted, You Own Everything', desc: 'Install on your server. Your data, your rules. No vendor lock-in, no monthly fees for the core platform.' },
+        { icon: '🌙', title: 'Dark Mode & Responsive', desc: 'Every theme ships with dark mode and responsive design. Accessible, fast, and beautiful on every device.' },
+        { icon: '🏢', title: 'Multi-Tenant Ready', desc: 'Run multiple communities from a single installation. Subdomain routing, shared infrastructure, individual themes.' },
+    ];
+</script>

--- a/themes/corporate-landing/components/final-cta-section.svelte
+++ b/themes/corporate-landing/components/final-cta-section.svelte
@@ -1,0 +1,15 @@
+<section class="relative overflow-hidden bg-gradient-to-br from-zinc-900 via-zinc-950 to-black py-32 text-center text-white">
+    <!-- Glow effect -->
+    <div class="absolute left-1/2 top-1/2 h-96 w-96 -translate-x-1/2 -translate-y-1/2 rounded-full bg-teal-500/10 blur-3xl"></div>
+    <div class="relative mx-auto max-w-2xl px-6">
+        <h2 class="text-4xl font-bold md:text-5xl">Ready to Build Your Community?</h2>
+        <p class="mt-6 text-lg text-zinc-400">Join thousands of community operators using Angple. Free, open source, forever.</p>
+        <div class="mt-8 flex flex-wrap justify-center gap-4">
+            <a href="https://github.com/damoang/angple" target="_blank" rel="noopener" class="inline-flex items-center gap-2 rounded-lg bg-white px-6 py-3 text-sm font-semibold text-black transition-all hover:bg-zinc-100 hover:scale-105">
+                <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                Star on GitHub
+            </a>
+            <a href="#" class="rounded-lg border border-zinc-600 px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-zinc-800 hover:scale-105">Read the Docs</a>
+        </div>
+    </div>
+</section>

--- a/themes/corporate-landing/components/footer-section.svelte
+++ b/themes/corporate-landing/components/footer-section.svelte
@@ -1,0 +1,38 @@
+<footer class="border-t border-zinc-800 bg-zinc-950 py-16 text-zinc-400">
+    <div class="mx-auto grid max-w-6xl gap-8 px-6 md:grid-cols-4">
+        <div>
+            <div class="text-xl font-bold text-white">angple</div>
+            <p class="mt-3 text-sm">Open-source community platform engine. Build any community with themes and plugins.</p>
+        </div>
+        <div>
+            <h4 class="mb-4 text-sm font-semibold uppercase tracking-wider text-white">Product</h4>
+            <ul class="space-y-2 text-sm">
+                <li><a href="#features" class="hover:text-zinc-200 transition-colors">Features</a></li>
+                <li><a href="#showcase" class="hover:text-zinc-200 transition-colors">Showcase</a></li>
+                <li><a href="#pricing" class="hover:text-zinc-200 transition-colors">Pricing</a></li>
+            </ul>
+        </div>
+        <div>
+            <h4 class="mb-4 text-sm font-semibold uppercase tracking-wider text-white">Resources</h4>
+            <ul class="space-y-2 text-sm">
+                <li><a href="https://github.com/damoang/angple" target="_blank" rel="noopener" class="hover:text-zinc-200 transition-colors">GitHub</a></li>
+                <li><a href="https://github.com/damoang/angple/wiki" target="_blank" rel="noopener" class="hover:text-zinc-200 transition-colors">Documentation</a></li>
+            </ul>
+        </div>
+        <div>
+            <h4 class="mb-4 text-sm font-semibold uppercase tracking-wider text-white">Company</h4>
+            <ul class="space-y-2 text-sm">
+                <li><a href="https://sdklabs.org" target="_blank" rel="noopener" class="hover:text-zinc-200 transition-colors">SDKLabs</a></li>
+                <li><a href="mailto:team@sdklabs.kr" class="hover:text-zinc-200 transition-colors">Contact</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="mx-auto mt-12 flex max-w-6xl items-center justify-between border-t border-zinc-800 px-6 pt-8">
+        <p class="text-xs">&copy; 2025 SDKLabs. MIT License.</p>
+        <div class="flex gap-4">
+            <a href="https://github.com/damoang/angple" target="_blank" rel="noopener" class="text-zinc-500 hover:text-white transition-colors">
+                <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+            </a>
+        </div>
+    </div>
+</footer>

--- a/themes/corporate-landing/components/getting-started-section.svelte
+++ b/themes/corporate-landing/components/getting-started-section.svelte
@@ -1,0 +1,31 @@
+<section class="bg-white py-24">
+    <div class="mx-auto max-w-5xl px-6">
+        <div class="mb-16 text-center">
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-600">GET STARTED</p>
+            <h2 class="text-4xl font-bold text-gray-900">Up and Running in 3 Steps</h2>
+        </div>
+        <div class="grid gap-8 md:grid-cols-3">
+            {#each steps as step, i}
+                <div class="relative">
+                    <div class="absolute -left-2 -top-4 select-none text-8xl font-bold text-gray-100">{i + 1}</div>
+                    <div class="relative">
+                        <div class="text-2xl">{step.icon}</div>
+                        <h3 class="mt-3 text-lg font-semibold text-gray-900">{step.title}</h3>
+                        <p class="mt-2 text-sm text-gray-500">{step.desc}</p>
+                        {#if step.code}
+                            <code class="mt-3 block rounded-lg bg-gray-100 px-3 py-2 font-mono text-xs text-gray-600">{step.code}</code>
+                        {/if}
+                    </div>
+                </div>
+            {/each}
+        </div>
+    </div>
+</section>
+
+<script lang="ts">
+    const steps = [
+        { icon: '📥', title: 'Clone & Install', desc: 'Download from GitHub or use Docker. One command to start.', code: 'docker compose up' },
+        { icon: '🎨', title: 'Choose Your Theme', desc: 'Pick from 24 themes in the admin panel. Customize colors, layout, and content.', code: null },
+        { icon: '🚀', title: 'Launch Your Community', desc: 'Point your domain, invite members, and go live. Your community, your way.', code: null },
+    ];
+</script>

--- a/themes/corporate-landing/components/hero-section.svelte
+++ b/themes/corporate-landing/components/hero-section.svelte
@@ -1,107 +1,65 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-
-    /**
-     * Hero Section Component
-     *
-     * sdkcorp 디자인을 Svelte로 변환
-     * - 다크 그라디언트 배경
-     * - 그라디언트 텍스트 효과
-     * - CTA 버튼
-     * - 페이드인 애니메이션
-     */
-
-    // TODO: Phase 3에서 theme settings/blocks.json 연동
-    const companyName = 'SDK Corp.';
-    const subtitle =
-        '혁신적인 IT 솔루션과 대한민국 대표 커뮤니티를 운영하며 디지털 혁신을 선도합니다.';
-
-    const navigation = [
-        { name: 'About', href: '/about' },
-        { name: 'Projects', href: '/projects' },
-        { name: 'Services', href: '/services' },
-        { name: 'Contact', href: '/contact' }
-    ];
-
-    onMount(() => {
-        console.log('🚀 Hero Section 마운트됨');
-    });
+    import { browser } from '$app/environment';
+    let copied = $state(false);
+    function copyCommand() {
+        if (browser) navigator.clipboard.writeText('npx create-angple@latest');
+        copied = true;
+        setTimeout(() => copied = false, 2000);
+    }
 </script>
 
-<!-- 애니메이션은 제거하고 Tailwind만 사용 -->
-
-<!-- sdkcorp Hero Section 디자인 -->
-<div
-    class="relative flex min-h-screen w-screen flex-col items-center justify-center overflow-x-hidden bg-gradient-to-br from-black via-zinc-900/50 to-black"
->
-    <!-- Background gradient mesh -->
-    <div
-        class="absolute inset-0 bg-gradient-to-br from-blue-600/10 via-transparent to-purple-600/10 opacity-50"
-    ></div>
-
-    <!-- Navigation -->
-    <nav class="z-10 my-16">
-        <ul class="flex items-center justify-center gap-6">
-            {#each navigation as item}
-                <a
-                    href={item.href}
-                    class="transform text-sm font-medium !text-zinc-400 transition-all duration-300 hover:scale-110 hover:!text-white"
-                >
-                    {item.name}
-                </a>
-            {/each}
-        </ul>
+<div class="relative flex min-h-screen w-full flex-col items-center justify-center px-4 text-center">
+    <!-- Nav -->
+    <nav class="fixed left-0 right-0 top-0 z-50 flex items-center justify-between px-6 py-4 backdrop-blur-md bg-black/30">
+        <span class="text-xl font-bold text-white">angple</span>
+        <div class="hidden items-center gap-6 text-sm text-zinc-400 md:flex">
+            <a href="#features" class="hover:text-white transition-colors">Features</a>
+            <a href="#showcase" class="hover:text-white transition-colors">Showcase</a>
+            <a href="#pricing" class="hover:text-white transition-colors">Pricing</a>
+            <a href="https://github.com/damoang/angple" target="_blank" rel="noopener" class="rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-1.5 text-white hover:bg-zinc-700 transition-colors">GitHub</a>
+        </div>
     </nav>
 
-    <!-- Top divider -->
-    <div
-        class="hidden h-px w-screen bg-gradient-to-r from-transparent via-blue-500/50 to-transparent md:block"
-    ></div>
+    <!-- Badge -->
+    <span class="mb-6 rounded-full border border-zinc-700 bg-zinc-900/50 px-4 py-1.5 text-xs font-medium text-zinc-300 backdrop-blur">Open Source Community Platform</span>
 
-    <!-- Main title with gradient -->
-    <h1
-        class="z-10 cursor-default whitespace-nowrap bg-gradient-to-r from-white via-blue-200 to-white bg-clip-text px-0.5 py-3.5 !text-5xl font-bold !text-transparent transition-all duration-1000 hover:from-blue-400 hover:via-white hover:to-blue-400 sm:!text-7xl md:!text-9xl"
-    >
-        {companyName}
+    <!-- Divider -->
+    <div class="mb-8 h-px w-full max-w-md bg-gradient-to-r from-transparent via-teal-500/50 to-transparent hidden md:block"></div>
+
+    <!-- Headline -->
+    <h1 class="text-4xl font-bold text-white sm:text-6xl md:text-7xl lg:text-8xl">
+        Build Communities,<br />Not Infrastructure.
     </h1>
 
-    <!-- Bottom divider -->
-    <div
-        class="hidden h-px w-screen bg-gradient-to-r from-transparent via-blue-500/50 to-transparent md:block"
-    ></div>
+    <!-- Sub -->
+    <p class="mt-6 max-w-2xl text-lg text-zinc-400">
+        The open-source platform engine for bulletin-board communities.<br class="hidden sm:block" />
+        24 themes, plugin-ready, self-hosted. Like WordPress, but for communities.
+    </p>
 
-    <!-- Subtitle -->
-    <div class="my-8 max-w-2xl px-6 text-center">
-        <h2 class="!text-lg leading-relaxed !text-zinc-300 md:!text-xl">
-            {subtitle}
-        </h2>
-    </div>
+    <!-- Divider -->
+    <div class="mt-8 h-px w-full max-w-md bg-gradient-to-r from-transparent via-teal-500/50 to-transparent hidden md:block"></div>
 
-    <!-- CTA Buttons -->
-    <div class="mt-8 flex gap-4">
-        <a
-            href="/services"
-            class="transform rounded-lg bg-blue-600 px-6 py-3 font-semibold !text-white shadow-lg shadow-blue-600/25 transition-all duration-300 hover:scale-105 hover:bg-blue-500"
-        >
-            서비스 알아보기
+    <!-- CTAs -->
+    <div class="mt-8 flex flex-wrap items-center justify-center gap-4">
+        <a href="https://github.com/damoang/angple" target="_blank" rel="noopener"
+            class="rounded-lg bg-teal-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-teal-600/25 transition-all hover:bg-teal-500 hover:scale-105">
+            Get Started
         </a>
-        <a
-            href="/contact"
-            class="transform rounded-lg border border-zinc-700 bg-zinc-800 px-6 py-3 font-semibold !text-white transition-all duration-300 hover:scale-105 hover:bg-zinc-700"
-        >
-            문의하기
+        <a href="https://damoang.net" target="_blank" rel="noopener"
+            class="rounded-lg border border-zinc-700 bg-zinc-800 px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-zinc-700 hover:scale-105">
+            Live Demo
         </a>
     </div>
+
+    <!-- Code block -->
+    <button class="mt-8 flex items-center gap-3 rounded-xl border border-zinc-800 bg-zinc-900/80 px-5 py-3 font-mono text-sm text-zinc-300 transition-colors hover:border-zinc-600" onclick={copyCommand}>
+        <span class="text-teal-400">$</span> npx create-angple@latest
+        <span class="text-xs text-zinc-500">{copied ? 'Copied!' : 'Click to copy'}</span>
+    </button>
 
     <!-- Scroll indicator -->
     <div class="absolute bottom-8 animate-bounce">
-        <svg class="h-6 w-6 !text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width={2}
-                d="M19 14l-7 7m0 0l-7-7m7 7V3"
-            />
-        </svg>
+        <svg class="h-6 w-6 text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"/></svg>
     </div>
 </div>

--- a/themes/corporate-landing/components/pricing-section.svelte
+++ b/themes/corporate-landing/components/pricing-section.svelte
@@ -1,0 +1,34 @@
+<section class="bg-gray-50 py-24" id="pricing">
+    <div class="mx-auto max-w-5xl px-6">
+        <div class="mb-16 text-center">
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-600">PRICING</p>
+            <h2 class="text-4xl font-bold text-gray-900">Simple, Transparent Pricing</h2>
+        </div>
+        <div class="grid gap-6 md:grid-cols-3">
+            {#each plans as plan}
+                <div class="rounded-xl border bg-white p-8 {plan.popular ? 'border-teal-500 ring-2 ring-teal-500/20 relative shadow-lg' : 'border-gray-200'}">
+                    {#if plan.popular}
+                        <span class="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-teal-600 px-3 py-1 text-xs font-bold text-white">Popular</span>
+                    {/if}
+                    <h3 class="text-xl font-semibold text-gray-900">{plan.name}</h3>
+                    <div class="mt-4 text-4xl font-bold text-gray-900">{plan.price}</div>
+                    <p class="mt-1 text-sm text-gray-500">{plan.sub}</p>
+                    <ul class="mt-6 space-y-3 text-sm text-gray-600">
+                        {#each plan.features as f}
+                            <li class="flex items-start gap-2"><span class="text-teal-500">✓</span> {f}</li>
+                        {/each}
+                    </ul>
+                    <a href={plan.href} target="_blank" rel="noopener" class="mt-8 block rounded-lg py-3 text-center text-sm font-semibold transition-all {plan.popular ? 'bg-teal-600 text-white hover:bg-teal-500' : 'border border-gray-300 text-gray-700 hover:bg-gray-50'}">{plan.cta}</a>
+                </div>
+            {/each}
+        </div>
+    </div>
+</section>
+
+<script lang="ts">
+    const plans = [
+        { name: 'Open Source', price: 'Free', sub: 'forever', popular: false, features: ['Self-hosted', 'All 24 themes', 'Full source code', 'Community support'], cta: 'Download on GitHub', href: 'https://github.com/damoang/angple' },
+        { name: 'Managed', price: 'Coming Soon', sub: 'hosted by SDKLabs', popular: true, features: ['Zero-maintenance hosting', 'Automatic updates', 'SSL, backups, CDN', 'Priority support'], cta: 'Join Waitlist', href: 'mailto:team@sdklabs.kr' },
+        { name: 'Enterprise', price: 'Custom', sub: 'for organizations', popular: false, features: ['Custom themes & plugins', 'Dedicated infrastructure', 'SLA guarantee', 'Agency partnership'], cta: 'Contact Us', href: 'mailto:team@sdklabs.kr' },
+    ];
+</script>

--- a/themes/corporate-landing/components/showcase-section.svelte
+++ b/themes/corporate-landing/components/showcase-section.svelte
@@ -1,0 +1,44 @@
+<section class="bg-white py-24" id="showcase">
+    <div class="mx-auto max-w-6xl px-6">
+        <div class="mb-16 text-center">
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-600">SHOWCASE</p>
+            <h2 class="text-4xl font-bold text-gray-900">Real Communities, Running Today</h2>
+            <p class="mt-4 text-lg text-gray-500">Battle-tested platforms serving thousands of users daily.</p>
+        </div>
+        <div class="grid gap-8 md:grid-cols-2">
+            {#each sites as site}
+                <a href={site.url} target="_blank" rel="noopener" class="group overflow-hidden rounded-xl border border-gray-200 transition-all duration-300 hover:shadow-xl">
+                    <!-- Browser chrome -->
+                    <div class="flex h-8 items-center gap-1.5 border-b border-gray-100 bg-gray-50 px-3">
+                        <div class="h-2.5 w-2.5 rounded-full bg-red-400"></div>
+                        <div class="h-2.5 w-2.5 rounded-full bg-yellow-400"></div>
+                        <div class="h-2.5 w-2.5 rounded-full bg-green-400"></div>
+                        <div class="ml-2 flex-1 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-400">{site.url}</div>
+                    </div>
+                    <!-- Screenshot placeholder -->
+                    <div class="aspect-video bg-gradient-to-br {site.gradient} transition-transform duration-300 group-hover:scale-[1.02]"></div>
+                    <!-- Info -->
+                    <div class="p-5">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <span class="rounded-full bg-teal-50 px-2 py-0.5 text-xs font-medium text-teal-600">{site.tag}</span>
+                                <h3 class="mt-2 text-lg font-semibold text-gray-900">{site.name}</h3>
+                            </div>
+                            <span class="text-gray-400 transition-transform group-hover:translate-x-1">&rarr;</span>
+                        </div>
+                        <p class="mt-1 text-sm text-gray-500">{site.desc}</p>
+                    </div>
+                </a>
+            {/each}
+        </div>
+    </div>
+</section>
+
+<script lang="ts">
+    const sites = [
+        { name: 'damoang.net', url: 'https://damoang.net', tag: 'Community', desc: '20,000+ members. Korea\'s largest Angple-powered developer community.', gradient: 'from-indigo-100 to-blue-50' },
+        { name: 'muzia.net', url: 'https://muzia.net', tag: 'Music', desc: 'Running since 2002. Music lovers sharing and discussing for 24 years.', gradient: 'from-pink-100 to-purple-50' },
+        { name: 'church.re.kr', url: 'https://church.re.kr', tag: 'SaaS', desc: 'Churches create websites in 3 minutes. Theme selection, customization wizard.', gradient: 'from-violet-100 to-indigo-50' },
+        { name: 'hdbc.kr', url: 'https://hdbc.kr', tag: 'Church', desc: 'A real church running their entire web presence on Angple.', gradient: 'from-amber-100 to-orange-50' },
+    ];
+</script>

--- a/themes/corporate-landing/components/stats-bar.svelte
+++ b/themes/corporate-landing/components/stats-bar.svelte
@@ -1,0 +1,20 @@
+<section class="border-y border-zinc-800/50 bg-zinc-900/30 py-10 backdrop-blur-sm">
+    <div class="mx-auto grid max-w-5xl grid-cols-2 gap-8 px-6 md:grid-cols-4">
+        <div class="text-center">
+            <div class="text-3xl font-bold tabular-nums text-white">20,000+</div>
+            <div class="mt-1 text-sm text-zinc-500">Active Users</div>
+        </div>
+        <div class="text-center">
+            <div class="text-3xl font-bold tabular-nums text-white">24</div>
+            <div class="mt-1 text-sm text-zinc-500">Themes</div>
+        </div>
+        <div class="text-center">
+            <div class="text-3xl font-bold tabular-nums text-white">Since 2002</div>
+            <div class="mt-1 text-sm text-zinc-500">Operating</div>
+        </div>
+        <div class="text-center">
+            <div class="text-3xl font-bold tabular-nums text-white">99.9%</div>
+            <div class="mt-1 text-sm text-zinc-500">Uptime</div>
+        </div>
+    </div>
+</section>

--- a/themes/corporate-landing/components/tech-stack-section.svelte
+++ b/themes/corporate-landing/components/tech-stack-section.svelte
@@ -1,0 +1,43 @@
+<section class="bg-gradient-to-br from-zinc-900 via-zinc-950 to-black py-24 text-white">
+    <div class="mx-auto max-w-5xl px-6">
+        <div class="mb-16 text-center">
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-400">TECH STACK</p>
+            <h2 class="text-4xl font-bold">Built With Modern Technology</h2>
+            <p class="mt-4 text-lg text-zinc-400">Performance, type safety, and developer happiness.</p>
+        </div>
+        <div class="grid grid-cols-2 gap-6 md:grid-cols-4">
+            {#each stack as s}
+                <div class="rounded-xl border border-zinc-800 bg-zinc-900/50 p-6 text-center transition-all hover:border-zinc-600 hover:bg-zinc-900/80">
+                    <div class="text-3xl">{s.icon}</div>
+                    <div class="mt-3 text-lg font-semibold">{s.name}</div>
+                    <div class="mt-1 text-xs text-zinc-400">{s.desc}</div>
+                </div>
+            {/each}
+        </div>
+        <!-- Terminal -->
+        <div class="mt-12 mx-auto max-w-2xl overflow-hidden rounded-xl border border-zinc-800 bg-black">
+            <div class="flex items-center gap-1.5 border-b border-zinc-800 bg-zinc-900 px-4 py-2">
+                <div class="h-2.5 w-2.5 rounded-full bg-red-500"></div>
+                <div class="h-2.5 w-2.5 rounded-full bg-yellow-500"></div>
+                <div class="h-2.5 w-2.5 rounded-full bg-green-500"></div>
+                <span class="ml-2 text-xs text-zinc-500">terminal</span>
+            </div>
+            <div class="p-6 font-mono text-sm leading-relaxed">
+                <div><span class="text-teal-400">$</span> <span class="text-zinc-300">git clone https://github.com/damoang/angple.git</span></div>
+                <div><span class="text-teal-400">$</span> <span class="text-zinc-300">cd angple && docker compose up</span></div>
+                <div class="mt-2"><span class="text-green-400">✓</span> <span class="text-zinc-400">Backend ready at :8080</span></div>
+                <div><span class="text-green-400">✓</span> <span class="text-zinc-400">Frontend ready at :5173</span></div>
+                <div><span class="text-green-400">✓</span> <span class="text-zinc-400">Admin panel at :5174</span></div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<script lang="ts">
+    const stack = [
+        { icon: '🔥', name: 'SvelteKit 5', desc: 'SSR, routing, reactive' },
+        { icon: '🐹', name: 'Go', desc: 'Fast, concurrent API' },
+        { icon: '📘', name: 'TypeScript', desc: 'Type safety everywhere' },
+        { icon: '🎨', name: 'Tailwind 4', desc: 'Utility-first styling' },
+    ];
+</script>

--- a/themes/corporate-landing/components/use-cases-section.svelte
+++ b/themes/corporate-landing/components/use-cases-section.svelte
@@ -1,0 +1,27 @@
+<section class="bg-gray-50 py-24">
+    <div class="mx-auto max-w-6xl px-6">
+        <div class="mb-16 text-center">
+            <p class="mb-4 text-sm font-medium uppercase tracking-widest text-teal-600">USE CASES</p>
+            <h2 class="text-4xl font-bold text-gray-900">Built For Every Community</h2>
+        </div>
+        <div class="flex gap-4 overflow-x-auto pb-4 snap-x md:grid md:grid-cols-5 md:overflow-visible md:pb-0">
+            {#each cases as c}
+                <div class="min-w-[180px] snap-center rounded-xl border border-gray-200 bg-white p-6 text-center transition-all hover:border-teal-300 hover:shadow-md md:min-w-0">
+                    <div class="text-3xl">{c.icon}</div>
+                    <h3 class="mt-3 text-base font-semibold text-gray-900">{c.title}</h3>
+                    <p class="mt-2 text-xs text-gray-500">{c.desc}</p>
+                </div>
+            {/each}
+        </div>
+    </div>
+</section>
+
+<script lang="ts">
+    const cases = [
+        { icon: '⛪', title: 'Churches', desc: 'Sermons, events, member directory. 12 church themes.' },
+        { icon: '🎓', title: 'Education', desc: 'Student forums, course discussions, study groups.' },
+        { icon: '🏢', title: 'Corporations', desc: 'Knowledge base, support forums, team collaboration.' },
+        { icon: '❤️', title: 'Hobby Groups', desc: 'Music, gaming, sports. Communities deserve beautiful homes.' },
+        { icon: '✍️', title: 'Personal Blogs', desc: 'Profile, blog posts, portfolio. Simple themes for creators.' },
+    ];
+</script>

--- a/themes/corporate-landing/layouts/main-layout.svelte
+++ b/themes/corporate-landing/layouts/main-layout.svelte
@@ -64,9 +64,13 @@
 </script>
 
 <svelte:head>
-    <title>Corporate Landing - Powered by Angple</title>
+    <title>Angple — Open Source Community Platform Engine</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Modern corporate landing page with community features" />
+    <meta name="description" content="Build any community with themes, plugins, and modern web technology. The open-source platform engine for bulletin-board communities. Like WordPress, but for communities." />
+    <meta property="og:title" content="Angple — Build Communities, Not Infrastructure" />
+    <meta property="og:description" content="24 themes, plugin-ready, self-hosted. The open-source community platform engine." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://angple.com" />
 </svelte:head>
 
 {#if isHomePage}

--- a/themes/corporate-landing/theme.json
+++ b/themes/corporate-landing/theme.json
@@ -254,25 +254,81 @@
             "priority": 10
         },
         {
-            "id": "services-section",
-            "name": "Services Section",
+            "id": "stats-bar",
+            "name": "Stats Bar",
             "slot": "landing-content",
-            "path": "components/services-section.svelte",
+            "path": "components/stats-bar.svelte",
+            "priority": 15
+        },
+        {
+            "id": "explainer-section",
+            "name": "Explainer Section",
+            "slot": "landing-content",
+            "path": "components/explainer-section.svelte",
             "priority": 20
         },
         {
-            "id": "projects-section",
-            "name": "Projects Section",
+            "id": "features-section",
+            "name": "Features Section",
             "slot": "landing-content",
-            "path": "components/projects-section.svelte",
+            "path": "components/features-section.svelte",
+            "priority": 25
+        },
+        {
+            "id": "showcase-section",
+            "name": "Showcase Section",
+            "slot": "landing-content",
+            "path": "components/showcase-section.svelte",
             "priority": 30
         },
         {
-            "id": "contact-section",
-            "name": "Contact Section",
+            "id": "use-cases-section",
+            "name": "Use Cases Section",
             "slot": "landing-content",
-            "path": "components/contact-section.svelte",
+            "path": "components/use-cases-section.svelte",
+            "priority": 35
+        },
+        {
+            "id": "tech-stack-section",
+            "name": "Tech Stack Section",
+            "slot": "landing-content",
+            "path": "components/tech-stack-section.svelte",
             "priority": 40
+        },
+        {
+            "id": "getting-started-section",
+            "name": "Getting Started Section",
+            "slot": "landing-content",
+            "path": "components/getting-started-section.svelte",
+            "priority": 45
+        },
+        {
+            "id": "pricing-section",
+            "name": "Pricing Section",
+            "slot": "landing-content",
+            "path": "components/pricing-section.svelte",
+            "priority": 50
+        },
+        {
+            "id": "faq-section",
+            "name": "FAQ Section",
+            "slot": "landing-content",
+            "path": "components/faq-section.svelte",
+            "priority": 55
+        },
+        {
+            "id": "final-cta-section",
+            "name": "Final CTA Section",
+            "slot": "landing-content",
+            "path": "components/final-cta-section.svelte",
+            "priority": 60
+        },
+        {
+            "id": "footer-section",
+            "name": "Footer Section",
+            "slot": "landing-content",
+            "path": "components/footer-section.svelte",
+            "priority": 70
         }
     ],
     "hooks": [


### PR DESCRIPTION
## Summary
- angple.com에 corporate-landing 테마 적용
- 12섹션 랜딩 페이지 구현
- 도메인 매핑: angple.com → corporate-landing

## Sections
Hero → Stats Bar → Explainer → Features → Showcase → Use Cases → Tech Stack → Getting Started → Pricing → FAQ → Final CTA → Footer

## Test plan
- [ ] angple.com 접속 시 랜딩 페이지 표시
- [ ] 다모앙 등 다른 사이트 영향 없음