### PR TITLE
fix(my-memos): 메모 상세 팝오버 내 URL 링크 클릭 가능 (#11771)

### DIFF
--- a/apps/web/src/routes/my/memos/+page.svelte
+++ b/apps/web/src/routes/my/memos/+page.svelte
@@ -66,6 +66,24 @@
         goto('/my/memos');
     }
 
+    // 메모 텍스트 내 URL 을 클릭 가능한 링크 세그먼트로 분리 (XSS 안전: 텍스트 그대로 바인딩)
+    const URL_RE = /https?:\/\/[^\s<>"'`]+/g;
+    function tokenizeMemo(
+        s: string | null | undefined
+    ): Array<{ type: 'text' | 'link'; value: string }> {
+        if (!s) return [];
+        const out: Array<{ type: 'text' | 'link'; value: string }> = [];
+        let last = 0;
+        for (const m of s.matchAll(URL_RE)) {
+            const start = m.index ?? 0;
+            if (start > last) out.push({ type: 'text', value: s.slice(last, start) });
+            out.push({ type: 'link', value: m[0] });
+            last = start + m[0].length;
+        }
+        if (last < s.length) out.push({ type: 'text', value: s.slice(last) });
+        return out;
+    }
+
     // memo-store 동적 로드
     type MemoStoreModule = {
         openModal: (memberId: string) => void;
@@ -440,7 +458,18 @@
                                                 <p
                                                     class="text-muted-foreground whitespace-pre-wrap text-xs"
                                                 >
-                                                    {memo.memo_detail}
+                                                    {#each tokenizeMemo(memo.memo_detail) as seg, i (i)}
+                                                        {#if seg.type === 'link'}
+                                                            <a
+                                                                href={seg.value}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer nofollow"
+                                                                class="text-primary underline"
+                                                                onclick={(e) => e.stopPropagation()}
+                                                                >{seg.value}</a
+                                                            >
+                                                        {:else}{seg.value}{/if}
+                                                    {/each}
                                                 </p>
                                             </PopoverContent>
                                         </Popover>


### PR DESCRIPTION
## 문제
\`/my/memos\` 활동 내역 페이지의 메모 상세 Popover 내 링크가 \`whitespace-pre-wrap text\` 로만 렌더되어 **클릭해도 이동 안 됨** (#11771 사용자 제보).

## 해결
\`tokenizeMemo()\` 인라인 함수로 http(s) URL 세그먼트 분리 → 텍스트는 바인딩, URL 은 \`<a target=\"_blank\" rel=\"noopener noreferrer nofollow\">\` 로 렌더 (XSS 안전, \`{@html}\` 미사용). \`onclick stopPropagation\` 으로 Popover 닫힘 방지.

## 관련
- Plugin 측 대응은 **angple-premium#35** 에서 진행
  - memo-modal 에 뷰 모드 추가 (배지 클릭 시 편집 폼 바로 열리지 않음)
  - memo-linked-text.svelte 신규 컴포넌트

## Test plan
- [ ] \`/my/memos\` 에서 상세 메모가 있는 항목 클릭 → Popover 안 URL 링크 노출 + 클릭 시 새 탭 이동
- [ ] 링크 클릭 시 Popover 가 닫히지 않음 (stopPropagation)
- [ ] 상세 메모 내 텍스트만 있을 때는 기존과 동일
- [ ] 특수문자/XSS 문자열 포함된 메모 안전 렌더