### PR TITLE
feat(member-memo): Phase 1C — wire applyFilter('post.list.enrich') in SSR

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -17,6 +17,7 @@ import { resolveGivingMeta } from '$lib/features/giving/model.js';
 import { searchByBoard } from '$lib/server/sphinx-search.js';
 import { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
+import { applyFilter } from '$lib/hooks/registry.js';
 
 // --- 인메모리 캐시: 비로그인 게시글 목록 (15초 TTL) ---
 interface PostsCacheData {
@@ -377,9 +378,19 @@ export const load: PageServerLoad = async ({
             };
 
             const trimmed = maybeTrimBoardListPayload(boardId, board, posts, notices);
+            // Phase 1C: 플러그인 enrich filter 호출 (member-memo author_memo 등).
+            // 미설치 시 pass-through. (premium PR #43 기준 stub)
+            const enrichedPosts = (await applyFilter(
+                'post.list.enrich',
+                trimmed.posts
+            )) as FreePost[];
+            const enrichedNotices = (await applyFilter(
+                'post.list.enrich',
+                trimmed.notices
+            )) as FreePost[];
             const result = {
-                posts: trimmed.posts,
-                notices: trimmed.notices,
+                posts: enrichedPosts,
+                notices: enrichedNotices,
                 pagination,
                 error
             };
@@ -557,9 +568,16 @@ export const load: PageServerLoad = async ({
         }
 
         const trimmed = maybeTrimBoardListPayload(boardId, board, posts, notices);
+        // Phase 1C: 플러그인 enrich filter 호출 (member-memo author_memo 등).
+        // 미설치 시 pass-through. (premium PR #43 기준 stub)
+        const enrichedPosts = (await applyFilter('post.list.enrich', trimmed.posts)) as FreePost[];
+        const enrichedNotices = (await applyFilter(
+            'post.list.enrich',
+            trimmed.notices
+        )) as FreePost[];
         const result = {
-            posts: trimmed.posts,
-            notices: trimmed.notices,
+            posts: enrichedPosts,
+            notices: enrichedNotices,
             pagination,
             error
         };

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -25,6 +25,7 @@ import { fetchCommentLikeStatuses } from '$lib/server/comment-likes.js';
 import { fetchPostLikeStatus } from '$lib/server/post-like-status.js';
 import { fetchTruthroomPostId, fetchTruthroomCommentMap } from '$lib/server/truthroom.js';
 import { BackendUnavailableError } from '$lib/server/backend-fetch.js';
+import { applyFilter } from '$lib/hooks/registry.js';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -571,9 +572,14 @@ export const load: PageServerLoad = async ({
             page: listPage
         };
 
+        // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).
+        // 미설치 시 pass-through. (premium PR #43 기준 stub)
+        const enrichedPostList = (await applyFilter('post.list.enrich', [post])) as FreePost[];
+        const enrichedPost = enrichedPostList[0] ?? post;
+
         return {
             boardId,
-            post,
+            post: enrichedPost,
             board: toDetailBoardPayload(board),
             commentsData,
             isScrapped: false,


### PR DESCRIPTION
## Summary

오픈소스 코어가 `plugins/member-memo/*` 를 직접 참조하지 않도록 분리하는 작업의 Phase 1C.

이번 PR 의 실제 변경은 SSR 의 `applyFilter('post.list.enrich', posts)` 훅 wiring 추가뿐이며, hardcoded `from '...plugins/member-memo'` 직접 import 은 prior PR 들에서 이미 모두 `loadPluginComponent` / `loadPluginLib` (build-time `import.meta.glob` 기반) 로 마이그레이션된 상태였음.

## 의존 PR / 진행 상황

| Phase | 내용 | 위치 | 상태 |
|---|---|---|---|
| 1A | plugin-server-loader 인프라 (.server.ts auto-discover) | angple #1279 | draft |
| 1B | premium plugin: server/queries.ts + enrich-posts.server.ts (pass-through stub) | premium #43 | draft |
| **1C** | **오픈소스 코어 hardcoded import 제거 + SSR applyFilter wiring** | **angple (this PR)** | **draft** |
| 1D | $lib/server/member-memo.ts + /my/memos/ 라우트 삭제 (premium 이동) | TBD | TBD |

## 변경 파일 (2개)

- `apps/web/src/routes/[boardId]/+page.server.ts` — promotion / 일반 양 SSR 경로에서 trim 후 `applyFilter('post.list.enrich', posts)` 통과
- `apps/web/src/routes/[boardId]/[postId]/+page.server.ts` — 단일 post 도 동일 filter 통과 (`[post]` 배열로 감싼 뒤 `[0]` 추출)

## Safety

- **동작 변경 0**: 현재 메인의 `plugin-loader.ts` 는 `.server.ts` 파일을 glob 에서 제외 → `enrich-posts.server.ts` 미로드 → `applyFilter` 는 `value` 그대로 반환 (pass-through)
- 1A merge + 1B merge 후에야 hook 이 등록되며, 그 시점에도 premium 의 enrich 함수 자체가 stub pass-through (Phase 1C TODO)
- 즉 어느 단계에서도 회귀 없이 단계별 deploy 가능

## 적용 못한 / 적용 안 한 영역 (의도된 범위 외)

- `apps/web/src/lib/server/member-memo.ts` — 삭제 금지 (Phase 1D)
- `apps/web/src/routes/my/memos/+page.{server.ts,svelte}` — 라우트 자체가 Phase 1D 에서 premium 으로 이동 예정. 이번엔 import 손대지 않음
- `apps/web/src/lib/components/features/board/{comment-list,comment-likers-dialog,layouts/list/card,layouts/view/{basic,report},skins/card}.svelte` 등 — 이미 `loadPluginComponent` / `loadPluginLib` 사용 중 (변경 불필요)
- `recent-posts.svelte`, `layouts/list/classic.svelte` — `pluginStore.isPluginActive('member-memo')` 문자열 체크만 사용 (hardcoded import 아님)

## 알려진 위험 / 후속

- Phase 1A 미머지 상태에서 단독 머지 시 `applyFilter('post.list.enrich', ...)` 는 영구 no-op 이지만 회귀는 없음
- Phase 1A → 1B → 1D 순으로 머지 권장. 본 PR (1C) 은 1A 와 독립적으로 머지 가능 (단순 wiring)
- `recentPosts` 는 SSR 비어있는 상태로 반환 (기존 동일) → 클라이언트 fetch 후 enrich 도 추후 plugin 측에서 자체 처리 필요시 고려

## Test plan

- [ ] dev.damoang.net 에서 게시판 목록 진입 시 author 옆 메모 배지 정상 표시 (member-memo plugin active)
- [ ] 게시글 상세 진입 시 author 메모 배지 정상 표시
- [ ] 비로그인 상태 SSR 캐시 (15s) 정상 동작 (캐시키 변화 없음)
- [ ] member-memo plugin 비활성 시에도 정상 (배지 미표시, 에러 없음)
- [ ] `pnpm check` typecheck 통과 (변경 면적 작음)