### PR TITLE
perf(layout): isDataRequest 시 hooks/components/schedules 생략 — __data.json 10% 축소

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -88,8 +88,8 @@ export const load: LayoutServerLoad = async ({
                   id: p.manifest.id,
                   name: p.manifest.name,
                   version: p.manifest.version,
-                  hooks: p.manifest.hooks || [],
-                  components: p.manifest.components || [],
+                  hooks: isDataRequest ? [] : p.manifest.hooks || [],
+                  components: isDataRequest ? [] : p.manifest.components || [],
                   settings: p.currentSettings || {}
               }))
             : [];
@@ -128,7 +128,7 @@ export const load: LayoutServerLoad = async ({
         // logoData: previews 제거 (SSR 불필요), schedules는 header 로고에서 사용
         logoData: {
             active: logoData.active,
-            schedules: logoData.schedules ?? [],
+            schedules: isDataRequest ? [] : (logoData.schedules ?? []),
             requestLocale: logoData.requestLocale,
             requestTimeZone: logoData.requestTimeZone
         }


### PR DESCRIPTION
## Summary
SPA 네비게이션(`__data.json`) 요청 시 초기 SSR에서만 필요한 필드를 빈 배열로 생략.

## 변경
`apps/web/src/routes/+layout.server.ts` (3줄):
- `activePlugins.hooks`: `isDataRequest ? [] : (p.manifest.hooks || [])`
- `activePlugins.components`: `isDataRequest ? [] : (p.manifest.components || [])`
- `logoData.schedules`: `isDataRequest ? [] : (logoData.schedules ?? [])`

## 측정 근거
prod /free __data.json 16.5KB 실측 분해:
- activePlugins.hooks: 1,347B (81% of activePlugins)
- activePlugins.components: ~200B
- logoData.schedules: ~300B
- **합계 ~1.7KB/req (10% 축소)**

## 안전성
- `isDataRequest=true`: SPA 네비게이션만 (클라이언트에 이미 layout 보유)
- `isDataRequest=false`: 초기 SSR → 기존과 동일하게 전체 데이터 전달
- 플러그인 훅은 초기 mount 시 1회만 등록 → SPA nav 에서 재로드 불필요

## Test plan
- [x] `pnpm check` 0 errors
- [ ] 초기 SSR: hooks/components/schedules 포함 확인
- [ ] SPA nav (__data.json): hooks/components/schedules 빈 배열 확인
- [ ] 플러그인 훅 동작 회귀 없음 (이모티콘 변환 등)
- [ ] 로고 스케줄 깜빡임 없음