### PR TITLE
fix: 공감/비공감 false 실패 알림 제거 (#12004)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1047,16 +1047,42 @@
             // 아바타 스택 갱신
             loadLikerAvatars();
         } catch (err) {
+            console.error('Failed to like post:', err);
+            if (err instanceof Error && err.message.includes('실명인증')) {
+                // 실명인증 미완 → 원래대로 롤백 후 인증 페이지로 이동
+                isLiked = prevLiked;
+                isDisliked = prevDisliked;
+                likeCount = prevLikeCount;
+                dislikeCount = prevDislikeCount;
+                goToCertification();
+                return;
+            }
+            // #12004: 모바일 네트워크 등에서 서버는 처리됐으나 응답 수신이 실패한 경우
+            // 서버 실제 상태를 재조회해서 사용자 의도와 일치하면 silent success 로 처리.
+            // 그렇지 않은 경우에만 롤백 + 알림.
+            try {
+                const status = await apiClient.getPostLikeStatus(boardId, String(data.post.id));
+                const intendedLiked = !prevLiked;
+                if (status.user_liked === intendedLiked) {
+                    isLiked = status.user_liked;
+                    isDisliked = status.user_disliked ?? false;
+                    likeCount = status.likes;
+                    dislikeCount = status.dislikes ?? 0;
+                    if (!prevLiked && isLiked) {
+                        trackEvent('like', { board_id: boardId, post_id: data.post.id });
+                    }
+                    loadLikerAvatars();
+                    return;
+                }
+            } catch {
+                // 재조회도 실패 → 기본 실패 경로로 폴백
+            }
             isLiked = prevLiked;
             isDisliked = prevDisliked;
             likeCount = prevLikeCount;
             dislikeCount = prevDislikeCount;
-            console.error('Failed to like post:', err);
-            if (err instanceof Error && err.message.includes('실명인증')) {
-                goToCertification();
-                return;
-            }
-            alert('공감에 실패했습니다.');
+            const msg = err instanceof Error && err.message ? err.message : '공감에 실패했습니다.';
+            alert(msg);
         } finally {
             isLiking = false;
         }
@@ -1076,6 +1102,7 @@
 
         if (isDisliking) return;
 
+        const prevDislikedForReconcile = isDisliked;
         isDisliking = true;
         try {
             const response = await apiClient.dislikePost(boardId, String(data.post.id));
@@ -1094,7 +1121,23 @@
                 goToCertification();
                 return;
             }
-            alert('비공감에 실패했습니다.');
+            // #12004: 서버는 처리됐으나 응답 수신이 실패한 경우 상태 재조회로 확인
+            try {
+                const status = await apiClient.getPostLikeStatus(boardId, String(data.post.id));
+                const intendedDisliked = !prevDislikedForReconcile;
+                if ((status.user_disliked ?? false) === intendedDisliked) {
+                    isLiked = status.user_liked;
+                    isDisliked = status.user_disliked ?? false;
+                    likeCount = status.likes;
+                    dislikeCount = status.dislikes ?? 0;
+                    return;
+                }
+            } catch {
+                // 재조회도 실패 → fallback
+            }
+            const msg =
+                err instanceof Error && err.message ? err.message : '비공감에 실패했습니다.';
+            alert(msg);
         } finally {
             isDisliking = false;
         }


### PR DESCRIPTION
## Summary
- 모바일 네트워크에서 서버는 성공했으나 응답 수신만 실패한 케이스에 "공감에 실패했습니다" 거짓 알림이 뜨던 문제 수정
- catch 에서 `getPostLikeStatus` 로 서버 실제 상태를 재조회해 사용자 의도와 일치하면 silent success 로 처리
- 재조회 실패 또는 상태 불일치 시에만 롤백 + 알림 (기존 동작)

## 근본 원인
- fetch timeout/connection reset 등으로 throw 발생해도 DB transaction 은 commit 된 상태
- 기존 로직은 throw = 실패로 단순 처리 → UI 롤백 + 경고
- 사용자 입장: 서버 상태는 공감됨, 화면만 '실패' 알림 → 혼란

## 변경
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte`
- handleLike / handleDislike 의 catch 블록에 reconcile 로직 추가
- alert 메시지 우선순위: `err.message` (서버 제공) → 기본 문구

## Test plan
- [ ] 느린 네트워크 조건(DevTools Network throttling)에서 공감 토글 시 거짓 알림 사라짐
- [ ] 정상 조건 공감/비공감 동작 회귀 없음
- [ ] 실명인증 미완 케이스 기존과 동일하게 인증 페이지로 이동
- [ ] 서버 validation 에러(예: "이미 비추천한 글") 시 구체 메시지 표시