### PR TITLE
fix: 레딧 임베드 redirect 미처리 (#12044)

### DIFF
--- a/apps/web/src/lib/plugins/auto-embed/platforms/reddit.ts
+++ b/apps/web/src/lib/plugins/auto-embed/platforms/reddit.ts
@@ -54,7 +54,10 @@ export const reddit: EmbedPlatform = {
         }
 
         const slug = info.params?.slug ? `/${info.params.slug}` : '';
-        const embedUrl = `https://www.redditmedia.com/${info.params?.type}/${info.params?.subreddit}/comments/${info.id}${slug}/?ref_source=embed&embed=true&theme=dark`;
+        // #12044: redditmedia.com 은 embed.reddit.com 으로 301 redirect 되며, 이 redirect 가
+        // sandbox/CSP 환경에서 정상 처리되지 않아 임베드가 비어있는 채로 남는 문제 발생.
+        // 처음부터 최종 도메인(embed.reddit.com)을 사용하도록 변경.
+        const embedUrl = `https://embed.reddit.com/${info.params?.type}/${info.params?.subreddit}/comments/${info.id}${slug}/?ref_source=embed&embed=true&theme=dark`;
 
         return `<iframe
 			src="${embedUrl}"


### PR DESCRIPTION
## Summary
- 댓글/본문 내 레딧 링크가 임베드 iframe 으로 변환되지만 비어있는 채로 남던 문제 수정
- 원인: `redditmedia.com` → `embed.reddit.com` 301 redirect 가 iframe sandbox/CSP 환경에서 정상 처리되지 않음
- Fix: 처음부터 최종 도메인 `embed.reddit.com` 사용

## 변경
- `apps/web/src/lib/plugins/auto-embed/platforms/reddit.ts` L57

## 배경
- 이전 #11888 에서 fix 시도, 미반영 → #12044 재문의

## Test plan
- [ ] 댓글에 reddit 링크 → 임베드 정상 노출
- [ ] 본문 reddit 링크도 동일 동작
- [ ] /s/ 단축링크는 기존대로 링크 카드로 fallback (회귀 없음)