### PR TITLE
perf(post-detail): scheduled_delete 별도 fetch 제거 — Posts API inline 사용

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -67,7 +67,14 @@ export interface FreePost {
     link2_affiliate?: boolean; // 링크2 제휴 변환 여부
     deleted_at?: string | null; // 소프트 삭제 시점
     deleted_by?: string | null; // 삭제한 사용자 ID
-    scheduled_delete_at?: string | null; // 삭제 예약된 시점 (g5_scheduled_deletes.scheduled_at, SSR enrichment)
+    scheduled_delete_at?: string | null; // 삭제 예약된 시점 (g5_scheduled_deletes.scheduled_at, SSR enrichment, 게시판 목록용)
+    scheduled_delete?: {
+        // 글 상세 응답에 백엔드가 inline 포함 (PR #430), 별도 /delete-status fetch 회피
+        scheduled_at: string;
+        requested_at: string;
+        requested_by?: string;
+        delay_minutes: number;
+    } | null;
     is_left?: boolean; // 작성자 탈퇴 여부 (SSR enrichment)
     report_count?: number | string; // wr_7 값: 숫자(신고수) 또는 "lock"(잠김)
     // 확장 필드 (PHP wr_1~wr_10 매핑)

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -434,25 +434,17 @@ export const load: PageServerLoad = async ({
                           userDisliked: false
                       }))
                     : Promise.resolve({ userLiked: false, userDisliked: false }),
-                // 삭제 예약 상태 조회 (Go 백엔드)
-                bFetch(`/api/v1/boards/${boardId}/posts/${postId}/delete-status`, {
-                    headers,
-                    timeout: 2_000
-                })
-                    .then(async (res) => {
-                        if (!res.ok) return null;
-                        const json = await res.json();
-                        if (json.scheduled) {
-                            return {
-                                scheduled: true,
-                                scheduled_at: json.scheduled_at,
-                                requested_at: json.requested_at,
-                                delay_minutes: json.delay_minutes
-                            };
-                        }
-                        return null;
-                    })
-                    .catch(() => null),
+                // 삭제 예약 상태 — Posts API 응답에 inline 포함 (별도 fetch 제거, 백엔드 PR #430)
+                Promise.resolve(
+                    post.scheduled_delete
+                        ? {
+                              scheduled: true,
+                              scheduled_at: post.scheduled_delete.scheduled_at,
+                              requested_at: post.scheduled_delete.requested_at,
+                              delay_minutes: post.scheduled_delete.delay_minutes
+                          }
+                        : null
+                ),
                 (() => {
                     if (!locals.user?.id || !commentsData.comments.items?.length) {
                         return Promise.resolve({ likedIds: [], dislikedIds: [] });


### PR DESCRIPTION
## Summary

글 상세 SSR이 `/api/v1/boards/:slug/posts/:id/delete-status` 별도 fetch 제거 → Posts API 응답의 inline `scheduled_delete` 필드 사용.

**짝 PR (먼저 배포 필수)**: damoang-backend#430

## 근거 (OTel 1h 데이터, 4/19)

- Top 15 SSR client fetch 중 **9개가 delete-status** (60%)
- avg 137ms, p95 503ms (PR #429 캐시 적용 후에도 비효율)
- Backend Phase 1 배포 후 inline 필드 활용 → SSR 추가 fetch **0**

## 변경

### `src/routes/[boardId]/[postId]/+page.server.ts` L437-455
```diff
- bFetch(`/api/v1/boards/${boardId}/posts/${postId}/delete-status`, {...})
-     .then(...) .catch(() => null)
+ Promise.resolve(post.scheduled_delete ? {scheduled: true, ...post.scheduled_delete} : null)
```

### `src/lib/api/types.ts` L70
```typescript
scheduled_delete?: { scheduled_at; requested_at; requested_by?; delay_minutes } | null;
```

## 배포 순서 (필수)

1. **damoang-backend#430 머지 + 새벽 4시 배포** ← 선행
2. 백엔드 검증: `curl https://damoang.net/api/v1/boards/free/posts/{id} | jq .data.scheduled_delete`
3. 이 PR 머지 + 새벽 4시 배포
4. 프론트 검증: `delete-status` endpoint 호출 0건/시간 (OTel)

**역순 배포 시 회귀**: 프론트만 먼저 배포되면 `scheduled_delete=null`로 들어와 "삭제 예약" 배너 표시 안 됨.

## 효과

| 지표 | 현재 | After |
|------|---:|---:|
| delete-status 호출 (1h) | ~750-840 | **0** |
| 글 상세 SSR Promise.allSettled | 9 items | 9 items (1개를 Promise.resolve로 대체) |
| 코드 라인 | 19줄 fetch | 9줄 inline |
| 보안 취약점 | 별도 endpoint 권한 누락 | Posts API 권한 자동 적용 |

## Test plan

- [x] `pnpm check` 0 errors
- [ ] CI 통과
- [ ] 백엔드 PR #430 배포 검증 후 머지
- [ ] dev 글 상세 페이지 → "삭제 예약" 배너 정상 표시 (예약된 글 + 미예약 글 양쪽)
- [ ] 새벽 4시 prod 배포 (사용자 명시 승인)
- [ ] OTel 검증: \`SELECT count() FROM otel.traces WHERE SpanAttributes['url.path'] LIKE '%/delete-status' AND Timestamp > now() - INTERVAL 1 HOUR\` = 0