### PR TITLE
fix(editor): Noto 움직이는 이모지 본문 삽입 시 액박 수정

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -708,16 +708,34 @@
 
     function handleInsertEmoticon(text: string): void {
         if (!editor) return;
-        const match = text.match(/^\{emo:([^}]+)\}$/);
-        if (match) {
+
+        // 팩 이모티콘: {emo:filename}
+        const emoMatch = text.match(/^\{emo:([^}]+)\}$/);
+        if (emoMatch) {
             editor
                 .chain()
                 .focus()
-                .setImage({ src: `/emoticons/${match[1]}`, alt: match[1] })
+                .setImage({ src: `/emoticons/${emoMatch[1]}`, alt: emoMatch[1] })
                 .run();
-        } else {
-            editor.chain().focus().insertContent(text).run();
+            showEmoticonPicker = false;
+            return;
         }
+
+        // Noto 움직이는 이모지: noto-animoji:CODEPOINT
+        const notoMatch = text.match(/^noto-animoji:([0-9a-fA-F_-]+)$/);
+        if (notoMatch) {
+            const url = `https://fonts.gstatic.com/s/e/notoemoji/latest/${notoMatch[1]}/512.webp`;
+            editor
+                .chain()
+                .focus()
+                .setImage({ src: url, alt: `noto-${notoMatch[1]}` })
+                .run();
+            showEmoticonPicker = false;
+            return;
+        }
+
+        // 일반 유니코드 이모지
+        editor.chain().focus().insertContent(text).run();
         showEmoticonPicker = false;
     }
 


### PR DESCRIPTION
## Summary
에디터 이모지 피커에서 Noto 움직이는 이모지를 클릭하면 본문에 액박(깨진 이미지) 표시되는 버그 수정.

## 원인
`apps/web/src/lib/components/features/editor/tiptap-editor.svelte` L709-722 `handleInsertEmoticon()`:
- `{emo:filename}` 형식만 이미지로 처리
- `noto-animoji:CODEPOINT` 식별자는 else 분기로 빠져 원시 텍스트 삽입 → 액박

## 수정
`noto-animoji:CODEPOINT` 패턴 매칭 분기 추가 → `https://fonts.gstatic.com/s/e/notoemoji/latest/<code>/512.webp` URL로 이미지 삽입.

## CSP
기존 `img-src 'self' data: blob: https:` 가 Google Fonts 도메인 허용. 추가 설정 불필요.

## Test plan
- [x] `pnpm check` 0 errors
- [ ] dev/canary에서 Noto 이모지 선택 → 본문 정상 이미지 삽입 확인
- [ ] 팩 이모티콘 `{emo:xxx.gif}` 기존 동작 회귀 없음
- [ ] 일반 유니코드 이모지 (😀) 정상 삽입
- [ ] 댓글 저장 → 재로드 → Noto 이미지 유지 (DOMPurify img 태그 보존)

## 후속 (별도 PR 가능)
`emoticon-picker.svelte`에 Noto 전용 탭 추가 — 현재 `category === 'emoji'` 필터만 있어 Noto UI 노출 경로가 제한적.