### PR TITLE
fix(hooks): withTimeout setTimeout 누수 — clearTimeout 추가

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -317,13 +317,22 @@ function getGlobalApiRateLimitKey(
     return clientIp ? `ip:${clientIp}` : null;
 }
 
-/** 타임아웃 래퍼: 지정 시간 내 미완료 시 null 반환 */
+/** 타임아웃 래퍼: 지정 시간 내 미완료 시 null 반환
+ *
+ * 2026-04-26: setTimeout clearTimeout 누락 수정.
+ * Promise.race 가 promise winner 일 때 timer 가 살아있어 매 SSR 요청 누적
+ * (12h × 수만 요청 = pod 메모리 +수백 MB). Serena Round A #2 발견.
+ */
 const AUTH_TIMEOUT_MS = 3000;
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
-    return Promise.race([
-        promise,
-        new Promise<null>((resolve) => setTimeout(() => resolve(null), ms))
-    ]);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), ms);
+        timer.unref?.();
+    });
+    return Promise.race([promise, timeoutPromise]).finally(() => {
+        if (timer) clearTimeout(timer);
+    });
 }
 
 /** SSR 인증: 서버사이드 세션 only (JWT 미사용) */


### PR DESCRIPTION
## 근본 원인 발견 — pod 메모리 plateau 460 MiB → 800+ MiB 누적의 큰 holder

`hooks.server.ts:322-326` `withTimeout()` — Promise.race winner 가 promise 일 때 setTimeout 이 clearTimeout 없이 살아있음. 매 SSR 요청 1-2 timer 누적. 12h × 수만 요청 = 큰 leak.

## Fix
- timer 변수 보관 + `.finally(clearTimeout)`
- `timer.unref()` 로 프로세스 종료 차단 안 함
- 동작 변경 없음 (timeout 시 null 반환 동일)

## 기대 효과
- pod RSS 시간대별 누적 leak 차단
- 12h+ 운영 pod 800 MiB → 500 MiB plateau 안정
- daily 03:00 cron 의존도 ↓
- 오늘 점심 OOM 알람 (90%) 재발 방지

## Verify
`finops.web_pod_memory` 24h 시간대별 추이 → 누적 곡선 사라짐 확인

## 관련
- 발견 출처: `/home/damoang/docs/work-tracker/memory-deep-dive-2026-04-25/final_harness_3agents.md` Round A #2
- 04:00 KST 배포 큐: PR #443 (머지), #1296 (머지), #1300 (머지), #1301 (cache 축소), #26 (k8s right-sizing), **#본 PR**