### PR TITLE
fix(home): 알뜰구매 4번째 탭 사용기 → 홍보 (#11939 follow-up)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -419,7 +419,7 @@ export interface ExploreData {
 }
 
 // 경제 탭 타입
-export type EconomyTabId = 'economy' | 'giving' | 'trade' | 'review';
+export type EconomyTabId = 'economy' | 'giving' | 'trade' | 'promotion';
 
 export interface EconomyPost {
     id: number;

--- a/apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte
+++ b/apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte
@@ -12,7 +12,7 @@
         { id: 'economy', label: '알뜰' },
         { id: 'giving', label: '나눔' },
         { id: 'trade', label: '장터' },
-        { id: 'review', label: '사용기' }
+        { id: 'promotion', label: '홍보' }
     ];
 
     function handleTabClick(tabId: EconomyTabId) {


### PR DESCRIPTION
## 변경
사용기(review)는 이미 새로운소식 위젯 3번째 탭에 있어 중복 → 알뜰구매 4번째 탭을 **홍보(직접홍보)** 로 교체.

### 최종 알뜰구매 4탭
| Tab | Board | 의미 |
|---|---|---|
| 알뜰 | economy | 할인/특가 |
| 나눔 | giving | 무상 나눔 |
| 장터 | trade | 중고 거래 |
| **홍보** | **promotion** | 직접홍보 |

모두 commerce-trading 맥락으로 통일.

## 변경 파일
- `apps/web/src/lib/api/types.ts` — `EconomyTabId` review → promotion
- `apps/web/src/lib/components/features/economy/components/tabs/economy-tabs.svelte` — 4번째 탭 라벨

## widgets.yaml
`/home/damoang/go-services/recommend-system/config/widgets.yaml` economy 섹션의 review 블록 → promotion 블록 동기화 **완료 + 서비스 재시작 완료** (이 세션에서).

## Test plan
- [ ] pnpm check
- [x] JSON 재생성 후 economy 탭에 promotion id 포함 확인
- [ ] canary 홈 "알뜰구매" 위젯 4번째 탭 '홍보' 노출 + 직접홍보 게시판 최신글