### PR TITLE
fix(deploy): immutable bundle 30일 보존 + IMAGE_TAG 복합 SHA (W4-M1+M3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,17 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      # Premium SHA를 IMAGE_TAG에 포함하기 위해 resolve 단계에서도 premium checkout
+      # 2026-04-19 incident: premium-only 변경 시 web git SHA 동일 → IMAGE_TAG 동일 → K8s rollout no-op
+      - name: Checkout premium (for SHA only)
+        if: ${{ !inputs.image_tag }}
+        uses: actions/checkout@v6
+        with:
+          repository: damoang/angple-premium
+          token: ${{ secrets.PREMIUM_REPO_TOKEN }}
+          path: _premium_sha
+          fetch-depth: 1
+
       - name: Resolve release mode
         id: release
         env:
@@ -69,7 +80,11 @@ jobs:
             echo "sha_tag=${INPUT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
             echo "should_build=false" >> "$GITHUB_OUTPUT"
           else
-            echo "sha_tag=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            WEB_SHA="${GITHUB_SHA:0:7}"
+            PREM_SHA=$(git -C _premium_sha rev-parse --short=7 HEAD 2>/dev/null || echo "none")
+            SHA_TAG="sha-${WEB_SHA}-p${PREM_SHA}"
+            echo "Computed IMAGE_TAG: ${SHA_TAG} (web=${WEB_SHA}, premium=${PREM_SHA})"
+            echo "sha_tag=${SHA_TAG}" >> "$GITHUB_OUTPUT"
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -113,8 +113,10 @@ echo -e "${BLUE}[2/5] 복사...${NC}"
 # immutable 파일(content-hash) 보존: 이전 클라이언트가 아직 로드하지 않은 chunk 404 방지
 rsync -a "$DEV_DIR/apps/web/build/" "$PROD_DIR/build/"
 rsync -a --delete --exclude='_app/immutable/' "$DEV_DIR/apps/web/build/" "$PROD_DIR/build/"
-# 2일 이상 된 이전 immutable 파일 정리 (백그라운드)
-(find "$PROD_DIR/build/_app/immutable/" -type f -mtime +2 -delete 2>/dev/null &)
+# 30일 이상 된 이전 immutable 파일 정리 (백그라운드)
+# 2026-04-19 incident: 2일로는 "이전 release bundle 404" 스모크 실패 발생
+# SvelteKit SSR이 구 HTML 서빙 → 활성 클라이언트가 구 chunk 요청 → 충분한 grace period 필요
+(find "$PROD_DIR/build/_app/immutable/" -type f -mtime +30 -delete 2>/dev/null &)
 rsync -a "$DEV_DIR/data/" "$PROD_DIR/data/"
 
 # .env 동기화


### PR DESCRIPTION
## Summary

4/19 배포 지옥 (4회 실패) 경험 기반 web repo 파이프라인 2가지 버그 수정.

## W4-M1: IMAGE_TAG에 premium SHA 포함

**원인**: \`.github/workflows/deploy.yml:72\` \`sha-\${GITHUB_SHA}\` — web git SHA만 사용. Premium-only 변경 시 태그 동일 → K8s \`kubectl set image\` no-op.

**해결**:
- resolve-release 단계에서 premium checkout (fetch-depth: 1)
- IMAGE_TAG 형식: \`sha-{web-7}-p{premium-7}\` (예: \`sha-abc1234-pdef5678\`)
- Promote (\`INPUT_IMAGE_TAG\` 사용) 시엔 원본 유지 (backward 호환)

## W4-M3: immutable bundle 30일 보존

**원인**: \`scripts/deploy.sh:117\` \`-mtime +2 -delete\` — 2일 이상 chunk 삭제. 활성 클라이언트가 구 SHA 참조 시 404 → \"이전 release bundle 검증 실패\" 자동 롤백.

**해결**: 2일 → 30일. 스토리지 증가 ~900MB (무시 가능).

## Well-Architected

| Pillar | 개선 |
|--------|------|
| Reliability | 배포 시 항상 새 태그 + pod 재시작 보장 |
| Operational | 태그만 봐도 web+premium 버전 추적 |
| Sustainability | 클라이언트 migration grace period 충분 |

## Test plan

- [ ] CI 통과
- [ ] 머지 후 다음 배포에서 IMAGE_TAG 새 형식 확인 (\`sha-*-p*\`)
- [ ] 30일 이상 파일이 로컬에 잔존 확인 (\`ls -la /home/damoang/www/apps/web/build/_app/immutable/\`)
- [ ] Premium-only dummy commit → K8s rollout 자동 트리거 확인
- [ ] 백엔드 짝 PR: angple-k8s#10 (SSM Parameter Store + annotation rollout 강제)

## 관련 PR

- **angple-k8s#10**: deploy.sh SSM GHCR fetch + annotation rollout 강제 (W4-M2)
- **angple-premium#36**: memo N+1 fix (이미 머지/배포됨)

## 후속 (W4-N, 별도 sprint)

- R2 (\`static.damoang.net/releases/\`) lifecycle 정책 확인 + 30일+ 로 정렬
- Grafana alert: deploy workflow failure 시 즉시 알림