### PR TITLE
feat(auth): apiClient timeout + user-widget skeleton guard (audit P1-A)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -59,6 +59,7 @@ import { browser } from '$app/environment';
 import { ApiRequestError } from './errors.js';
 import { fetchWithRetry, type RetryConfig, DEFAULT_RETRY_CONFIG } from './retry.js';
 import { safeRandomUUID } from '$lib/utils/uuid';
+import { timedFetch, TimedFetchError } from '$lib/utils/timed-fetch';
 
 // 서버/클라이언트 환경에 따라 API URL 분기
 // 클라이언트: 상대경로 (nginx 프록시)
@@ -1965,15 +1966,28 @@ class ApiClient {
      */
     async login(request: LoginRequest): Promise<LoginResponse> {
         // SvelteKit 프록시 경유: 세션 생성 + 쿠키 설정을 서버가 처리
-        const response = await fetch('/api/auth/login', {
-            method: 'POST',
-            headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
-            credentials: 'include',
-            body: JSON.stringify({
-                username: request.username,
-                password: request.password
-            })
-        });
+        // timedFetch: 12s timeout — auth fetch hang 시 user-widget skeleton 영구화 방지 (audit P1-A)
+        let response: Response;
+        try {
+            response = await timedFetch(
+                '/api/auth/login',
+                {
+                    method: 'POST',
+                    headers: this.buildHeaders({ 'Content-Type': 'application/json' }),
+                    credentials: 'include',
+                    body: JSON.stringify({
+                        username: request.username,
+                        password: request.password
+                    })
+                },
+                { timeout: 12_000, retries: 0 }
+            );
+        } catch (err) {
+            if (err instanceof TimedFetchError && err.kind === 'timeout') {
+                throw new Error('로그인 요청 시간 초과 (12초). 네트워크 상태를 확인하세요.');
+            }
+            throw new Error(err instanceof Error ? err.message : '네트워크 오류');
+        }
 
         if (!response.ok) {
             const errorData = await response.json().catch(() => null);
@@ -2124,11 +2138,27 @@ class ApiClient {
      * NOTE: 이 엔드포인트는 v2 API에만 존재
      */
     async exchangeToken(): Promise<LoginResponse> {
-        const response = await fetch(`${API_V2_URL}/auth/exchange`, {
-            method: 'POST',
-            headers: this.buildHeaders(),
-            credentials: 'include'
-        });
+        // timedFetch: 12s timeout — auth fetch hang 시 user-widget skeleton 영구화 방지 (audit P1-A)
+        let response: Response;
+        try {
+            response = await timedFetch(
+                `${API_V2_URL}/auth/exchange`,
+                {
+                    method: 'POST',
+                    headers: this.buildHeaders(),
+                    credentials: 'include'
+                },
+                { timeout: 12_000, retries: 0 }
+            );
+        } catch (err) {
+            if (err instanceof TimedFetchError && err.kind === 'timeout') {
+                throw {
+                    response: { status: 504 },
+                    data: { message: '토큰 교환 시간 초과 (12초)' }
+                };
+            }
+            throw { response: { status: 0 }, data: { message: '네트워크 오류' } };
+        }
 
         if (!response.ok) {
             const error = await response.json().catch(() => ({}));

--- a/apps/web/src/lib/components/layout/user-widget.svelte
+++ b/apps/web/src/lib/components/layout/user-widget.svelte
@@ -47,6 +47,36 @@
     let isLoggedIn = $derived(getIsLoggedIn());
     let isLoading = $derived(getIsLoading());
 
+    // Skeleton guard (audit P1-A): auth fetch 가 12s 이상 hang 하면 fallback UI 표시.
+    // 강제 로그아웃은 하지 않고, 사용자가 새로고침 버튼으로 재시도할 수 있게 함.
+    const SKELETON_TIMEOUT_MS = 12_000;
+    let loadingTimedOut = $state(false);
+    let isRetrying = $state(false);
+
+    $effect(() => {
+        if (!isLoading) {
+            loadingTimedOut = false;
+            return;
+        }
+        const timer = setTimeout(() => {
+            loadingTimedOut = true;
+        }, SKELETON_TIMEOUT_MS);
+        return () => clearTimeout(timer);
+    });
+
+    async function handleRetry() {
+        if (isRetrying) return;
+        isRetrying = true;
+        loadingTimedOut = false;
+        try {
+            await authActions.fetchCurrentUser();
+        } catch {
+            // 실패 시 effect 가 다시 12s 후 fallback 노출
+        } finally {
+            isRetrying = false;
+        }
+    }
+
     let gradeName = $derived(user ? getGradeName(user.mb_level) : '');
 
     // 아바타 URL (mb_image 우선 → avatar_url → member_image 경로 폴백)
@@ -80,13 +110,30 @@
 </script>
 
 <div class={compact ? 'bg-card mb-1 rounded-lg border p-2' : 'bg-card mb-3 rounded-lg border p-3'}>
-    {#if isLoading}
-        <!-- 로딩 상태 -->
+    {#if isLoading && !loadingTimedOut}
+        <!-- 로딩 상태 (12s 이내) -->
         <div class="flex items-center gap-2">
             <Skeleton class="h-8 w-8 rounded-full" />
             <div class="flex-1 space-y-1">
                 <Skeleton class="h-3 w-20" />
                 <Skeleton class="h-2 w-14" />
+            </div>
+        </div>
+    {:else if isLoading && loadingTimedOut}
+        <!-- Skeleton timeout fallback (audit P1-A): 강제 로그아웃 X, 재시도만 제공 -->
+        <div class="flex items-center gap-2">
+            <div class="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-full">
+                <User class="text-muted-foreground h-4 w-4" />
+            </div>
+            <div class="min-w-0 flex-1">
+                <p class="text-muted-foreground truncate text-xs">로그인 정보 확인 지연</p>
+                <button
+                    onclick={handleRetry}
+                    disabled={isRetrying}
+                    class="text-primary text-xs hover:underline disabled:opacity-50"
+                >
+                    {isRetrying ? '확인 중…' : '새로고침'}
+                </button>
             </div>
         </div>
     {:else if isLoggedIn && user}


### PR DESCRIPTION
## Summary
- 좌측 사이드바 user-widget skeleton 무한 표시 안티패턴 제거 (2026-05-01 widget audit P1-A 첫 번째)
- `apiClient.login()` / `exchangeToken()` 의 bare fetch 를 `timedFetch` (12s, no retry) 로 교체
- user-widget 에 12s skeleton timeout fallback UI 추가 — 강제 로그아웃 X, 새로고침 버튼 제공

## 근본 원인
`authStore.isLoading` 이 true 인 동안 user-widget 은 `Skeleton` 만 렌더링. 기존 `client.ts` 의 `request()` 는 `fetchWithRetry` 로 timeout 처리되지만 `login()` / `exchangeToken()` 의 bare `fetch()` 는 무한 hang 가능. 또한 SSR 인증 후에도 어떤 이유로든 `isLoading` 이 풀리지 않으면 skeleton 영구 노출.

## 변경
### `apps/web/src/lib/api/client.ts`
- `import { timedFetch, TimedFetchError }` 추가 (PR #1349 의 표준 유틸 재사용)
- `login()`: bare fetch -> `timedFetch(..., { timeout: 12_000, retries: 0 })`. timeout 시 한국어 에러 메시지.
- `exchangeToken()`: 동일 적용. 기존 throw 형태 (`{ response: { status }, data }`) 유지.

### `apps/web/src/lib/components/layout/user-widget.svelte`
- `loadingTimedOut` / `isRetrying` 상태 + `$effect` 로 12s 타이머
- `isLoading && !loadingTimedOut` -> 기존 skeleton
- `isLoading && loadingTimedOut` -> "로그인 정보 확인 지연" + 새로고침 버튼 (강제 로그아웃 X)
- 새로고침 버튼은 `authActions.fetchCurrentUser()` 호출, 실패 시 effect 가 다시 12s 후 fallback 노출

## 회귀 위험
인증 흐름에 timeout 이 추가되어 매우 느린 네트워크 (>12s) 환경에서 `login()` / `exchangeToken()` 이 실패할 수 있음. 다만:
- 기존에도 사용자는 무한 hang 을 경험 (skeleton 영구화)
- 명시적 에러 메시지가 더 나은 UX
- 12s 는 PR #1349 의 `timed-fetch` 표준 timeout 과 동일

## Test plan
- [ ] 정상 시나리오: 로그인 -> user-widget 정상 렌더 (skeleton -> 사용자 정보)
- [ ] timeout 시나리오: dev 환경에서 backend 응답 의도적 지연 (예: nginx delay) -> 12s 후 "로그인 정보 확인 지연" + 새로고침 버튼 노출 확인
- [ ] 새로고침 버튼 클릭 -> `apiClient.getCurrentUser()` 재호출, 정상 응답 시 기존 UI 복귀
- [ ] `pnpm check` 통과 (관련 파일에 신규 에러 없음 확인됨, pre-existing `packages/types/zod` 에러 2건은 무관)
- [ ] CI E2E 인증 테스트 통과