### PR TITLE
fix: 상세 페이지 최근글 목록이 이전 게시판 상태 유지 (#12040)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1943,16 +1943,20 @@
 </div>
 
 <!-- 게시판 최근글 목록 -->
+<!-- #12040: boardId 변경 시 RecentPosts 를 강제 재생성하여 이전 게시판의
+     posts state 가 남아있다가 잘못된 URL 로 이동하는 문제 방지 -->
 {#if canRead}
-    <RecentPosts
-        {boardId}
-        {boardTitle}
-        currentPostId={data.post.id}
-        limit={20}
-        initialPage={data.recentPosts?.page || Number($page.url.searchParams.get('page')) || 1}
-        {promotionPosts}
-        displaySettings={data.board?.display_settings}
-    />
+    {#key boardId}
+        <RecentPosts
+            {boardId}
+            {boardTitle}
+            currentPostId={data.post.id}
+            limit={20}
+            initialPage={data.recentPosts?.page || Number($page.url.searchParams.get('page')) || 1}
+            {promotionPosts}
+            displaySettings={data.board?.display_settings}
+        />
+    {/key}
 {/if}
 
 {#if authStore.isAuthenticated}


### PR DESCRIPTION
## Summary
- RecentPosts 컴포넌트가 SPA 네비게이션 시 boardId prop 변경을 감지 못해 이전 게시판의 posts state 가 잔존
- 그 목록 클릭 시 현재 boardId + 이전 post.id 조합으로 '없는 글' 에러 발생
- `{#key boardId}` 로 래핑해 boardId 변경 시 컴포넌트 강제 재생성

## 재현
1. `/new` 목록 보는 중
2. 알림에서 다른 게시판(예: `/groups/macmoang/123`) 글 클릭
3. 글 본문 하단 "최근글 목록" 이 `/new` 글 목록으로 표시됨
4. 해당 목록의 글 클릭 → `/macmoang/<new_post_id>` 로 이동 → 에러

## 변경
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` — RecentPosts `{#key boardId}` 래핑

## Test plan
- [ ] `/new` → 알림에서 `/groups/macmoang/X` 이동 시 하단 목록이 macmoang 목록으로 교체
- [ ] 같은 게시판 내 이동(`/free/A` → `/free/B`) 시 목록 상태 유지 (회귀 없음)
- [ ] 페이지네이션 상태: 다른 게시판 이동 시 1페이지 초기화, 같은 게시판은 유지