### PR TITLE
fix(comment): 댓글 YouTube iframe aspect-ratio (#12081, #11904 회귀)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1781,6 +1781,22 @@
 {/if}
 
 <style>
+    /* 댓글 내 iframe/video 폭 제한 (인라인 width/height 속성 오버라이드) */
+    :global(.comment-body iframe),
+    :global(.comment-body video) {
+        max-width: 100% !important;
+        height: auto !important;
+    }
+
+    /* 댓글 내 YouTube iframe 16:9 비율 유지 (#11904, #12081 회귀 방지) */
+    :global(.comment-body iframe[src*='youtube']),
+    :global(.comment-body iframe[src*='youtu.be']),
+    :global(.comment-body iframe.tiptap-youtube) {
+        aspect-ratio: 16 / 9;
+        width: 100% !important;
+        height: auto !important;
+    }
+
     /* 댓글 내 임베드 컨테이너 스타일 */
     :global(.embed-container) {
         position: relative;


### PR DESCRIPTION
## Summary
- damoang.net 버그 #12081 회귀 수정 — 댓글에 YouTube iframe 임베드 시 세로로 길게 letterbox 표시되던 문제
- `.prose` (게시글 본문)에는 `iframe[src*='youtube']`에 `aspect-ratio: 16/9` + `max-width/height: auto !important` 규칙이 있었으나, `comment-list.svelte`의 `.comment-body` 영역에는 누락
- `.embed-container` 래퍼 없이 raw `<iframe width="560" height="315">` 형태로 저장된 댓글에서 인라인 `height` 속성이 그대로 적용 + CSS `width: 100%`로 늘어나 letterbox 발생

## 변경
`apps/web/src/lib/components/features/board/comment-list.svelte` (+16줄)
- `:global(.comment-body iframe)` / `video`에 `max-width: 100% !important; height: auto !important;`
- `:global(.comment-body iframe[src*='youtube'])` / `youtu.be` / `.tiptap-youtube`에 `aspect-ratio: 16/9 + width: 100% + height: auto !important`
- `markdown.svelte` L491-504과 동일 패턴

## 회귀 추정 사유
#11904 fix 당시 `.prose` 영역(`markdown.svelte`)만 패치되고 댓글 영역(`comment-list.svelte`)에는 동일 룰이 적용되지 않음. 이후 #12050 Bluesky DID 임베드 작업이 `.embed-container` 경로만 다뤘기 때문에 raw iframe 케이스가 계속 노출됨.

## Test plan
- [ ] 로컬 dev에서 댓글에 YouTube `<iframe>` 임베드 입력 → 16:9로 표시되는지 확인
- [ ] `.embed-container` 래퍼 사용 케이스(정상 OEmbed) 동작 회귀 없는지 확인
- [ ] Twitter/Instagram 등 다른 플랫폼 임베드 영향 없음 확인 (해당 룰들은 `.embed-container[data-platform=...]` 셀렉터가 더 구체적이라 cascade 안전)
- [ ] svelte-check 0 errors (확인됨)

Closes #12081