### PR TITLE
feat(ads): AdSlot watchdog + GAM preload canary 5% (audit P0-B, 5/22 미팅 직결)

### DIFF
--- a/apps/web/src/lib/ads/prebid-config.ts
+++ b/apps/web/src/lib/ads/prebid-config.ts
@@ -16,6 +16,16 @@ export const CANARY_PCT = Number(
         ?.PUBLIC_PHASE_B1_CANARY_PCT ?? '0'
 );
 
+/**
+ * GAM `gpt.js` preload canary 비율 (audit P0-B, 5/22 미팅 직결).
+ * `PUBLIC_GAM_PRELOAD_CANARY_PCT` env: 0~100 정수. 기본 0 (OFF).
+ * Prebid canary 와 분리 — GAM preload 는 first-impression 지연 측정 용도.
+ */
+export const GAM_PRELOAD_CANARY_PCT = Number(
+    (import.meta as ImportMeta & { env?: Record<string, string> }).env
+        ?.PUBLIC_GAM_PRELOAD_CANARY_PCT ?? '0'
+);
+
 export const PREBID_BIDDER_TIMEOUT_MS = 1000;
 
 export const PHASE_B1_SLOTS = new Set<string>([
@@ -81,4 +91,22 @@ export function isInCanary(userKey: string | null | undefined): boolean {
             (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
     }
     return hash % 100 < CANARY_PCT;
+}
+
+/**
+ * GAM gpt.js preload canary 그룹 결정 (Prebid 와 분리된 hash salt 사용).
+ * Prebid canary 와 같은 사용자 hash 충돌을 피하기 위해 prefix 추가.
+ */
+export function isInPreloadCanary(userKey: string | null | undefined): boolean {
+    if (!GAM_PRELOAD_CANARY_PCT || GAM_PRELOAD_CANARY_PCT <= 0 || GAM_PRELOAD_CANARY_PCT > 100)
+        return false;
+    if (GAM_PRELOAD_CANARY_PCT >= 100) return true;
+    const salted = `gam-preload:${userKey ?? ''}`;
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < salted.length; i++) {
+        hash ^= salted.charCodeAt(i);
+        hash =
+            (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+    }
+    return hash % 100 < GAM_PRELOAD_CANARY_PCT;
 }

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
@@ -79,6 +79,39 @@ function ensureAdNetworkPreconnect() {
     }
 }
 
+/**
+ * GAM `gpt.js` <link rel="preload"> 삽입 (canary 사용자만 호출됨).
+ * audit P0-B (4-2, 5/22 미팅 직결). preconnect 와 별도로 LCP 직후 즉시 사용 가능하도록.
+ * CSP `script-src` 가 `securepubads.g.doubleclick.net` 이미 허용 (hooks.server.ts:528) → 추가 변경 불필요.
+ */
+export function ensureGAMPreload() {
+    if (!browser) return;
+    const href = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
+    if (document.querySelector(`link[rel="preload"][href="${href}"]`)) return;
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = 'script';
+    link.href = href;
+    link.crossOrigin = 'anonymous';
+    document.head.appendChild(link);
+}
+
+/**
+ * Watchdog 강제 empty render — `slotRenderEnded` 가 N초 내 도착하지 않을 때 호출.
+ * 이미 loaded 된 slot 은 무시. AdFit fallback 트리거를 위해 emptyRetry max 까지 누적.
+ * audit §2-4 / §5-D / P0-B.
+ */
+export function forceEmptyRender(slotId: string) {
+    if (!browser) return;
+    const registry = getRegistry();
+    const state = registry.slots.get(slotId);
+    if (!state) return;
+    if (state.loaded) return;
+    state.loaded = true;
+    state.empty = true;
+    emitRender(slotId, true);
+}
+
 function getRegistry(): Registry {
     if (!browser) return createRegistry();
     const win = window as Window & { [REGISTRY_KEY]?: Registry };

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -22,12 +22,22 @@
     } from './ad-slot-registry.js';
     import {
         isInCanary,
+        isInPreloadCanary,
         PHASE_B1_SLOTS,
         PREBID_BIDDERS_DEFAULT,
         PREBID_SIZES_BY_POSITION
     } from '$lib/ads/prebid-config.js';
     import { runPrebidAuction } from '$lib/ads/prebid-loader.js';
+    import { ensureGAMPreload } from './ad-slot-registry.js';
     import { page } from '$app/stores';
+
+    /**
+     * Watchdog: `attachSlot` 후 N ms 내 `slotRenderEnded` 가 도착하지 않으면
+     * 강제 `handleRender(true)` 호출 → empty path → emptyRetry → AdFit fallback.
+     * audit §2-4 / §5-D / P0-B (5/22 미팅 직결: fill rate 측정 정확도 ↑).
+     * 12s 는 audit 권장값. lazyLoad fetchMargin=400% 이라 일반 광고는 충분히 먼저 응답.
+     */
+    const AD_WATCHDOG_MS = 12_000;
 
     /** 삭제된 글/비밀글 상세 페이지에서는 모든 광고를 숨김 (애드센스 정책) */
     const isDeletedPost = $derived(!!($page as any).data?.post?.deleted_at);
@@ -76,6 +86,7 @@
     let detached = false;
     let containerEl: HTMLDivElement | null = null;
     let visibilityObserver: IntersectionObserver | null = null;
+    let watchdogTimer: ReturnType<typeof setTimeout> | null = null;
     // 데스크톱 전용 position: 모바일/태블릿에서 GPT slot 초기화를 차단하여 무의미한 impression 방지
     const DESKTOP_ONLY_POSITIONS: Record<string, number> = {
         'wing-left': 1600,
@@ -169,8 +180,16 @@
         };
     }
 
+    function clearWatchdog() {
+        if (watchdogTimer) {
+            clearTimeout(watchdogTimer);
+            watchdogTimer = null;
+        }
+    }
+
     function handleRender(isEmpty: boolean) {
         if (detached) return;
+        clearWatchdog();
         isLoaded = true;
         hasAd = !isEmpty;
         // GAM이 나중에 채워지면 애드핏 숨기기
@@ -235,6 +254,14 @@
             }
         }
 
+        // P0-B canary 5%: GAM gpt.js <link rel="preload"> 삽입 (5/22 미팅 직결).
+        // hash(mb_id) 기반 안정적 분류 — 같은 사용자는 항상 같은 결과.
+        // 비로그인은 slotId 사용 (페이지/포지션마다 분산되어 통계적으로 ~5%).
+        const preloadKey = ($page as any).data?.user?.mb_id ?? slotId;
+        if (isInPreloadCanary(preloadKey)) {
+            ensureGAMPreload();
+        }
+
         await attachSlot({
             key: resolvedSlotKey,
             position,
@@ -247,6 +274,17 @@
             onRender: handleRender,
             onFallback: adfitConfig ? handleFallback : undefined
         });
+
+        // P0-B watchdog: attachSlot 후 12s 내 slotRenderEnded 안 오면 강제 empty.
+        // 이미 detached 또는 loaded 상태면 setup 자체 skip.
+        if (!detached && !isLoaded) {
+            clearWatchdog();
+            watchdogTimer = setTimeout(() => {
+                watchdogTimer = null;
+                if (detached || isLoaded) return;
+                handleRender(true);
+            }, AD_WATCHDOG_MS);
+        }
     }
 
     onMount(() => {
@@ -255,6 +293,7 @@
 
     onDestroy(() => {
         detached = true;
+        clearWatchdog();
         visibilityObserver?.disconnect();
         if (!slotId) return;
         adDensityStore.unregister(slotId);


### PR DESCRIPTION
## Summary

5/22 AdSense 매니저 미팅 직결 — baseline 측정 정확도 향상 + first-impression 지연 최적화.

참고: \`docs/2026-05-01-widget-audit-report.md\` §2-4 (empty fallback chain timeout 부재), §4-2 (preload 미적용), §5-D (AdSlot 전용 watchdog), §6 (P0 두 번째).

## 변경

### 1. AdSlot watchdog (전체 적용, ~25 LOC)
- **파일**: \`apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte\` + \`ad-slot-registry.ts\`
- \`attachSlot\` 후 **12s** 내 \`slotRenderEnded\` 가 도착하지 않으면 \`handleRender(true)\` 강제 호출
- empty path → \`scheduleEmptyRetry\` → \`onFallback\` (AdFit) 정상 chain 진입
- audit 권장 12s. \`lazyLoad fetchMargin=400%\` 이라 정상 광고는 12s 안에 충분히 응답
- 보수적 설계: \`onDestroy\` / \`handleRender\` 진입 시 watchdog 자동 cleanup → 정상 광고 false-positive 없음

### 2. GAM \`gpt.js\` \`<link rel=\"preload\">\` canary (~35 LOC)
- **파일**: \`apps/web/src/lib/ads/prebid-config.ts\` (\`isInPreloadCanary\` + 별도 env), \`ad-slot-registry.ts\` (\`ensureGAMPreload\` export)
- env: \`PUBLIC_GAM_PRELOAD_CANARY_PCT\` 0~100 정수 (기본 0 = OFF). 5/22 전 5 로 ramp.
- \`hash(mb_id ?? slotId) % 100 < pct\` — 같은 사용자 고정. Prebid canary 와 별도 salt (\`gam-preload:\` prefix) 로 hash 충돌 방지.
- **CSP**: \`script-src\` 에 \`securepubads.g.doubleclick.net\` 이미 허용 (\`hooks.server.ts:528\`) → 추가 변경 불필요.
- 적용 위치: AdSlot \`initAdSlot()\` 내 \`attachSlot\` 직전. preconnect 와 별도로 LCP 직후 즉시 사용 가능하도록.

### 3. canary gating
- watchdog: **전체 적용** (안전장치 — fill rate 측정 정확도 보장)
- preload: **5% canary** (env-driven ramp-up). 정상 광고 트래픽에 영향 없음 → 측정 비교 baseline 확보 후 단계적 증대.

## 측정 방법 (5/22 미팅 baseline)

ClickHouse \`aplog.ad_events\` 에서 canary on/off 비교:

\`\`\`sql
-- slotRenderEnded - pageshow Δ (first-impression 지연)
SELECT
    position,
    canary_group,        -- 'preload_on' | 'preload_off' (mb_id hash 기반 분류)
    quantile(0.5)(slot_render_ts - page_show_ts) AS p50_ms,
    quantile(0.95)(slot_render_ts - page_show_ts) AS p95_ms,
    count() AS samples
FROM aplog.ad_events
WHERE event_type = 'ad_impression'
  AND ts >= now() - INTERVAL 7 DAY
  AND slot_render_ts > 0 AND page_show_ts > 0
GROUP BY position, canary_group
ORDER BY position, canary_group
\`\`\`

**기대 효과**: preload 그룹의 p50/p95 가 off 그룹 대비 100~300 ms 단축 (audit §4-2 추정).

## Test plan

- [ ] dev 환경 \`PUBLIC_GAM_PRELOAD_CANARY_PCT=100\` 으로 \`<link rel=\"preload\">\` DOM 삽입 확인 (DevTools Network → priority high)
- [ ] watchdog 트리거 검증: 네트워크 throttling 으로 GPT 차단 → 12s 후 AdFit fallback 노출 확인
- [ ] 정상 광고 (12s 이내 응답) 에서 watchdog cleanup 확인 — false-positive empty 이벤트 없음
- [ ] \`pnpm check\` 통과 (svelte-check 0 신규 error — 기존 2 errors 는 packages/types/zod 미설치, 본 변경과 무관)
- [ ] \`hooks.server.ts\` CSP \`script-src\` 점검 → preload 차단 없음
- [ ] canary 5% 적용 후 1주: ClickHouse 위 쿼리로 p50/p95 Δ 비교, 5/22 미팅 자료 준비

## 운영 적용 절차

1. PR merge (canary OFF — env 미설정으로 영향 0)
2. 운영 \`PUBLIC_GAM_PRELOAD_CANARY_PCT=5\` 적용 (다음 새벽 4시 + 사용자 승인)
3. 1주 후 ClickHouse 비교 → ramp-up 25 → 50 → 100 의사결정