### PR TITLE
fix: XS 묶음 — 메인 스크롤바/글쓰기 헤더/모바일 메뉴 (#11769 #9220 #9270)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -139,7 +139,7 @@
                 )}
                 <details class="mt-1" open={hasShiftActive || undefined}>
                     <summary
-                        class="text-muted-foreground hover:text-foreground flex cursor-pointer select-none items-center gap-1 px-2 py-1 text-[10px] transition-colors"
+                        class="text-muted-foreground hover:text-foreground flex cursor-pointer select-none items-center gap-1 px-2 py-1 text-xs transition-colors"
                     >
                         <ChevronRight
                             class="h-3 w-3 transition-transform duration-200 [[open]_&]:rotate-90"
@@ -152,7 +152,7 @@
                             <a
                                 href="/{entry.boardId}"
                                 class={cn(
-                                    'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors',
+                                    'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
                                     active
                                         ? 'bg-primary text-primary-foreground'
                                         : 'hover:bg-accent text-muted-foreground'

--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -44,7 +44,7 @@
 </script>
 
 {#if visibleMenus.length > 0}
-    <nav class="flex gap-1.5 overflow-x-auto {className}" aria-label="빠른 이동">
+    <nav class="tag-nav flex gap-1.5 overflow-x-auto {className}" aria-label="빠른 이동">
         {#each visibleMenus as menu (menu.key)}
             <a
                 href={menu.url}
@@ -68,3 +68,13 @@
         {/each}
     </nav>
 {/if}
+
+<style>
+    /* #11769 메인 바로가기 가로 스크롤바 숨김 (스크롤 동작은 유지) */
+    .tag-nav {
+        scrollbar-width: none;
+    }
+    .tag-nav::-webkit-scrollbar {
+        display: none;
+    }
+</style>


### PR DESCRIPTION
## Summary

XS 묶음 PR — 1차 fix sweep (XS 3건 중 2건 적용, 1건 이미 해소).

### 적용 (2건)

- **#11769 메인 바로가기 가로 스크롤바 거슬림** — `lib/components/ui/tag-nav/tag-nav.svelte`
  - `scrollbar-width: none` + `::-webkit-scrollbar { display: none }` 추가
  - 스크롤 동작은 유지하고 시각적 스크롤바만 제거

- **#9270 [폰] 왼쪽 추가 메뉴 텍스트 크기 개선** — `lib/components/layout/sidebar.svelte`
  - "추가 단축키" 섹션의 summary 글자 `text-[10px]` → `text-xs` (1단계 ↑)
  - shift slot 항목 글자 `text-xs` → `text-sm` (1단계 ↑)

### Skip (1건)

- **#9220 글쓰기 화면 게시판명 헤더 표시** — 이미 PR #998 에서 적용됨
  - `routes/[boardId]/write/+page.svelte` line 234 에 `<h1 class="text-foreground mb-4 text-xl font-bold">{boardTitle} — 새 글 작성</h1>` 존재
  - 추가 변경 없음

## Test plan

- [ ] 메인 페이지에서 tag-nav 영역 가로 스크롤바 노출 안 됨 확인 (Chrome / Safari / Firefox)
- [ ] tag-nav 좌우 swipe 스크롤 정상 동작 (모바일)
- [ ] 사이드바 즐겨찾기에 "추가 단축키" (Shift+숫자 슬롯) 등록한 회원 화면에서 글자 크기 1단계 커진 것 시인성 확인
- [ ] 글쓰기 화면 (`/free/write` 등) 진입 시 게시판명 헤더 노출 (#9220 회귀 확인)
- [ ] svelte-check 0 errors (워크플로우에서)

## 참고

분석 보고서: `/home/angple/docs/2026-04-30-bug-sweep-followup-batch.md` Brief A 섹션