### PR TITLE
fix: Apple OAuth 콜백 CSRF 면제 (#11875)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -239,7 +239,8 @@ const CSRF_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
 /** CSRF 검증에서 제외할 경로 */
 const CSRF_EXEMPT_PATHS = [
-    '/plugin/social/', // OAuth 콜백 (프로바이더가 POST)
+    '/auth/callback/', // OAuth 콜백 (Apple response_mode=form_post 포함 외부 프로바이더 POST)
+    '/plugin/social/', // OAuth 콜백 (레거시 경로)
     '/api/', // SvelteKit 내부 API 라우트 (same-origin, SvelteKit Origin 검증으로 보호)
     '/cert/inicis/result' // KG이니시스 인증 콜백 (외부 POST)
 ];


### PR DESCRIPTION
Apple Sign In은 response_mode=form_post로 외부에서 POST 콜백을 보내는데, 기존 로그인 세션이 있으면 CSRF 검증에 걸려 403. /auth/callback/ 경로 면제 추가. 배포 일정은 금요일/토요일 넘어가는 새벽이며, 사전 확인은 canary.damoang.net 에서 가능합니다.