### PR TITLE
feat(admin): heap snapshot 다운로드 endpoint

### DIFF
--- a/apps/web/src/routes/api/admin/heap-snapshot/+server.ts
+++ b/apps/web/src/routes/api/admin/heap-snapshot/+server.ts
@@ -1,0 +1,41 @@
+/**
+ * 관리자 전용 heap snapshot 다운로드 API
+ *
+ * GET /api/admin/heap-snapshot
+ *
+ * V8 의 `getHeapSnapshot()` 으로 Readable stream 을 생성하고
+ * 그대로 HTTP 응답으로 스트리밍 → 메모리 spike 없이 큰 snapshot 가능.
+ *
+ * 사용:
+ *   curl -H "Cookie: angple_sid=<admin_session>" \
+ *     https://damoang.net/api/admin/heap-snapshot \
+ *     -o pod-$(hostname)-$(date +%s).heapsnapshot
+ *   # → Chrome DevTools 의 Memory 탭에서 분석
+ *
+ * 주의:
+ * - hooks.server.ts 가 /api/admin/* 경로에서 admin 권한 검증
+ * - snapshot 생성 중 5-30초 동안 V8 GC pause 발생 (idle pod 권장)
+ * - snapshot 파일 크기 ~heapUsed 와 비슷 (수백 MB)
+ */
+
+import { Readable } from 'node:stream';
+import { getHeapSnapshot } from 'node:v8';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+    const stream: NodeJS.ReadableStream = getHeapSnapshot();
+    const filename = `heap-${process.env.HOSTNAME || 'pod'}-${Date.now()}.heapsnapshot`;
+
+    // Node Readable → Web ReadableStream (SvelteKit Response 호환)
+    const webStream = Readable.toWeb(stream as Readable) as unknown as ReadableStream;
+
+    return new Response(webStream, {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/octet-stream',
+            'Content-Disposition': `attachment; filename="${filename}"`,
+            'Cache-Control': 'no-store',
+            'X-Robots-Tag': 'noindex'
+        }
+    });
+};


### PR DESCRIPTION
## Summary
2026-04-25 발견 — idle SvelteKit pod heapUsed **640 MB** (정상 100-200 MB 의 4배). Root cause 진단을 위한 안전한 heap snapshot 수집 인프라.

## 변경
- `GET /api/admin/heap-snapshot` 신규
- `node:v8.getHeapSnapshot()` Readable stream → HTTP 응답으로 직접 스트리밍
- 메모리 spike 없이 큰 snapshot 다운로드 가능 (in-process inspector 방식의 OOM 위험 회피)

## 배경
인스펙터(SIGUSR1) 직접 snapshot 시도 시 직렬화 메모리 spike 로 1 pod restart 발생.
이 PR 의 stream 방식은 V8 가 바로 chunk 단위 출력 → 추가 메모리 거의 사용 안 함.

## 보안
- `/api/admin/*` 경로는 \`hooks.server.ts\` 가 admin 권한 (mb_level >= 10) 검증
- 응답: \`Cache-Control: no-store\`, \`X-Robots-Tag: noindex\`
- 추후 IP allowlist 미들웨어 추가 검토 (옵션)

## Verify
\`\`\`bash
# admin 세션 쿠키로 다운로드
curl -H 'Cookie: angple_sid=<admin_session>' \\
  https://damoang.net/api/admin/heap-snapshot \\
  -o pod-\$(date +%s).heapsnapshot

# Chrome DevTools → Memory 탭 → Load → 분석
\`\`\`

## 주의
- snapshot 생성 중 5-30s V8 GC pause 발생. **idle pod** (HPA 자동 traffic 분산) 권장
- snapshot 파일 크기 ~heap_used (현재 600-800 MB)

## 다음 단계
이 endpoint 머지 후 04:00 KST 배포 → 다음 세션에서 1 pod 대상 snapshot → DevTools 분석 → 진짜 root cause 식별 → 추가 PR