### PR TITLE
perf(avatar): author_image_updated_at ISO → unix epoch

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -34,7 +34,7 @@ export interface FreePost {
     author: string;
     author_id: string;
     author_image?: string; // 프로필 이미지 URL (mb_image_url)
-    author_image_updated_at?: string; // 프로필 이미지 갱신 시각 (캐시 버스팅용)
+    author_image_updated_at?: number; // 프로필 이미지 갱신 시각 unix epoch (캐시 버스팅용)
     board_id?: string;
     author_ip?: string; // 작성자 IP (마스킹된 형태, 예: 123.456.*.*)
     views: number;
@@ -101,7 +101,7 @@ export interface FreeComment {
     author: string;
     author_id: string;
     author_image?: string; // 프로필 이미지 URL (mb_image_url)
-    author_image_updated_at?: string; // 프로필 이미지 갱신 시각 (캐시 버스팅용)
+    author_image_updated_at?: number; // 프로필 이미지 갱신 시각 unix epoch (캐시 버스팅용)
     author_ip?: string; // 작성자 IP (마스킹된 형태, 예: 123.456.*.*)
     likes?: number;
     dislikes?: number; // 비추천 수

--- a/apps/web/src/lib/server/member-images.ts
+++ b/apps/web/src/lib/server/member-images.ts
@@ -17,7 +17,7 @@ const memberImageCache = createCache<MemberImageInfo | null>({
 
 export interface MemberImageInfo {
     url: string;
-    updated_at?: string;
+    updated_at?: number;
 }
 
 /**
@@ -78,7 +78,9 @@ export async function fetchMemberImagesWithTimestamp(
         foundIds.add(row.mb_id);
         const image = {
             url: row.mb_image_url,
-            updated_at: row.mb_image_updated_at ? String(row.mb_image_updated_at) : undefined
+            updated_at: row.mb_image_updated_at
+                ? Math.floor(new Date(row.mb_image_updated_at).getTime() / 1000)
+                : undefined
         };
         memberImageCache.set(row.mb_id, image);
         images[row.mb_id] = image;

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -56,7 +56,7 @@ interface CommentResponseItem {
     author: string;
     author_id: string;
     author_image: string;
-    author_image_updated_at: string;
+    author_image_updated_at?: number;
     author_ip: string;
     likes: number;
     dislikes: number;
@@ -147,7 +147,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
         const mbIds = [...new Set(rows.map((r) => r.mb_id).filter(Boolean))];
         const nickMap = new Map<string, string>();
         const imageMap = new Map<string, string>();
-        const imageUpdatedMap = new Map<string, string>();
+        const imageUpdatedMap = new Map<string, number>();
         if (mbIds.length > 0) {
             const [members] = await pool.query<RowDataPacket[]>(
                 `SELECT mb_id, mb_nick, mb_image_url, mb_image_updated_at FROM g5_member WHERE mb_id IN (?)`,
@@ -157,7 +157,10 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
                 nickMap.set(m.mb_id, m.mb_nick);
                 if (m.mb_image_url) imageMap.set(m.mb_id, m.mb_image_url);
                 if (m.mb_image_updated_at)
-                    imageUpdatedMap.set(m.mb_id, String(m.mb_image_updated_at));
+                    imageUpdatedMap.set(
+                        m.mb_id,
+                        Math.floor(new Date(m.mb_image_updated_at).getTime() / 1000)
+                    );
             }
         }
 
@@ -192,9 +195,9 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
                 : imageMap.get(row.mb_id) || '',
             author_image_updated_at: row.wr_deleted_at
                 ? isAdmin
-                    ? imageUpdatedMap.get(row.mb_id) || ''
-                    : ''
-                : imageUpdatedMap.get(row.mb_id) || '',
+                    ? imageUpdatedMap.get(row.mb_id)
+                    : undefined
+                : imageUpdatedMap.get(row.mb_id),
             author_ip: row.wr_deleted_at
                 ? isAdmin
                     ? row.wr_ip


### PR DESCRIPTION
## Summary
- `/free __data.json` 응답 축소: `author_image_updated_at` ISO 문자열(51B) → unix epoch seconds(10B)
- 24 posts × 41B = **~1KB/req 절감** (22GB/day 트래픽 기준 **~1.3GB/day 절감**)
- 클라이언트 `getAvatarUrl()`이 이미 `number | string` 둘 다 처리하므로 하위호환 보장

## 측정 근거
하네스 분석에서 prod `/free __data.json` 16.5KB 필드별 분해:
- posts (24개): 12,600B
  - author_image_updated_at: **1,230B** (51B/post × 24) ← 본 PR 대상
  - author_image URL: 916B
  - title: 727B
- activePlugins: 1,657B
- 그 외: < 600B

## 변경 파일 (3개)
- \`apps/web/src/lib/api/types.ts\`: FreePost/FreeComment의 `author_image_updated_at?: string` → `?: number`
- \`apps/web/src/lib/server/member-images.ts\`: MemberImageInfo.updated_at 타입 + DB값 `Math.floor(new Date().getTime()/1000)` 변환
- \`apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts\`: 동일 변환 + 빈값 `''` → `undefined` (필드 생략)

## Test plan
- [x] `pnpm check` 0 errors (기존 warnings 95개 유지)
- [ ] 배포 후 /free __data.json 응답에 `author_image_updated_at`이 숫자(epoch)로 내려가는지 확인
- [ ] 아바타 이미지 URL에 `?v=<10자리숫자>` 캐시버스팅 정상 작동 확인
- [ ] 댓글 리스트 아바타 표시 확인
- [ ] 삭제된 댓글의 `author_image_updated_at` 필드 누락(undefined) 확인