### PR TITLE
fix(avatar): size prop 기본값 제거 — Lambda 미배포 시 원본 URL 사용

### DIFF
--- a/apps/web/src/lib/components/ui/Avatar.svelte
+++ b/apps/web/src/lib/components/ui/Avatar.svelte
@@ -1,14 +1,16 @@
 <!--
-  Avatar 컴포넌트 — Lambda variant 지원.
+  Avatar 컴포넌트 — Lambda variant 지원 (optional).
 
-  - size="list"    : 32px base, 64px 2x retina (게시글 목록/댓글용)
-  - size="profile" : 96px base, 192px 2x retina (프로필 페이지/홈 상단용)
+  - size 미지정(default): **원본 URL** 사용 (Lambda variant 불필요, 하위 호환)
+  - size="list"    : 32px base + 64px srcset 2x (variant 요청)
+  - size="profile" : 96px base + 192px srcset 2x (variant 요청)
 
-  Lambda (avatar-resize) 가 variant 를 생성하지 않은 경우 (기존 이미지 or 오류)
-  onerror → 원본 이미지 fallback.
+  Lambda (avatar-resize) variant 가 없으면 onerror → 원본 URL fallback.
 
   usage:
-    <Avatar path={user.mb_image} updatedAt={user.mb_image_updated_at} size="list" alt={user.nickname} />
+    <Avatar path={user.mb_image} updatedAt={user.mb_image_updated_at} alt={user.nickname} />
+    <Avatar ... size="list" />      # Lambda 배포 후 적용
+    <Avatar ... size="profile" />   # 프로필 페이지
 -->
 <script lang="ts">
     import { getAvatarUrl, type AvatarSize } from '$lib/utils/member-icon';
@@ -19,14 +21,21 @@
         size?: 'list' | 'profile';
         alt?: string;
         class?: string;
+        width?: number;
+        height?: number;
     }
 
-    let { path, updatedAt, size = 'list', alt = '', class: className = '' }: Props = $props();
+    let { path, updatedAt, size, alt = '', class: className = '', width, height }: Props = $props();
 
-    const sizes: [AvatarSize, AvatarSize] = $derived(size === 'profile' ? [96, 192] : [32, 64]);
-    const base = $derived(sizes[0]);
-    const src = $derived(getAvatarUrl(path, updatedAt, sizes[0]));
-    const src2x = $derived(getAvatarUrl(path, updatedAt, sizes[1]));
+    const sizes: [AvatarSize, AvatarSize] | null = $derived(
+        size === 'profile' ? [96, 192] : size === 'list' ? [32, 64] : null
+    );
+    const src = $derived(
+        sizes ? getAvatarUrl(path, updatedAt, sizes[0]) : getAvatarUrl(path, updatedAt)
+    );
+    const src2x = $derived(sizes ? getAvatarUrl(path, updatedAt, sizes[1]) : null);
+    const widthAttr = $derived(sizes ? sizes[0] : width);
+    const heightAttr = $derived(sizes ? sizes[0] : (height ?? width));
     const fallback = $derived(getAvatarUrl(path, updatedAt));
 
     let errored = $state(false);
@@ -46,8 +55,8 @@
     <img
         {src}
         srcset={src2x ? `${src} 1x, ${src2x} 2x` : undefined}
-        width={base}
-        height={base}
+        width={widthAttr}
+        height={heightAttr}
         {alt}
         class={className}
         loading="lazy"


### PR DESCRIPTION
## Summary

Avatar 컴포넌트 `size` default를 `'list'` 에서 `undefined`로 변경.

## Why

Lambda avatar-resize가 미배포인 현재 상태에서 `<Avatar>` 기본 동작이:
1. `size='list'` 기본값 → `_resized/{name}_32.jpg` variant 요청
2. Lambda 없음 → S3 404
3. onerror → 원본 URL fallback

→ **모든 avatar 이미지당 404 요청 + fallback 2회 요청 발생**

## Changes

- `size` default `'list'` → `undefined`
- `size` 미지정 시: 원본 URL + `?v=timestamp` (기존 동작 100% 호환)
- `size='list'|'profile'` 명시 시: Lambda variant 요청
- `width`/`height` props 추가 (size 미지정 시 CLS 방지용)

## Migration path

1. **Now** (이 PR): Avatar 컴포넌트 도입 가능 — 원본 URL 유지, 안전
2. **Lambda 배포 후**: callsite별로 `size='list'` 또는 `size='profile'` 추가 (점진적)

## Test plan

- [ ] `<Avatar path={...} />` — 원본 URL 렌더링 확인
- [ ] `<Avatar path={...} size="list" />` — variant URL + srcset 렌더링
- [ ] `pnpm check` 타입 검사 통과

## Related

- PR #1271 (Avatar 초기) — merged
- Runbook: `/home/damoang/docs/2026-04-23-avatar-resize-runbook.md`