### PR TITLE
feat(post-detail): preloadMemos로 글 작성자 author_memo cache 채우기 (W4-X3)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -185,6 +185,10 @@
     let MemoBadge = $state<Component | null>(null);
     let MemoInlineEditor = $state<Component | null>(null);
     let loadMemosForAuthors = $state<((memberIds: string[]) => Promise<void>) | null>(null);
+    // W4-X3: backend inline author_memo cache 채우기 → memo-badge mount 시 fetch 0
+    let preloadMemos = $state<
+        ((items: Array<{ author_id?: string; author_memo?: unknown }>) => void) | null
+    >(null);
 
     $effect(() => {
         if (memoPluginActive) {
@@ -192,14 +196,25 @@
             loadPluginComponent('member-memo', 'memo-inline-editor').then(
                 (c) => (MemoInlineEditor = c)
             );
-            loadPluginLib<{ loadMemosForAuthors: (ids: string[]) => Promise<void> }>(
-                'member-memo',
-                'memo-store'
-            ).then((module) => {
+            loadPluginLib<{
+                loadMemosForAuthors: (ids: string[]) => Promise<void>;
+                preloadMemos?: (
+                    items: Array<{ author_id?: string; author_memo?: unknown }>
+                ) => void;
+            }>('member-memo', 'memo-store').then((module) => {
                 loadMemosForAuthors = module?.loadMemosForAuthors ?? null;
+                preloadMemos = module?.preloadMemos ?? null;
             });
         } else {
             loadMemosForAuthors = null;
+            preloadMemos = null;
+        }
+    });
+
+    // 글 상세 post의 author_memo로 cache 채우기 (backend PR #438 inline embed 활용)
+    $effect(() => {
+        if (preloadMemos && data.post) {
+            preloadMemos([data.post]);
         }
     });
 


### PR DESCRIPTION
## Summary

W4-X 시리즈 마무리. 글 상세 페이지에서 post.author_memo (backend PR #438 inline) 데이터로 memo-store cache 미리 채워 별도 fetch 회피.

## 분석 결과

[boardId]/+page.svelte (게시판 목록), recent-posts.svelte는 **자체 batch fetch 사용** (memo-badge에 prop 직접 전달) — N+1 없음.

[boardId]/[postId]/+page.svelte (**글 상세**) 만 memo-store loadMemosForAuthors 사용 → memo-badge mount 시 single fetch.

## 변경

`apps/web/src/routes/[boardId]/[postId]/+page.svelte`:
- preloadMemos optional 함수 동적 import 추가
- $effect: `preloadMemos([data.post])` — post 작성자 cache 등록
- memo-badge mount 시 cache hit → fetch 0

## 호환성

- preloadMemos 없으면 (구 premium) 기존 loadMemosForAuthors fallback
- author_memo 없으면 (구 backend) null 등록 → 메모 없음 표시 정상

## 예상 효과

- 글 상세 페이지 /memo individual 호출 0
- comment-list (PR #1252) + 이번 PR로 W4-X 완결
- 408/5min → ~50/5min (캐시된 구 클라 일부 잔존)

## Test plan

- [x] pnpm check 0 errors
- [ ] CI pass
- [ ] 새벽 4시 prod 배포
- [ ] OTel: /memo individual 추세 감소 확인