### PR TITLE
fix(comment): 댓글 빈 단락 줄바꿈 보존 (#12169)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1930,6 +1930,12 @@
         margin-top: 0.75em;
     }
 
+    /* 빈 <p></p> 및 <p><br></p> 태그도 줄바꿈으로 표시 (에디터 엔터키 반영, #12169) */
+    :global(.comment-body p:empty),
+    :global(.comment-body p:has(> br:only-child)) {
+        min-height: 1em;
+    }
+
     /* 댓글 코드 블록 스타일 (게시글 본문 .prose와 동일) */
     :global(.comment-body pre) {
         background-color: var(--muted);


### PR DESCRIPTION
## Summary
- damoang.net 버그 #12169 — 댓글에서 엔터 두 번 입력 시 빈 줄(단락 구분)이 시각적으로 사라지는 문제 수정
- 원인은 sanitize/transform 단계가 아닌 **CSS 누락**. TipTap 에디터는 `<p></p>` 빈 단락을 DB 에 정상 저장하고(예: 댓글 wr_id=12171), DOMPurify 도 빈 `<p>` 를 보존함을 검증 (테스트 코드로 확인). 다만 `.comment-body p { ... }` 스타일에 빈 단락 높이 보존 규칙이 없어 0px 로 collapse 됨
- 게시글 본문 `.prose` 에는 이미 동일 규칙이 적용되어 있음 (`markdown.svelte` L349-352). 같은 패턴을 댓글에 일관 적용

## Changes
- `apps/web/src/lib/components/features/board/comment-list.svelte` (+6 lines)
  - `:global(.comment-body p:empty)`, `:global(.comment-body p:has(> br:only-child))` 에 `min-height: 1em`
- 코드/sanitize/transform 흐름은 무변경 — 순수 CSS 한 블록 추가

## Test plan
- [ ] 운영에서 댓글 작성 시 엔터 두 번 입력 → 빈 줄(단락 구분) 시각적으로 보임
- [ ] 기존 댓글 #12171 (`<p>...</p><p></p><p>...</p>`) 새로고침 → 단락 사이 한 줄 공백 표시
- [ ] 일반 단락(빈 줄 없음) 댓글은 기존 간격 유지 (회귀 없음)
- [ ] `<p><br></p>` 형식(다른 에디터 출력)도 정상 표시

## Notes
- DB 검증: `g5_write_bug` wr_id=12171 → wr_content 에 `<p></p>` 저장됨 확인. DB → DOMPurify 출력까지 빈 `<p>` 보존 검증 (jsdom + dompurify 테스트). 표시 단계 CSS 만의 문제로 confirm
- canary.damoang.net 에서 우선 확인 권장