### PR TITLE
feat(plugin): server-side hook loader — Phase 1A open-core separation

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -12,6 +12,12 @@ import { checkAndPromoteMember } from '$lib/server/auth/auto-promotion.js';
 import { generateAccessToken } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { parseUserBasicCookie } from '$lib/server/auth/user-basic.js';
+import { loadAllPluginServerHooks } from '$lib/server/plugin-server-loader.js';
+
+// Phase 1A (open-core separation) — plugin server hooks 로드.
+// Fire-and-forget: load 실패해도 앱 전체가 멈추지 않음.
+// 모듈 load 시점 1회 실행 (최초 요청 전 ready).
+void loadAllPluginServerHooks();
 import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
 import { mapGnuboardUrl, mapRhymixUrl } from '$lib/server/url-compat.js';
 

--- a/apps/web/src/lib/server/plugin-server-loader.ts
+++ b/apps/web/src/lib/server/plugin-server-loader.ts
@@ -1,0 +1,73 @@
+/**
+ * Server-side plugin hook loader (Phase 1A of open-core separation).
+ *
+ * Mirrors client-side `$lib/hooks/plugin-loader.ts` but for SSR-only hooks.
+ * Client loader excludes `.server.ts`; this module INCLUDES them.
+ *
+ * ## Pattern: self-registering
+ *
+ * Plugin server hook file (`plugins/{id}/hooks/*.server.ts`):
+ * ```typescript
+ * import { registerHook } from '$lib/hooks/registry';
+ *
+ * registerHook(
+ *     'post.list.enrich',
+ *     async (posts) => {
+ *         // e.g. attach member memos
+ *         return enriched;
+ *     },
+ *     10,
+ *     'plugin:member-memo',
+ *     'filter'
+ * );
+ * ```
+ * Just importing the file registers the hook.
+ *
+ * ## Open-core compliance
+ *
+ * 오픈소스 코어는 *어떤* hook이 등록될지 몰라도 됨. 실행할 hook이 없으면 no-op.
+ * damoang 전용 플러그인 (member-memo, da-reaction 등)은 premium repo에만 존재,
+ * 오픈소스 빌드 시 glob 결과가 비어있어 이 loader는 0개 hook을 로드함.
+ */
+
+// Vite glob — SSR 전용 파일만 (`.server.ts`). 클라이언트 번들 유입 방지.
+const serverHooks = import.meta.glob('../../../../../plugins/**/hooks/*.server.{ts,js}');
+const customServerHooks = import.meta.glob(
+    '../../../../../custom-plugins/**/hooks/*.server.{ts,js}'
+);
+
+const allServerHooks = { ...serverHooks, ...customServerHooks };
+
+/** Idempotency — 한번 로드된 경로는 재import 안 함 (singleton registry 중복 방지). */
+const loadedPaths = new Set<string>();
+
+/**
+ * 발견된 모든 plugin server hook 파일을 import (self-register 실행).
+ *
+ * - hook 파일 없음 → no-op
+ * - 일부 파일 실패 → 해당 파일만 skip, 나머지 계속 시도
+ * - 이미 로드된 파일은 skip (HMR에서도 중복 등록 방지)
+ *
+ * 호출 시점: hooks.server.ts 모듈 load 직후 (최초 요청 전).
+ */
+export async function loadAllPluginServerHooks(): Promise<void> {
+    for (const [path, loader] of Object.entries(allServerHooks)) {
+        if (loadedPaths.has(path)) continue;
+        try {
+            await loader();
+            loadedPaths.add(path);
+        } catch (err) {
+            console.error(`[Plugin Server Loader] Failed: ${path}`, err);
+        }
+    }
+}
+
+/** 로드된 hook 파일 수 (모니터링/디버깅용). */
+export function getLoadedServerHookCount(): number {
+    return loadedPaths.size;
+}
+
+/** 로드된 hook 파일 경로 리스트 (디버깅용). */
+export function getLoadedServerHookPaths(): string[] {
+    return Array.from(loadedPaths);
+}


### PR DESCRIPTION
## Summary

오픈소스 코어가 plugin SSR hook을 로드할 수 있는 인프라. member-memo/da-reaction 등 damoang 전용 플러그인을 core에서 분리하기 위한 4 Phase 의 **첫 단계 (Phase 1A)**.

## Changes

### 신규: `$lib/server/plugin-server-loader.ts`
- `import.meta.glob` 으로 `plugins/**/hooks/*.server.{ts,js}` 수집
- self-registering 패턴 (각 hook 파일이 module scope에서 `registerHook` 호출)
- idempotent — HMR 중복 방지
- 실패 시 해당 파일만 skip, 앱 전체 영향 0

### `hooks.server.ts` 수정
- `loadAllPluginServerHooks()` import + 모듈 load 시점 1회 호출 (fire-and-forget)

## Open-core compliance

- **오픈소스 빌드**: `/plugins/` 디렉토리에 damoang 전용 플러그인 부재 → glob 결과 empty → 0개 hook 로드 → 영향 zero
- **damoang 빌드**: `install.sh` 로 premium plugins이 `/plugins/` 에 복사 → 이 loader가 자동 로드 → registry 공유

## 관련 Phase

| Phase | 내용 | PR |
|---|---|---|
| **1A** | 오픈소스 코어 인프라 (이 PR) | 이 PR |
| 1B | premium member-memo 보강 (파일 이사 + server hook 신규) | 별도 |
| 1C | 오픈소스 26개 파일 decouple (member-memo hardcoded import 제거) | 별도 |
| 1D | 오픈소스 member-memo 관련 파일 삭제 | 별도 |

## Test plan

- [ ] `pnpm check` 타입 통과
- [ ] `pnpm test:unit`
- [ ] 현재 `/plugins/` 에 .server.ts hook 없으므로 loader 호출 = no-op 확인
- [ ] 서버 콘솔 warning/error 없음 확인
- [ ] member-memo 현재 동작 불변 확인 (Phase 1A 는 member-memo 미수정)

## Risk

**매우 낮음** — 신규 파일 2개 + 기존 파일 1개에 import + void 호출 1줄. 모든 경로 실패 시에도 fire-and-forget 이라 메인 쿠키/CSRF/auth 경로 영향 없음.

## Related

- Plan: `/home/damoang/docs/2026-04-23-member-memo-core-decoupling-plan.md`
- Open-core 전략: `/home/damoang/docs/frontend/migration/open-core-separation.md`
- Damoang 전용 플러그인 목록 (premium): member-memo, da-reaction, ad-widget, affiliate-link, bracket-image, emoticon, giving, interaction-analysis, trade (9개)