### PR TITLE
feat: 광고주 계정 일반 게시판 글쓰기 차단

### DIFF
--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -84,9 +84,11 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
                 link_url: linkUrl,
                 display_date: row.display_date,
                 is_active: true,
-                target_member_id: anonymous ? undefined : (row.target_member_id || undefined),
-                target_member_nick: anonymous ? undefined : (row.target_member_nick || undefined),
-                target_member_photo: anonymous ? undefined : getMemberPhotoUrl(row.target_member_image_url),
+                target_member_id: anonymous ? undefined : row.target_member_id || undefined,
+                target_member_nick: anonymous ? undefined : row.target_member_nick || undefined,
+                target_member_photo: anonymous
+                    ? undefined
+                    : getMemberPhotoUrl(row.target_member_image_url),
                 external_link: row.external_url || undefined,
                 link_target: row.link_target || '_blank',
                 sort_order: row.sort_order || 0,

--- a/apps/web/src/routes/[boardId]/write/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/write/+page.server.ts
@@ -22,6 +22,11 @@ export const load: PageServerLoad = async ({ locals, params }) => {
         redirect(302, `/login?redirect=/${boardId}/write`);
     }
 
+    // 광고주 계정은 promotion 외 일반 게시판 글쓰기 차단
+    if (boardId !== 'promotion' && locals.user.advertiser_status === 'ongoing') {
+        error(403, '광고주 계정은 일반 게시판에 글을 작성할 수 없습니다.');
+    }
+
     const certError = await checkCertification(boardId, locals.user.id);
     if (certError) {
         redirect(302, '/register/cert');


### PR DESCRIPTION
## Summary
- 광고주 계정(advertiser_status=ongoing)이 promotion 외 게시판 글쓰기 페이지 접근 시 403 차단
- 백엔드 RejectAdvertiser 미들웨어와 함께 이중 차단 (damoang-backend#87)

## Test plan
- [ ] 광고주 계정 → `/free/write` 접근 → 403 확인
- [ ] 광고주 계정 → `/promotion/write` → 정상 접근 확인
- [ ] 일반 계정 → `/free/write` → 정상 접근 확인