### PR TITLE
perf(jwt-cache): MAX 50000 → 10000 defensive cap

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -47,7 +47,10 @@ function parseJWTPayload(token: string): { mb_id?: string } | null {
 // --- JWT 인메모리 캐시 (세션별, 5분 TTL) ---
 const jwtCache = new Map<string, { token: string; expiry: number }>();
 const JWT_CACHE_TTL = 5 * 60 * 1000; // 5분
-const MAX_JWT_CACHE_SIZE = 50000;
+// Cap 50000 → 10000 (2026-04-24 postmortem 후속 defensive).
+// 5분 TTL + 60s cleanup이면 정상 운영 동시 세션 < 5000,
+// 10000이면 최악의 경우에도 ~8 MB (entry ~800B × 10k) 로 상한 고정.
+const MAX_JWT_CACHE_SIZE = 10000;
 
 // 만료 entry 주기적 정리 — 4/22 prod 메모리 누수 근본 원인.
 // 기존 eviction은 size >= MAX일 때만 실행되어, size < MAX면 만료된 entry가


### PR DESCRIPTION
## Summary
- JWT 인메모리 캐시 `MAX_JWT_CACHE_SIZE` **50000 → 10000** (2026-04-24 postmortem 후속 defensive fix)
- Serena 세맨틱 분석 교정: JWT 캐시의 50k cap은 이론상 ~42 MB 상한 → 실제 900 MiB/9h leak의 주 원인은 아니었음 (SSR HTML 리텐션이 메인, PR #1282 gzip으로 이미 완화)
- 그럼에도 60s cleanup + 5분 TTL 체제에서 10k cap이면 **최악 상황 상한 ~8 MB**로 고정되어 안전마진 확보

## Rationale
- 정상 운영 시 동시 활성 세션 < 5000 추정 (현재 18:00 기준 measured ~3-4k)
- 5분 TTL × 60s 주기 cleanup → 이론상 10k 넘길 시나리오: 초당 ~33 신규 세션 (현 트래픽 대비 5배)
- Cap을 낮춰도 기능 손실 없음 (TTL eviction이 먼저 동작)

## Test plan
- [ ] `pnpm check` 통과
- [ ] CI green
- [ ] 배포 후 24h 관측: jwtCache.size 히스토그램 (< 5000 유지 확인)
- [ ] Eviction 빈도 증가 없음 (5분 TTL이 먼저 동작)

## Rollback
- 1 line revert: `MAX_JWT_CACHE_SIZE = 50000`