### PR TITLE
fix: 댓글/본문 유튜브 임베드 폭 560px 제한 (#12006)

### DIFF
--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -114,7 +114,7 @@ export function transformVideos(html: string): string {
             if (embedParams.length > 0) embedSrc += '?' + embedParams.join('&');
             const platform = isShorts ? 'youtube-shorts' : 'youtube';
             const aspectRatio = isShorts ? '177.78%' : '56.25%';
-            const maxWidth = isShorts ? '400px' : '100%';
+            const maxWidth = isShorts ? '400px' : '560px';
             return `<div class="embed-container" data-platform="${platform}" style="--aspect-ratio: ${aspectRatio}; --max-width: ${maxWidth};"><iframe src="${embedSrc}" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; picture-in-picture" style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div>`;
         }
 


### PR DESCRIPTION
## Summary
- 댓글·게시글 본문에서 일반 YouTube 임베드가 전체 폭으로 렌더되던 문제 수정
- \`content-transform.ts\` 의 \`maxWidth = isShorts ? '400px' : '100%'\` → \`'560px'\` 로 변경
- auto-embed Svelte 컴포넌트(youtube.ts)와 값 일치 (560px)

## 배경
- PR #1220 (#11904 수정) 은 Svelte 컴포넌트 경로만 고쳤고, HTML 변환 경로(content-transform) 누락
- #12006 제보자가 '조치 완료라 답변받았으나 적용 안 됨' 보고한 정확한 원인

## Test plan
- [ ] 댓글 본문에 YouTube URL 입력 → 560px 폭 제한 확인
- [ ] 게시글 본문 YouTube URL 동일 확인
- [ ] YouTube Shorts 400px 유지 (regression 체크)
- [ ] oembed 태그 경로(CKEditor5 미디어 삽입) 도 동일 폭 적용