### PR TITLE
fix: 홈 공감글 터치 오인식 근본 원인 3건 (#11998)

### DIFF
--- a/apps/web/src/lib/components/features/recommended/components/ai-trend/ai-trend-card.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/ai-trend/ai-trend-card.svelte
@@ -35,6 +35,8 @@
             src="{import.meta.env
                 .VITE_S3_URL}/data/editor/2509/5770b-68ca37f63464f-24fb734ab222da3cff7aee7898aedce5e1c3c360.webp"
             alt="앙 AI 캐릭터"
+            width="48"
+            height="48"
             class="size-12 object-contain"
             loading="lazy"
         />

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -49,12 +49,15 @@
     ]);
 
     // 모바일 목록처럼 터치가 빈번한 위치: no fill이어도 즉시 축소하지 않음 (CLS 방지)
+    // 홈 공감글 터치 오인식(#11998) — 공감글 아래 위젯들이 index-middle 광고 높이 변화로 밀리는 것을 방지
     const TOUCH_SAFE_POSITIONS = new Set([
         'header-after',
         'board-list-infeed',
         'board-list-top',
         'board-list-bottom',
         'index-top',
+        'index-middle-1',
+        'index-middle-2',
         'board-content',
         'board-before-comments'
     ]);

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -75,8 +75,10 @@
                 : undefined,
             explore: data.exploreData ? { data: data.exploreData } : undefined
         },
-        celebration: (data.celebrationRecent ?? data.celebration)?.length
-            ? { data: data.celebrationRecent ?? data.celebration }
-            : undefined
+        // 홈 공감글 터치 오인식(#11998) — SSR 데이터가 빈 배열일 때 undefined 를 넘기면
+        // 클라이언트 $effect 가 재요청을 보내 축하메시지 Card 가 hydration 직후 삽입되며
+        // 그 아래 위젯이 밀리는 레이아웃 shift 를 유발. 빈 배열이라도 항상 prefetchData 로
+        // 넘겨서 클라이언트 재요청을 차단함.
+        celebration: { data: data.celebrationRecent ?? data.celebration ?? [] }
     }}
 />


### PR DESCRIPTION
## Summary
홈 공감글 터치 시 위/아래 인접 항목이 눌리는 버그(#11998) 의 근본 원인 3건 fix.

### 근본 원인 (Explore 에이전트 2차 분석)
1. **축하메시지 hydration 직후 삽입으로 레이아웃 shift** — SSR 이 `celebrationRecent=[]` 를 반환하면 +page.svelte 가 `prefetchData=undefined` 를 넘겼고, 위젯의 \`\$effect()\` 가 재요청해 Card 가 삽입되며 아래 위젯이 밀림
2. **광고 슬롯 높이 점프** — \`TOUCH_SAFE_POSITIONS\` 에 \`index-middle-1/2\` 미포함 → iframe 로드 시점에 공감글 아래 요소 순간 이동
3. **AI 트렌드 카드 이미지 intrinsic size 없음** — lazy 로드 시 reserved height 없어 미세 점프

### CLS 측정이 0.0 이었던 이유
layout shift 가 hydration 직후 약 0.1~0.3초 안에 발생하고 그 이후 안정. Playwright \`buffered:true\` 로 관측 가능하나 사용자 제보는 \"페이지가 새로고침되며 좌표가 바뀌는\" 순간의 miss-touch 로 hitbox 이전 좌표가 잠시 유효.

## 변경 파일
- \`apps/web/src/routes/+page.svelte\` — celebration prefetchData 항상 주입
- \`apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte\` — TOUCH_SAFE_POSITIONS 에 index-middle-1·index-middle-2 추가
- \`apps/web/src/lib/components/features/recommended/components/ai-trend/ai-trend-card.svelte\` — 이미지 width·height 속성 추가

## Test plan
- [ ] 홈 진입 후 공감글 리스트 위치 (\`getBoundingClientRect().top\`) 가 1초간 변화 없음 확인
- [ ] 광고 영역 iframe 로드 전/후 공감글 y좌표 동일
- [ ] 축하메시지 없는 시점 홈 진입 시 /api/ads/celebration/today 재요청 안 함 (Network 탭)
- [ ] 실기기 (갤럭시 S25) 재현 재확인 — AI 댓글 #12020 으로 제보자께 canary 확인 요청 예정

## 관련 PR
- PR #1257 (#12006 유튜브) · PR #1258 (#11996 공감자 청크) 는 이미 머지됨
- 별도 PR-H2 (게시글 액션바 버튼 44px, #12016) 후속 진행