### PR TITLE
feat(widgets): notice/banner/giving/ai-analysis/celebration timed-fetch (audit P1-B)

### DIFF
--- a/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
+++ b/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
@@ -4,6 +4,7 @@
     import { aplogTrack } from '$lib/services/aplog';
     import { authStore } from '$lib/stores/auth.svelte';
     import { getCachedBanners } from '$lib/stores/app-init.svelte';
+    import { timedFetch } from '$lib/utils/timed-fetch';
 
     interface Props {
         position?: string;
@@ -127,8 +128,13 @@
         }
 
         try {
-            // damoang-ads API 호출 - 항상 4개 요청
-            const response = await fetch(`/api/ads/banners?position=${position}&limit=4`);
+            // timedFetch: 각 시도마다 12s timeout 보장 → fetch hang 시 retry 무한 누적 방지.
+            // (audit 2026-05-01 §3-2). retries=0 으로 두고 외부 MAX_SIDE_RETRIES 로 상위 제어.
+            const response = await timedFetch(
+                `/api/ads/banners?position=${position}&limit=4`,
+                {},
+                { retries: 0 }
+            );
             const result = await response.json();
 
             if (result.success && result.data?.banners?.length > 0) {

--- a/widgets/ai-analysis/index.svelte
+++ b/widgets/ai-analysis/index.svelte
@@ -22,6 +22,25 @@
     let loading = $state(true);
     let error = $state<string | null>(null);
 
+    // apiClient 는 자체 abort 를 노출하지 않으므로 Promise.race 타임가드 적용.
+    // (audit 2026-05-01 §3-1)
+    const FETCH_TIMEOUT_MS = 12_000;
+    function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('timeout')), ms);
+            p.then(
+                (v) => {
+                    clearTimeout(timer);
+                    resolve(v);
+                },
+                (e) => {
+                    clearTimeout(timer);
+                    reject(e);
+                }
+            );
+        });
+    }
+
     function calculateStats(data: RecommendedDataWithAI) {
         let total_recommends = 0;
         let total_comments = 0;
@@ -44,13 +63,17 @@
         loading = true;
         error = null;
         try {
-            const data = await apiClient.getRecommendedPostsWithAI(period);
+            const data = await withTimeout(
+                apiClient.getRecommendedPostsWithAI(period),
+                FETCH_TIMEOUT_MS
+            );
             analysis = data.ai_analysis ?? null;
             if (analysis && showStats) {
                 stats = calculateStats(data);
             }
         } catch (err) {
-            error = err instanceof Error ? err.message : '분석 데이터 로드 실패';
+            const msg = err instanceof Error ? err.message : '분석 데이터 로드 실패';
+            error = msg === 'timeout' ? '응답이 늦어지고 있어요. 잠시 후 다시 시도해 주세요.' : msg;
         } finally {
             loading = false;
         }

--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -3,6 +3,7 @@
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
     import { PartyPopper, ChevronRight } from '../lucide.js';
     import type { WidgetConfig } from '$lib/stores/widget-layout.svelte';
+    import { timedFetch } from '$lib/utils/timed-fetch';
 
     interface Banner {
         id: number;
@@ -29,7 +30,9 @@
 
     $effect(() => {
         if (!loaded && browser) {
-            fetch('/api/ads/celebration/today?mode=recent')
+            // timedFetch: 12s timeout + 1회 retry. hasBanners=false 면 위젯 자체가 미표시되므로
+            // silent fail 정책 유지. (audit 2026-05-01 §3-1)
+            timedFetch('/api/ads/celebration/today?mode=recent')
                 .then((r) => r.json())
                 .then((res) => {
                     if (res.success && res.data) {

--- a/widgets/giving/index.svelte
+++ b/widgets/giving/index.svelte
@@ -6,6 +6,7 @@
     import type { WidgetProps } from '$lib/types/widget-props';
     import { onMount } from 'svelte';
     import { Gift } from '../lucide.js';
+    import { timedFetch } from '$lib/utils/timed-fetch';
 
     let { config, slot, isEditMode = false }: WidgetProps = $props();
 
@@ -32,7 +33,8 @@
 
     onMount(async () => {
         try {
-            const res = await fetch('/api/plugins/giving/list?tab=active&limit=5&sort=urgent');
+            // timedFetch: 12s timeout + 1회 retry. (audit 2026-05-01 §3-1)
+            const res = await timedFetch('/api/plugins/giving/list?tab=active&limit=5&sort=urgent');
             if (res.ok) {
                 const data = await res.json();
                 if (data.success) {

--- a/widgets/image-text-banner/index.svelte
+++ b/widgets/image-text-banner/index.svelte
@@ -6,6 +6,7 @@
     import type { WidgetProps } from '$lib/types/widget-props';
     import { onMount } from 'svelte';
     import { LayoutGrid, Image as ImageIcon } from '../lucide.js';
+    import { timedFetch, TimedFetchError } from '$lib/utils/timed-fetch';
 
     let { config, slot, isEditMode = false, prefetchData }: WidgetProps = $props();
 
@@ -28,15 +29,22 @@
         }
 
         try {
-            const res = await fetch('/api/widgets/image-text-banner?limit=4');
+            // timedFetch: 12s timeout + 1회 retry. fetch hang 시 skeleton 무한 대기 방지.
+            // (audit 2026-05-01 §3-1)
+            const res = await timedFetch('/api/widgets/image-text-banner?limit=4');
             if (res.ok) {
                 const data = await res.json();
                 banners = data.data ?? [];
             } else {
                 error = true;
             }
-        } catch {
-            error = true;
+        } catch (err) {
+            // TimedFetchError(timeout/network) 모두 silent 에러 UI 로 fallback.
+            if (err instanceof TimedFetchError || err instanceof Error) {
+                error = true;
+            } else {
+                error = true;
+            }
         } finally {
             loading = false;
         }

--- a/widgets/notice/index.svelte
+++ b/widgets/notice/index.svelte
@@ -16,6 +16,25 @@
     let loading = $state(true);
     let error = $state(false);
 
+    // apiClient 는 자체 abort 를 노출하지 않으므로 Promise.race 타임가드로 skeleton 무한 대기 방지.
+    // (audit 2026-05-01 §3-1)
+    const FETCH_TIMEOUT_MS = 12_000;
+    function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('timeout')), ms);
+            p.then(
+                (v) => {
+                    clearTimeout(timer);
+                    resolve(v);
+                },
+                (e) => {
+                    clearTimeout(timer);
+                    reject(e);
+                }
+            );
+        });
+    }
+
     onMount(async () => {
         if (prefetchData) {
             notices = prefetchData as FreePost[];
@@ -24,10 +43,13 @@
         }
 
         try {
-            const [noticesData, latestData] = await Promise.all([
-                apiClient.getBoardNotices('free'),
-                apiClient.getBoardPosts('notice', 1, 1).catch(() => null)
-            ]);
+            const [noticesData, latestData] = await withTimeout(
+                Promise.all([
+                    apiClient.getBoardNotices('free'),
+                    apiClient.getBoardPosts('notice', 1, 1).catch(() => null)
+                ]),
+                FETCH_TIMEOUT_MS
+            );
             notices = noticesData.slice(0, 5);
             if (latestData?.items?.length) {
                 latestNotice = latestData.items[0];


### PR DESCRIPTION
## 배경

2026-05-01 작성된 [widget audit 보고서](../tree/main/docs/2026-05-01-widget-audit-report.md) §3-1, §3-2 의 High 영역 fix.

PR #1349 (P0-A) 에서 도입한 `$lib/utils/timed-fetch.ts` 를 5개 High 위젯 + 사이드 이미지+텍스트 배너 UI 컴포넌트에 적용.

## Summary

- **widgets/image-text-banner** (홈 4-그리드 배너) — raw fetch → `timedFetch` (12s timeout + 1회 retry). silent 에러 UI fallback.
- **widgets/giving** (사이드바 진행중 나눔) — raw fetch → `timedFetch`. 12s 후 "진행중인 나눔이 없어요" fallback.
- **widgets/celebration** (축하메시지 배너) — raw fetch → `timedFetch`. silent fail (banners=0 시 위젯 미표시 정책 유지).
- **widgets/notice** (공지사항) — `apiClient` 사용 (자체 abort 미지원) → `Promise.race` 타임가드 (12s). 타임아웃 시 "아직 공지사항이 없어요" fallback.
- **widgets/ai-analysis** (AI 트렌드) — `apiClient` 사용 → `Promise.race` 타임가드. timeout 한글 메시지: "응답이 늦어지고 있어요. 잠시 후 다시 시도해 주세요."
- **components/ui/image-text-banner (사이드 배너)** (audit §3-2 추가 권고) — raw fetch → `timedFetch({ retries: 0 })`. 외부 `MAX_SIDE_RETRIES=2` retry 루프 유지하되 각 시도마다 12s 안에 abort 보장 → retry 무한 누적 방지.

## 회귀 위험 평가

- `notice` / `ai-analysis`: apiClient 가 12s 안에 응답하면 동작 동일. 12s 초과 시 reject 되는 점이 신규 동작이지만 기존 무한 skeleton 보다 사용자에게 명시적 에러가 낫다. (위험: 낮음)
- `image-text-banner` widget / `giving` / `celebration`: 단발 fetch → timedFetch 로 1회 retry 추가. 모든 호출이 idempotent GET 이라 안전. (위험: 낮음)
- 사이드 배너 ui 컴포넌트: 외부 retry 루프(2회) + `timedFetch(retries=0)` → 누적 retry 횟수 기존과 동일. (위험: 낮음)
- 다른 fetch 패턴 (apiClient vs raw fetch) 을 무리하게 통일하지 않고 위젯별 개별 적용 — 기존 코드 형태 최대한 보존.

## 적용 위젯

5/5 (notice, image-text-banner, giving, ai-analysis, celebration) + 사이드 배너 UI 컴포넌트 1건 보너스.
skip 한 건 없음.

## 변경량

`6 files changed, 77 insertions(+), 13 deletions(-)` — 명세 ~120 LOC 이내.

## Test plan

- [ ] `pnpm check` 0 errors (확인 완료, 기존 warning 만 잔존)
- [ ] dev 환경 또는 prod canary 에서 5개 위젯 정상 로딩 확인
- [ ] 백엔드 의도적 hang (예: nginx delay) 시 12s 후 에러 UI 표시 확인
- [ ] 사이드 배너: 의도적 504 + hang 조합에서 retry 누적이 12s × 3 = 36s 안에 종료되는지 확인

## Refs

- audit report: `docs/2026-05-01-widget-audit-report.md` §3-1, §3-2
- P0-A 선행 PR: #1349 (timed-fetch 유틸 + Recommended/Explore)