### PR TITLE
fix: CSRF 사파리 호환 + 트위터 dead code 제거 (#11913, #11888)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -806,40 +806,6 @@
         }
     });
 
-    // 댓글 내 Twitter/X 트윗 임베드 (widgets.js 로드)
-    function loadTwitterWidgetsInComments() {
-        if (!commentListEl?.querySelector('.twitter-tweet')) return;
-        const w = window as unknown as {
-            twttr?: { widgets?: { load?: (el: HTMLElement) => void } };
-        };
-        if (w.twttr?.widgets?.load) {
-            w.twttr.widgets.load(commentListEl);
-        } else if (!document.querySelector('script[src*="platform.twitter.com/widgets.js"]')) {
-            const s = document.createElement('script');
-            s.src = 'https://platform.twitter.com/widgets.js';
-            s.async = true;
-            s.onload = () => {
-                const tw = window as unknown as {
-                    twttr?: { widgets?: { load?: (el: HTMLElement) => void } };
-                };
-                tw.twttr?.widgets?.load?.(commentListEl);
-            };
-            document.head.appendChild(s);
-        }
-    }
-
-    onMount(() => {
-        loadTwitterWidgetsInComments();
-    });
-
-    // 댓글 추가/변경 시 Twitter 임베드 재로드
-    $effect(() => {
-        void processedComments.size;
-        if (commentListEl) {
-            tick().then(() => loadTwitterWidgetsInComments());
-        }
-    });
-
     // 댓글 본문 이미지 data-original 폴백 (최적화된 이미지 로드 실패 시 원본으로 대체)
     $effect(() => {
         void processedComments.size;

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -248,26 +248,6 @@
     let proseEl: HTMLDivElement;
 
     onMount(() => {
-        // Twitter 공식 widgets.js 로드 (blockquote → 실제 트윗으로 변환)
-        function loadTwitterWidgets() {
-            if (proseEl?.querySelector('.twitter-tweet')) {
-                const w = window as unknown as {
-                    twttr?: { widgets?: { load?: (el: HTMLElement) => void } };
-                };
-                if (w.twttr?.widgets?.load) {
-                    w.twttr.widgets.load(proseEl);
-                } else if (
-                    !document.querySelector('script[src*="platform.twitter.com/widgets.js"]')
-                ) {
-                    const s = document.createElement('script');
-                    s.src = 'https://platform.twitter.com/widgets.js';
-                    s.async = true;
-                    document.head.appendChild(s);
-                }
-            }
-        }
-        loadTwitterWidgets();
-
         const cleanupLightbox = attachLightbox(proseEl);
 
         return () => {
@@ -300,46 +280,6 @@
         if (browser && proseEl) {
             tick().then(() => highlightAllCodeBlocks(proseEl));
         }
-    });
-
-    // Twitter/X 임베드: renderedHtml 변경 시 widgets.js 로드 + 재호출
-    $effect(() => {
-        void renderedHtml;
-        if (!browser || !proseEl) return;
-        tick().then(() => {
-            if (!proseEl?.querySelector('.twitter-tweet')) return;
-
-            type TwttrWindow = { twttr?: { widgets?: { load?: (el: HTMLElement) => void } } };
-
-            function tryLoad() {
-                (window as unknown as TwttrWindow).twttr?.widgets?.load?.(proseEl);
-            }
-
-            if ((window as unknown as TwttrWindow).twttr?.widgets?.load) {
-                tryLoad();
-            } else {
-                // widgets.js 스크립트가 없으면 삽입
-                if (!document.querySelector('script[src*="platform.twitter.com/widgets.js"]')) {
-                    const s = document.createElement('script');
-                    s.src = 'https://platform.twitter.com/widgets.js';
-                    s.async = true;
-                    s.onload = tryLoad;
-                    document.head.appendChild(s);
-                } else {
-                    // 스크립트 삽입됨 but twttr 아직 없음 → 폴링 대기
-                    let tries = 0;
-                    const poll = setInterval(() => {
-                        tries++;
-                        if ((window as unknown as TwttrWindow).twttr?.widgets?.load) {
-                            clearInterval(poll);
-                            tryLoad();
-                        } else if (tries > 50) {
-                            clearInterval(poll);
-                        }
-                    }, 100);
-                }
-            }
-        });
     });
 
     // 본문 이미지 data-original 폴백 (최적화된 이미지 로드 실패 시 원본으로 대체)

--- a/apps/web/src/routes/api/auth/login/+server.ts
+++ b/apps/web/src/routes/api/auth/login/+server.ts
@@ -106,7 +106,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         cookies.set(CSRF_COOKIE_NAME, session.csrfToken, {
             path: '/',
             httpOnly: false,
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true,
             maxAge: SESSION_COOKIE_MAX_AGE,
             ...domainOpt


### PR DESCRIPTION
- CSRF 쿠키 sameSite strict→lax (사파리 POST 시 쿠키 미전송 문제)
- twttr.widgets.load() dead code 제거 (iframe 방식 전환 후 불필요, setInterval 폴링 포함)
- comment-list.svelte, markdown.svelte 총 95줄 제거

배포 일정은 금요일/토요일 넘어가는 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.