### PR TITLE
fix(post): link1 자동 동영상 임베드 레이아웃 통일 (#12111)

### DIFF
--- a/apps/web/src/lib/utils/link1-embed.ts
+++ b/apps/web/src/lib/utils/link1-embed.ts
@@ -1,0 +1,25 @@
+/**
+ * link1 (그누보드 wr_link1) 자동 동영상 임베드 헬퍼.
+ *
+ * 게시글 본문 위에 link1 동영상이 자동 삽입될 때, auto-embed 플러그인이 만드는
+ * `<div class="embed-container" data-platform="youtube">…</div>` 마크업과
+ * 에디터(TipTap)가 직접 삽입한 `<div data-youtube-video><iframe class="tiptap-youtube">…</iframe></div>`
+ * 마크업의 시각적 차이를 없애기 위해, link1 자동 임베드를 TipTap 형식으로 통일한다.
+ *
+ * 관련 버그: damoang.net 버그 게시판 #12111
+ */
+
+const YOUTUBE_ID_REGEX =
+    /(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+/**
+ * URL 이 YouTube 동영상이면 TipTap Youtube extension 과 동일한 마크업으로 변환.
+ * YouTube 가 아니면 null 반환 → 호출 측이 기존 auto-embed 경로로 위임하면 됨.
+ */
+export function embedAsTiptapYoutube(url: string): string | null {
+    if (!url) return null;
+    const m = url.match(YOUTUBE_ID_REGEX);
+    if (!m) return null;
+    const vid = m[1];
+    return `<div data-youtube-video=""><iframe class="tiptap-youtube" width="640" height="480" allowfullscreen="true" src="https://www.youtube.com/embed/${vid}"></iframe></div>`;
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -52,6 +52,7 @@
     import { page } from '$app/stores';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { isEmbeddable } from '$lib/plugins/auto-embed';
+    import { embedAsTiptapYoutube } from '$lib/utils/link1-embed';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import AdsenseMultiplex from '$lib/components/ui/adsense-multiplex/adsense-multiplex.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
@@ -246,7 +247,9 @@
         data.post.deleted_at
             ? ''
             : link1Original && isEmbeddable(link1Original)
-              ? `${link1Original}\n${renderedPostContent}`
+              ? // YouTube 는 TipTap 형식으로 통일해 에디터 직접 삽입과 레이아웃 일치 (#12111).
+                // 그 외 플랫폼 (vimeo 등) 은 기존 auto-embed 경로 (plain URL → embed-container) 유지.
+                `${embedAsTiptapYoutube(link1Original) ?? link1Original}\n${renderedPostContent}`
               : renderedPostContent
     );
 


### PR DESCRIPTION
## 요약

damoang.net 버그 게시판 #12111 — 게시글 link1 (출처 URL) 자동 동영상 임베드의 레이아웃이 에디터에서 직접 삽입한 동영상과 다르게 깨져 보이는 문제 수정.

## 원인

`apps/web/src/routes/[boardId]/[postId]/+page.svelte` 가 link1 동영상 URL 을 본문 앞에 plain text 로 prepend 하면, auto-embed 플러그인이 `<div class="embed-container" data-platform="youtube">…</div>` 마크업으로 변환합니다. 반면 에디터(TipTap)가 직접 삽입한 동영상은 `<div data-youtube-video><iframe class="tiptap-youtube">…</iframe></div>` 마크업입니다. 두 마크업은 클래스/래퍼 구조와 CSS 가 달라 시각적으로 레이아웃이 다르게 보입니다.

상세 분석: `/home/angple/docs/2026-04-30-bug-analysis-12175-12111.md` (Option A 권고).

## 변경

- 신규 `apps/web/src/lib/utils/link1-embed.ts` — `embedAsTiptapYoutube(url)` 헬퍼. YouTube URL 을 TipTap Youtube extension 과 동일한 마크업으로 변환.
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` — link1 prepend 시 YouTube URL 이라면 TipTap 형식 마크업을 직접 prepend. YouTube 외 (vimeo 등) 는 기존 auto-embed 경로 유지.

회귀 위험 최소화: 마크업만 통일, CSS 변경 없음. YouTube 외 플랫폼은 기존 동작 보존.

## 테스트 계획

- [ ] dev 또는 staging 에서 wr_link1=`https://youtu.be/<id>` 게시글 작성 → 본문 위 자동 임베드가 TipTap 형식 (`tiptap-youtube` 클래스) 으로 출력되는지 확인.
- [ ] 같은 글에서 본문 에디터로 직접 삽입한 YouTube 와 시각적으로 동일한지 확인.
- [ ] 기존 production 글 https://damoang.net/free/6192527 와 같은 형태에서 link1 / link2 동영상이 모두 정상 표시되는지 확인.
- [ ] `pnpm check` (svelte-check 0 errors)
- [ ] vimeo 등 YouTube 외 플랫폼은 기존 `embed-container` 마크업 그대로 출력되는지 확인.