### PR TITLE
fix: 댓글 공감자 배치 50개 청크 분할 (#11996)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -865,19 +865,26 @@
         reportingCommentId = null;
     }
 
-    // 댓글 추천자 아바타 배치 로드
+    // 댓글 추천자 아바타 배치 로드 — 서버 batch IDs 한도(50)에 맞춰 청크 분할
+    // 50개 초과 시 한 번에 보내면 뒤쪽 댓글이 조용히 잘려 나가 "특정번째 이후 댓글 공감자 미노출" 제보(#11996) 재현됨
+    const COMMENT_LIKERS_BATCH_CHUNK = 50;
     async function loadCommentLikerAvatarsBatch(commentIds: string[]): Promise<void> {
         if (!boardId || !postId || commentIds.length === 0) return;
         try {
-            const result = await apiClient.getCommentLikersBatch(
-                boardId,
-                String(postId),
-                commentIds,
-                5
+            const chunks: string[][] = [];
+            for (let i = 0; i < commentIds.length; i += COMMENT_LIKERS_BATCH_CHUNK) {
+                chunks.push(commentIds.slice(i, i + COMMENT_LIKERS_BATCH_CHUNK));
+            }
+            const results = await Promise.all(
+                chunks.map((chunk) =>
+                    apiClient.getCommentLikersBatch(boardId, String(postId), chunk, 5)
+                )
             );
-            for (const [commentId, data] of Object.entries(result)) {
-                commentLikersList.set(commentId, data.likers);
-                commentLikersTotal.set(commentId, data.total);
+            for (const result of results) {
+                for (const [commentId, data] of Object.entries(result)) {
+                    commentLikersList.set(commentId, data.likers);
+                    commentLikersTotal.set(commentId, data.total);
+                }
             }
         } catch (err) {
             console.error('Failed to load comment liker avatars:', err);


### PR DESCRIPTION
## Summary
- 댓글 공감자 batch API 클라이언트가 전체 commentIds 를 한 번에 보내 서버의 EXTERNAL_COMMENT_LIKERS_BATCH_IDS=50 한도에 의해 51번째 이후 댓글이 preview 데이터를 못 받던 버그 수정
- 50개 청크로 Promise.all 병렬 호출로 해결

## 배경
- PR #1239 (#11963) 은 batch IDs 한도를 10→50 으로 올렸으나, 50개 초과 댓글 케이스는 여전히 남아있었음
- 제보 #11996 "특정번째 이후 댓글 공감자 리스트 확인 안됨" 의 원인

## Test plan
- [ ] 댓글 50개 초과인 게시글에서 51번째 이후 댓글의 공감자 미리보기 노출 확인
- [ ] 기존 50개 이하 게시글 regression 없음 (청크 1개 = 기존과 동일)
- [ ] 네트워크 탭에서 likers-batch 호출이 50개 단위로 나뉘어 병렬 실행됨을 확인