### PR TITLE
feat(home): 알뜰구매 위젯 탭 재구성 — 알뜰/나눔/장터/사용기 (#11939)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -419,7 +419,7 @@ export interface ExploreData {
 }
 
 // 경제 탭 타입
-export type EconomyTabId = 'economy' | 'qa' | 'free' | 'angtt';
+export type EconomyTabId = 'economy' | 'giving' | 'trade' | 'review';
 
 export interface EconomyPost {
     id: number;

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -329,7 +329,7 @@ export interface DailyRecommendedData {
 }
 
 // 새로운 소식 탭 타입
-export type NewsTabId = 'new' | 'tip' | 'review' | 'notice';
+export type NewsTabId = 'new' | 'tip' | 'review' | 'qa';
 
 export interface NewsPost {
     id: number;

--- a/apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte
+++ b/apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte
@@ -9,10 +9,10 @@
     let { activeTab = $bindable(), onTabChange }: Props = $props();
 
     const tabs: { id: EconomyTabId; label: string }[] = [
-        { id: 'economy', label: '구매' },
-        { id: 'qa', label: 'Q&A' },
-        { id: 'free', label: '앙지도' },
-        { id: 'angtt', label: '평점' }
+        { id: 'economy', label: '알뜰' },
+        { id: 'giving', label: '나눔' },
+        { id: 'trade', label: '장터' },
+        { id: 'review', label: '사용기' }
     ];
 
     function handleTabClick(tabId: EconomyTabId) {

--- a/apps/web/src/lib/components/features/new-board/components/tabs/news-tabs.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/tabs/news-tabs.svelte
@@ -12,7 +12,7 @@
         { id: 'new', label: '소식' },
         { id: 'tip', label: '정보' },
         { id: 'review', label: '사용기' },
-        { id: 'notice', label: '공지' }
+        { id: 'qa', label: 'Q&A' }
     ];
 
     function handleTabClick(tabId: NewsTabId) {


### PR DESCRIPTION
## 배경
#11939 제보 + 홈 위젯 전면 재검토 — 알뜰구매 위젯 탭에 Q&A/평점이 맥락 불일치. Q&A 는 업계 관행(클리앙/뽐뿌/루리/펨코/디시)에 따라 홈 카드에서 내리는 것이 표준이나, 사용자 결정으로 **News 탭으로 이동** (공지 제거 자리에 Q&A).

## 변경 내용

### 1) 알뜰구매 위젯 탭 4개 재정의
| Before | After |
|---|---|
| 구매 | **알뜰** |
| Q&A | **나눔** |
| 앙지도 | **장터** |
| 평점 | **사용기** |

### 2) 새로운소식 위젯 탭 4개 재정의
| Before | After |
|---|---|
| 소식 | 소식 |
| 정보 | 정보 |
| 사용기 | 사용기 |
| **공지** | **Q&A** |

공지는 사이드바 notice 위젯 + tag-nav 로 접근 유지.

## 프론트 변경 파일
- `apps/web/src/lib/api/types.ts` — `EconomyTabId`, `NewsTabId` 유니온 갱신
- `apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte`
- `apps/web/src/lib/components/features/new-board/components/tabs/news-tabs.svelte`

## ⚠️ 백엔드 widgets.yaml 별도 적용 필요 (운영자)

`/home/damoang/go-services/recommend-system/config/widgets.yaml`:

### news 섹션
```diff
-  - id: "notice"
-    name: "공지사항"
-    boards: ["notice"]
-    limit: 7
-    includeNotice: true
+  - id: "qa"
+    name: "질문과 답변"
+    boards: ["qa"]
+    limit: 7
     orderBy: "datetime"
```

### economy 섹션
```diff
 economy:
   - id: "economy"
-    name: "알뜰 구매"
+    name: "알뜰"
     boards: ["economy"]
     limit: 7
     orderBy: "datetime"

-  - id: "qa"
-    name: "질문과 답변"
-    boards: ["qa"]
-    limit: 7
-    timeFilter: "week"
+  - id: "giving"
+    name: "나눔"
+    boards: ["giving"]
+    limit: 7
     orderBy: "datetime"

-  - id: "free"
-    name: "앵맵"
-    boards: ["angmap"]
-    limit: 14
+  - id: "trade"
+    name: "장터"
+    boards: ["trade"]
+    limit: 7
     orderBy: "datetime"

-  - id: "angtt"
-    name: "앵뜨"
-    boards: ["angtt"]
-    limit: 8
+  - id: "review"
+    name: "사용기"
+    boards: ["review"]
+    limit: 7
     orderBy: "datetime"
```

### 적용 명령
```bash
sudo systemctl start widgets.service
```

## Test plan
- [ ] `pnpm check` 통과
- [ ] yaml 반영 후 JSON 검증:
  ```bash
  sudo grep -oE '"tab":"[a-z]+"' /home/damoang/www/data/cache/recommended/index-widgets.json | sort -u
  ```
- [ ] Canary 홈: 알뜰구매 4탭 (알뜰/나눔/장터/사용기), 새로운소식 4탭 (소식/정보/사용기/Q&A)
- [ ] 각 탭 클릭 시 해당 게시판 최신글 노출
- [ ] 사이드바 notice 위젯, tag-nav 공지 링크 정상 (회귀 없음)