### PR TITLE
feat(telemetry): heap_metrics 에 pod 필드 추가 (cluster-wide → per-pod alert)

### DIFF
--- a/apps/web/src/lib/server/telemetry.ts
+++ b/apps/web/src/lib/server/telemetry.ts
@@ -133,6 +133,8 @@ if (OTEL_ENABLED) {
         console.log(
             JSON.stringify({
                 event: 'heap_metrics',
+                // pod 식별 (4/30 cluster-wide alert pod-level 분리용). K8s 가 HOSTNAME = pod name 자동 set.
+                pod: process.env.HOSTNAME || 'unknown',
                 rss: m.rss,
                 heapTotal: m.heapTotal,
                 heapUsed: m.heapUsed,


### PR DESCRIPTION
## Summary

`telemetry.ts:91` heap_metrics JSON 에 `pod: process.env.HOSTNAME` 추가. ClickHouse alert 가 pod 별 식별 가능해짐.

## Context

4/30 cluster cleanup sprint 단계 1 (`clickhouse-heap-alert.sh`) 작성 시 발견:
- heap_metrics JSON 에 pod 필드 없음
- OTel ResourceAttributes 비어있음 → pod 식별 불가
- 임시 해결: cluster-wide max 임계만 alert (이미 운영 중)

이 PR 머지 후:
- pod 별 GROUP BY 가능
- alert 메시지에 정확한 pod 이름 포함
- `clickhouse-heap-alert.sh` 후속 update (별도 commit) 으로 per-pod alert 활성

## Changes

- `apps/web/src/lib/server/telemetry.ts:90` heap_metrics JSON 에 `pod: process.env.HOSTNAME || 'unknown'`

## Risk + Rollback
- 위험: 0 (단순 JSON 필드 추가, ClickHouse 파싱 backward compatible)
- Rollback: revert

## Related
- alert script: `/home/damoang/scripts/clickhouse-heap-alert.sh` (활성, 5분 cron, Telegram)
- Sprint Contract: `/home/damoang/docs/optimization/2026-04-30-clickhouse-alert-sprint.md`
- 단계 1 완료 후 Grafana Alerting (단계 2) 으로 마이그레이션

## Test plan
- [ ] CI 통과
- [ ] canary 자동 배포 후 ClickHouse heap_metrics 의 pod 필드 확인
- [ ] alert 스크립트 update (pod 별 query) → 별도 commit