### PR TITLE
fix(comments): 11번째+ 댓글 공감자 리스트 팝업 + Invalid Date 방어 (#11963)

### DIFF
--- a/apps/web/src/lib/utils/format-date.ts
+++ b/apps/web/src/lib/utils/format-date.ts
@@ -11,11 +11,13 @@
  * 행 높이가 일정하게 유지됨
  */
 export function formatDateCompact(dateString: string): string {
+    if (!dateString) return '';
     let normalized = dateString;
     if (/^\d{8}$/.test(dateString)) {
         normalized = `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
     }
     const date = new Date(normalized);
+    if (isNaN(date.getTime())) return '';
     const now = new Date();
 
     const toSeoulDateStr = (d: Date) => d.toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
@@ -49,12 +51,17 @@ export function isToday(dateString: string): boolean {
 }
 
 export function formatDate(dateString: string): string {
+    // 빈 값/무효 입력은 빈 문자열 반환. 과거 Invalid Date → toLocaleTimeString 이
+    // "Invalid Date" (production minify 시 "va.id.Da" 등)로 노출되던 문제 방지.
+    if (!dateString) return '';
+
     // Gnuboard YYYYMMDD 형식 (mb_leave_date 등) → ISO 변환
     let normalized = dateString;
     if (/^\d{8}$/.test(dateString)) {
         normalized = `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
     }
     const date = new Date(normalized);
+    if (isNaN(date.getTime())) return '';
     const now = new Date();
 
     // 서울 시간 기준 YYYY-MM-DD 문자열 추출

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -91,6 +91,8 @@ export const load: LayoutServerLoad = async ({
               };
 
     // 실패 로깅 (크래시 안 함)
+    // settings는 /admin 경로에서만 필요 (관리자 UI) → 일반 페이지에서 null로 축소 (__data.json 절감)
+    const isAdminPath = url.pathname.startsWith('/admin');
     const activePlugins =
         pluginsResult.status === 'fulfilled'
             ? pluginsResult.value.map((p) => ({
@@ -99,7 +101,7 @@ export const load: LayoutServerLoad = async ({
                   version: p.manifest.version,
                   hooks: [],
                   components: [],
-                  settings: p.currentSettings || null
+                  settings: isAdminPath ? p.currentSettings || null : null
               }))
             : [];
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
@@ -15,8 +15,16 @@ import { getCommentLikersVersion } from '$lib/server/member-activity-cache';
 
 const COMMENT_LIKERS_CACHE_TTL_SEC = 15;
 const INTERNAL_COMMENT_LIKERS_LIMIT = 50;
-const EXTERNAL_COMMENT_LIKERS_LIMIT = 10;
-const MAX_EXTERNAL_COMMENT_LIKERS_PAGE = 1;
+const EXTERNAL_COMMENT_LIKERS_LIMIT = 50;
+const MAX_EXTERNAL_COMMENT_LIKERS_PAGE = 5;
+
+// bg_datetime 이 null / '' / '0000-...' 일 때 Invalid Date 로 렌더되어
+// "va.id.Da" (minified "Invalid Date") 로 보이는 버그 방지.
+function toSafeIso(raw: unknown): string {
+    const s = typeof raw === 'string' ? raw : raw == null ? '' : String(raw);
+    if (!s || s.startsWith('0000')) return '';
+    return s.replace(' ', 'T') + 'Z';
+}
 
 /** IP 마스킹: 두 번째 옥텟을 ♡로 (예: 222.114.55.158 → 222.♡.55.158) */
 function maskIp(ip: string | null | undefined): string {
@@ -125,7 +133,7 @@ export const GET: RequestHandler = async ({ params, url, cookies, request }) => 
             mb_image: row.mb_image_url || '',
             mb_image_updated_at: row.mb_image_updated_at || undefined,
             bg_ip: isAuthenticated ? maskIp(row.bg_ip) : '',
-            liked_at: String(row.bg_datetime).replace(' ', 'T') + 'Z'
+            liked_at: toSafeIso(row.bg_datetime)
         }));
 
         const payload = {

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
@@ -16,8 +16,19 @@ import { getCommentLikersBatchVersion } from '$lib/server/member-activity-cache'
 const COMMENT_LIKERS_BATCH_CACHE_TTL_SEC = 15;
 const INTERNAL_COMMENT_LIKERS_BATCH_LIMIT = 50;
 const EXTERNAL_COMMENT_LIKERS_BATCH_LIMIT = 5;
-const INTERNAL_COMMENT_LIKERS_BATCH_IDS = 20;
-const EXTERNAL_COMMENT_LIKERS_BATCH_IDS = 10;
+const INTERNAL_COMMENT_LIKERS_BATCH_IDS = 50;
+// 외부 배치 IDs 한도. 과거 10이면 11번째 이후 댓글은 preview/팝업 데이터가 아예 비어,
+// 사용자가 해당 댓글의 공감자 리스트를 열 수 없었음.
+const EXTERNAL_COMMENT_LIKERS_BATCH_IDS = 50;
+
+// bg_datetime 이 null / '' / '0000-00-00 00:00:00' 일 때 new Date() 가
+// Invalid Date 를 반환하며, 이후 toLocaleString() 결과가 minify 돼서
+// "va.id.Da" 같은 값으로 노출됨.
+function toSafeIso(raw: unknown): string {
+    const s = typeof raw === 'string' ? raw : raw == null ? '' : String(raw);
+    if (!s || s.startsWith('0000')) return '';
+    return s.replace(' ', 'T') + 'Z';
+}
 
 function maskIp(ip: string | null | undefined): string {
     if (!ip) return '';
@@ -164,7 +175,7 @@ export const GET: RequestHandler = async ({ params, url, cookies, request }) => 
                     mb_image: row.mb_image_url || '',
                     mb_image_updated_at: row.mb_image_updated_at || undefined,
                     bg_ip: isAuthenticated ? maskIp(row.bg_ip) : '',
-                    liked_at: String(row.bg_datetime).replace(' ', 'T') + 'Z'
+                    liked_at: toSafeIso(row.bg_datetime)
                 });
             }
         }


### PR DESCRIPTION
## 증상
모바일에서 게시글 상세 하단 댓글 34개 중 **~20번째 이후** 댓글:
- 공감 아바타 프리뷰/+N 뱃지 **미노출**
- ♥ 숫자만 보이고 **클릭해도 공감자 팝업 안 열림**
- 공감자 팝업에서 시간 라벨이 **\`va.id.Da\`** 같은 깨진 문자열

## Root cause
1. \`/api/boards/{b}/posts/{p}/comments/likers-batch\` 의 외부 요청 한도:
   \`\`\`
   EXTERNAL_COMMENT_LIKERS_BATCH_IDS = 10
   \`\`\`
   클라이언트는 모든 commentIds(34개)를 한 번에 보내는데, 서버는 10개로 잘라버림.
   11번째 이후 댓글은 응답에 없어 \`commentLikersList\`에 키 부재 → comment-list.svelte의 \`AvatarStack\` 블록 조건(\`commentLikersList.has(...)\`) 불만족 → 렌더 안 됨 → 클릭 핸들러도 없음.

2. \`bg_datetime\` 이 null 또는 \`'0000-00-00 00:00:00'\` 인 경우:
   \`\`\`ts
   liked_at: String(row.bg_datetime).replace(' ', 'T') + 'Z'
   // → 'nullZ' 또는 '0000-00-00T00:00:00Z'
   \`\`\`
   \`new Date(...)\` → Invalid Date → \`toLocaleTimeString()\` → \"Invalid Date\" → production 번들 minify 로 \"va.id.Da\" 로 렌더.

## Fix
| 파일 | 변경 |
|---|---|
| \`likers-batch/+server.ts\` | EXTERNAL/INTERNAL BATCH_IDS 50 통일 + \`toSafeIso()\` |
| \`[commentId]/likers/+server.ts\` | EXTERNAL 상한 50, page 5 허용 + \`toSafeIso()\` |
| \`format-date.ts\` | \`formatDate\`/\`formatDateCompact\` 에 빈 값/Invalid Date guard |

\`toSafeIso\` 는 null/empty/\`'0000...'\` 을 빈 문자열로 반환 → \`formatDate('')\` 도 빈 문자열 반환 → UI에 깨진 라벨 대신 공백.

## Test plan
- [ ] 댓글 많은 게시글(≥ 20개)에서 15번째, 25번째 댓글의 공감 아바타 프리뷰/팝업 정상 노출 확인
- [ ] 공감자 팝업 시간 라벨 정상 (HH:MM / MM.DD / YY.MM.DD 등)
- [ ] 비정상 \`bg_datetime\` row 가 섞여도 \"va.id.Da\"/\"Invalid Date\" 미노출
- [ ] 비로그인 상태에서도 동일 동작
- [ ] 기존 공감 기능 회귀 없음 (좋아요, 취소, 단일 댓글 공감자)