### PR TITLE
perf(ssr): 301/308 redirect 응답 CDN 24h 캐시

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -943,6 +943,9 @@ export const handle: Handle = async ({ event, resolve }) => {
     response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
 
     // 캐시 제어:
+    // - 301/308 영구 redirect → CDN 1일 캐시 (예: /free/ → /free, trailing slash 제거)
+    //   2026-04-26: CloudFront 통계상 /free/ 등 trailing slash 308 응답이 origin
+    //   매번 도달 (2.6M req/3d, hit 0.6%). 영구 redirect 는 거의 안 변하므로 안전.
     // - _app/immutable/ → SvelteKit 기본 장기 캐시 유지 (content-hash)
     // - 비로그인 + 공개 페이지 → CDN stale-while-revalidate (ISR-like)
     // - 나머지 → 캐시 금지 (인증 데이터 포함)
@@ -951,7 +954,13 @@ export const handle: Handle = async ({ event, resolve }) => {
     const hasExplicitPublicCache =
         existingCacheControl?.includes('public') && pathname.startsWith('/api/');
 
-    if (hasExplicitPublicCache) {
+    if (response.status === 301 || response.status === 308) {
+        // 영구 redirect: CDN 24h + browser 1h, swr 7d
+        response.headers.set(
+            'Cache-Control',
+            'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800'
+        );
+    } else if (hasExplicitPublicCache) {
         // API 핸들러가 설정한 Cache-Control 유지 (celebration, banners, levels, reactions, init 등)
     } else if (event.url.pathname.startsWith('/_app/immutable')) {
         // SvelteKit이 이미 설정 → 그대로 유지


### PR DESCRIPTION
## Summary
CloudFront 통계 분석 결과 — `/free/` (trailing slash) 가 308 redirect 임에도 매번 origin 도달.

| URL | Status | CF | hit% (3d) |
|---|---|---|---|
| `/free` | 200 | HIT ✅ | - |
| **`/free/`** | **308** | **DYNAMIC** ⚠️ | **0.6%** (2.6M req) |
| `/` | 200 | HIT ✅ | - |
| `/economy/` | 308 | DYNAMIC | - |

→ 308 응답에 Cache-Control 없음 → CDN 매번 미스.

## 변경
**`apps/web/src/hooks.server.ts`** (+10/-1) — 캐시 분기 chain 첫번째에 redirect 처리 추가:
\`\`\`ts
if (response.status === 301 || response.status === 308) {
    response.headers.set(
        'Cache-Control',
        'public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800'
    );
}
\`\`\`

CDN 24h, browser 1h, stale 7d. 영구 redirect 는 거의 안 변하므로 안전.

## 예상 효과
- `/free/`, `/economy/`, `/qa/` 등 trailing slash 요청 **origin 부담 -90%+**
- 3일 기준 ~3M req origin 제거
- pod CPU 추가 -5~10%
- 비용 -\$1-3/day 추정

## Verify (배포 후 24h)
\`\`\`bash
curl -I https://damoang.net/free/ | grep -iE "cache-control|cf-cache"
clickhouse-client -q "SELECT date, path_prefix, round(100*sum(hits)/sum(requests),1) hit FROM finops.cloudfront_stats FINAL WHERE date >= today()-1 AND path_prefix='/free/' GROUP BY date,path_prefix"
\`\`\`

## Rollback
hooks.server.ts 한 if 블록 revert (10줄).

## 관련 분석
- Plan: \`/home/angple/.claude/plans/declarative-noodling-volcano.md\` Phase B ★★★ #1
- Discovery: \`finops.cloudfront_stats\` path_prefix 별 hit% 측정 결과