### PR TITLE
feat(bluesky): SSR DID prefetch wiring (PR-B2 of #12050)

### DIFF
--- a/apps/web/src/lib/server/bluesky/ssr-wiring.integration.test.ts
+++ b/apps/web/src/lib/server/bluesky/ssr-wiring.integration.test.ts
@@ -1,0 +1,114 @@
+/**
+ * SSR wiring 통합 테스트 (PR-B2 of #12050)
+ *
+ * `+page.server.ts` 와 `comments/+server.ts` 가 본문/댓글 본문 단위로
+ * `prefetchBlueskyDIDs` 를 호출하는 사용 패턴을 그대로 재현하여
+ *   1) 본문 + 다수 댓글에 걸친 일괄 변환이 동작하는지
+ *   2) 일부 본문이 실패해도 다른 본문은 정상 치환되는지
+ *   3) 호출자가 try/catch 로 graceful degradation 한다는 약속을 지키는지
+ * 를 검증한다.
+ *
+ * resolver 는 모킹하여 외부 API 호출 없이 결정적 결과를 만든다.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const resolveBlueskyHandle = vi.fn();
+vi.mock('./resolver.js', () => ({
+    resolveBlueskyHandle: (h: string) => resolveBlueskyHandle(h)
+}));
+
+import { prefetchBlueskyDIDs } from './transform';
+
+const DID_ALICE = 'did:plc:aliceplaceholderxxxxxxxx';
+const DID_BOB = 'did:plc:bobplaceholderxxxxxxxxxx';
+
+describe('SSR wiring (post + comments batch)', () => {
+    beforeEach(() => {
+        resolveBlueskyHandle.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('post body + 댓글 본문들에 대해 병렬 prefetch 가 모두 치환', async () => {
+        resolveBlueskyHandle.mockImplementation(async (h: string) => {
+            if (h === 'alice.bsky.social') return DID_ALICE;
+            if (h === 'bob.bsky.social') return DID_BOB;
+            return null;
+        });
+
+        const postBody = '<p>참고: https://bsky.app/profile/alice.bsky.social/post/postA</p>';
+        const commentBodies = [
+            '댓글1: https://bsky.app/profile/alice.bsky.social/post/cmt1',
+            '댓글2: https://bsky.app/profile/bob.bsky.social/post/cmt2',
+            '댓글3: 일반 텍스트만 있음',
+            '댓글4: https://bsky.app/profile/missing.bsky.social/post/cmt4'
+        ];
+
+        // +page.server.ts 패턴: post.content 단독 await
+        const transformedPost = await prefetchBlueskyDIDs(postBody);
+
+        // comments/+server.ts 패턴: comments.map(c => prefetchBlueskyDIDs(c.content))
+        const transformedComments = await Promise.all(
+            commentBodies.map((body) => prefetchBlueskyDIDs(body).catch(() => body))
+        );
+
+        expect(transformedPost).toBe(
+            `<p>참고: https://bsky.app/profile/${DID_ALICE}/post/postA</p>`
+        );
+        expect(transformedComments[0]).toContain(`profile/${DID_ALICE}/post/cmt1`);
+        expect(transformedComments[1]).toContain(`profile/${DID_BOB}/post/cmt2`);
+        // 매칭 없는 본문은 그대로 통과
+        expect(transformedComments[2]).toBe(commentBodies[2]);
+        // resolve 실패한 handle 은 원본 보존
+        expect(transformedComments[3]).toContain('profile/missing.bsky.social/post/cmt4');
+    });
+
+    it('댓글 한 건의 resolver throw 가 다른 댓글의 치환을 차단하지 않는다', async () => {
+        // 첫 호출은 throw, 이후는 정상 — 호출자(comments/+server.ts) 의 .catch 패턴 검증.
+        resolveBlueskyHandle.mockImplementation(async (h: string) => {
+            if (h === 'broken.bsky.social') {
+                throw new Error('network down');
+            }
+            if (h === 'alice.bsky.social') return DID_ALICE;
+            return null;
+        });
+
+        const bodies = [
+            'X: https://bsky.app/profile/broken.bsky.social/post/x1',
+            'Y: https://bsky.app/profile/alice.bsky.social/post/y1'
+        ];
+
+        const out = await Promise.all(bodies.map((b) => prefetchBlueskyDIDs(b).catch(() => b)));
+
+        // throw 한 본문은 원본 유지
+        expect(out[0]).toBe(bodies[0]);
+        // 다른 본문은 정상 치환
+        expect(out[1]).toContain(`profile/${DID_ALICE}/post/y1`);
+    });
+
+    it('동일 handle 이 post + 여러 댓글에 흩어져 있어도 호출자별로 의존하지 않고 각각 동작', async () => {
+        // resolver 는 stateless 하게 동일 결과 반환. (실 운영에선 Redis 캐시가 dedupe.)
+        resolveBlueskyHandle.mockResolvedValue(DID_ALICE);
+
+        const postBody = 'P: https://bsky.app/profile/alice.bsky.social/post/p1';
+        const comments = [
+            'C1: https://bsky.app/profile/alice.bsky.social/post/c1',
+            'C2: https://bsky.app/profile/alice.bsky.social/post/c2'
+        ];
+
+        const [tp, tc] = await Promise.all([
+            prefetchBlueskyDIDs(postBody),
+            Promise.all(comments.map((c) => prefetchBlueskyDIDs(c)))
+        ]);
+
+        expect(tp).toContain(`profile/${DID_ALICE}/post/p1`);
+        expect(tc[0]).toContain(`profile/${DID_ALICE}/post/c1`);
+        expect(tc[1]).toContain(`profile/${DID_ALICE}/post/c2`);
+
+        // 각 본문 단위로 1 회씩 호출 (3개 본문 × unique handle 1개)
+        expect(resolveBlueskyHandle).toHaveBeenCalledTimes(3);
+        expect(resolveBlueskyHandle).toHaveBeenCalledWith('alice.bsky.social');
+    });
+});

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -26,6 +26,7 @@ import { fetchPostLikeStatus } from '$lib/server/post-like-status.js';
 import { fetchTruthroomPostId, fetchTruthroomCommentMap } from '$lib/server/truthroom.js';
 import { BackendUnavailableError } from '$lib/server/backend-fetch.js';
 import { applyFilter } from '$lib/hooks/registry.js';
+import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -198,6 +199,18 @@ export const load: PageServerLoad = async ({
             }
             if (filesData.downloads?.length) {
                 post.downloads = filesData.downloads;
+            }
+        }
+
+        // Bluesky handle → DID prefetch (#12050).
+        // content-transform 직전에 본문 내 `bsky.app/profile/<handle>/post/<id>`
+        // URL 의 handle 을 DID 로 일괄 치환. 실패 시 원본 유지 → UX 악화 없음.
+        if (post.content) {
+            try {
+                post.content = await prefetchBlueskyDIDs(post.content);
+            } catch (e) {
+                // graceful degradation — 본문 보존, 운영 모니터링용 로그만.
+                console.warn('[bluesky] prefetchBlueskyDIDs(post) failed:', e);
             }
         }
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -18,6 +18,7 @@ import {
 } from '$lib/server/affiliate-links';
 import { isLinkProcessingPluginEnabled } from '$lib/server/link-processing/runtime';
 import { isInternalAppRequest } from '$lib/server/internal-api.js';
+import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 
 interface CommentRow extends RowDataPacket {
     wr_id: number;
@@ -221,6 +222,26 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
                   }
                 : {})
         }));
+
+        // Bluesky handle → DID prefetch (#12050).
+        // 댓글 본문 내 `bsky.app/profile/<handle>/post/<id>` URL 의 handle 을 DID 로
+        // 일괄 치환. content-transform (affiliate, embed) 단계 전에 수행한다.
+        // Redis 30일 TTL 캐시로 동일 handle 재요청 부담 최소.
+        // 실패 시 원본 본문 유지 → UX 악화 없음.
+        try {
+            const transformed = await Promise.all(
+                comments.map((c) =>
+                    typeof c.content === 'string' && c.content
+                        ? prefetchBlueskyDIDs(c.content).catch(() => c.content)
+                        : Promise.resolve(c.content)
+                )
+            );
+            comments.forEach((c, i) => {
+                c.content = transformed[i];
+            });
+        } catch (e) {
+            console.warn('[bluesky] prefetchBlueskyDIDs(comments) failed:', e);
+        }
 
         const affiliateEnabled = await isLinkProcessingPluginEnabled().catch(() => false);
         const commentAffiliateRows = affiliateEnabled


### PR DESCRIPTION
## Summary

PR-B1 (#1312) 에서 추가한 `resolveBlueskyHandle` / `prefetchBlueskyDIDs` 모듈을 SSR 경로에 wiring.

- `apps/web/src/routes/[boardId]/[postId]/+page.server.ts` — 게시글 본문 로드 직후, files merge 다음 단계에서 `post.content` 에 `prefetchBlueskyDIDs` 적용
- `apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts` — 댓글 응답 빌드 후 affiliate 변환 직전, `comments.content` 들을 `Promise.all` 로 병렬 prefetch
- 본문에서 `bsky.app/profile/<handle>/post/<id>` URL 의 handle 을 DID 로 치환 → 이후 `bluesky.ts` 임베더가 `did:plc:...` 로 임베드 생성, 기존 \"Invalid DID\" 에러 해소

## Behavior

- 이미 `did:` 형식인 URL → 그대로 통과 (regression 없음)
- resolve 실패 (네트워크 / 404 / Redis 장애) → 원본 본문 유지 (UX 악화 없음)
- 호출자 try/catch + 개별 `.catch(() => 원본)` 으로 graceful degradation

## SSR Latency Impact

- handle 1개당 외부 API 100~300ms, **Redis 30일 TTL 캐시 hit 시 ~5ms**
- 댓글 본문은 `Promise.all` 병렬 처리로 N개 댓글이라도 가장 느린 1건 시간만 영향
- Redis 캐시 정책상 동일 커뮤니티에 자주 등장하는 handle 의 두 번째 요청부터는 사실상 무비용

## Out of Scope

- `BSKY_RESOLVE_ENABLED` 환경변수 토글은 Open Question (별도 결정)
- `bluesky.ts` 정규식/네이밍 정리는 PR-B3
- 게시판 외(쪽지/메시지) 본문 적용 여부는 향후 검토

## Test plan

- [x] `pnpm test:unit -- --run src/lib/server/bluesky/` — 31 files / 315 tests pass (기존 transform.test.ts + 신규 ssr-wiring.integration.test.ts 모두 그린)
- [x] `pnpm check` — 0 errors / 97 pre-existing warnings
- [ ] 운영 canary — 실제 `bsky.app/profile/<handle>/post/<id>` 본문 임베드 정상 렌더 확인
- [ ] Redis 캐시 hit 률 모니터링 (`bsky:handle:*` 키 동작)
- [ ] handle resolve 실패 시 원본 URL 유지 + 콘솔 경고만 노출 확인

Refs: damoang.net/issues/12050, #1312 (PR-B1)