### PR TITLE
feat(board-list): 삭제 예정 게시글 '삭제예정' 뱃지 (#11825)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -67,6 +67,7 @@ export interface FreePost {
     link2_affiliate?: boolean; // 링크2 제휴 변환 여부
     deleted_at?: string | null; // 소프트 삭제 시점
     deleted_by?: string | null; // 삭제한 사용자 ID
+    scheduled_delete_at?: string | null; // 삭제 예약된 시점 (g5_scheduled_deletes.scheduled_at, SSR enrichment)
     is_left?: boolean; // 작성자 탈퇴 여부 (SSR enrichment)
     report_count?: number | string; // wr_7 값: 숫자(신고수) 또는 "lock"(잠김)
     // 확장 필드 (PHP wr_1~wr_10 매핑)

--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -96,6 +96,14 @@
                                             class="shrink-0 px-1.5 py-0 text-[10px]">19</Badge
                                         >
                                     {/if}
+                                    {#if post.scheduled_delete_at}
+                                        <Badge
+                                            variant="outline"
+                                            class="shrink-0 border-amber-300 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+                                            title={`삭제 예정: ${post.scheduled_delete_at}`}
+                                            >삭제예정</Badge
+                                        >
+                                    {/if}
                                     {#if post.is_secret}
                                         <Lock class="text-muted-foreground h-4 w-4 shrink-0" />
                                     {/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -192,6 +192,13 @@
                             >19</Badge
                         >
                     {/if}
+                    {#if post.scheduled_delete_at}
+                        <Badge
+                            variant="outline"
+                            class="shrink-0 border-amber-300 bg-amber-50 px-1 py-0 text-[10px] text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+                            title={`삭제 예정: ${post.scheduled_delete_at}`}>삭제예정</Badge
+                        >
+                    {/if}
                     {#if post.is_secret}
                         <Lock class="text-muted-foreground h-3.5 w-3.5 shrink-0" />
                     {/if}

--- a/apps/web/src/lib/server/scheduled-deletes.ts
+++ b/apps/web/src/lib/server/scheduled-deletes.ts
@@ -1,0 +1,46 @@
+/**
+ * 삭제 예약 게시글 서버사이드 배치 조회 (SSR용)
+ *
+ * g5_scheduled_deletes 테이블에서 pending 상태 레코드만 조회해
+ * (wr_id → scheduled_at) 매핑을 반환한다. 목록에서 "삭제예정" 뱃지
+ * 표시에 사용.
+ */
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+const MAX_IDS = 500;
+
+interface ScheduledRow extends RowDataPacket {
+    wr_id: number;
+    scheduled_at: string;
+}
+
+/**
+ * @param boardId bo_table 값
+ * @param postIds wr_id 숫자 배열
+ * @returns Map<wr_id, scheduled_at ISO string>
+ */
+export async function fetchScheduledDeletes(
+    boardId: string,
+    postIds: number[]
+): Promise<Map<number, string>> {
+    const safeBoardId = boardId.replace(/[^a-zA-Z0-9_-]/g, '');
+    const validIds = postIds.filter((n) => Number.isFinite(n) && n > 0).slice(0, MAX_IDS);
+
+    if (!safeBoardId || validIds.length === 0) return new Map();
+
+    const placeholders = validIds.map(() => '?').join(',');
+    const [rows] = await pool.query<ScheduledRow[]>(
+        `SELECT wr_id, scheduled_at FROM g5_scheduled_deletes
+         WHERE bo_table = ? AND wr_id IN (${placeholders})
+           AND wr_is_comment = 0 AND status = 'pending'`,
+        [safeBoardId, ...validIds]
+    );
+
+    const result = new Map<number, string>();
+    for (const row of rows) {
+        const val = row.scheduled_at;
+        if (val) result.set(Number(row.wr_id), String(val));
+    }
+    return result;
+}

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -10,6 +10,7 @@ import type { PromotionBoardPost } from '$lib/server/ads/promotion.js';
 import { backendFetch as bFetch, createAuthHeaders } from '$lib/server/backend-fetch.js';
 import { fetchMemberImagesWithTimestamp } from '$lib/server/member-images.js';
 import { fetchWithdrawnMemberIds } from '$lib/server/withdrawn-members.js';
+import { fetchScheduledDeletes } from '$lib/server/scheduled-deletes.js';
 import { createCache } from '$lib/server/cache.js';
 import { getCachedBoard, resolveCanonicalBoardId } from '$lib/server/board-cache.js';
 import { resolveGivingMeta } from '$lib/features/giving/model.js';
@@ -344,10 +345,12 @@ export const load: PageServerLoad = async ({
             const allPosts = [...posts, ...notices];
             if (allPosts.length > 0) {
                 const mbIds = [...new Set(allPosts.map((p) => p.author_id).filter(Boolean))];
+                const postIds = allPosts.map((p) => Number(p.id)).filter((n) => Number.isFinite(n));
                 try {
-                    const [imageMap, withdrawnIds] = await Promise.all([
+                    const [imageMap, withdrawnIds, scheduledMap] = await Promise.all([
                         fetchMemberImagesWithTimestamp(mbIds),
-                        fetchWithdrawnMemberIds(mbIds)
+                        fetchWithdrawnMemberIds(mbIds),
+                        fetchScheduledDeletes(boardId, postIds)
                     ]);
                     for (const p of allPosts) {
                         if (p.author_id && imageMap[p.author_id]) {
@@ -357,6 +360,8 @@ export const load: PageServerLoad = async ({
                         if (p.author_id && withdrawnIds.has(p.author_id)) {
                             p.is_left = true;
                         }
+                        const sched = scheduledMap.get(Number(p.id));
+                        if (sched) p.scheduled_delete_at = sched;
                     }
                 } catch {
                     // ignore
@@ -528,10 +533,12 @@ export const load: PageServerLoad = async ({
         }
         if (allPosts.length > 0) {
             const mbIds = [...new Set(allPosts.map((p) => p.author_id).filter(Boolean))];
+            const postIds = allPosts.map((p) => Number(p.id)).filter((n) => Number.isFinite(n));
             try {
-                const [imageMap, withdrawnIds] = await Promise.all([
+                const [imageMap, withdrawnIds, scheduledMap] = await Promise.all([
                     fetchMemberImagesWithTimestamp(mbIds),
-                    fetchWithdrawnMemberIds(mbIds)
+                    fetchWithdrawnMemberIds(mbIds),
+                    fetchScheduledDeletes(boardId, postIds)
                 ]);
                 for (const p of allPosts) {
                     if (p.author_id && imageMap[p.author_id]) {
@@ -541,6 +548,8 @@ export const load: PageServerLoad = async ({
                     if (p.author_id && withdrawnIds.has(p.author_id)) {
                         p.is_left = true;
                     }
+                    const sched = scheduledMap.get(Number(p.id));
+                    if (sched) p.scheduled_delete_at = sched;
                 }
             } catch {
                 // 조회 실패해도 게시글 표시는 정상 진행


### PR DESCRIPTION
## 문제
상세 페이지에는 \"이 게시물은 삭제가 예약되어 있습니다\" amber 배너가 표시되지만 목록에는 어떤 표시도 없음. 사용자가 삭제 예정 글을 식별 못 함 (#11825).

## 해결
1. **신규 \`\$lib/server/scheduled-deletes.ts\`**: \`g5_scheduled_deletes\` 테이블의 pending 레코드를 wr_id 배치로 조회
2. **\`[boardId]/+page.server.ts\` 두 enrichment 블록**: 기존 프로필/탈퇴 enrichment 옆에 \`fetchScheduledDeletes\` 추가, \`scheduled_at\` 을 \`post.scheduled_delete_at\` 필드로 주입 (N+1 없음, Promise.all 병렬)
3. **\`FreePost\` 타입**에 \`scheduled_delete_at?: string | null\` 필드 추가
4. **classic / card 레이아웃**에 amber 뱃지 추가 (is_adult 다음 위치)

## 범위 한정
기본 사용자 경험인 classic + card 두 레이아웃만 우선 적용. 나머지 11개 레이아웃(gallery, webzine, trade, giving, notice 등)은 동일 패턴으로 후속 PR에서 확장 예정.

## Test plan
- [ ] \`/bug\` 목록 방문 — 삭제 예약된 글에 amber \"삭제예정\" 뱃지 표시 확인
- [ ] 뱃지 hover/tooltip으로 예정 일시 확인
- [ ] 삭제 예약 취소된 글에는 뱃지 미표시 (status='pending' 조건)
- [ ] 이미 삭제된 글(deleted_at)에는 기존 삭제 처리 유지
- [ ] 기존 19+/비밀/카테고리 뱃지 배치 영향 없음
- [ ] 쿼리 성능 — 500개 제한, \`(bo_table, wr_id)\` 인덱스 사용