### PR TITLE
fix: S 묶음 — 페이지네이션/하단 목록/댓글 글씨 크기 (#11941 #11972 #9365)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -22,6 +22,8 @@
     import { uiSettingsStore, type ListViewMode } from '$lib/stores/ui-settings.svelte.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { pluginStore } from '$lib/stores/plugin.svelte.js';
+    import { goto } from '$app/navigation';
+    import { page as pageStore } from '$app/stores';
 
     // 코어 레이아웃 초기화 (중복 호출 안전)
     initCoreLayouts();
@@ -146,9 +148,28 @@
     // 목록 컨테이너 참조
     let listContainer: HTMLElement | undefined = $state();
 
-    // 페이지 변경
+    // 게시글 상세 하단의 페이지네이션은 목록 페이지(/[boardId]?page=N)로 이동
+    // (#11972) — 본문 + 목록 동시 로드 회피, 사용자가 목록 컨텍스트로 명확히 전환
+    const isOnPostDetail = $derived.by(() => {
+        if (!browser) return false;
+        // /[boardId]/[postId] 형태 — boardId 뒤에 추가 segment 가 있으면 상세 페이지
+        const path = $pageStore.url.pathname;
+        return path.startsWith(`/${boardId}/`) && path.length > boardId.length + 1;
+    });
+
+    function pageHref(page: number): string {
+        return page > 1 ? `/${boardId}?page=${page}` : `/${boardId}`;
+    }
+
+    // 페이지 변경 (목록 페이지에서는 AJAX, 상세 페이지에서는 list 로 navigate)
     async function goToPage(page: number): Promise<void> {
         if (page < 1 || page > totalPages || page === currentPage) return;
+
+        if (isOnPostDetail) {
+            // #11972: 본문 SSR 없이 목록 페이지로 이동
+            await goto(pageHref(page));
+            return;
+        }
 
         loading = true;
         try {

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -23,6 +23,11 @@ interface UiSettings {
     lineHeight: LineHeight;
     fontFamily: FontFamily;
     contentFontSize: ContentFontSize;
+    /**
+     * 댓글 글씨 크기 (#9365). 'inherit' 이면 contentFontSize 를 따라가고,
+     * 그 외 값이면 본문과 독립적으로 적용됩니다.
+     */
+    commentFontSize: ContentFontSize | 'inherit';
     hideMyProfile: boolean;
     // 게시판
     contentBlur: boolean;
@@ -57,6 +62,7 @@ const DEFAULTS: UiSettings = {
     lineHeight: 'normal',
     fontFamily: 'default',
     contentFontSize: 'base',
+    commentFontSize: 'inherit',
     hideMyProfile: false,
     contentBlur: true,
     hidePostList: false,
@@ -154,10 +160,16 @@ function createUiSettingsStore() {
             LIST_FONT_SIZES[settings.recommendFontSize]
         );
 
-        // 본문·댓글·에디터에 contentFontSize 연동
+        // 본문·에디터에 contentFontSize 연동
         html.style.setProperty('--content-font-size', CONTENT_FONT_SIZES[settings.contentFontSize]);
-        html.style.setProperty('--comment-font-size', CONTENT_FONT_SIZES[settings.contentFontSize]);
         html.style.setProperty('--editor-font-size', CONTENT_FONT_SIZES[settings.contentFontSize]);
+
+        // 댓글 글씨 크기 (#9365): 'inherit' 이면 본문과 동일, 그 외엔 독립값
+        const commentSize =
+            settings.commentFontSize === 'inherit'
+                ? CONTENT_FONT_SIZES[settings.contentFontSize]
+                : CONTENT_FONT_SIZES[settings.commentFontSize];
+        html.style.setProperty('--comment-font-size', commentSize);
 
         const fontVal = FONT_FAMILY_VALUES[settings.fontFamily];
         if (fontVal) {
@@ -220,6 +232,14 @@ function createUiSettingsStore() {
                     settings.contentFontSize = order[next];
                 }
             }
+            save();
+            applyCSS();
+        },
+        get commentFontSize() {
+            return settings.commentFontSize;
+        },
+        setCommentFontSize(v: ContentFontSize | 'inherit') {
+            settings.commentFontSize = v;
             save();
             applyCSS();
         },

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1147,11 +1147,16 @@
 
             <!-- 페이지네이션 -->
             {#if shouldShowPagination}
-                <div class="mt-8 flex items-center justify-center gap-2">
-                    {#if pagination.page > 3}
-                        <Button variant="outline" size="sm" onclick={() => goToPage(1)}>처음</Button
-                        >
-                    {/if}
+                <div class="mt-8 flex items-center justify-center gap-1 sm:gap-2">
+                    <!-- #11941: 첫페이지 단축 — 항상 노출 (1페이지일 때만 비활성) -->
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        title="처음으로"
+                        aria-label="첫 페이지"
+                        disabled={pagination.page === 1}
+                        onclick={() => goToPage(1)}>&laquo;</Button
+                    >
                     <Button
                         variant="outline"
                         size="sm"
@@ -1171,6 +1176,17 @@
                         disabled={!paginationHasNext}
                         onclick={() => goToPage(pagination.page + 1)}>다음</Button
                     >
+                    <!-- #11941: 끝페이지 단축 — totalPages 알 때만 -->
+                    {#if paginationTotalPages > 0}
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            title="마지막으로"
+                            aria-label="마지막 페이지"
+                            disabled={pagination.page === paginationTotalPages}
+                            onclick={() => goToPage(paginationTotalPages)}>&raquo;</Button
+                        >
+                    {/if}
                 </div>
                 {#if widgetLayoutStore.hasEnabledAds}
                     <div class="mt-3">

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -102,6 +102,20 @@
         { value: '3xlarge', label: '최대 (26px)' }
     ];
 
+    // #9365: 댓글 글씨 크기 — '본문과 동일' 옵션 + 본문 사이즈 옵션 재사용
+    const commentFontSizeOptions: {
+        value: ContentFontSize | 'inherit';
+        label: string;
+    }[] = [
+        { value: 'inherit', label: '본문과 동일' },
+        { value: 'small', label: '작게 (14px)' },
+        { value: 'base', label: '보통 (16px)' },
+        { value: 'large', label: '크게 (18px)' },
+        { value: 'xlarge', label: '아주 크게 (20px)' },
+        { value: '2xlarge', label: '매우 크게 (22px)' },
+        { value: '3xlarge', label: '최대 (26px)' }
+    ];
+
     const listFontSizeOptions: { value: ListFontSize; label: string }[] = [
         { value: 'xsmall', label: '아주 작게 (13px)' },
         { value: 'small', label: '작게 (14px)' },
@@ -440,6 +454,34 @@
                                     ? 'border-primary bg-primary/10 text-foreground'
                                     : 'border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground'}"
                                 onclick={() => uiSettingsStore.setContentFontSize(opt.value)}
+                            >
+                                {opt.label}
+                            </button>
+                        {/each}
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle class="flex items-center gap-2">
+                        <MessageSquare class="h-5 w-5" />
+                        댓글 글씨 크기
+                    </CardTitle>
+                    <CardDescription
+                        >댓글 영역의 글씨 크기를 본문과 별도로 설정합니다. 모바일에서 본문은 크게,
+                        댓글은 작게 보고 싶을 때 유용합니다. (#9365)</CardDescription
+                    >
+                </CardHeader>
+                <CardContent>
+                    <div class="flex flex-wrap gap-2">
+                        {#each commentFontSizeOptions as opt (opt.value)}
+                            <button
+                                class="rounded-lg border px-4 py-2 text-sm transition-colors {uiSettingsStore.commentFontSize ===
+                                opt.value
+                                    ? 'border-primary bg-primary/10 text-foreground'
+                                    : 'border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground'}"
+                                onclick={() => uiSettingsStore.setCommentFontSize(opt.value)}
                             >
                                 {opt.label}
                             </button>


### PR DESCRIPTION
## Summary

3건 S 묶음 PR. 각 영역이 다르지만 회귀 위험이 낮은 단일 컴포넌트 / 단일 스토어 수정으로 묶음.

### #11941 — 게시판 페이지네이션 첫·끝 페이지 단축
- `routes/[boardId]/+page.svelte` 하단 페이지네이션
- 기존: `처음` 버튼이 `pagination.page > 3` 조건부 노출 → 모바일 4-5페이지에서 1페이지 점프 어려움
- 변경: `«` (첫 페이지), `»` (마지막 페이지) 항상 노출 (1p / 마지막 페이지일 때만 disabled)
- 모바일 갭 축소 (gap-1 sm:gap-2)

### #11972 — 게시글 상세 하단 페이지네이션 → 목록 페이지로 이동
- `lib/components/features/board/recent-posts.svelte`
- 기존: 페이지 클릭 시 AJAX 로 posts 만 갱신 + scrollIntoView → 본문은 위에 그대로 남아 사용자 혼란
- 변경: 게시글 상세 페이지(`/[boardId]/[postId]`)에서 클릭 시 `/[boardId]?page=N` 으로 navigate
- 목록 페이지에서 사용 시(혹시) 기존 AJAX 동작 유지 — `isOnPostDetail` derived 로 분기

### #9365 — 모바일 댓글 글씨 크기 별도 설정
- `lib/stores/ui-settings.svelte.ts` + `routes/member/settings/ui/+page.svelte`
- 기존: `--comment-font-size` CSS 변수가 `contentFontSize` 에 강제로 묶여있어 모바일에서 본문은 크게 / 댓글은 작게 보고 싶은 사용자 요구 충족 불가
- 변경: `commentFontSize` 필드 추가 (default `'inherit'` → 기존 동작 유지), '본문과 동일' + 6단계 옵션 제공
- 기존 사용자는 default `'inherit'` 로 본문과 같은 크기 유지 → 회귀 없음

## 회귀 위험 평가

| 항목 | 위험 | 사유 |
|---|---|---|
| #11941 | 매우 낮음 | 단일 컴포넌트 UI 추가, 기존 `처음` 버튼 → `«` 으로 치환만 |
| #11972 | 낮음 | 라우트 컨텍스트 분기 (`isOnPostDetail`). 게시글 상세 외 컨텍스트(예: 검색) 에서 RecentPosts 가 사용되는지 확인 필요. 사용처: `/[boardId]/[postId]/+page.svelte` 1곳 (확인) |
| #9365 | 매우 낮음 | default `'inherit'` 로 기존 사용자 동작 보존. 신규 옵션은 사용자가 명시적으로 선택해야 활성 |

## Test plan

- [ ] `/board/free` 4-5p 진입 후 `«` 버튼으로 1p 점프 확인 (#11941)
- [ ] 게시글 상세 페이지 하단 RecentPosts 의 페이지 번호 클릭 → `/free?page=N` URL 로 이동 확인 (#11972)
- [ ] `/free?page=2` 같은 목록 페이지에서 사용 시 (실제 사용처 없음) 기존 AJAX 갱신 동작 유지 (회귀 방지 확인용)
- [ ] `/member/settings/ui` 에서 댓글 글씨 크기 설정 → 댓글 영역 폰트 변경 (본문은 그대로) (#9365)
- [ ] 댓글 글씨 크기 `본문과 동일` 선택 시 contentFontSize 따라가는지 확인
- [ ] localStorage 미설정인 기존 사용자가 새 빌드 후에도 댓글 폰트가 본문과 같은 크기로 보이는지 (default `'inherit'`)

## 참고

- `/home/angple/docs/2026-04-30-bug-sweep-april.md` — #11941 / #11972
- `/home/angple/docs/2026-04-30-bug-sweep-mid.md` — #9365 / #9224
- `/home/angple/docs/2026-04-30-bug-sweep-followup-batch.md` — S 묶음 분류

`pnpm check`: 0 errors (97 pre-existing warnings, none in modified files).