### PR TITLE
fix(my): 모바일 마이페이지 탭 row 가로 스크롤 방지

### DIFF
--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -177,11 +177,14 @@
     </div>
 
     <!-- 탭 네비게이션 (즉시 렌더링) -->
-    <div class="border-border mb-6 flex gap-2 border-b pb-2">
+    <div
+        class="border-border -mx-4 mb-6 flex gap-2 overflow-x-auto whitespace-nowrap border-b px-4 pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    >
         {#each tabs as tab (tab.id)}
             <Button
                 variant={data.tab === tab.id ? 'default' : 'ghost'}
                 size="sm"
+                class="shrink-0"
                 onclick={() => changeTab(tab.id)}
             >
                 <tab.icon class="mr-1.5 h-4 w-4" />


### PR DESCRIPTION
## Summary

- /my 페이지 4-탭 row (내가 쓴 글/댓글/공감한 글/전체분석) 가 모바일에서 viewport 폭 초과 → 페이지 자체 가로 스크롤 발생
- 탭 row 에 `overflow-x-auto whitespace-nowrap shrink-0` 적용해 탭 영역 내부 가로 스크롤로 전환
- 페이지 가로 스크롤 차단

## Root cause

- `apps/web/src/routes/my/+page.svelte:180` 탭 row 가 `flex gap-2` 한 줄 강제
- mobile content area ~358px (390px viewport - px-4×2) 에서 4 개 size-sm 버튼 (icon+label) 합 ~460px → overflow
- 부모 `max-w-4xl mx-auto px-4` 만 있고 `overflow-x-clip` 없음 → 페이지 자체에 가로 스크롤 노출

## Fix

탭 row:
```diff
- <div class=\"border-border mb-6 flex gap-2 border-b pb-2\">
+ <div class=\"border-border mb-6 -mx-4 flex gap-2 overflow-x-auto whitespace-nowrap border-b px-4 pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden\">
```
- `overflow-x-auto` + `whitespace-nowrap` — 탭 영역 자체 가로 스크롤
- `shrink-0` — 버튼이 줄어들지 않도록
- `-mx-4 px-4` — border-b 라인은 컨테이너 폭 끝까지 유지
- 스크롤바 숨김 (Firefox `[scrollbar-width:none]` + WebKit pseudo)

## Test plan

- [ ] dev 모바일 viewport (390x844 / iPhone 13) `/my` 진입 → 페이지 가로 스크롤 없음
- [ ] 탭 row 좌우 스와이프 → 4 개 탭 모두 접근 가능
- [ ] 데스크톱 (>768px) 4 개 탭 한 줄 노출, 가로 스크롤 안 보임
- [ ] iOS Safari + Firefox 모바일 양쪽 검증 (제보 환경)

Refs: bug #12100