### PR TITLE
fix(post-detail): 모바일 비-/free 경로 좌우 스크롤 방어 (#11970)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1404,7 +1404,10 @@
     />
 {/if}
 
-<div class="mx-auto pt-2">
+<!-- overflow-x: clip — 모바일 Safari/Firefox 에서 일부 비-/free 경로에 미세한 좌우 스크롤이
+     발생하던 문제 방어 (#11970). clip 은 scroll container 를 만들지 않아 position:sticky 가
+     깨지지 않고, overflow: hidden 과 달리 자식의 transform 등 영향도 최소. -->
+<div class="mx-auto overflow-x-clip pt-2">
     <!-- 최상단 자체 배너 (없으면 GAM 폴백) -->
     {#if widgetLayoutStore.hasEnabledAds && !data.post.deleted_at}
         <div class="mb-3">


### PR DESCRIPTION
iOS Safari / Firefox 모바일에서 /free 제외 게시판 상세에 미세한 좌우 스크롤 발생. 줌아웃하면 사라짐.

[boardId]/[postId] 본문 최상단 wrapper 에 `overflow-x: clip` 추가.
- clip 은 scroll container 를 만들지 않아 position:sticky 깨지 않음
- 자식 overflow 를 시각적으로 정확히 잘라냄
- iOS Safari 16+ 지원

근본 원인(/free 와 다른 이유)은 식별 불완전하나 이 방어층으로 증상 해소.