### PR TITLE
fix(home): 대문 위젯에 키워드 차단 필터 적용 (#11850)

### DIFF
--- a/widgets/post-list/index.svelte
+++ b/widgets/post-list/index.svelte
@@ -21,6 +21,7 @@
     import GivingView from './layouts/giving-view.svelte';
     import TradeView from './layouts/trade-view.svelte';
     import type { EconomyPost, GalleryPost, GroupTabsData, NewsPost } from '$lib/api/types';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte';
 
     interface DefaultLayoutPost {
         id: number;
@@ -138,10 +139,19 @@
     const groupTabsData = $derived(
         (prefetchData as GroupTabsData | null | undefined) ?? indexWidgetsStore.groupTabs
     );
-    const defaultPosts = $derived(fetchedPosts as DefaultLayoutPost[]);
-    const messagePosts = $derived(fetchedPosts as MessageLayoutPost[]);
-    const givingPosts = $derived(fetchedPosts as GivingLayoutPost[]);
-    const tradePosts = $derived(fetchedPosts as TradeLayoutPost[]);
+    // 키워드 차단 필터: 대문 위젯에도 설정된 차단 키워드 반영
+    const defaultPosts = $derived(
+        (fetchedPosts as DefaultLayoutPost[]).filter((p) => !uiSettingsStore.isMuted(p.title ?? ''))
+    );
+    const messagePosts = $derived(
+        (fetchedPosts as MessageLayoutPost[]).filter((p) => !uiSettingsStore.isMuted(p.title ?? ''))
+    );
+    const givingPosts = $derived(
+        (fetchedPosts as GivingLayoutPost[]).filter((p) => !uiSettingsStore.isMuted(p.title ?? ''))
+    );
+    const tradePosts = $derived(
+        (fetchedPosts as TradeLayoutPost[]).filter((p) => !uiSettingsStore.isMuted(p.title ?? ''))
+    );
 
     // 기존 스토어 데이터가 아닌 경우 API에서 fetch
     $effect(() => {


### PR DESCRIPTION
## 문제
사용자 설정의 키워드 차단(NBA 등)이 게시판 상세(/[boardId])에서는 적용되지만 **대문(홈)에서는 안 먹음**. 특정 게시판에 들어가야만 필터링되는 현상 (#11850).

## 원인
- [boardId]/+page.svelte는 PR #1230(#11935)에서 \`uiSettingsStore.isMuted()\` 필터 적용됨
- 홈 post-list 위젯(\`widgets/post-list/index.svelte\`)은 \`fetchedPosts\`를 필터 없이 렌더링

## 해결
\`defaultPosts\`, \`messagePosts\`, \`givingPosts\`, \`tradePosts\` 파생 시 \`isMuted(title)\` 으로 차단.

## 범위
- ✅ 범용 게시판 위젯 (자유/사용기/강좌/정보 등 layouts/*-view.svelte)
- ❌ native 전용 컴포넌트 (NewBoard, EconomyTabs, GalleryGrid, GroupTabs) — 추후 검토. 오늘은 사용자 제보 경로 위주 최소 범위.

## Test plan
- [ ] UI 설정에서 특정 키워드(예: NBA) 차단 등록
- [ ] 대문 자유게시판 위젯에 해당 키워드 글 **안 보임** 확인
- [ ] /free 상세 페이지에서도 차단 동작 유지
- [ ] 차단 키워드 없을 때 글 수 변화 없음
- [ ] 거래/나눔/메모 위젯도 동일 동작