### PR TITLE
fix(settings): /member/settings 500 오류 — mb_nick_date Date 객체 처리 (#11974)

### DIFF
--- a/apps/web/src/lib/server/auth/member-update.ts
+++ b/apps/web/src/lib/server/auth/member-update.ts
@@ -23,7 +23,7 @@ export interface MemberFullProfile {
     mb_signature: string;
     mb_open: number;
     mb_mailling: number;
-    mb_nick_date: string;
+    mb_nick_date: string | Date | null; // mysql2 DATE → Date 객체로 반환
     mb_hp: string;
     mb_password: string;
     mb_leave_date: string;
@@ -32,7 +32,7 @@ export interface MemberFullProfile {
     mb_image_url: string;
     mb_image_updated_at: string;
     mb_certify: string;
-    mb_datetime: string;
+    mb_datetime: string | Date | null; // mysql2 DATETIME → Date 객체로 반환
 }
 
 /** 프로필 전체 정보 조회 */
@@ -116,19 +116,32 @@ export async function updateNickname(
 }
 
 /**
+ * Date | string | null | undefined → 'YYYY-MM-DD' 문자열로 정규화
+ * mysql2 는 DATE/DATETIME 컬럼을 Date 객체로 반환하므로 직접 string 메서드 호출 금지.
+ */
+function toYmd(value: unknown): string {
+    if (!value) return '';
+    if (value instanceof Date) {
+        if (isNaN(value.getTime())) return '';
+        return value.toISOString().slice(0, 10);
+    }
+    return String(value).slice(0, 10);
+}
+
+/**
  * 신규 회원의 첫 닉네임 변경 여부 판단
  * - mb_nick_date가 비어있거나 '0000-00-00'이거나
  * - mb_nick_date가 가입일(mb_datetime)과 같은 날이면 → 아직 한 번도 변경 안 함
  */
 export function isFirstNickChange(profile: {
-    mb_nick_date?: string | null;
-    mb_datetime?: string | null;
+    mb_nick_date?: string | Date | null;
+    mb_datetime?: string | Date | null;
 }): boolean {
-    const nickDate = profile.mb_nick_date || '';
+    const nickDate = toYmd(profile.mb_nick_date);
     if (!nickDate || nickDate.startsWith('0000')) return true;
-    if (!profile.mb_datetime) return false;
-    const regDate = String(profile.mb_datetime).slice(0, 10); // 'YYYY-MM-DD'
-    return nickDate.slice(0, 10) === regDate;
+    const regDate = toYmd(profile.mb_datetime);
+    if (!regDate) return false;
+    return nickDate === regDate;
 }
 
 /**


### PR DESCRIPTION
## 긴급 핫픽스

### 증상
\`/member/settings\` 접근 시 **500 에러** (본서버 + canary 동일).
사용자 제보 #11974 스크린샷: SvelteKit 500 에러 페이지.

### Pod 로그 (결정적 증거)
\`\`\`
[Server Error] 500 /member/settings: nickDate.startsWith is not a function
\`\`\` (반복 발생)

### 원인
\`mysql2\` 가 \`g5_member.mb_nick_date\` (DATE), \`mb_datetime\` (DATETIME) 컬럼을 **Date 객체**로 반환. 하지만 \`isFirstNickChange()\` 는 문자열을 가정하고 \`startsWith()\` 를 직접 호출 → \`TypeError\`.

PR #1228 (#11944 — 신규회원 첫 닉네임 변경) 도입 시 누락된 케이스. 해당 PR 이 배포된 이후 settings 페이지 접근 불가 상태.

### 변경
- \`toYmd()\` 헬퍼: \`Date | string | null → 'YYYY-MM-DD'\` 정규화
- \`isFirstNickChange()\` 인자 타입 확장 (\`string | Date | null\`)
- \`MemberFullProfile\` 타입에 Date 가능성 반영

### Test plan
- [ ] \`/member/settings\` GET 200 응답
- [ ] 닉네임 변경 폼 정상 로드
- [ ] 신규 회원(첫 변경) — 쿨다운 예외 정상 적용
- [ ] 기존 회원(30일 이내 변경 기록) — 쿨다운 메시지 정상