### PR TITLE
feat(auth): user_basic cookie 파서 (Phase B scaffolding)

### DIFF
--- a/apps/web/src/lib/server/auth/user-basic.test.ts
+++ b/apps/web/src/lib/server/auth/user-basic.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { parseUserBasicCookie } from './user-basic';
+
+describe('parseUserBasicCookie', () => {
+    const validUser = {
+        id: 'abc',
+        nickname: '닉네임',
+        mb_level: 3,
+        as_level: 15,
+        mb_image: 'data/member_image/ab/abc.webp',
+        mb_image_updated_at: 1760156943
+    };
+
+    function encode(obj: unknown) {
+        return Buffer.from(JSON.stringify(obj), 'utf-8').toString('base64');
+    }
+
+    it('valid cookie → 파싱 성공', () => {
+        expect(parseUserBasicCookie(encode(validUser))).toEqual(validUser);
+    });
+
+    it('null/undefined/empty → null', () => {
+        expect(parseUserBasicCookie(null)).toBeNull();
+        expect(parseUserBasicCookie(undefined)).toBeNull();
+        expect(parseUserBasicCookie('')).toBeNull();
+    });
+
+    it('invalid base64 → null', () => {
+        expect(parseUserBasicCookie('not-base64-!@#')).toBeNull();
+    });
+
+    it('valid base64, invalid JSON → null', () => {
+        expect(parseUserBasicCookie(Buffer.from('not json').toString('base64'))).toBeNull();
+    });
+
+    it('id 누락 → null', () => {
+        const { id: _id, ...rest } = validUser;
+        expect(parseUserBasicCookie(encode(rest))).toBeNull();
+    });
+
+    it('mb_level 숫자 아님 → null', () => {
+        expect(parseUserBasicCookie(encode({ ...validUser, mb_level: '3' }))).toBeNull();
+    });
+
+    it('optional 필드 누락 — null로 채움', () => {
+        const { mb_image: _i, mb_image_updated_at: _t, ...rest } = validUser;
+        const result = parseUserBasicCookie(encode(rest));
+        expect(result?.mb_image).toBeNull();
+        expect(result?.mb_image_updated_at).toBeNull();
+    });
+});

--- a/apps/web/src/lib/server/auth/user-basic.ts
+++ b/apps/web/src/lib/server/auth/user-basic.ts
@@ -1,0 +1,52 @@
+/**
+ * user_basic 쿠키 파싱 유틸리티 (Phase B of split cookie).
+ *
+ * login 시 base64 JSON 으로 emit된 user_basic 쿠키를 서버사이드에서 파싱.
+ * 이 파일은 **Phase B 스캐폴딩** — 실제 authenticateSSR 통합은 별도 PR에서.
+ *
+ * 보안:
+ * - user_basic은 HttpOnly=false → client JS 접근 허용 (XSS 주의)
+ * - **민감 정보(email/accessToken) 제외** — 단순 profile 표시용
+ * - 권한 판단은 기존 session 검증에서 수행, 이 쿠키를 신뢰 X
+ */
+
+export interface UserBasic {
+    id: string;
+    nickname: string;
+    mb_level: number;
+    as_level: number;
+    mb_image: string | null;
+    mb_image_updated_at: number | null;
+}
+
+/**
+ * user_basic 쿠키 값을 UserBasic 객체로 파싱.
+ * 유효성/타입 검증 실패 시 null 반환 (fallback: /api/auth/me).
+ */
+export function parseUserBasicCookie(encoded: string | null | undefined): UserBasic | null {
+    if (!encoded) return null;
+    try {
+        const json = Buffer.from(encoded, 'base64').toString('utf-8');
+        const data = JSON.parse(json) as unknown;
+
+        if (!data || typeof data !== 'object') return null;
+        const d = data as Record<string, unknown>;
+
+        if (typeof d.id !== 'string' || d.id.length === 0) return null;
+        if (typeof d.nickname !== 'string') return null;
+        if (typeof d.mb_level !== 'number') return null;
+        if (typeof d.as_level !== 'number') return null;
+
+        return {
+            id: d.id,
+            nickname: d.nickname,
+            mb_level: d.mb_level,
+            as_level: d.as_level,
+            mb_image: typeof d.mb_image === 'string' ? d.mb_image : null,
+            mb_image_updated_at:
+                typeof d.mb_image_updated_at === 'number' ? d.mb_image_updated_at : null
+        };
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Phase A (PR #1270) 에서 login 시 emit하는 user_basic 쿠키의 서버사이드 파서 유틸리티. 스캐폴딩만 — 실제 authenticateSSR 통합은 **별도 wire-up PR**에서.

## Changes

- `$lib/server/auth/user-basic.ts` — `parseUserBasicCookie()` 유틸리티
- `user-basic.test.ts` — 단위 테스트 7건

## Security

- HttpOnly=false (client JS 접근 허용)
- 민감 정보 제외 (email/accessToken 없음)
- **권한 판단 금지** — 기존 session 검증 유지
- 파싱 실패 시 null 반환 → fallback `/api/auth/me`

## Usage (후속 PR 예시)

```ts
// Phase B wire-up 시 authenticateSSR 확장
const basic = parseUserBasicCookie(event.cookies.get('user_basic'));
if (basic && basic.id === session.mbId) {
    // DB 조회 skip, cookie 데이터로 locals.user 구성
    event.locals.user = { ... basic };
} else {
    const member = await getMemberById(session.mbId); // fallback
}
```

## Risk

**매우 낮음** — 새 파일 2개, 사용처 없음. 현재 동작에 영향 0.

## Follow-up

- Phase B wire-up: authenticateSSR 통합 (DB 조회 skip)
- Phase C: client-side document.cookie 파싱 + `/api/auth/me` 제거

## Test plan

- [ ] `pnpm test:unit src/lib/server/auth/user-basic.test.ts` 통과 (7건)
- [ ] `pnpm check` 타입 검사
- [ ] PR #1270 머지 후 dev 환경에서 actual cookie parse 검증

## Related

- Phase A (이미 머지): PR #1270 user_basic emit
- Plan: `/home/angple/.claude/plans/declarative-noodling-volcano.md`
- Spec: `/home/damoang/docs/2026-04-23-auth-cookie-normalization.md`