### PR TITLE
fix(post): 긴 제목 표시 보강 (#12177)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -89,6 +89,7 @@
                                         ? 'text-muted-foreground font-normal'
                                         : 'text-foreground'}"
                                     style="font-size: var(--list-font-size);"
+                                    title={post.title}
                                 >
                                     {#if post.is_adult}
                                         <Badge

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -211,6 +211,7 @@
                         <span
                             class="truncate {readClass}"
                             class:font-semibold={uiSettingsStore.titleBold}
+                            title={post.title}
                         >
                             {#if post.report_count === 'lock'}
                                 <span class="text-muted-foreground italic"

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -80,6 +80,7 @@
                         ? 'text-muted-foreground'
                         : 'text-foreground'}"
                     style="font-size: var(--list-font-size);"
+                    title={post.title}
                 >
                     {#if post.is_adult}
                         <Badge variant="destructive" class="shrink-0 px-1.5 py-0 text-[10px]"

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -109,6 +109,7 @@
                             ? 'text-muted-foreground'
                             : 'text-foreground'}"
                         style="font-size: var(--list-font-size);"
+                        title={post.title}
                     >
                         {#if searchQuery}
                             {@html highlightQuery(post.title, searchQuery)}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1511,7 +1511,7 @@
         <span class="text-muted-foreground/50">/</span>
         <a href="/{data.boardId}" class="hover:text-foreground transition-colors">{boardTitle}</a>
         <span class="text-muted-foreground/50">/</span>
-        <span class="text-foreground max-w-[200px] truncate sm:max-w-[400px]"
+        <span class="text-foreground min-w-0 break-words" title={data.post.title}
             >{data.post.title}</span
         >
     </nav>


### PR DESCRIPTION
## 요약
damoang.net 버그 #12177 — 긴 제목이 잘려서 일부만 보이는 문제 수정.

## 변경 내용
- **게시판 목록 (`classic` / `compact` / `card` / `webzine`)**: 기존 truncate/line-clamp 동작은 그대로 유지하면서 `title={post.title}` 속성을 추가. 데스크톱 hover 시 브라우저 native tooltip 으로 전체 제목 확인 가능.
- **게시글 상세 페이지 breadcrumb** (`routes/[boardId]/[postId]/+page.svelte`): 기존 `max-w-[200px] truncate sm:max-w-[400px]` 제거 → `min-w-0 break-words` 로 자연스러운 줄바꿈 허용. 추가 안전장치로 `title` 속성도 부여.

## 영향
- 짧은 제목: 동작 동일 (회귀 없음)
- 긴 제목: 목록은 hover tooltip 으로 전체 노출, 상세 페이지는 줄바꿈으로 전체 노출
- 모바일: 목록 truncate 그대로 유지 (정렬 보존), 상세 페이지는 자연 줄바꿈

## 테스트
- [ ] svelte-check pass (0 errors)
- [ ] 짧은 제목 정상 표시
- [ ] 100자 이상 긴 제목 — 목록 hover 시 tooltip 노출
- [ ] 100자 이상 긴 제목 — 상세 페이지 breadcrumb 가 줄바꿈으로 전체 표시
- [ ] 모바일 viewport 회귀 없음

Fixes damoang.net 버그 리포트 #12177