### PR TITLE
feat(payment): 토스/네이버페이/페이팔 멀티사이트 결제 플러그인 (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,13 @@ SESSION_NOTES.md
 
 # Dev-linked premium assets (symlinks to angple-premium)
 themes/damoang-default
-plugins/
+# 1단계 패턴(plugins/*)으로 두어, 트래킹할 플러그인만 명시 예외로 추가한다.
+# 기존 추적 플러그인은 ignore 추가 후에도 유지되지만, 그 안에 새 파일을 추가하려면 예외 등록 필요.
+plugins/*
+!plugins/affiliate-link/
+!plugins/affiliate-link-private/
+!plugins/auto-embed/
+!plugins/payment/
 !apps/web/src/routes/api/plugins/
 !apps/web/src/routes/admin/plugins/
 !apps/web/src/lib/plugins/

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,9 @@ SESSION_NOTES.md
 themes/damoang-default
 plugins/
 !apps/web/src/routes/api/plugins/
+!apps/web/src/routes/admin/plugins/
 !apps/web/src/lib/plugins/
+!apps/web/src/lib/server/plugins/
 apps/web/src/lib/components/ui/podcast-player/
 
 # Claude Code

--- a/apps/web/src/lib/server/plugins/index.ts
+++ b/apps/web/src/lib/server/plugins/index.ts
@@ -19,6 +19,8 @@ import {
 import { pluginSettingsProvider } from '../settings/plugin-settings-provider';
 import { TieredCache } from '$lib/server/cache';
 import type { ExtensionManifest } from '@angple/types';
+import { runPluginMigrations, rollbackPluginMigrations } from './migration-runner';
+import { invalidateHandlerCache } from './route-dispatcher';
 
 /**
  * 설치된 플러그인의 전체 정보
@@ -130,18 +132,32 @@ export async function invalidateActivePluginsCache(): Promise<void> {
 /**
  * 플러그인 활성화
  *
- * settings.json의 activePlugins 배열에 플러그인 ID를 추가합니다.
+ * settings.json의 activePlugins 배열에 플러그인 ID를 추가하고,
+ * 매니페스트의 migrations를 실행합니다 (#1289).
  */
 export async function activatePlugin(pluginId: string): Promise<boolean> {
-    // 플러그인이 설치되어 있는지 확인
     if (!(await isPluginInstalled(pluginId))) {
         console.error(`[Plugin API] 플러그인이 설치되지 않음: ${pluginId}`);
         return false;
     }
 
-    // Provider를 통해 플러그인 활성화
+    const manifest = await getPluginManifest(pluginId);
+    if (manifest?.migrations && manifest.migrations.length > 0) {
+        const pluginPath = await getPluginPath(pluginId);
+        try {
+            const result = await runPluginMigrations(pluginId, pluginPath, manifest.migrations);
+            console.info(
+                `[Plugin API] ${pluginId} migrations: applied=${result.applied.length}, skipped=${result.skipped.length}`
+            );
+        } catch (err) {
+            console.error(`[Plugin API] migration 실패: ${pluginId}`, err);
+            return false;
+        }
+    }
+
     await pluginSettingsProvider.activatePlugin(pluginId);
     await invalidateActivePluginsCache();
+    invalidateHandlerCache();
 
     return true;
 }
@@ -150,12 +166,49 @@ export async function activatePlugin(pluginId: string): Promise<boolean> {
  * 플러그인 비활성화
  *
  * settings.json의 activePlugins 배열에서 플러그인 ID를 제거합니다.
+ * 데이터 보존을 위해 migration은 자동으로 롤백되지 않습니다.
+ * 명시적 롤백은 `rollbackPlugin` 사용.
  */
 export async function deactivatePlugin(pluginId: string): Promise<boolean> {
-    // Provider를 통해 플러그인 비활성화
     await pluginSettingsProvider.deactivatePlugin(pluginId);
     await invalidateActivePluginsCache();
+    invalidateHandlerCache();
 
+    return true;
+}
+
+/**
+ * 플러그인 명시적 롤백 (관리자 액션).
+ * 비활성화 + migration down 실행.
+ */
+export async function rollbackPlugin(pluginId: string): Promise<boolean> {
+    const manifest = await getPluginManifest(pluginId);
+    if (!manifest) {
+        console.error(`[Plugin API] 매니페스트 없음: ${pluginId}`);
+        return false;
+    }
+
+    await pluginSettingsProvider.deactivatePlugin(pluginId);
+
+    if (manifest.migrations && manifest.migrations.length > 0) {
+        const pluginPath = await getPluginPath(pluginId);
+        try {
+            const result = await rollbackPluginMigrations(
+                pluginId,
+                pluginPath,
+                manifest.migrations
+            );
+            console.info(
+                `[Plugin API] ${pluginId} rollback: rolledBack=${result.rolledBack.length}`
+            );
+        } catch (err) {
+            console.error(`[Plugin API] rollback 실패: ${pluginId}`, err);
+            return false;
+        }
+    }
+
+    await invalidateActivePluginsCache();
+    invalidateHandlerCache();
     return true;
 }
 

--- a/apps/web/src/lib/server/plugins/migration-runner.ts
+++ b/apps/web/src/lib/server/plugins/migration-runner.ts
@@ -68,10 +68,10 @@ export async function runPluginMigrations(
             for (const stmt of splitStatements(sql)) {
                 await conn.query(stmt);
             }
-            await conn.query(
-                'INSERT INTO plugin_migrations (plugin_id, version) VALUES (?, ?)',
-                [pluginId, m.version]
-            );
+            await conn.query('INSERT INTO plugin_migrations (plugin_id, version) VALUES (?, ?)', [
+                pluginId,
+                m.version
+            ]);
             await conn.commit();
             result.applied.push(m.version);
             console.info(`${LOG_PREFIX} applied ${pluginId}@${m.version} (${m.description})`);
@@ -122,10 +122,10 @@ export async function rollbackPluginMigrations(
             for (const stmt of splitStatements(sql)) {
                 await conn.query(stmt);
             }
-            await conn.query(
-                'DELETE FROM plugin_migrations WHERE plugin_id = ? AND version = ?',
-                [pluginId, m.version]
-            );
+            await conn.query('DELETE FROM plugin_migrations WHERE plugin_id = ? AND version = ?', [
+                pluginId,
+                m.version
+            ]);
             await conn.commit();
             result.rolledBack.push(m.version);
             console.info(`${LOG_PREFIX} rolled back ${pluginId}@${m.version}`);

--- a/apps/web/src/lib/server/plugins/migration-runner.ts
+++ b/apps/web/src/lib/server/plugins/migration-runner.ts
@@ -1,0 +1,153 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { pool } from '$lib/server/db';
+import type { RowDataPacket } from 'mysql2/promise';
+import type { ExtensionMigration } from '@angple/types';
+
+const LOG_PREFIX = '[plugin-migration]';
+
+const TRACKING_TABLE_DDL = `
+CREATE TABLE IF NOT EXISTS plugin_migrations (
+    plugin_id VARCHAR(50) NOT NULL,
+    version VARCHAR(100) NOT NULL,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (plugin_id, version),
+    INDEX idx_plugin (plugin_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`;
+
+let bootstrapped = false;
+async function ensureBootstrap(): Promise<void> {
+    if (bootstrapped) return;
+    await pool.query(TRACKING_TABLE_DDL);
+    bootstrapped = true;
+}
+
+async function getAppliedVersions(pluginId: string): Promise<Set<string>> {
+    await ensureBootstrap();
+    const [rows] = await pool.query<RowDataPacket[]>(
+        'SELECT version FROM plugin_migrations WHERE plugin_id = ?',
+        [pluginId]
+    );
+    return new Set(rows.map((r) => r.version as string));
+}
+
+// MySQL는 single-statement만 받으므로 ;로 분리해서 순서대로 실행한다.
+function splitStatements(sql: string): string[] {
+    return sql
+        .split(/;\s*\n/m)
+        .map((s) => s.trim())
+        .filter(Boolean);
+}
+
+export interface PluginMigrationResult {
+    applied: string[];
+    skipped: string[];
+}
+
+export async function runPluginMigrations(
+    pluginId: string,
+    pluginPath: string,
+    migrations: ExtensionMigration[] | undefined
+): Promise<PluginMigrationResult> {
+    const result: PluginMigrationResult = { applied: [], skipped: [] };
+    if (!migrations || migrations.length === 0) return result;
+
+    const appliedSet = await getAppliedVersions(pluginId);
+
+    for (const m of migrations) {
+        if (appliedSet.has(m.version)) {
+            result.skipped.push(m.version);
+            continue;
+        }
+        const sqlPath = path.join(pluginPath, m.up);
+        const sql = await fs.readFile(sqlPath, 'utf-8');
+
+        const conn = await pool.getConnection();
+        try {
+            await conn.beginTransaction();
+            for (const stmt of splitStatements(sql)) {
+                await conn.query(stmt);
+            }
+            await conn.query(
+                'INSERT INTO plugin_migrations (plugin_id, version) VALUES (?, ?)',
+                [pluginId, m.version]
+            );
+            await conn.commit();
+            result.applied.push(m.version);
+            console.info(`${LOG_PREFIX} applied ${pluginId}@${m.version} (${m.description})`);
+        } catch (err) {
+            await conn.rollback();
+            const message = (err as Error).message;
+            throw new Error(`Migration ${pluginId}@${m.version} failed: ${message}`);
+        } finally {
+            conn.release();
+        }
+    }
+
+    return result;
+}
+
+export interface PluginRollbackResult {
+    rolledBack: string[];
+    skipped: string[];
+}
+
+export async function rollbackPluginMigrations(
+    pluginId: string,
+    pluginPath: string,
+    migrations: ExtensionMigration[] | undefined,
+    options: { until?: string } = {}
+): Promise<PluginRollbackResult> {
+    const result: PluginRollbackResult = { rolledBack: [], skipped: [] };
+    if (!migrations || migrations.length === 0) return result;
+
+    const appliedSet = await getAppliedVersions(pluginId);
+    const reversed = [...migrations].reverse();
+
+    for (const m of reversed) {
+        if (options.until && m.version === options.until) break;
+        if (!appliedSet.has(m.version)) continue;
+        if (!m.down) {
+            result.skipped.push(m.version);
+            console.warn(`${LOG_PREFIX} no down script for ${pluginId}@${m.version}, skipped`);
+            continue;
+        }
+
+        const sqlPath = path.join(pluginPath, m.down);
+        const sql = await fs.readFile(sqlPath, 'utf-8');
+
+        const conn = await pool.getConnection();
+        try {
+            await conn.beginTransaction();
+            for (const stmt of splitStatements(sql)) {
+                await conn.query(stmt);
+            }
+            await conn.query(
+                'DELETE FROM plugin_migrations WHERE plugin_id = ? AND version = ?',
+                [pluginId, m.version]
+            );
+            await conn.commit();
+            result.rolledBack.push(m.version);
+            console.info(`${LOG_PREFIX} rolled back ${pluginId}@${m.version}`);
+        } catch (err) {
+            await conn.rollback();
+            const message = (err as Error).message;
+            throw new Error(`Rollback ${pluginId}@${m.version} failed: ${message}`);
+        } finally {
+            conn.release();
+        }
+    }
+
+    return result;
+}
+
+export async function getAppliedMigrations(
+    pluginId: string
+): Promise<Array<{ version: string; appliedAt: Date }>> {
+    await ensureBootstrap();
+    const [rows] = await pool.query<RowDataPacket[]>(
+        'SELECT version, applied_at FROM plugin_migrations WHERE plugin_id = ? ORDER BY applied_at ASC',
+        [pluginId]
+    );
+    return rows.map((r) => ({ version: r.version as string, appliedAt: r.applied_at as Date }));
+}

--- a/apps/web/src/lib/server/plugins/route-dispatcher.ts
+++ b/apps/web/src/lib/server/plugins/route-dispatcher.ts
@@ -1,0 +1,94 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { RequestEvent } from '@sveltejs/kit';
+import type { ExtensionAPIRoute } from '@angple/types';
+import { getPluginById } from './index';
+
+const LOG_PREFIX = '[plugin-route]';
+
+type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type HandlerFn = (event: RequestEvent) => Response | Promise<Response>;
+type HandlerModule = Partial<Record<Method, HandlerFn>> & { default?: HandlerFn };
+
+const moduleCache = new Map<string, HandlerModule>();
+
+async function loadHandler(absolutePath: string): Promise<HandlerModule> {
+    const cached = moduleCache.get(absolutePath);
+    if (cached) return cached;
+    const mod = (await import(pathToFileURL(absolutePath).href)) as HandlerModule;
+    moduleCache.set(absolutePath, mod);
+    return mod;
+}
+
+function matchRoute(
+    routes: ExtensionAPIRoute[],
+    requestPath: string,
+    method: Method,
+    prefix: string
+): ExtensionAPIRoute | null {
+    const normalizedPrefix = prefix.startsWith('/') ? prefix : `/${prefix}`;
+    const stripped = requestPath.startsWith(normalizedPrefix)
+        ? requestPath.slice(normalizedPrefix.length) || '/'
+        : requestPath;
+
+    for (const route of routes) {
+        if (route.method !== method) continue;
+        if (route.path === stripped || route.path === requestPath) return route;
+    }
+    return null;
+}
+
+export interface DispatchInput {
+    pluginId: string;
+    /** plugin prefix를 제거한 나머지 경로 (앞에 '/' 포함) */
+    rest: string;
+    method: Method;
+    event: RequestEvent;
+}
+
+export async function dispatchPluginRoute(input: DispatchInput): Promise<Response> {
+    const plugin = await getPluginById(input.pluginId);
+    if (!plugin) {
+        return new Response(`Plugin not found: ${input.pluginId}`, { status: 404 });
+    }
+    if (!plugin.isActive) {
+        return new Response(`Plugin not active: ${input.pluginId}`, { status: 404 });
+    }
+
+    const restApi = plugin.manifest.api?.rest;
+    if (!restApi || !restApi.routes || restApi.routes.length === 0) {
+        return new Response(`Plugin has no routes: ${input.pluginId}`, { status: 404 });
+    }
+
+    const matched = matchRoute(restApi.routes, input.rest, input.method, restApi.prefix);
+    if (!matched) {
+        return new Response(`Route not found in plugin: ${input.pluginId}${input.rest}`, {
+            status: 404
+        });
+    }
+
+    const handlerPath = path.join(plugin.path, matched.handler);
+    let mod: HandlerModule;
+    try {
+        mod = await loadHandler(handlerPath);
+    } catch (err) {
+        console.error(`${LOG_PREFIX} failed to load handler ${handlerPath}:`, err);
+        return new Response(`Plugin handler load error`, { status: 500 });
+    }
+
+    const fn = mod[input.method] ?? mod.default;
+    if (typeof fn !== 'function') {
+        return new Response(`Plugin handler missing ${input.method} export`, { status: 500 });
+    }
+
+    try {
+        return await fn(input.event);
+    } catch (err) {
+        console.error(`${LOG_PREFIX} handler error in ${input.pluginId}${input.rest}:`, err);
+        return new Response(`Plugin handler error`, { status: 500 });
+    }
+}
+
+export function invalidateHandlerCache(): void {
+    moduleCache.clear();
+}

--- a/apps/web/src/lib/server/plugins/scanner.test.ts
+++ b/apps/web/src/lib/server/plugins/scanner.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { safeValidateExtensionManifest } from '@angple/types';
+
+describe('plugin manifest schema (#1289 L1 regression)', () => {
+    it('새 migrations 필드는 옵셔널 — 누락해도 검증 통과', () => {
+        expect.hasAssertions();
+        const minimal = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts'
+        };
+        const result = safeValidateExtensionManifest(minimal);
+        expect(result.success).toBe(true);
+    });
+
+    it('migrations 배열 검증 통과', () => {
+        expect.hasAssertions();
+        const withMigrations = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            migrations: [
+                {
+                    version: '001',
+                    description: 'create table',
+                    up: 'migrations/001_up.sql',
+                    down: 'migrations/001_down.sql'
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(withMigrations);
+        expect(result.success).toBe(true);
+    });
+
+    it('migrations down은 옵셔널', () => {
+        expect.hasAssertions();
+        const withoutDown = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            migrations: [
+                {
+                    version: '001',
+                    description: 'create table',
+                    up: 'migrations/001_up.sql'
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(withoutDown);
+        expect(result.success).toBe(true);
+    });
+
+    it('migrations version/description/up은 필수', () => {
+        expect.hasAssertions();
+        const invalid = {
+            id: 'test-plugin',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'desc',
+            author: { name: 'a' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            migrations: [
+                {
+                    description: 'missing version and up'
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(invalid);
+        expect(result.success).toBe(false);
+    });
+
+    it('기존 plugin.json 형태(routes/admin/migrations 없음)도 통과', () => {
+        expect.hasAssertions();
+        const legacy = {
+            id: 'wiki',
+            name: '위키',
+            version: '0.1.0',
+            description: '위키 플러그인',
+            author: { name: 'Angple', url: 'https://angple.com' },
+            license: 'MIT',
+            category: 'plugin' as const,
+            main: 'index.ts',
+            tags: ['wiki'],
+            components: [
+                {
+                    id: 'wiki-board',
+                    name: '위키 문서 목록',
+                    slot: 'board-list',
+                    path: 'components/wiki-board.svelte',
+                    priority: 10
+                }
+            ],
+            hooks: [
+                {
+                    name: 'board.layout.register',
+                    type: 'action' as const,
+                    callback: 'hooks/register-wiki.ts',
+                    priority: 10
+                }
+            ]
+        };
+        const result = safeValidateExtensionManifest(legacy);
+        expect(result.success).toBe(true);
+    });
+});

--- a/apps/web/src/lib/utils/plugin-optional-loader.ts
+++ b/apps/web/src/lib/utils/plugin-optional-loader.ts
@@ -9,6 +9,8 @@ import type { Component } from 'svelte';
 
 // Glob all plugin components (lazy, not eager)
 const pluginComponents = import.meta.glob('../../../../../plugins/*/components/*.svelte');
+// Admin / arbitrary svelte files under plugin (used by admin sidebar entries)
+const pluginAnySvelte = import.meta.glob('../../../../../plugins/*/**/*.svelte');
 // Note: Exclude .server.ts files from glob to prevent server-only code from being bundled for client
 const pluginLibs = import.meta.glob([
     '../../../../../plugins/*/lib/*.svelte',
@@ -30,6 +32,28 @@ export async function loadPluginComponent(
 ): Promise<Component | null> {
     const path = `../../../../../plugins/${pluginId}/components/${componentName}.svelte`;
     const loader = pluginComponents[path];
+    if (!loader) return null;
+
+    try {
+        const module = (await loader()) as { default: Component };
+        return module.default;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Load a plugin svelte file by its relative path from the plugin root.
+ * Used by admin sidebar entries — manifest's `ui.admin.menu.component` is a relative path
+ * (e.g. "admin/settings.svelte"), so we glob the entire plugin tree.
+ */
+export async function loadPluginSvelteByPath(
+    pluginId: string,
+    relativePath: string
+): Promise<Component | null> {
+    const normalized = relativePath.startsWith('./') ? relativePath.slice(2) : relativePath;
+    const fullPath = `../../../../../plugins/${pluginId}/${normalized}`;
+    const loader = pluginAnySvelte[fullPath];
     if (!loader) return null;
 
     try {

--- a/apps/web/src/routes/admin/plugins/[id]/+page.server.ts
+++ b/apps/web/src/routes/admin/plugins/[id]/+page.server.ts
@@ -1,0 +1,20 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { getPluginById } from '$lib/server/plugins';
+
+export const load: PageServerLoad = async ({ params }) => {
+    const plugin = await getPluginById(params.id);
+    if (!plugin) throw error(404, `Plugin not found: ${params.id}`);
+    if (!plugin.isActive) throw error(404, `Plugin not active: ${params.id}`);
+
+    const adminMenu = plugin.manifest.ui?.admin?.menu;
+    if (!adminMenu?.component) {
+        throw error(404, `Plugin '${params.id}' has no admin menu`);
+    }
+
+    return {
+        pluginId: plugin.manifest.id,
+        title: adminMenu.title,
+        componentPath: adminMenu.component
+    };
+};

--- a/apps/web/src/routes/admin/plugins/[id]/+page.svelte
+++ b/apps/web/src/routes/admin/plugins/[id]/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+    import type { Component } from 'svelte';
+    import { loadPluginSvelteByPath } from '$lib/utils/plugin-optional-loader';
+    import type { PageData } from './$types';
+
+    let { data }: { data: PageData } = $props();
+
+    let PluginComponent = $state<Component | null>(null);
+    let loadError = $state<string | null>(null);
+
+    $effect(() => {
+        loadPluginSvelteByPath(data.pluginId, data.componentPath)
+            .then((c) => {
+                if (!c) {
+                    loadError = `Component not found: ${data.componentPath}`;
+                } else {
+                    PluginComponent = c;
+                }
+            })
+            .catch((err: unknown) => {
+                loadError = `Load failed: ${(err as Error).message}`;
+            });
+    });
+</script>
+
+<svelte:head>
+    <title>{data.title} — Admin</title>
+</svelte:head>
+
+<div class="plugin-admin-page">
+    <h1>{data.title}</h1>
+
+    {#if PluginComponent}
+        <PluginComponent />
+    {:else if loadError}
+        <div class="error">
+            플러그인 컴포넌트 로드 실패: {loadError}
+        </div>
+    {:else}
+        <div class="loading">로딩 중…</div>
+    {/if}
+</div>
+
+<style>
+    .plugin-admin-page {
+        padding: 1rem;
+    }
+    .error {
+        color: #c33;
+        background: #fee;
+        padding: 0.75rem 1rem;
+        border-radius: 4px;
+    }
+    .loading {
+        color: #666;
+    }
+</style>

--- a/apps/web/src/routes/api/plugins/[id]/[...rest]/+server.ts
+++ b/apps/web/src/routes/api/plugins/[id]/[...rest]/+server.ts
@@ -1,0 +1,20 @@
+import type { RequestHandler } from './$types';
+import { dispatchPluginRoute } from '$lib/server/plugins/route-dispatcher';
+
+function makeHandler(method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'): RequestHandler {
+    return async (event) => {
+        const { id, rest } = event.params;
+        return dispatchPluginRoute({
+            pluginId: id ?? '',
+            rest: `/${rest ?? ''}`,
+            method,
+            event
+        });
+    };
+}
+
+export const GET: RequestHandler = makeHandler('GET');
+export const POST: RequestHandler = makeHandler('POST');
+export const PUT: RequestHandler = makeHandler('PUT');
+export const PATCH: RequestHandler = makeHandler('PATCH');
+export const DELETE: RequestHandler = makeHandler('DELETE');

--- a/packages/types/src/extension-schema.ts
+++ b/packages/types/src/extension-schema.ts
@@ -41,6 +41,16 @@ export const ExtensionEnginesSchema = z.object({
     angple: z.string().optional()
 });
 
+/**
+ * DB 마이그레이션 정의 (플러그인 전용)
+ */
+export const ExtensionMigrationSchema = z.object({
+    version: z.string().min(1, '마이그레이션 version은 필수입니다'),
+    description: z.string().min(1, '마이그레이션 설명은 필수입니다'),
+    up: z.string().min(1, 'up SQL 파일 경로는 필수입니다'),
+    down: z.string().optional()
+});
+
 // ============================================================================
 // 설정 필드 스키마
 // ============================================================================
@@ -257,6 +267,7 @@ const BaseExtensionManifestSchema = z.object({
     api: ExtensionAPISchema.optional(),
     ui: ExtensionUISchema.optional(),
     settings: z.record(z.string(), ExtensionSettingFieldSchema).optional(),
+    migrations: z.array(ExtensionMigrationSchema).optional(),
     dependencies: z.record(z.string(), z.string()).optional(),
     devDependencies: z.record(z.string(), z.string()).optional(),
     homepage: z.string().url().optional(),

--- a/packages/types/src/extension.ts
+++ b/packages/types/src/extension.ts
@@ -351,6 +351,25 @@ export interface ExtensionUI {
 }
 
 /**
+ * DB 마이그레이션 정의.
+ * 플러그인 활성화 시 `up` 파일이 순서대로 실행되며, 비활성화/롤백 시 `down` 파일이 사용됩니다.
+ * `plugin_migrations` 추적 테이블이 중복 실행을 방지합니다.
+ */
+export interface ExtensionMigration {
+    /** 마이그레이션 버전 (예: "001", "20260501-add-payments") */
+    version: string;
+
+    /** 마이그레이션 설명 */
+    description: string;
+
+    /** Up SQL 파일 경로 (플러그인 루트 기준 상대 경로) */
+    up: string;
+
+    /** Down SQL 파일 경로 (롤백용, 선택) */
+    down?: string;
+}
+
+/**
  * Extension 엔진 요구사항
  */
 export interface ExtensionEngines {
@@ -435,6 +454,15 @@ export interface ExtensionManifest {
 
     /** Extension 설정 필드 */
     settings?: Record<string, ExtensionSettingField>;
+
+    /**
+     * DB 마이그레이션 정의 (플러그인 활성화 시 자동 실행).
+     * 각 항목의 `up` 파일이 순서대로 실행되며, `down`은 비활성화/롤백 시 사용됩니다.
+     * `plugin_migrations` 추적 테이블로 중복 실행을 방지합니다.
+     *
+     * 플러그인 전용 필드 — 테마는 일반적으로 사용하지 않습니다.
+     */
+    migrations?: ExtensionMigration[];
 
     /** npm 의존성 (package.json처럼) */
     dependencies?: Record<string, string>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,6 +44,7 @@ export type {
     ExtensionEditorUI,
     ExtensionUI,
     ExtensionEngines,
+    ExtensionMigration,
     ExtensionManifest,
     ExtensionRuntime,
     ExtensionInstallOptions,
@@ -69,7 +70,8 @@ export {
     ExtensionAdminMenuSchema,
     ExtensionAdminUISchema,
     ExtensionEditorUISchema,
-    ExtensionUISchema
+    ExtensionUISchema,
+    ExtensionMigrationSchema
 } from './extension-schema.js';
 
 export type { ExtensionManifestValidated, PartialExtensionManifest } from './extension-schema.js';

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -4,7 +4,7 @@
 
 import type { HookDefinition } from './hook.js';
 import type { ComponentDefinition } from './theme.js';
-import type { ExtensionManifest, PluginType } from './extension.js';
+import type { ExtensionManifest, ExtensionMigration, PluginType } from './extension.js';
 
 /**
  * 플러그인 API 엔드포인트 정의
@@ -31,20 +31,10 @@ export interface ApiEndpoint {
 
 /**
  * 데이터베이스 마이그레이션 정의
+ *
+ * @deprecated `ExtensionMigration` (extension.ts)을 사용하세요. 하위 호환성을 위한 별칭입니다.
  */
-export interface Migration {
-    /** 마이그레이션 버전 */
-    version: string;
-
-    /** 마이그레이션 설명 */
-    description: string;
-
-    /** Up 스크립트 경로 */
-    up: string;
-
-    /** Down 스크립트 경로 */
-    down: string;
-}
+export type Migration = ExtensionMigration;
 
 /**
  * 플러그인 메타데이터 (plugin.json)

--- a/plugins/payment/admin/index.svelte
+++ b/plugins/payment/admin/index.svelte
@@ -59,9 +59,7 @@
                 {/each}
             </tbody>
         </table>
-        <p class="todo">
-            상세 키 입력 / 거래 조회 / 환불 기능은 후속 PR에서 추가됩니다.
-        </p>
+        <p class="todo">상세 키 입력 / 거래 조회 / 환불 기능은 후속 PR에서 추가됩니다.</p>
     {/if}
 </div>
 

--- a/plugins/payment/admin/index.svelte
+++ b/plugins/payment/admin/index.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+
+    type ProviderRow = {
+        provider: 'toss' | 'naver' | 'paypal';
+        sandbox: boolean;
+        active: boolean;
+        hasCredentials: boolean;
+    };
+
+    let rows = $state<ProviderRow[]>([]);
+    let loading = $state(true);
+    let loadError = $state<string | null>(null);
+
+    onMount(async () => {
+        try {
+            const res = await fetch('/api/plugins/payment/admin/providers');
+            if (!res.ok) {
+                loadError = `상태 조회 실패 (HTTP ${res.status})`;
+                return;
+            }
+            rows = (await res.json()) as ProviderRow[];
+        } catch (err) {
+            loadError = (err as Error).message;
+        } finally {
+            loading = false;
+        }
+    });
+</script>
+
+<div class="payment-admin">
+    <h1>결제 관리</h1>
+    <p class="hint">사이트별 PG 키와 활성 여부를 관리합니다.</p>
+
+    {#if loading}
+        <div class="loading">로딩 중…</div>
+    {:else if loadError}
+        <div class="error">{loadError}</div>
+    {:else}
+        <table>
+            <thead>
+                <tr>
+                    <th>PG</th>
+                    <th>모드</th>
+                    <th>활성</th>
+                    <th>키 등록</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each rows as row (row.provider)}
+                    <tr>
+                        <td>{row.provider}</td>
+                        <td>{row.sandbox ? 'Sandbox' : 'Production'}</td>
+                        <td>{row.active ? '✓' : '–'}</td>
+                        <td>{row.hasCredentials ? '✓' : '–'}</td>
+                        <td><a href="/admin/plugins/payment/{row.provider}">설정</a></td>
+                    </tr>
+                {/each}
+            </tbody>
+        </table>
+        <p class="todo">
+            상세 키 입력 / 거래 조회 / 환불 기능은 후속 PR에서 추가됩니다.
+        </p>
+    {/if}
+</div>
+
+<style>
+    .payment-admin {
+        padding: 1rem;
+    }
+    .hint {
+        color: #666;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+    }
+    th,
+    td {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #eee;
+        text-align: left;
+    }
+    .error {
+        color: #c33;
+        background: #fee;
+        padding: 0.75rem;
+        border-radius: 4px;
+    }
+    .todo {
+        color: #888;
+        font-size: 0.9rem;
+        margin-top: 1rem;
+    }
+</style>

--- a/plugins/payment/hooks/site-context.ts
+++ b/plugins/payment/hooks/site-context.ts
@@ -1,0 +1,17 @@
+/**
+ * 멀티사이트 site_id 해석.
+ *
+ * 본 헬퍼는 #1224 (멀티사이트 도메인→테마/SEO DB 매핑) 진행에 따라 교체 예정.
+ * 현재는 host → site_id 매핑이 DB에 없으므로 fallback (0 = "기본 사이트") 으로 동작합니다.
+ *
+ * #1224 가 머지되면 angple_sites 테이블 조회로 교체:
+ *   SELECT id FROM angple_sites WHERE domain = ? AND active = 1
+ */
+
+const FALLBACK_SITE_ID = 0;
+
+export function resolveSiteId(host: string | undefined | null): number {
+    if (!host) return FALLBACK_SITE_ID;
+    // TODO(#1224): replace with angple_sites lookup
+    return FALLBACK_SITE_ID;
+}

--- a/plugins/payment/index.ts
+++ b/plugins/payment/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Payment plugin entry point.
+ *
+ * 매니페스트의 `main` 필드 (plugin.json: "main": "index.ts").
+ * 현재는 import side-effect만 노출 — 실제 라우트/DB 등록은 Phase 1 plugin loader가 매니페스트 기반으로 자동 처리.
+ */
+
+export { tossProvider } from './providers/toss/index.js';
+export { naverProvider } from './providers/naver/index.js';
+export { paypalProvider } from './providers/paypal/index.js';
+export { getProvider, listProviders } from './providers/registry.js';
+
+export type { PaymentProvider, PaymentProviderId, PaymentOrder, ProviderConfig } from './types/index.js';

--- a/plugins/payment/index.ts
+++ b/plugins/payment/index.ts
@@ -10,4 +10,9 @@ export { naverProvider } from './providers/naver/index.js';
 export { paypalProvider } from './providers/paypal/index.js';
 export { getProvider, listProviders } from './providers/registry.js';
 
-export type { PaymentProvider, PaymentProviderId, PaymentOrder, ProviderConfig } from './types/index.js';
+export type {
+    PaymentProvider,
+    PaymentProviderId,
+    PaymentOrder,
+    ProviderConfig
+} from './types/index.js';

--- a/plugins/payment/migrations/001_payment_orders.down.sql
+++ b/plugins/payment/migrations/001_payment_orders.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS payment_orders

--- a/plugins/payment/migrations/001_payment_orders.up.sql
+++ b/plugins/payment/migrations/001_payment_orders.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS payment_orders (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    site_id INT NOT NULL DEFAULT 0,
+    user_id INT NOT NULL,
+    order_uid VARCHAR(64) NOT NULL UNIQUE,
+    provider VARCHAR(32) NOT NULL,
+    pg_order_id VARCHAR(128) NULL,
+    pg_transaction_id VARCHAR(128) NULL,
+    amount DECIMAL(18,2) NOT NULL,
+    currency CHAR(3) NOT NULL DEFAULT 'KRW',
+    status ENUM('pending','prepared','paid','cancelled','refunded','failed') NOT NULL DEFAULT 'pending',
+    description VARCHAR(255) NULL,
+    metadata_json JSON NULL,
+    paid_at DATETIME NULL,
+    refunded_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_site_user (site_id, user_id),
+    INDEX idx_provider_pg_order (provider, pg_order_id),
+    INDEX idx_status_created (status, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/payment/migrations/002_payment_provider_configs.down.sql
+++ b/plugins/payment/migrations/002_payment_provider_configs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS payment_provider_configs

--- a/plugins/payment/migrations/002_payment_provider_configs.up.sql
+++ b/plugins/payment/migrations/002_payment_provider_configs.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS payment_provider_configs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    site_id INT NOT NULL DEFAULT 0,
+    provider VARCHAR(32) NOT NULL,
+    sandbox TINYINT(1) NOT NULL DEFAULT 1,
+    active TINYINT(1) NOT NULL DEFAULT 0,
+    credentials_json JSON NOT NULL,
+    config_json JSON NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_site_provider (site_id, provider),
+    INDEX idx_active (active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/payment/migrations/003_payment_events.down.sql
+++ b/plugins/payment/migrations/003_payment_events.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS payment_events

--- a/plugins/payment/migrations/003_payment_events.up.sql
+++ b/plugins/payment/migrations/003_payment_events.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS payment_events (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    order_id BIGINT NULL,
+    site_id INT NOT NULL DEFAULT 0,
+    provider VARCHAR(32) NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    payload_json JSON NOT NULL,
+    signature_valid TINYINT(1) NULL,
+    received_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_order (order_id),
+    INDEX idx_provider_type (provider, event_type),
+    INDEX idx_received (received_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/payment/plugin.json
+++ b/plugins/payment/plugin.json
@@ -1,0 +1,113 @@
+{
+    "id": "payment",
+    "name": "결제",
+    "version": "0.1.0",
+    "author": {
+        "name": "Angple",
+        "url": "https://angple.com"
+    },
+    "category": "plugin",
+    "pluginType": "PAYMENT",
+    "license": "MIT",
+    "main": "index.ts",
+    "description": "다중 PG (토스/네이버페이/페이팔) 통합 결제 플러그인. 멀티사이트 키 분리.",
+    "tags": ["payment", "toss", "naver-pay", "paypal", "결제", "commerce"],
+    "migrations": [
+        {
+            "version": "001",
+            "description": "payment_orders: 주문/결제 메인 테이블",
+            "up": "migrations/001_payment_orders.up.sql",
+            "down": "migrations/001_payment_orders.down.sql"
+        },
+        {
+            "version": "002",
+            "description": "payment_provider_configs: 사이트별 PG 키 분리",
+            "up": "migrations/002_payment_provider_configs.up.sql",
+            "down": "migrations/002_payment_provider_configs.down.sql"
+        },
+        {
+            "version": "003",
+            "description": "payment_events: webhook/이벤트 로그",
+            "up": "migrations/003_payment_events.up.sql",
+            "down": "migrations/003_payment_events.down.sql"
+        }
+    ],
+    "api": {
+        "rest": {
+            "prefix": "/api/plugins/payment",
+            "routes": [
+                {
+                    "method": "POST",
+                    "path": "/checkout/start",
+                    "handler": "routes/checkout/start.ts",
+                    "authenticated": true
+                },
+                {
+                    "method": "POST",
+                    "path": "/checkout/complete",
+                    "handler": "routes/checkout/complete.ts",
+                    "authenticated": true
+                },
+                {
+                    "method": "POST",
+                    "path": "/webhook/toss",
+                    "handler": "routes/webhook/toss.ts"
+                },
+                {
+                    "method": "POST",
+                    "path": "/webhook/naver",
+                    "handler": "routes/webhook/naver.ts"
+                },
+                {
+                    "method": "POST",
+                    "path": "/webhook/paypal",
+                    "handler": "routes/webhook/paypal.ts"
+                },
+                {
+                    "method": "POST",
+                    "path": "/refund",
+                    "handler": "routes/refund/index.ts",
+                    "authenticated": true
+                }
+            ]
+        }
+    },
+    "ui": {
+        "admin": {
+            "menu": {
+                "title": "결제 관리",
+                "icon": "credit-card",
+                "position": 60,
+                "component": "admin/index.svelte"
+            }
+        }
+    },
+    "settings": {
+        "toss_enabled": {
+            "label": "토스 페이먼츠 활성화",
+            "type": "boolean",
+            "default": false,
+            "description": "토스 결제 모듈을 사용 중지/활성화합니다 (사이트별 키는 admin에서 관리)."
+        },
+        "naver_enabled": {
+            "label": "네이버페이 활성화",
+            "type": "boolean",
+            "default": false
+        },
+        "paypal_enabled": {
+            "label": "PayPal 활성화",
+            "type": "boolean",
+            "default": false
+        },
+        "default_currency": {
+            "label": "기본 통화",
+            "type": "select",
+            "default": "KRW",
+            "options": [
+                { "label": "원 (KRW)", "value": "KRW" },
+                { "label": "달러 (USD)", "value": "USD" }
+            ],
+            "description": "기본 표시/계산 통화. PayPal 등 다통화 지원 PG에 영향."
+        }
+    }
+}

--- a/plugins/payment/providers/naver/index.ts
+++ b/plugins/payment/providers/naver/index.ts
@@ -1,0 +1,127 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type {
+    PaymentProvider,
+    ProviderConfig,
+    PreparePaymentInput,
+    PreparePaymentResult,
+    CompletePaymentInput,
+    CompletePaymentResult,
+    RefundInput,
+    RefundResult,
+    VerifyWebhookInput
+} from '../../types/index.js';
+
+interface NaverCreds {
+    clientId: string;
+    clientSecret: string;
+    chainId: string;
+    /** webhook signature secret */
+    webhookSecret?: string;
+}
+
+const NAVER_API_BASE_PROD = 'https://apis.naver.com/naverpay-partner/naverpay/payments/v2.2';
+const NAVER_API_BASE_SANDBOX = 'https://dev.apis.naver.com/naverpay-partner/naverpay/payments/v2.2';
+
+function naverHeaders(creds: NaverCreds): Record<string, string> {
+    return {
+        'X-Naver-Client-Id': creds.clientId,
+        'X-Naver-Client-Secret': creds.clientSecret,
+        'X-NaverPay-Chain-Id': creds.chainId,
+        'X-NaverPay-Idempotency-Key': `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+    };
+}
+
+async function naverFetch(
+    config: ProviderConfig<NaverCreds>,
+    path: string,
+    form: Record<string, string>
+): Promise<Record<string, unknown>> {
+    const base = config.sandbox ? NAVER_API_BASE_SANDBOX : NAVER_API_BASE_PROD;
+    const body = new URLSearchParams(form).toString();
+    const res = await fetch(`${base}${path}`, {
+        method: 'POST',
+        headers: naverHeaders(config.credentials),
+        body
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    const code = (json.code as string) ?? '';
+    if (!res.ok || code !== 'Success') {
+        const message = (json.message as string) ?? 'Naver Pay API error';
+        throw new Error(`NaverPay ${code || `HTTP_${res.status}`}: ${message}`);
+    }
+    return (json.body as Record<string, unknown>) ?? json;
+}
+
+export const naverProvider: PaymentProvider = {
+    id: 'naver',
+
+    async prepare(
+        _config: ProviderConfig<NaverCreds>,
+        input: PreparePaymentInput
+    ): Promise<PreparePaymentResult> {
+        // 네이버페이는 클라이언트 SDK(JS)에서 reserve → 서버에서 apply 흐름.
+        // prepare 단계에서는 클라이언트가 SDK 호출에 사용할 파라미터를 그대로 반환.
+        return {
+            sdkParams: {
+                merchantUserKey: input.customerKey,
+                merchantPayKey: input.order.orderUid,
+                productName: input.order.description ?? '상품',
+                totalPayAmount: input.order.amount,
+                taxScopeAmount: input.order.amount,
+                taxExScopeAmount: 0,
+                returnUrl: input.returnUrl
+            },
+            pgOrderId: input.order.orderUid
+        };
+    },
+
+    async complete(
+        config: ProviderConfig<NaverCreds>,
+        input: CompletePaymentInput
+    ): Promise<CompletePaymentResult> {
+        if (!input.pgPaymentKey) {
+            throw new Error('NaverPay complete requires pgPaymentKey (paymentId)');
+        }
+        const body = await naverFetch(config, '/apply/payment', {
+            paymentId: input.pgPaymentKey
+        });
+        const detail = (body.detail as Record<string, unknown>) ?? body;
+        return {
+            pgTransactionId: (detail.paymentId as string) ?? input.pgPaymentKey,
+            paidAt: new Date((detail.admissionYmdt as string) ?? Date.now()),
+            raw: body
+        };
+    },
+
+    async refund(
+        config: ProviderConfig<NaverCreds>,
+        input: RefundInput
+    ): Promise<RefundResult> {
+        const body = await naverFetch(config, '/cancel', {
+            paymentId: input.pgTransactionId,
+            cancelAmount: String(input.amount),
+            cancelReason: input.reason ?? '환불',
+            cancelRequester: '2'
+        });
+        return {
+            pgRefundId: (body.cancelId as string) ?? `naver-refund-${Date.now()}`,
+            refundedAt: new Date(),
+            raw: body
+        };
+    },
+
+    verifyWebhook(config: ProviderConfig<NaverCreds>, input: VerifyWebhookInput): boolean {
+        const secret = config.credentials.webhookSecret;
+        const signature = input.headers['x-naverpay-signature'] ?? input.headers['X-NaverPay-Signature'];
+        if (!secret || !signature) return false;
+        const expected = createHmac('sha256', secret).update(input.rawBody).digest('hex');
+        const sig = signature.toLowerCase();
+        if (sig.length !== expected.length) return false;
+        try {
+            return timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+        } catch {
+            return false;
+        }
+    }
+};

--- a/plugins/payment/providers/naver/index.ts
+++ b/plugins/payment/providers/naver/index.ts
@@ -94,10 +94,7 @@ export const naverProvider: PaymentProvider = {
         };
     },
 
-    async refund(
-        config: ProviderConfig<NaverCreds>,
-        input: RefundInput
-    ): Promise<RefundResult> {
+    async refund(config: ProviderConfig<NaverCreds>, input: RefundInput): Promise<RefundResult> {
         const body = await naverFetch(config, '/cancel', {
             paymentId: input.pgTransactionId,
             cancelAmount: String(input.amount),
@@ -113,7 +110,8 @@ export const naverProvider: PaymentProvider = {
 
     verifyWebhook(config: ProviderConfig<NaverCreds>, input: VerifyWebhookInput): boolean {
         const secret = config.credentials.webhookSecret;
-        const signature = input.headers['x-naverpay-signature'] ?? input.headers['X-NaverPay-Signature'];
+        const signature =
+            input.headers['x-naverpay-signature'] ?? input.headers['X-NaverPay-Signature'];
         if (!secret || !signature) return false;
         const expected = createHmac('sha256', secret).update(input.rawBody).digest('hex');
         const sig = signature.toLowerCase();

--- a/plugins/payment/providers/paypal/index.ts
+++ b/plugins/payment/providers/paypal/index.ts
@@ -1,0 +1,170 @@
+import type {
+    PaymentProvider,
+    ProviderConfig,
+    PreparePaymentInput,
+    PreparePaymentResult,
+    CompletePaymentInput,
+    CompletePaymentResult,
+    RefundInput,
+    RefundResult,
+    VerifyWebhookInput
+} from '../../types/index.js';
+
+interface PayPalCreds {
+    clientId: string;
+    clientSecret: string;
+    /** Webhook ID — webhook 검증에 사용 (PayPal verify-webhook-signature API) */
+    webhookId?: string;
+}
+
+const PAYPAL_API_BASE_PROD = 'https://api-m.paypal.com';
+const PAYPAL_API_BASE_SANDBOX = 'https://api-m.sandbox.paypal.com';
+
+function baseUrl(config: ProviderConfig<PayPalCreds>): string {
+    return config.sandbox ? PAYPAL_API_BASE_SANDBOX : PAYPAL_API_BASE_PROD;
+}
+
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
+async function getAccessToken(config: ProviderConfig<PayPalCreds>): Promise<string> {
+    const key = `${config.siteId}:${config.sandbox ? 'sb' : 'prod'}:${config.credentials.clientId}`;
+    const cached = tokenCache.get(key);
+    const now = Date.now();
+    if (cached && cached.expiresAt > now + 30_000) return cached.token;
+
+    const auth = Buffer.from(
+        `${config.credentials.clientId}:${config.credentials.clientSecret}`
+    ).toString('base64');
+    const res = await fetch(`${baseUrl(config)}/v1/oauth2/token`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Basic ${auth}`,
+            'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'grant_type=client_credentials'
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (!res.ok) {
+        throw new Error(`PayPal OAuth failed: ${(json.error_description as string) ?? res.status}`);
+    }
+    const token = json.access_token as string;
+    const expiresIn = (json.expires_in as number) ?? 3000;
+    tokenCache.set(key, { token, expiresAt: now + expiresIn * 1000 });
+    return token;
+}
+
+async function paypalFetch<T>(
+    config: ProviderConfig<PayPalCreds>,
+    path: string,
+    init: RequestInit
+): Promise<T> {
+    const token = await getAccessToken(config);
+    const res = await fetch(`${baseUrl(config)}${path}`, {
+        ...init,
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+            ...(init.headers ?? {})
+        }
+    });
+    const json = (await res.json()) as T;
+    if (!res.ok) {
+        const errMsg = (json as Record<string, unknown>).message ?? `HTTP_${res.status}`;
+        throw new Error(`PayPal: ${errMsg}`);
+    }
+    return json;
+}
+
+export const paypalProvider: PaymentProvider = {
+    id: 'paypal',
+
+    async prepare(
+        config: ProviderConfig<PayPalCreds>,
+        input: PreparePaymentInput
+    ): Promise<PreparePaymentResult> {
+        const order = await paypalFetch<Record<string, unknown>>(config, '/v2/checkout/orders', {
+            method: 'POST',
+            body: JSON.stringify({
+                intent: 'CAPTURE',
+                purchase_units: [
+                    {
+                        reference_id: input.order.orderUid,
+                        description: input.order.description ?? 'Order',
+                        amount: {
+                            currency_code: input.order.currency,
+                            value: input.order.amount.toFixed(2)
+                        }
+                    }
+                ],
+                application_context: {
+                    return_url: input.returnUrl,
+                    cancel_url: input.cancelUrl
+                }
+            })
+        });
+
+        const links = (order.links as Array<Record<string, string>>) ?? [];
+        const approve = links.find((l) => l.rel === 'approve' || l.rel === 'payer-action');
+        return {
+            redirectUrl: approve?.href,
+            pgOrderId: order.id as string
+        };
+    },
+
+    async complete(
+        config: ProviderConfig<PayPalCreds>,
+        input: CompletePaymentInput
+    ): Promise<CompletePaymentResult> {
+        const captured = await paypalFetch<Record<string, unknown>>(
+            config,
+            `/v2/checkout/orders/${encodeURIComponent(input.pgOrderId)}/capture`,
+            { method: 'POST' }
+        );
+        const purchaseUnits =
+            (captured.purchase_units as Array<Record<string, unknown>>) ?? [];
+        const captures =
+            (purchaseUnits[0]?.payments as Record<string, unknown>)?.captures as
+                | Array<Record<string, unknown>>
+                | undefined;
+        const capture = captures?.[0];
+        return {
+            pgTransactionId: (capture?.id as string) ?? (captured.id as string),
+            paidAt: new Date((capture?.create_time as string) ?? Date.now()),
+            raw: captured
+        };
+    },
+
+    async refund(
+        config: ProviderConfig<PayPalCreds>,
+        input: RefundInput
+    ): Promise<RefundResult> {
+        const refund = await paypalFetch<Record<string, unknown>>(
+            config,
+            `/v2/payments/captures/${encodeURIComponent(input.pgTransactionId)}/refund`,
+            {
+                method: 'POST',
+                body: JSON.stringify({
+                    amount: { value: input.amount.toFixed(2), currency_code: 'USD' },
+                    note_to_payer: input.reason
+                })
+            }
+        );
+        return {
+            pgRefundId: refund.id as string,
+            refundedAt: new Date((refund.create_time as string) ?? Date.now()),
+            raw: refund
+        };
+    },
+
+    verifyWebhook(_config: ProviderConfig<PayPalCreds>, input: VerifyWebhookInput): boolean {
+        // 정식 검증은 PayPal의 /v1/notifications/verify-webhook-signature API 호출이 필요.
+        // 동기 verifyWebhook 시그니처를 유지하기 위해 본 메서드는 1차 페이로드 형식만 검증하고,
+        // 실제 verify는 webhook 핸들러에서 별도로 호출하는 패턴을 권장.
+        try {
+            const json = JSON.parse(input.rawBody) as Record<string, unknown>;
+            return Boolean(json.event_type && json.id);
+        } catch {
+            return false;
+        }
+    }
+};

--- a/plugins/payment/providers/paypal/index.ts
+++ b/plugins/payment/providers/paypal/index.ts
@@ -120,12 +120,10 @@ export const paypalProvider: PaymentProvider = {
             `/v2/checkout/orders/${encodeURIComponent(input.pgOrderId)}/capture`,
             { method: 'POST' }
         );
-        const purchaseUnits =
-            (captured.purchase_units as Array<Record<string, unknown>>) ?? [];
-        const captures =
-            (purchaseUnits[0]?.payments as Record<string, unknown>)?.captures as
-                | Array<Record<string, unknown>>
-                | undefined;
+        const purchaseUnits = (captured.purchase_units as Array<Record<string, unknown>>) ?? [];
+        const captures = (purchaseUnits[0]?.payments as Record<string, unknown>)?.captures as
+            | Array<Record<string, unknown>>
+            | undefined;
         const capture = captures?.[0];
         return {
             pgTransactionId: (capture?.id as string) ?? (captured.id as string),
@@ -134,10 +132,7 @@ export const paypalProvider: PaymentProvider = {
         };
     },
 
-    async refund(
-        config: ProviderConfig<PayPalCreds>,
-        input: RefundInput
-    ): Promise<RefundResult> {
+    async refund(config: ProviderConfig<PayPalCreds>, input: RefundInput): Promise<RefundResult> {
         const refund = await paypalFetch<Record<string, unknown>>(
             config,
             `/v2/payments/captures/${encodeURIComponent(input.pgTransactionId)}/refund`,

--- a/plugins/payment/providers/registry.test.ts
+++ b/plugins/payment/providers/registry.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { getProvider, listProviders } from './registry.js';
+
+describe('payment provider registry', () => {
+    it('toss/naver/paypal 모두 등록됨', () => {
+        expect.hasAssertions();
+        const all = listProviders();
+        expect(all).toHaveLength(3);
+        expect(all.map((p) => p.id).sort()).toEqual(['naver', 'paypal', 'toss']);
+    });
+
+    it('각 provider는 prepare/complete/refund/verifyWebhook 메서드를 가짐', () => {
+        expect.hasAssertions();
+        for (const id of ['toss', 'naver', 'paypal'] as const) {
+            const p = getProvider(id);
+            expect(typeof p.prepare).toBe('function');
+            expect(typeof p.complete).toBe('function');
+            expect(typeof p.refund).toBe('function');
+            expect(typeof p.verifyWebhook).toBe('function');
+        }
+    });
+
+    it('알 수 없는 provider id는 throw', () => {
+        expect.hasAssertions();
+        expect(() => getProvider('unknown' as never)).toThrow();
+    });
+});
+
+describe('payment provider verifyWebhook', () => {
+    it('toss: 잘못된 JSON은 false', () => {
+        expect.hasAssertions();
+        const result = getProvider('toss').verifyWebhook(
+            { siteId: 0, provider: 'toss', sandbox: true, active: true, credentials: {} as never },
+            { rawBody: 'not json', headers: {} }
+        );
+        expect(result).toBe(false);
+    });
+
+    it('paypal: event_type+id 없는 페이로드는 false', () => {
+        expect.hasAssertions();
+        const result = getProvider('paypal').verifyWebhook(
+            { siteId: 0, provider: 'paypal', sandbox: true, active: true, credentials: {} as never },
+            { rawBody: '{"foo":"bar"}', headers: {} }
+        );
+        expect(result).toBe(false);
+    });
+
+    it('naver: 시그니처 헤더 없으면 false', () => {
+        expect.hasAssertions();
+        const result = getProvider('naver').verifyWebhook(
+            {
+                siteId: 0,
+                provider: 'naver',
+                sandbox: true,
+                active: true,
+                credentials: { clientId: 'c', clientSecret: 's', chainId: 'x', webhookSecret: 'w' } as never
+            },
+            { rawBody: '{}', headers: {} }
+        );
+        expect(result).toBe(false);
+    });
+});

--- a/plugins/payment/providers/registry.test.ts
+++ b/plugins/payment/providers/registry.test.ts
@@ -39,7 +39,13 @@ describe('payment provider verifyWebhook', () => {
     it('paypal: event_type+id 없는 페이로드는 false', () => {
         expect.hasAssertions();
         const result = getProvider('paypal').verifyWebhook(
-            { siteId: 0, provider: 'paypal', sandbox: true, active: true, credentials: {} as never },
+            {
+                siteId: 0,
+                provider: 'paypal',
+                sandbox: true,
+                active: true,
+                credentials: {} as never
+            },
             { rawBody: '{"foo":"bar"}', headers: {} }
         );
         expect(result).toBe(false);
@@ -53,7 +59,12 @@ describe('payment provider verifyWebhook', () => {
                 provider: 'naver',
                 sandbox: true,
                 active: true,
-                credentials: { clientId: 'c', clientSecret: 's', chainId: 'x', webhookSecret: 'w' } as never
+                credentials: {
+                    clientId: 'c',
+                    clientSecret: 's',
+                    chainId: 'x',
+                    webhookSecret: 'w'
+                } as never
             },
             { rawBody: '{}', headers: {} }
         );

--- a/plugins/payment/providers/registry.ts
+++ b/plugins/payment/providers/registry.ts
@@ -1,0 +1,20 @@
+import type { PaymentProvider, PaymentProviderId } from '../types/index.js';
+import { tossProvider } from './toss/index.js';
+import { naverProvider } from './naver/index.js';
+import { paypalProvider } from './paypal/index.js';
+
+const providers: Record<PaymentProviderId, PaymentProvider> = {
+    toss: tossProvider,
+    naver: naverProvider,
+    paypal: paypalProvider
+};
+
+export function getProvider(id: PaymentProviderId): PaymentProvider {
+    const p = providers[id];
+    if (!p) throw new Error(`Unknown payment provider: ${id}`);
+    return p;
+}
+
+export function listProviders(): PaymentProvider[] {
+    return Object.values(providers);
+}

--- a/plugins/payment/providers/toss/index.ts
+++ b/plugins/payment/providers/toss/index.ts
@@ -1,0 +1,118 @@
+import type {
+    PaymentProvider,
+    ProviderConfig,
+    PreparePaymentInput,
+    PreparePaymentResult,
+    CompletePaymentInput,
+    CompletePaymentResult,
+    RefundInput,
+    RefundResult,
+    VerifyWebhookInput
+} from '../../types/index.js';
+
+interface TossCreds {
+    clientKey: string;
+    secretKey: string;
+}
+
+const TOSS_API_BASE = 'https://api.tosspayments.com/v1';
+
+function basicAuth(secretKey: string): string {
+    return 'Basic ' + Buffer.from(`${secretKey}:`).toString('base64');
+}
+
+async function tossFetch(
+    secretKey: string,
+    path: string,
+    body: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+    const res = await fetch(`${TOSS_API_BASE}${path}`, {
+        method: 'POST',
+        headers: {
+            Authorization: basicAuth(secretKey),
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body)
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (!res.ok) {
+        const code = (json.code as string) ?? `HTTP_${res.status}`;
+        const message = (json.message as string) ?? 'Toss API error';
+        throw new Error(`Toss ${code}: ${message}`);
+    }
+    return json;
+}
+
+export const tossProvider: PaymentProvider = {
+    id: 'toss',
+
+    async prepare(
+        config: ProviderConfig<TossCreds>,
+        input: PreparePaymentInput
+    ): Promise<PreparePaymentResult> {
+        return {
+            sdkParams: {
+                clientKey: config.credentials.clientKey,
+                customerKey: input.customerKey,
+                orderId: input.order.orderUid,
+                orderName: input.order.description ?? '주문',
+                amount: input.order.amount,
+                currency: input.order.currency,
+                successUrl: input.returnUrl,
+                failUrl: input.cancelUrl
+            },
+            pgOrderId: input.order.orderUid
+        };
+    },
+
+    async complete(
+        config: ProviderConfig<TossCreds>,
+        input: CompletePaymentInput
+    ): Promise<CompletePaymentResult> {
+        if (!input.pgPaymentKey) {
+            throw new Error('Toss complete requires pgPaymentKey');
+        }
+        const json = await tossFetch(config.credentials.secretKey, '/payments/confirm', {
+            paymentKey: input.pgPaymentKey,
+            orderId: input.pgOrderId,
+            amount: input.amount
+        });
+        return {
+            pgTransactionId: (json.paymentKey as string) ?? input.pgPaymentKey,
+            paidAt: new Date((json.approvedAt as string) ?? Date.now()),
+            raw: json
+        };
+    },
+
+    async refund(
+        config: ProviderConfig<TossCreds>,
+        input: RefundInput
+    ): Promise<RefundResult> {
+        const json = await tossFetch(
+            config.credentials.secretKey,
+            `/payments/${encodeURIComponent(input.pgTransactionId)}/cancel`,
+            {
+                cancelReason: input.reason ?? '환불',
+                cancelAmount: input.amount
+            }
+        );
+        const cancels = json.cancels as Array<Record<string, unknown>> | undefined;
+        const last = cancels?.[cancels.length - 1];
+        return {
+            pgRefundId: (last?.transactionKey as string) ?? `toss-refund-${Date.now()}`,
+            refundedAt: new Date((last?.canceledAt as string) ?? Date.now()),
+            raw: json
+        };
+    },
+
+    verifyWebhook(_config: ProviderConfig<TossCreds>, input: VerifyWebhookInput): boolean {
+        // Toss는 webhook 전용 시그니처 필드를 별도로 제공하지 않고, 응답 본문 자체를 다시 confirm API로 재검증하는 패턴.
+        // sandbox/초기 단계에서는 IP allow-list + body 파싱 가능 여부로 1차 검증.
+        try {
+            JSON.parse(input.rawBody);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+};

--- a/plugins/payment/providers/toss/index.ts
+++ b/plugins/payment/providers/toss/index.ts
@@ -84,10 +84,7 @@ export const tossProvider: PaymentProvider = {
         };
     },
 
-    async refund(
-        config: ProviderConfig<TossCreds>,
-        input: RefundInput
-    ): Promise<RefundResult> {
+    async refund(config: ProviderConfig<TossCreds>, input: RefundInput): Promise<RefundResult> {
         const json = await tossFetch(
             config.credentials.secretKey,
             `/payments/${encodeURIComponent(input.pgTransactionId)}/cancel`,

--- a/plugins/payment/routes/checkout/complete.ts
+++ b/plugins/payment/routes/checkout/complete.ts
@@ -1,0 +1,60 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { resolveSiteId } from '../../hooks/site-context.js';
+import { getProviderConfig } from '../../server/config-store.js';
+import { getOrderByUid, updateOrderStatus, recordEvent } from '../../server/orders-store.js';
+import { getProvider } from '../../providers/registry.js';
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    const user = event.locals.user;
+    if (!user) throw error(401, 'authentication required');
+
+    const body = (await event.request.json()) as {
+        orderUid: string;
+        pgOrderId: string;
+        pgPaymentKey?: string;
+        amount: number;
+    };
+
+    if (!body.orderUid || !body.pgOrderId || !body.amount) {
+        throw error(400, 'missing required fields');
+    }
+
+    const order = await getOrderByUid(body.orderUid);
+    if (!order) throw error(404, 'order not found');
+    if (order.amount !== body.amount) {
+        throw error(400, 'amount mismatch');
+    }
+
+    const siteId = resolveSiteId(event.url.host);
+    const config = await getProviderConfig(siteId, order.provider);
+    if (!config) throw error(400, `provider not configured: ${order.provider}`);
+
+    const provider = getProvider(order.provider);
+    const result = await provider.complete(config, {
+        pgOrderId: body.pgOrderId,
+        pgPaymentKey: body.pgPaymentKey,
+        amount: body.amount
+    });
+
+    await updateOrderStatus(order.id, 'paid', {
+        pgOrderId: body.pgOrderId,
+        pgTransactionId: result.pgTransactionId,
+        paidAt: result.paidAt
+    });
+    await recordEvent({
+        orderId: order.id,
+        siteId,
+        provider: order.provider,
+        eventType: 'checkout.complete',
+        payload: result.raw,
+        signatureValid: null
+    });
+
+    return json({
+        orderUid: order.orderUid,
+        status: 'paid',
+        pgTransactionId: result.pgTransactionId,
+        paidAt: result.paidAt.toISOString()
+    });
+}

--- a/plugins/payment/routes/checkout/start.ts
+++ b/plugins/payment/routes/checkout/start.ts
@@ -1,0 +1,64 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { resolveSiteId } from '../../hooks/site-context.js';
+import { getProviderConfig } from '../../server/config-store.js';
+import { createOrder } from '../../server/orders-store.js';
+import { getProvider } from '../../providers/registry.js';
+import type { Currency, PaymentProviderId } from '../../types/index.js';
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    const user = event.locals.user;
+    if (!user) throw error(401, 'authentication required');
+
+    const body = (await event.request.json()) as {
+        provider: PaymentProviderId;
+        amount: number;
+        currency?: Currency;
+        description?: string;
+        returnUrl: string;
+        cancelUrl: string;
+        metadata?: Record<string, unknown>;
+    };
+
+    if (!body.provider || !body.amount || !body.returnUrl || !body.cancelUrl) {
+        throw error(400, 'missing required fields');
+    }
+
+    const siteId = resolveSiteId(event.url.host);
+    const config = await getProviderConfig(siteId, body.provider);
+    if (!config) throw error(400, `provider not configured: ${body.provider}`);
+
+    const orderUid = `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const order = await createOrder({
+        siteId,
+        userId: user.mb_no ?? user.id ?? 0,
+        orderUid,
+        provider: body.provider,
+        amount: body.amount,
+        currency: body.currency ?? 'KRW',
+        description: body.description,
+        metadata: body.metadata
+    });
+
+    const provider = getProvider(body.provider);
+    const prep = await provider.prepare(config, {
+        order: {
+            orderUid: order.orderUid,
+            amount: order.amount,
+            currency: order.currency,
+            description: order.description ?? null
+        },
+        returnUrl: body.returnUrl,
+        cancelUrl: body.cancelUrl,
+        customerKey: String(order.userId)
+    });
+
+    return json({
+        orderUid: order.orderUid,
+        provider: order.provider,
+        sandbox: config.sandbox,
+        sdkParams: prep.sdkParams ?? null,
+        redirectUrl: prep.redirectUrl ?? null,
+        pgOrderId: prep.pgOrderId
+    });
+}

--- a/plugins/payment/routes/refund/index.ts
+++ b/plugins/payment/routes/refund/index.ts
@@ -1,0 +1,53 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { resolveSiteId } from '../../hooks/site-context.js';
+import { getProviderConfig } from '../../server/config-store.js';
+import { getOrderByUid, updateOrderStatus, recordEvent } from '../../server/orders-store.js';
+import { getProvider } from '../../providers/registry.js';
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    const user = event.locals.user;
+    if (!user) throw error(401, 'authentication required');
+    if ((user.level ?? 0) < 10) throw error(403, 'admin only');
+
+    const body = (await event.request.json()) as {
+        orderUid: string;
+        amount?: number;
+        reason?: string;
+    };
+    if (!body.orderUid) throw error(400, 'orderUid required');
+
+    const order = await getOrderByUid(body.orderUid);
+    if (!order) throw error(404, 'order not found');
+    if (order.status !== 'paid') throw error(400, `cannot refund order in status: ${order.status}`);
+    if (!order.pgTransactionId) throw error(400, 'order has no pgTransactionId');
+
+    const siteId = resolveSiteId(event.url.host);
+    const config = await getProviderConfig(siteId, order.provider);
+    if (!config) throw error(400, 'provider not configured');
+
+    const refundAmount = body.amount ?? order.amount;
+    const provider = getProvider(order.provider);
+    const result = await provider.refund(config, {
+        pgTransactionId: order.pgTransactionId,
+        amount: refundAmount,
+        reason: body.reason
+    });
+
+    await updateOrderStatus(order.id, 'refunded', { refundedAt: result.refundedAt });
+    await recordEvent({
+        orderId: order.id,
+        siteId,
+        provider: order.provider,
+        eventType: 'refund',
+        payload: result.raw,
+        signatureValid: null
+    });
+
+    return json({
+        orderUid: order.orderUid,
+        status: 'refunded',
+        pgRefundId: result.pgRefundId,
+        refundedAt: result.refundedAt.toISOString()
+    });
+}

--- a/plugins/payment/routes/webhook/_handler.ts
+++ b/plugins/payment/routes/webhook/_handler.ts
@@ -1,0 +1,47 @@
+import { json } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { resolveSiteId } from '../../hooks/site-context.js';
+import { getProviderConfig } from '../../server/config-store.js';
+import { recordEvent } from '../../server/orders-store.js';
+import { getProvider } from '../../providers/registry.js';
+import type { PaymentProviderId } from '../../types/index.js';
+
+export async function handleWebhook(
+    providerId: PaymentProviderId,
+    event: RequestEvent
+): Promise<Response> {
+    const rawBody = await event.request.text();
+    const headers: Record<string, string> = {};
+    event.request.headers.forEach((v, k) => {
+        headers[k.toLowerCase()] = v;
+    });
+
+    const siteId = resolveSiteId(event.url.host);
+    const config = await getProviderConfig(siteId, providerId);
+
+    let valid: boolean | null = null;
+    if (config) {
+        valid = getProvider(providerId).verifyWebhook(config, { rawBody, headers });
+    }
+
+    let payload: Record<string, unknown> = {};
+    try {
+        payload = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+        payload = { _rawBody: rawBody.slice(0, 500) };
+    }
+
+    await recordEvent({
+        orderId: null,
+        siteId,
+        provider: providerId,
+        eventType: (payload.event_type as string) ?? (payload.type as string) ?? 'unknown',
+        payload,
+        signatureValid: valid
+    });
+
+    if (!config) return json({ ok: false, reason: 'provider not configured' }, { status: 200 });
+    if (!valid) return json({ ok: false, reason: 'invalid signature' }, { status: 200 });
+
+    return json({ ok: true });
+}

--- a/plugins/payment/routes/webhook/naver.ts
+++ b/plugins/payment/routes/webhook/naver.ts
@@ -1,0 +1,6 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { handleWebhook } from './_handler.js';
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    return handleWebhook('naver', event);
+}

--- a/plugins/payment/routes/webhook/paypal.ts
+++ b/plugins/payment/routes/webhook/paypal.ts
@@ -1,0 +1,6 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { handleWebhook } from './_handler.js';
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    return handleWebhook('paypal', event);
+}

--- a/plugins/payment/routes/webhook/toss.ts
+++ b/plugins/payment/routes/webhook/toss.ts
@@ -1,0 +1,6 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { handleWebhook } from './_handler.js';
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    return handleWebhook('toss', event);
+}

--- a/plugins/payment/server/config-store.ts
+++ b/plugins/payment/server/config-store.ts
@@ -57,7 +57,12 @@ export async function listSiteProviders(siteId: number): Promise<ProviderConfig[
 export async function upsertProviderConfig(
     siteId: number,
     provider: PaymentProviderId,
-    update: { sandbox: boolean; active: boolean; credentials: Record<string, string>; config?: Record<string, unknown> }
+    update: {
+        sandbox: boolean;
+        active: boolean;
+        credentials: Record<string, string>;
+        config?: Record<string, unknown>;
+    }
 ): Promise<void> {
     await pool.query<ResultSetHeader>(
         `INSERT INTO payment_provider_configs (site_id, provider, sandbox, active, credentials_json, config_json)

--- a/plugins/payment/server/config-store.ts
+++ b/plugins/payment/server/config-store.ts
@@ -1,0 +1,80 @@
+/**
+ * payment_provider_configs 테이블 조회/저장 헬퍼.
+ * 사이트별 PG 키를 격리 저장.
+ *
+ * 주의: credentials_json은 평문 저장이지만 Phase 3에서 KMS/envelope 암호화로 교체 예정.
+ */
+
+import type { RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import { pool } from '$lib/server/db';
+import type { PaymentProviderId, ProviderConfig } from '../types/index.js';
+
+interface ConfigRow extends RowDataPacket {
+    id: number;
+    site_id: number;
+    provider: string;
+    sandbox: number;
+    active: number;
+    credentials_json: string;
+    config_json: string | null;
+}
+
+export async function getProviderConfig(
+    siteId: number,
+    provider: PaymentProviderId
+): Promise<ProviderConfig | null> {
+    const [rows] = await pool.query<ConfigRow[]>(
+        'SELECT * FROM payment_provider_configs WHERE site_id = ? AND provider = ? AND active = 1 LIMIT 1',
+        [siteId, provider]
+    );
+    if (rows.length === 0) return null;
+    const r = rows[0];
+    return {
+        siteId: r.site_id,
+        provider: r.provider as PaymentProviderId,
+        sandbox: r.sandbox === 1,
+        active: r.active === 1,
+        credentials: JSON.parse(r.credentials_json) as Record<string, string>,
+        config: r.config_json ? (JSON.parse(r.config_json) as Record<string, unknown>) : undefined
+    };
+}
+
+export async function listSiteProviders(siteId: number): Promise<ProviderConfig[]> {
+    const [rows] = await pool.query<ConfigRow[]>(
+        'SELECT * FROM payment_provider_configs WHERE site_id = ? AND active = 1',
+        [siteId]
+    );
+    return rows.map((r) => ({
+        siteId: r.site_id,
+        provider: r.provider as PaymentProviderId,
+        sandbox: r.sandbox === 1,
+        active: r.active === 1,
+        credentials: JSON.parse(r.credentials_json) as Record<string, string>,
+        config: r.config_json ? (JSON.parse(r.config_json) as Record<string, unknown>) : undefined
+    }));
+}
+
+export async function upsertProviderConfig(
+    siteId: number,
+    provider: PaymentProviderId,
+    update: { sandbox: boolean; active: boolean; credentials: Record<string, string>; config?: Record<string, unknown> }
+): Promise<void> {
+    await pool.query<ResultSetHeader>(
+        `INSERT INTO payment_provider_configs (site_id, provider, sandbox, active, credentials_json, config_json)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+            sandbox = VALUES(sandbox),
+            active = VALUES(active),
+            credentials_json = VALUES(credentials_json),
+            config_json = VALUES(config_json),
+            updated_at = CURRENT_TIMESTAMP`,
+        [
+            siteId,
+            provider,
+            update.sandbox ? 1 : 0,
+            update.active ? 1 : 0,
+            JSON.stringify(update.credentials),
+            update.config ? JSON.stringify(update.config) : null
+        ]
+    );
+}

--- a/plugins/payment/server/orders-store.ts
+++ b/plugins/payment/server/orders-store.ts
@@ -1,0 +1,142 @@
+import type { RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import { pool } from '$lib/server/db';
+import type {
+    Currency,
+    PaymentOrder,
+    PaymentProviderId,
+    PaymentStatus
+} from '../types/index.js';
+
+interface OrderRow extends RowDataPacket {
+    id: number;
+    site_id: number;
+    user_id: number;
+    order_uid: string;
+    provider: string;
+    pg_order_id: string | null;
+    pg_transaction_id: string | null;
+    amount: string | number;
+    currency: string;
+    status: string;
+    description: string | null;
+    metadata_json: string | null;
+    paid_at: Date | null;
+    refunded_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+}
+
+function rowToOrder(r: OrderRow): PaymentOrder {
+    return {
+        id: r.id,
+        siteId: r.site_id,
+        userId: r.user_id,
+        orderUid: r.order_uid,
+        provider: r.provider as PaymentProviderId,
+        pgOrderId: r.pg_order_id,
+        pgTransactionId: r.pg_transaction_id,
+        amount: typeof r.amount === 'string' ? parseFloat(r.amount) : r.amount,
+        currency: r.currency as Currency,
+        status: r.status as PaymentStatus,
+        description: r.description,
+        metadata: r.metadata_json ? (JSON.parse(r.metadata_json) as Record<string, unknown>) : null,
+        paidAt: r.paid_at,
+        refundedAt: r.refunded_at,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at
+    };
+}
+
+export async function createOrder(input: {
+    siteId: number;
+    userId: number;
+    orderUid: string;
+    provider: PaymentProviderId;
+    amount: number;
+    currency: Currency;
+    description?: string;
+    metadata?: Record<string, unknown>;
+}): Promise<PaymentOrder> {
+    const [result] = await pool.query<ResultSetHeader>(
+        `INSERT INTO payment_orders
+         (site_id, user_id, order_uid, provider, amount, currency, description, metadata_json, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending')`,
+        [
+            input.siteId,
+            input.userId,
+            input.orderUid,
+            input.provider,
+            input.amount,
+            input.currency,
+            input.description ?? null,
+            input.metadata ? JSON.stringify(input.metadata) : null
+        ]
+    );
+    const id = result.insertId;
+    const order = await getOrderById(id);
+    if (!order) throw new Error('order create failed');
+    return order;
+}
+
+export async function getOrderById(id: number): Promise<PaymentOrder | null> {
+    const [rows] = await pool.query<OrderRow[]>(
+        'SELECT * FROM payment_orders WHERE id = ? LIMIT 1',
+        [id]
+    );
+    return rows[0] ? rowToOrder(rows[0]) : null;
+}
+
+export async function getOrderByUid(orderUid: string): Promise<PaymentOrder | null> {
+    const [rows] = await pool.query<OrderRow[]>(
+        'SELECT * FROM payment_orders WHERE order_uid = ? LIMIT 1',
+        [orderUid]
+    );
+    return rows[0] ? rowToOrder(rows[0]) : null;
+}
+
+export async function updateOrderStatus(
+    id: number,
+    status: PaymentStatus,
+    extra: { pgOrderId?: string; pgTransactionId?: string; paidAt?: Date; refundedAt?: Date } = {}
+): Promise<void> {
+    await pool.query<ResultSetHeader>(
+        `UPDATE payment_orders SET
+            status = ?,
+            pg_order_id = COALESCE(?, pg_order_id),
+            pg_transaction_id = COALESCE(?, pg_transaction_id),
+            paid_at = COALESCE(?, paid_at),
+            refunded_at = COALESCE(?, refunded_at)
+         WHERE id = ?`,
+        [
+            status,
+            extra.pgOrderId ?? null,
+            extra.pgTransactionId ?? null,
+            extra.paidAt ?? null,
+            extra.refundedAt ?? null,
+            id
+        ]
+    );
+}
+
+export async function recordEvent(input: {
+    orderId: number | null;
+    siteId: number;
+    provider: PaymentProviderId;
+    eventType: string;
+    payload: Record<string, unknown>;
+    signatureValid: boolean | null;
+}): Promise<void> {
+    await pool.query<ResultSetHeader>(
+        `INSERT INTO payment_events
+         (order_id, site_id, provider, event_type, payload_json, signature_valid)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [
+            input.orderId,
+            input.siteId,
+            input.provider,
+            input.eventType,
+            JSON.stringify(input.payload),
+            input.signatureValid === null ? null : input.signatureValid ? 1 : 0
+        ]
+    );
+}

--- a/plugins/payment/server/orders-store.ts
+++ b/plugins/payment/server/orders-store.ts
@@ -1,11 +1,6 @@
 import type { RowDataPacket, ResultSetHeader } from 'mysql2/promise';
 import { pool } from '$lib/server/db';
-import type {
-    Currency,
-    PaymentOrder,
-    PaymentProviderId,
-    PaymentStatus
-} from '../types/index.js';
+import type { Currency, PaymentOrder, PaymentProviderId, PaymentStatus } from '../types/index.js';
 
 interface OrderRow extends RowDataPacket {
     id: number;

--- a/plugins/payment/types/index.ts
+++ b/plugins/payment/types/index.ts
@@ -1,0 +1,94 @@
+export type PaymentProviderId = 'toss' | 'naver' | 'paypal';
+
+export type Currency = 'KRW' | 'USD';
+
+export type PaymentStatus = 'pending' | 'prepared' | 'paid' | 'cancelled' | 'refunded' | 'failed';
+
+export interface PaymentOrder {
+    id: number;
+    siteId: number;
+    userId: number;
+    orderUid: string;
+    provider: PaymentProviderId;
+    pgOrderId?: string | null;
+    pgTransactionId?: string | null;
+    amount: number;
+    currency: Currency;
+    status: PaymentStatus;
+    description?: string | null;
+    metadata?: Record<string, unknown> | null;
+    paidAt?: Date | null;
+    refundedAt?: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+/** 사이트별 PG 키/설정 (DB의 payment_provider_configs 1행) */
+export interface ProviderConfig<TCreds = Record<string, string>> {
+    siteId: number;
+    provider: PaymentProviderId;
+    sandbox: boolean;
+    active: boolean;
+    credentials: TCreds;
+    config?: Record<string, unknown>;
+}
+
+/** 결제 준비 입력 */
+export interface PreparePaymentInput {
+    order: Pick<PaymentOrder, 'orderUid' | 'amount' | 'currency' | 'description'>;
+    /** 결제 완료 후 리다이렉트할 절대/상대 URL */
+    returnUrl: string;
+    /** 결제 실패/취소 시 리다이렉트 URL */
+    cancelUrl: string;
+    /** 사용자 식별 (PG 측 customerKey 등으로 활용) */
+    customerKey: string;
+}
+
+/** 결제 준비 결과 — PG별로 다른 형태 (리다이렉트 URL 또는 SDK 파라미터) */
+export interface PreparePaymentResult {
+    /** redirect 방식 PG (페이팔 등): 사용자가 이동할 URL */
+    redirectUrl?: string;
+    /** widget/SDK 방식 PG (토스 등): 클라이언트 SDK 호출에 필요한 파라미터 */
+    sdkParams?: Record<string, unknown>;
+    /** PG 측 주문 식별자 (이후 complete/refund 시 사용) */
+    pgOrderId: string;
+}
+
+export interface CompletePaymentInput {
+    pgOrderId: string;
+    /** PG가 콜백/리턴 시 전달하는 식별자 (예: Toss의 paymentKey) */
+    pgPaymentKey?: string;
+    amount: number;
+}
+
+export interface CompletePaymentResult {
+    pgTransactionId: string;
+    paidAt: Date;
+    /** PG 응답 원본 (감사용) */
+    raw: Record<string, unknown>;
+}
+
+export interface RefundInput {
+    pgTransactionId: string;
+    amount: number;
+    reason?: string;
+}
+
+export interface RefundResult {
+    pgRefundId: string;
+    refundedAt: Date;
+    raw: Record<string, unknown>;
+}
+
+export interface VerifyWebhookInput {
+    rawBody: string;
+    headers: Record<string, string>;
+}
+
+export interface PaymentProvider {
+    readonly id: PaymentProviderId;
+    prepare(config: ProviderConfig, input: PreparePaymentInput): Promise<PreparePaymentResult>;
+    complete(config: ProviderConfig, input: CompletePaymentInput): Promise<CompletePaymentResult>;
+    refund(config: ProviderConfig, input: RefundInput): Promise<RefundResult>;
+    verifyWebhook(config: ProviderConfig, input: VerifyWebhookInput): boolean;
+}


### PR DESCRIPTION
## Summary

Phase 1 (#1346) plugin loader 강화 위에 결제 플러그인 도입.
다모앙/뮤지아/처치 테마에서 공통 사용, 사이트별 PG 키 분리 (`payment_provider_configs(site_id, provider)`).

## Phase 1 의존성

이 PR은 #1346 (plugin loader 강화) 머지가 선행되어야 합니다. 베이스가 `feat/plugin-loader-enhancement-1289`로 잡혀 있어 Phase 1이 머지되면 자동으로 main 기준으로 재정렬됩니다.

## 구성

### plugins/payment/
- `plugin.json`: routes 6개 (checkout/start, complete, webhook×3, refund), migrations 3쌍, ui.admin.menu, settings 4개
- `migrations/`: `payment_orders` / `payment_provider_configs` / `payment_events` 3쌍 (up/down)
- `types/index.ts`: PaymentProvider 어댑터 인터페이스 (prepare/complete/refund/verifyWebhook)
- `providers/toss/naver/paypal`: sandbox 지원, 각 PG의 인증 패턴
  - Toss: Basic auth → `/v1/payments/confirm`, `/cancel`
  - NaverPay: X-Naver-Client headers + idempotency key, HMAC-SHA256 webhook
  - PayPal: OAuth2 token 캐시 + Orders v2 capture/refund + sandbox 자동 분기
- `providers/registry.ts` + test: dispatch 검증
- `server/{config-store,orders-store}.ts`: DB 헬퍼
- `routes/`: SvelteKit 핸들러 (Phase 1 catch-all `/api/plugins/payment/*` 경유)
- `hooks/site-context.ts`: site_id 해석 — 현재 fallback(0), #1224 진행 후 angple_sites lookup으로 교체

### Admin UI
- `admin/index.svelte`: 결제 관리 placeholder (PG 활성/sandbox/키 등록 상태 표)

### .gitignore 정정
- `plugins/`(전체 차단) → `plugins/*` + 명시 예외 (`affiliate-link`, `affiliate-link-private`, `auto-embed`, `payment`)
- 기존 추적 플러그인 무영향, 신규 플러그인은 명시 opt-in 필요

## Test plan

- [x] `pnpm check` 무회귀 (사전 6 errors `@opentelemetry/*` 그대로)
- [x] `pnpm test:unit --run` 320/320
- [ ] sandbox PG 키 등록 → /api/plugins/payment/checkout/start 호출 → SDK params 반환 확인 (사용자 환경에서)
- [ ] Toss sandbox 결제 1회 (Playwright e2e — Phase 3 예정)
- [ ] webhook 수신 로그 (`payment_events` 테이블 insert 확인)

## Phase 3 예고

- credentials 평문 → KMS/envelope 암호화
- vite/vitest config에 `plugins/` 포함 → `plugins/payment/providers/registry.test.ts` 자동 실행
- PayPal `verifyWebhook` 비동기 분리 (별도 admin verify 헬퍼)
- 결제 완료 후 hook 발화 (`payment.complete`, `payment.refund`) — 다른 플러그인이 구독 가능
- e2e 결제 흐름 (Toss sandbox)

## 사용자 결정 필요

- 테스트 PG 키 보유 여부 (없으면 sandbox UI에서 임의 키 입력 후 진행)
- #1224 (angple_sites 테이블) 진행 시점에 site-context.ts 교체