### PR TITLE
fix: 댓글 자동 반영 + 글 하단 목록 메모 표시 (#11946, #11949)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -20,6 +20,8 @@
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { uiSettingsStore, type ListViewMode } from '$lib/stores/ui-settings.svelte.js';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { pluginStore } from '$lib/stores/plugin.svelte.js';
 
     // 코어 레이아웃 초기화 (중복 호출 안전)
     initCoreLayouts();
@@ -68,6 +70,45 @@
     const LayoutComponent = $derived(layoutEntry?.component || CompactLayout);
     const wrapperClass = $derived(layoutEntry?.manifest.wrapperClass || 'space-y-1');
 
+    // 회원 메모 (#11949: 목록과 동일하게 상세 페이지 하단 목록에도 표시)
+    let memoByAuthorId = $state<Record<string, { content: string; color: string } | null>>({});
+    let lastMemoKey = '';
+    async function loadMemos(posts: FreePost[]): Promise<void> {
+        if (!browser) return;
+        if (!authStore.isAuthenticated || !pluginStore.isPluginActive('member-memo')) {
+            memoByAuthorId = {};
+            return;
+        }
+        const ids = [...new Set(posts.map((p) => p.author_id).filter(Boolean))];
+        if (ids.length === 0) {
+            memoByAuthorId = {};
+            return;
+        }
+        const key = ids.sort().join(',');
+        if (key === lastMemoKey) return;
+        lastMemoKey = key;
+        try {
+            const res = await fetch(
+                `/api/v1/members/batch/memo?ids=${ids.map(encodeURIComponent).join(',')}`,
+                { credentials: 'include' }
+            );
+            if (!res.ok) return;
+            const json = await res.json();
+            const payload = (json?.data ?? {}) as Record<
+                string,
+                { content?: string; color?: string }
+            >;
+            const next: Record<string, { content: string; color: string } | null> = {};
+            for (const id of ids) {
+                const m = payload[id];
+                next[id] = m?.content ? { content: m.content, color: m.color ?? 'yellow' } : null;
+            }
+            memoByAuthorId = next;
+        } catch {
+            // 실패 시 메모 표시 안 함 (기능 저하만, 에러 무시)
+        }
+    }
+
     // 프로모션 셔플 (매 렌더마다 랜덤)
     let shuffledPromos = $derived.by(() => {
         const arr = [...promotionPosts];
@@ -78,6 +119,11 @@
         return arr;
     });
     let posts = $state<FreePost[]>(initialPosts);
+
+    // posts 변경 시 메모 로드 (#11949)
+    $effect(() => {
+        loadMemos(posts);
+    });
     let loading = $state(initialPosts.length === 0);
     let error = $state<string | null>(null);
 
@@ -250,6 +296,7 @@
                 <LayoutComponent
                     {post}
                     {displaySettings}
+                    memo={memoByAuthorId[post.author_id] ?? null}
                     href="/{boardId}/{post.id}{currentPage > 1 ? `?page=${currentPage}` : ''}"
                     isRead={showReadState && readPostsStore.isRead(boardId, post.id)}
                     isPriority={i === 0}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1191,7 +1191,21 @@
                 images
             });
 
-            // 서버에서 정렬된 댓글 목록 다시 가져오기
+            // Optimistic update: 서버 응답 즉시 목록에 추가 (#11946)
+            if (newComment && newComment.id) {
+                const optimistic = {
+                    ...newComment,
+                    author_id: authStore.user.mb_id || '',
+                    author_image_url: authStore.user.mb_image || '',
+                    author_level: authStore.user.mb_level ?? 0
+                } as unknown as FreeComment;
+                if (!comments.some((c) => c.id === optimistic.id)) {
+                    comments = [...comments, optimistic];
+                    commentsTotal = commentsTotal + 1;
+                }
+            }
+
+            // 서버에서 정렬된 댓글 목록 다시 가져오기 (중복 제거 포함)
             await refetchComments();
 
             // @멘션 알림 전송 (fire-and-forget)
@@ -1231,6 +1245,20 @@
                 is_secret: isSecret,
                 images
             });
+
+            // Optimistic update: 대댓글도 즉시 목록에 추가 (#11946)
+            if (replyComment && replyComment.id) {
+                const optimistic = {
+                    ...replyComment,
+                    author_id: authStore.user.mb_id || '',
+                    author_image_url: authStore.user.mb_image || '',
+                    author_level: authStore.user.mb_level ?? 0
+                } as unknown as FreeComment;
+                if (!comments.some((c) => c.id === optimistic.id)) {
+                    comments = [...comments, optimistic];
+                    commentsTotal = commentsTotal + 1;
+                }
+            }
 
             // 서버에서 정렬된 댓글 목록 다시 가져오기
             await refetchComments();


### PR DESCRIPTION
refetchComments 완료 전까지 댓글이 표시되지 않아 수동 새로고침 필요하던 문제. Optimistic update로 서버 응답 즉시 목록에 추가 (중복 체크). 배포 일정은 금요일/토요일 넘어가는 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.