### PR TITLE
feat(board-list): preloadMemos로 memo-store cache 채움 — N+1 최종 완결 (W4-X4)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -107,6 +107,7 @@
     import BoardSubscribeButton from '$lib/components/features/board/board-subscribe-button.svelte';
     import { Watermark } from '$lib/components/ui/watermark/index.js';
     import { pluginStore } from '$lib/stores/plugin.svelte';
+    import { loadPluginLib } from '$lib/utils/plugin-optional-loader';
     import Trash2 from '@lucide/svelte/icons/trash-2';
 
     // Q&A 게시판 타입 등록
@@ -190,6 +191,25 @@
     let memoByAuthorId = $state<Record<string, { content: string; color: string } | null>>({});
     let lastMemoRequestKey = $state('');
     let memoScheduleToken: number | ReturnType<typeof setTimeout> | null = null;
+    // W4-X4: backend inline author_memo로 memo-store memoCache 채우기
+    // (memo-badge 컴포넌트 내부 loadMemo 호출 시 cache hit → individual fetch 0)
+    let preloadMemos = $state<
+        ((items: Array<{ author_id?: string; author_memo?: unknown }>) => void) | null
+    >(null);
+
+    $effect(() => {
+        if (pluginStore.isPluginActive('member-memo')) {
+            loadPluginLib<{
+                preloadMemos?: (
+                    items: Array<{ author_id?: string; author_memo?: unknown }>
+                ) => void;
+            }>('member-memo', 'memo-store').then((m) => {
+                preloadMemos = m?.preloadMemos ?? null;
+            });
+        } else {
+            preloadMemos = null;
+        }
+    });
 
     const MEMO_CACHE_TTL_MS = 30_000;
     const memoBatchCache = new Map<
@@ -341,9 +361,15 @@
         const result = data.postsData;
         if (!result) return;
 
-        const authorIds = [...result.posts, ...(result.notices || [])]
-            .map((p) => p.author_id)
-            .filter((id): id is string => Boolean(id));
+        const items = [...result.posts, ...(result.notices || [])];
+
+        // W4-X4: backend inline author_memo로 memo-store cache 채우기 (PR #438 + #37 활용)
+        // memo-badge 컴포넌트가 loadMemo() 호출해도 cache hit → /members/{id}/memo individual fetch 0
+        if (preloadMemos) {
+            preloadMemos(items);
+        }
+
+        const authorIds = items.map((p) => p.author_id).filter((id): id is string => Boolean(id));
         const usesInlineListMemo = listLayoutId === 'classic';
 
         if (usesInlineListMemo) {


### PR DESCRIPTION
## Summary

게시판 목록 페이지에서 backend inline author_memo (PR #438)로 memo-store memoCache 미리 채우기. memo-badge가 내부에서 loadMemo() 호출해도 cache hit → \`/api/v1/members/{id}/memo\` individual fetch 0.

## 4/21 측정

| 시각 | individual | batch | 비율 |
|------|---:|---:|---:|
| 11:20 | 1,412 | 1,365 | **1.03** |
| 12:30 | 1,120 | 1,097 | 1.02 |

**1:1 비율 정체** = 매 batch 호출 시마다 individual 1회 추가 발생.

## 근본 원인 (이중 cache 불일치)

\`[boardId]/+page.svelte\`에 2개의 독립된 cache:
1. **page 자체 \`memoByAuthorId\`** (L190) — 자체 batch fetch
2. **memo-store \`memoCache\`** (premium plugin) — memo-badge가 조회

memo-badge가 \`$derived(getMemo(id))\` 호출 → memoCache 조회 → 없음 → \`loadMemo()\` → batch queue → **또 batch 1회**.

## 해결

\`preloadMemos(posts)\` 로 memoCache 직접 채움:
- memo-badge \`loadMemo()\` cache hit → fetch 0
- 기존 자체 batch는 inline classic layout 렌더링 용도로 유지
- 후속 PR에서 자체 batch 제거 가능 (W4-X5)

## 변경

\`[boardId]/+page.svelte\`:
1. \`loadPluginLib\` import 추가
2. \`preloadMemos\` state + 동적 import \$effect
3. 목록 데이터 \$effect 내 \`preloadMemos(items)\` 호출

## 안전성

- preloadMemos 없어도 (구 premium) 회귀 없음 (기존 flow 유지)
- idempotent (cache 있으면 skip)
- 자체 batch + preloadMemos 중복 무해 (cache hit로 마지막 쿼리 skip)

## Test plan

- [x] \`pnpm check\` 0 errors
- [ ] CI pass
- [ ] 새벽 4시 prod 배포
- [ ] OTel: individual 1,400/10min → **10 이하** (목표)
- [ ] 메모 배지 정상 표시 (회귀 0)

## 관련 (W4-X 시리즈)

- Phase 1: damoang-backend#438 (author_memo inline) ✅
- Phase 2: damoang-premium#37 (preloadMemos) + damoang#1252 (comment-list) ✅
- Phase 3: damoang#1253 (post-detail) ✅
- **Phase 4 (이 PR)**: board-list — 최종 완결

## 후속 (W4-X5+, 1주 후)

- 자체 \`memoByAuthorId\` local state 제거
- Legacy GET /memo endpoint deprecate (W4-C 패턴)