### PR TITLE
fix(editor): TipTap 묶음 — 편집 모드 링크/이미지 후 줄바꿈 (#9223 #9328)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -264,6 +264,22 @@
             ],
             content,
             editable: !disabled,
+            // #9223: 편집 모드에서 링크(<a>) 클릭 시 외부 이동 방지.
+            // Link extension 의 openOnClick:false 는 mark 만 처리하므로,
+            // LinkedImage 가 렌더하는 <a><img></a> 구조에서는 브라우저 기본 동작이 살아있음.
+            // ProseMirror DOM 이벤트로 anchor 클릭을 일괄 차단한다.
+            editorProps: {
+                handleDOMEvents: {
+                    click: (_view, event) => {
+                        const target = event.target as HTMLElement | null;
+                        const anchor = target?.closest?.('a');
+                        if (anchor) {
+                            event.preventDefault();
+                        }
+                        return false;
+                    }
+                }
+            },
             onUpdate: ({ editor: ed }) => {
                 onUpdate?.(ed.getHTML());
                 // Svelte $state 변경은 Tiptap 트랜잭션 밖에서 실행 (state_unsafe_mutation 방지)
@@ -332,7 +348,8 @@
         try {
             const imageUrl = await onImageUpload(file);
             if (imageUrl) {
-                editor.chain().focus().setImage({ src: imageUrl }).run();
+                // #9328: 이미지 삽입 후 빈 paragraph 추가 — 사용자가 이미지 다음 줄에 바로 입력 가능하도록
+                editor.chain().focus().setImage({ src: imageUrl }).createParagraphNear().run();
             }
         } catch (err) {
             console.error('Image upload failed:', err);
@@ -351,9 +368,13 @@
             const imageUrl = await onImageUpload(file);
             if (imageUrl) {
                 // 특정 위치에 이미지 삽입 (기존 내용 유지)
+                // #9328: 이미지 다음에 빈 paragraph 함께 삽입 — 사용자가 이미지 아래 줄에 바로 입력 가능하도록
                 editor
                     .chain()
-                    .insertContentAt(pos, { type: 'image', attrs: { src: imageUrl } })
+                    .insertContentAt(pos, [
+                        { type: 'image', attrs: { src: imageUrl } },
+                        { type: 'paragraph' }
+                    ])
                     .run();
             }
         } catch (err) {
@@ -617,10 +638,12 @@
             editor.chain().focus().setTextSelection(to).run();
         }
 
+        // #9328: 이미지 삽입 후 빈 paragraph 추가 — 사용자가 이미지 다음 줄에 바로 입력 가능하도록
         editor
             .chain()
             .focus()
             .setImage({ src: imageUrl, alt: imageAlt || '' })
+            .createParagraphNear()
             .run();
 
         showImageDialog = false;


### PR DESCRIPTION
## Summary

TipTap 에디터 UX 묶음 fix (Brief B / 2026-04-30 bug-sweep follow-up).

- **#9223**: 편집 모드에서 링크 클릭 시 외부 사이트로 이동되는 문제 수정. `Link.configure({ openOnClick: false })` 는 Link mark 에만 동작하지만, `LinkedImage` 가 렌더하는 `<a><img></a>` 구조에서는 브라우저 기본 anchor 동작이 살아 있었음. `editorProps.handleDOMEvents.click` 으로 에디터 내부 anchor 클릭을 일괄 `preventDefault` 처리.
- **#9328**: 이미지 삽입 후 커서가 이미지 노드에 갇혀 다음 줄 입력이 어려운 문제 수정. 3개 삽입 경로(파일 업로드, 드래그앤드롭, URL 다이얼로그) 모두 이미지 뒤에 빈 paragraph 가 생성되도록 보강.

## 변경 파일
- `apps/web/src/lib/components/features/editor/tiptap-editor.svelte`
  - `editorProps.handleDOMEvents.click` 추가 (#9223)
  - `handleImageFile`: `setImage` 뒤 `createParagraphNear()` 체이닝 (#9328)
  - `handleImageFileAtPosition`: `insertContentAt` 시 image+paragraph 배열 삽입 (#9328)
  - `insertImage` (URL 다이얼로그): `setImage` 뒤 `createParagraphNear()` 체이닝 (#9328)

## 회귀 위험
낮음 — TipTap extension/chain 설정만 변경. 기존 텍스트 편집/링크 mark/이미지 렌더는 영향 없음.
- 링크 클릭 차단은 에디터 내부 (`ProseMirror` DOM) 한정 — 본문 렌더 화면(읽기 모드)은 영향 없음.
- 이미지 다음 빈 paragraph 는 콘텐츠 저장 시 정상 HTML (`<p></p>`) 로 직렬화되어 화면 표시에도 자연스러움.

## Test plan
- [ ] 편집 화면에서 본문 내 링크 클릭 시 외부 이동되지 않음 (#9223)
- [ ] 편집 화면에서 이미지(LinkedImage) 클릭 시 외부 이동되지 않음 (#9223)
- [ ] 본문 렌더 화면(글 보기)에서 링크 클릭 시 정상적으로 외부 이동 (회귀 없음 확인)
- [ ] 파일 업로드로 이미지 삽입 후 바로 텍스트 입력 가능 (#9328)
- [ ] 드래그앤드롭으로 이미지 삽입 후 다음 줄에 텍스트 입력 가능 (#9328)
- [ ] URL 다이얼로그로 이미지 삽입 후 다음 줄에 텍스트 입력 가능 (#9328)
- [ ] svelte-check 신규 에러 없음 (확인 완료 — pre-existing zod 에러 2건만 잔존, 본 변경과 무관)