### PR TITLE
feat: /content-market 플레이스홀더 + 사이드바 단독 메뉴 정렬/아이콘 수정

### DIFF
--- a/apps/web/src/routes/content-market/+page.svelte
+++ b/apps/web/src/routes/content-market/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import Sparkles from '@lucide/svelte/icons/sparkles';
+</script>
+
+<svelte:head>
+    <title>컨텐츠마켓 | 다모앙</title>
+    <meta name="description" content="다모앙 컨텐츠마켓 — 준비 중입니다." />
+</svelte:head>
+
+<div class="container mx-auto max-w-2xl px-4 py-20 text-center">
+    <Sparkles class="text-muted-foreground mx-auto mb-4 h-12 w-12" />
+    <h1 class="text-foreground text-2xl font-bold">컨텐츠마켓</h1>
+    <p class="text-muted-foreground mt-3 text-sm">곧 찾아뵙겠습니다. 현재 준비 중입니다.</p>
+</div>


### PR DESCRIPTION
## Summary
- **/content-market 라우트 신설** — 신규 '컨텐츠마켓' 메뉴(관리자 사이드바에서 DB insert) 링크 대상 랜딩 페이지
- **사이드바 아이콘 맵 보강** — `ShoppingBag`·`Package` 가 iconMap 에 없어 상점·컨텐츠마켓이 Circle 폴백되던 문제 수정
- **사이드바 top-level 단독 메뉴 정렬** — `Button` (h-9 px-3) 이 `AccordionTrigger` (px-0 py-4) 와 달라 상점·컨텐츠마켓·위키앙이 들여쓰기처럼 보이던 문제 수정
- **외부링크 새 탭** — `menu.target='_blank'` 시 `<a target="_blank" rel="noopener noreferrer">` 로 렌더 (위키앙 외부링크)

## Test plan
- [ ] 로컬 pnpm dev → 사이드바에서 상점·컨텐츠마켓·위키앙이 커뮤/정보/리뷰/게임과 같은 레벨로 flush-left 정렬 확인
- [ ] 상점·컨텐츠마켓 앞 아이콘이 Circle 이 아닌 ShoppingBag·Package 로 노출
- [ ] 위키앙 클릭 시 새 탭에서 wikiang.org 열림
- [ ] `/content-market` 접근 시 'Sparkles + 준비 중입니다' 렌더
- [ ] 비로그인 / 로그인 회귀 없음