### PR TITLE
refactor(avatar): getAvatarUrl → <Avatar> 컴포넌트 대량 교체

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
@@ -2,7 +2,7 @@
     import { Badge } from '$lib/components/ui/badge/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
-    import { getAvatarUrl } from '$lib/utils/member-icon.js';
+    import Avatar from '$lib/components/ui/Avatar.svelte';
     import { formatCommentCountBadge } from '$lib/utils/comment-count.js';
     import { formatDate, formatDateCompact, isToday } from '$lib/utils/format-date.js';
     import { highlightQuery } from '$lib/utils/highlight.js';
@@ -29,7 +29,6 @@
     const originalLink = $derived(post.link1 || '');
     const sourceBoard = $derived(post.extra_1 || '');
     const sourcePostId = $derived(post.extra_2 || '');
-    const iconUrl = $derived(getAvatarUrl(post.author_image, post.author_image_updated_at));
     const readClass = $derived(
         isRead ? `post-title-read-${readPostStyleStore.value}` : 'post-title'
     );
@@ -127,17 +126,12 @@
                 <span
                     class="post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:pl-1"
                 >
-                    {#if iconUrl}
-                        <img
-                            src={iconUrl}
-                            alt=""
-                            class="h-5 w-5 shrink-0 rounded-full object-cover"
-                            onerror={(e) => {
-                                const img = e.currentTarget as HTMLImageElement;
-                                img.style.display = 'none';
-                            }}
-                        />
-                    {/if}
+                    <Avatar
+                        path={post.author_image}
+                        updatedAt={post.author_image_updated_at}
+                        alt=""
+                        class="h-5 w-5 shrink-0 rounded-full object-cover"
+                    />
                     <AuthorLink
                         authorId={post.author_id}
                         authorName={post.author}
@@ -164,17 +158,12 @@
                 <!-- 모바일 메타 (Line 2) -->
                 <div class="mobile-meta">
                     <span class="inline-flex items-center gap-0.5">
-                        {#if iconUrl}
-                            <img
-                                src={iconUrl}
-                                alt=""
-                                class="h-5 w-5 shrink-0 rounded-full object-cover"
-                                onerror={(e) => {
-                                    const img = e.currentTarget as HTMLImageElement;
-                                    img.style.display = 'none';
-                                }}
-                            />
-                        {/if}
+                        <Avatar
+                            path={post.author_image}
+                            updatedAt={post.author_image_updated_at}
+                            alt=""
+                            class="h-5 w-5 shrink-0 rounded-full object-cover"
+                        />
                         <AuthorLink
                             authorId={post.author_id}
                             authorName={post.author}

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -6,7 +6,7 @@
     import Play from '@lucide/svelte/icons/play';
     import Pin from '@lucide/svelte/icons/pin';
     import Heart from '@lucide/svelte/icons/heart';
-    import { getAvatarUrl } from '$lib/utils/member-icon.js';
+    import Avatar from '$lib/components/ui/Avatar.svelte';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { formatDate, formatDateCompact, isToday } from '$lib/utils/format-date.js';
     import { formatCompactNumber } from '$lib/utils/format-number.js';
@@ -43,9 +43,6 @@
             '<mark class="bg-yellow-200 dark:bg-yellow-800 rounded px-0.5">$1</mark>'
         );
     }
-
-    // 회원 아이콘 URL
-    const iconUrl = $derived(getAvatarUrl(post.author_image, post.author_image_updated_at));
 
     /**
      * 추천 색상 단계 — 레거시 rcmd-box 기반
@@ -267,17 +264,12 @@
                         ? 'hidden'
                         : 'post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:pl-1'}
                 >
-                    {#if iconUrl}
-                        <img
-                            src={iconUrl}
-                            alt=""
-                            class="h-5 w-5 shrink-0 rounded-full object-cover"
-                            onerror={(e) => {
-                                const img = e.currentTarget as HTMLImageElement;
-                                img.style.display = 'none';
-                            }}
-                        />
-                    {/if}
+                    <Avatar
+                        path={post.author_image}
+                        updatedAt={post.author_image_updated_at}
+                        alt=""
+                        class="h-5 w-5 shrink-0 rounded-full object-cover"
+                    />
                     <AuthorLink
                         authorId={post.author_id}
                         authorName={post.author}


### PR DESCRIPTION
## Summary

`getAvatarUrl()` 직접 호출을 `<Avatar>` 컴포넌트로 교체하는 대량 refactoring 작업의 1차분입니다.

- **변경 범위**: 단순 패턴(Pattern A + B 변형)의 2개 파일만 안전하게 교체
- **size prop 미지정**: Avatar 컴포넌트 size prop 없이 호출 → Lambda 미배포 상태에서도 원본 URL 사용, 동작 100% 동일
- Lambda 배포 후 별도 PR에서 `size="list"` / `size="profile"` 추가 예정

## Changed Files

- `apps/web/src/lib/components/features/board/layouts/list/archive.svelte` (2 call sites)
- `apps/web/src/lib/components/features/board/layouts/list/classic.svelte` (1 call site)

## Skipped Files (후속 PR 대상)

다음 파일들은 sibling fallback div (이미지 로드 실패 시 이니셜 표시) 패턴을 사용 중이라 Avatar 컴포넌트로 교체 시 동작이 달라질 수 있어 이번 PR에서 제외했습니다:

- `comment-form.svelte` — initial fallback + $state 결합
- `comment-likers-dialog.svelte` — sibling fallback
- `comment-list.svelte` — iconUrl 변수 + sibling fallback
- `layouts/list/message.svelte` — showIcon $state + initial fallback
- `layouts/view/basic.svelte`, `view/report.svelte` — sibling fallback
- `follow-list-dialog.svelte` — sibling fallback
- `ui/avatar-stack/avatar-stack.svelte` — sibling fallback
- `routes/[boardId]/[postId]/+page.svelte` — sibling fallback
- `routes/my/+page.svelte` — $state + initial fallback
- `routes/member/[id]/+page.svelte` — overrideImageUrl $state
- `routes/member/settings/+page.svelte` — $state 변수 + 업로드 UI
- `layout/header.svelte`, `layout/user-widget.svelte` — layout 민감도 높음 (의도적으로 별도 PR)

## 다음 단계

1. Avatar 컴포넌트에 이니셜 fallback 지원 추가 (별도 PR)
2. header + user-widget 전용 PR (가장 민감)
3. Lambda avatar-resize 배포 후 `size` prop 추가 PR

## Test plan

- [ ] 로컬에서 게시판 리스트 페이지(archive/classic 레이아웃) 아바타 정상 표시 확인
- [ ] 모바일/데스크톱 뷰 모두 확인
- [ ] `pnpm check` 타입 에러 없는지 확인