### PR TITLE
fix(autolink): 자동 링크 변환 시 한글 흡수 방지 (#12175)

### DIFF
--- a/apps/web/src/lib/server/affiliate-links.test.ts
+++ b/apps/web/src/lib/server/affiliate-links.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { linkifyPlainTextUrls } from './affiliate-links';
+
+/**
+ * #12175 회귀 테스트 — `linkifyPlainTextUrls` 의 자동 링크 변환이
+ * 한글/CJK 문자를 URL 본문으로 흡수하지 않아야 한다.
+ *
+ * 원래 정규식 `(?:www\.)[^\s<>"']+` 는 negation 클래스에 한글이 포함되어
+ * "www.여기는도메인주소가들어갑니다" 같은 입력 전체를 한 URL 로 매칭하던 버그.
+ */
+describe('linkifyPlainTextUrls', () => {
+    it('does not absorb Korean characters following www.', () => {
+        const input = '예: 어쩌구 저쩌구 www.여기는도메인주소가들어갑니다 어쩌구저쩌구';
+        const output = linkifyPlainTextUrls(input);
+
+        // 한글이 흡수된 가짜 URL 로 <a> 태그가 생성되어선 안 됨
+        expect(output).not.toContain('href="https://www.여기는도메인주소가들어갑니다"');
+        expect(output).not.toContain('>www.여기는도메인주소가들어갑니다<');
+        // 입력 텍스트 자체는 보존
+        expect(output).toContain('www.여기는도메인주소가들어갑니다');
+    });
+
+    it('does not absorb Korean after partial www. prefix', () => {
+        const input = '"www.여기는 도메인  주소가들어갑니다"';
+        const output = linkifyPlainTextUrls(input);
+
+        // www.여기는 도 링크가 되면 안 됨
+        expect(output).not.toMatch(/<a [^>]*href="https:\/\/www\.여기는/);
+    });
+
+    it('still converts plain ASCII www. domains', () => {
+        const output = linkifyPlainTextUrls('방문하세요 www.example.com 감사합니다');
+        expect(output).toContain('href="https://www.example.com"');
+        expect(output).toContain('>www.example.com<');
+    });
+
+    it('still converts https:// URLs', () => {
+        const output = linkifyPlainTextUrls('방문하세요 https://www.naver.com 감사합니다');
+        expect(output).toContain('href="https://www.naver.com"');
+    });
+
+    it('marks damoang.net links without target=_blank', () => {
+        const output = linkifyPlainTextUrls('https://damoang.net/free 보세요');
+        expect(output).toContain('href="https://damoang.net/free"');
+        expect(output).not.toMatch(/href="https:\/\/damoang\.net\/free"[^>]*target="_blank"/);
+    });
+
+    it('marks external links with target=_blank rel=noopener', () => {
+        const output = linkifyPlainTextUrls('https://example.com 보세요');
+        expect(output).toContain('target="_blank"');
+        expect(output).toContain('rel="noopener noreferrer"');
+    });
+
+    it('handles ASCII domain followed by Korean without absorbing Korean', () => {
+        const input = 'example.com한글이어붙은';
+        const output = linkifyPlainTextUrls(input);
+        // 한글이 URL 의 path 로 들어가면 안 됨
+        expect(output).not.toContain('href="https://example.com한글이어붙은"');
+    });
+
+    it('does not linkify inside existing <a> tags', () => {
+        const input = '<a href="https://example.com">www.naver.com</a>';
+        const output = linkifyPlainTextUrls(input);
+        // 기존 anchor 안의 텍스트는 추가 변환되면 안 됨
+        const anchorOpenCount = (output.match(/<a\s/gi) || []).length;
+        expect(anchorOpenCount).toBe(1);
+    });
+
+    it('strips trailing punctuation from matched URL', () => {
+        const output = linkifyPlainTextUrls('보세요 https://example.com.');
+        // 마지막 . 는 URL 에서 제외되어야 함
+        expect(output).toContain('href="https://example.com"');
+        expect(output).toMatch(/<\/a>\.\s*$/);
+    });
+});

--- a/apps/web/src/lib/server/affiliate-links.ts
+++ b/apps/web/src/lib/server/affiliate-links.ts
@@ -134,8 +134,14 @@ function mapDecisionToRow(
 export function linkifyPlainTextUrls(html: string): string {
     const parts = html.split(/(<[^>]+>)/g);
     let insideAnchor = false;
-    const urlPattern =
-        /(^|[\s(>])((?:https?:\/\/|\/\/|www\.)[^\s<>"']+|(?:[a-z0-9-]+\.)+[a-z]{2,}[^\s<>"']*)/gi;
+    // URL 본문은 RFC 3986 호환 ASCII 만 허용 (한글/CJK 가 URL 의 path 로 흡수되어
+    // false-positive 자동 링크가 만들어지는 #12175 회귀 방지).
+    // 허용 문자: 영숫자, 그리고 - . _ ~ : / ? # [ ] @ ! $ & ' ( ) * + , ; = %
+    const URL_BODY = "[A-Za-z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]";
+    const urlPattern = new RegExp(
+        `(^|[\\s(>])((?:https?:\\/\\/|\\/\\/|www\\.)${URL_BODY}+|(?:[a-z0-9-]+\\.)+[a-z]{2,}(?:${URL_BODY}*))`,
+        'gi'
+    );
 
     return parts
         .map((part) => {


### PR DESCRIPTION
## 요약

- damoang.net 버그 #12175 수정. 댓글/본문 자동 링크 변환 시 한글이 URL 끝에 잘못 붙는 문제.
- `apps/web/src/lib/server/affiliate-links.ts` 의 `linkifyPlainTextUrls` 정규식 `(?:www\.)[^\s<>"']+` 가 한글을 URL 경계로 인정하지 않아 `www.여기는도메인주소가들어갑니다` 입력 전체가 하나의 URL 로 매칭되던 문제.
- URL 본문을 RFC 3986 호환 ASCII 문자 클래스 `[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]` 로 제한하여 CJK 가 URL path 로 흡수되지 않도록 수정.

## 변경 내용

- `apps/web/src/lib/server/affiliate-links.ts` — 자동 링크 정규식을 ASCII 안전 클래스로 교체
- `apps/web/src/lib/server/affiliate-links.test.ts` — 회귀 방지용 단위 테스트 9건 추가

## 영향 범위

- `linkifyPlainTextUrls` 는 게시글/댓글 본문 affiliate 렌더 경로에서 호출됨.
- 정상 ASCII 도메인 (`www.example.com/path?q=1`) 매칭 동작 유지.
- 부수 효과: 한글 IDN 직접 입력 (`한글.kr`) 은 매칭에서 빠짐 — 정책상 수용 가능 (브라우저는 punycode 사용).

## 검증

- [x] 신규 테스트 9건 pass (`pnpm test:unit -- --run src/lib/server/affiliate-links.test.ts`)
- [x] 전체 unit 테스트 289/289 pass
- [x] `pnpm check` 0 errors (관련 신규 경고 없음)
- [ ] dev 환경에서 댓글에 `www.여기는도메인주소가들어갑니다` 작성 → 자동 링크 미발생 확인 (수동)
- [ ] 기존 ASCII 도메인 자동 링크 (`www.naver.com`, `https://example.com`) 정상 동작 확인 (수동)

## Sprint Contract

분석 보고서 `/home/angple/docs/2026-04-30-bug-analysis-12175-12111.md` 의 #12175 Option A 권고 따름.