### PR TITLE
fix(post-delete): 삭제 실패 시 백엔드 사유 노출 (#12098)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -963,7 +963,12 @@
             goto(`/${boardId}`);
         } catch (err) {
             console.error('Failed to delete post:', err);
-            alert('게시글 삭제에 실패했습니다.');
+            // #12098: 백엔드의 구체 사유(예: '질문게시판은 답변이 있으면 삭제가 불가능합니다',
+            // '소명글은 삭제할 수 없습니다' 등) 가 사용자에게 안내되도록 err.message 우선 노출.
+            // err.message 가 비어있을 때만 generic fallback.
+            const msg =
+                err instanceof Error && err.message ? err.message : '게시글 삭제에 실패했습니다.';
+            alert(msg);
         } finally {
             isDeleting = false;
         }


### PR DESCRIPTION
## Summary
- 게시글 삭제 실패 시 백엔드의 구체 사유가 generic alert("게시글 삭제에 실패했습니다.")로 덮여서 사용자가 원인을 알 수 없던 문제 수정
- err.message 우선 노출, 비어있을 때만 generic fallback

## 원인 (분석)
- 제보된 글들 (qa/65161, qa/67647) 은 본인이 작성한 글이지만 댓글(답변) 이 있어 삭제 불가 정책에 걸림
- 백엔드 `/api/v1/boards/qa/posts/:id/soft-delete` 에서 `slug=='qa' && comments.length > 0` 시 403 + `질문게시판은 답변이 있으면 삭제가 불가능합니다` 메시지 반환
- 하지만 frontend 의 catch 블록이 모든 에러를 generic 으로 덮어 사용자가 사유 모름

## 변경
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` handleDelete catch — err.message 우선 노출

## 영향
- 다른 정책성 거부도 자연스럽게 안내됨:
  - "소명글은 삭제할 수 없습니다."
  - "삭제 권한이 없습니다"
  - "이미 삭제된 게시글입니다"
- 회귀 위험 거의 없음 (분기 추가만)

## 후속 (별도 논의 필요)
- 정책 검토: 본인이 작성한 QA 글에 본인 댓글만 있어도 삭제 불가가 합리적인지
- UI 개선: 답변 있는 QA 글은 삭제 버튼을 비활성화 + 안내 툴팁

## Test plan
- [ ] qa 게시판 댓글 있는 본인 글 삭제 시 "질문게시판은 답변이 있으면 삭제가 불가능합니다" 명확히 노출
- [ ] 일반 게시판 정상 삭제 동작 회귀 없음
- [ ] 네트워크 오류 시 generic fallback 정상