### PR TITLE
fix(damoang-banner): 자체 광고 배너 새 탭으로 열기 (다모앙 이탈 방지)

### DIFF
--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -211,8 +211,12 @@
         </a>
     {:else if adsBanner}
         <!-- 다모앙 자체 광고 배너 -->
+        <!-- 광고 클릭은 새 탭으로 열어 사용자가 뒤로가기로 본 페이지로 복귀할 수 있게 함
+             (기획팀 피드백: 광고 클릭 시 새 탭이 일반적이고 다모앙 이탈을 줄임) -->
         <a
             href={toLocalHref(adsBanner.landingUrl)}
+            target="_blank"
+            rel="noopener noreferrer"
             onclick={handleAdsClick}
             use:aplogTrack={{
                 adId: adsBanner.id,


### PR DESCRIPTION
## Summary
- 자유게시판 등에서 표시되는 다모앙 자체 광고(damoang-banner) 클릭 시 같은 탭에서 랜딩 페이지로 이동되어 사용자가 뒤로가기로 본 페이지에 복귀하기 어렵던 문제 수정
- `target="_blank" rel="noopener noreferrer"` 적용 → 새 탭에서 랜딩 페이지 열림, 본 페이지(자유게시판 등) 그대로 보존

## 배경
- 기획팀 피드백: "광고 클릭은 새창(또는 새탭) 으로 열기가 일반적이고 자연스럽다. 현 구조는 사실상 다모앙 이탈을 전제로 동작 중"
- toLocalHref 가 광고 URL 을 같은 도메인 상대경로로 변환하는 케이스가 섞여 있어 SvelteKit 클라이언트 navigation 으로 history 가 깔끔하지 않음 — 새 탭으로 통일

## 변경
- `apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte` — adsBanner 분기의 `<a>` 에만 적용
- celebration 배너 / GAM 폴백 / 사이드바 placeholder 는 변경 없음

## 영향
- 클릭 추적(`navigator.sendBeacon` + `aplogTrack`) 영향 없음 (sendBeacon 은 unload 와 무관)
- 광고주가 referrer 로 사이트 식별이 필요하면 후속으로 `rel="noopener"` 만 두는 옵션 검토 가능

## Test plan
- [ ] 자유게시판 진입 → 광고 클릭 → 새 탭에서 랜딩 페이지 열림, 본 페이지는 자유게시판 그대로
- [ ] 외부 URL 광고: 새 탭에서 외부 사이트 정상 진입
- [ ] 내부 URL 광고: 새 탭에서 해당 페이지 열림
- [ ] aplog.ad_events 클릭 이벤트 정상 기록 (slot_key=damoang-banner:*)
- [ ] 축하메시지 배너 / GAM 폴백 회귀 없음