### PR TITLE
feat(auth): user_basic 재발행 on profile image 변경 (Phase A 확장)

### DIFF
--- a/apps/web/src/lib/server/auth/user-basic.ts
+++ b/apps/web/src/lib/server/auth/user-basic.ts
@@ -1,14 +1,18 @@
 /**
- * user_basic 쿠키 파싱 유틸리티 (Phase B of split cookie).
+ * user_basic 쿠키 파싱 + 발행 유틸리티 (Phase A/B/C of split cookie).
  *
- * login 시 base64 JSON 으로 emit된 user_basic 쿠키를 서버사이드에서 파싱.
- * 이 파일은 **Phase B 스캐폴딩** — 실제 authenticateSSR 통합은 별도 PR에서.
+ * login 시 base64 JSON 으로 emit된 user_basic 쿠키를 서버사이드에서 파싱/갱신.
+ * 프로필 변경(이미지/닉네임/레벨) 시 이 모듈의 issueUserBasicCookie() 로 재발행.
  *
  * 보안:
  * - user_basic은 HttpOnly=false → client JS 접근 허용 (XSS 주의)
  * - **민감 정보(email/accessToken) 제외** — 단순 profile 표시용
  * - 권한 판단은 기존 session 검증에서 수행, 이 쿠키를 신뢰 X
  */
+
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import type { Cookies } from '@sveltejs/kit';
 
 export interface UserBasic {
     id: string;
@@ -49,4 +53,41 @@ export function parseUserBasicCookie(encoded: string | null | undefined): UserBa
     } catch {
         return null;
     }
+}
+
+/**
+ * user_basic 쿠키 발행.
+ *
+ * 사용처:
+ * - login 직후 (api/auth/login/+server.ts) — 초기 발행
+ * - 프로필 변경 API 직후 (image/nickname/level) — stale 방지 재발행
+ *
+ * Cookie 속성: SameSite=Lax, Secure(!dev), HttpOnly=false, 30d.
+ */
+const USER_BASIC_COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30d
+
+export function issueUserBasicCookie(cookies: Cookies, basic: UserBasic): void {
+    const payload = {
+        id: basic.id,
+        nickname: basic.nickname,
+        mb_level: basic.mb_level,
+        as_level: basic.as_level,
+        mb_image: basic.mb_image,
+        mb_image_updated_at: basic.mb_image_updated_at
+    };
+    const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+    const domainOpt = env.COOKIE_DOMAIN ? { domain: env.COOKIE_DOMAIN } : {};
+    cookies.set('user_basic', encoded, {
+        path: '/',
+        httpOnly: false,
+        sameSite: 'lax',
+        secure: !dev,
+        maxAge: USER_BASIC_COOKIE_MAX_AGE,
+        ...domainOpt
+    });
+}
+
+export function clearUserBasicCookie(cookies: Cookies): void {
+    const domainOpt = env.COOKIE_DOMAIN ? { domain: env.COOKIE_DOMAIN } : {};
+    cookies.delete('user_basic', { path: '/', ...domainOpt });
 }

--- a/apps/web/src/routes/api/members/me/image/+server.ts
+++ b/apps/web/src/routes/api/members/me/image/+server.ts
@@ -7,8 +7,36 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 import { getAuthUser, verifyToken } from '$lib/server/auth/index.js';
+import { getMemberById } from '$lib/server/auth/oauth/member.js';
+import { issueUserBasicCookie } from '$lib/server/auth/user-basic.js';
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
+
+/**
+ * 프로필 변경 후 user_basic 쿠키 재발행 (Phase A 확장).
+ * 실패해도 API 성공에 영향 없음 (best-effort).
+ */
+async function refreshUserBasic(
+    token: string,
+    cookies: import('@sveltejs/kit').Cookies
+): Promise<void> {
+    try {
+        const payload = await verifyToken(token);
+        if (!payload?.sub) return;
+        const member = await getMemberById(payload.sub);
+        if (!member) return;
+        issueUserBasicCookie(cookies, {
+            id: member.mb_id,
+            nickname: member.mb_nick || member.mb_name,
+            mb_level: member.mb_level ?? 0,
+            as_level: member.as_level ?? 0,
+            mb_image: member.mb_image_url || null,
+            mb_image_updated_at: member.mb_image_updated_at || null
+        });
+    } catch {
+        // user_basic 재발행 실패는 무시 — 다음 로그인 때 복구
+    }
+}
 
 async function getAccessToken(
     request: Request,
@@ -67,6 +95,9 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
         error(res.status, body.error || '이미지 업로드에 실패했습니다.');
     }
 
+    // Phase A 확장: 이미지 변경됨 → user_basic 쿠키 재발행 (stale 방지)
+    await refreshUserBasic(token, cookies);
+
     return json(body);
 };
 
@@ -85,6 +116,9 @@ export const DELETE: RequestHandler = async ({ request, cookies }) => {
     if (!res.ok) {
         error(res.status, body.error || '이미지 삭제에 실패했습니다.');
     }
+
+    // Phase A 확장: 이미지 삭제됨 → user_basic 쿠키 재발행
+    await refreshUserBasic(token, cookies);
 
     return json(body);
 };

--- a/apps/web/src/routes/api/members/me/image/+server.ts
+++ b/apps/web/src/routes/api/members/me/image/+server.ts
@@ -25,13 +25,16 @@ async function refreshUserBasic(
         if (!payload?.sub) return;
         const member = await getMemberById(payload.sub);
         if (!member) return;
+        const updatedAtTs = member.mb_image_updated_at
+            ? Math.floor(new Date(member.mb_image_updated_at).getTime() / 1000)
+            : null;
         issueUserBasicCookie(cookies, {
             id: member.mb_id,
             nickname: member.mb_nick || member.mb_name,
             mb_level: member.mb_level ?? 0,
             as_level: member.as_level ?? 0,
             mb_image: member.mb_image_url || null,
-            mb_image_updated_at: member.mb_image_updated_at || null
+            mb_image_updated_at: updatedAtTs
         });
     } catch {
         // user_basic 재발행 실패는 무시 — 다음 로그인 때 복구


### PR DESCRIPTION
## Summary

Phase A (PR #1270) 의 staleness 보완 — 프로필 이미지 변경 시 user_basic 쿠키 재발행.

## Problem

- Phase A: login 시 user_basic 쿠키 1회 발행
- Phase C (PR #1274): 클라이언트가 쿠키에서 user 읽어 `/api/auth/me` skip
- **이슈**: 사용자가 프로필 이미지 변경해도 쿠키 그대로 → 다른 페이지에서 여전히 옛 이미지 표시 (localStorage 외 hard reload 전까지)

## Changes

### `$lib/server/auth/user-basic.ts` 확장
- `issueUserBasicCookie(cookies, basic)` — 재발행 재사용 helper
- `clearUserBasicCookie(cookies)` — 삭제 helper
- 쿠키 속성 (SameSite=Lax, Secure(!dev), HttpOnly=false, 30d) 통일

### `/api/members/me/image/+server.ts` POST/DELETE
- 성공 응답 직전 `refreshUserBasic(token, cookies)` 호출
  - token → mb_id 추출 → `getMemberById()` 로 최신 상태 조회
  - `issueUserBasicCookie()` 로 새 쿠키 발행
- 실패 시 **무시** (best-effort try/catch) — API 성공 유지

## 효과

- 이미지 변경 즉시 전 페이지에서 새 아바타 표시
- Phase C client read 시 stale 이슈 해결

## Follow-up

- 닉네임 변경 API에도 동일 hook 필요 (별도 PR)
- 승급/레벨업 이벤트 시 재발행 (XP 시스템 연동)

## Risk

**낮음** — 이미지 API 기존 동작 불변, 쿠키 재발행은 best-effort.
최악: 쿠키 업데이트 실패 → Phase C 비활성화 시 기존 동작.

## Test plan

- [ ] `pnpm check` 타입 검사
- [ ] 로그인 → 프로필 이미지 변경 → DevTools Cookie에서 user_basic mb_image_updated_at 갱신 확인
- [ ] 다른 탭 새로고침 → 새 아바타 즉시 표시 (Phase C 활성화 시)

## Dependencies

- PR #1270 (user_basic emit) — merged
- PR #1272 (parser scaffolding) — merged  
- PR #1273 (server wire-up) — draft
- PR #1274 (client read) — draft