### PR TITLE
perf(cache): TieredCache L1 maxSize 축소 (재제출)

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/member.ts
+++ b/apps/web/src/lib/server/auth/oauth/member.ts
@@ -8,8 +8,10 @@ import { TieredCache } from '$lib/server/cache.js';
 import type { RowDataPacket } from 'mysql2';
 import type { MemberRow } from './types.js';
 
-// L1: 1분, L2: 5분(300초), 최대 5,000 항목
-const memberCache = new TieredCache<MemberRow>('member', 60_000, 300, 5000);
+// L1: 1분, L2: 5분(300초), 최대 1,000 항목
+// 2026-04-26: maxL1 5000 → 1000 (pod 메모리 -20~50 MB).
+// L2 Redis fallback 으로 hit% 영향 미미 (실 동시 활성 멤버 < 2000).
+const memberCache = new TieredCache<MemberRow>('member', 60_000, 300, 1000);
 
 /** 멤버 캐시 무효화 (로그아웃, 회원정보 변경 시 호출) */
 export async function invalidateMemberCache(mbId: string): Promise<void> {

--- a/apps/web/src/lib/server/auth/session-store.ts
+++ b/apps/web/src/lib/server/auth/session-store.ts
@@ -44,8 +44,9 @@ interface SessionRow extends RowDataPacket {
 }
 
 // --- 2-tier 세션 캐시: L1(Map) → L2(Redis) ---
-// L1: 1분, L2: 5분 (Redis), 최대 10,000 항목
-const sessionCache = new TieredCache<SessionData>('sess', 60_000, 300, 10000);
+// 2026-04-26: maxL1 10000 → 2000 (pod 메모리 -30~100 MB).
+// L1 miss 시 Redis L2 fallback 정상 동작 (실 동시세션 < 5000).
+const sessionCache = new TieredCache<SessionData>('sess', 60_000, 300, 2000);
 
 // last_active_at DB 업데이트 추적 (L1 전용, Redis 불필요)
 const lastDbUpdateMap = new Map<string, number>();

--- a/apps/web/src/lib/server/menu-loader.ts
+++ b/apps/web/src/lib/server/menu-loader.ts
@@ -15,7 +15,8 @@ import { TieredCache } from '$lib/server/cache';
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
 
 // 메뉴는 거의 안 바뀜 → L1 24시간, L2(Redis) 7일. 변경 시 invalidateMenuCache() 호출
-const menuCache = new TieredCache<MenuItem[]>('menus:sidebar', 86_400_000, 604_800);
+// 2026-04-26: maxL1=100 명시 (이전엔 무제한). 사이트별 1키만 사용해 충분.
+const menuCache = new TieredCache<MenuItem[]>('menus:sidebar', 86_400_000, 604_800, 100);
 
 /**
  * 백엔드 연결 불가 시 최소한의 기본 메뉴


### PR DESCRIPTION
이전 PR #1298 (closed without merge) 재제출. Serena 3-라운드 + harness 분석 결과.

## 변경 (3 파일, +9/-5)
| 파일 | 변경 | 절감 |
|---|---|---|
| auth/session-store.ts:48 | maxL1 10000→2000 | -30~100 MB/pod |
| auth/oauth/member.ts:12 | maxL1 5000→1000 | -20~50 MB/pod |
| menu-loader.ts:18 | maxL1 무제한→100 | safety guard |

## 안전성
- L1 miss 시 Redis L2 fallback 정상 동작 — hit% 영향 미미
- 실 동시세션 < 5000, 활성 멤버 < 2000 (보수적 측정)
- pod RSS 460 → 360 MiB 추정 (~22% 감소)

## 04:00 KST 배포
- 17 pods × ~100 MB = ~1.7 GB 호스트 회수
- node 메모리 commit 함께 감소

## Verify
`finops.web_pod_memory` 24h plateau 비교 (460→360 MiB 검증)

## 관련
- 이전 PR #1298 — branch/commit 혼선으로 closed
- 함께 배포: PR #26 (k8s right-sizing), backend #443 (이미 머지)