### PR TITLE
feat(auth): authenticateSSR user_basic fast-path (Phase B wire-up)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -11,6 +11,7 @@ import { grantLoginPoint } from '$lib/server/auth/point-grant.js';
 import { checkAndPromoteMember } from '$lib/server/auth/auto-promotion.js';
 import { generateAccessToken } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
+import { parseUserBasicCookie } from '$lib/server/auth/user-basic.js';
 import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
 import { mapGnuboardUrl, mapRhymixUrl } from '$lib/server/url-compat.js';
 
@@ -308,6 +309,36 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
         try {
             const session = await withTimeout(getSession(sessionId), AUTH_TIMEOUT_MS);
             if (session) {
+                // FAST PATH: user_basic 쿠키 + JWT cache hit → DB 조회 0 (Phase B wire-up)
+                // feature flag USER_BASIC_FAST_PATH=true 시 활성화. default off.
+                if (env.USER_BASIC_FAST_PATH === 'true') {
+                    const basic = parseUserBasicCookie(event.cookies.get('user_basic'));
+                    const cachedJwt = jwtCache.get(session.mbId);
+                    const nowFp = Date.now();
+                    if (
+                        basic &&
+                        basic.id === session.mbId &&
+                        cachedJwt &&
+                        nowFp < cachedJwt.expiry
+                    ) {
+                        event.locals.user = {
+                            id: basic.id,
+                            nickname: basic.nickname,
+                            level: basic.mb_level,
+                            as_level: basic.as_level,
+                            mb_certify: '',
+                            mb_image: basic.mb_image || undefined,
+                            mb_image_updated_at: basic.mb_image_updated_at || undefined,
+                            advertiser_end_date: undefined,
+                            advertiser_status: undefined
+                        };
+                        event.locals.sessionId = sessionId;
+                        event.locals.csrfToken = session.csrfToken;
+                        event.locals.accessToken = cachedJwt.token;
+                        return;
+                    }
+                }
+
                 const member = await withTimeout(getMemberById(session.mbId), AUTH_TIMEOUT_MS);
                 if (member) {
                     event.locals.user = {


### PR DESCRIPTION
## Summary

Phase A (PR #1270 쿠키 emit) + Phase B scaffolding (PR #1272 파서) 기반 위에 `authenticateSSR` 통합.

**feature flag `USER_BASIC_FAST_PATH=true` 활성화 시**:
- user_basic 쿠키 존재 + session.mbId 일치 + JWT cache hit 조건 만족 시
- `getMemberById` DB 조회 **skip**
- 인증 SSR 요청당 DB 1건 감소

## Fast-path 조건 (AND 관계, 모두 충족 시)

1. `env.USER_BASIC_FAST_PATH === 'true'`
2. user_basic 쿠키 **유효 파싱** (parseUserBasicCookie non-null)
3. `cookie.id === session.mbId` (spoofing 방지)
4. JWT cache **hit** (access token 생성용 member 불필요)

## Fallback

위 조건 미충족 시 → **기존 getMemberById 경로** (backward compat 100%).

## Code diff

```typescript
if (env.USER_BASIC_FAST_PATH === 'true') {
    const basic = parseUserBasicCookie(event.cookies.get('user_basic'));
    const cachedJwt = jwtCache.get(session.mbId);
    const nowFp = Date.now();
    if (basic && basic.id === session.mbId && cachedJwt && nowFp < cachedJwt.expiry) {
        event.locals.user = { /* cookie 데이터 */ };
        event.locals.sessionId = sessionId;
        event.locals.csrfToken = session.csrfToken;
        event.locals.accessToken = cachedJwt.token;
        return;
    }
}
// 기존 경로로 fallback
```

## 제약 및 미래 과제

- **쿠키 staleness**: 프로필 수정(nickname/level/avatar) 시 user_basic 재발행 필요 → **Phase A 확장 별도 PR** (profile update API 훅)
- **mb_certify / advertiser_* 누락**: 쿠키에 없음 → 빈 값 처리. 필요 시 별도 조회 엔드포인트
- **mb_today_login 갱신 skip**: 매일 첫 SSR만 getMemberById 돌게 하는 보완 필요 (별도 PR)

## Test plan

- [ ] `pnpm check` 타입 검사
- [ ] `pnpm test:unit` 통과
- [ ] staging에서 `USER_BASIC_FAST_PATH=false` (default) 동작 동일 확인
- [ ] staging에서 `USER_BASIC_FAST_PATH=true` 로 전환 후:
  - [ ] 로그인 유저 페이지 표시 정상 (nickname/avatar)
  - [ ] CSRF 정상 (csrfToken 세팅 확인)
  - [ ] /api/... 호출 정상 (accessToken 세팅 확인)
  - [ ] 로그인/로그아웃 동작
- [ ] CloudWatch Metrics: backend `getMemberById` 호출 수 감소 관찰

## Rollback

**즉시 (1분)**: env `USER_BASIC_FAST_PATH=false` (또는 제거) + pod restart.

## Dependency

- PR #1270 (user_basic emit) — 머지됨
- PR #1272 (parseUserBasicCookie) — 머지됨

## Related

- Spec: `/home/damoang/docs/2026-04-23-auth-cookie-normalization.md`
- Plan: `/home/angple/.claude/plans/declarative-noodling-volcano.md`