### PR TITLE
fix(memory): lastDbUpdateMap 누수 — SessionData entry merge

### DIFF
--- a/apps/web/src/lib/server/auth/session-store.ts
+++ b/apps/web/src/lib/server/auth/session-store.ts
@@ -29,6 +29,8 @@ export interface SessionData {
     createdAt: Date;
     lastActiveAt: Date;
     expiresAt: Date;
+    /** 마지막 last_active_at DB UPDATE 시각 (epoch ms). sessionCache lifecycle 와 묶여 자동 cleanup. */
+    lastDbUpdate?: number;
 }
 
 interface SessionRow extends RowDataPacket {
@@ -46,10 +48,11 @@ interface SessionRow extends RowDataPacket {
 // --- 2-tier 세션 캐시: L1(Map) → L2(Redis) ---
 // 2026-04-26: maxL1 10000 → 2000 (pod 메모리 -30~100 MB).
 // L1 miss 시 Redis L2 fallback 정상 동작 (실 동시세션 < 5000).
+//
+// 2026-04-27: lastDbUpdate 를 SessionData entry 안으로 merge (PR #1303).
+// 기존 별도 unbounded Map(lastDbUpdateMap) 이 12h+ 누수 source 였음 — 익명/크롤러 트래픽이
+// 영원히 누적. 이제 sessionCache 의 LRU evict 시 자동 cleanup.
 const sessionCache = new TieredCache<SessionData>('sess', 60_000, 300, 2000);
-
-// last_active_at DB 업데이트 추적 (L1 전용, Redis 불필요)
-const lastDbUpdateMap = new Map<string, number>();
 
 /** 세션 ID 생성 (32 bytes → 64 hex chars) */
 function generateSessionId(): string {
@@ -109,9 +112,10 @@ export async function getSession(sessionId: string): Promise<SessionData | null>
     const cached = await sessionCache.get(sessionIdHash);
     if (cached) {
         // last_active_at 비동기 업데이트 (5분 간격, fire-and-forget)
-        const lastUpdate = lastDbUpdateMap.get(sessionIdHash) || 0;
+        // L1 entry mutate — sessionCache evict 시 자연 cleanup. L2(Redis) 는 다음 miss 후 fresh set.
+        const lastUpdate = cached.lastDbUpdate ?? 0;
         if (now - lastUpdate > LAST_ACTIVE_UPDATE_INTERVAL) {
-            lastDbUpdateMap.set(sessionIdHash, now);
+            cached.lastDbUpdate = now;
             pool.query<ResultSetHeader>(
                 `UPDATE angple_sessions SET last_active_at = NOW() WHERE session_id_hash = ?`,
                 [sessionIdHash]
@@ -169,12 +173,12 @@ export async function getSession(sessionId: string): Promise<SessionData | null>
         userAgent: row.user_agent,
         createdAt: new Date(row.created_at),
         lastActiveAt: new Date(row.last_active_at),
-        expiresAt: new Date(row.expires_at)
+        expiresAt: new Date(row.expires_at),
+        lastDbUpdate: now
     };
 
     // 3. 2-tier 캐시에 저장 (L1 + L2)
     await sessionCache.set(sessionIdHash, sessionData);
-    lastDbUpdateMap.set(sessionIdHash, now);
 
     return sessionData;
 }
@@ -185,7 +189,6 @@ export async function getSession(sessionId: string): Promise<SessionData | null>
 export async function destroySession(sessionId: string): Promise<void> {
     const sessionIdHash = hashSessionId(sessionId);
     await sessionCache.delete(sessionIdHash);
-    lastDbUpdateMap.delete(sessionIdHash);
     await pool.query<ResultSetHeader>(`DELETE FROM angple_sessions WHERE session_id_hash = ?`, [
         sessionIdHash
     ]);


### PR DESCRIPTION
## Summary
`lastDbUpdateMap`(별도 unbounded Map)이 매일 +135 MiB/p95 누수 source 였음. SessionData entry 안으로 merge → sessionCache LRU evict 시 자동 cleanup.

## Root cause
- `apps/web/src/lib/server/auth/session-store.ts:51` (이전):
  ```ts
  const lastDbUpdateMap = new Map<string, number>();
  ```
- set: 매 cache hit (L113) + DB load (L177)
- delete: 명시적 logout 만 (L188) — **익명/크롤러 트래픽은 영원히 누적**
- PR #1301 (sessionCache L1 10000→2000) 후에도 이 Map 은 무관하게 계속 누적
- 4/26 가속 시점 (+135 MiB) 정확 매치

## Fix
- `SessionData` 에 `lastDbUpdate?: number` 추가
- `lastDbUpdateMap` 제거
- L1 entry mutate (`cached.lastDbUpdate = now`) — sessionCache evict 시 자연 cleanup
- L2(Redis) 는 다음 miss 후 fresh set 으로 sync
- 추가 timer 0, 추가 인프라 0

## Effect (예상)
- 24h plateau p95: 825 → ≤600 MiB
- min(restart 직후): 55-57 그대로 (기존 정상)
- max: 997 → ≤700 MiB

## Test plan
- [ ] CI 통과 (lint, typecheck, build)
- [ ] 새벽 04:00 머지 + 배포 (production guardrail)
- [ ] 배포 24h 후 ClickHouse \`finops.web_pod_memory\` p95 측정
- [ ] heap snapshot fix 전후 비교 (Map 객체 retained size)

## Related
- 임시 완화 (별도 적용): daily-restart cron 03:00 → 03:00+15:00
- PR #1300/#1301/#1302 (4/26 leak fix 들) 의 잔여 누수
- 4/24 PR #1284 jwtCache cap 의 setInterval cleanup 패턴 참고