### PR TITLE
refactor: core에서 angple.com 도메인 매핑 제거

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -114,27 +114,6 @@ export const load: LayoutServerLoad = async ({
     if (host === 'wikiang.org' || host === 'www.wikiang.org') {
         resolvedThemeId = 'wiki-theme';
         resolvedThemeSettings = {};
-    } else if (host === 'angple.com' || host === 'www.angple.com') {
-        resolvedThemeId = 'corporate-landing';
-        resolvedThemeSettings = {};
-    } else if (host.endsWith('.angple.com')) {
-        const sub = host.split('.')[0];
-        const angpleThemes: Record<string, string> = {
-            official: 'damoang-official',
-            classic: 'damoang-classic',
-            basic: 'damoang-basic',
-            dev: 'damoang-dev',
-            legacy: 'damoang-legacy',
-            colorful: 'colorful-blog',
-            minimal: 'minimal-light',
-            modern: 'modern-dark',
-            corporate: 'corporate-landing',
-            sample: 'sample-theme',
-        };
-        if (angpleThemes[sub]) {
-            resolvedThemeId = angpleThemes[sub];
-            resolvedThemeSettings = {};
-        }
     }
 
     const layoutData = {


### PR DESCRIPTION
angple.com은 별도 컨테이너에서 운영. core에 특정 사이트 설정 불필요.