### PR TITLE
fix(memory): 4개 unbounded Map cap + bulk evict (Tier 2 audit)

### DIFF
--- a/apps/web/src/lib/server/affiliate-redirect.ts
+++ b/apps/web/src/lib/server/affiliate-redirect.ts
@@ -10,6 +10,7 @@ export interface AffiliateRedirectPayload {
 
 const REDIRECT_PREFIX = 'affiliate:go:';
 const REDIRECT_TTL_SEC = 60 * 60 * 24 * 180;
+const L1_CACHE_MAX = 1_000; // 180일 TTL — 누수 방지 cap
 
 const l1Cache = new Map<string, { payload: AffiliateRedirectPayload; expiresAt: number }>();
 
@@ -33,6 +34,15 @@ function buildRedirectId(payload: AffiliateRedirectPayload): string {
 }
 
 function setL1(id: string, payload: AffiliateRedirectPayload): void {
+    // Backstop: 180일 TTL 이라 lazy evict 만으로는 부족 — cap 도달 시 oldest 50% bulk evict
+    if (l1Cache.size >= L1_CACHE_MAX) {
+        const targetSize = Math.floor(L1_CACHE_MAX / 2);
+        let toDrop = l1Cache.size - targetSize;
+        for (const k of l1Cache.keys()) {
+            if (toDrop-- <= 0) break;
+            l1Cache.delete(k);
+        }
+    }
     l1Cache.set(id, {
         payload,
         expiresAt: Date.now() + REDIRECT_TTL_SEC * 1000

--- a/apps/web/src/lib/server/daily-recommended-loader.ts
+++ b/apps/web/src/lib/server/daily-recommended-loader.ts
@@ -17,6 +17,19 @@ const DAILY_CACHE_DIR =
 const cache = new Map<string, { data: unknown; timestamp: number }>();
 const TODAY_TTL_MS = 60_000; // 오늘 데이터: 60초
 const PAST_TTL_MS = 3_600_000; // 과거 데이터: 1시간
+const CACHE_MAX = 200; // date 키 — 365일 이상 누적 시 cap (insertion order evict)
+
+function setCacheBounded(key: string, data: unknown, timestamp: number): void {
+    if (cache.size >= CACHE_MAX) {
+        const targetSize = Math.floor(CACHE_MAX / 2);
+        let toDrop = cache.size - targetSize;
+        for (const k of cache.keys()) {
+            if (toDrop-- <= 0) break;
+            cache.delete(k);
+        }
+    }
+    cache.set(key, { data, timestamp });
+}
 
 /** KST 기준 오늘 날짜 (YYYY-MM-DD) */
 export function getTodayKST(): string {
@@ -44,7 +57,7 @@ export async function loadDailyCalendar(): Promise<DailyCalendar | null> {
     try {
         const content = await readFile(filePath, 'utf-8');
         const data: DailyCalendar = JSON.parse(content);
-        cache.set(cacheKey, { data, timestamp: Date.now() });
+        setCacheBounded(cacheKey, data, Date.now());
         return data;
     } catch (err) {
         console.error('[daily-recommended-loader] calendar.json 읽기 실패:', err);

--- a/apps/web/src/lib/server/member-levels.ts
+++ b/apps/web/src/lib/server/member-levels.ts
@@ -14,6 +14,7 @@ import { calculateLevelFromExp } from '$lib/utils/level-thresholds';
 
 const MAX_IDS = 100;
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const LEVEL_CACHE_MAX = 5_000; // mbId 별 entry — 회원수 증가 시 누수 방지
 
 type CacheEntry = {
     level: number;
@@ -22,6 +23,16 @@ type CacheEntry = {
 
 const levelCache = new Map<string, CacheEntry>();
 const inflightBatches = new Map<string, Promise<Record<string, number>>>();
+
+function evictLevelCacheIfFull(): void {
+    if (levelCache.size < LEVEL_CACHE_MAX) return;
+    const targetSize = Math.floor(LEVEL_CACHE_MAX / 2);
+    let toDrop = levelCache.size - targetSize;
+    for (const k of levelCache.keys()) {
+        if (toDrop-- <= 0) break;
+        levelCache.delete(k);
+    }
+}
 
 function normalizeIds(ids: string[]): string[] {
     return [...new Set(ids.filter((id) => id && /^[a-zA-Z0-9_-]+$/.test(id)).slice(0, MAX_IDS))];
@@ -50,6 +61,7 @@ async function queryMemberLevels(ids: string[]): Promise<Record<string, number>>
 
     const expiresAt = Date.now() + CACHE_TTL_MS;
     for (const [mbId, level] of Object.entries(levels)) {
+        evictLevelCacheIfFull();
         levelCache.set(mbId, { level, expiresAt });
     }
 

--- a/apps/web/src/lib/server/singo-role.ts
+++ b/apps/web/src/lib/server/singo-role.ts
@@ -8,6 +8,7 @@ interface SingoRoleRow extends RowDataPacket {
 }
 
 const ROLE_CACHE_TTL_MS = 60_000;
+const ROLE_CACHE_MAX = 5_000; // mbId 별 entry — 회원수 증가 시 누수 방지
 const roleCache = new Map<string, { role: SingoRole; expiresAt: number }>();
 
 export async function getSingoRole(mbId: string | null | undefined): Promise<SingoRole> {
@@ -25,6 +26,17 @@ export async function getSingoRole(mbId: string | null | undefined): Promise<Sin
     );
 
     const role: SingoRole = rows[0]?.role ?? null;
+
+    // Backstop: cap 도달 시 oldest 50% bulk evict (insertion order)
+    if (roleCache.size >= ROLE_CACHE_MAX) {
+        const targetSize = Math.floor(ROLE_CACHE_MAX / 2);
+        let toDrop = roleCache.size - targetSize;
+        for (const k of roleCache.keys()) {
+            if (toDrop-- <= 0) break;
+            roleCache.delete(k);
+        }
+    }
+
     roleCache.set(mbId, { role, expiresAt: now + ROLE_CACHE_TTL_MS });
     return role;
 }


### PR DESCRIPTION
## Summary
Tier 2 audit (4/27) 의 ★★★ 위험도 4 개 unbounded Map 에 cap + bulk evict backstop 추가.

## Files
| File | Cache | Max | Key | TTL |
|---|---|---|---|---|
| singo-role.ts | roleCache | 5,000 | mbId | 60s |
| daily-recommended-loader.ts | cache | 200 | date (YYYY-MM-DD) | 60s/1h 동적 |
| member-levels.ts | levelCache | 5,000 | mbId | 5min |
| affiliate-redirect.ts | l1Cache | 1,000 | sha256 id | **180일** (lazy evict 부족) |

## Pattern (동일 4곳)
\`\`\`ts
if (cache.size >= MAX) {
  const targetSize = Math.floor(MAX / 2);
  let toDrop = cache.size - targetSize;
  for (const k of cache.keys()) {
    if (toDrop-- <= 0) break;
    cache.delete(k);
  }
}
cache.set(key, value);
\`\`\`

## Effect (예상)
- 정상 운영 시 영향 0 (cap 절대 도달 안 함)
- 누수 시 자동 protection — OOM 방지
- 메모리 추정: lazy evict 누적 +20-50 MiB → bounded

## Test plan
- [ ] CI 통과
- [ ] 새벽 04:00 머지 + 배포
- [ ] 24h plateau (PR #1303 + #1315 + #1317 합산 효과)

## Related
- PR #1303 (lastDbUpdateMap)
- PR #1315 (viewcount cap)
- PR #1316 (ssrCachePending) — 다음 사이클
- Tier 2 audit: 22개 module-level state 중 ★★★ 4개