### PR TITLE
feat(bluesky): handle → DID resolver (PR-B1 of #12050)

### DIFF
--- a/apps/web/src/lib/server/bluesky/resolver.test.ts
+++ b/apps/web/src/lib/server/bluesky/resolver.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+// --- Redis 모듈 모킹 ---
+// 각 테스트에서 get/setex 동작을 자유롭게 바꾸기 위해 vi.fn() 으로 래핑.
+const redisGet = vi.fn();
+const redisSetex = vi.fn();
+
+vi.mock('../redis.js', () => ({
+    getRedis: () => ({
+        get: redisGet,
+        setex: redisSetex
+    })
+}));
+
+// 모킹 후에 import (vi.mock 은 hoist 되지만 명시적으로 안전 보장).
+import { resolveBlueskyHandle, isValidDID } from './resolver';
+
+const VALID_DID = 'did:plc:abc123xyzhandle';
+
+function mockFetchOk(did: string): Mock {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ did })
+    });
+}
+
+function mockFetchStatus(status: number): Mock {
+    return vi.fn().mockResolvedValue({
+        ok: false,
+        status,
+        json: async () => ({})
+    });
+}
+
+describe('isValidDID', () => {
+    it('did:plc:* / did:web:* 만 통과', () => {
+        expect(isValidDID('did:plc:abc123')).toBe(true);
+        expect(isValidDID('did:web:example.com')).toBe(true);
+        expect(isValidDID('did:bad:abc')).toBe(false);
+        expect(isValidDID('handle.bsky.social')).toBe(false);
+        expect(isValidDID(undefined)).toBe(false);
+        expect(isValidDID(null)).toBe(false);
+        expect(isValidDID(123)).toBe(false);
+    });
+});
+
+describe('resolveBlueskyHandle', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+        redisGet.mockReset();
+        redisSetex.mockReset();
+        originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('빈 입력은 null 반환', async () => {
+        await expect(resolveBlueskyHandle('')).resolves.toBeNull();
+        // @ts-expect-error 의도적 잘못된 타입 입력
+        await expect(resolveBlueskyHandle(undefined)).resolves.toBeNull();
+    });
+
+    it('이미 DID 형식이면 fetch 없이 그대로 반환', async () => {
+        const fetchMock = vi.fn();
+        globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+        await expect(resolveBlueskyHandle(VALID_DID)).resolves.toBe(VALID_DID);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(redisGet).not.toHaveBeenCalled();
+    });
+
+    it('Redis 캐시 히트 시 fetch 없이 DID 반환', async () => {
+        redisGet.mockResolvedValue(VALID_DID);
+        const fetchMock = vi.fn();
+        globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+        const result = await resolveBlueskyHandle('AAGaming.me');
+        expect(result).toBe(VALID_DID);
+        // 키는 lowercase 정규화되어야 함.
+        expect(redisGet).toHaveBeenCalledWith('bsky:handle:aagaming.me');
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(redisSetex).not.toHaveBeenCalled();
+    });
+
+    it('Redis NX 센티넬 히트 시 fetch 없이 null 반환', async () => {
+        redisGet.mockResolvedValue('NX');
+        const fetchMock = vi.fn();
+        globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+        await expect(resolveBlueskyHandle('missing.bsky.social')).resolves.toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('Redis 미스 → fetch 성공 → 30일 TTL 로 캐시', async () => {
+        redisGet.mockResolvedValue(null);
+        redisSetex.mockResolvedValue('OK');
+        globalThis.fetch = mockFetchOk(VALID_DID) as unknown as typeof globalThis.fetch;
+
+        const result = await resolveBlueskyHandle('aagaming.me');
+        expect(result).toBe(VALID_DID);
+        expect(redisSetex).toHaveBeenCalledWith(
+            'bsky:handle:aagaming.me',
+            60 * 60 * 24 * 30,
+            VALID_DID
+        );
+    });
+
+    it('Redis 미스 → fetch 404 → NX 센티넬 10분 TTL 로 캐시 + null 반환', async () => {
+        redisGet.mockResolvedValue(null);
+        redisSetex.mockResolvedValue('OK');
+        globalThis.fetch = mockFetchStatus(404) as unknown as typeof globalThis.fetch;
+
+        const result = await resolveBlueskyHandle('missing.bsky.social');
+        expect(result).toBeNull();
+        expect(redisSetex).toHaveBeenCalledWith('bsky:handle:missing.bsky.social', 60 * 10, 'NX');
+    });
+
+    it('Redis get 장애 → 직접 fetch + setex 호출하지 않음', async () => {
+        redisGet.mockRejectedValue(new Error('connection refused'));
+        globalThis.fetch = mockFetchOk(VALID_DID) as unknown as typeof globalThis.fetch;
+
+        const result = await resolveBlueskyHandle('aagaming.me');
+        expect(result).toBe(VALID_DID);
+        // get 이 던지면 redisAvailable=false 가 되어 setex 도 건드리지 않아야 함.
+        expect(redisSetex).not.toHaveBeenCalled();
+    });
+
+    it('fetch 응답에 잘못된 DID 형식이 오면 null + NX 캐시', async () => {
+        redisGet.mockResolvedValue(null);
+        redisSetex.mockResolvedValue('OK');
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ did: 'not-a-did' })
+        }) as unknown as typeof globalThis.fetch;
+
+        const result = await resolveBlueskyHandle('weird.example');
+        expect(result).toBeNull();
+        expect(redisSetex).toHaveBeenCalledWith('bsky:handle:weird.example', 60 * 10, 'NX');
+    });
+
+    it('fetch 자체가 throw → null + NX 캐시', async () => {
+        redisGet.mockResolvedValue(null);
+        redisSetex.mockResolvedValue('OK');
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValue(new Error('network down')) as unknown as typeof globalThis.fetch;
+        // console.warn 잡기.
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const result = await resolveBlueskyHandle('flaky.example');
+        expect(result).toBeNull();
+        expect(redisSetex).toHaveBeenCalledWith('bsky:handle:flaky.example', 60 * 10, 'NX');
+    });
+});

--- a/apps/web/src/lib/server/bluesky/resolver.ts
+++ b/apps/web/src/lib/server/bluesky/resolver.ts
@@ -1,0 +1,132 @@
+/**
+ * Bluesky handle → DID resolver (server-only)
+ *
+ * `bsky.app/profile/<handle>/post/<id>` 임베드는 embed.bsky.app 측에서 DID
+ * (`did:plc:...` / `did:web:...`) 만 허용한다. 본문에 들어 있는 handle 을 SSR
+ * 단계에서 DID 로 미리 변환해두기 위한 모듈.
+ *
+ * 캐시 정책:
+ *   - Redis 키: `bsky:handle:<lowercase-handle>`
+ *   - 성공값: DID 문자열, 30 일 TTL
+ *   - 실패값: `NX` sentinel, 10 분 TTL (404 / 비정상 응답에 대한 retry 폭주 방지)
+ *   - Redis 장애 시: 직접 fetch 후 캐시 없이 DID 반환 (graceful degradation)
+ *
+ * 외부 API:
+ *   - GET https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle
+ *   - 공개 API, 인증 불필요. SSRF 위험 없음 (도메인 고정).
+ *
+ * Bug: damoang.net #12050
+ */
+import { getRedis } from '../redis.js';
+
+const RESOLVE_API = 'https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle';
+const REDIS_KEY_PREFIX = 'bsky:handle:';
+const TTL_SUCCESS_SEC = 60 * 60 * 24 * 30; // 30 일
+const TTL_NX_SEC = 60 * 10; // 10 분
+const NX_SENTINEL = 'NX';
+const FETCH_TIMEOUT_MS = 3000;
+
+/**
+ * DID 문자열 형식 검증.
+ * `did:plc:...` 또는 `did:web:...` 만 허용.
+ */
+export function isValidDID(value: unknown): value is string {
+    if (typeof value !== 'string') return false;
+    return /^did:(plc|web):[a-zA-Z0-9._:%-]+$/.test(value);
+}
+
+function normalizeHandle(handle: string): string {
+    return handle.trim().toLowerCase();
+}
+
+/**
+ * public.api.bsky.app 에 직접 fetch.
+ * 타임아웃과 에러 처리 포함. 실패 시 null 반환.
+ */
+async function fetchDID(handle: string): Promise<string | null> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+        const url = `${RESOLVE_API}?handle=${encodeURIComponent(handle)}`;
+        const res = await fetch(url, {
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+            signal: controller.signal
+        });
+
+        if (!res.ok) {
+            return null;
+        }
+
+        const body = (await res.json()) as { did?: unknown };
+        if (isValidDID(body.did)) {
+            return body.did;
+        }
+        return null;
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn('[bluesky-resolver] fetch failed for', handle, '-', msg);
+        return null;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/**
+ * Bluesky handle 을 DID 로 변환.
+ *
+ * @param handle Bluesky handle (예: `aagaming.me`).
+ *   이미 `did:` 로 시작하는 값이 들어오면 형식 검증 후 그대로 반환.
+ * @returns DID 문자열 또는 null (resolve 실패).
+ */
+export async function resolveBlueskyHandle(handle: string): Promise<string | null> {
+    if (!handle || typeof handle !== 'string') return null;
+
+    // 이미 DID 면 그대로 반환 (input safety).
+    if (handle.startsWith('did:')) {
+        return isValidDID(handle) ? handle : null;
+    }
+
+    const normalized = normalizeHandle(handle);
+    if (!normalized) return null;
+
+    const cacheKey = `${REDIS_KEY_PREFIX}${normalized}`;
+
+    // 1. Redis lookup 시도. 장애 시 곧바로 fetch fallback.
+    let redisAvailable = true;
+    try {
+        const redis = getRedis();
+        const cached = await redis.get(cacheKey);
+        if (cached === NX_SENTINEL) {
+            return null;
+        }
+        if (cached && isValidDID(cached)) {
+            return cached;
+        }
+    } catch (err) {
+        redisAvailable = false;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn('[bluesky-resolver] Redis unavailable, falling back to direct fetch:', msg);
+    }
+
+    // 2. Redis 미스 → 외부 API 호출.
+    const did = await fetchDID(normalized);
+
+    // 3. 결과를 Redis 에 캐시 (Redis 사용 가능한 경우만).
+    if (redisAvailable) {
+        try {
+            const redis = getRedis();
+            if (did) {
+                await redis.setex(cacheKey, TTL_SUCCESS_SEC, did);
+            } else {
+                await redis.setex(cacheKey, TTL_NX_SEC, NX_SENTINEL);
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.warn('[bluesky-resolver] Redis setex failed:', msg);
+        }
+    }
+
+    return did;
+}

--- a/apps/web/src/lib/server/bluesky/transform.test.ts
+++ b/apps/web/src/lib/server/bluesky/transform.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// resolver 를 모킹해서 transform 만 검증.
+const resolveBlueskyHandle = vi.fn();
+vi.mock('./resolver.js', () => ({
+    resolveBlueskyHandle: (h: string) => resolveBlueskyHandle(h)
+}));
+
+import { prefetchBlueskyDIDs } from './transform';
+
+const DID_AA = 'did:plc:aaaaaaaaaaaaaaaaaaaaaaaa';
+const DID_BB = 'did:plc:bbbbbbbbbbbbbbbbbbbbbbbb';
+
+describe('prefetchBlueskyDIDs', () => {
+    beforeEach(() => {
+        resolveBlueskyHandle.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('빈 입력 / 비문자열은 그대로 반환', async () => {
+        await expect(prefetchBlueskyDIDs('')).resolves.toBe('');
+        // @ts-expect-error 의도적 잘못된 타입 입력
+        await expect(prefetchBlueskyDIDs(null)).resolves.toBe(null);
+        expect(resolveBlueskyHandle).not.toHaveBeenCalled();
+    });
+
+    it('bsky.app URL 이 없으면 원본 그대로', async () => {
+        const html = '<p>일반 텍스트와 <a href="https://example.com">링크</a></p>';
+        const out = await prefetchBlueskyDIDs(html);
+        expect(out).toBe(html);
+        expect(resolveBlueskyHandle).not.toHaveBeenCalled();
+    });
+
+    it('handle URL → DID URL 치환', async () => {
+        resolveBlueskyHandle.mockResolvedValue(DID_AA);
+        const html = '<p>https://bsky.app/profile/aagaming.me/post/3kabc123def</p>';
+        const out = await prefetchBlueskyDIDs(html);
+        expect(out).toBe(`<p>https://bsky.app/profile/${DID_AA}/post/3kabc123def</p>`);
+        expect(resolveBlueskyHandle).toHaveBeenCalledWith('aagaming.me');
+        expect(resolveBlueskyHandle).toHaveBeenCalledTimes(1);
+    });
+
+    it('이미 DID 형식이면 resolver 호출 없이 그대로 통과', async () => {
+        const html = `<p>https://bsky.app/profile/${DID_AA}/post/3kabc123def</p>`;
+        const out = await prefetchBlueskyDIDs(html);
+        expect(out).toBe(html);
+        expect(resolveBlueskyHandle).not.toHaveBeenCalled();
+    });
+
+    it('동일 handle 이 여러 번 등장해도 한 번만 resolve + 모두 치환', async () => {
+        resolveBlueskyHandle.mockResolvedValue(DID_AA);
+        const html = [
+            'https://bsky.app/profile/aagaming.me/post/post1',
+            'https://bsky.app/profile/aagaming.me/post/post2',
+            'https://bsky.app/profile/aagaming.me/post/post3'
+        ].join('\n');
+
+        const out = await prefetchBlueskyDIDs(html);
+        expect(resolveBlueskyHandle).toHaveBeenCalledTimes(1);
+        expect(out).toContain(`https://bsky.app/profile/${DID_AA}/post/post1`);
+        expect(out).toContain(`https://bsky.app/profile/${DID_AA}/post/post2`);
+        expect(out).toContain(`https://bsky.app/profile/${DID_AA}/post/post3`);
+        expect(out).not.toContain('aagaming.me');
+    });
+
+    it('서로 다른 handle 은 각각 resolve 후 치환', async () => {
+        resolveBlueskyHandle.mockImplementation(async (h: string) => {
+            if (h === 'alice.bsky.social') return DID_AA;
+            if (h === 'bob.bsky.social') return DID_BB;
+            return null;
+        });
+
+        const html = [
+            'https://bsky.app/profile/alice.bsky.social/post/p1',
+            'https://bsky.app/profile/bob.bsky.social/post/p2'
+        ].join('\n');
+
+        const out = await prefetchBlueskyDIDs(html);
+        expect(out).toContain(`https://bsky.app/profile/${DID_AA}/post/p1`);
+        expect(out).toContain(`https://bsky.app/profile/${DID_BB}/post/p2`);
+    });
+
+    it('resolve null 반환 시 원본 handle URL 보존', async () => {
+        resolveBlueskyHandle.mockResolvedValue(null);
+        const html = '<p>https://bsky.app/profile/missing.bsky.social/post/p1</p>';
+        const out = await prefetchBlueskyDIDs(html);
+        expect(out).toBe(html);
+    });
+
+    it('handle + 이미 DID 인 URL 혼재', async () => {
+        resolveBlueskyHandle.mockResolvedValue(DID_AA);
+        const html = [
+            `https://bsky.app/profile/${DID_BB}/post/keepme`,
+            'https://bsky.app/profile/aagaming.me/post/replaceme'
+        ].join('\n');
+
+        const out = await prefetchBlueskyDIDs(html);
+        expect(resolveBlueskyHandle).toHaveBeenCalledTimes(1);
+        expect(resolveBlueskyHandle).toHaveBeenCalledWith('aagaming.me');
+        expect(out).toContain(`https://bsky.app/profile/${DID_BB}/post/keepme`);
+        expect(out).toContain(`https://bsky.app/profile/${DID_AA}/post/replaceme`);
+    });
+
+    it('일부 handle resolve 실패해도 성공한 것은 치환', async () => {
+        resolveBlueskyHandle.mockImplementation(async (h: string) => {
+            if (h === 'alice.bsky.social') return DID_AA;
+            return null;
+        });
+
+        const html = [
+            'https://bsky.app/profile/alice.bsky.social/post/p1',
+            'https://bsky.app/profile/missing.bsky.social/post/p2'
+        ].join('\n');
+
+        const out = await prefetchBlueskyDIDs(html);
+        expect(out).toContain(`https://bsky.app/profile/${DID_AA}/post/p1`);
+        expect(out).toContain('https://bsky.app/profile/missing.bsky.social/post/p2');
+    });
+});

--- a/apps/web/src/lib/server/bluesky/transform.ts
+++ b/apps/web/src/lib/server/bluesky/transform.ts
@@ -1,0 +1,74 @@
+/**
+ * Bluesky handle → DID 본문 치환 (server-only)
+ *
+ * 본문 HTML 에서 `bsky.app/profile/<handle>/post/<id>` 패턴을 모두 추출해
+ * handle 을 DID 로 일괄 변환한 뒤 URL 을 치환한다. SSR content-transform 직전
+ * 호출하면 이후 `bluesky.ts` 의 embedder 가 DID 기반 URL 을 받아 정상 임베드를
+ * 생성한다.
+ *
+ * 동작 원칙:
+ *   - 이미 `did:` 로 시작하는 identifier 는 건너뜀 (regression 방지).
+ *   - resolve 가 null 을 반환하면 원본 URL 보존 (UX 악화 없음).
+ *   - 동일 handle 중복 호출 없이 unique set 만 병렬 resolve.
+ *
+ * Bug: damoang.net #12050
+ */
+import { resolveBlueskyHandle } from './resolver.js';
+
+/**
+ * `bsky.app/profile/<identifier>/post/<rkey>` 매칭.
+ * - 선행 슬래시(`/`) 없음 → 도메인 직전 텍스트와 무관하게 동작
+ * - identifier: `[^/\s"'<>]+` (URL 안전 문자만, HTML 어트리뷰트 경계 보호)
+ * - rkey: `[\w]+`
+ */
+const BSKY_POST_URL_RE = /bsky\.app\/profile\/([^/\s"'<>]+)\/post\/(\w+)/g;
+
+function isAlreadyDID(identifier: string): boolean {
+    return identifier.startsWith('did:');
+}
+
+/**
+ * HTML 본문에서 Bluesky handle URL 을 발견해 DID URL 로 치환.
+ *
+ * @param html 원본 HTML.
+ * @returns 치환된 HTML. handle 매칭이 없거나 모두 resolve 실패해도 안전하게
+ *   원본을 유지한 결과를 반환.
+ */
+export async function prefetchBlueskyDIDs(html: string): Promise<string> {
+    if (!html || typeof html !== 'string') return html;
+
+    // 1. 본문 내 모든 매칭 수집 + handle 만 unique 추출.
+    const handles = new Set<string>();
+    let match: RegExpExecArray | null;
+    BSKY_POST_URL_RE.lastIndex = 0;
+    while ((match = BSKY_POST_URL_RE.exec(html)) !== null) {
+        const identifier = match[1];
+        if (!isAlreadyDID(identifier)) {
+            handles.add(identifier);
+        }
+    }
+
+    if (handles.size === 0) return html;
+
+    // 2. 병렬 resolve. 각 handle 별 결과를 Map 에 저장.
+    const handleList = Array.from(handles);
+    const dids = await Promise.all(handleList.map((h) => resolveBlueskyHandle(h)));
+    const resolved = new Map<string, string>();
+    handleList.forEach((h, i) => {
+        const did = dids[i];
+        if (did) resolved.set(h, did);
+    });
+
+    if (resolved.size === 0) return html;
+
+    // 3. 본문 치환. 새 RegExp 인스턴스로 lastIndex 안전 보장.
+    return html.replace(
+        /bsky\.app\/profile\/([^/\s"'<>]+)\/post\/(\w+)/g,
+        (full, identifier: string, rkey: string) => {
+            if (isAlreadyDID(identifier)) return full;
+            const did = resolved.get(identifier);
+            if (!did) return full;
+            return `bsky.app/profile/${did}/post/${rkey}`;
+        }
+    );
+}


### PR DESCRIPTION
## Summary

`bsky.app/profile/<handle>/post/<id>` 임베드가 embed.bsky.app 측 "Invalid DID" 검증으로 실패하는 #12050 의 1단계 PR. 설계 문서: `docs/2026-04-26-bluesky-did-resolution-design-12050.md`

이 PR 은 **server-only 모듈 + 단위 테스트만** 추가합니다. SSR 호출 wiring 은 PR-B2 에서 별도로 진행하며, 본 PR 은 동작 변경이 전혀 없습니다 (regression 위험 0).

## Files

- `apps/web/src/lib/server/bluesky/resolver.ts` — `resolveBlueskyHandle(handle): Promise<string | null>`
  - Redis 캐시 우선 (`bsky:handle:<lowercase>` 키, 성공 30일 / NX 10분 TTL)
  - 미스 시 `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle` 호출 (3 초 timeout)
  - DID 형식 검증 (`did:plc:*` / `did:web:*`)
  - Redis 장애 시 직접 fetch + 캐시 skip (graceful degradation)
- `apps/web/src/lib/server/bluesky/transform.ts` — `prefetchBlueskyDIDs(html): Promise<string>`
  - 본문에서 handle URL 추출 → unique set 으로 병렬 resolve → URL 치환
  - 이미 DID 인 URL 은 통과, resolve 실패 시 원본 유지
- 단위 테스트 2 개 (총 19 케이스)

## Test plan

- [x] `pnpm test:unit -- --run src/lib/server/bluesky/` — 19/19 pass
- [x] `pnpm check` — 0 errors (변경 파일 기준)
- [ ] PR-B2 에서 `+page.server.ts` wiring 후 dev 환경 실 임베드 검증
- [ ] PR-B2 머지 후 운영 canary 에서 Redis 캐시 hit/miss 비율 모니터링

## Out of scope (다음 PR)

- PR-B2: SSR 호출 사이트 (`+page.server.ts`, 댓글 endpoint)
- PR-B3: `bluesky.ts` 정규식 / 변수명 정리 (선택적)
- 환경변수 토글 (`BSKY_RESOLVE_ENABLED`) — 설계 문서 Open Question, 데이터 보고 결정

Refs: damoang.net #12050