### PR TITLE
fix(search): 작성자 검색 결과에 삭제된 글 노출 차단 (#12173)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -445,7 +445,8 @@ export const load: PageServerLoad = async ({
                                 wr_1 AS extra_1, wr_2 AS extra_2, wr_3 AS extra_3,
                                 wr_4 AS extra_4, wr_5 AS extra_5, wr_6 AS extra_6, wr_7 AS extra_7
                          FROM ${tableName}
-                         WHERE wr_id IN (${ph}) AND wr_is_comment = 0`,
+                         WHERE wr_id IN (${ph}) AND wr_is_comment = 0
+                           AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')`,
                         sphinxResult.ids
                     ),
                     readPool.execute<RowDataPacket[]>(

--- a/apps/web/src/routes/api/search/+server.ts
+++ b/apps/web/src/routes/api/search/+server.ts
@@ -27,6 +27,7 @@ interface PostAuthorRow extends RowDataPacket {
     wr_id: number;
     wr_name: string;
     mb_id: string;
+    wr_deleted_at: string | null;
 }
 
 interface BoardFileRow extends RowDataPacket {
@@ -90,6 +91,9 @@ export const GET: RequestHandler = async ({ url, locals }) => {
         // 게시판별 작성자 정보 + 첨부파일 병렬 조회
         const authorMap = new Map<string, { wr_name: string; mb_id: string }>();
         const fileSet = new Set<string>();
+        // Sphinx 인덱스가 소프트 삭제된 글을 즉시 반영하지 못해 검색 결과에 노출되는 문제(#12173)
+        // 방지를 위해 MySQL 에서 wr_deleted_at 가 설정되었거나 행이 사라진 글을 추적해 제외한다.
+        const deletedSet = new Set<string>();
 
         const perBoardPromises = boardIds.map(async (boardId) => {
             const rows = boardMap.get(boardId)!;
@@ -98,17 +102,33 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
             const ph = wrIds.map(() => '?').join(',');
 
-            // 작성자 정보 조회
+            // 작성자 정보 + 삭제 상태 조회
             try {
                 const [authorRows] = await readPool.execute<PostAuthorRow[]>(
-                    `SELECT wr_id, wr_name, mb_id FROM g5_write_${boardId} WHERE wr_id IN (${ph})`,
+                    `SELECT wr_id, wr_name, mb_id, wr_deleted_at FROM g5_write_${boardId} WHERE wr_id IN (${ph})`,
                     wrIds
                 );
+                const seen = new Set<number>();
                 for (const a of authorRows) {
+                    seen.add(a.wr_id);
+                    const deletedAt = a.wr_deleted_at;
+                    const isDeleted =
+                        deletedAt !== null &&
+                        deletedAt !== undefined &&
+                        String(deletedAt) !== '0000-00-00 00:00:00' &&
+                        String(deletedAt) !== '';
+                    if (isDeleted) {
+                        deletedSet.add(`${boardId}:${a.wr_id}`);
+                        continue;
+                    }
                     authorMap.set(`${boardId}:${a.wr_id}`, {
                         wr_name: a.wr_name,
                         mb_id: a.mb_id
                     });
+                }
+                // MySQL 에 존재하지 않는 wr_id (이미 hard delete 된 글)도 노출하지 않는다.
+                for (const id of wrIds) {
+                    if (!seen.has(id)) deletedSet.add(`${boardId}:${id}`);
                 }
             } catch {
                 // 테이블 없는 경우 무시
@@ -131,15 +151,24 @@ export const GET: RequestHandler = async ({ url, locals }) => {
         const [boardNameMap] = await Promise.all([boardNamePromise, ...perBoardPromises]);
 
         // 4) 결과 조립 (게시판별 limitPerBoard개, 총 결과 수 기준 내림차순)
+        //    Sphinx 인덱스가 소프트 삭제 반영 전이거나 hard delete 직후인 wr_id 는 deletedSet 으로 걸러낸다 (#12173).
+        let totalAfterFilter = 0;
         const results = boardIds
             .map((boardId) => {
                 const rows = boardMap.get(boardId)!;
+                const liveRows = rows
+                    .slice(0, limitPerBoard)
+                    .filter((row) => !deletedSet.has(`${boardId}:${row.wr_id}`));
+                const liveTotal = rows.filter(
+                    (row) => !deletedSet.has(`${boardId}:${row.wr_id}`)
+                ).length;
+                totalAfterFilter += liveTotal;
                 return {
                     board_id: boardId,
                     board_name: boardNameMap.get(boardId) || boardId,
-                    total: rows.length,
+                    total: liveTotal,
                     is_comment: isCommentSearch,
-                    posts: rows.slice(0, limitPerBoard).map((row) => {
+                    posts: liveRows.map((row) => {
                         const author = authorMap.get(`${boardId}:${row.wr_id}`);
                         return {
                             id: row.wr_id,
@@ -158,13 +187,14 @@ export const GET: RequestHandler = async ({ url, locals }) => {
                     })
                 };
             })
+            .filter((board) => board.posts.length > 0)
             .sort((a, b) => b.total - a.total);
 
         return json({
             success: true,
             data: {
                 results,
-                total: sphinxRows.length,
+                total: totalAfterFilter,
                 query
             }
         });


### PR DESCRIPTION
## Summary

- damoang.net 버그 #12173 — `/search?sfl=author&q=…` 결과 하단에 `wr_deleted_at` 가 설정된(소프트 삭제) 글이 노출되던 문제를 수정합니다.
- 글로벌 검색(`/api/search/+server.ts`)과 보드 내 검색(`[boardId]/+page.server.ts`) 두 경로 모두에서 MySQL refetch 단계에 삭제 여부 필터를 추가했습니다.
- Sphinx 인덱스 자체에는 손을 대지 않았습니다 (운영 변경이라 본 PR 범위 외 — 추후 sql_query_killlist 또는 sql_attr_timestamp 보강은 별도 issue 권장).

## Cause

- 검색은 SvelteKit 서버 라우트가 직접 SphinxQL → MySQL refetch 로 동작합니다.
- Sphinx 결과를 MySQL 에서 작성자/첨부 정보만 가져올 뿐, `wr_deleted_at` 필터를 걸지 않아 소프트 삭제된 글이 그대로 응답에 들어갔습니다.
- 보드 내 검색의 `SELECT … WHERE wr_id IN (?) AND wr_is_comment = 0` 도 동일한 누락이 있었습니다.

## Changes

- `apps/web/src/routes/api/search/+server.ts`
  - 작성자 정보 조회 시 `wr_deleted_at` 까지 함께 SELECT.
  - `wr_deleted_at` 가 NULL/`'0000-00-00 00:00:00'`/`''` 가 아니면 `deletedSet` 에 마킹.
  - MySQL 에 row 가 없는 wr_id (hard delete 직후) 도 `deletedSet` 에 마킹.
  - 결과 조립 시 `deletedSet` 매칭 wr_id 를 제거하고, 보드 단위 `total` / 전체 `total` 도 필터링 후 값으로 보정.
- `apps/web/src/routes/[boardId]/+page.server.ts`
  - 보드 내 검색 refetch SQL 의 WHERE 절에 `(wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')` 추가.

## Out of scope (follow-up)

- Sphinx 인덱스에 `sql_query_killlist` / `wr_deleted_at = '0000-00-00 00:00:00'` 조건 보강은 운영 sphinx.conf 변경이 필요하므로 본 PR 에서 제외.
- 정렬/필터(#12058 정보광장 family) 와는 분리된 fix 이며, 해당 작업은 sdk-kr/recommend-system worktree PR 사용자 cleanup 후 별도 진행 예정.

## Test plan

- [ ] dev 또는 prod canary 에서 `https://damoang.net/search?sfl=author&q=google_9cd40980` 호출 시 삭제된 글이 결과에서 제외되는지 확인.
- [ ] `/{boardId}?sfl=author&stx=…` 검색에서도 삭제된 글이 안 보이는지 확인.
- [ ] 검색 결과 비어있는 보드는 응답 `results` 에서도 제외되는지 확인 (board.posts.length === 0 인 보드 미노출).
- [ ] 정상 글만 있는 검색어로 회귀 — 결과 수와 작성자/첨부파일 정보가 변하지 않는지 확인.