### PR TITLE
perf(layout): activePlugins.settings를 /admin 경로에만 전송

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -91,6 +91,8 @@ export const load: LayoutServerLoad = async ({
               };
 
     // 실패 로깅 (크래시 안 함)
+    // settings는 /admin 경로에서만 필요 (관리자 UI) → 일반 페이지에서 null로 축소 (__data.json 절감)
+    const isAdminPath = url.pathname.startsWith('/admin');
     const activePlugins =
         pluginsResult.status === 'fulfilled'
             ? pluginsResult.value.map((p) => ({
@@ -99,7 +101,7 @@ export const load: LayoutServerLoad = async ({
                   version: p.manifest.version,
                   hooks: [],
                   components: [],
-                  settings: p.currentSettings || null
+                  settings: isAdminPath ? p.currentSettings || null : null
               }))
             : [];
 


### PR DESCRIPTION
## Summary

- \`+layout.server.ts\`에서 \`activePlugins[].settings\`를 \`url.pathname.startsWith('/admin')\`일 때만 전송
- 일반 페이지 __data.json에서 플러그인 settings 제거 (~1-3KB/req 절감)

## 왜

#1226 (hooks/components 지연 로딩)에 이어 추가 축소. 일반 유저는 플러그인 settings가 필요 없음 (관리자 UI만 사용).

## 안전성

- **#1221 패턴 아님**: \`url.pathname\` 분기는 SSR/SPA 모두 동일 URL에서 동일 결과 반환 (invalidation loop 불가)
- \`isDataRequest\` 분기는 사용하지 않음 (금지 사항)
- /admin 페이지 접근 시 settings 정상 로드 (SPA nav도 동일)

## 효과

- req당 ~1-3KB 절감
- 11.4M req/day × 2KB = **~23GB/day** = ~\$0.7/day CF 트래픽 절감

## Test plan

- [ ] dev /__data.json에 \`activePlugins[].settings === null\` 확인
- [ ] dev /admin/__data.json에 \`activePlugins[].settings\` 존재 확인
- [ ] SPA nav \`/\` → \`/admin\` → settings 로드 확인
- [ ] 배포 후 4시간 CPU 회귀 모니터링 (#1221 재발 방지)