### PR TITLE
fix(post): 글 상세 페이지 하단 최근글에 키워드 필터 적용 (#12215)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -122,9 +122,13 @@
     });
     let posts = $state<FreePost[]>(initialPosts);
 
-    // posts 변경 시 메모 로드 (#11949)
+    // 차단 키워드 적용: 차단된 글은 목록에서 완전 제외 (#12215)
+    // 게시판 목록(`[boardId]/+page.svelte`)과 동일한 필터 (#11935)
+    const filteredPosts = $derived(posts.filter((p) => !uiSettingsStore.isMuted(p.title)));
+
+    // posts 변경 시 메모 로드 (#11949) — 필터링된 결과 기준으로 불필요한 메모 호출 방지
     $effect(() => {
-        loadMemos(posts);
+        loadMemos(filteredPosts);
     });
     let loading = $state(initialPosts.length === 0);
     let error = $state<string | null>(null);
@@ -288,7 +292,7 @@
     <div class="py-8 text-center">
         <p class="text-muted-foreground text-sm">{error}</p>
     </div>
-{:else if posts.length === 0}
+{:else if filteredPosts.length === 0}
     <div class="py-8 text-center">
         <p class="text-muted-foreground text-sm">최근 글이 없습니다.</p>
     </div>
@@ -308,7 +312,7 @@
                 </div>
             </div>
         {/if}
-        {#each posts as post, i (post.id)}
+        {#each filteredPosts as post, i (post.id)}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
                 class={post.id === currentPostId ? 'current-post-highlight' : ''}


### PR DESCRIPTION
## Summary
- 자유게시판 글 상세 페이지 하단의 RecentPosts 컴포넌트가 게시판 목록과 달리 사용자의 차단 키워드(`muteKeywords`)를 적용하지 않아, 목록에서는 가려졌던 게시글이 상세 페이지 하단에서는 그대로 노출되던 버그 수정
- `recent-posts.svelte` 에 `filteredPosts = posts.filter((p) => !uiSettingsStore.isMuted(p.title))` 도입 — 게시판 목록(`[boardId]/+page.svelte#L455`, #11935)과 동일한 필터 패턴
- 빈 상태 체크 및 `{#each}` 렌더링을 `filteredPosts` 기준으로 변경, 메모 로드(#11949)도 필터링된 결과 기준으로 호출하여 차단된 글 작성자 메모는 불러오지 않도록 정합성 확보

## Issue
- damoang.net 버그 #12215
- 제보: "최근에 필터링 버그 보완해주셔서 안심하고 있었는데, 자유게시판 글 내용으로 들어가서 하단에 보이는 자유게시판 글 리스트는 필터링이 안 되네요"

## Test plan
- [ ] 차단 키워드를 설정한 상태에서 자유게시판 목록(`/free`) 진입 — 차단된 글이 목록에서 보이지 않음 (기존 동작 유지)
- [ ] 자유게시판 글 상세(`/free/{id}`) 진입 — 하단 최근글 리스트에서도 차단된 글이 보이지 않음 (수정된 동작)
- [ ] 페이지네이션 동작 확인 (필터로 인한 페이지 수 변화 없음 — 서버 응답의 `total/total_pages` 그대로 사용)
- [ ] 차단 키워드 미설정 사용자: 모든 글 정상 노출 (`isMuted` early-return 으로 비용 0)
- [ ] hello 등 다른 게시판 상세 페이지에서도 동일하게 적용되는지 확인

## Files changed
- `apps/web/src/lib/components/features/board/recent-posts.svelte` (+8 / −4)

## Regression risk
- **낮음**. 게시판 목록 코드는 미수정. RecentPosts 단일 컴포넌트 내부 변경.
- 차단 키워드 미설정 시 `muteKeywords.length === 0` → `isMuted` 즉시 false 반환 → 기존 동작 그대로.
- 페이지네이션 정책은 목록과 동일 (서버 total 그대로 사용 — 필터 적용 후 표시 건수가 줄어들 수 있는 점은 목록과 동일한 trade-off).