### PR TITLE
fix(memory): ssrCache cap 우회 누수 — forced evict 추가

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -854,7 +854,7 @@ export const handle: Handle = async ({ event, resolve }) => {
             if (response.status === 200 && isHtml) {
                 const body = await response.text();
 
-                // 캐시 크기 제한: 오래된 항목 정리
+                // 캐시 크기 제한: 오래된 항목 정리 + cap 강제
                 if (ssrCache.size >= MAX_SSR_CACHE_SIZE) {
                     const now = Date.now();
                     for (const [key, entry] of ssrCache) {
@@ -865,6 +865,16 @@ export const handle: Handle = async ({ event, resolve }) => {
                                   ? SSR_CACHE_TTL_POST
                                   : SSR_CACHE_TTL_BOARD;
                         if (now - entry.timestamp > ttl) ssrCache.delete(key);
+                    }
+                    // 만료 청소 후에도 cap 도달 시 oldest forced evict (insertion order).
+                    // 피크 시간 set 빈도 > 만료 빈도 시 cap 우회 누수 방지.
+                    if (ssrCache.size >= MAX_SSR_CACHE_SIZE) {
+                        const targetSize = Math.floor(MAX_SSR_CACHE_SIZE / 2);
+                        let toDrop = ssrCache.size - targetSize;
+                        for (const k of ssrCache.keys()) {
+                            if (toDrop-- <= 0) break;
+                            ssrCache.delete(k);
+                        }
                     }
                 }
                 ssrCache.set(cacheKey, { body: compressSsrBody(body), timestamp: Date.now() });


### PR DESCRIPTION
## Summary
\`ssrCache\` (gzip body Map, MAX_SSR_CACHE_SIZE=500) 의 cap 우회 버그 수정.

## Root cause
\`hooks.server.ts:858-870\`:
\`\`\`ts
if (ssrCache.size >= MAX_SSR_CACHE_SIZE) {
    for (const [key, entry] of ssrCache) {
        if (now - entry.timestamp > ttl) ssrCache.delete(key);
    }
    // ← 만료 청소만. 청소 후에도 cap 도달이면 어떻게 됨? evict 없음!
}
ssrCache.set(cacheKey, ...);  // ← cap 우회 set → 501, 502, ...
\`\`\`

## Fix
만료 청소 후 cap 재확인 → oldest 50% bulk forced evict (insertion order).

## 검증 — Tier 2 audit re-evaluation
- ssrCachePending (★★★★ 추정) → **실제 누수 없음** (finally block 이 reject/throw 모두 cover)
- ssrCache (★★★★★ 추정) → **진짜 누수 vector** (cap 우회 버그)

## Effect
- 정상 운영: 영향 0 (만료 청소로 cap 도달 안 함)
- 피크 시간 (set > 만료): cap 보장 — gzip body 7-12 KB × 500 = 3.5-6 MB max bound
- avg vs p95 누수 패턴의 잔여 후보 — 24h schedule 후 효과 검증

## Related
- PR #1303 (lastDbUpdateMap)
- PR #1315 (viewcount cap)
- PR #1316 (4 unbounded Maps cap)
- 4/27 배포 후 추세: avg plateau 555 안정 + p95 733→857 (3.5h마다 +30 MiB) → 이번 PR 의 fix 후 plateau 기대