### PR TITLE
fix(search): /search content-type 헤더 직렬화 허용 (#11937)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -705,7 +705,8 @@ export const handle: Handle = async ({ event, resolve }) => {
 
         const renderPromise = (async () => {
             const response = await resolve(event, {
-                transformPageChunk: ({ html }) => rewriteImmutableAssetUrls(html)
+                transformPageChunk: ({ html }) => rewriteImmutableAssetUrls(html),
+                filterSerializedResponseHeaders: (name) => name.toLowerCase() === 'content-type'
             });
 
             const contentType = response.headers.get('Content-Type') || '';
@@ -772,7 +773,8 @@ export const handle: Handle = async ({ event, resolve }) => {
                 html.replace('<html lang="ko">', `<html lang="ko"${cls}${sty}>`),
                 assetRecoveryBust
             );
-        }
+        },
+        filterSerializedResponseHeaders: (name) => name.toLowerCase() === 'content-type'
     });
 
     // CORS 헤더 (허용된 origin만 credentials 허용)


### PR DESCRIPTION
## 문제
전역 검색(`/search`) 페이지가 로그인 상태에서도 결과를 못 보여주고 "검색 중 오류가 발생했습니다" 토스트만 표시. 웹 파드 로그:

\`\`\`
전체 검색 에러: Error: Failed to get response header "content-type" — it must be included by the `filterSerializedResponseHeaders` option
\`\`\`

## 원인 체인
1. \`/search/+page.ts\` (universal load)가 SSR에서 내부 fetch로 \`/api/search\` 호출
2. SvelteKit이 해당 응답을 클라이언트 hydration용으로 직렬화
3. 기본 \`filterSerializedResponseHeaders\`가 \`content-type\`을 제외
4. \`safeJson()\`이 \`response.headers.get('content-type')\` 읽을 때 SvelteKit이 Error throw
5. catch 블록 → \`error: '검색 중 오류가 발생했습니다.'\`

## 해결
\`hooks.server.ts\`의 두 \`resolve()\` 호출(SSR 캐시 경로, 기본 경로) 모두에 \`filterSerializedResponseHeaders: (name) => name.toLowerCase() === 'content-type'\` 추가.

## 관련 PR
- #1211 (Sphinx wr_is_notice 컬럼 에러) — 이미 머지/배포되어 게시판 내 검색은 정상화. 이 PR은 전역 검색 페이지 별도 이슈 해결.

## Test plan
- [ ] 로그인 상태에서 상단 돋보기 → 키워드 입력 → 검색 결과 정상 렌더 확인
- [ ] 비로그인 시 "로그인 후 검색할 수 있습니다" 토스트 정상 표시
- [ ] \`/search?q=...\` 직접 접근 시 결과 노출 확인
- [ ] 게시판 내 검색(\`/free?sfl=...&stx=...\`)은 영향 없는지 회귀 확인