### PR TITLE
fix(csp): STATIC_ASSET_ORIGIN fallback + deploy runbook 강화

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -91,6 +91,7 @@ function isAllowedOrigin(origin: string): boolean {
 const ADS_URL = env.ADS_URL || '';
 const LEGACY_URL = env.LEGACY_URL || '';
 const ASSET_BASE_URL = (env.ASSET_BASE_URL || '').replace(/\/+$/, '');
+const STATIC_ASSET_ORIGIN = 'https://static.damoang.net';
 
 /** CDN 캐시 가능한 공개 경로 (비로그인 시만 적용) */
 const PUBLIC_CACHEABLE_PATHS = ['/feed', '/games', '/info'];
@@ -427,7 +428,13 @@ function buildCsp(): string {
     // 사이트별 도메인을 CSP에 동적 추가
     const adsHost = ADS_URL ? ` ${ADS_URL}` : '';
     const legacyHost = LEGACY_URL ? ` ${LEGACY_URL}` : '';
-    const assetOrigin = ASSET_BASE_URL ? ` ${new URL(ASSET_BASE_URL).origin}` : '';
+    const assetOrigins = new Set<string>([STATIC_ASSET_ORIGIN]);
+
+    if (ASSET_BASE_URL) {
+        assetOrigins.add(new URL(ASSET_BASE_URL).origin);
+    }
+
+    const assetOrigin = assetOrigins.size > 0 ? ` ${Array.from(assetOrigins).join(' ')}` : '';
 
     const directives: string[] = [
         "default-src 'self' https://damoang.net https://*.damoang.net",

--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -11,71 +11,81 @@
 
 ## 기본 원칙
 
-- production 직행 배포 금지
-- canary에서 확인한 동일 `sha-*`만 production 승격
-- rollback은 재빌드가 아니라 기존 `sha-*` 재승격으로 처리
-- 장애 중에는 개선보다 복구를 우선
+-   production 직행 배포 금지
+-   canary에서 확인한 동일 `sha-*`만 production 승격
+-   rollback은 재빌드가 아니라 기존 `sha-*` 재승격으로 처리
+-   장애 중에는 개선보다 복구를 우선
+-   web immutable 자산은 `https://static.damoang.net/releases/<sha>` 단일 경로만 사용
 
 ## dev 확인 항목
 
-- 상세 페이지가 500 없이 열린다
-- `목록으로`가 실제 목록으로 이동한다
-- 댓글 목록이 보인다
-- 댓글 에디터가 입력 가능하다
-- 뒤로가기/재진입이 멈추지 않는다
+-   상세 페이지가 500 없이 열린다
+-   `목록으로`가 실제 목록으로 이동한다
+-   댓글 목록이 보인다
+-   댓글 에디터가 입력 가능하다
+-   뒤로가기/재진입이 멈추지 않는다
 
 ## canary 확인 항목
 
-- 상세 페이지 500 없음
-- `__data.json` 정상
-- 댓글 목록 정상
-- 댓글 에디터 정상
-- `목록으로` 정상
-- 뒤로가기/재진입 정상
-- blocker 콘솔 에러 없음
-  - `effect_update_depth_exceeded`
-  - `DOMPurify ... sanitize is not a function`
-  - chunk load failure
+-   상세 페이지 500 없음
+-   `__data.json` 정상
+-   댓글 목록 정상
+-   댓글 에디터 정상
+-   `목록으로` 정상
+-   뒤로가기/재진입 정상
+-   blocker 콘솔 에러 없음
+    -   `effect_update_depth_exceeded`
+    -   `DOMPurify ... sanitize is not a function`
+    -   chunk load failure
 
 ## production 승인 기준
 
-- `verify-canary` success
-- 핵심 시나리오 확인 완료
-- canary와 production이 같은 `sha-*` 아티팩트임을 확인
+-   `verify-canary` success
+-   핵심 시나리오 확인 완료
+-   canary와 production이 같은 `sha-*` 아티팩트임을 확인
+-   `ASSET_RELEASE_ID`, `ASSET_BASE_URL`, image tag가 같은 SHA인지 확인
+-   CSP가 `https://static.damoang.net`을 허용하는지 확인
 
 ## rollback 기준
 
 즉시 rollback:
 
-- 상세 페이지 전반 500
-- 댓글/목록/내비게이션 공통 장애
-- canary와 동일 SHA가 production에서 회귀
+-   상세 페이지 전반 500
+-   댓글/목록/내비게이션 공통 장애
+-   canary와 동일 SHA가 production에서 회귀
 
 rollback 시 아래 3개를 같은 SHA로 맞춘다.
 
-- image
-- `ASSET_RELEASE_ID`
-- `ASSET_BASE_URL`
+-   image
+-   `ASSET_RELEASE_ID`
+-   `ASSET_BASE_URL`
+
+## 장애 시 purge 원칙
+
+-   current release asset이 200이면 `/_app/immutable/*` 전체 purge 금지
+-   먼저 HTML shell만 purge
+-   기본 경로: `/`, `/free`, `/hot`, `/best`, `/new`, `/manifest.json`, `/sw.js`
+-   상세 제보가 있으면 최근 상세 1건만 추가
 
 ## 체크리스트
 
 ### dev
 
-- [ ] 수정이 dev에서 재현/해결 확인됨
-- [ ] 상세 페이지 500 없음
-- [ ] `목록으로` 정상
-- [ ] 댓글 목록 정상
-- [ ] 댓글 에디터 정상
-- [ ] 뒤로가기/재진입 정상
+-   [ ] 수정이 dev에서 재현/해결 확인됨
+-   [ ] 상세 페이지 500 없음
+-   [ ] `목록으로` 정상
+-   [ ] 댓글 목록 정상
+-   [ ] 댓글 에디터 정상
+-   [ ] 뒤로가기/재진입 정상
 
 ### canary
 
-- [ ] canary-only 배포
-- [ ] `verify-canary` success
-- [ ] 핵심 시나리오 수동 확인 완료
+-   [ ] canary-only 배포
+-   [ ] `verify-canary` success
+-   [ ] 핵심 시나리오 수동 확인 완료
 
 ### production
 
-- [ ] canary와 same artifact SHA 확인
-- [ ] production gate 승인
-- [ ] `verify-production` success
+-   [ ] canary와 same artifact SHA 확인
+-   [ ] production gate 승인
+-   [ ] `verify-production` success


### PR DESCRIPTION
## 배경

2026-04-22 새벽 7:38 화면 깨짐 장애. `kubectl apply -f prod/angple-web.yaml`
실행 시 yaml에 없던 `ASSET_BASE_URL`, `ASSET_RELEASE_ID` env가 drop됨
(deploy.sh가 런타임 주입한 값이 apply에 의해 삭제). CSP 빌더가
\`ASSET_BASE_URL\` 기반으로 \`https://static.damoang.net\` 을 추가했는데 env가
빈값이 되어 CSP에서 누락 → 브라우저 CSP 위반으로 asset 로드 차단 → 화면 깨짐.

## 변경

1. \`hooks.server.ts\` \`buildCsp()\`:
   - \`STATIC_ASSET_ORIGIN\` 상수 도입 (https://static.damoang.net)
   - CSP asset origin 집합에 항상 포함 (env 누락/파싱 실패에도 일관)
   - \`ASSET_BASE_URL\` 값이 유효하면 추가로 set에 추가

2. \`docs/deploy-runbook.md\`:
   - web immutable asset 경로 규약 명시
   - 배포 후 ASSET_RELEASE_ID/ASSET_BASE_URL/image tag 동일 SHA 확인 체크리스트
   - CSP 허용 확인 체크리스트
   - 장애 시 purge 원칙 (current release 200이면 전체 purge 금지, HTML shell만)

## Test plan

- [ ] 배포 후 \`curl -I https://damoang.net/\` 로 \`Content-Security-Policy\` 헤더에
      \`https://static.damoang.net\` 포함되는지 확인
- [ ] 브라우저 DevTools Console에 CSP 위반 없음 확인
- [ ] 의도적 drift 테스트: kubectl unset env ASSET_BASE_URL 후에도 화면 정상 동작

## 관련

- 4/22 07:38 장애 회고 (kubectl apply env drop drift)