### PR TITLE
feat(ads): AdFit fallback timeout + Dantry event (audit P1-C, 5/22 미팅 직결)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -29,6 +29,7 @@
     } from '$lib/ads/prebid-config.js';
     import { runPrebidAuction } from '$lib/ads/prebid-loader.js';
     import { ensureGAMPreload } from './ad-slot-registry.js';
+    import { trackAdEvent, isAdSdkBlocked } from '$lib/services/ad-telemetry.js';
     import { page } from '$app/stores';
 
     /**
@@ -282,6 +283,13 @@
             watchdogTimer = setTimeout(() => {
                 watchdogTimer = null;
                 if (detached || isLoaded) return;
+                // P1-C (5/22 미팅 직결): GAM/AdFit SDK 둘 다 부재 → 광고 차단기 추정
+                if (isAdSdkBlocked()) {
+                    trackAdEvent('ad_sdk_blocked', {
+                        position,
+                        reason: 'no_googletag_no_adfit'
+                    });
+                }
                 handleRender(true);
             }, AD_WATCHDOG_MS);
         }
@@ -330,7 +338,7 @@
         style:transition="min-height 0ms"
     >
         {#if showAdfit && adfitUnit}
-            <AdfitSlot unit={adfitUnit} id={slotId || position} />
+            <AdfitSlot unit={adfitUnit} id={slotId || position} {position} />
         {/if}
         {#if slotId}
             <div

--- a/apps/web/src/lib/components/ui/adfit-slot/adfit-slot.svelte
+++ b/apps/web/src/lib/components/ui/adfit-slot/adfit-slot.svelte
@@ -2,25 +2,48 @@
     /**
      * 카카오 애드핏 광고 슬롯
      * GAM이 빈 슬롯일 때 폴백으로 사용
+     *
+     * audit P1-C (5/22 미팅 직결): SDK 로드 status 별 Dantry 이벤트 송신.
+     * - success / failed / timeout 분리 → fill rate 정확도 ↑
      */
     import { onMount, onDestroy, tick } from 'svelte';
     import { loadAdfitSDK, renderAdfitAd, destroyAdfitAd } from '$lib/utils/adfit-loader.js';
+    import { trackAdEvent } from '$lib/services/ad-telemetry.js';
     import type { AdfitUnit } from '$lib/config/ad-config.js';
 
     interface Props {
         unit: AdfitUnit;
         id: string;
+        /** GAM position 라벨 (텔레메트리 분류용) */
+        position?: string;
     }
 
-    let { unit, id }: Props = $props();
+    let { unit, id, position }: Props = $props();
 
     let ready = $state(false);
     let destroyed = false;
     const containerId = `adfit-${id}`;
 
     onMount(async () => {
-        await loadAdfitSDK();
+        const status = await loadAdfitSDK();
         if (destroyed) return;
+
+        // P1-C: SDK 로드 결과를 Dantry 로 보고
+        const eventName =
+            status === 'success'
+                ? 'ad_fallback_success'
+                : status === 'timeout'
+                  ? 'ad_fallback_timeout'
+                  : 'ad_fallback_failed';
+        trackAdEvent(eventName, {
+            ad_unit: unit.unitId,
+            position: position ?? '',
+            reason: status
+        });
+
+        // success 가 아니면 ins 렌더 의미 없음 (SDK 함수 부재)
+        if (status !== 'success') return;
+
         ready = true;
         // ins 엘리먼트가 DOM에 렌더링된 후 명시적으로 SDK에 알림
         await tick();

--- a/apps/web/src/lib/services/ad-telemetry.ts
+++ b/apps/web/src/lib/services/ad-telemetry.ts
@@ -1,0 +1,88 @@
+/**
+ * 광고 폴백/차단 이벤트 텔레메트리 (Dantry → ClickHouse)
+ *
+ * audit P1-C: AdFit fallback silent fail 해소.
+ * 5/22 AdSense 매니저 미팅 직결 — fill rate 정확 측정.
+ *
+ * 이벤트 타입:
+ * - ad_fallback_success : AdFit SDK 로드 성공 (폴백 정상 동작)
+ * - ad_fallback_failed  : AdFit SDK 로드 명시적 실패 (script.onerror)
+ * - ad_fallback_timeout : AdFit SDK 8s 내 미로드 (네트워크 지연/차단)
+ * - ad_sdk_blocked      : googletag + kakao_ad 둘 다 미존재 (uBlock / Brave 추정)
+ *
+ * 송신 정책: navigator.sendBeacon 우선 (페이지 unload 무관), 미지원 시 fetch keepalive.
+ * PII 미송신 (mb_id 는 PHPSESSID → Dantry 측에서 매핑).
+ *
+ * ClickHouse 집계 예 (PR body 참고):
+ *   SELECT toDate(ts) AS d, message, count() AS c
+ *   FROM error_logs.js_errors
+ *   WHERE message IN ('ad_fallback_success','ad_fallback_failed',
+ *                     'ad_fallback_timeout','ad_sdk_blocked')
+ *     AND ts >= now() - INTERVAL 7 DAY
+ *   GROUP BY d, message ORDER BY d DESC;
+ */
+
+const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
+
+export type AdTelemetryEventName =
+    | 'ad_fallback_success'
+    | 'ad_fallback_failed'
+    | 'ad_fallback_timeout'
+    | 'ad_sdk_blocked';
+
+export interface AdTelemetryPayload {
+    ad_unit?: string;
+    position?: string;
+    reason?: string;
+    [key: string]: unknown;
+}
+
+// 같은 슬롯+이벤트 중복 송신 방지 (페이지 단위)
+const sentKeys = new Set<string>();
+
+export function trackAdEvent(name: AdTelemetryEventName, props: AdTelemetryPayload = {}): void {
+    if (typeof window === 'undefined') return;
+
+    const dedupeKey = `${name}:${props.position ?? ''}:${props.ad_unit ?? ''}`;
+    if (sentKeys.has(dedupeKey)) return;
+    sentKeys.add(dedupeKey);
+
+    const payload = {
+        message: name,
+        type: 'ad_telemetry',
+        url: location.href,
+        userAgent: navigator.userAgent,
+        ts: Date.now(),
+        ...props
+    };
+
+    try {
+        const body = JSON.stringify(payload);
+        if (typeof navigator.sendBeacon === 'function') {
+            const blob = new Blob([body], { type: 'application/json' });
+            if (navigator.sendBeacon(DANTRY_URL, blob)) return;
+        }
+        fetch(DANTRY_URL, {
+            mode: 'cors',
+            credentials: 'include',
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+            keepalive: true
+        }).catch(() => {});
+    } catch {
+        // 송신 실패는 무시 (모니터링 데이터, 사용자 영향 X)
+    }
+}
+
+/**
+ * SDK 차단 감지: googletag + kakao_ad (adfit) 둘 다 미존재 시 true.
+ * uBlock Origin / Brave Shields 등 광고 차단기 사용자 추정.
+ */
+export function isAdSdkBlocked(): boolean {
+    if (typeof window === 'undefined') return false;
+    const w = window as any;
+    const hasGam = !!w.googletag && typeof w.googletag.cmd !== 'undefined';
+    const hasAdfit = typeof w.adfit === 'function';
+    return !hasGam && !hasAdfit;
+}

--- a/apps/web/src/lib/utils/adfit-loader.ts
+++ b/apps/web/src/lib/utils/adfit-loader.ts
@@ -1,32 +1,51 @@
 /**
  * 카카오 애드핏 SDK 지연 로딩
  * GAM이 빈 슬롯일 때만 로드하여 불필요한 네트워크 요청 방지
+ *
+ * audit P1-C: SDK 로드 결과를 status 로 반환 → adfit-slot 이 텔레메트리 송신.
+ * 8s timeout — 차단/네트워크 지연 케이스 검출 (5/22 미팅 fill rate 측정).
  */
 
 const ADFIT_SDK_URL = 'https://t1.daumcdn.net/kas/static/ba.min.js';
-let loadPromise: Promise<void> | null = null;
+const ADFIT_LOAD_TIMEOUT_MS = 8_000;
+
+export type AdfitLoadStatus = 'success' | 'failed' | 'timeout';
+
+let loadPromise: Promise<AdfitLoadStatus> | null = null;
 const activeAds = new Set<string>();
 
-export function loadAdfitSDK(): Promise<void> {
+export function loadAdfitSDK(): Promise<AdfitLoadStatus> {
     if (loadPromise) return loadPromise;
 
-    loadPromise = new Promise<void>((resolve) => {
+    loadPromise = new Promise<AdfitLoadStatus>((resolve) => {
         if (typeof window === 'undefined') {
-            resolve();
+            resolve('failed');
             return;
         }
 
         const existing = document.querySelector(`script[src*="kas/static/ba.min.js"]`);
         if (existing) {
-            resolve();
+            // 이미 삽입된 스크립트: adfit 함수 존재 여부로 success/failed 판정
+            resolve(typeof (window as any).adfit === 'function' ? 'success' : 'failed');
             return;
         }
 
         const script = document.createElement('script');
         script.src = ADFIT_SDK_URL;
         script.async = true;
-        script.onload = () => resolve();
-        script.onerror = () => resolve(); // 실패해도 resolve (폴백이 또 실패하면 빈 슬롯)
+
+        let settled = false;
+        const finish = (status: AdfitLoadStatus) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve(status);
+        };
+
+        const timer = setTimeout(() => finish('timeout'), ADFIT_LOAD_TIMEOUT_MS);
+
+        script.onload = () => finish('success');
+        script.onerror = () => finish('failed');
         document.head.appendChild(script);
     });
 


### PR DESCRIPTION
## Summary

- **audit P1-C** ([report §4-3, §4-4, §6](../blob/main/docs/2026-05-01-widget-audit-report.md)) — AdFit SDK 폴백이 silent fail 로 처리되어 운영 모니터링/fill rate 측정 정확도 부재 해소.
- **5/22 AdSense 매니저 미팅 직결**: fill rate / SDK 차단율 / fallback 성공률 정량 데이터 확보.
- AdFit SDK 로드를 8s timeout 으로 감싸고 status 별로 Dantry 이벤트 송신 (`ad_fallback_success` / `ad_fallback_failed` / `ad_fallback_timeout`), 광고 차단기 추정 시 `ad_sdk_blocked` 별도 송신.

## Changes

| File | LOC | Description |
|---|---|---|
| `apps/web/src/lib/services/ad-telemetry.ts` (new) | ~75 | Dantry 송신 (`navigator.sendBeacon` 우선 → `fetch keepalive` fallback). Per-page dedupe. PII 미포함. |
| `apps/web/src/lib/utils/adfit-loader.ts` | +20/-5 | `loadAdfitSDK()` → `Promise<AdfitLoadStatus>` 반환. 8s timeout. |
| `apps/web/src/lib/components/ui/adfit-slot/adfit-slot.svelte` | +20/-3 | status 별 텔레메트리 송신. SDK 부재 시 ins 렌더 skip. `position` prop 추가. |
| `apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte` | +10/-2 | watchdog 발화 시 `isAdSdkBlocked()` 체크 → `ad_sdk_blocked` 송신. AdfitSlot 에 position 전달. |

## Telemetry events

| Event | Trigger | Props |
|---|---|---|
| `ad_fallback_success` | AdFit SDK 로드 성공 (script.onload) | `ad_unit`, `position`, `reason='success'` |
| `ad_fallback_failed` | AdFit SDK 명시적 실패 (script.onerror) | `ad_unit`, `position`, `reason='failed'` |
| `ad_fallback_timeout` | AdFit SDK 8s 내 미로드 (네트워크 지연 / DNS 차단) | `ad_unit`, `position`, `reason='timeout'` |
| `ad_sdk_blocked` | watchdog 12s 발화 + `googletag` & `kakao_ad` 둘 다 부재 (uBlock / Brave 추정) | `position`, `reason='no_googletag_no_adfit'` |

송신처: `POST https://aplog.damoang.net/api/v1/dantry` → ClickHouse `error_logs.js_errors`.

## ClickHouse 집계 SQL (5/22 미팅 자료용)

### 1. 일별 이벤트 카운트 (전체 추세)
```sql
SELECT
    toDate(ts) AS d,
    message AS event,
    count() AS c
FROM error_logs.js_errors
WHERE message IN ('ad_fallback_success', 'ad_fallback_failed',
                  'ad_fallback_timeout', 'ad_sdk_blocked')
  AND ts >= now() - INTERVAL 7 DAY
GROUP BY d, event
ORDER BY d DESC, c DESC;
```

### 2. position 별 fallback 성공률 (fill rate gap 분석)
```sql
SELECT
    JSONExtractString(extra, 'position') AS position,
    countIf(message = 'ad_fallback_success') AS success,
    countIf(message = 'ad_fallback_failed')  AS failed,
    countIf(message = 'ad_fallback_timeout') AS timeout,
    round(success / (success + failed + timeout) * 100, 2) AS success_rate_pct
FROM error_logs.js_errors
WHERE message IN ('ad_fallback_success', 'ad_fallback_failed', 'ad_fallback_timeout')
  AND ts >= now() - INTERVAL 1 DAY
GROUP BY position
ORDER BY (success + failed + timeout) DESC;
```

### 3. 광고 차단율 (SDK 차단기 사용자 비율)
```sql
SELECT
    toDate(ts) AS d,
    countIf(message = 'ad_sdk_blocked') AS blocked,
    countIf(message LIKE 'ad_fallback_%') AS total_fallback,
    round(blocked / (blocked + total_fallback) * 100, 2) AS block_pct
FROM error_logs.js_errors
WHERE message IN ('ad_fallback_success', 'ad_fallback_failed',
                  'ad_fallback_timeout', 'ad_sdk_blocked')
  AND ts >= now() - INTERVAL 7 DAY
GROUP BY d
ORDER BY d DESC;
```

## 제약 / 안전장치

- **PII 미송신**: `mb_id` 송신 안 함. PHPSESSID 쿠키 → Dantry 측에서 매핑 (기존 hooks.client 동일 정책).
- **adblock 사용자 영향 X**: 단순 모니터링 데이터, 광고 표시 로직 불변. 송신 실패는 모두 silent.
- **rate limit 친화적**: per-page dedupe (`Set<string>`) 로 같은 슬롯+이벤트 1회만 송신.
- **`navigator.sendBeacon` 우선**: 페이지 unload 직전에도 안정적 송신.
- **fetch fallback `keepalive: true`**: SPA 네비 도중에도 송신 보장.

## Test plan

- [ ] Dev 로컬 (또는 staging) 에서 광고 슬롯 마운트 → DevTools Network 탭에서 `aplog.damoang.net/api/v1/dantry` 로 `ad_fallback_*` POST 확인
- [ ] uBlock Origin 활성화 상태에서 페이지 진입 → 12s 후 `ad_sdk_blocked` 송신 확인
- [ ] AdFit 도메인 (`t1.daumcdn.net`) 차단 후 진입 → `ad_fallback_failed` 또는 `ad_fallback_timeout` 송신 확인
- [ ] `pnpm check` 신규 에러 0건 (이미 검증, pre-existing zod 에러는 unrelated)
- [ ] ClickHouse `error_logs.js_errors` 에 신규 message 4종 적재 확인 (배포 후 30분)
- [ ] 5/22 미팅 전 일주일치 데이터 SQL 3종 실행 결과 정리

## Follow-up

- 5/22 미팅 자료 작성 시 위 SQL 결과 활용
- 차단율 / timeout 율 임계값 도출 후 Telegram alert 추가 검토 (Phase A2 sphinx 패턴 참고)