### PR TITLE
feat(telemetry): RSS/heap+external 임계 자동 heap snapshot capture

### DIFF
--- a/apps/web/src/lib/server/telemetry.ts
+++ b/apps/web/src/lib/server/telemetry.ts
@@ -34,6 +34,50 @@ process.on('SIGUSR2', () => {
     }
 });
 
+/**
+ * Auto heap-watch — 4/30 OOM 사고 후속 (수동 SIGUSR2 영구 폐기, 1+ GB pod OOMKill 위험).
+ *
+ * 임계 OR 조건:
+ *   - rss > HEAP_RSS_THRESHOLD_MB MB (default 1280, container limit 1536 Mi 의 83%)
+ *   - heapUsed + external > HEAP_HEAP_THRESHOLD_MB MB (default 935, max-old 1100 의 85%)
+ *
+ * heapUsed 단독은 Buffer/external 누수 (4/24 gzip Buffer 누수 케이스) 못 잡음 — smoke test 검증.
+ * 두 임계 OR 로 V8 JS heap 누수 + external memory 누수 모두 capture.
+ *
+ * HEAP_WATCH_DIR 미설정 시 비활성 (feature flag, dev/test 환경 영향 0).
+ * 12h cooldown — pod 당 반복 fire 방지.
+ */
+const HEAP_WATCH_INTERVAL_MS = 30_000;
+const HEAP_RSS_THRESHOLD = parseInt(process.env.HEAP_RSS_THRESHOLD_MB || '1280', 10) * 1024 * 1024;
+const HEAP_HEAP_THRESHOLD = parseInt(process.env.HEAP_HEAP_THRESHOLD_MB || '935', 10) * 1024 * 1024;
+const HEAP_WATCH_COOLDOWN_MS = 12 * 60 * 60 * 1000;
+const HEAP_WATCH_DIR = process.env.HEAP_WATCH_DIR;
+let lastHeapDumpAt = 0;
+
+if (HEAP_WATCH_DIR) {
+    const heapWatchTimer = setInterval(() => {
+        const m = process.memoryUsage();
+        const now = Date.now();
+        const trigger = m.rss > HEAP_RSS_THRESHOLD || m.heapUsed + m.external > HEAP_HEAP_THRESHOLD;
+        if (!trigger) return;
+        if (now - lastHeapDumpAt < HEAP_WATCH_COOLDOWN_MS) return;
+        lastHeapDumpAt = now;
+        const filename = `${HEAP_WATCH_DIR}/heap-${process.env.HOSTNAME || 'unknown'}-${now}.heapsnapshot`;
+        try {
+            writeHeapSnapshot(filename);
+            // eslint-disable-next-line no-console
+            console.log(
+                `[telemetry] auto heap-watch dump: ${filename} ` +
+                    `(rss=${(m.rss / 1e6).toFixed(0)}MB heapUsed=${(m.heapUsed / 1e6).toFixed(0)}MB external=${(m.external / 1e6).toFixed(0)}MB)`
+            );
+        } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error('[telemetry] auto heap-watch error:', err);
+        }
+    }, HEAP_WATCH_INTERVAL_MS);
+    heapWatchTimer.unref?.();
+}
+
 if (OTEL_ENABLED) {
     const { NodeSDK } = await import('@opentelemetry/sdk-node');
     const { OTLPTraceExporter } = await import('@opentelemetry/exporter-trace-otlp-grpc');


### PR DESCRIPTION
## Summary

`telemetry.ts` 에 30초 interval heap-watch 추가. 임계 (RSS 또는 heapUsed+external) 도달 시 명시적 path 에 자동 heap snapshot dump. 수동 SIGUSR2 영구 폐기.

## Context — 왜

**4/30 08:59 KST OOM 사고**: hot pod p5gcq (RES 1067 MiB) 에 수동 SIGUSR2 → V8 writeHeapSnapshot 추가 ~600 MB 임시 메모리 → container limit 1536 Mi 초과 → web container OOMKilled, 30초 다운. HPA 흡수, cascade 없음.

**RCA**: 1+ GB heap pod 에 writeHeapSnapshot = OOMKill 확정. plan 의 위험 평가 ("low") 가 1+ GB pod 케이스 미반영.

**결정**: 사람을 trigger 에서 영구 제거 → V8 자동 capture (메모리: \`feedback_heap_snapshot_safety.md\`).

## Changes

- \`apps/web/src/lib/server/telemetry.ts\` line 36 다음에 heap-watch 함수 추가 (~44 lines)
- 환경변수: \`HEAP_WATCH_DIR\`, \`HEAP_RSS_THRESHOLD_MB\` (default 1280), \`HEAP_HEAP_THRESHOLD_MB\` (default 935)
- 12h cooldown — pod 당 반복 fire 방지

## 임계 OR 조건 (smoke test 발견)

- \`rss > HEAP_RSS_THRESHOLD_MB\` — container 입장 메모리, OOM 직전 신호 (external 포함)
- \`heapUsed + external > HEAP_HEAP_THRESHOLD_MB\` — V8 JS heap + Buffer/SDK external 합

**heapUsed 단독은 Buffer/external 누수 못 잡음** (smoke test 검증, 4/24 gzip Buffer 누수 같은 케이스). 두 임계 OR 로 둘 다 capture.

## 안전장치 (모범사례)

- **Feature flag**: \`HEAP_WATCH_DIR\` 미설정 시 setInterval 등록 안 함 → dev/test/다른 사이트 영향 0
- **이 PR 단독으로는 prod 영향 0** — k8s yaml 에서 \`HEAP_WATCH_DIR\` 환경변수 추가해야 활성화
- **timer.unref()** — process 종료 막지 않음
- **try/catch** — writeHeapSnapshot 실패 시 console.error 만, 서비스 영향 없음

## Verification

### 사전 검증 (완료)
- [x] Standalone smoke test PASS (dumps=3, cooldownSkips=8, valid heapsnapshot JSON, exit 0)
- [x] Fresh snapshot baseline 추출 (745k nodes, 87 MB self_size)
- [x] heapUsed metric 한계 검증 (Buffer.alloc/string repeat 모두 미반영 → Array of Numbers 만 V8 heap 점유)

### 배포 후 검증 (Reviewer)
- [ ] CI 통과 (lint, typecheck, build)
- [ ] canary 24h 관찰 (k8s yaml PR 머지 후): OOMKill 빈도 비회귀, latency p95 비회귀
- [ ] canary 에서 1주 내 자동 fire 확인 (HEAP_RSS_THRESHOLD_MB=600, HEAP_HEAP_THRESHOLD_MB=450 override 적용)
- [ ] 본 deploy 후 1주 내 prod fire 확인

## Risk + Rollback

- 위험: low — feature flag 가 활성화 막음
- Rollback: yaml 의 \`HEAP_WATCH_DIR\` env 제거 → 30초 내 비활성. 또는 환경변수 \`HEAP_WATCH_DIR=\"\"\` (간단)
- 코드 revert: git revert 60초 내

## Related

- k8s yaml PR: damoang/angple-k8s#29 (환경변수 + hostPath 마운트, 같은 branch 명)
- Sprint Contract: \`/home/damoang/docs/optimization/2026-04-30-heap-audit-phase2-sprint.md\` (v3)
- 사고 RCA: \`/home/damoang/docs/optimization/2026-04-30-heap-audit-progress.md\`
- 메모리 RULE: \`feedback_heap_snapshot_safety.md\`, \`project_2026_04_30_oom_incident.md\`

## 배포 윈도우

5/1-7 04:00 KST. 두 PR (web + k8s yaml) 같이 머지. canary first → 24h → 본 deploy.

## Test plan

- [ ] CI 통과
- [ ] 코드 리뷰 (heap-watch 함수 + 환경변수 + feature flag)
- [ ] k8s yaml PR 머지 (별도 repo)
- [ ] canary 배포 + 24h 관찰
- [ ] 본 deploy + 1주 fire 검증