### PR TITLE
perf(layout): hooks/components 지연 로딩 — __data.json 1.5KB 축소

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -88,9 +88,9 @@ export const load: LayoutServerLoad = async ({
                   id: p.manifest.id,
                   name: p.manifest.name,
                   version: p.manifest.version,
-                  hooks: p.manifest.hooks || [],
-                  components: p.manifest.components || [],
-                  settings: p.currentSettings || {}
+                  hooks: [],
+                  components: [],
+                  settings: p.currentSettings || null
               }))
             : [];
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -444,6 +444,17 @@
                 });
         }
 
+        // 플러그인 hooks/components 지연 로드 (SSR에서는 빈 배열로 전달하여 __data.json 축소)
+        if ((data.activePlugins?.length ?? 0) > 0) {
+            fetch('/api/layout/hooks')
+                .then((res) => (res.ok ? res.json() : null))
+                .then((payload: { activePlugins?: typeof data.activePlugins } | null) => {
+                    if (!payload?.activePlugins?.length) return;
+                    pluginStore.initFromServer(payload.activePlugins);
+                })
+                .catch(() => {});
+        }
+
         // 부분 layout 데이터 로드 (banners, celebration, plugins, GA4)
         // SSR payload에서 분리하여 __data.json 바이트 절감
         const cachedLayoutInit = readLayoutInitCache();

--- a/apps/web/src/routes/api/layout/hooks/+server.ts
+++ b/apps/web/src/routes/api/layout/hooks/+server.ts
@@ -1,0 +1,25 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+    const { getActivePlugins } = await import('$lib/server/plugins/index.js');
+    const plugins = await getActivePlugins();
+
+    const activePlugins = plugins.map((p) => ({
+        id: p.manifest.id,
+        name: p.manifest.name,
+        version: p.manifest.version,
+        hooks: p.manifest.hooks || [],
+        components: p.manifest.components || [],
+        settings: p.currentSettings || null
+    }));
+
+    return json(
+        { activePlugins },
+        {
+            headers: {
+                'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=1800, max-age=60'
+            }
+        }
+    );
+};


### PR DESCRIPTION
## Summary
`activePlugins.hooks/components`를 SSR에서 항상 빈 배열로 전달, 클라이언트 `onMount`에서 `/api/layout/hooks` API로 별도 로드.

## #1221 교훈 적용
- **`isDataRequest` 분기 0** — SSR/SPA 동일 구조 (`hooks: [], components: []`)
- menus 패턴 참고 (L424-445, 검증됨)
- `pluginStore.initFromServer()`는 id 기반 dedup → hooks 업데이트 시 정상 반영

## 변경 (3 파일)
- `+layout.server.ts`: hooks/components 항상 `[]`, settings `null`
- `+layout.svelte`: onMount에서 `/api/layout/hooks` fetch → pluginStore 업데이트
- `api/layout/hooks/+server.ts` (신규): Cache-Control `s-maxage=300`

## 효과
- __data.json **-1.5KB/req** (hooks 1,347B + components ~200B)
- API 응답 5분 캐시 → 반복 호출 없음
- 플러그인 훅 ~50-100ms 지연 로드 (체감 미미)

## Test plan
- [x] `pnpm check` 0 errors
- [ ] SSR 첫 로드: 이모티콘 변환 정상 (hooks 지연 로드 후)
- [ ] SPA nav: hooks 이미 클라에 등록 → 정상
- [ ] **CPU pod당 <100m 4시간 유지** (invalidation loop 재현 안 됨)
- [ ] /api/layout/hooks 200 OK + 올바른 hooks 데이터