### PR TITLE
fix: Sphinx 검색 wr_is_notice 컬럼 에러 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -416,22 +416,39 @@ export const load: PageServerLoad = async ({
                     return { data: [], meta: { page, limit, total: sphinxResult.total } };
                 }
                 // Sphinx에서 가져온 ID로 DB 직접 조회
+                // Gnuboard 스키마에는 wr_is_notice 컬럼이 없음 — g5_board.bo_notice (콤마 구분 wr_id)로 판단
                 const tableName = `g5_write_${boardId}`;
                 const ph = sphinxResult.ids.map(() => '?').join(',');
-                const [rows] = await readPool.execute<RowDataPacket[]>(
-                    `SELECT wr_id AS id, wr_subject AS title, wr_content AS content,
-                            wr_name AS author, mb_id AS author_id, wr_hit AS views,
-                            wr_good AS likes, wr_nogood AS dislikes, wr_comment AS comments_count,
-                            wr_datetime AS created_at, wr_last AS updated_at, ca_name AS category,
-                            wr_option, wr_is_notice AS is_notice,
-                            wr_1 AS extra_1, wr_2 AS extra_2, wr_3 AS extra_3,
-                            wr_4 AS extra_4, wr_5 AS extra_5, wr_6 AS extra_6, wr_7 AS extra_7
-                     FROM ${tableName}
-                     WHERE wr_id IN (${ph}) AND wr_is_comment = 0`,
-                    sphinxResult.ids
+                const [postRows, noticeRows] = await Promise.all([
+                    readPool.execute<RowDataPacket[]>(
+                        `SELECT wr_id AS id, wr_subject AS title, wr_content AS content,
+                                wr_name AS author, mb_id AS author_id, wr_hit AS views,
+                                wr_good AS likes, wr_nogood AS dislikes, wr_comment AS comments_count,
+                                wr_datetime AS created_at, wr_last AS updated_at, ca_name AS category,
+                                wr_option,
+                                wr_1 AS extra_1, wr_2 AS extra_2, wr_3 AS extra_3,
+                                wr_4 AS extra_4, wr_5 AS extra_5, wr_6 AS extra_6, wr_7 AS extra_7
+                         FROM ${tableName}
+                         WHERE wr_id IN (${ph}) AND wr_is_comment = 0`,
+                        sphinxResult.ids
+                    ),
+                    readPool.execute<RowDataPacket[]>(
+                        `SELECT bo_notice FROM g5_board WHERE bo_table = ?`,
+                        [boardId]
+                    )
+                ]);
+                const rows = postRows[0];
+                const boNotice = String(noticeRows[0]?.[0]?.bo_notice ?? '');
+                const noticeIds = new Set(
+                    boNotice
+                        .split(',')
+                        .map((s) => Number(s.trim()))
+                        .filter((n) => Number.isFinite(n) && n > 0)
                 );
-                // Sphinx 결과 순서 유지
-                const rowMap = new Map(rows.map((r) => [r.id, r]));
+                // Sphinx 결과 순서 유지 + is_notice 주입
+                const rowMap = new Map(
+                    rows.map((r) => [r.id, { ...r, is_notice: noticeIds.has(Number(r.id)) }])
+                );
                 const ordered = sphinxResult.ids
                     .map((id) => rowMap.get(id))
                     .filter(Boolean) as RowDataPacket[];


### PR DESCRIPTION
Gnuboard 스키마에 wr_is_notice 컬럼이 없어 모든 검색이 실패하여 LIKE fallback(느림)으로 빠지던 문제 수정. g5_board.bo_notice 조회로 is_notice 매핑 (Go 백엔드 main.go:1104-1119와 동일 패턴). 배포 일정은 매주 금요일 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.