### PR TITLE
fix(cache): cacheKey 홈 query 누락 — pathname + search 일관성

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -790,7 +790,8 @@ export const handle: Handle = async ({ event, resolve }) => {
     if (!isDataRequest && isAnonymousPublicHtml) {
         // 캐시 키에 query string 포함 — pathname만 쓰면 ?page=N 요청이
         // ?page=1 캐시에 섞여 "뒤로 간 것처럼" 보이는 교차 오염 발생.
-        const cacheKey = isHomePage ? '/' : pathname + event.url.search;
+        // 2026-04-29: isHomePage 도 search 포함 (이전 '/' 만 사용 시 query 누락 버그).
+        const cacheKey = pathname + event.url.search;
         const cacheTtl = isHomePage
             ? SSR_CACHE_TTL_HOME
             : isPostDetail


### PR DESCRIPTION
## Summary
\`hooks.server.ts:794\` 의 cacheKey 가 홈 (\`/\`) 일 때 \`event.url.search\` 누락.

## Bug
\`\`\`ts
// Before (버그)
const cacheKey = isHomePage ? '/' : pathname + event.url.search;
//                            ↑ query 무시

// After (fix)
const cacheKey = pathname + event.url.search;  // 홈도 search 포함
\`\`\`

## 영향
- 홈에 \`?page=2\`, \`?utm_source=...\`, \`?ref=...\` 같은 query 모두 \`/\` cache 에 섞임 → 교차 오염
- 코드 주석 자체가 \"교차 오염 발생\" 명시 했는데 홈만 누락됨 (모순)

## 영향 분석
- **현실 영향: 미미** — 홈 페이지에 \`?page=\` 사용 거의 없음
- **utm_*, ref 같은 외부 tag**: SvelteKit 이 page render 시 어차피 query 무시하니 결과 동일
- **fix 후**: utm 변종마다 다른 cache key — cache miss 약간 ↑ 가능 but 일관성 우선

## Test plan
- [ ] CI 통과
- [ ] 새벽 4시 머지 + 배포
- [ ] 24h 후 ssrCache hit% 변화 측정 (큰 변화 없어야 정상)

## Related
- Tier 5 audit (Plan agent 발견)
- ssrCache forced evict (PR #1317)