### PR TITLE
fix: 임시저장 시 첨부파일 보존 + 용량 초과 경고 (#12029)

### DIFF
--- a/apps/web/src/lib/components/features/board/draft-list.svelte
+++ b/apps/web/src/lib/components/features/board/draft-list.svelte
@@ -24,6 +24,11 @@
         isSecret: boolean;
         savedAt: string;
         boardId: string;
+        tags?: string[];
+        link1?: string;
+        link2?: string;
+        // #12029: 첨부파일 목록도 draft 에 포함시켜 복원 시 소실 방지
+        uploadedFiles?: unknown[];
     }
 
     // 임시저장 목록
@@ -53,7 +58,11 @@
                             category: data.category || '',
                             isSecret: data.isSecret || false,
                             savedAt: data.savedAt,
-                            boardId
+                            boardId,
+                            tags: data.tags,
+                            link1: data.link1,
+                            link2: data.link2,
+                            uploadedFiles: data.uploadedFiles
                         });
                     }
                 } catch {

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -148,7 +148,11 @@
         link1: string;
         link2: string;
         savedAt: string;
+        uploadedFiles?: UploadedFile[];
     }
+
+    // #12029: localStorage quota 초과 시 사용자에게 한 번만 안내 (자동저장 매번 경고 방지)
+    let quotaWarned = false;
 
     // 임시저장 저장
     function saveDraft(): void {
@@ -164,7 +168,9 @@
             tags,
             link1,
             link2,
-            savedAt: new Date().toISOString()
+            savedAt: new Date().toISOString(),
+            // #12029: FileUploader 로 첨부한 파일이 draft 복원 시 소실되지 않도록 저장
+            uploadedFiles
         };
 
         try {
@@ -173,6 +179,17 @@
             hasUnsavedChanges = false;
         } catch (err) {
             console.error('임시저장 실패:', err);
+            // QuotaExceededError — silent 실패로 이전 draft 만 남아 사용자가
+            // 제목만 남은 것처럼 보이는 문제(#12029) 방지
+            const isQuota =
+                err instanceof DOMException &&
+                (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED');
+            if (isQuota && !quotaWarned) {
+                quotaWarned = true;
+                alert(
+                    '임시저장 용량이 가득 찼습니다.\n본문에 붙여넣기한 이미지는 서버 업로드가 완료되어야 용량이 줄어듭니다.\n바로 정식 등록하시거나 이미지를 먼저 업로드 후 다시 시도해 주세요.'
+                );
+            }
         } finally {
             isSaving = false;
         }
@@ -211,6 +228,10 @@
             tags = draft.tags || [];
             link1 = draft.link1 || '';
             link2 = draft.link2 || '';
+            // #12029: 업로드된 첨부파일 목록도 함께 복원
+            if (draft.uploadedFiles && draft.uploadedFiles.length > 0) {
+                uploadedFiles = draft.uploadedFiles;
+            }
             lastSavedAt = new Date(draft.savedAt);
             hasUnsavedChanges = false;
         }
@@ -403,6 +424,7 @@
         tags?: string[];
         link1?: string;
         link2?: string;
+        uploadedFiles?: UploadedFile[];
     }): void {
         title = draft.title;
         content = draft.content;
@@ -411,6 +433,10 @@
         tags = draft.tags || [];
         link1 = draft.link1 || '';
         link2 = draft.link2 || '';
+        // #12029: 첨부파일 목록도 복원
+        if (draft.uploadedFiles && draft.uploadedFiles.length > 0) {
+            uploadedFiles = draft.uploadedFiles;
+        }
         hasUnsavedChanges = true;
     }
 

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -424,7 +424,7 @@
         tags?: string[];
         link1?: string;
         link2?: string;
-        uploadedFiles?: UploadedFile[];
+        uploadedFiles?: unknown[];
     }): void {
         title = draft.title;
         content = draft.content;
@@ -433,9 +433,9 @@
         tags = draft.tags || [];
         link1 = draft.link1 || '';
         link2 = draft.link2 || '';
-        // #12029: 첨부파일 목록도 복원
+        // #12029: 첨부파일 목록도 복원 (DraftList의 DraftItem은 unknown[]로 type)
         if (draft.uploadedFiles && draft.uploadedFiles.length > 0) {
-            uploadedFiles = draft.uploadedFiles;
+            uploadedFiles = draft.uploadedFiles as UploadedFile[];
         }
         hasUnsavedChanges = true;
     }


### PR DESCRIPTION
## Summary
- 자동저장이 FileUploader 첨부파일(`uploadedFiles`) 을 DraftData 에 포함시키지 않아 draft 복원 시 제목/본문만 남고 이미지가 소실되던 문제 수정
- localStorage `QuotaExceededError` 가 silent 실패로 처리되어 이전 title-only draft 만 남아 "제목만 남고 싹 사라짐" 으로 보이던 문제 수정
- 용량 초과 감지 시 한 번만 사용자에게 alert 로 안내 (매 자동저장마다 경고 방지)

## 재현 가설
- 본문에 이미지를 붙여넣으면 업로드 완료 전 base64 data URI 로 잠시 존재
- 자동저장(10초) 이 이 시점에 실행되면 localStorage 5MB 한도 초과 → 저장 실패
- 사용자 UI 에는 'unsaved' 플래그가 유지되지만 내부적으로 직전 성공 draft (title 만 있던 상태) 가 계속 잔존
- 창 닫고 재방문 시 DraftList 에 title-only draft 가 보여서 "본문/이미지 소실" 로 인식

## 변경
- `apps/web/src/lib/components/features/board/post-form.svelte`
  - `DraftData` 에 `uploadedFiles` 추가
  - `saveDraft` 에서 `uploadedFiles` 함께 저장 + `QuotaExceededError` 처리
  - `restoreDraft` / `handleLoadDraft` 에서 `uploadedFiles` 복원
- `apps/web/src/lib/components/features/board/draft-list.svelte`
  - `DraftItem` 에 `tags`/`link1`/`link2`/`uploadedFiles` 추가
  - `loadAllDrafts` 에서 그대로 전달

## Test plan
- [ ] 새 글 작성 → 이미지 첨부 → 창 닫기 → 재방문 → 첨부 이미지 목록 유지
- [ ] 본문에 base64 이미지 다수 페이스트 → 자동저장 실패 시 경고 alert 1회 노출
- [ ] 정상 케이스(소용량) 에서 기존 동작 회귀 없음