### PR TITLE
fix: 사이드바 단독 메뉴 정렬/아이콘/외부링크 (PR #1254 누락분)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -337,22 +337,24 @@
                             </AccordionContent>
                         </AccordionItem>
                     {:else}
-                        <!-- 하위 메뉴가 없는 단독 메뉴 -->
+                        <!-- 하위 메뉴가 없는 단독 메뉴 (accordion trigger 와 시각적 정렬 일치) -->
                         {@const active = isActive(menu.url)}
-                        <Button
-                            variant={active ? 'default' : 'ghost'}
-                            class={cn(
-                                'w-full justify-start gap-2',
-                                active
-                                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-                                    : 'hover:bg-accent'
-                            )}
+                        {@const external = menu.target === '_blank'}
+                        <a
                             href={menu.url}
-                            rel="external"
+                            target={external ? '_blank' : undefined}
+                            rel={external ? 'noopener noreferrer' : 'external'}
+                            class={cn(
+                                'flex w-full items-center gap-2 rounded-md py-4 text-sm font-semibold transition-colors',
+                                active
+                                    ? 'bg-primary text-primary-foreground hover:bg-primary/90 px-2'
+                                    : 'hover:bg-accent hover:text-accent-foreground px-0',
+                                isCollapsed && 'justify-center px-0'
+                            )}
                         >
-                            <IconComponent class="size-5" />
+                            <IconComponent class="text-muted-foreground size-5" />
                             <span class={cn(isCollapsed && 'hidden')}>{menu.title}</span>
-                        </Button>
+                        </a>
                     {/if}
                 {/each}
             </Accordion>

--- a/apps/web/src/lib/utils/icon-map.ts
+++ b/apps/web/src/lib/utils/icon-map.ts
@@ -19,6 +19,8 @@ import MapPin from '@lucide/svelte/icons/map-pin';
 import Star from '@lucide/svelte/icons/star';
 import TrendingUp from '@lucide/svelte/icons/trending-up';
 import ShoppingCart from '@lucide/svelte/icons/shopping-cart';
+import ShoppingBag from '@lucide/svelte/icons/shopping-bag';
+import Package from '@lucide/svelte/icons/package';
 import Megaphone from '@lucide/svelte/icons/megaphone';
 import Sparkles from '@lucide/svelte/icons/sparkles';
 import Coffee from '@lucide/svelte/icons/coffee';
@@ -109,6 +111,8 @@ export const iconMap: Record<string, typeof Circle> = {
     Star,
     TrendingUp,
     ShoppingCart,
+    ShoppingBag,
+    Package,
     Megaphone,
     Sparkles,
     Coffee,


### PR DESCRIPTION
## Summary
PR #1254 squash merge 타이밍 이슈로 누락된 사이드바 수정분 별도 PR.

- **아이콘 맵 보강** — `ShoppingBag`·`Package` 추가 (상점·컨텐츠마켓이 Circle 폴백되던 문제)
- **top-level 단독 메뉴 정렬** — `Button(h-9 px-3)` → `<a>(px-0 py-4)` 로 변경해 AccordionTrigger 와 시각적 정렬 일치
- **외부링크 새 탭** — `menu.target='_blank'` 시 target=_blank + rel=noopener (위키앙)

## Test plan
- [ ] 사이드바에서 상점·컨텐츠마켓·위키앙이 커뮤/정보/리뷰/게임과 같은 레벨로 flush-left 정렬
- [ ] 상점·컨텐츠마켓 앞 아이콘이 Circle 이 아닌 ShoppingBag·Package
- [ ] 위키앙 클릭 시 새 탭에서 wikiang.org 열림