### PR TITLE
fix(auth): 재로그인 시 mb_leave_date 클리어 + 기존 계정 복구 마이그레이션 (#9395)

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/member.ts
+++ b/apps/web/src/lib/server/auth/oauth/member.ts
@@ -91,10 +91,10 @@ export async function findMemberByEmail(email: string): Promise<MemberRow | null
     return (rows[0] as MemberRow) || null;
 }
 
-/** 로그인 시각/IP 업데이트 */
+/** 로그인 시각/IP 업데이트 — 재로그인 시 mb_leave_date 도 클리어(복귀 처리) */
 export async function updateLoginTimestamp(mbId: string, ip: string): Promise<void> {
     await pool.query(
-        'UPDATE g5_member SET mb_today_login = NOW(), mb_login_ip = ? WHERE mb_id = ?',
+        "UPDATE g5_member SET mb_today_login = NOW(), mb_login_ip = ?, mb_leave_date = '' WHERE mb_id = ?",
         [ip, mbId]
     );
     await invalidateMemberCache(mbId);

--- a/migrations/002_clear_stale_mb_leave_date.sql
+++ b/migrations/002_clear_stale_mb_leave_date.sql
@@ -1,0 +1,34 @@
+-- 002_clear_stale_mb_leave_date.sql
+--
+-- Purpose: 탈퇴(mb_leave_date) 표시가 남아있으나 이미 다시 로그인하여
+--          활동 중인 회원의 mb_leave_date 를 빈 문자열로 복구.
+--          (#9395 참조 — 프로필에 '탈퇴'로 표시되지만 댓글/접속 기록이 있음)
+--
+-- Safety:
+--   - mb_today_login 이 STR_TO_DATE(mb_leave_date, '%Y%m%d') 보다 이후인 경우만 대상
+--     → 탈퇴 후 실제 재로그인이 발생한 계정만 클리어
+--   - mb_intercept_date 는 건드리지 않음 (어드민 정지는 별도 필드)
+--   - mb_leave_date 가 '0000-00-00' 이거나 null 인 경우는 제외
+--
+-- Rollback 참고:
+--   별도 백업 테이블에 현재 상태 스냅샷을 먼저 남기기 권장:
+--     CREATE TABLE g5_member_leave_backup_20260419 AS
+--     SELECT mb_id, mb_leave_date, mb_today_login
+--     FROM g5_member
+--     WHERE mb_leave_date != '' AND mb_leave_date != '0000-00-00';
+--
+-- Verify (DRY RUN):
+--   SELECT COUNT(*) AS affected
+--   FROM g5_member
+--   WHERE mb_leave_date != ''
+--     AND mb_leave_date != '0000-00-00'
+--     AND mb_today_login IS NOT NULL
+--     AND mb_today_login > STR_TO_DATE(mb_leave_date, '%Y%m%d');
+--
+-- Apply:
+UPDATE g5_member
+SET mb_leave_date = ''
+WHERE mb_leave_date != ''
+  AND mb_leave_date != '0000-00-00'
+  AND mb_today_login IS NOT NULL
+  AND mb_today_login > STR_TO_DATE(mb_leave_date, '%Y%m%d');


### PR DESCRIPTION
## 문제
탈퇴 후 다시 소셜 로그인한 회원의 \`mb_leave_date\` 가 클리어되지 않아 프로필에는 '탈퇴'로 표시되지만 실제로는 정상 활동 중 (#9395).

예: \`kakao_86650815\` (\"돌아온조앙\") — \`mb_leave_date=20260312\`, \`mb_today_login=2026-04-05\`, \`mb_point=5630\`

## 영향 범위
\`\`\`sql
SELECT COUNT(*) FROM g5_member
WHERE mb_leave_date != '' AND mb_leave_date != '0000-00-00'
  AND mb_today_login IS NOT NULL
  AND mb_today_login > STR_TO_DATE(mb_leave_date, '%Y%m%d');
-- 결과: 1,973
\`\`\`

## 변경
### 1. \`updateLoginTimestamp\` (oauth/member.ts)
UPDATE 에 \`mb_leave_date = ''\` 추가 — 로그인 성공 시마다 탈퇴 플래그 함께 클리어해 '복귀' 상태로 복원.
- \`mb_leave_date\` 는 **본인 탈퇴 플로우(member-leave.ts)에서만** 설정되므로 로그인 시 클리어가 안전.
- 어드민 정지는 별도 필드 \`mb_intercept_date\` 로 분리되어 있어 영향 없음.
- social-login-postprocess.ts 에서 호출되는 경로로 모든 OAuth 로그인에 자동 적용.

### 2. \`migrations/002_clear_stale_mb_leave_date.sql\`
기존 1,973개 stale 계정 복구용 **수동 실행** 마이그레이션.
- \`mb_today_login > mb_leave_date\` 조건으로 실제 재로그인 발생 계정만 대상
- 백업 쿼리 + DRY RUN 쿼리 주석 포함
- 운영자가 수동으로 타이밍 선택하여 실행

## Test plan
- [ ] 로컬 dev: 계정 1개에 \`mb_leave_date='20260101'\` 수동 설정 → 소셜 로그인 → 로그인 후 \`mb_leave_date\` 가 \`''\` 으로 클리어되는지 확인
- [ ] 정상 회원은 로그인 시 \`mb_leave_date\` 값 변함 없음
- [ ] 어드민이 \`mb_intercept_date\` 로 정지시킨 계정은 로그인 차단 플로우 여전히 작동
- [ ] 마이그레이션 DRY RUN 쿼리 결과 = 1,973
- [ ] 마이그레이션 실행 후 \`kakao_86650815\` 프로필에서 탈퇴 표시 사라짐

## 운영 적용 순서
1. 이 PR 머지 + 금요일 새벽 4시 배포
2. 배포 후 **운영자가 수동으로** \`migrations/002_*.sql\` 실행 (백업 먼저)
3. 실행 후 #9395 신고자(\`naver_xxxx\`)에게 확인 댓글 예정