### PR TITLE
feat(plugin-loader): #1289 매니페스트 기반 자동 등록 (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,9 @@ SESSION_NOTES.md
 themes/damoang-default
 plugins/
 !apps/web/src/routes/api/plugins/
+!apps/web/src/routes/admin/plugins/
 !apps/web/src/lib/plugins/
+!apps/web/src/lib/server/plugins/
 apps/web/src/lib/components/ui/podcast-player/
 
 # Claude Code

--- a/apps/web/src/lib/server/plugins/index.ts
+++ b/apps/web/src/lib/server/plugins/index.ts
@@ -19,6 +19,8 @@ import {
 import { pluginSettingsProvider } from '../settings/plugin-settings-provider';
 import { TieredCache } from '$lib/server/cache';
 import type { ExtensionManifest } from '@angple/types';
+import { runPluginMigrations, rollbackPluginMigrations } from './migration-runner';
+import { invalidateHandlerCache } from './route-dispatcher';
 
 /**
  * 설치된 플러그인의 전체 정보
@@ -130,18 +132,32 @@ export async function invalidateActivePluginsCache(): Promise<void> {
 /**
  * 플러그인 활성화
  *
- * settings.json의 activePlugins 배열에 플러그인 ID를 추가합니다.
+ * settings.json의 activePlugins 배열에 플러그인 ID를 추가하고,
+ * 매니페스트의 migrations를 실행합니다 (#1289).
  */
 export async function activatePlugin(pluginId: string): Promise<boolean> {
-    // 플러그인이 설치되어 있는지 확인
     if (!(await isPluginInstalled(pluginId))) {
         console.error(`[Plugin API] 플러그인이 설치되지 않음: ${pluginId}`);
         return false;
     }
 
-    // Provider를 통해 플러그인 활성화
+    const manifest = await getPluginManifest(pluginId);
+    if (manifest?.migrations && manifest.migrations.length > 0) {
+        const pluginPath = await getPluginPath(pluginId);
+        try {
+            const result = await runPluginMigrations(pluginId, pluginPath, manifest.migrations);
+            console.info(
+                `[Plugin API] ${pluginId} migrations: applied=${result.applied.length}, skipped=${result.skipped.length}`
+            );
+        } catch (err) {
+            console.error(`[Plugin API] migration 실패: ${pluginId}`, err);
+            return false;
+        }
+    }
+
     await pluginSettingsProvider.activatePlugin(pluginId);
     await invalidateActivePluginsCache();
+    invalidateHandlerCache();
 
     return true;
 }
@@ -150,12 +166,49 @@ export async function activatePlugin(pluginId: string): Promise<boolean> {
  * 플러그인 비활성화
  *
  * settings.json의 activePlugins 배열에서 플러그인 ID를 제거합니다.
+ * 데이터 보존을 위해 migration은 자동으로 롤백되지 않습니다.
+ * 명시적 롤백은 `rollbackPlugin` 사용.
  */
 export async function deactivatePlugin(pluginId: string): Promise<boolean> {
-    // Provider를 통해 플러그인 비활성화
     await pluginSettingsProvider.deactivatePlugin(pluginId);
     await invalidateActivePluginsCache();
+    invalidateHandlerCache();
 
+    return true;
+}
+
+/**
+ * 플러그인 명시적 롤백 (관리자 액션).
+ * 비활성화 + migration down 실행.
+ */
+export async function rollbackPlugin(pluginId: string): Promise<boolean> {
+    const manifest = await getPluginManifest(pluginId);
+    if (!manifest) {
+        console.error(`[Plugin API] 매니페스트 없음: ${pluginId}`);
+        return false;
+    }
+
+    await pluginSettingsProvider.deactivatePlugin(pluginId);
+
+    if (manifest.migrations && manifest.migrations.length > 0) {
+        const pluginPath = await getPluginPath(pluginId);
+        try {
+            const result = await rollbackPluginMigrations(
+                pluginId,
+                pluginPath,
+                manifest.migrations
+            );
+            console.info(
+                `[Plugin API] ${pluginId} rollback: rolledBack=${result.rolledBack.length}`
+            );
+        } catch (err) {
+            console.error(`[Plugin API] rollback 실패: ${pluginId}`, err);
+            return false;
+        }
+    }
+
+    await invalidateActivePluginsCache();
+    invalidateHandlerCache();
     return true;
 }
 

--- a/apps/web/src/lib/server/plugins/migration-runner.ts
+++ b/apps/web/src/lib/server/plugins/migration-runner.ts
@@ -68,10 +68,10 @@ export async function runPluginMigrations(
             for (const stmt of splitStatements(sql)) {
                 await conn.query(stmt);
             }
-            await conn.query(
-                'INSERT INTO plugin_migrations (plugin_id, version) VALUES (?, ?)',
-                [pluginId, m.version]
-            );
+            await conn.query('INSERT INTO plugin_migrations (plugin_id, version) VALUES (?, ?)', [
+                pluginId,
+                m.version
+            ]);
             await conn.commit();
             result.applied.push(m.version);
             console.info(`${LOG_PREFIX} applied ${pluginId}@${m.version} (${m.description})`);
@@ -122,10 +122,10 @@ export async function rollbackPluginMigrations(
             for (const stmt of splitStatements(sql)) {
                 await conn.query(stmt);
             }
-            await conn.query(
-                'DELETE FROM plugin_migrations WHERE plugin_id = ? AND version = ?',
-                [pluginId, m.version]
-            );
+            await conn.query('DELETE FROM plugin_migrations WHERE plugin_id = ? AND version = ?', [
+                pluginId,
+                m.version
+            ]);
             await conn.commit();
             result.rolledBack.push(m.version);
             console.info(`${LOG_PREFIX} rolled back ${pluginId}@${m.version}`);

--- a/apps/web/src/lib/server/plugins/migration-runner.ts
+++ b/apps/web/src/lib/server/plugins/migration-runner.ts
@@ -1,0 +1,153 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { pool } from '$lib/server/db';
+import type { RowDataPacket } from 'mysql2/promise';
+import type { ExtensionMigration } from '@angple/types';
+
+const LOG_PREFIX = '[plugin-migration]';
+
+const TRACKING_TABLE_DDL = `
+CREATE TABLE IF NOT EXISTS plugin_migrations (
+    plugin_id VARCHAR(50) NOT NULL,
+    version VARCHAR(100) NOT NULL,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (plugin_id, version),
+    INDEX idx_plugin (plugin_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`;
+
+let bootstrapped = false;
+async function ensureBootstrap(): Promise<void> {
+    if (bootstrapped) return;
+    await pool.query(TRACKING_TABLE_DDL);
+    bootstrapped = true;
+}
+
+async function getAppliedVersions(pluginId: string): Promise<Set<string>> {
+    await ensureBootstrap();
+    const [rows] = await pool.query<RowDataPacket[]>(
+        'SELECT version FROM plugin_migrations WHERE plugin_id = ?',
+        [pluginId]
+    );
+    return new Set(rows.map((r) => r.version as string));
+}
+
+// MySQL는 single-statement만 받으므로 ;로 분리해서 순서대로 실행한다.
+function splitStatements(sql: string): string[] {
+    return sql
+        .split(/;\s*\n/m)
+        .map((s) => s.trim())
+        .filter(Boolean);
+}
+
+export interface PluginMigrationResult {
+    applied: string[];
+    skipped: string[];
+}
+
+export async function runPluginMigrations(
+    pluginId: string,
+    pluginPath: string,
+    migrations: ExtensionMigration[] | undefined
+): Promise<PluginMigrationResult> {
+    const result: PluginMigrationResult = { applied: [], skipped: [] };
+    if (!migrations || migrations.length === 0) return result;
+
+    const appliedSet = await getAppliedVersions(pluginId);
+
+    for (const m of migrations) {
+        if (appliedSet.has(m.version)) {
+            result.skipped.push(m.version);
+            continue;
+        }
+        const sqlPath = path.join(pluginPath, m.up);
+        const sql = await fs.readFile(sqlPath, 'utf-8');
+
+        const conn = await pool.getConnection();
+        try {
+            await conn.beginTransaction();
+            for (const stmt of splitStatements(sql)) {
+                await conn.query(stmt);
+            }
+            await conn.query(
+                'INSERT INTO plugin_migrations (plugin_id, version) VALUES (?, ?)',
+                [pluginId, m.version]
+            );
+            await conn.commit();
+            result.applied.push(m.version);
+            console.info(`${LOG_PREFIX} applied ${pluginId}@${m.version} (${m.description})`);
+        } catch (err) {
+            await conn.rollback();
+            const message = (err as Error).message;
+            throw new Error(`Migration ${pluginId}@${m.version} failed: ${message}`);
+        } finally {
+            conn.release();
+        }
+    }
+
+    return result;
+}
+
+export interface PluginRollbackResult {
+    rolledBack: string[];
+    skipped: string[];
+}
+
+export async function rollbackPluginMigrations(
+    pluginId: string,
+    pluginPath: string,
+    migrations: ExtensionMigration[] | undefined,
+    options: { until?: string } = {}
+): Promise<PluginRollbackResult> {
+    const result: PluginRollbackResult = { rolledBack: [], skipped: [] };
+    if (!migrations || migrations.length === 0) return result;
+
+    const appliedSet = await getAppliedVersions(pluginId);
+    const reversed = [...migrations].reverse();
+
+    for (const m of reversed) {
+        if (options.until && m.version === options.until) break;
+        if (!appliedSet.has(m.version)) continue;
+        if (!m.down) {
+            result.skipped.push(m.version);
+            console.warn(`${LOG_PREFIX} no down script for ${pluginId}@${m.version}, skipped`);
+            continue;
+        }
+
+        const sqlPath = path.join(pluginPath, m.down);
+        const sql = await fs.readFile(sqlPath, 'utf-8');
+
+        const conn = await pool.getConnection();
+        try {
+            await conn.beginTransaction();
+            for (const stmt of splitStatements(sql)) {
+                await conn.query(stmt);
+            }
+            await conn.query(
+                'DELETE FROM plugin_migrations WHERE plugin_id = ? AND version = ?',
+                [pluginId, m.version]
+            );
+            await conn.commit();
+            result.rolledBack.push(m.version);
+            console.info(`${LOG_PREFIX} rolled back ${pluginId}@${m.version}`);
+        } catch (err) {
+            await conn.rollback();
+            const message = (err as Error).message;
+            throw new Error(`Rollback ${pluginId}@${m.version} failed: ${message}`);
+        } finally {
+            conn.release();
+        }
+    }
+
+    return result;
+}
+
+export async function getAppliedMigrations(
+    pluginId: string
+): Promise<Array<{ version: string; appliedAt: Date }>> {
+    await ensureBootstrap();
+    const [rows] = await pool.query<RowDataPacket[]>(
+        'SELECT version, applied_at FROM plugin_migrations WHERE plugin_id = ? ORDER BY applied_at ASC',
+        [pluginId]
+    );
+    return rows.map((r) => ({ version: r.version as string, appliedAt: r.applied_at as Date }));
+}

--- a/apps/web/src/lib/server/plugins/route-dispatcher.ts
+++ b/apps/web/src/lib/server/plugins/route-dispatcher.ts
@@ -1,0 +1,94 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { RequestEvent } from '@sveltejs/kit';
+import type { ExtensionAPIRoute } from '@angple/types';
+import { getPluginById } from './index';
+
+const LOG_PREFIX = '[plugin-route]';
+
+type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type HandlerFn = (event: RequestEvent) => Response | Promise<Response>;
+type HandlerModule = Partial<Record<Method, HandlerFn>> & { default?: HandlerFn };
+
+const moduleCache = new Map<string, HandlerModule>();
+
+async function loadHandler(absolutePath: string): Promise<HandlerModule> {
+    const cached = moduleCache.get(absolutePath);
+    if (cached) return cached;
+    const mod = (await import(pathToFileURL(absolutePath).href)) as HandlerModule;
+    moduleCache.set(absolutePath, mod);
+    return mod;
+}
+
+function matchRoute(
+    routes: ExtensionAPIRoute[],
+    requestPath: string,
+    method: Method,
+    prefix: string
+): ExtensionAPIRoute | null {
+    const normalizedPrefix = prefix.startsWith('/') ? prefix : `/${prefix}`;
+    const stripped = requestPath.startsWith(normalizedPrefix)
+        ? requestPath.slice(normalizedPrefix.length) || '/'
+        : requestPath;
+
+    for (const route of routes) {
+        if (route.method !== method) continue;
+        if (route.path === stripped || route.path === requestPath) return route;
+    }
+    return null;
+}
+
+export interface DispatchInput {
+    pluginId: string;
+    /** plugin prefix를 제거한 나머지 경로 (앞에 '/' 포함) */
+    rest: string;
+    method: Method;
+    event: RequestEvent;
+}
+
+export async function dispatchPluginRoute(input: DispatchInput): Promise<Response> {
+    const plugin = await getPluginById(input.pluginId);
+    if (!plugin) {
+        return new Response(`Plugin not found: ${input.pluginId}`, { status: 404 });
+    }
+    if (!plugin.isActive) {
+        return new Response(`Plugin not active: ${input.pluginId}`, { status: 404 });
+    }
+
+    const restApi = plugin.manifest.api?.rest;
+    if (!restApi || !restApi.routes || restApi.routes.length === 0) {
+        return new Response(`Plugin has no routes: ${input.pluginId}`, { status: 404 });
+    }
+
+    const matched = matchRoute(restApi.routes, input.rest, input.method, restApi.prefix);
+    if (!matched) {
+        return new Response(`Route not found in plugin: ${input.pluginId}${input.rest}`, {
+            status: 404
+        });
+    }
+
+    const handlerPath = path.join(plugin.path, matched.handler);
+    let mod: HandlerModule;
+    try {
+        mod = await loadHandler(handlerPath);
+    } catch (err) {
+        console.error(`${LOG_PREFIX} failed to load handler ${handlerPath}:`, err);
+        return new Response(`Plugin handler load error`, { status: 500 });
+    }
+
+    const fn = mod[input.method] ?? mod.default;
+    if (typeof fn !== 'function') {
+        return new Response(`Plugin handler missing ${input.method} export`, { status: 500 });
+    }
+
+    try {
+        return await fn(input.event);
+    } catch (err) {
+        console.error(`${LOG_PREFIX} handler error in ${input.pluginId}${input.rest}:`, err);
+        return new Response(`Plugin handler error`, { status: 500 });
+    }
+}
+
+export function invalidateHandlerCache(): void {
+    moduleCache.clear();
+}

--- a/apps/web/src/lib/server/plugins/scanner.test.ts
+++ b/apps/web/src/lib/server/plugins/scanner.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { safeValidateExtensionManifest } from '@angple/types';
+
+describe('plugin manifest schema (#1289 L1 regression)', () => {
+    it('새 migrations 필드는 옵셔널 — 누락해도 검증 통과', () => {
+        expect.hasAssertions();
+        const minimal = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts'
+        };
+        const result = safeValidateExtensionManifest(minimal);
+        expect(result.success).toBe(true);
+    });
+
+    it('migrations 배열 검증 통과', () => {
+        expect.hasAssertions();
+        const withMigrations = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            migrations: [
+                {
+                    version: '001',
+                    description: 'create table',
+                    up: 'migrations/001_up.sql',
+                    down: 'migrations/001_down.sql'
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(withMigrations);
+        expect(result.success).toBe(true);
+    });
+
+    it('migrations down은 옵셔널', () => {
+        expect.hasAssertions();
+        const withoutDown = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            migrations: [
+                {
+                    version: '001',
+                    description: 'create table',
+                    up: 'migrations/001_up.sql'
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(withoutDown);
+        expect(result.success).toBe(true);
+    });
+
+    it('migrations version/description/up은 필수', () => {
+        expect.hasAssertions();
+        const invalid = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            migrations: [
+                {
+                    description: 'missing version and up'
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(invalid);
+        expect(result.success).toBe(false);
+    });
+
+    it('기존 plugin.json 형태(routes/admin/migrations 없음)도 통과', () => {
+        expect.hasAssertions();
+        const legacy = {
+            id: 'wiki',
+            name: '위키',
+            version: '0.1.0',
+            description: '위키 플러그인',
+            author: { name: 'Angple', url: 'https://angple.com' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            tags: ['wiki'],
+            components: [
+                {
+                    id: 'wiki-board',
+                    name: '위키 문서 목록',
+                    slot: 'board-list',
+                    path: 'components/wiki-board.svelte',
+                    priority: 10
+                }
+            ],
+            hooks: [
+                {
+                    name: 'board.layout.register',
+                    type: 'action' as const,
+                    callback: 'hooks/register-wiki.ts',
+                    priority: 10
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(legacy);
+        expect(result.success).toBe(true);
+    });
+});

--- a/apps/web/src/lib/utils/plugin-optional-loader.ts
+++ b/apps/web/src/lib/utils/plugin-optional-loader.ts
@@ -9,6 +9,8 @@ import type { Component } from 'svelte';
 
 // Glob all plugin components (lazy, not eager)
 const pluginComponents = import.meta.glob('../../../../../plugins/*/components/*.svelte');
+// Admin / arbitrary svelte files under plugin (used by admin sidebar entries)
+const pluginAnySvelte = import.meta.glob('../../../../../plugins/*/**/*.svelte');
 // Note: Exclude .server.ts files from glob to prevent server-only code from being bundled for client
 const pluginLibs = import.meta.glob([
     '../../../../../plugins/*/lib/*.svelte',
@@ -30,6 +32,28 @@ export async function loadPluginComponent(
 ): Promise<Component | null> {
     const path = `../../../../../plugins/${pluginId}/components/${componentName}.svelte`;
     const loader = pluginComponents[path];
+    if (!loader) return null;
+
+    try {
+        const module = (await loader()) as { default: Component };
+        return module.default;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Load a plugin svelte file by its relative path from the plugin root.
+ * Used by admin sidebar entries — manifest's `ui.admin.menu.component` is a relative path
+ * (e.g. "admin/settings.svelte"), so we glob the entire plugin tree.
+ */
+export async function loadPluginSvelteByPath(
+    pluginId: string,
+    relativePath: string
+): Promise<Component | null> {
+    const normalized = relativePath.startsWith('./') ? relativePath.slice(2) : relativePath;
+    const fullPath = `../../../../../plugins/${pluginId}/${normalized}`;
+    const loader = pluginAnySvelte[fullPath];
     if (!loader) return null;
 
     try {

--- a/apps/web/src/routes/admin/plugins/[id]/+page.server.ts
+++ b/apps/web/src/routes/admin/plugins/[id]/+page.server.ts
@@ -1,0 +1,20 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { getPluginById } from '$lib/server/plugins';
+
+export const load: PageServerLoad = async ({ params }) => {
+    const plugin = await getPluginById(params.id);
+    if (!plugin) throw error(404, `Plugin not found: ${params.id}`);
+    if (!plugin.isActive) throw error(404, `Plugin not active: ${params.id}`);
+
+    const adminMenu = plugin.manifest.ui?.admin?.menu;
+    if (!adminMenu?.component) {
+        throw error(404, `Plugin '${params.id}' has no admin menu`);
+    }
+
+    return {
+        pluginId: plugin.manifest.id,
+        title: adminMenu.title,
+        componentPath: adminMenu.component
+    };
+};

--- a/apps/web/src/routes/admin/plugins/[id]/+page.svelte
+++ b/apps/web/src/routes/admin/plugins/[id]/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+    import type { Component } from 'svelte';
+    import { loadPluginSvelteByPath } from '$lib/utils/plugin-optional-loader';
+    import type { PageData } from './$types';
+
+    let { data }: { data: PageData } = $props();
+
+    let PluginComponent = $state<Component | null>(null);
+    let loadError = $state<string | null>(null);
+
+    $effect(() => {
+        loadPluginSvelteByPath(data.pluginId, data.componentPath)
+            .then((c) => {
+                if (!c) {
+                    loadError = `Component not found: ${data.componentPath}`;
+                } else {
+                    PluginComponent = c;
+                }
+            })
+            .catch((err: unknown) => {
+                loadError = `Load failed: ${(err as Error).message}`;
+            });
+    });
+</script>
+
+<svelte:head>
+    <title>{data.title} — Admin</title>
+</svelte:head>
+
+<div class="plugin-admin-page">
+    <h1>{data.title}</h1>
+
+    {#if PluginComponent}
+        <PluginComponent />
+    {:else if loadError}
+        <div class="error">
+            플러그인 컴포넌트 로드 실패: {loadError}
+        </div>
+    {:else}
+        <div class="loading">로딩 중…</div>
+    {/if}
+</div>
+
+<style>
+    .plugin-admin-page {
+        padding: 1rem;
+    }
+    .error {
+        color: #c33;
+        background: #fee;
+        padding: 0.75rem 1rem;
+        border-radius: 4px;
+    }
+    .loading {
+        color: #666;
+    }
+</style>

--- a/apps/web/src/routes/api/plugins/[id]/[...rest]/+server.ts
+++ b/apps/web/src/routes/api/plugins/[id]/[...rest]/+server.ts
@@ -1,0 +1,20 @@
+import type { RequestHandler } from './$types';
+import { dispatchPluginRoute } from '$lib/server/plugins/route-dispatcher';
+
+function makeHandler(method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'): RequestHandler {
+    return async (event) => {
+        const { id, rest } = event.params;
+        return dispatchPluginRoute({
+            pluginId: id ?? '',
+            rest: `/${rest ?? ''}`,
+            method,
+            event
+        });
+    };
+}
+
+export const GET: RequestHandler = makeHandler('GET');
+export const POST: RequestHandler = makeHandler('POST');
+export const PUT: RequestHandler = makeHandler('PUT');
+export const PATCH: RequestHandler = makeHandler('PATCH');
+export const DELETE: RequestHandler = makeHandler('DELETE');

--- a/packages/types/src/extension-schema.ts
+++ b/packages/types/src/extension-schema.ts
@@ -41,6 +41,16 @@ export const ExtensionEnginesSchema = z.object({
     angple: z.string().optional()
 });
 
+/**
+ * DB 마이그레이션 정의 (플러그인 전용)
+ */
+export const ExtensionMigrationSchema = z.object({
+    version: z.string().min(1, '마이그레이션 version은 필수입니다'),
+    description: z.string().min(1, '마이그레이션 설명은 필수입니다'),
+    up: z.string().min(1, 'up SQL 파일 경로는 필수입니다'),
+    down: z.string().optional()
+});
+
 // ============================================================================
 // 설정 필드 스키마
 // ============================================================================
@@ -257,6 +267,7 @@ const BaseExtensionManifestSchema = z.object({
     api: ExtensionAPISchema.optional(),
     ui: ExtensionUISchema.optional(),
     settings: z.record(z.string(), ExtensionSettingFieldSchema).optional(),
+    migrations: z.array(ExtensionMigrationSchema).optional(),
     dependencies: z.record(z.string(), z.string()).optional(),
     devDependencies: z.record(z.string(), z.string()).optional(),
     homepage: z.string().url().optional(),

--- a/packages/types/src/extension.ts
+++ b/packages/types/src/extension.ts
@@ -351,6 +351,25 @@ export interface ExtensionUI {
 }
 
 /**
+ * DB 마이그레이션 정의.
+ * 플러그인 활성화 시 `up` 파일이 순서대로 실행되며, 비활성화/롤백 시 `down` 파일이 사용됩니다.
+ * `plugin_migrations` 추적 테이블이 중복 실행을 방지합니다.
+ */
+export interface ExtensionMigration {
+    /** 마이그레이션 버전 (예: "001", "20260501-add-payments") */
+    version: string;
+
+    /** 마이그레이션 설명 */
+    description: string;
+
+    /** Up SQL 파일 경로 (플러그인 루트 기준 상대 경로) */
+    up: string;
+
+    /** Down SQL 파일 경로 (롤백용, 선택) */
+    down?: string;
+}
+
+/**
  * Extension 엔진 요구사항
  */
 export interface ExtensionEngines {
@@ -435,6 +454,15 @@ export interface ExtensionManifest {
 
     /** Extension 설정 필드 */
     settings?: Record<string, ExtensionSettingField>;
+
+    /**
+     * DB 마이그레이션 정의 (플러그인 활성화 시 자동 실행).
+     * 각 항목의 `up` 파일이 순서대로 실행되며, `down`은 비활성화/롤백 시 사용됩니다.
+     * `plugin_migrations` 추적 테이블로 중복 실행을 방지합니다.
+     *
+     * 플러그인 전용 필드 — 테마는 일반적으로 사용하지 않습니다.
+     */
+    migrations?: ExtensionMigration[];
 
     /** npm 의존성 (package.json처럼) */
     dependencies?: Record<string, string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,6 +44,7 @@ export type {
     ExtensionEditorUI,
     ExtensionUI,
     ExtensionEngines,
+    ExtensionMigration,
     ExtensionManifest,
     ExtensionRuntime,
     ExtensionInstallOptions,
@@ -69,7 +70,8 @@ export {
     ExtensionAdminMenuSchema,
     ExtensionAdminUISchema,
     ExtensionEditorUISchema,
-    ExtensionUISchema
+    ExtensionUISchema,
+    ExtensionMigrationSchema
 } from './extension-schema.js';
 
 export type { ExtensionManifestValidated, PartialExtensionManifest } from './extension-schema.js';

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -4,7 +4,7 @@
 
 import type { HookDefinition } from './hook.js';
 import type { ComponentDefinition } from './theme.js';
-import type { ExtensionManifest, PluginType } from './extension.js';
+import type { ExtensionManifest, ExtensionMigration, PluginType } from './extension.js';
 
 /**
  * 플러그인 API 엔드포인트 정의
@@ -31,20 +31,10 @@ export interface ApiEndpoint {
 
 /**
  * 데이터베이스 마이그레이션 정의
+ *
+ * @deprecated `ExtensionMigration` (extension.ts)을 사용하세요. 하위 호환성을 위한 별칭입니다.
  */
-export interface Migration {
-    /** 마이그레이션 버전 */
-    version: string;
-
-    /** 마이그레이션 설명 */
-    description: string;
-
-    /** Up 스크립트 경로 */
-    up: string;
-
-    /** Down 스크립트 경로 */
-    down: string;
-}
+export type Migration = ExtensionMigration;
 
 /**
  * 플러그인 메타데이터 (plugin.json)


### PR DESCRIPTION
## Summary

#1289 의 Plugin loader 강화 1단계 — 매니페스트 기반 자동 등록 인프라.
다음 단계인 결제 플러그인(`plugins/payment/`)이 이 위에서 동작합니다.

## 주요 변경

### 1. ExtensionManifest 스키마 확장
- `migrations: ExtensionMigration[]` 필드 추가 (기존 `Migration` 타입을 별칭으로 통일)
- Zod 스키마 동기화

### 2. 자동 라우트 등록
- `apps/web/src/routes/api/plugins/[id]/[...rest]/+server.ts` 카치-올
- `route-dispatcher.ts`: 활성 플러그인 매니페스트의 `api.rest.routes` 매칭 → 핸들러 동적 import
- 비활성 플러그인은 404, 핸들러 미존재 시 500

### 3. Admin sidebar 자동 등록 + 페이지
- 기존 `+layout.server.ts`가 `ui.admin.menu` 자동 로드 (이미 존재)
- 신규 `routes/admin/plugins/[id]/+page.{server.ts,svelte}` — `menu.component` Vite glob 동적 렌더
- `loadPluginSvelteByPath()` 헬퍼 추가

### 4. DB Migration runner
- `migration-runner.ts`: `plugin_migrations` 추적 테이블 (idempotent), 트랜잭션 실행, 롤백 지원
- 활성화 시 미적용 migration 자동 실행
- 비활성화는 데이터 보존, 신규 `rollbackPlugin` API로 명시 롤백

### 5. .gitignore 수정
`plugins/` 패턴이 `apps/web/src/lib/server/plugins/`까지 무시하던 버그 수정 (예외 추가)

## Test plan

- [x] `pnpm check` 무회귀 — 사전 6 errors (`@opentelemetry/*` 누락) 그대로
- [x] `pnpm test:unit --run` 320/320 통과 (신규 `scanner.test.ts` 5개 포함)
- [ ] Dev 서버 띄워서 `/admin/plugins` 토글 → migration 적용 확인 (사용자 환경)
- [ ] 신규 플러그인이 `api.rest.routes`로 라우트 선언 → catch-all 경유 응답 확인 (Phase 2 결제 플러그인에서 검증)

## Phase 2 예고 (다음 PR)

`plugins/payment/` — 멀티사이트 (다모앙/뮤지아/처치) 공통 결제 플러그인:
- Toss / 네이버페이 / PayPal 어댑터
- `payment_provider_configs(site_id, provider, ...)`로 사이트별 PG 키 분리
- 본 PR의 인프라 위에서 동작