### PR TITLE
perf(layout): activePlugins.settings {} → null

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -90,7 +90,7 @@ export const load: LayoutServerLoad = async ({
                   version: p.manifest.version,
                   hooks: p.manifest.hooks || [],
                   components: p.manifest.components || [],
-                  settings: p.currentSettings || {}
+                  settings: p.currentSettings || null
               }))
             : [];
 


### PR DESCRIPTION
## Summary
`activePlugins.settings`: 빈 객체 `{}` → `null`. 클라이언트 `plugin?.settings || {}` fallback 이미 존재.

**isDataRequest 분기 없음** — SSR/SPA 동일 구조 유지 (#1221 교훈).

## Test plan
- [x] `pnpm check` 0 errors
- [ ] 플러그인 settings 정상 동작