### PR TITLE
feat(avatar): Lambda variant 지원 — getAvatarUrl size + <Avatar> 컴포넌트

### DIFF
--- a/apps/web/src/lib/components/ui/Avatar.svelte
+++ b/apps/web/src/lib/components/ui/Avatar.svelte
@@ -1,0 +1,57 @@
+<!--
+  Avatar 컴포넌트 — Lambda variant 지원.
+
+  - size="list"    : 32px base, 64px 2x retina (게시글 목록/댓글용)
+  - size="profile" : 96px base, 192px 2x retina (프로필 페이지/홈 상단용)
+
+  Lambda (avatar-resize) 가 variant 를 생성하지 않은 경우 (기존 이미지 or 오류)
+  onerror → 원본 이미지 fallback.
+
+  usage:
+    <Avatar path={user.mb_image} updatedAt={user.mb_image_updated_at} size="list" alt={user.nickname} />
+-->
+<script lang="ts">
+    import { getAvatarUrl, type AvatarSize } from '$lib/utils/member-icon';
+
+    interface Props {
+        path: string | null | undefined;
+        updatedAt?: number | string | null;
+        size?: 'list' | 'profile';
+        alt?: string;
+        class?: string;
+    }
+
+    let { path, updatedAt, size = 'list', alt = '', class: className = '' }: Props = $props();
+
+    const sizes: [AvatarSize, AvatarSize] = $derived(size === 'profile' ? [96, 192] : [32, 64]);
+    const base = $derived(sizes[0]);
+    const src = $derived(getAvatarUrl(path, updatedAt, sizes[0]));
+    const src2x = $derived(getAvatarUrl(path, updatedAt, sizes[1]));
+    const fallback = $derived(getAvatarUrl(path, updatedAt));
+
+    let errored = $state(false);
+
+    function handleError(e: Event) {
+        if (errored) return;
+        errored = true;
+        const img = e.currentTarget as HTMLImageElement;
+        if (fallback && img.src !== fallback) {
+            img.src = fallback;
+            img.removeAttribute('srcset');
+        }
+    }
+</script>
+
+{#if src}
+    <img
+        {src}
+        srcset={src2x ? `${src} 1x, ${src2x} 2x` : undefined}
+        width={base}
+        height={base}
+        {alt}
+        class={className}
+        loading="lazy"
+        decoding="async"
+        onerror={handleError}
+    />
+{/if}

--- a/apps/web/src/lib/utils/member-icon.test.ts
+++ b/apps/web/src/lib/utils/member-icon.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { getAvatarUrl } from './member-icon';
+
+describe('getAvatarUrl', () => {
+    const CDN = 'https://s3.damoang.net';
+    const path = 'data/member_image/ad/admin_1760156943.webp';
+
+    it('size 미지정 — 원본 URL + ?v=timestamp', () => {
+        const url = getAvatarUrl(path, 1760156943);
+        expect(url).toBe(`${CDN}/${path}?v=1760156943`);
+    });
+
+    it('size 미지정 + updatedAt 없음 — 원본 URL only', () => {
+        const url = getAvatarUrl(path);
+        expect(url).toBe(`${CDN}/${path}`);
+    });
+
+    it('size=32 — Lambda variant path (jpg)', () => {
+        const url = getAvatarUrl(path, 1760156943, 32);
+        expect(url).toBe(`${CDN}/data/member_image/_resized/ad/admin_1760156943_32.jpg`);
+        // variant URL 은 ?v= 쿼리 제거 (path 자체에 version 내재)
+        expect(url).not.toContain('?v=');
+    });
+
+    it('size=192 — profile-size variant', () => {
+        const url = getAvatarUrl(path, null, 192);
+        expect(url).toBe(`${CDN}/data/member_image/_resized/ad/admin_1760156943_192.jpg`);
+    });
+
+    it('null imageUrl — null 반환', () => {
+        expect(getAvatarUrl(null)).toBeNull();
+        expect(getAvatarUrl(undefined, 123, 64)).toBeNull();
+        expect(getAvatarUrl('', undefined, 32)).toBeNull();
+    });
+
+    it('이미 variant 경로 — 그대로 유지', () => {
+        const variant = 'data/member_image/_resized/ad/admin_1760156943_96.jpg';
+        const url = getAvatarUrl(variant, 999, 96);
+        expect(url).toBe(`${CDN}/${variant}`);
+    });
+
+    it('패턴 불일치 경로 — size 무시, 원본 그대로', () => {
+        const weird = 'data/other/some.jpg';
+        const url = getAvatarUrl(weird, 100, 96);
+        expect(url).toBe(`${CDN}/${weird}`);
+    });
+});

--- a/apps/web/src/lib/utils/member-icon.ts
+++ b/apps/web/src/lib/utils/member-icon.ts
@@ -7,23 +7,51 @@ import { normalizeMediaUrl } from '$lib/utils/media-url';
 
 const CDN_BASE_URL = (import.meta.env.VITE_S3_URL || 'https://s3.damoang.net').replace(/\/$/, '');
 
+/** Lambda 가 생성하는 variant 크기 (avatar-resize) */
+export type AvatarSize = 32 | 64 | 96 | 192;
+
+const VARIANT_PREFIX = 'data/member_image/_resized/';
+
+/**
+ * size 파라미터가 주어지면 Lambda resize variant path로 재작성.
+ *   data/member_image/ab/admin_1760156943.webp  →
+ *   data/member_image/_resized/ab/admin_1760156943_96.jpg
+ *
+ * size 미지정 시 원본 경로 유지 (하위 호환).
+ */
+function toVariantPath(imageUrl: string, size: AvatarSize | undefined): string {
+    if (!size) return imageUrl;
+    // 이미 variant 경로면 그대로
+    if (imageUrl.includes('/_resized/')) return imageUrl;
+
+    const match = imageUrl.match(/^data\/member_image\/([^/]+)\/(.+)\.(jpe?g|png|gif|webp)$/i);
+    if (!match) return imageUrl; // 패턴 불일치 — 원본 그대로
+    const [, ab, name] = match;
+    return `${VARIANT_PREFIX}${ab}/${name}_${size}.jpg`;
+}
+
 /**
  * mb_image_url(DB)로 전체 URL 생성
  * @param imageUrl API에서 받은 mb_image / author_image (예: data/member_image/ad/admin_1760156943.webp)
  * @param updatedAt mb_image_updated_at (Unix timestamp 또는 ISO 문자열) — 캐시 버스팅용
+ * @param size Lambda variant 크기 (32/64/96/192). 미지정 시 원본.
  * @returns 전체 URL 또는 null
  */
 export function getAvatarUrl(
     imageUrl: string | null | undefined,
-    updatedAt?: number | string | null
+    updatedAt?: number | string | null,
+    size?: AvatarSize
 ): string | null {
     if (!imageUrl) return null;
 
-    const url = normalizeMediaUrl(imageUrl, CDN_BASE_URL);
+    const path = toVariantPath(imageUrl, size);
+    const url = normalizeMediaUrl(path, CDN_BASE_URL);
     if (!url) return null;
 
-    // 캐시 버스팅: ?v=timestamp 추가
-    if (updatedAt) {
+    // Variant URL은 path에 version 포함 (Lambda 재생성 시 다른 원본 = 다른 name) →
+    // 원본 변경 시 mb_image_url 전체가 달라지므로 cache-bust 쿼리 불필요.
+    // size 미지정(원본) 경로는 기존 방식으로 ?v=timestamp 유지.
+    if (!size && updatedAt) {
         const v =
             typeof updatedAt === 'number'
                 ? updatedAt


### PR DESCRIPTION
## Summary

사용자 지적 "프로필 이미지 리사이즈 안 됨 + 캐시가 CloudFront에서 처리됨"의 장기 해결 Step 2.

### Context
- Step 1 (완료): Go Lambda `avatar-resize` ECR push (`damoang-lambda:avatar-resize-ba48849`) — 32/64/96/192 JPEG variant 생성
- Step 2 (본 PR): Frontend에서 variant 활용 + 하위 호환 fallback
- Step 3-4 (후속): Backfill 배치, 호출처 `<Avatar>` 점진적 교체

## Changes

### `getAvatarUrl` 확장 (member-icon.ts)
```typescript
getAvatarUrl(imageUrl, updatedAt, size?: 32|64|96|192)
```
- `size` 전달 시: `data/member_image/{ab}/{name}.{ext}` → `_resized/{ab}/{name}_{size}.jpg`
- Variant는 path-based versioning (`name`에 timestamp 포함) → `?v=` 쿼리 제거
- `size` 미전달 시 기존 동작 유지 (**하위 호환 100%**)

### `<Avatar>` 컴포넌트 (신규)
- `size='list'` : 32px base + 64px srcset 2x — 게시글 목록/댓글
- `size='profile'` : 96px base + 192px srcset 2x — 프로필 페이지
- `onerror` → 원본 URL fallback (Lambda variant 미존재 시)
- `loading="lazy"`, `decoding="async"`, `width`/`height` 명시 (CLS 방지)

### Unit tests (7건)
- size 미지정 + updatedAt — `?v=timestamp` 유지
- size 32/192 — variant path (`.jpg`)
- null/empty — null 반환
- 이미 variant 경로 — idempotent
- 패턴 불일치 — 원본 유지

## Safety

**이 PR 단독 머지 안전** (Lambda 미가동 상태에서도):
1. 호출처가 `size` 전달 안 하면 = 변경 없음
2. 호출처가 `size` 전달 + Lambda variant 미존재 = `onerror`로 원본 fallback

## Lambda 상태

- 이미지 ECR push: ✅ `avatar-resize-ba48849` @ `damoang-lambda`
- Lambda 함수 생성: **사용자 Console 작업 필요** (runbook 별도 제공 예정)
- S3 Event 연결: **사용자 Console 작업 필요**

## Follow-up PRs

1. **Runbook 문서**: `/home/damoang/docs/` — user Console 설정 가이드
2. **Backfill CLI 실행**: 기존 이미지 Lambda Invoke (동시성 5)
3. **호출처 교체 PR 시리즈**: `<Avatar>` 점진적 도입
   - 게시글 목록/댓글 → `size="list"`
   - 프로필 페이지/홈 상단 → `size="profile"`

## Test plan

- [ ] `pnpm test:unit src/lib/utils/member-icon.test.ts` 통과 (7건)
- [ ] `pnpm check` 타입 검사 통과
- [ ] `pnpm lint` 통과
- [ ] staging canary 15분 관찰 (avatar 이미지 로드 정상)
- [ ] 새벽 4시 prod 배포 (함께 PR #1268/#1269/#1270와 배포 가능)

## Related

- Plan: `/home/angple/.claude/plans/declarative-noodling-volcano.md`
- Spec: `/home/damoang/docs/2026-04-23-lambda-image-pipeline-spec.md`
- 사용자 지적: "프로필 이미지 작게 줄이지 않음", "프로필 캐시가 CloudFront에서 처리됨"