### PR TITLE
perf(post-detail): SSR 1단계 블로킹 축소 — timeout + 제휴 스트리밍

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -105,7 +105,9 @@ export const load: PageServerLoad = async ({
             // 게시글 (Go 백엔드 직접 호출)
             bFetch(`/api/v1/boards/${boardId}/posts/${postId}`, {
                 headers,
-                timeout: 5_000,
+                // 2초: 5초는 백엔드 장애 시 사용자 체감 대기를 과도하게 늘림.
+                // 실패 분기(BackendUnavailableError → 503, 그 외 → 404)는 기존 동일.
+                timeout: 2_000,
                 bypassCircuitBreaker: true
             }).then(async (res) => {
                 if (!res.ok) throw new Error(`Post API error: ${res.status}`);
@@ -211,57 +213,10 @@ export const load: PageServerLoad = async ({
             }
         }
 
-        // 본문 제휴 링크 변환은 2단계 스트리밍으로 이동 (초기 렌더 블로킹 방지)
-        const affiliateContext = { bo_table: boardId, wr_id: Number(postId) };
-        const affiliateEnabled = await isLinkProcessingPluginEnabled().catch(() => false);
-        const postAffiliateRows = affiliateEnabled
-            ? await fetchPostAffiliateLinks(boardId, Number(postId)).catch(() => [])
-            : [];
-
-        // 링크1/링크2는 본문/댓글 Hook를 타지 않으므로 별도 제휴 변환한다.
-        if (post.link1 || post.link2) {
-            try {
-                const [link1Result, link2Result] = await Promise.race([
-                    Promise.allSettled([
-                        post.link1 ? Promise.resolve(post.link1) : Promise.resolve(null),
-                        post.link2 ? Promise.resolve(post.link2) : Promise.resolve(null)
-                    ]),
-                    new Promise<PromiseSettledResult<string | null>[]>((resolve) =>
-                        setTimeout(() => resolve([]), 1500)
-                    )
-                ]);
-
-                if (link1Result?.status === 'fulfilled') {
-                    const row = findAffiliateFieldRow(postAffiliateRows, 'post_link1');
-                    const originalLink = post.link1;
-                    if (originalLink) {
-                        const result = applyAffiliateField(originalLink, row);
-                        if (result.href !== originalLink) {
-                            post.link1_display = result.displayUrl;
-                            post.link1 = result.href;
-                            post.link1_affiliate = result.affiliate;
-                        }
-                    }
-                }
-
-                if (link2Result?.status === 'fulfilled') {
-                    const row = findAffiliateFieldRow(postAffiliateRows, 'post_link2');
-                    const originalLink = post.link2;
-                    if (originalLink) {
-                        const result = applyAffiliateField(originalLink, row);
-                        if (result.href !== originalLink) {
-                            post.link2_display = result.displayUrl;
-                            post.link2 = result.href;
-                            post.link2_affiliate = result.affiliate;
-                        }
-                    }
-                }
-            } catch {
-                // 변환 실패 시 원본 링크 유지
-            }
-        }
-
-        // 스크랩 여부는 2단계 스트리밍으로 이동 (초기 렌더 블로킹 방지)
+        // 본문/링크 제휴 변환은 auxiliaryDataPromise(2단계 스트리밍) 로 이동.
+        // 1단계에서 isLinkProcessingPluginEnabled + fetchPostAffiliateLinks 2회 DB 왕복으로
+        // 본문 렌더가 블로킹되던 문제 해소. 클라이언트는 streamed 결과 도착 시 link 값을 업데이트.
+        // 스크랩 여부도 2단계 스트리밍에 포함 (초기 렌더 블로킹 방지)
 
         // 직접홍보 게시판: 활성 광고주가 아닌 글은 만료 처리 (공지글 제외)
         let promotionExpired = false;
@@ -397,6 +352,41 @@ export const load: PageServerLoad = async ({
         })();
 
         const auxiliaryDataPromise = (async () => {
+            // 제휴 변환에 필요한 plugin flag + row 를 이 스트리밍 단계에서 조회.
+            // (이전에는 1단계에서 await 하여 본문 SSR 을 블로킹)
+            const affiliateEnabled = await isLinkProcessingPluginEnabled().catch(() => false);
+            const postAffiliateRows = affiliateEnabled
+                ? await fetchPostAffiliateLinks(boardId, Number(postId)).catch(() => [])
+                : [];
+
+            // link1/link2 제휴 변환 결과 계산 (post 객체는 mutate 하지 않고 별도 payload 로 전달).
+            const linkAffiliate: {
+                link1?: string;
+                link2?: string;
+                link1_display?: string;
+                link2_display?: string;
+                link1_affiliate?: boolean;
+                link2_affiliate?: boolean;
+            } = {};
+            if (post.link1) {
+                const row = findAffiliateFieldRow(postAffiliateRows, 'post_link1');
+                const result = applyAffiliateField(post.link1, row);
+                if (result.href !== post.link1) {
+                    linkAffiliate.link1 = result.href;
+                    linkAffiliate.link1_display = result.displayUrl;
+                    linkAffiliate.link1_affiliate = result.affiliate;
+                }
+            }
+            if (post.link2) {
+                const row = findAffiliateFieldRow(postAffiliateRows, 'post_link2');
+                const result = applyAffiliateField(post.link2, row);
+                if (result.href !== post.link2) {
+                    linkAffiliate.link2 = result.href;
+                    linkAffiliate.link2_display = result.displayUrl;
+                    linkAffiliate.link2_affiliate = result.affiliate;
+                }
+            }
+
             const [
                 promotionResult,
                 reactionsResult,
@@ -531,7 +521,8 @@ export const load: PageServerLoad = async ({
                 postLikeStatus,
                 scheduledDelete,
                 commentLikeStatuses,
-                truthroomCommentMap
+                truthroomCommentMap,
+                linkAffiliate
             };
         })();
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -203,6 +203,16 @@
         }
     });
 
+    // 제휴 변환된 link1/link2 필드 (auxiliaryDataPromise 에서 스트리밍으로 도착)
+    let linkAffiliate = $state<{
+        link1?: string;
+        link2?: string;
+        link1_display?: string;
+        link2_display?: string;
+        link1_affiliate?: boolean;
+        link2_affiliate?: boolean;
+    }>({});
+
     // 제휴 변환 결과를 data.post 위에 덮은 derived — streamed linkAffiliate 가 도착하면 반영.
     // ViewComponent 와 link1Original 모두 이 값을 사용해 제휴 변환 후 링크 버튼 href 가 올바르게 갱신됨.
     const displayPost = $derived({ ...data.post, ...linkAffiliate });
@@ -302,15 +312,6 @@
     let comments = $state<FreeComment[]>(data.commentsData?.comments.items || []);
     let commentsTotal = $state<number>(data.commentsData?.comments.total || comments.length);
     let truthroomCommentMap = $state<Record<number, number>>({});
-    // 제휴 변환된 link1/link2 필드 (auxiliaryDataPromise 에서 스트리밍으로 도착)
-    let linkAffiliate = $state<{
-        link1?: string;
-        link2?: string;
-        link1_display?: string;
-        link2_display?: string;
-        link1_affiliate?: boolean;
-        link2_affiliate?: boolean;
-    }>({});
     let promotionPosts = $state<PromotionPost[]>([]);
     let revisions = $state<PostRevision[]>([]);
     let initialLikedCommentIds = $state<number[]>([]);

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -203,9 +203,13 @@
         }
     });
 
+    // 제휴 변환 결과를 data.post 위에 덮은 derived — streamed linkAffiliate 가 도착하면 반영.
+    // ViewComponent 와 link1Original 모두 이 값을 사용해 제휴 변환 후 링크 버튼 href 가 올바르게 갱신됨.
+    const displayPost = $derived({ ...data.post, ...linkAffiliate });
+
     // link1이 동영상 URL이면 본문 앞에 삽입 (그누보드 wr_link1 호환)
     // link1_display: 제휴 변환 전 원본 URL (변환된 경우), 없으면 link1 자체가 원본
-    const link1Original = $derived(data.post.link1_display || data.post.link1);
+    const link1Original = $derived(displayPost.link1_display || displayPost.link1);
     let renderedPostContent = $state(data.post.content);
     let renderedPostContentPostId = data.post.id;
     $effect(() => {
@@ -298,6 +302,15 @@
     let comments = $state<FreeComment[]>(data.commentsData?.comments.items || []);
     let commentsTotal = $state<number>(data.commentsData?.comments.total || comments.length);
     let truthroomCommentMap = $state<Record<number, number>>({});
+    // 제휴 변환된 link1/link2 필드 (auxiliaryDataPromise 에서 스트리밍으로 도착)
+    let linkAffiliate = $state<{
+        link1?: string;
+        link2?: string;
+        link1_display?: string;
+        link2_display?: string;
+        link1_affiliate?: boolean;
+        link2_affiliate?: boolean;
+    }>({});
     let promotionPosts = $state<PromotionPost[]>([]);
     let revisions = $state<PostRevision[]>([]);
     let initialLikedCommentIds = $state<number[]>([]);
@@ -343,6 +356,7 @@
         postReactions = undefined;
         reactionsMap = undefined;
         lastFetchedReactionsKey = '';
+        linkAffiliate = {};
 
         if (!promise) {
             // SPA 내비게이션: auxiliaryData 없음 → 리액션 직접 fetch
@@ -379,6 +393,10 @@
 
                 if (result.transformedPostContent) {
                     renderedPostContent = result.transformedPostContent;
+                }
+
+                if (result.linkAffiliate && typeof result.linkAffiliate === 'object') {
+                    linkAffiliate = result.linkAffiliate as typeof linkAffiliate;
                 }
 
                 if (result.isScrapped) {
@@ -1611,7 +1629,7 @@
         <!-- 게시글 카드 (뷰 레이아웃) -->
         {#if ViewComponent}
             <ViewComponent
-                post={data.post}
+                post={displayPost}
                 board={data.board}
                 {boardId}
                 {isAuthor}


### PR DESCRIPTION
글 상세 진입 체감 지연 개선 Phase 1 (사용자 제보 + 검증 문서 기반). **수치 확정은 배포 후 계측**.

## 변경
1. Post API SSR timeout `5_000` → `2_000` (백엔드 장애 시 과도 대기 방지, 실패 분기 동일)
2. 1단계에서 await 하던 `isLinkProcessingPluginEnabled` + `fetchPostAffiliateLinks` + link1/link2 제휴 변환 블록을 `auxiliaryDataPromise` 로 이동

## 근거
- 원본 분석: `/home/damoang/docs/performance-analysis/2026-04-20-post-navigation-delay.md`
- 검증 문서: `/home/damoang/docs/2026-04-20-navigation-delay-analysis-validation.md`
- Promise.race 1500ms 는 dead safety net (inner 즉시 resolve, applyAffiliateField 는 sync). **실제 1단계 블로킹은 DB 2회 왕복**.

## 클라이언트 처리
- `linkAffiliate` $state + 글 변경 시 리셋
- streamed auxiliaryData 도착 시 linkAffiliate 주입
- `displayPost` $derived 로 `data.post + linkAffiliate` 병합 → ViewComponent (basic/report) 에 전달
- `link1Original` 이 displayPost 기준 재계산 → 임베드 삽입에도 반영

## Test plan
- [ ] pnpm check
- [ ] canary 글 상세 진입/뒤로가기 정상
- [ ] 제휴 링크(유튜브/쿠팡 등) — SSR 은 원본 URL 로 임베드/렌더, hydration 후 링크 버튼 href/rel 은 변환된 값으로 교체
- [ ] basic.svelte / report.svelte 회귀 없음
- [ ] 로그인/비로그인 공통 동작
- [ ] timeout 2초 실패율 24h 모니터링