### PR TITLE
feat(auth): client-side user_basic read — /api/auth/me 생략 (Phase C)

### DIFF
--- a/apps/web/src/lib/utils/user-basic-client.ts
+++ b/apps/web/src/lib/utils/user-basic-client.ts
@@ -1,0 +1,60 @@
+/**
+ * user_basic 쿠키 client-side 파서 (Phase C of split cookie).
+ *
+ * document.cookie에서 user_basic 값을 추출/파싱.
+ * base64 decode는 atob() (browser + Node 16+ 모두 동작).
+ *
+ * 서버 사이드 parser는 `$lib/server/auth/user-basic.ts` 참조 (Buffer 기반).
+ */
+
+export interface UserBasic {
+    id: string;
+    nickname: string;
+    mb_level: number;
+    as_level: number;
+    mb_image: string | null;
+    mb_image_updated_at: number | null;
+}
+
+function validateUserBasic(data: unknown): UserBasic | null {
+    if (!data || typeof data !== 'object') return null;
+    const d = data as Record<string, unknown>;
+    if (typeof d.id !== 'string' || d.id.length === 0) return null;
+    if (typeof d.nickname !== 'string') return null;
+    if (typeof d.mb_level !== 'number') return null;
+    if (typeof d.as_level !== 'number') return null;
+    return {
+        id: d.id,
+        nickname: d.nickname,
+        mb_level: d.mb_level,
+        as_level: d.as_level,
+        mb_image: typeof d.mb_image === 'string' ? d.mb_image : null,
+        mb_image_updated_at:
+            typeof d.mb_image_updated_at === 'number' ? d.mb_image_updated_at : null
+    };
+}
+
+/**
+ * base64 encoded JSON 을 UserBasic 으로 파싱.
+ */
+export function parseUserBasicBase64(encoded: string | null | undefined): UserBasic | null {
+    if (!encoded) return null;
+    try {
+        const json = atob(encoded);
+        const data = JSON.parse(json) as unknown;
+        return validateUserBasic(data);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * document.cookie 문자열에서 user_basic 쿠키를 찾아 파싱.
+ * 없으면 null.
+ */
+export function readUserBasicFromCookie(cookieString: string): UserBasic | null {
+    if (!cookieString) return null;
+    const match = cookieString.match(/(?:^|;\s*)user_basic=([^;]+)/);
+    if (!match) return null;
+    return parseUserBasicBase64(decodeURIComponent(match[1]));
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -32,6 +32,8 @@
     import { updatePageTargeting } from '$lib/components/ui/ad-slot/ad-slot-registry.js';
     import { consumePendingAuthEvent, initGA4, trackPageView } from '$lib/services/ga4';
     import type { MenuItem } from '$lib/api/types';
+    import { readUserBasicFromCookie } from '$lib/utils/user-basic-client';
+    import { env } from '$env/dynamic/public';
 
     const LAYOUT_INIT_STORAGE_KEY = 'angple:layout-init:v1';
     const LAYOUT_INIT_STORAGE_TTL_MS = 5 * 60 * 1000;
@@ -492,23 +494,55 @@
             if (authStore.isAuthenticated) blockedUsersStore.load();
         } else {
             // SSR에서 user 없음 (SSR_STRIP_USER=true 또는 비로그인)
-            // HttpOnly 쿠키는 document.cookie로 읽을 수 없으므로 항상 /api/auth/me 시도
-            // credentials: 'same-origin'이 HttpOnly 쿠키를 자동 전송
-            fetch('/api/auth/me', { credentials: 'same-origin' })
-                .then((res) => (res.ok ? res.json() : null))
-                .then((meData) => {
-                    if (meData?.user) {
-                        syncAuth({ ...data, ...meData });
+
+            // Phase C: user_basic 쿠키 (JS-readable) 우선 시도
+            // PUBLIC_USER_BASIC_CLIENT_READ=true 활성화 시 /api/auth/me fetch 생략
+            let fastPathApplied = false;
+            if (env.PUBLIC_USER_BASIC_CLIENT_READ === 'true') {
+                try {
+                    const basic = readUserBasicFromCookie(document.cookie);
+                    if (basic) {
+                        syncAuth({
+                            ...data,
+                            user: {
+                                id: basic.id,
+                                nickname: basic.nickname,
+                                level: basic.mb_level,
+                                as_level: basic.as_level,
+                                mb_certify: '',
+                                mb_image: basic.mb_image ?? undefined,
+                                mb_image_updated_at: basic.mb_image_updated_at ?? undefined,
+                                advertiser_end_date: undefined,
+                                advertiser_status: undefined
+                            }
+                        });
                         blockedUsersStore.load();
-                    } else {
-                        authActions.initAuth();
+                        authInitialized = true;
+                        fastPathApplied = true;
                     }
-                    authInitialized = true;
-                })
-                .catch(() => {
-                    authActions.initAuth();
-                    authInitialized = true;
-                });
+                } catch {
+                    // cookie parse 실패 시 /api/auth/me fallback
+                }
+            }
+
+            if (!fastPathApplied) {
+                // 전통 경로: HttpOnly 세션 쿠키로 /api/auth/me fetch
+                fetch('/api/auth/me', { credentials: 'same-origin' })
+                    .then((res) => (res.ok ? res.json() : null))
+                    .then((meData) => {
+                        if (meData?.user) {
+                            syncAuth({ ...data, ...meData });
+                            blockedUsersStore.load();
+                        } else {
+                            authActions.initAuth();
+                        }
+                        authInitialized = true;
+                    })
+                    .catch(() => {
+                        authActions.initAuth();
+                        authInitialized = true;
+                    });
+            }
         }
 
         // postMessage 리스너 (Admin에서 테마 변경 시 리로드)


### PR DESCRIPTION
## Summary

Phase A (cookie emit, #1270) + Phase B (server fast-path, #1272/#1273) 완결편.

**PUBLIC_USER_BASIC_CLIENT_READ=true** 활성화 시:
- `+layout.svelte` onMount에서 `document.cookie` 의 user_basic을 **먼저 파싱**
- 성공 시 `syncAuth` 호출 + 기존 `/api/auth/me` fetch **완전 생략**

## 효과 (플래그 on)

- 로그인 유저 페이지당 `/api/auth/me` 호출 **0건**
- Cloudflare request 수 감소 (현재 모든 auth 페이지 당 1회 호출)
- backend CPU 부하 감소 (session 조회 + JWT 검증 skip)
- Page load latency 단축 (fetch 대기 시간 제거)

## Changes

1. **`$lib/utils/user-basic-client.ts`** (신규)
   - `parseUserBasicBase64(encoded)` — atob 기반 pure parser
   - `readUserBasicFromCookie(cookieString)` — document.cookie 검색 + 파싱

2. **`+layout.svelte`** 수정
   - else 분기 (SSR user null) 로직 확장:
     1. `PUBLIC_USER_BASIC_CLIENT_READ==='true'` → cookie parse 시도
     2. 성공 → `syncAuth` + `fastPathApplied=true`
     3. 실패 or flag off → 기존 `/api/auth/me` fetch **(fallback 유지)**

## Risk / Staleness

- 프로필 수정 시 user_basic 쿠키 미갱신 → nickname/level 표시 stale
- 완화: **Phase A 확장 별도 PR** — profile update API에서 user_basic 재발행
- **권한 판단 금지** — user_basic은 UI 표시용, 권한 체크는 서버에서

## Feature Flag 전략

- 기본 off
- 활성화: `PUBLIC_USER_BASIC_CLIENT_READ=true` 환경변수
- **단계적 롤아웃**:
  1. dev: 활성화 + 관찰 1일
  2. canary: 활성화 + 관찰 1일
  3. prod: 활성화

## Test plan

- [ ] `pnpm check` 타입 검사
- [ ] `pnpm build` 성공 (PUBLIC_ env는 client bundle 포함)
- [ ] dev에서 `PUBLIC_USER_BASIC_CLIENT_READ=false` (default) — 기존 동작 확인
- [ ] dev에서 `PUBLIC_USER_BASIC_CLIENT_READ=true` — `/api/auth/me` fetch 0건 확인 (DevTools Network)
- [ ] 로그인 유저 hydration 정상: nickname/avatar/level 모두 표시
- [ ] 로그아웃 → 쿠키 delete → 새 탭 → fetch path로 fallback 동작
- [ ] 프로필 편집 시 stale 여부 확인 (알려진 한계)

## Rollback

`PUBLIC_USER_BASIC_CLIENT_READ` env 제거 → hard reload → 기존 `/api/auth/me` path 복구. 1분 내.

## Dependencies

- PR #1270 (emit) — merged
- PR #1272 (scaffolding parser) — merged
- PR #1273 (server wire-up) — draft

## Related

- Spec: `/home/damoang/docs/2026-04-23-auth-cookie-normalization.md`
- Plan: `/home/angple/.claude/plans/declarative-noodling-volcano.md`