### PR TITLE
test: #1221 revert만 — CPU 회귀 테스트 (1순위)

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -88,8 +88,8 @@ export const load: LayoutServerLoad = async ({
                   id: p.manifest.id,
                   name: p.manifest.name,
                   version: p.manifest.version,
-                  hooks: isDataRequest ? [] : p.manifest.hooks || [],
-                  components: isDataRequest ? [] : p.manifest.components || [],
+                  hooks: p.manifest.hooks || [],
+                  components: p.manifest.components || [],
                   settings: p.currentSettings || {}
               }))
             : [];
@@ -128,7 +128,7 @@ export const load: LayoutServerLoad = async ({
         // logoData: previews 제거 (SSR 불필요), schedules는 header 로고에서 사용
         logoData: {
             active: logoData.active,
-            schedules: isDataRequest ? [] : (logoData.schedules ?? []),
+            schedules: logoData.schedules ?? [],
             requestLocale: logoData.requestLocale,
             requestTimeZone: logoData.requestTimeZone
         }


### PR DESCRIPTION
1221(layout isDataRequest) revert만 적용. 나머지 4개 PR(#1218,#1219,#1220,#1222)은 포함. 카나리 배포 후 pod당 CPU 관찰. 70m 유지되면 #1221이 원인 확정.