### PR TITLE
feat(widgets): timed-fetch 유틸 + Recommended/Explore 적용 (audit P0-A)

### DIFF
--- a/apps/web/src/lib/components/features/explore/explore-preview.svelte
+++ b/apps/web/src/lib/components/features/explore/explore-preview.svelte
@@ -13,6 +13,7 @@
     import { getReadPostClasses } from '$lib/stores/read-post-style.svelte.js';
     import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
     import type { ExploreData, ExploreMode, ExplorePost } from '$lib/api/types.js';
+    import { TimedFetchError, timedFetch } from '$lib/utils/timed-fetch';
 
     interface Props {
         prefetchData?: { data: ExploreData } | unknown;
@@ -37,6 +38,10 @@
     let activeMode = $state<ExploreMode>('hot');
     let rootEl = $state<HTMLElement | null>(null);
     let requested = $state(false);
+    let loadStatus = $state<'idle' | 'loading' | 'success' | 'error'>(
+        ssrData?.data ? 'success' : 'idle'
+    );
+    let errorMessage = $state<string | null>(null);
 
     const modePosts = $derived.by<ExplorePost[]>(() => {
         if (!exploreData?.modes) return [];
@@ -52,22 +57,54 @@
     });
 
     async function loadExploreData(): Promise<void> {
-        if (requested || exploreData) {
+        if (loadStatus === 'loading') return;
+        if (exploreData) {
             loading = false;
+            loadStatus = 'success';
             return;
         }
+
         requested = true;
+        loadStatus = 'loading';
+        errorMessage = null;
 
         try {
-            const res = await fetch('/api/widgets/explore/data');
-            if (res.ok) {
-                exploreData = await res.json();
+            // timed-fetch: 12s 타임아웃 + 1회 retry → silent fail / 영구 placeholder 방지 (audit 2-2)
+            const res = await timedFetch(
+                '/api/widgets/explore/data',
+                {},
+                { timeout: 12_000, retries: 1, throwOnHTTPError: true }
+            );
+            exploreData = await res.json();
+            loadStatus = 'success';
+        } catch (err) {
+            if (err instanceof TimedFetchError) {
+                if (err.kind === 'timeout') {
+                    errorMessage = '응답이 늦어지고 있어요.';
+                } else if (err.kind === 'network') {
+                    errorMessage = '네트워크 오류로 불러오지 못했어요.';
+                } else if (err.kind === 'http') {
+                    errorMessage = `데이터를 불러오지 못했어요 (HTTP ${err.status ?? '?'})`;
+                } else {
+                    errorMessage = '요청이 취소되었어요.';
+                }
+            } else {
+                errorMessage = '데이터를 불러오지 못했어요.';
             }
-        } catch {
-            // silent fail
+            loadStatus = 'error';
+            console.error('모아보기 위젯 로드 실패:', err);
         } finally {
             loading = false;
         }
+    }
+
+    function retryExplore(): void {
+        // 재시도 가능하도록 requested 플래그 리셋
+        requested = false;
+        loadStatus = 'idle';
+        errorMessage = null;
+        loading = true;
+        void loadExploreData();
     }
 
     function scheduleLoad(): void {
@@ -165,6 +202,18 @@
                             <div class="bg-muted h-4 flex-1 animate-pulse rounded"></div>
                         </div>
                     {/each}
+                </div>
+            {:else if loadStatus === 'error'}
+                <div class="text-muted-foreground py-6 text-center text-sm">
+                    <p>{errorMessage ?? '데이터를 불러오지 못했어요.'}</p>
+                    <button
+                        type="button"
+                        class="text-primary mt-2 inline-flex items-center gap-1 text-xs underline-offset-2 hover:underline"
+                        onclick={retryExplore}
+                    >
+                        <Compass class="h-3 w-3" />
+                        다시 불러오기
+                    </button>
                 </div>
             {:else if modePosts.length === 0}
                 <div class="text-muted-foreground py-6 text-center text-sm">

--- a/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
+++ b/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
@@ -8,6 +8,7 @@
     import { PostList } from './components/post-list';
     import { SkeletonLoader } from './components/loading';
     import { getCurrentTabVisibility } from './utils/index.js';
+    import { TimedFetchError, timedFetch } from '$lib/utils/timed-fetch';
 
     interface Props {
         /** SSR prefetch 데이터 (있으면 즉시 표시, 없으면 클라이언트 fetch) */
@@ -110,8 +111,12 @@
 
         try {
             // PHP 크론이 생성한 JSON 캐시 파일을 SvelteKit API를 통해 읽음
-            const res = await fetch(`/api/widgets/recommended/data?period=${period}`);
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            // timed-fetch: 12s 타임아웃 + 1회 retry → skeleton 영구 대기 방지 (audit 2-1)
+            const res = await timedFetch(
+                `/api/widgets/recommended/data?period=${period}`,
+                {},
+                { timeout: 12_000, retries: 1, throwOnHTTPError: true }
+            );
             const newData: RecommendedDataWithAI = await res.json();
             dataCache.set(period, newData);
             persistCacheToSessionStorage();
@@ -120,11 +125,29 @@
                 data = newData;
             }
         } catch (err) {
-            error = err instanceof Error ? err.message : '데이터 로드 실패';
+            if (err instanceof TimedFetchError) {
+                if (err.kind === 'timeout') {
+                    error = '응답이 늦어지고 있어요. 잠시 후 다시 시도해 주세요.';
+                } else if (err.kind === 'network') {
+                    error = '네트워크 오류로 불러오지 못했어요.';
+                } else if (err.kind === 'http') {
+                    error = `데이터를 불러오지 못했어요 (HTTP ${err.status ?? '?'})`;
+                } else {
+                    error = '요청이 취소되었어요.';
+                }
+            } else {
+                error = err instanceof Error ? err.message : '데이터 로드 실패';
+            }
             console.error('추천 글 로드 실패:', err);
         } finally {
             loading = false;
         }
+    }
+
+    function retryLoad() {
+        // 캐시 무효화 후 현재 탭 재시도
+        dataCache.delete(activeTab);
+        loadData(activeTab, true);
     }
 
     function handleTabChange(tabId: RecommendedPeriod) {
@@ -158,6 +181,13 @@
             <div class="flex items-center justify-center py-8">
                 <div class="text-center">
                     <p class="text-destructive text-sm">{error}</p>
+                    <button
+                        type="button"
+                        class="text-primary mt-2 text-xs underline-offset-2 hover:underline"
+                        onclick={retryLoad}
+                    >
+                        다시 불러오기
+                    </button>
                 </div>
             </div>
         {:else if data}

--- a/apps/web/src/lib/utils/timed-fetch.test.ts
+++ b/apps/web/src/lib/utils/timed-fetch.test.ts
@@ -1,0 +1,149 @@
+/**
+ * timed-fetch.ts 테스트
+ * - 정상 응답
+ * - 타임아웃 abort
+ * - 외부 signal abort
+ * - retry 1회 동작 후 정상
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TimedFetchError, timedFetch } from './timed-fetch';
+
+describe('timedFetch', () => {
+    const realFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        globalThis.fetch = realFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('정상 응답 — 한 번에 통과', async () => {
+        const ok = new Response('{"ok":true}', { status: 200 });
+        globalThis.fetch = vi.fn().mockResolvedValue(ok);
+
+        const res = await timedFetch('/api/test', {}, { timeout: 5000, retries: 0 });
+
+        expect(res.status).toBe(200);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('타임아웃 — controller.abort() 후 TimedFetchError(kind=timeout)', async () => {
+        // fetch 가 영원히 pending 인 시나리오. signal.aborted === true 가 되면 reject.
+        globalThis.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+            return new Promise((_resolve, reject) => {
+                init.signal?.addEventListener('abort', () => {
+                    const e = new Error('aborted');
+                    e.name = 'AbortError';
+                    reject(e);
+                });
+            });
+        });
+
+        const promise = timedFetch('/api/test', {}, { timeout: 100, retries: 0 });
+        // 미처리 rejection 경고 방지 (실제 검증은 try/catch 로)
+        promise.catch(() => undefined);
+
+        // timer 발화 → abort → reject
+        await vi.advanceTimersByTimeAsync(150);
+
+        let caught: unknown;
+        try {
+            await promise;
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeInstanceOf(TimedFetchError);
+        expect((caught as TimedFetchError).kind).toBe('timeout');
+    });
+
+    it('외부 signal abort — TimedFetchError(kind=aborted) + retry 안 함', async () => {
+        const fetchSpy = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+            return new Promise((_resolve, reject) => {
+                init.signal?.addEventListener('abort', () => {
+                    const e = new Error('aborted');
+                    e.name = 'AbortError';
+                    reject(e);
+                });
+            });
+        });
+        globalThis.fetch = fetchSpy;
+
+        const external = new AbortController();
+        const promise = timedFetch(
+            '/api/test',
+            {},
+            { timeout: 10_000, retries: 3, signal: external.signal }
+        );
+        promise.catch(() => undefined);
+
+        // 외부 abort 트리거
+        external.abort();
+        await vi.advanceTimersByTimeAsync(0);
+
+        let caught: unknown;
+        try {
+            await promise;
+        } catch (e) {
+            caught = e;
+        }
+        expect((caught as TimedFetchError).kind).toBe('aborted');
+        // 외부 abort 후에는 추가 retry 가 일어나지 않아야 함.
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('retry — 첫 시도 네트워크 실패, 두 번째 시도 성공', async () => {
+        const ok = new Response('ok', { status: 200 });
+        const fetchSpy = vi
+            .fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(ok);
+        globalThis.fetch = fetchSpy;
+
+        const promise = timedFetch('/api/test', {}, { timeout: 5000, retries: 1, retryDelay: 200 });
+
+        // retry delay 통과
+        await vi.advanceTimersByTimeAsync(250);
+
+        const res = await promise;
+        expect(res.status).toBe(200);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('retry 소진 — 마지막 에러 throw', async () => {
+        const fetchSpy = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+        globalThis.fetch = fetchSpy;
+
+        const promise = timedFetch('/api/test', {}, { timeout: 5000, retries: 1, retryDelay: 50 });
+        promise.catch(() => undefined);
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        let caught: unknown;
+        try {
+            await promise;
+        } catch (e) {
+            caught = e;
+        }
+        expect((caught as TimedFetchError).kind).toBe('network');
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('throwOnHTTPError — 4xx/5xx 는 즉시 throw + retry 안 함', async () => {
+        const bad = new Response('err', { status: 503 });
+        const fetchSpy = vi.fn().mockResolvedValue(bad);
+        globalThis.fetch = fetchSpy;
+
+        const promise = timedFetch(
+            '/api/test',
+            {},
+            { timeout: 5000, retries: 3, throwOnHTTPError: true }
+        );
+
+        await expect(promise).rejects.toMatchObject({ kind: 'http', status: 503 });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/src/lib/utils/timed-fetch.ts
+++ b/apps/web/src/lib/utils/timed-fetch.ts
@@ -1,0 +1,126 @@
+/**
+ * timed-fetch — fetch + AbortController + timeout + 1회 retry + 에러 분류
+ *
+ * 위젯 / 광고 / 사이드바 컴포넌트에서 fetch 가 hang 했을 때 skeleton 이 영구적으로 남는
+ * 안티패턴 (2026-05-01 widget audit) 을 제거하기 위한 표준 유틸.
+ *
+ * 호출 측은 throw 된 `TimedFetchError` 의 `kind` 로 사용자 메시지를 분기할 수 있다:
+ *   - 'timeout'  : controller.abort() 로 인한 AbortError
+ *   - 'network'  : 그 외 fetch reject (DNS, offline, CORS 등)
+ *   - 'http'     : !res.ok && throwOnHTTPError === true
+ *   - 'aborted'  : 호출 측이 외부 signal 로 abort
+ */
+
+export interface TimedFetchOptions {
+    /** abort 까지 허용하는 ms. 기본 12_000. */
+    timeout?: number;
+    /** 실패 시 추가 시도 횟수 (timeout/network 만 재시도, http 는 재시도 안 함). 기본 1. */
+    retries?: number;
+    /** 재시도 사이 지연 ms. 기본 800. */
+    retryDelay?: number;
+    /** !res.ok 일 때 TimedFetchError('http') 를 throw 할지. 기본 false. */
+    throwOnHTTPError?: boolean;
+    /** 호출 측에서 외부 abort 신호를 주입하고 싶을 때. */
+    signal?: AbortSignal;
+}
+
+export type TimedFetchErrorKind = 'timeout' | 'network' | 'http' | 'aborted';
+
+export class TimedFetchError extends Error {
+    readonly kind: TimedFetchErrorKind;
+    readonly status?: number;
+    readonly cause?: unknown;
+
+    constructor(
+        kind: TimedFetchErrorKind,
+        message: string,
+        opts: { status?: number; cause?: unknown } = {}
+    ) {
+        super(message);
+        this.name = 'TimedFetchError';
+        this.kind = kind;
+        this.status = opts.status;
+        this.cause = opts.cause;
+    }
+}
+
+const DEFAULT_TIMEOUT_MS = 12_000;
+const DEFAULT_RETRIES = 1;
+const DEFAULT_RETRY_DELAY_MS = 800;
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * `fetch` 를 timeout 과 1회 retry 로 감싼 안전한 호출.
+ *
+ * 외부 abort 신호가 먼저 발화되면 더 이상 retry 하지 않고 'aborted' 로 즉시 throw.
+ */
+export async function timedFetch(
+    url: string,
+    init: RequestInit = {},
+    opts: TimedFetchOptions = {}
+): Promise<Response> {
+    const timeout = opts.timeout ?? DEFAULT_TIMEOUT_MS;
+    const retries = Math.max(0, opts.retries ?? DEFAULT_RETRIES);
+    const retryDelay = opts.retryDelay ?? DEFAULT_RETRY_DELAY_MS;
+    const throwOnHTTPError = opts.throwOnHTTPError ?? false;
+    const externalSignal = opts.signal;
+
+    let lastError: TimedFetchError | null = null;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        if (externalSignal?.aborted) {
+            throw new TimedFetchError('aborted', '호출 측에서 abort 됨');
+        }
+
+        const controller = new AbortController();
+        let timedOut = false;
+        const timer = setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+        }, timeout);
+
+        const onExternalAbort = () => controller.abort();
+        externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+
+        try {
+            const res = await fetch(url, { ...init, signal: controller.signal });
+
+            if (throwOnHTTPError && !res.ok) {
+                throw new TimedFetchError('http', `HTTP ${res.status}`, { status: res.status });
+            }
+
+            return res;
+        } catch (err) {
+            if (err instanceof TimedFetchError && err.kind === 'http') {
+                // HTTP 4xx/5xx 는 재시도 안 함 — 즉시 전파.
+                throw err;
+            }
+
+            if (externalSignal?.aborted && !timedOut) {
+                throw new TimedFetchError('aborted', '호출 측에서 abort 됨', { cause: err });
+            }
+
+            const kind: TimedFetchErrorKind = timedOut ? 'timeout' : 'network';
+            lastError = new TimedFetchError(
+                kind,
+                kind === 'timeout' ? `요청 시간 초과 (${timeout}ms)` : '네트워크 오류',
+                { cause: err }
+            );
+
+            if (attempt < retries) {
+                await delay(retryDelay);
+                continue;
+            }
+            throw lastError;
+        } finally {
+            clearTimeout(timer);
+            externalSignal?.removeEventListener('abort', onExternalAbort);
+        }
+    }
+
+    // 도달 불가 — 안전망
+    throw lastError ?? new TimedFetchError('network', 'unknown');
+}


### PR DESCRIPTION
## 배경

2026-05-01 작성된 [위젯 audit 보고서](../tree/main/docs/2026-05-01-widget-audit-report.md) §2-1, §2-2 의 Critical 항목 fix.

13개 위젯 / 5개 광고 컴포넌트를 전수 점검한 결과, **AbortController + 명시적 timeout 도입 0건** 으로 fetch hang 시 skeleton 이 영구히 남는 안티패턴이 시스템 광역으로 존재.
이 PR 은 그 중 가장 빈번하게 노출되는 두 위젯 (RecommendedPosts / ExplorePreview) 을 우선 fix.

## Summary

- **신규 `$lib/utils/timed-fetch.ts`**
  - `timedFetch(url, init?, opts?)` — `fetch` 를 `AbortController` 로 감싸 12s 후 abort
  - 1회 retry (timeout/network 에 한해; HTTP 4xx/5xx 는 즉시 throw)
  - `TimedFetchError` 로 `kind: 'timeout' | 'network' | 'http' | 'aborted'` 분류 → 호출 측이 사용자 메시지 분기 가능
  - 외부 `AbortSignal` 주입 지원 (호출 측이 abort 하면 더 이상 retry 안 함)
- **`RecommendedPosts`**: fetch → timedFetch 로 치환, 에러 종류별 한글 메시지 + `다시 불러오기` 버튼 노출
- **`ExplorePreview`**: silent fail 제거, `idle/loading/success/error` 상태 머신 도입, 에러 시 Compass 아이콘 + 클릭 가능 retry 영역
- **단위 테스트** (`timed-fetch.test.ts`) — 6 케이스: 정상 / 타임아웃 / 외부 signal abort / retry 1회 후 성공 / retry 소진 / HTTP 4xx/5xx 즉시 throw

## 변경 통계

| | 파일 | LOC |
|---|---|---|
| 신규 | `apps/web/src/lib/utils/timed-fetch.ts` | +126 |
| 신규 | `apps/web/src/lib/utils/timed-fetch.test.ts` | +149 |
| 수정 | `recommended-posts.svelte` | +30/-3 |
| 수정 | `explore-preview.svelte` | +55/-6 |
| **합계** | | **+360/-9** |

## 회귀 위험 평가

**낮음.**

- SSR prefetch 데이터가 있을 때의 즉시 표시 경로는 그대로 (`canUseSSR`, `ssrData?.data` 분기 변경 없음).
- 클라이언트 fetch 경로만 timed-fetch 로 교체. timeout (12s) 은 백엔드 평균 응답 (수십~수백 ms) 대비 매우 여유 있음.
- skeleton 이 12s 후 자동으로 error UI 로 전환 → 사용자가 `다시 불러오기` 버튼으로 명시적 retry 가능.
- HTTP 4xx/5xx 는 retry 안 함 (백엔드 부하 폭증 방지).
- 모든 단위 테스트 6/6 통과, `pnpm check` 0 errors.

## Test plan

- [x] `pnpm vitest run --project server src/lib/utils/timed-fetch.test.ts` (6/6 pass)
- [x] `pnpm check` (0 errors, 97 warnings — 모두 pre-existing)
- [ ] dev/prod 환경에서 `RecommendedPosts` 백엔드 503 시나리오 재현 → 12s 후 retry 버튼 노출 확인
- [ ] `ExplorePreview` IO 트리거 후 백엔드 hang → 12s 후 Compass + "다시 불러오기" 노출 확인
- [ ] `다시 불러오기` 클릭 시 캐시 무효화 + 재 fetch 동작 확인

## Audit 후속 PR (별도)

- P0-B: `feat(ads): AdSlot watchdog + GAM preload (canary 5%)` — 5/22 AdSense 미팅 직결
- P1-A: `fix(auth): apiClient timeout + user-widget Skeleton guard`
- P1-B: `feat(widgets): notice/image-text-banner/giving/ai-analysis/celebration timed-fetch 적용`
- P2-A: `feat(widgets): widget-wrapper Skeleton 15s timeout guard` (single-source fallback)