### PR TITLE
feat(admin): plugin admin.menu 항목 자동 사이드바 추가 (M1 A2 Sprint 1)

### DIFF
--- a/apps/web/src/lib/components/admin/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/admin/layout/sidebar.svelte
@@ -20,12 +20,28 @@
         StickyNote,
         TrendingUp,
         Award,
+        Plug,
         Image as ImageIcon
     } from '@lucide/svelte/icons';
 
     /**
      * Admin 사이드바 네비게이션
+     *
+     * Phase 1 (issue #1289): 활성 plugin 의 admin.menu 항목을 자동 추가.
+     * `pluginEntries` 가 없거나 빈 배열이면 기존 동작과 동일.
      */
+
+    interface PluginEntry {
+        pluginId: string;
+        title: string;
+        href: string;
+        icon?: string;
+        position?: number;
+    }
+
+    let { pluginEntries = [] as PluginEntry[] } = $props<{
+        pluginEntries?: PluginEntry[];
+    }>();
 
     const menuItems = [
         {
@@ -140,7 +156,7 @@
     </div>
 
     <!-- 메뉴 영역 -->
-    <nav class="flex-1 space-y-1 p-4">
+    <nav class="flex-1 space-y-1 overflow-y-auto p-4">
         {#each menuItems as item (item.href)}
             {@const Icon = item.icon}
             <a
@@ -156,6 +172,28 @@
                 <span>{item.title}</span>
             </a>
         {/each}
+
+        {#if pluginEntries.length > 0}
+            <div class="border-border my-3 border-t"></div>
+            <div class="text-muted-foreground px-3 pb-1 text-xs font-semibold uppercase">
+                플러그인
+            </div>
+            {#each pluginEntries as entry (entry.pluginId)}
+                <a
+                    href={entry.href}
+                    class={cn(
+                        'hover:bg-accent hover:text-accent-foreground flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                        isActive(entry.href)
+                            ? 'bg-accent text-accent-foreground'
+                            : 'text-muted-foreground'
+                    )}
+                    title={entry.pluginId}
+                >
+                    <Plug class="h-5 w-5" />
+                    <span>{entry.title}</span>
+                </a>
+            {/each}
+        {/if}
     </nav>
 
     <!-- 하단 정보 -->

--- a/apps/web/src/routes/admin/+layout.server.ts
+++ b/apps/web/src/routes/admin/+layout.server.ts
@@ -1,13 +1,47 @@
 import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { safeRedirectUrl } from '$lib/server/safe-redirect';
+import { getActivePlugins } from '$lib/server/plugins';
 
 /**
  * Admin 레이아웃 서버 로드
  *
  * hooks.server.ts에서 이미 SSR 인증 완료 → event.locals 사용
  * level >= 10 이면 관리자
+ *
+ * Phase 1 (issue #1289): 활성 plugin 의 admin.menu 항목을 사이드바에 자동 추가.
  */
+
+interface PluginAdminMenuEntry {
+    pluginId: string;
+    title: string;
+    href: string;
+    icon?: string;
+    position?: number;
+}
+
+async function loadPluginAdminMenuEntries(): Promise<PluginAdminMenuEntry[]> {
+    try {
+        const plugins = await getActivePlugins();
+        const entries: PluginAdminMenuEntry[] = [];
+        for (const plugin of plugins) {
+            const menu = plugin.manifest.ui?.admin?.menu;
+            if (!menu) continue;
+            entries.push({
+                pluginId: plugin.manifest.id,
+                title: menu.title,
+                href: `/admin/plugins/${plugin.manifest.id}`,
+                icon: menu.icon,
+                position: menu.position
+            });
+        }
+        entries.sort((a, b) => (a.position ?? 9999) - (b.position ?? 9999));
+        return entries;
+    } catch (err) {
+        console.error('[admin layout] failed to load plugin admin menu entries:', err);
+        return [];
+    }
+}
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
     // 설치 페이지는 권한 체크 제외
@@ -26,7 +60,13 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
                 const redirectTo = safeRedirectUrl(url.searchParams.get('redirect'), '/admin');
                 throw redirect(303, redirectTo);
             }
-            return { isAdmin: true, authChecked: true, nickname: user.nickname };
+            const pluginAdminMenuEntries = await loadPluginAdminMenuEntries();
+            return {
+                isAdmin: true,
+                authChecked: true,
+                nickname: user.nickname,
+                pluginAdminMenuEntries
+            };
         }
 
         // 로그인됐지만 관리자 아님
@@ -42,7 +82,8 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
     const skipAuth = import.meta.env.VITE_SKIP_AUTH === 'true';
     if (skipAuth) {
         if (isLoginPage) throw redirect(303, '/admin');
-        return { isAdmin: true, authChecked: true };
+        const pluginAdminMenuEntries = await loadPluginAdminMenuEntries();
+        return { isAdmin: true, authChecked: true, pluginAdminMenuEntries };
     }
 
     // 로그인 페이지는 그대로 표시

--- a/apps/web/src/routes/admin/+layout@.svelte
+++ b/apps/web/src/routes/admin/+layout@.svelte
@@ -53,7 +53,7 @@
         </div>
     {:else if showSidebar}
         <div class="flex h-screen overflow-hidden">
-            <AdminSidebar />
+            <AdminSidebar pluginEntries={data.pluginAdminMenuEntries ?? []} />
             <main class="flex-1 overflow-y-auto p-6">
                 {@render children?.()}
             </main>


### PR DESCRIPTION
## Summary
issue #1289 (M1 A2 — Plugin loader 강화) Sprint 1.

활성 plugin 의 \`manifest.ui.admin.menu\` 필드를 admin 사이드바에 동적 항목으로 추가.

## Why

ExtensionManifest 의 \`ui.admin.menu\` schema 는 이미 존재 (\`packages/types/src/extension.ts\` L300). 하지만 wiring 이 없어 admin UI 가 활용 안 함. 본 PR 은 wiring 만 추가.

## Changes

### \`apps/web/src/routes/admin/+layout.server.ts\`
- \`getActivePlugins()\` 호출 → \`admin.menu\` 가 정의된 plugin 만 추출
- \`pluginAdminMenuEntries\` 를 layout data 로 전달
- 정렬: \`menu.position\` (없으면 9999)
- 실패 시 빈 배열 반환 (admin layout 영향 0)

### \`apps/web/src/routes/admin/+layout@.svelte\`
- \`<AdminSidebar pluginEntries={data.pluginAdminMenuEntries ?? []} />\`

### \`apps/web/src/lib/components/admin/layout/sidebar.svelte\`
- \`pluginEntries: PluginEntry[]\` prop (default \`[]\`)
- 빈 배열 시 기존 사이드바와 100% 동일
- 항목 있으면 메뉴 하단에 구분선 + "플러그인" 섹션 + 항목 (Plug 아이콘)

## 운영 무손상

| 항목 | 상태 |
|---|---|
| 기존 plugin 영향 | 0 (admin.menu 정의된 plugin 0개 — 빈 배열만 전달) |
| DDL | 없음 |
| feature flag | 불필요 (default 빈 배열) |
| svelte-check | 0 errors (95 warnings — 기존부터) |
| breaking change | 없음 |

## Out of Scope (별 Sprint Contract)
- A2 Sprint 2: routes 자동 등록 (\`manifest.routes\` → SvelteKit 라우트)
- A2 Sprint 3: DB migration runner (\`plugin/migrations/*.sql\` 자동 실행)
- 동적 Lucide 아이콘 (현재 Plug 단일 아이콘) — 추후 \`menu.icon\` 활용

## Test plan
- [ ] dev 서버 부팅 → \`/admin\` 진입 → 기존 메뉴 항목 17개 정상
- [ ] 활성 plugin 중 \`ui.admin.menu\` 정의된 것 (테스트용) 추가 → 사이드바 하단에 \"플러그인\" 섹션 표시
- [ ] plugin 비활성화 → 항목 즉시 사라짐 (다음 페이지 로드)
- [ ] svelte-check 0 errors

## 연관

- 부모: #1287, #1289
- M1 RFC (A1 빌더): \`/home/damoang/docs/2026-04-25-builder-rfc.md\`
- M1 sub-issue 인덱스: #1287 댓글 [4317324208](https://github.com/damoang/angple/issues/1287#issuecomment-4317324208)