### PR TITLE
fix(mention): @닉네임 멘션 링크가 404 인 문제 수정 (#9266)

### DIFF
--- a/apps/web/src/lib/utils/mention-parser.test.ts
+++ b/apps/web/src/lib/utils/mention-parser.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { extractMentions, highlightMentions } from './mention-parser';
+
+describe('extractMentions', () => {
+    it('extracts @nick from plain text', () => {
+        const result = extractMentions('hello @alice and @bob');
+        expect(result).toEqual(['alice', 'bob']);
+    });
+
+    it('deduplicates repeated mentions', () => {
+        const result = extractMentions('@alice @alice @bob');
+        expect(result).toEqual(['alice', 'bob']);
+    });
+
+    it('extracts from data-mention attribute in HTML', () => {
+        const html = '<span data-type="mention" data-mention="charlie">@charlie</span>';
+        expect(extractMentions(html)).toEqual(['charlie']);
+    });
+
+    it('ignores @ inside URLs and emails', () => {
+        const result = extractMentions(
+            'email me at user@example.com or visit https://x.com/u@page'
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('supports Korean nicknames', () => {
+        const result = extractMentions('@홍길동 안녕');
+        expect(result).toEqual(['홍길동']);
+    });
+
+    it('returns empty array for empty input', () => {
+        expect(extractMentions('')).toEqual([]);
+    });
+});
+
+describe('highlightMentions', () => {
+    it('wraps @nick with anchor pointing to /member/<nick> (regression #9266)', () => {
+        const result = highlightMentions('hi @alice');
+        expect(result).toContain('href="/member/alice"');
+        expect(result).toContain('data-mention="alice"');
+        expect(result).toContain('>@alice<');
+    });
+
+    it('does NOT use the legacy /profile/ route (regression #9266)', () => {
+        const result = highlightMentions('@alice');
+        expect(result).not.toContain('/profile/');
+        expect(result).not.toContain('href="/profile');
+    });
+
+    it('encodes Korean nicknames safely', () => {
+        const result = highlightMentions('안녕 @홍길동');
+        // encodeURIComponent("홍길동") === "%ED%99%8D%EA%B8%B8%EB%8F%99"
+        expect(result).toContain(`href="/member/${encodeURIComponent('홍길동')}"`);
+        // data-mention keeps the raw nickname for downstream consumers
+        expect(result).toContain('data-mention="홍길동"');
+    });
+
+    it('does not transform @ inside email/URL', () => {
+        const input = 'mail user@example.com';
+        const result = highlightMentions(input);
+        expect(result).toBe(input);
+    });
+
+    it('does not transform @ inside HTML tags', () => {
+        const input = '<a href="mailto:foo@bar.com">@inside</a> @outside';
+        const result = highlightMentions(input);
+        // tag content untouched
+        expect(result).toContain('mailto:foo@bar.com');
+        // outside the tag is wrapped
+        expect(result).toContain('href="/member/outside"');
+    });
+
+    it('returns input untouched when no mentions present', () => {
+        expect(highlightMentions('plain text')).toBe('plain text');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(highlightMentions('')).toBe('');
+    });
+});

--- a/apps/web/src/lib/utils/mention-parser.ts
+++ b/apps/web/src/lib/utils/mention-parser.ts
@@ -39,6 +39,9 @@ export function extractMentions(content: string): string[] {
  * plain text의 @닉네임을 클릭 가능한 링크로 변환
  * DOMPurify를 통과할 수 있도록 <a> 태그 사용
  * HTML 태그 내부 및 URL/이메일 내 @는 변환하지 않음
+ *
+ * 라우트 주의: 회원 프로필 라우트는 `/member/[id]` 이며 `[id]` 는 mb_id 이다.
+ * `/profile/...` 라우트는 존재하지 않으므로 사용 금지 (#9266).
  */
 export function highlightMentions(content: string): string {
     if (!content) return content;
@@ -51,7 +54,7 @@ export function highlightMentions(content: string): string {
             return part.replace(
                 /(?<![a-zA-Z0-9.+_\-/])@([a-zA-Z0-9_가-힣]+)/g,
                 (_match, nick) =>
-                    `<a href="/profile/${encodeURIComponent(nick)}" class="mention-link text-primary font-medium hover:underline" data-mention="${nick}">@${nick}</a>`
+                    `<a href="/member/${encodeURIComponent(nick)}" class="mention-link text-primary font-medium hover:underline" data-mention="${nick}">@${nick}</a>`
             );
         })
         .join('');


### PR DESCRIPTION
## 배경
댓글 본문의 \`@닉네임\` 멘션을 클릭하면 404 가 반환되는 버그(#9266).

원인: \`highlightMentions\` 가 \`/profile/<nick>\` 형식의 href 를 생성하지만, SvelteKit 라우트 트리에 \`/profile\` 디렉토리가 존재하지 않음. 실제 회원 프로필 라우트는 \`/member/[id]\` (\`apps/web/src/routes/member/[id]/+page.svelte\`).

## 변경 요약
- \`apps/web/src/lib/utils/mention-parser.ts\`
  - \`href=\"/profile/${nick}\"\` → \`href=\"/member/${nick}\"\`
  - encodeURIComponent 는 그대로 유지 (한글 닉 안전)
  - 라우트 주의 코멘트 추가 (mb_id 사용 명시)
- \`apps/web/src/lib/utils/mention-parser.test.ts\` 신규
  - extractMentions: 추출, 중복 제거, data-mention 속성, URL/이메일 제외, 한글 닉
  - highlightMentions: \`/member/<nick>\` 회귀 가드, \`/profile/\` 금지 가드, 한글 encode, 이메일/HTML 태그 무시

## 라우트 매개변수 메모
\`/member/[id]\` 의 \`[id]\` 는 \`mb_id\` 이며 백엔드 \`/api/members/[id]/profile\` 는 \`^[a-zA-Z0-9_-]+$\` 만 허용한다. 멘션 텍스트가 \`mb_id\` 와 동일한 경우(영문/숫자) 정상 동작한다. 한글 닉네임만 mention 한 경우는 별도 이슈로 mb_nick → mb_id 해석 게이트웨이가 필요하다 (이번 PR 범위 외).

## 검증
- \`pnpm exec vitest run src/lib/utils/mention-parser.test.ts\` → 13/13 passed
- \`pnpm check\` → 0 errors, 97 warnings(기존)
- \`pnpm build\` 는 서버 정책상 미실행 (CI 의존)

## Test plan
- [ ] 로컬 dev 에서 \`@영문ID\` 멘션 클릭 시 \`/member/<id>\` 로 정상 이동 확인
- [ ] 댓글에 \`@홍길동\` 입력 시 href 가 \`/member/%ED%99%8D...\` 로 인코딩 확인
- [ ] 이메일/URL 안의 \`@\` 가 변환되지 않는지 확인