### PR TITLE
fix(recommended): 메인화면 공감글 글씨 크기 설정이 적용되도록 CSS 변수 변경

### DIFF
--- a/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
@@ -81,7 +81,7 @@
                                 showReadState &&
                                     readPostsStore.isRead(getBoardId(post.url), post.id)
                             )}"
-                            style="font-size: var(--list-font-size);"
+                            style="font-size: var(--recommend-font-size, 1rem);"
                         >
                             {post.title}
                         </span>


### PR DESCRIPTION
## Summary

- 메인화면 추천글/공감글 위젯의 제목 글씨 크기가 UI 설정의 \"공감글 글씨 크기\" 와 무관하게 동작하던 문제 수정
- `post-list.svelte` 의 제목 element 가 `var(--list-font-size)` 를 읽고 있어 \"목록 글씨 크기\" 설정만 적용되던 상태
- store 가 세팅하는 `--recommend-font-size` 를 사용하도록 변경 (fallback `1rem`)

## Root cause

- `ui-settings.svelte.ts:153-155` 가 `setRecommendFontSize` 호출 시 `--recommend-font-size` 로 CSS 변수 세팅
- 그러나 홈 위젯 RecommendedPosts → post-list 의 제목 element 는 `var(--list-font-size)` 사용
- UI 설정 \"공감글 글씨 크기\" 변경 → CSS 변수는 갱신되지만 위젯이 다른 변수를 읽음 → 시각적 변화 없음

## Test plan

- [ ] dev: `/member/settings/ui` → \"공감글 글씨 크기\" 5XL 변경
- [ ] 홈으로 이동 → 추천글/공감글 위젯의 제목 시각적으로 큼
- [ ] \"목록 글씨 크기\" 설정은 게시판 목록에만 영향, 추천글에는 영향 없음 (회귀 확인)
- [ ] 일일 추천글 페이지 (`/recommended`) — 기존 `--recommend-font-size` 유지, 영향 없음

Refs: bug #12084