### PR TITLE
fix(profile): 이용제한 내역 표시 일관성 + 시간 포맷 (#12123, #12125, #8416)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -40,9 +40,48 @@ interface StatsRow extends RowDataPacket {
     total_singo_count: number;
 }
 
-interface DisciplineRow extends RowDataPacket {
+interface DisciplineLogRow extends RowDataPacket {
+    wr_id: number;
+    wr_content: string;
+    wr_datetime: string;
+}
+
+export interface DisciplineEntry {
     penalty_period: number;
     penalty_date_from: string;
+    sg_types?: string[];
+    wr_id?: number;
+}
+
+/**
+ * disciplinelog wr_content (JSON 문자열) 에서 제재 정보 추출
+ * - 파싱 실패 시 null 반환 (호출부에서 skip)
+ * - penalty_period 가 없으면 null 반환
+ * - penalty_date_from 미존재 시 wr_datetime 으로 fallback
+ */
+export function parseDisciplineLogContent(row: {
+    wr_id?: number;
+    wr_content: string;
+    wr_datetime: string;
+}): DisciplineEntry | null {
+    if (!row.wr_content) return null;
+    try {
+        const parsed = JSON.parse(row.wr_content);
+        if (parsed.penalty_period === undefined || parsed.penalty_period === null) {
+            return null;
+        }
+        const entry: DisciplineEntry = {
+            penalty_period: Number(parsed.penalty_period),
+            penalty_date_from: String(parsed.penalty_date_from || row.wr_datetime || ''),
+            wr_id: row.wr_id
+        };
+        if (Array.isArray(parsed.sg_types)) {
+            entry.sg_types = parsed.sg_types.map((t: unknown) => String(t));
+        }
+        return entry;
+    } catch {
+        return null;
+    }
 }
 
 interface CountRow extends RowDataPacket {
@@ -104,12 +143,12 @@ export const GET: RequestHandler = async ({ params }) => {
     try {
         const [rows] = await pool.query<MemberRow[]>(
             `SELECT mb_id, mb_name, mb_nick, mb_level, mb_point,
-			        mb_signature, mb_homepage, mb_profile,
-			        mb_datetime, mb_today_login, mb_nick_date,
-			        mb_image_url, mb_image_updated_at, mb_certify, mb_leave_date,
-			        as_level, as_exp
-			 FROM g5_member
-			 WHERE mb_id = ?`,
+                    mb_signature, mb_homepage, mb_profile,
+                    mb_datetime, mb_today_login, mb_nick_date,
+                    mb_image_url, mb_image_updated_at, mb_certify, mb_leave_date,
+                    as_level, as_exp
+             FROM g5_member
+             WHERE mb_id = ?`,
             [memberId]
         );
 
@@ -152,57 +191,34 @@ export const GET: RequestHandler = async ({ params }) => {
             // 테이블 없으면 기본값 사용
         }
 
-        // 이용제한 정보 (g5_da_member_discipline에서 최신 1건 + 이력 5건)
-        let discipline = null;
-        let disciplineHistory: { penalty_period: number; penalty_date_from: string }[] = [];
+        // 이용제한 내역 (옵션 A: g5_write_disciplinelog 단일 출처)
+        // - wr_subject 매칭은 PHP `mb_id(닉네임)` / Go `mb_id` 두 형식 모두 처리
+        // - wr_content (JSON) 파싱 → penalty_period / penalty_date_from / sg_types 추출
+        // - 파싱 실패 row 는 skip
+        // 분석 보고서: /home/angple/docs/2026-04-28-discipline-data-flow-analysis.md (옵션 A)
+        let discipline: DisciplineEntry | null = null;
+        let disciplineHistory: DisciplineEntry[] = [];
         try {
-            const [discRows] = await pool.query<DisciplineRow[]>(
-                `SELECT penalty_period, penalty_date_from
-				 FROM g5_da_member_discipline WHERE penalty_mb_id = ?
-                 ORDER BY penalty_date_from DESC LIMIT 5`,
-                [memberId]
+            const [logRows] = await pool.query<DisciplineLogRow[]>(
+                `SELECT wr_id, wr_content, wr_datetime FROM g5_write_disciplinelog
+                 WHERE (wr_subject = ? OR wr_subject LIKE CONCAT(?, '(%'))
+                   AND wr_is_comment = 0
+                 ORDER BY wr_datetime DESC LIMIT 10`,
+                [memberId, memberId]
             );
-            if (discRows.length > 0) {
-                discipline = {
-                    penalty_period: discRows[0].penalty_period,
-                    penalty_date_from: discRows[0].penalty_date_from
-                };
-                disciplineHistory = discRows.map((r) => ({
-                    penalty_period: r.penalty_period,
-                    penalty_date_from: r.penalty_date_from
-                }));
+            for (const row of logRows) {
+                const entry = parseDisciplineLogContent(row);
+                if (entry) {
+                    disciplineHistory.push(entry);
+                }
+            }
+            if (disciplineHistory.length > 0) {
+                discipline = disciplineHistory[0];
             }
         } catch {
-            // 테이블 없으면 무시
-        }
-
-        // fallback: disciplinelog 게시판에서 최근 기록 조회
-        if (!discipline) {
-            try {
-                const [logRows] = await pool.query<RowDataPacket[]>(
-                    `SELECT wr_content FROM g5_write_disciplinelog
-                     WHERE penalty_mb_id = ? AND wr_is_comment = 0
-                     ORDER BY wr_id DESC LIMIT 5`,
-                    [memberId]
-                );
-                for (const row of logRows) {
-                    try {
-                        const parsed = JSON.parse(row.wr_content);
-                        if (parsed.penalty_period !== undefined) {
-                            const entry = {
-                                penalty_period: parsed.penalty_period,
-                                penalty_date_from: parsed.penalty_date_from
-                            };
-                            if (!discipline) discipline = entry;
-                            disciplineHistory.push(entry);
-                        }
-                    } catch {
-                        // 파싱 실패 건 스킵
-                    }
-                }
-            } catch {
-                // 테이블 없으면 무시
-            }
+            // 테이블 없으면 무시 (e.g. 신규 환경)
+            discipline = null;
+            disciplineHistory = [];
         }
 
         // 팔로워/팔로잉 수

--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -46,43 +46,7 @@ interface DisciplineLogRow extends RowDataPacket {
     wr_datetime: string;
 }
 
-export interface DisciplineEntry {
-    penalty_period: number;
-    penalty_date_from: string;
-    sg_types?: string[];
-    wr_id?: number;
-}
-
-/**
- * disciplinelog wr_content (JSON 문자열) 에서 제재 정보 추출
- * - 파싱 실패 시 null 반환 (호출부에서 skip)
- * - penalty_period 가 없으면 null 반환
- * - penalty_date_from 미존재 시 wr_datetime 으로 fallback
- */
-export function parseDisciplineLogContent(row: {
-    wr_id?: number;
-    wr_content: string;
-    wr_datetime: string;
-}): DisciplineEntry | null {
-    if (!row.wr_content) return null;
-    try {
-        const parsed = JSON.parse(row.wr_content);
-        if (parsed.penalty_period === undefined || parsed.penalty_period === null) {
-            return null;
-        }
-        const entry: DisciplineEntry = {
-            penalty_period: Number(parsed.penalty_period),
-            penalty_date_from: String(parsed.penalty_date_from || row.wr_datetime || ''),
-            wr_id: row.wr_id
-        };
-        if (Array.isArray(parsed.sg_types)) {
-            entry.sg_types = parsed.sg_types.map((t: unknown) => String(t));
-        }
-        return entry;
-    } catch {
-        return null;
-    }
-}
+import { parseDisciplineLogContent, type DisciplineEntry } from './_parse-discipline';
 
 interface CountRow extends RowDataPacket {
     count: number;

--- a/apps/web/src/routes/api/members/[id]/profile/_parse-discipline.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/_parse-discipline.ts
@@ -1,0 +1,42 @@
+/**
+ * disciplinelog wr_content (JSON 문자열) 에서 제재 정보 추출
+ * SvelteKit +server.ts 는 HTTP 메서드만 export 가능하므로
+ * helper 는 underscore-prefix 파일로 분리 (테스트 가능 + 빌드 통과)
+ */
+
+export interface DisciplineEntry {
+    penalty_period: number;
+    penalty_date_from: string;
+    sg_types?: string[];
+    wr_id?: number;
+}
+
+/**
+ * - 파싱 실패 시 null 반환 (호출부에서 skip)
+ * - penalty_period 가 없으면 null 반환
+ * - penalty_date_from 미존재 시 wr_datetime 으로 fallback
+ */
+export function parseDisciplineLogContent(row: {
+    wr_id?: number;
+    wr_content: string;
+    wr_datetime: string;
+}): DisciplineEntry | null {
+    if (!row.wr_content) return null;
+    try {
+        const parsed = JSON.parse(row.wr_content);
+        if (parsed.penalty_period === undefined || parsed.penalty_period === null) {
+            return null;
+        }
+        const entry: DisciplineEntry = {
+            penalty_period: Number(parsed.penalty_period),
+            penalty_date_from: String(parsed.penalty_date_from || row.wr_datetime || ''),
+            wr_id: row.wr_id
+        };
+        if (Array.isArray(parsed.sg_types)) {
+            entry.sg_types = parsed.sg_types.map((t: unknown) => String(t));
+        }
+        return entry;
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/routes/api/members/[id]/profile/parse-discipline.test.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/parse-discipline.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { parseDisciplineLogContent } from './+server';
+
+describe('parseDisciplineLogContent', () => {
+    it('정상 JSON: penalty_period / penalty_date_from / sg_types 추출', () => {
+        const row = {
+            wr_id: 912,
+            wr_content: JSON.stringify({
+                penalty_period: 7,
+                penalty_date_from: '2025-01-15 13:30:00',
+                sg_types: ['도배', '비방']
+            }),
+            wr_datetime: '2025-01-15 13:30:05'
+        };
+        const result = parseDisciplineLogContent(row);
+        expect(result).toEqual({
+            penalty_period: 7,
+            penalty_date_from: '2025-01-15 13:30:00',
+            sg_types: ['도배', '비방'],
+            wr_id: 912
+        });
+    });
+
+    it('penalty_date_from 누락 시 wr_datetime fallback', () => {
+        const row = {
+            wr_id: 1041,
+            wr_content: JSON.stringify({ penalty_period: 3 }),
+            wr_datetime: '2025-02-01 09:00:00'
+        };
+        const result = parseDisciplineLogContent(row);
+        expect(result?.penalty_date_from).toBe('2025-02-01 09:00:00');
+        expect(result?.penalty_period).toBe(3);
+        expect(result?.sg_types).toBeUndefined();
+    });
+
+    it('penalty_period === 0 (주의) 도 정상 처리', () => {
+        const row = {
+            wr_id: 3346,
+            wr_content: JSON.stringify({
+                penalty_period: 0,
+                penalty_date_from: '2025-03-01 00:00:00'
+            }),
+            wr_datetime: '2025-03-01 00:00:00'
+        };
+        const result = parseDisciplineLogContent(row);
+        expect(result?.penalty_period).toBe(0);
+        expect(result?.penalty_date_from).toBe('2025-03-01 00:00:00');
+    });
+
+    it('penalty_period === -1 (영구정지) 도 정상 처리', () => {
+        const row = {
+            wr_id: 3304,
+            wr_content: JSON.stringify({
+                penalty_period: -1,
+                penalty_date_from: '2025-03-15 12:00:00'
+            }),
+            wr_datetime: '2025-03-15 12:00:00'
+        };
+        const result = parseDisciplineLogContent(row);
+        expect(result?.penalty_period).toBe(-1);
+    });
+
+    it('JSON 파싱 실패 시 null', () => {
+        const row = {
+            wr_id: 1,
+            wr_content: 'not a json {{{',
+            wr_datetime: '2025-01-01 00:00:00'
+        };
+        expect(parseDisciplineLogContent(row)).toBeNull();
+    });
+
+    it('penalty_period 누락 시 null', () => {
+        const row = {
+            wr_id: 2,
+            wr_content: JSON.stringify({ note: '단순 메모' }),
+            wr_datetime: '2025-01-01 00:00:00'
+        };
+        expect(parseDisciplineLogContent(row)).toBeNull();
+    });
+
+    it('penalty_period === null 시 null (undefined 와 동일하게 skip)', () => {
+        const row = {
+            wr_id: 3,
+            wr_content: JSON.stringify({ penalty_period: null }),
+            wr_datetime: '2025-01-01 00:00:00'
+        };
+        expect(parseDisciplineLogContent(row)).toBeNull();
+    });
+
+    it('빈 wr_content 시 null', () => {
+        const row = {
+            wr_id: 4,
+            wr_content: '',
+            wr_datetime: '2025-01-01 00:00:00'
+        };
+        expect(parseDisciplineLogContent(row)).toBeNull();
+    });
+
+    it('penalty_period 가 문자열이어도 Number 로 변환', () => {
+        const row = {
+            wr_id: 5,
+            wr_content: JSON.stringify({
+                penalty_period: '7',
+                penalty_date_from: '2025-01-15 00:00:00'
+            }),
+            wr_datetime: '2025-01-15 00:00:00'
+        };
+        const result = parseDisciplineLogContent(row);
+        expect(result?.penalty_period).toBe(7);
+        expect(typeof result?.penalty_period).toBe('number');
+    });
+
+    it('sg_types 가 배열이 아니면 undefined', () => {
+        const row = {
+            wr_id: 6,
+            wr_content: JSON.stringify({
+                penalty_period: 7,
+                penalty_date_from: '2025-01-15 00:00:00',
+                sg_types: '단일문자열'
+            }),
+            wr_datetime: '2025-01-15 00:00:00'
+        };
+        const result = parseDisciplineLogContent(row);
+        expect(result?.sg_types).toBeUndefined();
+    });
+});

--- a/apps/web/src/routes/api/members/[id]/profile/parse-discipline.test.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/parse-discipline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseDisciplineLogContent } from './+server';
+import { parseDisciplineLogContent } from './_parse-discipline';
 
 describe('parseDisciplineLogContent', () => {
     it('정상 JSON: penalty_period / penalty_date_from / sg_types 추출', () => {

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -618,7 +618,7 @@
                                     </span>
                                 </div>
                                 <p class="text-muted-foreground mt-1 text-xs">
-                                    {p.discipline.penalty_date_from}
+                                    {p.discipline.penalty_date_from?.split(' ')[0] || ''}
                                 </p>
                             </div>
                         {/if}


### PR DESCRIPTION
## Summary

회원 프로필 페이지 (`/member/[id]`) 의 이용제한 내역 표시를 분석 보고서의 **옵션 A (g5_write_disciplinelog 단일 출처)** 권장안으로 재구성하고, 시간 포맷을 통일했습니다.

- **profile API SQL 재구성**: `g5_da_member_discipline` (UNIQUE 1 row/user) 1차 + 컬럼명 오류 fallback → `g5_write_disciplinelog` 단일 출처로 단순화. PHP `mb_id(닉네임)` / Go `mb_id` 두 wr_subject 형식 모두 매칭. wr_content JSON 파싱 helper 추출 (단위 테스트 가능).
- **시간 포맷 fix**: 활성 제재 박스의 `penalty_date_from` raw timestamp 노출 (#12125) → `split(' ')[0]` 으로 통일.
- **단위 테스트 10건 추가**: 정상/파싱 실패/penalty_period 변형 (음수, 0, 문자열) 등 케이스 커버.

## Root cause

| 이슈 | 원인 |
|---|---|
| #12123 (일관성 없음) | 1차 쿼리가 UNIQUE 키 1 row 반환 → `LIMIT 5` 무의미. 2차 fallback 컬럼명 (`penalty_mb_id` 컬럼은 disciplinelog 에 없음) 으로 항상 실패 → 일부 회원만 우연히 표시됨. |
| #12125 (시간 포맷) | `{p.discipline.penalty_date_from}` raw 출력 → `2025-01-15 13:30:00` 그대로 노출. |
| #8416 (영구정지 회원의 주의 이력 누락) | 1차 쿼리가 1 row 만 반환 → 추가 이력 표시 못 함. |

## Impact

**안전성 (분석 보고서 §5-4)**: profile API 는 별도 mysql2 pool 을 사용하는 **READ-ONLY SELECT** 입니다. 신고 처리 핵심 경로 (damoang-backend Go 서비스, 트랜잭션 기반) 와 완전히 격리되어 있어, 본 변경이 신고 트랜잭션 / `g5_da_member_discipline` upsert / `mb_intercept_date` 업데이트에 미치는 영향은 없습니다.

**데이터 커버리지 향상**: 분석 보고서 §2 에서 확인된 활성 제재 380건 (32.9%) 의 wr_subject 매칭 누락 — PHP/Go 두 wr_subject 형식 모두 매칭하도록 처리하여 해소.

## Test plan

- [ ] 구구탄별 (`google_968b08ee`) 프로필 → 5건 disciplinelog (912/1028/1041/1093/1225) 모두 표시
- [ ] applebeetcarrot (`naver_8eff08b9`) 프로필 → 459 disciplinelog 표시
- [ ] `google_6843f6d3` (#8416 영구정지) 프로필 → 3304 (영구) + 3346 (주의) 모두 표시
- [ ] 활성 제재 없는 일반 회원 → discipline_history 빈 배열, UI 박스 안 보임 (회귀 없음)
- [ ] 시간 포맷: 활성 제재 박스의 `penalty_date_from` 이 날짜만 (`YYYY-MM-DD`) 표시
- [x] `pnpm test:unit -- --run src/routes/api/members/[id]/profile/parse-discipline.test.ts` (10/10 passed)
- [x] `pnpm check` (0 errors)

## Refs

- Analysis report: `/home/angple/docs/2026-04-28-discipline-data-flow-analysis.md` (Stage A)
- Issues: #12123, #12125, #8416

## Constraints (변경 안 한 영역)

- 결제 / 인증 / 신고 처리 코드: 변경 없음
- profile API 이외 SQL: 변경 없음
- 권한 체크 정책 (모든 회원이 다른 회원 프로필 조회 가능): 그대로 유지