### PR TITLE
fix: TagNav active 메뉴 클릭 시 새로고침 (#12027)

### DIFF
--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { page } from '$app/stores';
+    import { invalidateAll } from '$app/navigation';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
 
     export interface TagNavMenu {
@@ -47,6 +48,16 @@
         {#each visibleMenus as menu (menu.key)}
             <a
                 href={menu.url}
+                onclick={(e) => {
+                    // 현재 페이지와 동일한 메뉴 클릭 시 SvelteKit 이 navigation 을 생략해
+                    // "클릭해도 아무 반응 없음" 처럼 보이는 문제(#12027) 방지.
+                    // 좌측 카테고리 링크와 동일하게 invalidateAll() 로 새로고침.
+                    if (isActive(menu.url)) {
+                        e.preventDefault();
+                        invalidateAll();
+                        window.scrollTo(0, 0);
+                    }
+                }}
                 class="shrink-0 whitespace-nowrap rounded-lg px-3 py-1.5 text-sm transition-all duration-200 ease-out
                     {isActive(menu.url)
                     ? 'bg-primary text-primary-foreground font-medium'


### PR DESCRIPTION
## Summary
- TagNav 상단 탭에서 현재 페이지에 해당하는 메뉴(active) 클릭 시 SvelteKit 이 동일 경로 navigation 을 생략해 아무 반응 없음
- 좌측 사이드바 카테고리 링크와 동일한 `invalidateAll()` + `scrollTo(0,0)` 패턴 적용으로 새로고침 동작 부여

## 원인
- `/free` 페이지에서 상단 TagNav "자유게시판" (active) 클릭 → 같은 경로 → goto 생략 → 화면 변화 없음
- 반면 좌측 사이드바 카테고리는 `<h1>` 의 onclick 과 동일 로직을 이미 가지고 있어 정상 새로고침

## 변경
- `apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte`
- `isActive(menu.url)` 일 때 `e.preventDefault()` + `invalidateAll()` + `scrollTo(0,0)`

## Test plan
- [ ] `/free` 에서 상단 TagNav "자유게시판" 클릭 시 데이터 재조회 + 스크롤 상단 이동
- [ ] `/explore` 등 다른 active 메뉴에서 동일 동작
- [ ] active 아닌 메뉴 클릭은 기존 navigation 유지