### PR TITLE
feat(telemetry): leak diagnostic 강화 (heap snapshot + cache size + external alert)

### DIFF
--- a/apps/web/src/lib/server/telemetry.ts
+++ b/apps/web/src/lib/server/telemetry.ts
@@ -12,7 +12,27 @@
 
 export {};
 
+import { writeHeapSnapshot } from 'node:v8';
+import { ssrCache } from '$lib/server/ssr-cache.js';
+
 const OTEL_ENABLED = process.env.OTEL_ENABLED === 'true';
+
+/**
+ * SIGUSR2 → heap snapshot 강제 캡처 (Tier 4 audit, 2026-04-28)
+ * 사용: kubectl exec <pod> -- kill -USR2 1   →  /tmp/heap-{ts}.heapsnapshot
+ * Chrome DevTools Memory > Load 로 분석. avg vs p95 spike pod 비교.
+ */
+process.on('SIGUSR2', () => {
+    const filename = `/tmp/heap-${Date.now()}.heapsnapshot`;
+    try {
+        writeHeapSnapshot(filename);
+        // eslint-disable-next-line no-console
+        console.log(`[telemetry] heap snapshot saved: ${filename}`);
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[telemetry] heap snapshot error:', err);
+    }
+});
 
 if (OTEL_ENABLED) {
     const { NodeSDK } = await import('@opentelemetry/sdk-node');
@@ -64,6 +84,7 @@ if (OTEL_ENABLED) {
     const HEAP_LOG_INTERVAL_MS = 60_000;
     const heapLogTimer = setInterval(() => {
         const m = process.memoryUsage();
+        const externalRatio = m.heapUsed > 0 ? m.external / m.heapUsed : 0;
         // eslint-disable-next-line no-console
         console.log(
             JSON.stringify({
@@ -73,9 +94,21 @@ if (OTEL_ENABLED) {
                 heapUsed: m.heapUsed,
                 external: m.external,
                 arrayBuffers: m.arrayBuffers,
-                uptime_s: Math.round(process.uptime())
+                uptime_s: Math.round(process.uptime()),
+                // Tier 4 audit (2026-04-28): cache size + external ratio diagnostic
+                ssrCacheSize: ssrCache.size,
+                externalRatio: Number(externalRatio.toFixed(3))
             })
         );
+        // Alert: external > heap*0.5 + heap > 200MB → Buffer/gzip/SDK 외부 메모리 의심
+        if (externalRatio > 0.5 && m.heapUsed > 200_000_000) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[telemetry] external/heap=${externalRatio.toFixed(2)} ` +
+                    `(external=${(m.external / 1e6).toFixed(0)}MB heap=${(m.heapUsed / 1e6).toFixed(0)}MB) ` +
+                    `— gzip/Buffer/AWS SDK/OTel BSP 외부 메모리 의심`
+            );
+        }
     }, HEAP_LOG_INTERVAL_MS);
     heapLogTimer.unref?.();
 


### PR DESCRIPTION
## Summary
Tier 4 audit 의 잔여 누수 source 추적용 diagnostic 강화. 3가지 추가:

1. **SIGUSR2 heap snapshot trigger** — kubectl exec <pod> -- kill -USR2 1 → /tmp/heap-{ts}.heapsnapshot
2. **ssrCacheSize** heap_metrics 에 추가 — PR #1317 cap 우회 fix 검증
3. **external/heap > 0.5 alert** — gzip/Buffer/AWS SDK/OTel BSP 외부 메모리 의심 source 식별

## Background
Tier 4 architectural audit:
- ad-hoc patching (PR #1303~#1318) 5개 진행
- 잔여 p95-only 패턴 의심: **OpenTelemetry BatchSpanProcessor** (★★★★★)
- 진단 부족 — process.memoryUsage 의 \`external\` 시계열 + cache size 시계열 필요

## Effect
- 즉시 효과 0 (read-only telemetry)
- heap snapshot 으로 진짜 누수 source 확정
- external > heap*0.5 alert 발동 시 OTel/AWS SDK pivot 신호

## Test plan
- [ ] CI 통과
- [ ] 새벽 04:00 머지 + 배포 (canary 권장)
- [ ] kubectl exec <pod> -- kill -USR2 1 → snapshot 정상 생성
- [ ] heap_metrics JSON 에 ssrCacheSize, externalRatio 포함 확인
- [ ] 24h 후 external alert 발동 여부 (의심 #5 OTel 진위 확인)

## Risk
very low — telemetry.ts only, ssrCache 는 이미 export 됨 (다른 module 영향 X), SIGUSR2 는 free signal.

## Related
- PR #1303~#1318 (ad-hoc patch fixes)
- angple-k8s PR #27 (HPA scaleDown 단축, K8s native)
- 6h cron rolling restart (host /etc/cron.d/angple-daily-restart)
- Tier 4 architectural audit