### PR TITLE
feat: multisite Phase 1 — Path D′ ConfigSiteResolver

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -31,3 +31,6 @@ vite.config.ts.timestamp-*
 /custom-themes
 /data/settings.json
 /data/uploads
+
+# Multisite Site-Resolver (premium install.sh 가 site-overrides.json 배치)
+/.angple/

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,6 +1,8 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 
+import type { SiteContext } from '$lib/server/site-resolver/index.js';
+
 // DamoangAds 타입 정의
 interface DamoangAdsInterface {
     render: (position: string) => void;
@@ -31,6 +33,8 @@ declare global {
             sessionId: string | null;
             /** CSRF 토큰 (세션에 연결, double-submit cookie 검증용) */
             csrfToken: string | null;
+            /** Phase 1: site-resolver 가 host 기반으로 주입한 site 컨텍스트. miss 시 null (기본 테마 사용). */
+            site: SiteContext | null;
         }
         // interface PageData {}
         // interface PageState {}

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -23,9 +23,19 @@ void loadAllPluginServerHooks();
 
 // Phase 1 (multisite domain → theme/SEO resolver) — Strategy 패턴.
 // 부팅 시 1회 ConfigSiteResolver 가 host-overrides JSON 로드. miss 시 null → 기본 테마.
-// USE_SITE_RESOLVER=false 면 resolver bypass (옛 하드코딩 폴백 경로 사용).
-const SITE_OVERRIDES_PATH = env.SITE_OVERRIDES_PATH ?? '/home/angple/premium/site-overrides.json';
-const siteResolver = new CompositeSiteResolver([new ConfigSiteResolver(SITE_OVERRIDES_PATH)]);
+// USE_SITE_RESOLVER=false 면 resolver bypass.
+//
+// 경로 우선순위 (각 ConfigSiteResolver 가 ENOENT 시 silent skip → CompositeSiteResolver 가 다음 사용):
+//   1. env SITE_OVERRIDES_PATH (배포/테스트 환경 명시 override)
+//   2. process.cwd() + '/.angple/site-overrides.json' (install.sh 가 angple core 에 배치)
+//
+// open-core 코어에 환경별 hardcode 0 — 운영자가 자체 site-overrides 배치 가능.
+const siteResolverPaths: string[] = [];
+if (env.SITE_OVERRIDES_PATH) siteResolverPaths.push(env.SITE_OVERRIDES_PATH);
+siteResolverPaths.push(`${process.cwd()}/.angple/site-overrides.json`);
+const siteResolver = new CompositeSiteResolver(
+    siteResolverPaths.map((p) => new ConfigSiteResolver(p))
+);
 void siteResolver.resolve('').catch(() => {}); // warm-up: load() 강제 실행
 
 import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -13,11 +13,21 @@ import { generateAccessToken } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { parseUserBasicCookie } from '$lib/server/auth/user-basic.js';
 import { loadAllPluginServerHooks } from '$lib/server/plugin-server-loader.js';
+import { CompositeSiteResolver } from '$lib/server/site-resolver/composite.js';
+import { ConfigSiteResolver } from '$lib/server/site-resolver/config.js';
 
 // Phase 1A (open-core separation) — plugin server hooks 로드.
 // Fire-and-forget: load 실패해도 앱 전체가 멈추지 않음.
 // 모듈 load 시점 1회 실행 (최초 요청 전 ready).
 void loadAllPluginServerHooks();
+
+// Phase 1 (multisite domain → theme/SEO resolver) — Strategy 패턴.
+// 부팅 시 1회 ConfigSiteResolver 가 host-overrides JSON 로드. miss 시 null → 기본 테마.
+// USE_SITE_RESOLVER=false 면 resolver bypass (옛 하드코딩 폴백 경로 사용).
+const SITE_OVERRIDES_PATH = env.SITE_OVERRIDES_PATH ?? '/home/angple/premium/site-overrides.json';
+const siteResolver = new CompositeSiteResolver([new ConfigSiteResolver(SITE_OVERRIDES_PATH)]);
+void siteResolver.resolve('').catch(() => {}); // warm-up: load() 강제 실행
+
 import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
 import { mapGnuboardUrl, mapRhymixUrl } from '$lib/server/url-compat.js';
 
@@ -553,6 +563,19 @@ const WRITE_API_RATE = { maxRequests: 60, windowMs: 60_000 }; // 쓰기 분당 6
 export const handle: Handle = async ({ event, resolve }) => {
     const { pathname } = event.url;
     const isDataRequest = isSvelteKitDataRequest(event);
+
+    // Phase 1: site-resolver 가 host → SiteContext 매핑. miss 시 null (기본 테마 fallback).
+    // USE_SITE_RESOLVER=false 면 bypass (옛 하드코딩 경로만 사용).
+    if (env.USE_SITE_RESOLVER !== 'false') {
+        try {
+            event.locals.site = await siteResolver.resolve(event.url.host);
+        } catch (err) {
+            console.error('[site-resolver] resolve failed:', err);
+            event.locals.site = null;
+        }
+    } else {
+        event.locals.site = null;
+    }
 
     if (isMalformedExternalImagePath(pathname)) {
         return new Response(null, {

--- a/apps/web/src/lib/server/site-resolver/composite.ts
+++ b/apps/web/src/lib/server/site-resolver/composite.ts
@@ -1,0 +1,13 @@
+import type { SiteContext, SiteResolver } from './index.js';
+
+export class CompositeSiteResolver implements SiteResolver {
+    constructor(private readonly resolvers: SiteResolver[]) {}
+
+    async resolve(host: string): Promise<SiteContext | null> {
+        for (const r of this.resolvers) {
+            const ctx = await r.resolve(host);
+            if (ctx) return ctx;
+        }
+        return null;
+    }
+}

--- a/apps/web/src/lib/server/site-resolver/config.ts
+++ b/apps/web/src/lib/server/site-resolver/config.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from 'node:fs';
+import type { SiteContext, SiteResolver } from './index.js';
+
+interface SiteOverrideEntry {
+    schema_version?: number;
+    domain: string;
+    aliases?: string[];
+    theme_id: string;
+    title?: string;
+    description?: string;
+    keywords?: string[];
+    logo_url?: string;
+    favicon_url?: string;
+}
+
+interface SiteOverridesFile {
+    schema_version: number;
+    overrides: SiteOverrideEntry[];
+}
+
+export class ConfigSiteResolver implements SiteResolver {
+    private map: Map<string, SiteContext> = new Map();
+    private loaded = false;
+
+    constructor(private readonly path: string) {}
+
+    async load(): Promise<void> {
+        if (this.loaded) return;
+        try {
+            const raw = await fs.readFile(this.path, 'utf-8');
+            const data = JSON.parse(raw) as SiteOverridesFile;
+            if (data.schema_version !== 1) {
+                console.warn(
+                    `[site-resolver] schema_version mismatch in ${this.path}: expected 1, got ${data.schema_version}`
+                );
+            }
+            for (const entry of data.overrides ?? []) {
+                const ctx: SiteContext = {
+                    id: `config:${entry.domain}`,
+                    theme_id: entry.theme_id,
+                    title: entry.title,
+                    description: entry.description,
+                    keywords: entry.keywords,
+                    logo_url: entry.logo_url,
+                    favicon_url: entry.favicon_url,
+                    source: 'config'
+                };
+                const keys = [entry.domain, ...(entry.aliases ?? [])];
+                for (const key of keys) {
+                    const lower = key.toLowerCase();
+                    if (this.map.has(lower)) {
+                        console.error(`[site-resolver] duplicate domain in ${this.path}: ${lower}`);
+                        continue;
+                    }
+                    this.map.set(lower, ctx);
+                }
+            }
+        } catch (err) {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code === 'ENOENT') {
+                // Config file optional — open-core users may not have one.
+                console.info(`[site-resolver] no config at ${this.path}, skipping`);
+            } else {
+                console.error(`[site-resolver] failed to load ${this.path}:`, err);
+            }
+        }
+        this.loaded = true;
+    }
+
+    async resolve(host: string): Promise<SiteContext | null> {
+        if (!this.loaded) await this.load();
+        return this.map.get(host.toLowerCase()) ?? null;
+    }
+}

--- a/apps/web/src/lib/server/site-resolver/index.ts
+++ b/apps/web/src/lib/server/site-resolver/index.ts
@@ -1,0 +1,14 @@
+export interface SiteContext {
+    id: string;
+    theme_id: string;
+    title?: string;
+    description?: string;
+    keywords?: string[];
+    logo_url?: string;
+    favicon_url?: string;
+    source: 'config' | 'manifest' | 'db' | 'env';
+}
+
+export interface SiteResolver {
+    resolve(host: string): Promise<SiteContext | null>;
+}

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -116,14 +116,15 @@ export const load: LayoutServerLoad = async ({
         }
     }
 
-    // 도메인별 테마 오버라이드
-    const host = url.host;
+    // 도메인별 테마 오버라이드 (Phase 1, Path D′ — site-resolver 단독 소스)
+    // hooks.server.ts 의 CompositeSiteResolver 가 host → locals.site 주입.
+    // miss 시 locals.site === null → 기본 테마 적용.
+    // 도메인-특이 매핑은 premium/site-overrides.json (open-core 코드에 도메인 hardcode 0).
     let resolvedThemeId = activeTheme?.manifest.id || null;
     let resolvedThemeSettings = activeTheme?.currentSettings || {};
 
-    // 도메인별 테마 오버라이드
-    if (host === 'wikiang.org' || host === 'www.wikiang.org') {
-        resolvedThemeId = 'wiki-theme';
+    if (locals.site?.theme_id) {
+        resolvedThemeId = locals.site.theme_id;
         resolvedThemeSettings = {};
     }
 
@@ -143,7 +144,9 @@ export const load: LayoutServerLoad = async ({
             schedules: logoData.schedules ?? [],
             requestLocale: logoData.requestLocale,
             requestTimeZone: logoData.requestTimeZone
-        }
+        },
+        // Phase 1 (Path D′): site-resolver 결과. miss 시 null. svelte:head 가 og:*/favicon 변수화에 사용.
+        site: locals.site ?? null
     };
 
     // 훅: 레이아웃 데이터 필터 (플러그인이 SSR 데이터를 수정/확장 가능)

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -616,7 +616,25 @@
 
 <svelte:head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href={favicon} />
+    <!-- Phase 1 (Path D′): data.site 가 있으면 site-resolver 의 SEO 메타 사용. 없으면 기본 favicon. -->
+    {#if data.site?.favicon_url}
+        <link rel="icon" href={data.site.favicon_url} />
+    {:else}
+        <link rel="icon" href={favicon} />
+    {/if}
+    {#if data.site?.title}
+        <meta property="og:title" content={data.site.title} />
+    {/if}
+    {#if data.site?.description}
+        <meta name="description" content={data.site.description} />
+        <meta property="og:description" content={data.site.description} />
+    {/if}
+    {#if data.site?.logo_url}
+        <meta property="og:image" content={data.site.logo_url} />
+    {/if}
+    {#if data.site?.keywords?.length}
+        <meta name="keywords" content={data.site.keywords.join(', ')} />
+    {/if}
 </svelte:head>
 
 <!-- /admin, /install 경로는 테마 레이아웃 없이 렌더링 -->


### PR DESCRIPTION
## Summary
- Strategy 패턴 도입 — `SiteResolver` 인터페이스 + `ConfigSiteResolver` + `CompositeSiteResolver`
- 도메인 → 테마/SEO 매핑을 open-core 코어에서 분리 → 외부 config (premium 영역) 로 이전
- `+layout.server.ts` 의 `wikiang.org → wiki-theme` 도메인 hardcode 제거
- `data.site` 기반 favicon/og:* 변수화 (`<svelte:head>`)
- `USE_SITE_RESOLVER=false` flag 로 resolver bypass 가능 (rollback 용)

## 핵심 설계 (Path D′)

```typescript
interface SiteResolver { resolve(host): Promise<SiteContext | null>; }
class ConfigSiteResolver implements SiteResolver { /* env JSON path 읽기 */ }
class CompositeSiteResolver implements SiteResolver { /* chain 우선순위 */ }
```

Phase 2 진입 시 `DBSiteResolver` 추가만으로 확장 — Open/Closed 원칙.

## 변경 파일 (7개)

| 파일 | 변경 |
|---|---|
| `apps/web/src/lib/server/site-resolver/index.ts` | 신규 — 인터페이스 |
| `apps/web/src/lib/server/site-resolver/config.ts` | 신규 — `ConfigSiteResolver` |
| `apps/web/src/lib/server/site-resolver/composite.ts` | 신규 — `CompositeSiteResolver` |
| `apps/web/src/app.d.ts` | `App.Locals.site: SiteContext \| null` |
| `apps/web/src/hooks.server.ts` | resolver 싱글톤 + handle 진입 시 `event.locals.site` 주입 |
| `apps/web/src/routes/+layout.server.ts` | hardcode 제거, `locals.site.theme_id` 사용, `data.site` payload |
| `apps/web/src/routes/+layout.svelte` | `<svelte:head>` 변수화 |

## 의존 PR
- premium repo: `feat/multisite-phase1-site-overrides` (`/home/angple/premium/site-overrides.json` 추가) — 같이 머지 필요

## 관련 결정 / 문서
- 아키텍처 평가: `/home/damoang/docs/2026-04-25-multisite-domain-resolver-architecture.md`
- Sprint Contract: `/home/damoang/docs/harness-task/task_plan.md`
- DB 가드: `/home/damoang/docs/2026-04-25-angple-db-table-name-guards.md`
- issue #1224 합의: [4316932837](https://github.com/damoang/angple/issues/1224#issuecomment-4316932837) / [4316951688](https://github.com/damoang/angple/issues/1224#issuecomment-4316951688) — \`angple_*\` prefix + DDL 채널

## Test plan
- [ ] (premium) site-overrides.json 머지 + 배포
- [ ] dev 환경에서 \`USE_SITE_RESOLVER=true\` 기본값 확인
- [ ] \`curl -i -H \"Host: wikiang.org\" https://www.example.com/\` → wiki-theme 렌더
- [ ] \`curl -i -H \"Host: damoang.net\" https://www.example.com/\` → 기본 테마
- [ ] \`USE_SITE_RESOLVER=false\` 환경변수 + 재시작 → resolver bypass 동작 (모든 호스트 기본 테마)
- [ ] svelte-check 0 errors (commit 시 husky 통과 확인됨)

## Rollback
- 1단계: \`USE_SITE_RESOLVER=false\` env 설정 → resolver bypass
- 2단계: \`git revert\` 본 PR
- premium config 파일 (\`site-overrides.json\`) 은 별도 보관, code revert 영향 없음

## Out of Scope (별도 PR)
- \`/admin/sites\` UI (Phase 2)
- \`DBSiteResolver\` (Phase 2)
- \`wiki.ts\` 의 \`wikiang_*\` DB prefix 일반화 (별 task)
- backend host-aware logic (Phase 2)

Closes Phase 1 (issue #1224)