### PR TITLE
feat(auth): emit user_basic cookie on login (Phase A of split cookie)

### DIFF
--- a/apps/web/src/routes/api/auth/login/+server.ts
+++ b/apps/web/src/routes/api/auth/login/+server.ts
@@ -112,6 +112,34 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
             ...domainOpt
         });
 
+        // user_basic 쿠키 — SSR/client 공유용 최소 프로필 정보
+        // /api/auth/me 호출 제거 + CDN cache key normalization 목표
+        // 민감 정보(email/token) 제외, nickname/level/avatar만
+        try {
+            const member = await getMemberById(mbId);
+            if (member) {
+                const userBasic = {
+                    id: member.mb_id,
+                    nickname: member.mb_nick || member.mb_name,
+                    mb_level: member.mb_level ?? 0,
+                    as_level: member.as_level ?? 0,
+                    mb_image: member.mb_image_url || null,
+                    mb_image_updated_at: member.mb_image_updated_at || null
+                };
+                const encoded = Buffer.from(JSON.stringify(userBasic), 'utf-8').toString('base64');
+                cookies.set('user_basic', encoded, {
+                    path: '/',
+                    httpOnly: false, // client JS 읽기 가능
+                    sameSite: 'lax',
+                    secure: true,
+                    maxAge: SESSION_COOKIE_MAX_AGE,
+                    ...domainOpt
+                });
+            }
+        } catch {
+            // user_basic 발행 실패는 로그인 성공을 막지 않음 (fallback: /api/auth/me)
+        }
+
         // 레거시 호환: refresh_token도 생성
         const { token: refreshToken } = await generateRefreshToken(mbId, {
             ip: clientIp,

--- a/apps/web/src/routes/api/auth/logout/+server.ts
+++ b/apps/web/src/routes/api/auth/logout/+server.ts
@@ -75,6 +75,9 @@ export const POST: RequestHandler = async ({ cookies, fetch, locals }) => {
     cookies.delete('damoang_jwt', { ...cookieOpts, httpOnly: false });
     cookies.delete('access_token', { ...cookieOpts, httpOnly: false });
 
+    // user_basic 쿠키 (SSR/client 공유 프로필, login에서 발행)
+    cookies.delete('user_basic', { ...cookieOpts, httpOnly: false });
+
     // 서브도메인 SSO 쿠키 삭제 (.damoang.net 도메인)
     clearDamoangSSOCookie(cookies);
 


### PR DESCRIPTION
## Summary

사용자 지적 "프로필 2번 로드" 해결 착수 (Phase A).

현재 Phase 2 부작용:
- SSR_STRIP_USER=true로 HTML 캐시 가능해졌지만
- Client가 `/api/auth/me`를 매번 호출 → request 수 증가

목표 (전체 설계):
- login 시 user_basic 쿠키로 profile 정보 동봉
- SSR/client 양쪽이 쿠키에서 즉시 읽음 → /api/auth/me 호출 불필요

이 PR은 **Phase A (emit only)**. Reader는 Phase B/C PR에서 추가.

## What changes

- `login/+server.ts`: getMemberById로 user_basic 조회 + base64 JSON cookie
- `logout/+server.ts`: user_basic cookie 삭제

## Cookie 구조

```json
{
  "id": "abc",
  "nickname": "닉네임",
  "mb_level": 3,
  "as_level": 15,
  "mb_image": "path/to/image.webp",
  "mb_image_updated_at": 1678912345
}
```
→ base64URL encoded, 200-300 bytes

**민감 정보 제외**: email, permissions, access_token

## Attributes

| 속성 | 값 | 이유 |
|---|---|---|
| Path | `/` | 전역 |
| SameSite | `Lax` | CSRF 방어 |
| Secure | `true` | HTTPS only |
| HttpOnly | **false** | client JS 읽기 가능 |
| Max-Age | `SESSION_COOKIE_MAX_AGE` | 세션과 동기 |

## Risk

**매우 낮음** — Phase A만:
- Reader 없음 (backward compatible)
- fallback `/api/auth/me` 유지됨
- user_basic 발행 실패 시 로그인 성공 유지 (try/catch 무시)

## Test plan

- [ ] 로컬 dev 로그인 → `document.cookie`에 `user_basic=...` 확인
- [ ] base64 decode 해서 프로필 데이터 검증
- [ ] 로그아웃 → cookie 삭제 확인
- [ ] `pnpm check` 통과
- [ ] staging canary 15분 관찰
- [ ] 새벽 4시 prod 배포

## Follow-up PRs

1. **Phase B**: `hooks.server.ts`에서 user_basic 쿠키 읽기 → fast-path auth (DB 조회 skip)
2. **Phase C**: `+layout.svelte`에서 document.cookie 파싱 → `/api/auth/me` fetch 제거
3. **Phase D**: `/api/auth/me` endpoint deprecated + 제거

## Related

- Spec: `/home/damoang/docs/2026-04-23-auth-cookie-normalization.md`
- CDN 비용 분석: `/home/damoang/docs/infra/2026-04-08-cdn-cost-longterm-plan.md`
- 사용자 지적: "프로필 2번 로드 (빌드된 JS와 HTML에서)"