### PR TITLE
feat(telemetry): heap metrics logger (60s stdout → otel.logs)

### DIFF
--- a/apps/web/src/lib/server/telemetry.ts
+++ b/apps/web/src/lib/server/telemetry.ts
@@ -57,6 +57,28 @@ if (OTEL_ENABLED) {
     // eslint-disable-next-line no-console
     console.log(`[telemetry] OTel started: endpoint=${endpoint} sampler=${samplerArg}`);
 
+    // Heap metrics logger — 4/22 OOM 이후 추가.
+    // process.memoryUsage()를 60초마다 stdout에 JSON으로 출력 → OTel collector filelog receiver가
+    // otel.logs 테이블에 수집 → Grafana 패널에서 heap 추이 관찰.
+    // 별도 metrics 파이프라인 없이 기존 logs 파이프라인 재활용.
+    const HEAP_LOG_INTERVAL_MS = 60_000;
+    const heapLogTimer = setInterval(() => {
+        const m = process.memoryUsage();
+        // eslint-disable-next-line no-console
+        console.log(
+            JSON.stringify({
+                event: 'heap_metrics',
+                rss: m.rss,
+                heapTotal: m.heapTotal,
+                heapUsed: m.heapUsed,
+                external: m.external,
+                arrayBuffers: m.arrayBuffers,
+                uptime_s: Math.round(process.uptime())
+            })
+        );
+    }, HEAP_LOG_INTERVAL_MS);
+    heapLogTimer.unref?.();
+
     process.on('SIGTERM', async () => {
         try {
             await sdk.shutdown();


### PR DESCRIPTION
## Summary

- 60초마다 \`process.memoryUsage()\`를 JSON으로 stdout 출력
- OTel collector filelog receiver → ClickHouse \`otel.logs\` 자동 수집
- 별도 OTLP metrics 파이프라인 없이 기존 logs 재활용 (최소 변경)

## 배경

4/22 prod OOM 후 회귀 조기 탐지를 위한 관찰성 개선.
web 컨테이너가 heap ~745MB에서 crash 했는데, RSS/heap 추이 시각화가
없어 사전 탐지 불가능했음. 이번 PR로 Grafana에서 heap curve 관찰 가능.

## Schema

\`\`\`json
{"event":"heap_metrics","rss":...,"heapTotal":...,"heapUsed":...,"external":...,"arrayBuffers":...,"uptime_s":...}
\`\`\`

## Test plan

- [ ] 배포 후 \`kubectl logs -n angple <pod> | grep heap_metrics\` → 60초 간격 JSON 확인
- [ ] ClickHouse \`SELECT Body FROM otel.logs WHERE Body LIKE '%heap_metrics%' ORDER BY Timestamp DESC LIMIT 10\` 로 수집 검증
- [ ] Grafana에 시계열 패널 추가 후 heap 추이 관찰 (후속)