### PR TITLE
feat(home): 위젯 타이틀 변경 — 정보광장 / 알뜰 · 장터 (#11939)

### DIFF
--- a/apps/web/src/lib/components/features/economy/economy-tabs.svelte
+++ b/apps/web/src/lib/components/features/economy/economy-tabs.svelte
@@ -30,7 +30,7 @@
             >
                 <ShoppingCart class="h-4 w-4 text-green-500" />
             </div>
-            <h3 class="text-foreground text-lg font-semibold">알뜰구매</h3>
+            <h3 class="text-foreground text-lg font-semibold">알뜰 · 장터</h3>
         </a>
         <EconomyTabs bind:activeTab onTabChange={handleTabChange} />
     </CardHeader>

--- a/apps/web/src/lib/components/features/new-board/new-board.svelte
+++ b/apps/web/src/lib/components/features/new-board/new-board.svelte
@@ -33,7 +33,7 @@
             >
                 <Newspaper class="h-4 w-4 text-blue-500" />
             </div>
-            <h3 class="text-foreground text-lg font-semibold">새로운 소식</h3>
+            <h3 class="text-foreground text-lg font-semibold">정보광장</h3>
         </a>
         <NewsTabs bind:activeTab onTabChange={handleTabChange} />
     </CardHeader>


### PR DESCRIPTION
PR #1247/#1249 로 탭 재구성 후 위젯 제목의 맥락 불일치 해소.

- '새로운 소식' → **정보광장** (소식/정보/사용기/Q&A 포용)
- '알뜰구매' → **알뜰 · 장터** (알뜰/나눔/장터/홍보 포용)
- 갤러리: 유지

링크·아이콘 유지, 보드 자체 페이지 제목은 영향 없음.