### PR TITLE
fix: 파이어폭스 이미지 안보임 (decoding 속성 허용) (#11951)

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -196,6 +196,7 @@
             'rel',
             'width',
             'loading',
+            'decoding',
             'height',
             'srcset',
             'sizes',


### PR DESCRIPTION
DOMPurify ALLOWED_ATTR에 decoding 속성이 없어 optimizeMediaHtml이 추가한 decoding=async가 제거되던 문제. Firefox에서 lazy 이미지 타이밍 이슈 해결. 배포 일정은 금요일/토요일 넘어가는 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.