### PR TITLE
fix(jwt-cache): 60s 주기 만료 entry cleanup (메모리 누수 차단)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -42,6 +42,17 @@ const jwtCache = new Map<string, { token: string; expiry: number }>();
 const JWT_CACHE_TTL = 5 * 60 * 1000; // 5분
 const MAX_JWT_CACHE_SIZE = 50000;
 
+// 만료 entry 주기적 정리 — 4/22 prod 메모리 누수 근본 원인.
+// 기존 eviction은 size >= MAX일 때만 실행되어, size < MAX면 만료된 entry가
+// 무한 누적 (9h 기준 pod당 RSS ~900Mi). 60s 주기로 만료분만 제거해 누수 차단.
+const jwtCleanupTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of jwtCache) {
+        if (now >= entry.expiry) jwtCache.delete(key);
+    }
+}, 60_000);
+jwtCleanupTimer.unref?.();
+
 // --- SSR 응답 캐시 (비로그인: 홈 + 게시판 목록 + 글 상세) ---
 import {
     ssrCache,


### PR DESCRIPTION
## 배경

4/22 prod 메모리 누수 근본 원인 조사 (Explore 에이전트):

- \`jwtCache\` Map이 size < MAX(50000)일 때 만료 entry 정리 **안 함** (line 325 조건부 cleanup)
- 만료된 JWT entry가 MAX 도달 전까지 계속 누적
- 9시간 runtime 기준 pod당 RSS ~900Mi 증가 관측
- 노드 메모리 86-92% 반복 fire, 오늘 3번 pod 수동 삭제/rollout restart 필요

## 수정

\`hooks.server.ts\` L41-44 아래에 setInterval 추가:

\`\`\`typescript
const jwtCleanupTimer = setInterval(() => {
    const now = Date.now();
    for (const [key, entry] of jwtCache) {
        if (now >= entry.expiry) jwtCache.delete(key);
    }
}, 60_000);
jwtCleanupTimer.unref?.();
\`\`\`

- 60초 주기로 만료 entry만 제거
- \`timer.unref()\` 로 graceful shutdown 차단 방지
- 기존 reactive eviction (L325-340) 그대로 유지 (size 폭증 시 안전장치)

## 예상 효과

- pod당 메모리 증가율: **~100Mi/h → 수십 Mi/h 이하**
- 노드 메모리 사용률: 장시간 안정
- HPA 스케일 out/in 횟수 감소
- 오늘 5회 이상 fire된 OOM 알림 빈도 크게 감소

## Test plan

- [ ] CI 통과
- [ ] canary 새벽 4시 배포, 6h 관측
  - \`kubectl top pod -n angple -l app=angple-web-canary\` 메모리 추이 확인
  - 증가율 < 20Mi/h 목표
- [ ] prod 배포 후 24h 관측
  - 노드 메모리 사용률 65% 이하 유지
  - 신규 pod OOMKill 0건
  - JWT 인증 회귀 없음

## 롤백

image rollback (canary 검증 실패 시) — 단일 파일 변경이라 reverts 간단.