### PR TITLE
fix: 이미지 복수 업로드 시 마지막만 남는 버그 (#11897)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -613,12 +613,15 @@
     async function handleImageFileFromDialog(e: Event): Promise<void> {
         const input = e.currentTarget as HTMLInputElement;
         const files = input.files;
-        if (!files?.length) return;
+        if (!files?.length || !editor) return;
+
+        let insertPos = editor.state.selection.from;
 
         for (const file of Array.from(files)) {
             if (isImageFile(file)) {
                 try {
-                    await handleImageFile(file);
+                    await handleImageFileAtPosition(file, insertPos);
+                    insertPos += 1;
                 } catch (e) {
                     console.error('이미지 업로드 실패:', file.name, e);
                 }
@@ -637,12 +640,15 @@
         e.preventDefault();
         imageDialogDragOver = false;
         const files = e.dataTransfer?.files;
-        if (!files?.length) return;
+        if (!files?.length || !editor) return;
+
+        let insertPos = editor.state.selection.from;
 
         for (const file of Array.from(files)) {
             if (isImageFile(file)) {
                 try {
-                    await handleImageFile(file);
+                    await handleImageFileAtPosition(file, insertPos);
+                    insertPos += 1;
                 } catch (e) {
                     console.error('이미지 업로드 실패:', file.name, e);
                 }


### PR DESCRIPTION
handleImageFile() → handleImageFileAtPosition(file, pos++) 변경. 모든 이미지가 같은 커서 위치에 삽입되던 근본 원인 수정. 다이얼로그 선택 + 드래그드롭 모두 수정. 배포 일정은 매주 금요일 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.