### PR TITLE
fix(ssr-cache): SSR 캐시 키에 query string 포함 (#11895)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -651,7 +651,9 @@ export const handle: Handle = async ({ event, resolve }) => {
         !bypassSsrCacheForRecovery &&
         (isHomePage || isBoardList || isPostDetail);
     if (!isDataRequest && isAnonymousPublicHtml) {
-        const cacheKey = isHomePage ? '/' : pathname;
+        // 캐시 키에 query string 포함 — pathname만 쓰면 ?page=N 요청이
+        // ?page=1 캐시에 섞여 "뒤로 간 것처럼" 보이는 교차 오염 발생.
+        const cacheKey = isHomePage ? '/' : pathname + event.url.search;
         const cacheTtl = isHomePage
             ? SSR_CACHE_TTL_HOME
             : isPostDetail


### PR DESCRIPTION
## 문제
비로그인 상태에서 자유게시판 메뉴 클릭과 F 단축키 이용 시 페이지 내용이 다르고, 가끔 "랜덤하게 과거 페이지로 이동되는 현상" 발생 (#11895).

## 원인
\`hooks.server.ts\` 비로그인 SSR 응답 캐시의 캐시 키가 **pathname만** 사용:

\`\`\`ts
const cacheKey = isHomePage ? '/' : pathname;
\`\`\`

그 결과:
- \`/free\` (page 1), \`/free?page=2\`, \`/free?page=3\` 요청이 모두 **같은 키**로 저장됨
- 먼저 캐시된 요청의 응답이 뒤에 오는 다른 페이지 요청에 그대로 반환
- 사용자 관점: page=3을 눌렀는데 page=1이 표시되는 "과거로 이동" 현상

1 post 차이 현상도 여러 pod에 각기 다른 스냅샷이 캐시되는 분산 캐시 코히런스 특성이지만, query string 오염이 더 큰 혼란의 원인.

## 해결
캐시 키를 \`pathname + event.url.search\`로 변경. 홈('/')은 쿼리 없는 경로이므로 기존대로 유지.

## Test plan
- [ ] 비로그인 상태에서 \`/free?page=3\` 접근 → page 3 내용 정상 표시
- [ ] \`/free\` 방문 후 \`/free?page=5\`로 이동 → 이전 캐시(page 1) 섞이지 않음
- [ ] F 단축키와 메뉴 클릭 모두 같은 페이지 내용 표시 (같은 pod 가정)
- [ ] 홈(/) 캐시는 기존 동작 유지 (HIT 비율 감소 없음)