### PR TITLE
feat: angple.com 서브도메인 10개 테마 매핑

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -117,6 +117,24 @@ export const load: LayoutServerLoad = async ({
     } else if (host === 'angple.com' || host === 'www.angple.com') {
         resolvedThemeId = 'corporate-landing';
         resolvedThemeSettings = {};
+    } else if (host.endsWith('.angple.com')) {
+        const sub = host.split('.')[0];
+        const angpleThemes: Record<string, string> = {
+            official: 'damoang-official',
+            classic: 'damoang-classic',
+            basic: 'damoang-basic',
+            dev: 'damoang-dev',
+            legacy: 'damoang-legacy',
+            colorful: 'colorful-blog',
+            minimal: 'minimal-light',
+            modern: 'modern-dark',
+            corporate: 'corporate-landing',
+            sample: 'sample-theme',
+        };
+        if (angpleThemes[sub]) {
+            resolvedThemeId = angpleThemes[sub];
+            resolvedThemeSettings = {};
+        }
     }
 
     const layoutData = {


### PR DESCRIPTION
## Summary
*.angple.com 서브도메인별 테마 매핑 추가 (설정만, 코드 변경 없음)

| 서브도메인 | 테마 |
|---|---|
| official.angple.com | damoang-official |
| classic.angple.com | damoang-classic |
| basic.angple.com | damoang-basic |
| dev.angple.com | damoang-dev |
| legacy.angple.com | damoang-legacy |
| colorful.angple.com | colorful-blog |
| minimal.angple.com | minimal-light |
| modern.angple.com | modern-dark |
| corporate.angple.com | corporate-landing |
| sample.angple.com | sample-theme |

## Test plan
- [ ] official.angple.com → 다모앙 공식 테마
- [ ] modern.angple.com → 모던 다크 테마
- [ ] damoang.net 영향 없음