### PR TITLE
fix(profile): 글삭제 건수 실시간 COUNT 보강 (#12113)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -47,6 +47,7 @@ interface DisciplineLogRow extends RowDataPacket {
 }
 
 import { parseDisciplineLogContent, type DisciplineEntry } from './_parse-discipline';
+import { calculateDeletePostCount } from './_recompute-counts';
 
 interface CountRow extends RowDataPacket {
     count: number;
@@ -153,6 +154,22 @@ export const GET: RequestHandler = async ({ params }) => {
             stats = statsRows[0] || defaultStats;
         } catch {
             // 테이블 없으면 기본값 사용
+        }
+
+        // delete_post_count 실시간 보강 (#12113)
+        // g5_member_board_status.delete_post_count 는 갱신 cron 부재로 stale.
+        // bo_use_search 보드들에 대해 UNION ALL COUNT 로 실시간 합산.
+        try {
+            // pool.query 와 시그니처 호환: <T>(sql, params) => [rows, fields]
+            const realDeleteCount = await calculateDeletePostCount(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (sql: string, params?: unknown[]) => pool.query(sql, params) as any,
+                memberId
+            );
+            stats = { ...stats, delete_post_count: realDeleteCount };
+        } catch (err) {
+            // 실시간 합산 실패 시 기존 stale 값 유지 (안전장치)
+            console.error('[Member Profile API] delete_post_count recompute failed:', err);
         }
 
         // 이용제한 내역 (옵션 A: g5_write_disciplinelog 단일 출처)

--- a/apps/web/src/routes/api/members/[id]/profile/_recompute-counts.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/_recompute-counts.ts
@@ -1,0 +1,76 @@
+/**
+ * 프로필 통계 — g5_member_board_status 의 stale 한 누적값(레거시 PHP)
+ * 대신 실시간 COUNT 를 사용하기 위한 헬퍼.
+ *
+ * 배경:
+ *   g5_member_board_status.delete_post_count 는 갱신하는 cron / sync 가 없어서
+ *   레거시 PHP 시절 누적된 값에서 멈춰있다 (#12113).
+ *   재계산 가능한 카운트만이라도 실시간으로 보강한다.
+ *
+ * 비용:
+ *   bo_use_search = 1 인 보드 리스트(~30개)에 대해 UNION ALL 단일 쿼리.
+ *   wr_deleted_at 인덱스 + mb_id 인덱스 활용 시 50ms 미만.
+ */
+export interface QueryFn {
+    <T>(sql: string, params?: unknown[]): Promise<[T[], unknown]>;
+}
+
+interface BoardRow {
+    bo_table: string;
+}
+
+interface CountRow {
+    cnt: number;
+}
+
+/**
+ * 회원의 "삭제된 글" 건수를 모든 검색 가능 보드에 대해 실시간 합산한다.
+ * - 댓글 제외 (wr_is_comment = 0)
+ * - 소프트삭제 판단: wr_deleted_at IS NOT NULL AND wr_deleted_at != '0000-00-00 00:00:00'
+ *
+ * @param query  pool.query 호환 함수 (테스트에서 mock 가능)
+ * @param mbId   회원 ID (caller 가 이미 검증했다고 가정 — 영숫자/_/- 만)
+ * @returns      삭제 글 수. 보드 조회 실패 / 개별 보드 쿼리 실패 시 0 또는 부분합 반환.
+ */
+export async function calculateDeletePostCount(query: QueryFn, mbId: string): Promise<number> {
+    // 1. 검색 가능 보드 목록 조회
+    let boards: BoardRow[];
+    try {
+        const [rows] = await query<BoardRow>(
+            'SELECT bo_table FROM g5_board WHERE bo_use_search = 1 ORDER BY bo_order'
+        );
+        boards = rows;
+    } catch {
+        return 0;
+    }
+    if (boards.length === 0) return 0;
+
+    // 2. bo_table 화이트리스트 검증 (식별자 escape 대비 영숫자/_ 만 허용)
+    const safeBoards = boards
+        .map((b) => b.bo_table)
+        .filter((t) => typeof t === 'string' && /^[a-zA-Z0-9_]+$/.test(t));
+    if (safeBoards.length === 0) return 0;
+
+    // 3. UNION ALL 단일 쿼리로 합산
+    //    각 보드 SELECT 는 (mb_id, wr_is_comment, wr_deleted_at) 조건 — 인덱스 활용 가능
+    const unionSql = safeBoards
+        .map(
+            (t) =>
+                `SELECT COUNT(*) AS cnt FROM g5_write_${t}
+                 WHERE mb_id = ? AND wr_is_comment = 0
+                   AND wr_deleted_at IS NOT NULL
+                   AND wr_deleted_at != '0000-00-00 00:00:00'`
+        )
+        .join(' UNION ALL ');
+    const params = safeBoards.map(() => mbId);
+
+    try {
+        const [rows] = await query<CountRow>(unionSql, params);
+        return rows.reduce((sum, r) => sum + (Number(r.cnt) || 0), 0);
+    } catch {
+        // 일부 보드의 g5_write_* 테이블이 없거나 wr_deleted_at 컬럼이 없을 수 있음 →
+        // UNION ALL 한 쿼리가 통째로 실패하므로 보수적으로 0 반환 (기존 stale 값 사용 X).
+        // 운영 환경에서는 모든 보드가 동일 스키마이므로 문제 없음.
+        return 0;
+    }
+}

--- a/apps/web/src/routes/api/members/[id]/profile/recompute-counts.test.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/recompute-counts.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { calculateDeletePostCount, type QueryFn } from './_recompute-counts';
+
+/**
+ * mockQuery: g5_board 조회 → 보드 목록 반환, UNION ALL → 보드별 COUNT 반환
+ * 호출 순서대로 응답을 큐에서 꺼낸다.
+ */
+function makeMockQuery(responses: unknown[][]): QueryFn {
+    let i = 0;
+    return (async (_sql: string, _params?: unknown[]) => {
+        const rows = responses[i++] ?? [];
+        return [rows, []];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any as QueryFn;
+}
+
+describe('calculateDeletePostCount', () => {
+    it('보드 합산: 3 + 2 + 0 = 5', async () => {
+        const query = makeMockQuery([
+            // g5_board → bo_use_search = 1 보드 3개
+            [{ bo_table: 'free' }, { bo_table: 'humor' }, { bo_table: 'qa' }],
+            // UNION ALL 결과 (각 보드 1 row 씩)
+            [{ cnt: 3 }, { cnt: 2 }, { cnt: 0 }]
+        ]);
+        const result = await calculateDeletePostCount(query, 'testuser');
+        expect(result).toBe(5);
+    });
+
+    it('보드 0개일 때 0 반환 (UNION 쿼리 호출 안 함)', async () => {
+        const calls: string[] = [];
+        const query: QueryFn = (async (sql: string) => {
+            calls.push(sql);
+            if (sql.includes('FROM g5_board')) return [[], []];
+            return [[], []];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any;
+        const result = await calculateDeletePostCount(query, 'testuser');
+        expect(result).toBe(0);
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toContain('g5_board');
+    });
+
+    it('g5_board 쿼리 실패 시 0 반환 (throw 안 함)', async () => {
+        const query: QueryFn = (async () => {
+            throw new Error('table not found');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any;
+        const result = await calculateDeletePostCount(query, 'testuser');
+        expect(result).toBe(0);
+    });
+
+    it('UNION ALL 쿼리 실패 시 0 반환', async () => {
+        let callCount = 0;
+        const query: QueryFn = (async (sql: string) => {
+            callCount++;
+            if (callCount === 1) return [[{ bo_table: 'free' }], []];
+            throw new Error('column wr_deleted_at not found');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any;
+        const result = await calculateDeletePostCount(query, 'testuser');
+        expect(result).toBe(0);
+    });
+
+    it('bo_table 비정상 값(특수문자) 은 화이트리스트로 제외', async () => {
+        const captured: { sql: string; params: unknown[] }[] = [];
+        const query: QueryFn = (async (sql: string, params?: unknown[]) => {
+            captured.push({ sql, params: params ?? [] });
+            if (sql.includes('FROM g5_board')) {
+                return [
+                    [
+                        { bo_table: 'free' },
+                        { bo_table: 'evil; DROP TABLE--' }, // 차단 대상
+                        { bo_table: 'humor' }
+                    ],
+                    []
+                ];
+            }
+            return [[{ cnt: 1 }, { cnt: 4 }], []];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any;
+
+        const result = await calculateDeletePostCount(query, 'testuser');
+        expect(result).toBe(5);
+
+        // UNION ALL 쿼리에서 evil 보드는 제외되었는지 확인
+        const unionCall = captured[1];
+        expect(unionCall.sql).toContain('g5_write_free');
+        expect(unionCall.sql).toContain('g5_write_humor');
+        expect(unionCall.sql).not.toContain('evil');
+        // params 는 보드 수와 동일 (각 보드당 mb_id 1번)
+        expect(unionCall.params).toEqual(['testuser', 'testuser']);
+    });
+
+    it('UNION ALL SQL 에 wr_is_comment = 0 + wr_deleted_at 조건 포함', async () => {
+        const captured: string[] = [];
+        const query: QueryFn = (async (sql: string) => {
+            captured.push(sql);
+            if (sql.includes('FROM g5_board')) {
+                return [[{ bo_table: 'free' }], []];
+            }
+            return [[{ cnt: 0 }], []];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any;
+
+        await calculateDeletePostCount(query, 'testuser');
+        const unionSql = captured[1];
+        expect(unionSql).toContain('wr_is_comment = 0');
+        expect(unionSql).toContain('wr_deleted_at IS NOT NULL');
+        expect(unionSql).toContain("wr_deleted_at != '0000-00-00 00:00:00'");
+    });
+
+    it('cnt 가 string 으로 와도 Number 변환 후 합산', async () => {
+        const query = makeMockQuery([
+            [{ bo_table: 'free' }, { bo_table: 'humor' }],
+            [{ cnt: '7' }, { cnt: '3' }]
+        ]);
+        const result = await calculateDeletePostCount(query, 'testuser');
+        expect(result).toBe(10);
+    });
+});


### PR DESCRIPTION
## Summary
- `g5_member_board_status.delete_post_count` 가 갱신 cron 부재로 stale → 프로필에 잘못된 글삭제 건수 노출 (#12113)
- `bo_use_search = 1` 보드들에 대해 UNION ALL COUNT 단일 쿼리로 실시간 합산하여 응답에 보강
- 다른 카운트(comment / singo 등)는 별도 PR 또는 cron 도입 시 함께 처리 (단기 픽스 범위 한정)

## Changes
- `apps/web/src/routes/api/members/[id]/profile/_recompute-counts.ts` (new)
  - `calculateDeletePostCount(query, mbId)` — 보드 화이트리스트 검증 후 UNION ALL
  - 인덱스 활용 시 < 50ms 예상 (~30개 보드 × 1 row)
  - 실패 시 0 반환 (caller 가 catch 하여 기존 stale 값 유지)
- `apps/web/src/routes/api/members/[id]/profile/recompute-counts.test.ts` (new)
  - mock pool 기반 단위테스트 7건 (보드 합산 / 0 보드 / 쿼리 실패 / 화이트리스트 / SQL 검증 / string→number)
- `apps/web/src/routes/api/members/[id]/profile/+server.ts`
  - stats 조회 후 `delete_post_count` 만 실시간 값으로 덮어씀
  - 합산 실패 시 기존 stale 값 유지 (안전장치)

## 근본 원인
- `delete_post_count` 컬럼을 갱신하는 cron / sync 작업 부재 (grep 0건)
- 레거시 PHP 시절 누적된 값에서 멈춰 있음

## Out of scope (별도 issue 권고)
- `total_post_count`, `total_comment_count`, `delete_comment_count` 등 나머지 카운트 동일 문제 → 별도 cron 도입 PR 에서 일괄 처리
- 댓글 삭제 건수는 `wr_is_comment >= 1` 조건으로 동일 패턴 적용 가능

## Test plan
- [x] `pnpm test:unit` — recompute-counts.test.ts 7/7 PASS, parse-discipline.test.ts 회귀 없음 (10/10)
- [x] `pnpm check` — 본 PR 변경 파일에서 신규 에러/경고 0건
- [ ] 운영/dev 환경 회원 프로필 응답에서 `stats.delete_post_count` 가 실제 삭제 글 수와 일치하는지 확인
- [ ] 회원 1명당 응답 시간 < 100ms (보드 30개 기준)