### PR TITLE
perf(api/themes): Cache-Control s-maxage=300 + swr=1800

### DIFF
--- a/apps/web/src/routes/api/themes/+server.ts
+++ b/apps/web/src/routes/api/themes/+server.ts
@@ -67,7 +67,9 @@ export const GET: RequestHandler = async () => {
             },
             {
                 headers: {
-                    'Cache-Control': 'public, max-age=120'
+                    // 2026-04-24: CF edge hit% 52% → s-maxage + swr 추가로 hit% 개선.
+                    // 다른 layout API 패턴과 일치 (s-maxage=300, swr=1800, max-age=60).
+                    'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=1800, max-age=60'
                 }
             }
         );


### PR DESCRIPTION
## Summary
- \`/api/themes\` Cache-Control: \`public, max-age=120\` → \`public, s-maxage=300, stale-while-revalidate=1800, max-age=60\`
- CF edge hit% 52% (24h 523K req/day) → 목표 80%+
- 다른 layout API 와 패턴 통일

## Verification
- [ ] CI green
- [ ] 배포 후 24h 관측: \`/api/themes\` hit% > 70%
- [ ] \`curl -I https://damoang.net/api/themes\` → \`cache-control\` 헤더 변경 확인

## Rollback
One-line revert