### PR TITLE
feat(auth): 소셜 계정 추가 연결(link) 모드 백엔드 (#12037)

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/social-profile.ts
+++ b/apps/web/src/lib/server/auth/oauth/social-profile.ts
@@ -50,6 +50,73 @@ export async function deleteSocialProfile(mpNo: number, mbId: string): Promise<b
 }
 
 /**
+ * 소셜 계정 추가 연결 전용 함수 (#12037).
+ *
+ * `upsertSocialProfile` 와 달리 다른 회원에게 연결된 동일 (provider, identifier) 행을
+ * **삭제하지 않고** 충돌 시 에러를 던진다. 신규가입/재로그인 흐름에서는 기존
+ * `upsertSocialProfile` 를 그대로 사용한다.
+ *
+ * 동작:
+ * - 동일 (provider, identifier) 가 다른 mb_id 에 연결돼 있으면 `already_linked_other` throw
+ * - 동일 mb_id 에 이미 동일 (provider, identifier) 가 있으면 idempotent 처리 (UPDATE only)
+ * - 동일 mb_id 에 같은 provider 의 다른 identifier 가 있으면 갱신
+ *   (한 회원이 한 provider 에 여러 identifier 를 가지지 않는다는 기존 제약 유지)
+ * - 그 외 → INSERT
+ */
+export async function linkSocialProfile(
+    mbId: string,
+    provider: string,
+    profile: OAuthUserProfile
+): Promise<void> {
+    const providerLower = provider.toLowerCase();
+    const objectSha = createHash('sha1').update(JSON.stringify(profile)).digest('hex');
+
+    // 다른 mb_id 가 동일 (provider, identifier) 에 이미 연결돼 있으면 차단
+    const conflicting = await findSocialProfile(providerLower, profile.identifier);
+    if (conflicting && conflicting.mb_id !== mbId) {
+        const err = new Error('already_linked_other');
+        (err as Error & { code: string }).code = 'already_linked_other';
+        throw err;
+    }
+
+    // 동일 mb_id + 동일 provider 의 기존 행이 있으면 UPDATE (idempotent / identifier 갱신)
+    const existing = await findSocialProfileByMember(mbId, providerLower);
+    if (existing) {
+        await pool.query(
+            `UPDATE g5_member_social_profiles
+                 SET object_sha = ?, identifier = ?, profileurl = ?, photourl = ?,
+                     displayname = ?, mp_latest_day = NOW()
+                 WHERE mp_no = ?`,
+            [
+                objectSha,
+                profile.identifier,
+                profile.profileUrl || '',
+                profile.photoUrl || '',
+                profile.displayName || '',
+                existing.mp_no
+            ]
+        );
+        return;
+    }
+
+    // 신규 INSERT
+    await pool.query(
+        `INSERT INTO g5_member_social_profiles
+             (mb_id, provider, object_sha, identifier, profileurl, photourl, displayname, description, mp_register_day, mp_latest_day)
+             VALUES (?, ?, ?, ?, ?, ?, ?, '', NOW(), NOW())`,
+        [
+            mbId,
+            providerLower,
+            objectSha,
+            profile.identifier,
+            profile.profileUrl || '',
+            profile.photoUrl || '',
+            profile.displayName || ''
+        ]
+    );
+}
+
+/**
  * 소셜 프로필 저장/업데이트
  * PHP의 social_user_profile_replace() 호환
  */

--- a/apps/web/src/lib/server/auth/oauth/state.test.ts
+++ b/apps/web/src/lib/server/auth/oauth/state.test.ts
@@ -1,0 +1,52 @@
+/**
+ * OAuth state 쿠키 round-trip 테스트.
+ * #12037 추가 연결(link) 모드의 linkTo 필드를 state 에 저장/검증하는 흐름을 보호한다.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { Cookies } from '@sveltejs/kit';
+
+vi.mock('$app/environment', () => ({ dev: true }));
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+import { createOAuthState, validateOAuthState } from './state.js';
+
+function createFakeCookies(): Cookies {
+    const store = new Map<string, string>();
+    return {
+        get: (name: string) => store.get(name),
+        set: (name: string, value: string) => {
+            store.set(name, value);
+        },
+        delete: (name: string) => {
+            store.delete(name);
+        },
+        getAll: () => Array.from(store.entries()).map(([name, value]) => ({ name, value })),
+        serialize: () => ''
+    } as unknown as Cookies;
+}
+
+describe('OAuth state with linkTo', () => {
+    it('round-trips state with linkTo when provided', () => {
+        const cookies = createFakeCookies();
+        const state = createOAuthState(cookies, 'apple', '/member/settings', 'mb_user_a');
+        const data = validateOAuthState(cookies, state);
+        expect(data).not.toBeNull();
+        expect(data?.linkTo).toBe('mb_user_a');
+        expect(data?.provider).toBe('apple');
+        expect(data?.redirect).toBe('/member/settings');
+    });
+
+    it('omits linkTo when not provided (regular login flow)', () => {
+        const cookies = createFakeCookies();
+        const state = createOAuthState(cookies, 'google', '/');
+        const data = validateOAuthState(cookies, state);
+        expect(data).not.toBeNull();
+        expect(data?.linkTo).toBeUndefined();
+    });
+
+    it('returns null when state mismatches (CSRF)', () => {
+        const cookies = createFakeCookies();
+        createOAuthState(cookies, 'naver', '/', 'mb_user_a');
+        expect(validateOAuthState(cookies, 'attacker_state')).toBeNull();
+    });
+});

--- a/apps/web/src/lib/server/auth/oauth/state.ts
+++ b/apps/web/src/lib/server/auth/oauth/state.ts
@@ -20,7 +20,8 @@ function generateRandomState(): string {
 export function createOAuthState(
     cookies: Cookies,
     provider: SocialProvider,
-    redirectUrl: string
+    redirectUrl: string,
+    linkTo?: string
 ): string {
     const state = generateRandomState();
 
@@ -28,7 +29,8 @@ export function createOAuthState(
         state,
         provider,
         redirect: redirectUrl,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        ...(linkTo ? { linkTo } : {})
     };
 
     cookies.set(STATE_COOKIE_NAME, JSON.stringify(data), {

--- a/apps/web/src/lib/server/auth/oauth/types.ts
+++ b/apps/web/src/lib/server/auth/oauth/types.ts
@@ -81,4 +81,10 @@ export interface OAuthStateData {
     provider: SocialProvider;
     redirect: string;
     timestamp: number;
+    /**
+     * 추가 연결(link) 모드일 때 연결 대상 mb_id.
+     * 서버 세션에서 직접 채워 넣으며, 클라이언트가 임의로 주입할 수 없음.
+     * 콜백에서 `locals.user.id === linkTo` 를 재검증한다.
+     */
+    linkTo?: string;
 }

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -10,7 +10,11 @@ import { normalizeProviderName, getProvider } from '$lib/server/auth/oauth/provi
 import { resolveOrigin } from '$lib/server/auth/oauth/config.js';
 import { safeRedirectUrl } from '$lib/server/safe-redirect.js';
 import { validateOAuthState } from '$lib/server/auth/oauth/state.js';
-import { findSocialProfile, upsertSocialProfile } from '$lib/server/auth/oauth/social-profile.js';
+import {
+    findSocialProfile,
+    linkSocialProfile,
+    upsertSocialProfile
+} from '$lib/server/auth/oauth/social-profile.js';
 import {
     getMemberById,
     findMemberByEmail,
@@ -91,6 +95,7 @@ async function generateInviteTempNickname(provider: string): Promise<string> {
 async function handleCallback(
     providerSlug: string,
     cookies: Parameters<RequestHandler>[0]['cookies'],
+    locals: Parameters<RequestHandler>[0]['locals'],
     code: string,
     stateParam: string,
     clientIp: string,
@@ -137,6 +142,41 @@ async function handleCallback(
             );
         } else {
             profile = await provider.getUserProfile(tokenResponse.access_token);
+        }
+
+        // 4-link. 추가 연결 모드(link)면 신규가입/세션재발급 로직을 모두 우회 (#12037)
+        if (stateData.linkTo) {
+            // 세션 재검증: state.linkTo 와 현재 로그인 세션이 정확히 일치해야 함
+            const sessionMbId = locals.user?.id;
+            if (!sessionMbId) {
+                redirect(
+                    302,
+                    `/login?redirect=${encodeURIComponent(stateData.redirect || '/member/settings')}`
+                );
+            }
+            if (sessionMbId !== stateData.linkTo) {
+                redirect(302, '/member/settings?error=link_session_mismatch');
+            }
+
+            try {
+                await linkSocialProfile(stateData.linkTo, providerName, profile);
+            } catch (linkErr) {
+                if (
+                    linkErr instanceof Error &&
+                    (linkErr as Error & { code?: string }).code === 'already_linked_other'
+                ) {
+                    redirect(
+                        302,
+                        `/member/settings?error=already_linked_other&provider=${providerName}`
+                    );
+                }
+                console.error('[OAuth Link]', providerName, linkErr);
+                redirect(302, `/member/settings?error=link_failed&provider=${providerName}`);
+            }
+
+            // 회원 캐시 무효화 후 세션 유지하며 설정 페이지로
+            await invalidateMemberCache(stateData.linkTo);
+            redirect(302, `/member/settings?linked=${providerName}`);
         }
 
         // 5. g5_member_social_profiles에서 기존 연결 확인
@@ -361,7 +401,14 @@ async function handleCallback(
 }
 
 /** GET 콜백 (대부분의 프로바이더) */
-export const GET: RequestHandler = async ({ url, cookies, request, getClientAddress, params }) => {
+export const GET: RequestHandler = async ({
+    url,
+    cookies,
+    request,
+    getClientAddress,
+    params,
+    locals
+}) => {
     const code = url.searchParams.get('code');
     const stateParam = url.searchParams.get('state');
     const errorParam = url.searchParams.get('error');
@@ -376,11 +423,17 @@ export const GET: RequestHandler = async ({ url, cookies, request, getClientAddr
 
     const clientIp = getClientAddress();
     const origin = resolveOrigin(request);
-    return handleCallback(params.provider!, cookies, code, stateParam, clientIp, origin);
+    return handleCallback(params.provider!, cookies, locals, code, stateParam, clientIp, origin);
 };
 
 /** POST 콜백 (Apple response_mode=form_post) */
-export const POST: RequestHandler = async ({ cookies, request, getClientAddress, params }) => {
+export const POST: RequestHandler = async ({
+    cookies,
+    request,
+    getClientAddress,
+    params,
+    locals
+}) => {
     const formData = await request.formData();
     const code = formData.get('code') as string;
     const stateParam = formData.get('state') as string;
@@ -396,5 +449,5 @@ export const POST: RequestHandler = async ({ cookies, request, getClientAddress,
 
     const clientIp = getClientAddress();
     const origin = resolveOrigin(request);
-    return handleCallback(params.provider!, cookies, code, stateParam, clientIp, origin);
+    return handleCallback(params.provider!, cookies, locals, code, stateParam, clientIp, origin);
 };

--- a/apps/web/src/routes/auth/start/+server.ts
+++ b/apps/web/src/routes/auth/start/+server.ts
@@ -16,12 +16,25 @@ import { TwitterProvider } from '$lib/server/auth/oauth/providers/twitter.js';
 
 const COOKIE_DOMAIN = env.COOKIE_DOMAIN || undefined;
 
-export const GET: RequestHandler = async ({ url, cookies, request }) => {
+export const GET: RequestHandler = async ({ url, cookies, request, locals }) => {
     const providerParam = url.searchParams.get('provider');
     const redirectUrl = url.searchParams.get('redirect') || '/';
+    // 추가 연결(link) 모드 — 쿼리 파라미터는 단순 플래그이며,
+    // 실제 연결 대상 mb_id 는 서버 세션에서만 결정한다 (#12037).
+    const isLinkMode = url.searchParams.get('link') === '1';
 
     if (!providerParam || !isValidProvider(providerParam)) {
         return new Response('지원하지 않는 로그인 방식입니다', { status: 400 });
+    }
+
+    // link=1 인데 비로그인이면 차단. 클라이언트가 임의 linkTo 를 박아도 무시된다.
+    let linkTo: string | undefined;
+    if (isLinkMode) {
+        const sessionMbId = locals.user?.id;
+        if (!sessionMbId) {
+            return new Response('로그인이 필요합니다', { status: 401 });
+        }
+        linkTo = sessionMbId;
     }
 
     const providerName = providerParam.toLowerCase() as SocialProvider;
@@ -29,7 +42,7 @@ export const GET: RequestHandler = async ({ url, cookies, request }) => {
     try {
         const origin = resolveOrigin(request);
         const provider = await getProvider(providerName, origin);
-        const state = createOAuthState(cookies, providerName, redirectUrl);
+        const state = createOAuthState(cookies, providerName, redirectUrl, linkTo);
 
         // Twitter는 PKCE 사용
         if (provider instanceof TwitterProvider) {


### PR DESCRIPTION
## 배경

- #12037 (4/22): 로그인 상태에서 Apple 소셜 추가 연결 시도 → `/login` 으로 우회된 뒤 **신규 회원가입 플로우** 로 빠짐
- 근본 원인: OAuth 파이프라인 전체에 "추가 연결(link)" 개념이 없음
- 설계 문서: `docs/2026-04-23-social-link-design-12037.md`

본 PR 은 **PR-A (백엔드 분리)**. UI 변경(`/member/settings` provider picker)은 별도 PR-B 로 진행. PR-A 머지 후 PR-B 가 의존.

## Summary

- `OAuthStateData.linkTo?` 추가 (state 쿠키에 추가 연결 대상 `mb_id` 저장)
- `/auth/start?link=1` → **서버 세션의 `locals.user.id` 만** state.linkTo 에 박아 넣음 · 비로그인 401
- `/auth/callback`: state.linkTo 분기 신설
  - 세션 재검증 (`locals.user.id === state.linkTo`)
  - 신규가입 / 임시계정 / 세션재발급 / 이메일 매칭 등의 기존 로직 **모두 우회**
  - 충돌 (다른 mb_id 가 동일 identifier 보유) → `?error=already_linked_other`
  - 성공 → `/member/settings?linked=<provider>`
- `linkSocialProfile()` 신설: `upsertSocialProfile` 의 `DELETE` 동작 없이 INSERT 만 수행 · 같은 mb_id 에 동일 provider 행이 있으면 idempotent UPDATE
- 단위 테스트 3건 (state round-trip with linkTo / 없을 때 omit / state 불일치)

## 보안

- `linkTo` 는 **서버 세션에서만** 채워짐. 클라이언트가 `?link=1&linkTo=victim_id` 같은 임의 파라미터를 보내도 서버가 무시
- callback 에서 `locals.user.id !== state.linkTo` 면 `link_session_mismatch` 로 차단 (세션 탈취/만료 방어)
- 다른 mb_id 가 점유 중인 (provider, identifier) 는 INSERT 거부 — 피해자 연결 하이재킹 방지

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/server/auth/oauth/types.ts` | `OAuthStateData.linkTo?` 추가 |
| `lib/server/auth/oauth/state.ts` | `createOAuthState(... , linkTo?)` 시그니처 확장 |
| `lib/server/auth/oauth/social-profile.ts` | `linkSocialProfile()` 신설 |
| `routes/auth/start/+server.ts` | `link=1` 처리 + 비로그인 401 |
| `routes/auth/callback/[provider]/+server.ts` | link 분기 + 세션 재검증 |
| `lib/server/auth/oauth/state.test.ts` | 신규 단위 테스트 |

## Test plan

- [x] `pnpm check` — 본 PR 변경 파일에서 0 error / 0 warning (zod 미설치 관련 2 error 는 main 에 기존 존재)
- [x] `pnpm test:unit src/lib/server/auth/oauth/state.test.ts` — 3 tests pass
- [ ] dev 환경 수동 검증
  - [ ] Google 로그인 상태에서 `/auth/start?provider=apple&link=1&redirect=/member/settings` 직접 호출 → Apple 인가 화면
  - [ ] 콜백 후 `/member/settings?linked=apple` 도착, 세션 유지
  - [ ] 비로그인에서 `link=1` 호출 → 401
  - [ ] 같은 Apple identifier 재시도 → idempotent
  - [ ] 다른 회원이 점유한 Apple identifier → `?error=already_linked_other`
- [ ] 기존 회귀
  - [ ] 비로그인 신규 Apple 로그인 → 회원가입 플로우 정상
  - [ ] 기존 Google 사용자 재로그인 → 세션 발급 정상

## 후속 작업

- **PR-B**: `/member/settings` 에 provider picker UI 추가 (이 백엔드를 호출). 머지/배포 순서: PR-A → PR-B
- #11818 (소셜 계정 수정 기능)은 PR-B 이후 별도 검토