### PR TITLE
fix: 축하메시지 클라이언트 API 익명 프사/닉네임 노출 버그 수정

### DIFF
--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -84,9 +84,11 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
                 link_url: linkUrl,
                 display_date: row.display_date,
                 is_active: true,
-                target_member_id: anonymous ? undefined : (row.target_member_id || undefined),
-                target_member_nick: anonymous ? undefined : (row.target_member_nick || undefined),
-                target_member_photo: anonymous ? undefined : getMemberPhotoUrl(row.target_member_image_url),
+                target_member_id: anonymous ? undefined : row.target_member_id || undefined,
+                target_member_nick: anonymous ? undefined : row.target_member_nick || undefined,
+                target_member_photo: anonymous
+                    ? undefined
+                    : getMemberPhotoUrl(row.target_member_image_url),
                 external_link: row.external_url || undefined,
                 link_target: row.link_target || '_blank',
                 sort_order: row.sort_order || 0,

--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -66,7 +66,7 @@ export const GET: RequestHandler = async () => {
                 `SELECT cb.id, cb.title, cb.content, cb.image_url, cb.link_url,
                         cb.external_url, cb.display_date, cb.target_member_id,
                         cb.link_target, cb.sort_order, cb.display_type,
-                        cb.source_wr_id, cb.updated_at AS cb_updated_at,
+                        cb.source_wr_id, cb.updated_at AS cb_updated_at, cb.is_anonymous,
                         m.mb_nick AS target_member_nick,
                         m.mb_image_url AS target_member_image_url,
                         wm.wr_content AS source_content
@@ -87,6 +87,7 @@ export const GET: RequestHandler = async () => {
                 const linkUrl =
                     row.external_url ||
                     (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
+                const anonymous = !!row.is_anonymous;
 
                 // source_wr_id가 있으면 원본 게시글에서 최신 이미지 추출 (동기화)
                 let imageUrl = row.image_url || '';
@@ -108,9 +109,11 @@ export const GET: RequestHandler = async () => {
                     link_url: linkUrl,
                     display_date: row.display_date,
                     is_active: true,
-                    target_member_id: row.target_member_id || undefined,
-                    target_member_nick: row.target_member_nick || undefined,
-                    target_member_photo: getMemberPhotoUrl(row.target_member_image_url),
+                    target_member_id: anonymous ? undefined : row.target_member_id || undefined,
+                    target_member_nick: anonymous ? undefined : row.target_member_nick || undefined,
+                    target_member_photo: anonymous
+                        ? undefined
+                        : getMemberPhotoUrl(row.target_member_image_url),
                     external_link: row.external_url || undefined,
                     link_target: row.link_target || '_blank',
                     sort_order: row.sort_order || 0,


### PR DESCRIPTION
## Summary
- 축하메시지를 익명(`is_anonymous=1`)으로 등록했는데, 롤링 배너에서 프사/닉네임이 그대로 노출되던 버그 수정
- SSR 코드(`$lib/server/celebration.ts`)에는 익명 처리가 있었지만, 클라이언트 API(`/api/ads/celebration/today`)에는 누락
- SQL SELECT에 `cb.is_anonymous` 컬럼 추가 + 익명일 때 `target_member_id`, `target_member_nick`, `target_member_photo`를 `undefined`로 처리

## Test plan
- [ ] 익명 축하메시지가 롤링 배너에서 프사/닉네임 없이 표시되는지 확인
- [ ] 비익명 축하메시지는 기존처럼 프사/닉네임 정상 표시되는지 확인