### PR TITLE
feat(hooks): ssr_auth cookie for CDN cache key normalization

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -469,6 +469,33 @@ function buildCsp(): string {
 
 const cspHeader = buildCsp();
 
+/**
+ * SSR auth cookie sync — CDN cache key normalization.
+ *
+ * CDN이 수많은 사용자 쿠키(angple_sid, damoang_jwt 등)로 cache key를 분산시키는 대신,
+ * 단일 binary cookie `ssr_auth=1`(로그인) / 없음(익명)으로 normalize.
+ * CDN cache rule에서 ssr_auth만 vary key로 포함하면 auth/anon 2개 cache entry로 통합.
+ *
+ * 조건: event.locals.user 여부 기준. authenticateSSR() 실행 직후 호출.
+ */
+function syncSsrAuthCookie(event: Parameters<Handle>[0]['event']): void {
+    const authed = !!event.locals.user;
+    const current = event.cookies.get('ssr_auth');
+    const domainOpt = COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {};
+    if (authed && current !== '1') {
+        event.cookies.set('ssr_auth', '1', {
+            path: '/',
+            sameSite: 'lax',
+            secure: !dev,
+            httpOnly: false,
+            maxAge: 60 * 60 * 24 * 30,
+            ...domainOpt
+        });
+    } else if (!authed && current) {
+        event.cookies.delete('ssr_auth', { path: '/', ...domainOpt });
+    }
+}
+
 /** 개발/내부 전용 경로 — 프로덕션에서 차단 */
 const DEV_ONLY_PATHS = ['/api-test', '/api-docs', '/api-doc', '/install'];
 
@@ -603,6 +630,9 @@ export const handle: Handle = async ({ event, resolve }) => {
 
     // SSR 인증
     await authenticateSSR(event);
+
+    // CDN cache key normalization — ssr_auth=1 / 없음 2-state로 쿠키 다양성 축소
+    syncSsrAuthCookie(event);
 
     // CSRF 검증: 세션 기반 double-submit cookie
     if (


### PR DESCRIPTION
## Summary

CDN req-hit%가 74% → 38%로 떨어진 주원인은 **cache key 다양성** (angple_sid/damoang_jwt 등 사용자별 쿠키 → 각각 별도 cache entry). 단일 binary cookie `ssr_auth`로 normalize하여 CDN이 auth/anon 2-state만 구분하도록 함.

## What changes

- `apps/web/src/hooks.server.ts`에 `syncSsrAuthCookie()` 함수 추가
- `authenticateSSR()` 실행 직후 호출
- `event.locals.user` 여부로 `ssr_auth=1` set or delete

## Cookie 속성
| 속성 | 값 |
|---|---|
| Path | `/` |
| SameSite | `Lax` |
| Secure | `!dev` |
| HttpOnly | `false` (client 읽기 허용) |
| Max-Age | 30d |

## 검증 (적용 전)

- [ ] `pnpm check` 통과
- [ ] 로그인 → `Set-Cookie: ssr_auth=1`
- [ ] 로그아웃 → `Set-Cookie: ssr_auth=; Max-Age=0`
- [ ] 익명 방문 → 쿠키 없음 유지

## 후속 작업 (이 PR 머지 후)

1. **Cloudflare cache rule**: cache key cookies → `include(ssr_auth)` (콘솔 or API)
2. **nginx Phase 5**: `skip_cache if $cookie_angple_sid` 제거 → `ssr_auth` 기반으로 대체 (또는 제거)

## 예상 효과

- CDN req-hit% 38% → 70%+ (4/8 baseline 복원)
- 비용 $21/day → $15-18/day

## Rollback

단일 함수 + 단일 호출 지점. 5분 내 revert 가능.

## Related docs

- `/home/damoang/docs/2026-04-23-auth-cookie-normalization.md` (spec)
- `/home/damoang/docs/infra/2026-04-13-ssr-cache-optimization-plan.md` (Phase 2-5 원본)
- `/home/damoang/docs/infra/2026-04-08-cdn-cost-longterm-plan.md` (longterm)

## Test plan

- [ ] 로컬 dev 서버에서 로그인/로그아웃 시 `ssr_auth` 쿠키 set/delete 확인
- [ ] `pnpm check` 타입 검사
- [ ] staging에서 15분 canary 관찰
- [ ] 새벽 4시 prod 배포
- [ ] 배포 30분 후 CF hit% 측정