### PR TITLE
fix: 게시글 액션바 버튼 모바일 터치 타겟 44px (#12016)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1463,8 +1463,10 @@
         >
     </nav>
 
-    <!-- 상단 네비게이션 -->
-    <div class="-mx-2 mb-2 flex items-center gap-3 px-2 py-2 md:mx-0 md:px-0">
+    <!-- 상단 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
+    <div
+        class="-mx-2 mb-2 flex items-center gap-3 px-2 py-2 md:mx-0 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+    >
         <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
 
@@ -1902,8 +1904,10 @@
             </div>
         {/if}
 
-        <!-- 댓글 아래 네비게이션 -->
-        <div class="-mx-2 mt-4 flex items-center gap-3 px-2 py-2 md:mx-0 md:px-0">
+        <!-- 댓글 아래 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
+        <div
+            class="-mx-2 mt-4 flex items-center gap-3 px-2 py-2 md:mx-0 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+        >
             <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0"
                 >←</Button
             >


### PR DESCRIPTION
## Summary
게시글 상·하단 액션바의 버튼(목록/뒤로/글쓰기/수정) 터치 타겟이 32~36px 로 Apple(44px) · Google(48dp) 모바일 접근성 권장값 미달 → #12016 제보자가 아래위 버튼이 같이 눌린다고 보고.

## 변경
- \`apps/web/src/routes/[boardId]/[postId]/+page.svelte\` L1467·L1908
- wrapper div 에 \`[&_a]:min-h-11 [&_button]:min-h-11 md:[&_a]:min-h-0 md:[&_button]:min-h-0\` 추가
- 모바일: 모든 내부 \`<a>\`/\`<button>\` 최소 높이 44px (Tailwind \`min-h-11\` = 2.75rem)
- 데스크톱: \`min-h-0\` 로 해제해 기존 \`size=\"sm\"\` (h-8=32px) 디자인 유지

## 선택 이유
- 기존 \`size=\"sm\"\` 인스턴스를 전부 수정하는 대신 wrapper 로 통제 → 인스턴스 누락 위험 낮춤
- \`min-height\` 는 \`height\` 보다 부작용 적음 (내용 늘어나면 그대로 확장)

## Test plan
- [ ] DevTools 모바일 뷰포트(375px)에서 상·하단 액션바 모든 버튼 \`getBoundingClientRect().height >= 44\`
- [ ] 데스크톱 뷰포트(1280px)에서 h-8 (32px) 유지
- [ ] Tailwind 의 임의 descendant selector(\`[&_button]:\`) 가 정상 컴파일
- [ ] 실기기 (Pixel 8A) 재현 확인 — AI 댓글 #12021 로 canary 확인 요청 예정

## 관련
- PR #1257 (#12006) · PR #1258 (#11996) · PR #1259 (#11998 H1) 와 같이 이번 스프린트의 터치/댓글 계열 근본 fix