### PR TITLE
feat(discipline): 운영 도구 보강 — 필터/바로가기/항목 클릭 (#12117 #12119 #12121)

### DIFF
--- a/apps/web/src/routes/disciplinelog/+page.server.ts
+++ b/apps/web/src/routes/disciplinelog/+page.server.ts
@@ -8,9 +8,15 @@ import { safeJson } from '$lib/api/safe-json.js';
 export const load: PageServerLoad = async ({ url }) => {
     const page = Number(url.searchParams.get('page')) || 1;
     const limit = 20;
+    const memberId = url.searchParams.get('member_id')?.trim() || '';
+
+    let endpoint = `/api/v1/discipline-logs?page=${page}&limit=${limit}`;
+    if (memberId) {
+        endpoint += `&member_id=${encodeURIComponent(memberId)}`;
+    }
 
     try {
-        const response = await backendFetch(`/api/v1/discipline-logs?page=${page}&limit=${limit}`, {
+        const response = await backendFetch(endpoint, {
             headers: {
                 Accept: 'application/json',
                 'User-Agent': 'Angple-Web-SSR/1.0'
@@ -18,7 +24,7 @@ export const load: PageServerLoad = async ({ url }) => {
         });
 
         if (!response.ok) {
-            return { logs: [], total: 0, page, limit };
+            return { logs: [], total: 0, page, limit, memberId };
         }
 
         const result = await safeJson(response);
@@ -26,9 +32,10 @@ export const load: PageServerLoad = async ({ url }) => {
             logs: result.data || [],
             total: result.meta?.total || 0,
             page,
-            limit
+            limit,
+            memberId
         };
     } catch {
-        return { logs: [], total: 0, page, limit };
+        return { logs: [], total: 0, page, limit, memberId };
     }
 };

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -5,10 +5,13 @@
     import { goto } from '$app/navigation';
     import * as Card from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
+    import { Input } from '$lib/components/ui/input/index.js';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import ChevronLeft from '@lucide/svelte/icons/chevron-left';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
     import Shield from '@lucide/svelte/icons/shield';
+    import Search from '@lucide/svelte/icons/search';
+    import X from '@lucide/svelte/icons/x';
     import { getPenaltyDisplay } from '$lib/api/discipline-log.js';
     import BoardFavoriteButton from '$lib/components/features/board/board-favorite-button.svelte';
     import BoardSubscribeButton from '$lib/components/features/board/board-subscribe-button.svelte';
@@ -19,14 +22,41 @@
     const logs = $derived(data.logs || []);
     const total = $derived(data.total || 0);
     const currentPage = $derived(data.page || 1);
+    const memberIdFilter = $derived(data.memberId || '');
     const pageSize = 20;
     const totalPages = $derived(Math.max(1, Math.ceil(total / pageSize)));
+
+    // 필터 입력값 (URL query 와 동기화)
+    let searchInput = $state('');
+    $effect(() => {
+        searchInput = memberIdFilter;
+    });
 
     function goToPage(page: number) {
         if (page < 1 || page > totalPages) return;
         const url = new URL(window.location.href);
         url.searchParams.set('page', String(page));
         goto(url.pathname + url.search);
+    }
+
+    function applyFilter() {
+        const value = searchInput.trim();
+        const params = new URLSearchParams();
+        if (value) params.set('member_id', value);
+        const qs = params.toString();
+        goto(`/disciplinelog${qs ? `?${qs}` : ''}`);
+    }
+
+    function clearFilter() {
+        searchInput = '';
+        goto('/disciplinelog');
+    }
+
+    function handleSearchKeydown(e: KeyboardEvent) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            applyFilter();
+        }
     }
 
     function getPenaltyBadgeVariant(
@@ -66,6 +96,39 @@
             <Card.Description>규정을 위반한 회원에 대한 제재 기록입니다.</Card.Description>
         </Card.Header>
         <Card.Content>
+            <!-- 회원 필터 (아이디/닉네임은 백엔드 검색 키 동일 — member_id 기준) -->
+            <div class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div class="relative flex-1">
+                    <Search
+                        class="text-muted-foreground pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2"
+                    />
+                    <Input
+                        type="text"
+                        placeholder="회원 아이디로 검색"
+                        class="pl-9"
+                        bind:value={searchInput}
+                        onkeydown={handleSearchKeydown}
+                    />
+                </div>
+                <div class="flex gap-2">
+                    <Button onclick={applyFilter} class="gap-1">
+                        <Search class="h-4 w-4" />
+                        검색
+                    </Button>
+                    {#if memberIdFilter}
+                        <Button variant="outline" onclick={clearFilter} class="gap-1">
+                            <X class="h-4 w-4" />
+                            전체
+                        </Button>
+                    {/if}
+                </div>
+            </div>
+            {#if memberIdFilter}
+                <div class="text-muted-foreground mb-4 text-sm">
+                    <span class="font-medium">{memberIdFilter}</span> 회원의 이용제한 기록만 표시 중
+                    (총 {total}건)
+                </div>
+            {/if}
             {#if logs.length === 0}
                 <div class="text-muted-foreground flex flex-col items-center justify-center py-12">
                     <p>이용제한 기록이 없습니다.</p>

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -3,7 +3,6 @@
      * 이용제한 기록 상세 페이지
      */
     import { page } from '$app/state';
-    import { onMount } from 'svelte';
     import * as Card from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import { Badge } from '$lib/components/ui/badge/index.js';
@@ -31,29 +30,36 @@
 
     const id = $derived(Number(page.params.id));
 
-    async function fetchMemberHistory(memberId: string) {
+    async function fetchMemberHistory(memberId: string, currentId: number) {
         try {
             const result = await getDisciplineLogs(1, 100, memberId);
+            // race-condition 방지: 이미 다른 id 로 이동했으면 폐기
+            if (currentId !== id) return;
             memberHistory = result.data;
         } catch {
+            if (currentId !== id) return;
             memberHistory = [];
         }
     }
 
-    async function fetchLog() {
+    async function fetchLog(targetId: number) {
         loading = true;
         error = null;
+        memberHistory = [];
         try {
-            const result = await getDisciplineLog(id);
+            const result = await getDisciplineLog(targetId);
+            // 비동기 응답 도착 시점에 id 가 바뀌었으면 폐기 (race-condition 방지)
+            if (targetId !== id) return;
             log = result.data;
             if (log.member_id) {
-                fetchMemberHistory(log.member_id);
+                fetchMemberHistory(log.member_id, targetId);
             }
-        } catch (e) {
+        } catch {
+            if (targetId !== id) return;
             error = '이용제한 기록을 불러오는데 실패했습니다.';
             log = null;
         } finally {
-            loading = false;
+            if (targetId === id) loading = false;
         }
     }
 
@@ -112,8 +118,11 @@
         return !!authStore.user && log.member_id === authStore.user.mb_id;
     }
 
-    onMount(() => {
-        fetchLog();
+    // id 가 바뀔 때마다 재조회 (목록/회원 이력에서 다른 row 클릭 시에도 반영)
+    $effect(() => {
+        if (Number.isFinite(id) && id > 0) {
+            fetchLog(id);
+        }
     });
 </script>
 
@@ -141,7 +150,9 @@
             >
                 <AlertTriangle class="mb-4 h-12 w-12" />
                 <p>{error || '이용제한 기록을 찾을 수 없습니다.'}</p>
-                <Button variant="outline" class="mt-4" onclick={() => fetchLog()}>다시 시도</Button>
+                <Button variant="outline" class="mt-4" onclick={() => fetchLog(id)}
+                    >다시 시도</Button
+                >
             </Card.Content>
         </Card.Root>
     {:else}

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -575,9 +575,23 @@
                         <!-- 이용제한 이력 -->
                         {#if p.discipline_history?.length > 0}
                             <div class="border-border rounded-lg border p-3">
-                                <div class="flex items-center gap-2 text-sm">
-                                    <Shield class="text-destructive h-4 w-4" />
-                                    <span class="text-foreground font-medium">이용제한 내역</span>
+                                <div class="flex items-center justify-between gap-2 text-sm">
+                                    <div class="flex items-center gap-2">
+                                        <Shield class="text-destructive h-4 w-4" />
+                                        <span class="text-foreground font-medium"
+                                            >이용제한 내역</span
+                                        >
+                                    </div>
+                                    {#if p.mb_id}
+                                        <a
+                                            href="/disciplinelog?member_id={encodeURIComponent(
+                                                p.mb_id
+                                            )}"
+                                            class="text-primary text-xs hover:underline"
+                                        >
+                                            전체 보기
+                                        </a>
+                                    {/if}
                                 </div>
                                 <ul class="mt-2 space-y-1">
                                     {#each p.discipline_history as d, i}
@@ -605,17 +619,29 @@
                             </div>
                         {:else if p.discipline}
                             <div class="border-border rounded-lg border p-3">
-                                <div class="flex items-center gap-2 text-sm">
-                                    <Shield class="text-destructive h-4 w-4" />
-                                    <span class="text-destructive font-medium">
-                                        {#if p.discipline.penalty_period > 0}
-                                            {p.discipline.penalty_period}일 이용제한
-                                        {:else if p.discipline.penalty_period === 0}
-                                            주의
-                                        {:else}
-                                            영구정지
-                                        {/if}
-                                    </span>
+                                <div class="flex items-center justify-between gap-2 text-sm">
+                                    <div class="flex items-center gap-2">
+                                        <Shield class="text-destructive h-4 w-4" />
+                                        <span class="text-destructive font-medium">
+                                            {#if p.discipline.penalty_period > 0}
+                                                {p.discipline.penalty_period}일 이용제한
+                                            {:else if p.discipline.penalty_period === 0}
+                                                주의
+                                            {:else}
+                                                영구정지
+                                            {/if}
+                                        </span>
+                                    </div>
+                                    {#if p.mb_id}
+                                        <a
+                                            href="/disciplinelog?member_id={encodeURIComponent(
+                                                p.mb_id
+                                            )}"
+                                            class="text-primary text-xs hover:underline"
+                                        >
+                                            전체 보기
+                                        </a>
+                                    {/if}
                                 </div>
                                 <p class="text-muted-foreground mt-1 text-xs">
                                     {p.discipline.penalty_date_from?.split(' ')[0] || ''}


### PR DESCRIPTION
## Summary

이용제한(disciplinelog) 게시판/프로필/상세 페이지의 운영 편의성 개선 3건 묶음.

- **#12117 — 회원 필터 UI**: `/disciplinelog` 상단에 회원 아이디 검색 입력 추가. 이미 백엔드는 `?member_id=` 쿼리를 지원하고 있었으나 UI가 없어 사용 불가능했음.
- **#12119 — 프로필 → 게시판 바로가기**: 회원 프로필 (`/member/[id]`) 의 이용제한 내역 박스 우측 상단에 "전체 보기" 링크 추가 → `/disciplinelog?member_id=<mb_id>`.
- **#12121 — 상세 페이지 row 클릭 미작동**: `/disciplinelog/[id]` 의 "이 회원의 전체 이용제한 내역" row 클릭 시 URL은 바뀌지만 화면 데이터가 재조회되지 않던 버그. `onMount` 단발 호출 → `$effect(id)` 로 교체하여 동일 [id] 라우트 내 이동 시에도 재조회되도록 수정. race-condition 방지 가드 포함.

## 변경 파일

- `apps/web/src/routes/disciplinelog/+page.server.ts` — `?member_id=` 쿼리 처리
- `apps/web/src/routes/disciplinelog/+page.svelte` — 검색 UI + Enter 즉시 검색 + 필터 안내 배너
- `apps/web/src/routes/disciplinelog/[id]/+page.svelte` — `$effect` 기반 재조회 + race-condition 가드
- `apps/web/src/routes/member/[id]/+page.svelte` — "전체 보기" 링크 (두 케이스: discipline_history / discipline)

## 권한 / 정책

- 권한 체크 변경 없음. 모든 회원이 disciplinelog 조회 가능한 기존 정책 유지.
- 백엔드 변경 없음 — 기존 `?member_id=` 파라미터 재사용.

## Test plan

- [ ] `/disciplinelog` 접근 → 검색 입력 노출 확인
- [ ] `/disciplinelog?member_id=test1234` 직접 접근 → 해당 회원 기록만 표시 + 안내 배너 표시
- [ ] 검색창에 회원 아이디 입력 후 Enter → 동일 동작
- [ ] "전체" 버튼 클릭 → `/disciplinelog` 로 이동, 필터 해제
- [ ] 페이지네이션 시 `member_id` 쿼리 유지 확인
- [ ] `/member/<id>` 접근 → 이용제한 내역 박스 우측 상단 "전체 보기" 노출 → 클릭 시 필터 적용된 disciplinelog 로 이동
- [ ] `/disciplinelog/<id>` 진입 → 하단 "이 회원의 전체 이용제한 내역" 다른 row 클릭 → 새 row 의 상세로 데이터 갱신 확인
- [ ] 빠른 연속 클릭 시 stale 응답이 화면에 반영되지 않는지 확인

## 회귀 위험 평가

- **낮음**: UI 추가/리팩터 위주이며 데이터 모델/권한/백엔드 무변경.
- **유의 1**: detail 페이지 `onMount` → `$effect` 전환은 SvelteKit reactivity 변경. 다만 신규 fetch 함수가 항상 `targetId === id` 검사로 stale 응답을 폐기하므로 race-condition 위험 낮음.
- **유의 2**: 검색 입력은 백엔드 `member_id` 정확 일치 검색에 의존 (부분일치/닉네임 검색은 별도 백엔드 작업 필요).

## 참고

- `docs/2026-04-28-discipline-data-flow-analysis.md`
- `docs/2026-04-28-discipline-system-audit.md`
- 선행 PR #1319 (profile SQL fix) 머지로 데이터 자체는 정상 표시됨