### PR TITLE
fix(memory): viewcount.ts cap + bulk evict backstop

### DIFF
--- a/apps/web/src/lib/server/viewcount.ts
+++ b/apps/web/src/lib/server/viewcount.ts
@@ -15,6 +15,12 @@ import { getRedis } from './redis';
 /** 키: `{boardId}:{postId}` → 누적 조회수 */
 const viewCounts = new Map<string, number>();
 
+/**
+ * 누수 backstop — cron(/api/viewcount/sync) 실패/지연 시 OOM 방지.
+ * 정상 운영(3분 cron) 시 절대 도달 안 함. 도달 = cron 미스 알람.
+ */
+const MAX_VIEW_COUNTS = 50_000;
+
 /** Redis 키 접두사 */
 const VIEWED_PREFIX = 'vc:';
 const VIEWED_TTL_SEC = 600; // 10분
@@ -48,6 +54,20 @@ export async function markViewed(ip: string, boardId: string, postId: number): P
 export function increment(boardId: string, postId: number): void {
     const key = `${boardId}:${postId}`;
     viewCounts.set(key, (viewCounts.get(key) || 0) + 1);
+
+    // Backstop: cron 실패 시 누수 방지 (oldest 50% bulk evict, insertion order)
+    if (viewCounts.size > MAX_VIEW_COUNTS) {
+        const targetSize = Math.floor(MAX_VIEW_COUNTS / 2);
+        const beforeSize = viewCounts.size;
+        let toDrop = beforeSize - targetSize;
+        for (const k of viewCounts.keys()) {
+            if (toDrop-- <= 0) break;
+            viewCounts.delete(k);
+        }
+        console.warn(
+            `[viewcount] cron miss 의심 — ${beforeSize - targetSize} entries evicted (size ${beforeSize} → ${targetSize}). /api/viewcount/sync cron 점검 필요.`
+        );
+    }
 }
 
 /** 모든 카운트를 스냅샷으로 반환하고 Map 초기화 */


### PR DESCRIPTION
## Summary
\`viewCounts\` Map 에 50,000 cap + bulk evict backstop 추가. cron 실패 시 OOM 방지.

## Root cause
- \`apps/web/src/lib/server/viewcount.ts:16\` \`viewCounts = new Map<string, number>()\` — unbounded
- 매 페이지뷰 \`increment()\` 시 \`{boardId}:{postId}\` 키 신규 생성
- \`flushAll()\` 은 cron(/api/viewcount/sync, 3분) 호출 시점에만
- **cron 실패/지연 시 무한 누적** — Tier 2 audit 의 ★★★★★ 위험도 #1

## Fix
- \`MAX_VIEW_COUNTS = 50_000\` (~2.5 MB max bound)
- \`increment()\` 에서 size > MAX 시 oldest 50% bulk evict (insertion order)
- \`console.warn\` 으로 cron 미스 알림

## Effect
- 정상 운영 (cron 3분) 시 영향 0 (절대 cap 도달 안 함)
- cron 실패 시 자동 protection — OOM 방지, 일부 조회수 손실 (허용 가능)
- 메모리 추정: 누적 시 +20-50 MiB → 0 회복 (cron 정상 가정)

## Test plan
- [ ] CI 통과 (lint, typecheck, build)
- [ ] 새벽 04:00 머지 + 배포
- [ ] 24h plateau p95 회복 측정 (PR #1303 + #1315 합산 효과)
- [ ] cron 정상 동작 시 console.warn 0회 확인

## Related
- Tier 2 audit (4/27): 22개 module-level state 중 ★★★★★ #1
- PR #1303 (lastDbUpdateMap)
- PR #1316 (ssrCachePending) — 별도 사이클 (medium risk)
- PR #1317 (createCache 통일) — 곧 작성