### PR TITLE
fix: 신규회원 닉네임 첫 변경 허용 + 변경 이력 (#11944)

### DIFF
--- a/apps/web/src/lib/server/auth/member-update.ts
+++ b/apps/web/src/lib/server/auth/member-update.ts
@@ -32,6 +32,7 @@ export interface MemberFullProfile {
     mb_image_url: string;
     mb_image_updated_at: string;
     mb_certify: string;
+    mb_datetime: string;
 }
 
 /** 프로필 전체 정보 조회 */
@@ -39,7 +40,8 @@ export async function getMemberFullProfile(mbId: string): Promise<MemberFullProf
     const [rows] = await pool.query<RowDataPacket[]>(
         `SELECT mb_id, mb_nick, mb_email, mb_homepage, mb_signature,
 		        mb_open, mb_mailling, mb_nick_date, mb_hp, mb_password,
-		        mb_leave_date, mb_intercept_date, mb_level, mb_image_url, mb_image_updated_at, mb_certify
+		        mb_leave_date, mb_intercept_date, mb_level, mb_image_url, mb_image_updated_at, mb_certify,
+		        mb_datetime
 		 FROM g5_member WHERE mb_id = ? LIMIT 1`,
         [mbId]
     );
@@ -66,8 +68,8 @@ export async function updateNickname(
         return { success: false, error: '현재 닉네임과 동일합니다.' };
     }
 
-    // 30일 쿨다운 체크
-    if (profile.mb_nick_date) {
+    // 30일 쿨다운 체크 (단, 신규 회원의 첫 변경은 예외)
+    if (profile.mb_nick_date && !isFirstNickChange(profile)) {
         const lastChange = new Date(profile.mb_nick_date);
         const now = new Date();
         const diffDays = Math.floor((now.getTime() - lastChange.getTime()) / (1000 * 60 * 60 * 24));
@@ -86,7 +88,7 @@ export async function updateNickname(
         return { success: false, error: validation.error };
     }
 
-    // UPDATE
+    // UPDATE + 이력 저장
     try {
         const [result] = await pool.query<ResultSetHeader>(
             'UPDATE g5_member SET mb_nick = ?, mb_nick_date = CURDATE() WHERE mb_id = ?',
@@ -95,12 +97,56 @@ export async function updateNickname(
         if (result.affectedRows === 0) {
             return { success: false, error: '회원 정보를 찾을 수 없습니다.' };
         }
+
+        // 닉네임 변경 이력 저장 (실패해도 변경 자체는 성공)
+        try {
+            await pool.query(
+                'INSERT INTO g5_member_nick_history (mb_id, old_nick, new_nick) VALUES (?, ?, ?)',
+                [mbId, profile.mb_nick, trimmed]
+            );
+        } catch (e) {
+            console.error('[updateNickname] 이력 저장 실패:', e);
+        }
     } catch {
         return { success: false, error: '닉네임 변경에 실패했습니다.' };
     }
 
     await invalidateMemberCache(mbId);
     return { success: true };
+}
+
+/**
+ * 신규 회원의 첫 닉네임 변경 여부 판단
+ * - mb_nick_date가 비어있거나 '0000-00-00'이거나
+ * - mb_nick_date가 가입일(mb_datetime)과 같은 날이면 → 아직 한 번도 변경 안 함
+ */
+export function isFirstNickChange(profile: {
+    mb_nick_date?: string | null;
+    mb_datetime?: string | null;
+}): boolean {
+    const nickDate = profile.mb_nick_date || '';
+    if (!nickDate || nickDate.startsWith('0000')) return true;
+    if (!profile.mb_datetime) return false;
+    const regDate = String(profile.mb_datetime).slice(0, 10); // 'YYYY-MM-DD'
+    return nickDate.slice(0, 10) === regDate;
+}
+
+/**
+ * 회원 닉네임 변경 이력 조회 (최신순)
+ */
+export async function getNickHistory(
+    mbId: string,
+    limit = 20
+): Promise<Array<{ old_nick: string; new_nick: string; changed_at: string }>> {
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT old_nick, new_nick, changed_at
+         FROM g5_member_nick_history
+         WHERE mb_id = ?
+         ORDER BY id DESC
+         LIMIT ?`,
+        [mbId, limit]
+    );
+    return rows as Array<{ old_nick: string; new_nick: string; changed_at: string }>;
 }
 
 /**

--- a/apps/web/src/routes/member/settings/+page.server.ts
+++ b/apps/web/src/routes/member/settings/+page.server.ts
@@ -9,7 +9,9 @@ import {
     updateNickname,
     updateEmail,
     changePassword,
-    updateProfile
+    updateProfile,
+    isFirstNickChange,
+    getNickHistory
 } from '$lib/server/auth/member-update.js';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -26,14 +28,17 @@ export const load: PageServerLoad = async ({ locals }) => {
         getMemberFullProfile(mbId)
     ]);
 
-    // 닉네임 변경 가능일 계산
+    // 닉네임 변경 가능일 계산 (신규 회원의 첫 변경은 예외 → 0일)
     let nickChangeDaysLeft = 0;
-    if (memberProfile?.mb_nick_date) {
+    if (memberProfile?.mb_nick_date && !isFirstNickChange(memberProfile)) {
         const lastChange = new Date(memberProfile.mb_nick_date);
         const now = new Date();
         const diffDays = Math.floor((now.getTime() - lastChange.getTime()) / (1000 * 60 * 60 * 24));
         nickChangeDaysLeft = Math.max(0, 30 - diffDays);
     }
+
+    // 닉네임 변경 이력 (최근 20건)
+    const nickHistory = await getNickHistory(mbId, 20).catch(() => []);
 
     return {
         mbId,
@@ -52,6 +57,7 @@ export const load: PageServerLoad = async ({ locals }) => {
               }
             : null,
         nickChangeDaysLeft,
+        nickHistory,
         socialProfiles: profiles.map((p) => ({
             mpNo: p.mp_no,
             provider: p.provider,

--- a/apps/web/src/routes/member/settings/+page.svelte
+++ b/apps/web/src/routes/member/settings/+page.svelte
@@ -458,6 +458,25 @@
                         </div>
                     </form>
 
+                    <!-- 닉네임 변경 이력 -->
+                    {#if data.nickHistory && data.nickHistory.length > 0}
+                        <div class="space-y-2 pt-2">
+                            <p class="text-muted-foreground text-xs font-medium">변경 이력</p>
+                            <ul class="text-muted-foreground space-y-1 text-xs">
+                                {#each data.nickHistory as item (item.changed_at)}
+                                    <li class="flex items-center gap-2">
+                                        <span class="line-through">{item.old_nick}</span>
+                                        <span>→</span>
+                                        <span class="text-foreground">{item.new_nick}</span>
+                                        <span class="text-muted-foreground/70 ml-auto">
+                                            {new Date(item.changed_at).toLocaleDateString('ko-KR')}
+                                        </span>
+                                    </li>
+                                {/each}
+                            </ul>
+                        </div>
+                    {/if}
+
                     <Separator />
 
                     <!-- 이메일 변경 (인증 메일 발송) -->


### PR DESCRIPTION
신규 가입자(mb_nick_date == mb_datetime)가 닉네임 변경 버튼 클릭해도 무반응이던 문제 수정 (30일 쿨다운 때문). 첫 변경은 예외로 허용하고, g5_member_nick_history 테이블에 old/new 저장, 설정 페이지에 본인 이력 표시. 배포 일정은 금요일/토요일 넘어가는 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.