### PR TITLE
fix(post): 모바일 게시글 상세 가로 스크롤 회귀 (#12048, #11773 회귀)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2001,18 +2001,24 @@
 <!-- 게시판 최근글 목록 -->
 <!-- #12040: boardId 변경 시 RecentPosts 를 강제 재생성하여 이전 게시판의
      posts state 가 남아있다가 잘못된 URL 로 이동하는 문제 방지 -->
+<!-- #12048: 본문 wrapper 외부의 RecentPosts 가 일부 모바일 환경(Samsung Internet/다뷰)
+     에서 가로 스크롤 유발. 동일한 overflow-x cascade 폴백 + clip 적용. -->
 {#if canRead}
-    {#key boardId}
-        <RecentPosts
-            {boardId}
-            {boardTitle}
-            currentPostId={data.post.id}
-            limit={20}
-            initialPage={data.recentPosts?.page || Number($page.url.searchParams.get('page')) || 1}
-            {promotionPosts}
-            displaySettings={data.board?.display_settings}
-        />
-    {/key}
+    <div style="overflow-x: hidden; overflow-x: clip;">
+        {#key boardId}
+            <RecentPosts
+                {boardId}
+                {boardTitle}
+                currentPostId={data.post.id}
+                limit={20}
+                initialPage={data.recentPosts?.page ||
+                    Number($page.url.searchParams.get('page')) ||
+                    1}
+                {promotionPosts}
+                displaySettings={data.board?.display_settings}
+            />
+        {/key}
+    </div>
 {/if}
 
 {#if authStore.isAuthenticated}


### PR DESCRIPTION
## 배경 (#12048 회귀)
- 회귀 체인: #11970 (PR #1245, `overflow-x: clip`) → #12048/#12096 (PR #1307, `hidden+clip` cascade) → #12048 일부 환경 잔존
- 사용자 환경: Samsung Internet (Galaxy) / 다뷰 어플
- 증상: 게시글 상세 페이지에서 모바일 우측 ~5mm 여백 + 가로 스크롤 (게시판 목록은 정상)

## 회귀 추정 사유
- PR #1307 의 cascade `overflow-x: hidden; overflow-x: clip;` 는 본문 wrapper (L1500–L1999) 에만 적용되어 있음
- `RecentPosts` (L2004 이후) 는 wrapper 외부에서 렌더링되어 보호 cascade 미적용
- 일부 모바일 환경에서 RecentPosts 의 wide column / 카드 콘텐츠가 viewport 를 미세하게 초과 → 페이지 전체 가로 스크롤 발생

## 변경
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte`
  - `RecentPosts` 를 본문 wrapper 와 동일한 `overflow-x: hidden; overflow-x: clip;` cascade `<div>` 로 감쌈
- 단순 wrapper 추가 (코드/레이아웃 영향 최소)

## 변경 라인 수
- +17 / -11 (실제 의미 있는 변경: wrapper `<div>` 1쌍 추가, prettier 자동 줄바꿈으로 인한 포맷 차이)

## 회귀 가능성
- RecentPosts 내부 sticky/transform 없음 → clip 부작용 없음
- 정상 너비 환경(데스크톱)에서 clip 은 visible 과 시각적 동일
- 페이지네이션/게시판 이동 동작 변화 없음

## Test plan
- [ ] Samsung Internet (Galaxy) 게시글 상세 — 우측 여백/가로 스크롤 재발 X
- [ ] 다뷰 앱 — 동일 검증
- [ ] iOS Safari / Chrome — 회귀 없음
- [ ] 데스크톱 — 레이아웃 변화 없음
- [ ] RecentPosts 페이지네이션 정상 동작
- [ ] 게시판 간 이동 (#12040 회귀 없음)

## 참고
- 정확한 overflow 발생 원인(어떤 element 가 viewport 초과하는지)은 사용자 실기기 검증 없이 단정 어려움. 본 fix 는 #1307 cascade pattern 의 적용 범위를 RecentPosts 까지 확장하는 보수적 방어층.