### PR TITLE
fix(ci): E2E 환경 — Redis service + DB/BACKEND env 명시

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,15 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -5,11 +5,29 @@ const port = isCI ? 3000 : 4173;
 
 export default defineConfig({
     webServer: {
+        // CI: SSR 이 실제 DB/Redis/백엔드와 통신하므로 env 명시 필요.
+        // - DB_*: ci.yml services.mysql 의 angple_user/pass
+        // - BACKEND_URL/INTERNAL_API_URL: ci.yml backend (8081)
+        // - REDIS_HOST: ci.yml services.redis 6379
         command: isCI
-            ? `ORIGIN=http://localhost:${port} PORT=${port} ALLOW_INSTALL_ROUTE_FOR_E2E=true node build`
+            ? [
+                  'DB_HOST=127.0.0.1',
+                  'DB_USER=angple_user',
+                  'DB_PASSWORD=angple_pass_2024',
+                  'DB_NAME=angple_db',
+                  'BACKEND_URL=http://localhost:8081',
+                  'INTERNAL_API_URL=http://localhost:8081/api/v2',
+                  'REDIS_HOST=127.0.0.1',
+                  'REDIS_PORT=6379',
+                  `ORIGIN=http://localhost:${port}`,
+                  `PORT=${port}`,
+                  'ALLOW_INSTALL_ROUTE_FOR_E2E=true',
+                  'node build'
+              ].join(' ')
             : 'pnpm run build && pnpm run preview',
         port,
-        timeout: isCI ? 30_000 : 120_000,
+        // 환경 setup 시간 고려해 timeout 확대 (30s → 60s)
+        timeout: isCI ? 60_000 : 120_000,
         reuseExistingServer: !isCI
     },
     use: {


### PR DESCRIPTION
## Summary
PR #1296 (heap snapshot endpoint) 의 Test (web) E2E job 실패 분석 결과, **본 PR 내용과 무관한 CI 환경 누락**.

## 발견된 환경 이슈 (실패 로그)
- \`[Redis] Connection error\` — \`services.redis\` 자체가 없음
- \`mysql2: Access denied for user 'root'@'172.18.0.1'\` — webServer 가 default root/no-pass 시도 (env 미설정)
- \`[API Proxy] ECONNREFUSED\` — \`BACKEND_URL\` 미설정 → default \`localhost:8090\` 시도 (실 백엔드 8081)
- 위 결과로 \`/boards/free\` 페이지 로드 timeout → \`write-post.test.ts\` fail

## 수정
### 1) \`.github/workflows/ci.yml\` — Redis service 추가
\`\`\`yaml
redis:
  image: redis:7-alpine
  ports: [6379:6379]
  options: --health-cmd="redis-cli ping" ...
\`\`\`

### 2) \`apps/web/playwright.config.ts\` — webServer env 명시
- \`DB_HOST/USER/PASSWORD/NAME\` = ci.yml services.mysql 자격증명
- \`BACKEND_URL\`, \`INTERNAL_API_URL\` = http://localhost:8081 (CI backend 포트)
- \`REDIS_HOST=127.0.0.1\`, \`REDIS_PORT=6379\`
- timeout 30s → 60s (env + service warm-up 여유)

## Verify
- Test (web) job pass 확인 → \`/boards/free\` 정상 로드 → write-post.test.ts pass

## Rollback
2 파일 단순 revert.

## 영향
- E2E 환경만 영향 (prod / app code 무관)
- 본 PR 머지 후 PR #1296 (heap snapshot endpoint) rebase 시 CI green 예상