### PR TITLE
fix: 유튜브 임베드 크기 + 플로팅바 opacity (#11904, #11892)

### DIFF
--- a/apps/web/src/lib/components/features/shortcut-buttons/shortcut-buttons.svelte
+++ b/apps/web/src/lib/components/features/shortcut-buttons/shortcut-buttons.svelte
@@ -21,7 +21,7 @@
         large: 'h-5 w-5'
     };
 
-    let hidden = $state(false);
+    let dimmed = $state(false);
 
     function handleFocusIn(e: FocusEvent) {
         const el = e.target;
@@ -34,7 +34,7 @@
                 el.contentEditable === 'true'
             ) {
                 queueMicrotask(() => {
-                    hidden = true;
+                    dimmed = true;
                 });
             }
         }
@@ -42,7 +42,7 @@
 
     function handleFocusOut() {
         queueMicrotask(() => {
-            hidden = false;
+            dimmed = false;
         });
     }
 
@@ -60,9 +60,11 @@
     let favorites = $derived(boardFavoritesStore.normalSlots.slice(0, 5));
 </script>
 
-{#if browser && uiSettingsStore.showShortcutButtons && !hidden}
+{#if browser && uiSettingsStore.showShortcutButtons}
     <nav
-        class="border-border bg-background/95 fixed bottom-[4.5rem] left-1/2 z-40 flex -translate-x-1/2 items-center gap-1 rounded-full border px-2 py-1.5 shadow-lg backdrop-blur-sm md:bottom-4"
+        class="border-border bg-background/95 fixed bottom-[4.5rem] left-1/2 z-40 flex -translate-x-1/2 items-center gap-1 rounded-full border px-2 py-1.5 shadow-lg backdrop-blur-sm transition-opacity duration-200 md:bottom-4 {dimmed
+            ? 'pointer-events-none opacity-30'
+            : 'opacity-100'}"
         aria-label="단축 버튼"
     >
         <!-- 고정 버튼: 홈 -->

--- a/apps/web/src/lib/plugins/auto-embed/platforms/youtube.ts
+++ b/apps/web/src/lib/plugins/auto-embed/platforms/youtube.ts
@@ -44,7 +44,7 @@ export const youtube: EmbedPlatform = {
                     id: videoId,
                     url,
                     aspectRatio: isShorts ? 177.78 : 56.25, // 9:16 vs 16:9
-                    maxWidth: isShorts ? 400 : undefined,
+                    maxWidth: isShorts ? 400 : 560,
                     params: Object.keys(params).length > 0 ? params : undefined
                 };
             }


### PR DESCRIPTION
- 유튜브 임베드 maxWidth 560px 제한 (댓글 내 과도 확장 방지)
- 플로팅바: input focus 시 완전 숨김 → opacity 30%로 전환

배포 일정은 금요일/토요일 넘어가는 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.