### PR TITLE
fix(ci): staging deploy GHCR 로그인을 GITHUB_TOKEN 으로 전환

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -165,8 +165,9 @@ jobs:
 
             echo "=== Staging Deploy Start ==="
 
-            # GHCR 로그인
-            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            # GHCR 로그인 — workflow 의 GITHUB_TOKEN 사용 (만료 X, packages:write 권한 보유)
+            # 기존 secrets.GHCR_TOKEN 은 만료/철회로 4-24 부터 staging deploy 모두 실패
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             # 이미지 pull
             docker pull ${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.image_tag }}


### PR DESCRIPTION
## Summary
4-24 부터 staging deploy 5건 연속 실패 — GHCR 로그인 거부 (\`secrets.GHCR_TOKEN\` 만료/철회 추정).

## Root cause
\`deploy-staging.yml\` L169:
\`\`\`yaml
echo \"\${{ secrets.GHCR_TOKEN }}\" | docker login ghcr.io ...
\`\`\`

\`GHCR_TOKEN\` 은 별도 PAT (사용자 계정 토큰). 만료/철회된 상태.

오류:
\`\`\`
Error response from daemon: Get \"https://ghcr.io/v2/\": denied: denied
\`\`\`

## Fix
\`secrets.GITHUB_TOKEN\` (workflow run 단위 자동 발급) 사용으로 변경:
- 만료 없음
- 본 workflow 의 \`packages: write\` 권한 보유 (build/push 와 동일 토큰)
- 같은 레포 prod deploy.yml 도 같은 패턴 (\`GHCR_TOKEN='\${{ secrets.GITHUB_TOKEN }}'\`)

## 영향 받은 PR (5건)
- 본 PR
- A2 Sprint 1 (#1293)
- Phase 1 multisite (#1286)
- perf/api-themes-cache-ttl (4-24)
- perf/jwt-cache-cap-10k (4-24)

본 fix 머지 후 위 PR 들의 staging deploy 재실행하면 정상화.

## Test plan
- [ ] 본 PR 머지
- [ ] PR #1286, #1293 에서 staging deploy 재실행 → SUCCESS 확인
- [ ] (선택) 만료된 \`secrets.GHCR_TOKEN\` 정리 (repo settings)

## Out of Scope
- Repo settings 의 \`GHCR_TOKEN\` secret 삭제 — 본 PR 미반영, 추후 정리

운영 무영향 (CI workflow 변경만, prod 무관).