### PR TITLE
fix(comments): 작성자 배지 색상 amber→blue (#11900)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1050,7 +1050,7 @@
                             <LevelBadge level={memberLevelStore.getLevel(comment.author_id)} />
                             {#if postAuthorId && comment.author_id === postAuthorId}
                                 <span
-                                    class="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+                                    class="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
                                     >작성자</span
                                 >
                             {/if}
@@ -1150,7 +1150,7 @@
                                         {/if}
                                         {#if postAuthorId && comment.author_id === postAuthorId}
                                             <span
-                                                class="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+                                                class="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
                                                 >작성자</span
                                             >
                                         {/if}


### PR DESCRIPTION
## 문제
버그 #11900: 댓글에 표시되는 **작성자** 배지(노란색/amber)가 메모 플러그인의 노란 메모와 색상이 충돌하여 구분이 어려움.

## 해결
- 작성자 배지 색상을 amber → blue 로 변경
- Light: `bg-blue-100 text-blue-700`
- Dark: `bg-blue-900/30 text-blue-300`
- Reddit의 OP 인디케이터와 유사한 톤

## 변경 파일
- \`apps/web/src/lib/components/features/board/comment-list.svelte\`
  - chat 레이아웃 (L1053)
  - 일반 레이아웃 (L1153)

## Test plan
- [ ] 게시글 상세 페이지에서 작성자가 단 댓글에 파란색 작성자 배지 표시 확인
- [ ] 다크모드에서 대비 양호 확인
- [ ] 메모 배지(노란색)와 시각적으로 명확히 구분되는지 확인
- [ ] chat/normal 두 레이아웃 모두에서 표시 확인