### PR TITLE
feat(multisite): #1224 angple_sites DB 매핑 + DbSiteResolver

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -15,6 +15,7 @@ import { parseUserBasicCookie } from '$lib/server/auth/user-basic.js';
 import { loadAllPluginServerHooks } from '$lib/server/plugin-server-loader.js';
 import { CompositeSiteResolver } from '$lib/server/site-resolver/composite.js';
 import { ConfigSiteResolver } from '$lib/server/site-resolver/config.js';
+import { DbSiteResolver } from '$lib/server/site-resolver/db.js';
 
 // Phase 1A (open-core separation) — plugin server hooks 로드.
 // Fire-and-forget: load 실패해도 앱 전체가 멈추지 않음.
@@ -25,17 +26,17 @@ void loadAllPluginServerHooks();
 // 부팅 시 1회 ConfigSiteResolver 가 host-overrides JSON 로드. miss 시 null → 기본 테마.
 // USE_SITE_RESOLVER=false 면 resolver bypass.
 //
-// 경로 우선순위 (각 ConfigSiteResolver 가 ENOENT 시 silent skip → CompositeSiteResolver 가 다음 사용):
-//   1. env SITE_OVERRIDES_PATH (배포/테스트 환경 명시 override)
-//   2. process.cwd() + '/.angple/site-overrides.json' (install.sh 가 angple core 에 배치)
+// 경로 우선순위 (각 resolver 가 null 반환 시 CompositeSiteResolver 가 다음 사용):
+//   1. env SITE_OVERRIDES_PATH (배포/테스트 환경 명시 override) — JSON
+//   2. process.cwd() + '/.angple/site-overrides.json' (install.sh 가 angple core 에 배치) — JSON
+//   3. DbSiteResolver (#1224) — angple_sites 테이블 조회
 //
-// open-core 코어에 환경별 hardcode 0 — 운영자가 자체 site-overrides 배치 가능.
+// open-core 코어에 환경별 hardcode 0 — 운영자가 자체 site-overrides 배치 또는 angple_sites 사용.
 const siteResolverPaths: string[] = [];
 if (env.SITE_OVERRIDES_PATH) siteResolverPaths.push(env.SITE_OVERRIDES_PATH);
 siteResolverPaths.push(`${process.cwd()}/.angple/site-overrides.json`);
-const siteResolver = new CompositeSiteResolver(
-    siteResolverPaths.map((p) => new ConfigSiteResolver(p))
-);
+const configResolvers = siteResolverPaths.map((p) => new ConfigSiteResolver(p));
+const siteResolver = new CompositeSiteResolver([...configResolvers, new DbSiteResolver()]);
 void siteResolver.resolve('').catch(() => {}); // warm-up: load() 강제 실행
 
 import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';

--- a/apps/web/src/lib/server/site-resolver/db.ts
+++ b/apps/web/src/lib/server/site-resolver/db.ts
@@ -1,0 +1,90 @@
+import type { RowDataPacket } from 'mysql2/promise';
+import { pool } from '$lib/server/db';
+import { TieredCache } from '$lib/server/cache';
+import type { SiteContext, SiteResolver } from './index.js';
+
+interface SiteRow extends RowDataPacket {
+    id: number;
+    domain: string;
+    theme_id: string;
+    site_title: string | null;
+    site_description: string | null;
+    site_url: string | null;
+    logo_url: string | null;
+    favicon_url: string | null;
+    keywords: string | null;
+    settings: string | null;
+    active: number;
+}
+
+interface AliasRow extends RowDataPacket {
+    site_id: number;
+}
+
+const cache = new TieredCache<SiteContext>('site:db', 60_000, 300, 200);
+
+function rowToContext(row: SiteRow): SiteContext {
+    let keywords: string[] | undefined;
+    if (row.keywords) {
+        try {
+            const parsed = JSON.parse(row.keywords) as unknown;
+            if (Array.isArray(parsed) && parsed.every((k) => typeof k === 'string')) {
+                keywords = parsed;
+            }
+        } catch {
+            // ignore malformed JSON
+        }
+    }
+    return {
+        id: `db:${row.id}`,
+        numericId: row.id,
+        theme_id: row.theme_id,
+        title: row.site_title ?? undefined,
+        description: row.site_description ?? undefined,
+        keywords,
+        logo_url: row.logo_url ?? undefined,
+        favicon_url: row.favicon_url ?? undefined,
+        source: 'db'
+    };
+}
+
+async function lookupByHost(host: string): Promise<SiteContext | null> {
+    const [rows] = await pool.query<SiteRow[]>(
+        'SELECT * FROM angple_sites WHERE domain = ? AND active = 1 LIMIT 1',
+        [host]
+    );
+    if (rows.length > 0) return rowToContext(rows[0]);
+
+    const [aliasRows] = await pool.query<AliasRow[]>(
+        'SELECT site_id FROM angple_site_aliases WHERE domain = ? LIMIT 1',
+        [host]
+    );
+    if (aliasRows.length === 0) return null;
+
+    const [siteRows] = await pool.query<SiteRow[]>(
+        'SELECT * FROM angple_sites WHERE id = ? AND active = 1 LIMIT 1',
+        [aliasRows[0].site_id]
+    );
+    return siteRows.length > 0 ? rowToContext(siteRows[0]) : null;
+}
+
+/**
+ * angple_sites 테이블 기반 host → SiteContext 해석.
+ * positive 결과만 TieredCache 적용 (L1 60s, L2 300s).
+ * 미설정 host 는 매번 DB lookup — 일반적으로 hot-path 도메인은 cache hit, unknown host 는 fallback resolver 로 즉시 흘러간다.
+ */
+export class DbSiteResolver implements SiteResolver {
+    async resolve(host: string): Promise<SiteContext | null> {
+        const key = host.toLowerCase();
+        const cached = await cache.get(key);
+        if (cached) return cached;
+
+        const found = await lookupByHost(key);
+        if (found) await cache.set(key, found);
+        return found;
+    }
+}
+
+export async function invalidateDbSiteCache(host: string): Promise<void> {
+    await cache.delete(host.toLowerCase());
+}

--- a/apps/web/src/lib/server/site-resolver/index.ts
+++ b/apps/web/src/lib/server/site-resolver/index.ts
@@ -1,5 +1,10 @@
 export interface SiteContext {
     id: string;
+    /**
+     * DB(angple_sites)에서 해석된 경우의 numeric primary key.
+     * config/manifest/env resolver 는 이 필드를 채우지 않음 — 플러그인은 fallback 0 으로 처리.
+     */
+    numericId?: number;
     theme_id: string;
     title?: string;
     description?: string;

--- a/migrations/003_angple_sites.sql
+++ b/migrations/003_angple_sites.sql
@@ -1,0 +1,32 @@
+-- #1224 멀티사이트 도메인→테마/SEO 매핑 DB 이전
+-- ConfigSiteResolver(JSON) 다음 순위로 동작하는 DbSiteResolver 의 데이터 소스.
+-- payment 플러그인의 site_id 도 이 테이블의 id 를 참조 (numeric).
+
+CREATE TABLE IF NOT EXISTS angple_sites (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    domain VARCHAR(255) NOT NULL,
+    theme_id VARCHAR(100) NOT NULL,
+    site_title VARCHAR(255) DEFAULT NULL,
+    site_description TEXT DEFAULT NULL,
+    site_url VARCHAR(500) DEFAULT NULL,
+    logo_url VARCHAR(500) DEFAULT NULL,
+    favicon_url VARCHAR(500) DEFAULT NULL,
+    keywords JSON DEFAULT NULL,
+    settings JSON DEFAULT NULL,
+    active TINYINT(1) NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_domain (domain),
+    INDEX idx_active (active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- 도메인 alias 지원 (config 의 aliases[] 와 동일한 역할)
+CREATE TABLE IF NOT EXISTS angple_site_aliases (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    site_id INT NOT NULL,
+    domain VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_alias_domain (domain),
+    INDEX idx_site (site_id),
+    CONSTRAINT fk_alias_site FOREIGN KEY (site_id) REFERENCES angple_sites(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/plugins/payment/hooks/site-context.ts
+++ b/plugins/payment/hooks/site-context.ts
@@ -1,17 +1,15 @@
 /**
  * 멀티사이트 site_id 해석.
  *
- * 본 헬퍼는 #1224 (멀티사이트 도메인→테마/SEO DB 매핑) 진행에 따라 교체 예정.
- * 현재는 host → site_id 매핑이 DB에 없으므로 fallback (0 = "기본 사이트") 으로 동작합니다.
- *
- * #1224 가 머지되면 angple_sites 테이블 조회로 교체:
- *   SELECT id FROM angple_sites WHERE domain = ? AND active = 1
+ * #1224 의 DbSiteResolver 가 hooks.server.ts 에서 이미 host → SiteContext 를 `locals.site` 에 주입.
+ * DB(`angple_sites`)에서 해석된 사이트는 `numericId` 를 가지며, config/manifest/env 로 해석된 사이트는
+ * 가지지 않으므로 fallback 0 ("기본 사이트") 로 처리한다.
  */
+
+import type { RequestEvent } from '@sveltejs/kit';
 
 const FALLBACK_SITE_ID = 0;
 
-export function resolveSiteId(host: string | undefined | null): number {
-    if (!host) return FALLBACK_SITE_ID;
-    // TODO(#1224): replace with angple_sites lookup
-    return FALLBACK_SITE_ID;
+export function resolveSiteId(event: RequestEvent): number {
+    return event.locals.site?.numericId ?? FALLBACK_SITE_ID;
 }

--- a/plugins/payment/routes/checkout/complete.ts
+++ b/plugins/payment/routes/checkout/complete.ts
@@ -26,7 +26,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
         throw error(400, 'amount mismatch');
     }
 
-    const siteId = resolveSiteId(event.url.host);
+    const siteId = resolveSiteId(event);
     const config = await getProviderConfig(siteId, order.provider);
     if (!config) throw error(400, `provider not configured: ${order.provider}`);
 

--- a/plugins/payment/routes/checkout/start.ts
+++ b/plugins/payment/routes/checkout/start.ts
@@ -24,7 +24,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
         throw error(400, 'missing required fields');
     }
 
-    const siteId = resolveSiteId(event.url.host);
+    const siteId = resolveSiteId(event);
     const config = await getProviderConfig(siteId, body.provider);
     if (!config) throw error(400, `provider not configured: ${body.provider}`);
 

--- a/plugins/payment/routes/refund/index.ts
+++ b/plugins/payment/routes/refund/index.ts
@@ -22,7 +22,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
     if (order.status !== 'paid') throw error(400, `cannot refund order in status: ${order.status}`);
     if (!order.pgTransactionId) throw error(400, 'order has no pgTransactionId');
 
-    const siteId = resolveSiteId(event.url.host);
+    const siteId = resolveSiteId(event);
     const config = await getProviderConfig(siteId, order.provider);
     if (!config) throw error(400, 'provider not configured');
 

--- a/plugins/payment/routes/webhook/_handler.ts
+++ b/plugins/payment/routes/webhook/_handler.ts
@@ -16,7 +16,7 @@ export async function handleWebhook(
         headers[k.toLowerCase()] = v;
     });
 
-    const siteId = resolveSiteId(event.url.host);
+    const siteId = resolveSiteId(event);
     const config = await getProviderConfig(siteId, providerId);
 
     let valid: boolean | null = null;


### PR DESCRIPTION
Closes #1224

## Summary

도메인→테마/SEO 매핑을 JSON config 외에 DB(`angple_sites`)에서도 해석할 수 있도록 `DbSiteResolver` 추가.
기존 `ConfigSiteResolver` 다음 순위로 동작 (config miss 시 fallback).

payment 플러그인의 `site_id` 가 이 테이블의 `id` 를 참조하여 사이트별 PG 키를 격리합니다.

## 변경

### DB
- `migrations/003_angple_sites.sql`
  - `angple_sites (id, domain UNIQUE, theme_id, site_title, site_description, site_url, logo_url, favicon_url, keywords JSON, settings JSON, active, timestamps)`
  - `angple_site_aliases (id, site_id FK, domain UNIQUE)` — alias 도메인 지원

### Resolver
- `apps/web/src/lib/server/site-resolver/db.ts`: `DbSiteResolver`
  - host → angple_sites 조회, miss 시 angple_site_aliases lookup
  - `TieredCache` positive-only 캐싱 (L1 60s, L2 300s, max 200 항목)
  - 미설정 host 는 매번 lookup → 다음 resolver 로 흘러감
- `site-resolver/index.ts`: `SiteContext.numericId?: number` 추가 (DB 해석 시만 채움)

### Wiring
- `hooks.server.ts`: `CompositeSiteResolver` 체인에 `DbSiteResolver` 추가
  ```
  Config(env) → Config(.angple) → Db
  ```

### Payment 플러그인 정합 (placeholder 제거)
- `plugins/payment/hooks/site-context.ts`: `resolveSiteId(host)` → `resolveSiteId(event)` 로 변경, `locals.site.numericId` 직접 사용 (별도 DB 쿼리 없음)
- payment routes 4개 (checkout/start, complete, refund, webhook handler) 시그니처 반영

## Test plan

- [x] `pnpm exec prettier --check`: pass (변경 파일 전부)
- [x] ESLint: 새 issue 없음
- [x] `pnpm check`: 사전 6 errors (`@opentelemetry/*`) 그대로
- [x] `pnpm test:unit --run`: 320/320
- [ ] DB 마이그레이션 적용 후 `INSERT INTO angple_sites VALUES (1, 'example.com', 'damoang-default', ...)` → host=example.com 요청 시 `locals.site.numericId === 1` 확인 (사용자 환경)
- [ ] alias 테스트: `INSERT INTO angple_site_aliases (site_id, domain) VALUES (1, 'www.example.com')` → www. 도메인도 동일 site 해석

## 마이그레이션 운영

`migrations/003_angple_sites.sql` — 기존 root migrations/ 디렉토리 흐름 (수동 또는 운영자 배포 스크립트 적용). plugins/<id>/migrations/ 와 다른 트랙.

## 후속

- Admin UI: `/admin/sites` (사이트 추가/수정/aliases) — 별도 PR
- payment 플러그인 admin 에서 활성 사이트 dropdown — 별도 PR