### PR TITLE
chore(ci): pnpm/action-setup v4 → v6 (Node.js 24 호환)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -294,7 +294,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -349,7 +349,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -415,7 +415,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -53,7 +53,7 @@ jobs:
         run: mkdir -p custom-themes custom-widgets extensions plugins widgets
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,7 +66,7 @@ jobs:
 
       # --- 네이티브 빌드 (ARM64 러너에서 직접) ---
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,7 @@ jobs:
         run: mkdir -p custom-themes custom-widgets extensions plugins widgets
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/safari-synthetic.yml
+++ b/.github/workflows/safari-synthetic.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
GitHub Actions deprecation warning 해결.

## Background
GitHub Actions 가 v4 (Node.js 20 기반) 사용 시 warning:
> Node.js 20 actions are deprecated. ... pnpm/action-setup@v4 ... 2026-09-16 제거. 6/2 이후 Node.js 24 강제.

## Change
- `pnpm/action-setup@v4` → `@v6` (latest stable, Node.js 24 지원)
- 7 file, 13 곳

## Risk
- CI workflow 만 변경 — production runtime 영향 0
- v6 의 breaking change: pnpm 자체 동작 무관 (action-setup 만 Node.js 런타임 업그레이드)

## Test plan
- [ ] CI 통과 (모든 workflow 새 v6 으로 정상 동작)
- [ ] deprecation warning 사라짐
- [ ] pnpm install / build / test 정상

## Related
- 사용자 요청: PR #1303 와 함께 git gate 배포