### PR TITLE
feat(plugin): loadPluginServerLib + Phase 1D-prep (member-memo route via plugin loader)

### DIFF
--- a/apps/web/src/lib/server/plugin-server-loader.ts
+++ b/apps/web/src/lib/server/plugin-server-loader.ts
@@ -71,3 +71,53 @@ export function getLoadedServerHookCount(): number {
 export function getLoadedServerHookPaths(): string[] {
     return Array.from(loadedPaths);
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Plugin server lib loader — server route에서 plugin module을 동적 import.
+// hook과 다르게 explicit lookup 패턴 (필요 시점에 호출).
+// 사용처 예: routes/my/memos/+page.server.ts → plugin queries 모듈
+// ────────────────────────────────────────────────────────────────────────────
+
+const serverLibs = import.meta.glob('../../../../../plugins/**/server/*.{ts,js}');
+const customServerLibs = import.meta.glob('../../../../../custom-plugins/**/server/*.{ts,js}');
+const allServerLibs = { ...serverLibs, ...customServerLibs };
+
+/**
+ * Plugin의 server lib 모듈을 동적 로드.
+ * Plugin 미설치 또는 모듈 미존재 시 null 반환 → 호출 측에서 graceful fallback.
+ *
+ * @param pluginId   `member-memo` 같은 plugin id
+ * @param libName    `queries` 같은 모듈 이름 (.ts/.js 확장자 제외)
+ * @returns 모듈 exports 객체 또는 null
+ *
+ * @example
+ * const queries = await loadPluginServerLib<{
+ *     getMyMemos: (mb: string, p: number, l: number) => Promise<unknown>;
+ * }>('member-memo', 'queries');
+ * if (!queries) return { items: [], total: 0 };
+ * const result = await queries.getMyMemos(memberId, 1, 20);
+ */
+export async function loadPluginServerLib<T = Record<string, unknown>>(
+    pluginId: string,
+    libName: string
+): Promise<T | null> {
+    const candidates = [
+        `../../../../../plugins/${pluginId}/server/${libName}.ts`,
+        `../../../../../plugins/${pluginId}/server/${libName}.js`,
+        `../../../../../custom-plugins/${pluginId}/server/${libName}.ts`,
+        `../../../../../custom-plugins/${pluginId}/server/${libName}.js`
+    ];
+
+    for (const path of candidates) {
+        const loader = allServerLibs[path];
+        if (!loader) continue;
+        try {
+            const module = (await loader()) as T;
+            return module;
+        } catch (err) {
+            console.error(`[Plugin Server Lib] Failed: ${path}`, err);
+            return null;
+        }
+    }
+    return null;
+}

--- a/apps/web/src/routes/my/memos/+page.server.ts
+++ b/apps/web/src/routes/my/memos/+page.server.ts
@@ -1,6 +1,32 @@
 import type { PageServerLoad } from './$types.js';
-import { getMyMemos, getMemoColorDistribution } from '$lib/server/member-memo.js';
-import type { MemoSearchParams } from '$lib/server/member-memo.js';
+import { loadPluginServerLib } from '$lib/server/plugin-server-loader.js';
+
+/**
+ * Phase 1D-prep: member-memo plugin lib을 dynamic import로 전환.
+ * 오픈소스 빌드 (member-memo plugin 없음) 시 plugin lib null → empty page.
+ * damoang 빌드: install.sh로 premium 복사 후 정상 동작.
+ */
+type MemoSearchParams = {
+    color?: string;
+    memo?: string;
+    detail?: string;
+    target?: string;
+};
+
+interface MemoModule {
+    getMyMemos: (
+        memberId: string,
+        page: number,
+        limit: number,
+        search?: MemoSearchParams
+    ) => Promise<{
+        items: unknown[];
+        total: number;
+        page: number;
+        totalPages: number;
+    }>;
+    getMemoColorDistribution: (memberId: string) => Promise<Record<string, number>>;
+}
 
 export const load: PageServerLoad = async ({ url, locals, depends }) => {
     depends('app:memos');
@@ -22,9 +48,16 @@ export const load: PageServerLoad = async ({ url, locals, depends }) => {
         return { memos: [], total: 0, page, totalPages: 1, search, colorDist: {} };
     }
 
+    // Phase 1D-prep: 직접 import 대신 plugin lib loader 사용.
+    // member-memo plugin 미설치 시 null → 빈 페이지.
+    const queries = await loadPluginServerLib<MemoModule>('member-memo', 'queries');
+    if (!queries) {
+        return { memos: [], total: 0, page, totalPages: 1, search, colorDist: {} };
+    }
+
     const [result, colorDist] = await Promise.all([
-        getMyMemos(locals.user.id, page, limit, search),
-        getMemoColorDistribution(locals.user.id)
+        queries.getMyMemos(locals.user.id, page, limit, search),
+        queries.getMemoColorDistribution(locals.user.id)
     ]);
     return {
         memos: result.items,

--- a/apps/web/src/routes/my/memos/+page.server.ts
+++ b/apps/web/src/routes/my/memos/+page.server.ts
@@ -13,6 +13,19 @@ type MemoSearchParams = {
     target?: string;
 };
 
+interface MemoItem {
+    id: number;
+    member_id: string;
+    target_member_id: string;
+    memo: string;
+    memo_detail: string | null;
+    color: string;
+    created_at: string;
+    updated_at: string | null;
+    target_mb_nick: string;
+    target_mb_image_url: string;
+}
+
 interface MemoModule {
     getMyMemos: (
         memberId: string,
@@ -20,7 +33,7 @@ interface MemoModule {
         limit: number,
         search?: MemoSearchParams
     ) => Promise<{
-        items: unknown[];
+        items: MemoItem[];
         total: number;
         page: number;
         totalPages: number;


### PR DESCRIPTION
## Summary

Phase 1D-prep — `/my/memos` 라우트가 `lib/server/member-memo.ts`를 직접 import하던 것을 plugin loader 기반으로 전환. Phase 1D (실제 파일 삭제)의 선결 조건.

## Changes

### `lib/server/plugin-server-loader.ts` 확장
`loadPluginServerLib<T>(pluginId, libName)` 추가:
- `plugins/{id}/server/*.{ts,js}` 동적 lookup
- 미설치 시 null 반환 (graceful degradation)

### `routes/my/memos/+page.server.ts` 리팩토링
- `import { getMyMemos } from '$lib/server/member-memo.js'` 제거
- `loadPluginServerLib<MemoModule>('member-memo', 'queries')` 동적 로드
- plugin 미설치 시 빈 페이지 반환 (오픈소스 빌드 호환)
- damoang 빌드: install.sh로 premium queries.ts 복사 → 정상 동작

## Open-core 효과

| 빌드 | /my/memos 동작 |
|---|---|
| 오픈소스 (member-memo 없음) | 빈 페이지 (graceful) |
| damoang (premium queries.ts 복사됨) | 기존 동작 100% 동일 |

## Phase 진행

- [x] 1A: plugin-server-loader (PR #1279)
- [x] 1B: premium queries.ts (premium #43)
- [x] 1C: SSR applyFilter wire (PR #1280)
- [x] **1D-prep: route → plugin loader (이 PR)**
- [ ] 1D: `lib/server/member-memo.ts` 삭제 (별도 PR, 이 PR + premium 검증 후)

## Risk

**낮음** — 동작 변경 없음 (member-memo 설치 시). 미설치 시 graceful empty page (오픈소스에선 정당).

## Test plan

- [ ] dev 서버에서 `/my/memos` 정상 렌더링
- [ ] member-memo 비활성화 시 빈 페이지 확인
- [ ] `pnpm check` 통과