### PR TITLE
perf(avatar): 게시판 리스트 Avatar size="list" — 64px variant

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
@@ -129,6 +129,7 @@
                     <Avatar
                         path={post.author_image}
                         updatedAt={post.author_image_updated_at}
+                        size="list"
                         alt=""
                         class="h-5 w-5 shrink-0 rounded-full object-cover"
                     />
@@ -161,6 +162,7 @@
                         <Avatar
                             path={post.author_image}
                             updatedAt={post.author_image_updated_at}
+                            size="list"
                             alt=""
                             class="h-5 w-5 shrink-0 rounded-full object-cover"
                         />

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -267,6 +267,7 @@
                     <Avatar
                         path={post.author_image}
                         updatedAt={post.author_image_updated_at}
+                        size="list"
                         alt=""
                         class="h-5 w-5 shrink-0 rounded-full object-cover"
                     />


### PR DESCRIPTION
## Summary
- 게시판 리스트 3 곳 Avatar 호출에 `size="list"` prop 추가
- Lambda `damoang-avatar-resize` 가 생성하는 64px variant (`_resized/{ab}/{name}_64.jpg`) 사용
- 5x5px 표시인데 풀사이즈 webp (50-100KB) 받던 문제 해결

## Background
2026-04-23 외부 시니어 지적: "프로필 이미지 작게 줄이지 않음". 4/26 검증 결과 Avatar 컴포넌트 + getAvatarUrl 의 size 매개변수는 이미 구현되어 있지만 실제 호출 시 size 미지정 → 풀사이즈 다운로드.

## Backend (전제)
- avatar-resize Lambda 신규 배포: `damoang-avatar-resize` (ARM64, 512MB, S3 trigger on `damoang-data-v1/data/member_image/`)
- 변환: `data/member_image/{ab}/{name}.{ext}` → `_resized/{ab}/{name}_{32|64|96|192}.jpg`
- Backfill 진행 중 (25,888건, ~33분)
- CloudWatch alarm 3개 등록 (Errors/Duration p99/Throttles)

## Effect
- 게시판 리스트 페이지 1회 로드 = 20개 글 × 95KB → ~1.9MB **→ ~100KB (95% 절감)**

## Test plan
- [ ] CI 통과 (lint, typecheck, build)
- [ ] backfill 완료 확인 후 머지 (broken image 방지)
- [ ] staging 배포 → 게시판 진입 → DevTools Network → avatar 응답 size < 10KB
- [ ] 5x5px 시각 회귀 없음
- [ ] 임의 variant 강제 404 시 원본 fallback (Avatar 컴포넌트의 onerror 향후 추가 예정)

## Deploy window
- 새벽 04:00 KST (production guardrail)