### PR TITLE
feat(ads): AdSlot 고정 공간 예약 — CLS 방지 (광고 부재 시 collapse X)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -55,19 +55,9 @@
         'board-after-comments'
     ]);
 
-    // 모바일 목록처럼 터치가 빈번한 위치: no fill이어도 즉시 축소하지 않음 (CLS 방지)
-    // 홈 공감글 터치 오인식(#11998) — 공감글 아래 위젯들이 index-middle 광고 높이 변화로 밀리는 것을 방지
-    const TOUCH_SAFE_POSITIONS = new Set([
-        'header-after',
-        'board-list-infeed',
-        'board-list-top',
-        'board-list-bottom',
-        'index-top',
-        'index-middle-1',
-        'index-middle-2',
-        'board-content',
-        'board-before-comments'
-    ]);
+    // 이전 TOUCH_SAFE_POSITIONS 화이트리스트는 제거됨 — 모든 in-flow 슬롯이
+    // 빈 광고 상태에서도 예약 공간(min-height)을 유지하도록 정책 변경 (CLS 방지).
+    // 사이드바/윙 등 부유 광고만 suppressPlaceholder 분기로 collapse 허용.
 
     let isLoaded = $state(false);
     let hasAd = $state(false);
@@ -86,7 +76,6 @@
 
     let isBTF = $derived(BTF_POSITIONS.has(position));
     let isWing = $derived(position === 'wing-left' || position === 'wing-right');
-    let isTouchSafe = $derived(TOUCH_SAFE_POSITIONS.has(position));
     let isEmpty = $derived(isLoaded && !hasAd && !showAdfit);
 
     // 애드핏 폴백 유닛 (반응형: 데스크톱/모바일 구분)
@@ -265,12 +254,14 @@
     const reservedHeights = $derived(getReservedHeights(getAdConfig()));
     const suppressPlaceholder = $derived(position === 'wing-right' || position.includes('sidebar'));
     const effectiveMinHeight = $derived.by(() => {
-        // 로드 전 + 사이드바 → 높이 예약 안 함
-        if (!isLoaded && suppressPlaceholder) return '0px';
-        // 터치 빈번한 목록 위치: 빈 광고라도 높이 유지 (CLS 방지)
-        if (isEmpty && isTouchSafe) return 'var(--ad-slot-min-height)';
-        // 일반: 빈 광고 → 축소
-        if (isEmpty) return '0px';
+        // 사이드바/윙 등 부유 광고는 빈 공간이 UX 를 해치므로 collapse 허용 (예외)
+        if (suppressPlaceholder) {
+            if (!isLoaded) return '0px';
+            if (isEmpty) return '0px';
+            return 'var(--ad-slot-min-height)';
+        }
+        // 일반 in-flow 슬롯: 로드 전/빈 광고/AdFit 실패 시에도 예약 높이 유지 → CLS 방지
+        // (광고가 실제로 채워지면 그 위에 렌더되므로 영향 없음)
         return 'var(--ad-slot-min-height)';
     });
 </script>
@@ -320,12 +311,19 @@
         background: transparent;
     }
 
+    /*
+     * 빈 광고 상태: collapse 하지 않고 예약 공간(min-height)을 유지하여 CLS 방지.
+     * 시각적으로는 투명하므로 사용자에게는 빈 공간으로 보이며, 광고가 채워지면
+     * 그 위에 그대로 렌더된다. (사이드바/윙 등 suppressPlaceholder 위치는
+     * effectiveMinHeight 로 0px 반환되어 collapse 됨)
+     */
     .ad-slot-empty {
         border: 0;
         background: transparent;
     }
 
     .ad-slot-empty-collapsed {
+        /* 시각적 placeholder UI 없이 투명 빈 공간 유지 (가장 보수적) */
         opacity: 0;
     }
 
@@ -348,22 +346,12 @@
         .gam-ad-slot {
             min-height: var(--ad-slot-min-height-tablet);
         }
-
-        .ad-slot-empty,
-        .ad-slot-empty .gam-ad-slot {
-            min-height: 0 !important;
-        }
     }
 
     @media (min-width: 970px) {
         .ad-slot-container,
         .gam-ad-slot {
             min-height: var(--ad-slot-min-height-desktop);
-        }
-
-        .ad-slot-empty,
-        .ad-slot-empty .gam-ad-slot {
-            min-height: 0 !important;
         }
     }
 


### PR DESCRIPTION
## 배경

광고 로드 실패 / GAM empty / AdFit fallback 도 실패 시 AdSlot 이 0 height 로 collapse → 페이지 layout shift 발생 (CLS 점수 악화).

- **Core Web Vitals (CLS) 개선** = SEO 점수 + AdSense 평가 개선
- **5/22 AdSense 매니저 미팅** 직결 (fill rate 외 CWV 도 평가 항목)
- audit 보고서 §4-1, §4-3, §5-D 와 연관 (`docs/2026-05-01-widget-audit-report.md`)
- 사용자 제안: "차라리 빈 공간 유지하고 CLS 안 일어나게 크기 고정"

## 변경 정책

| 슬롯 타입 | 빈 광고 상태 동작 |
|---|---|
| in-flow (header-after, board-content, board-list-*, index-*, board-after-comments 등) | **예약 높이 유지** (CLS 방지) |
| 부유 (sidebar*, wing-right) | 기존 **collapse 동작 유지** (`suppressPlaceholder`) — 빈 사이드 공간이 UX 저하 |
| wing-left | in-flow 슬롯과 동일하게 처리 (현재 코드 동작 그대로) |

## 세부 변경

`apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte`:

1. **`effectiveMinHeight` 단순화** — `TOUCH_SAFE_POSITIONS` 화이트리스트 제거. in-flow 슬롯은 항상 `var(--ad-slot-min-height)` 반환 (모바일 base / 태블릿 / 데스크톱 viewport 에 따라 미디어 쿼리로 자동 upscale).
2. **미디어 쿼리 `min-height: 0 !important` 삭제** — 728px+/970px+ 에서 `.ad-slot-empty .gam-ad-slot` 을 강제 collapse 하던 룰 제거. 태블릿/데스크톱에서도 예약 높이 유지.
3. **`.ad-slot-empty-collapsed { opacity: 0 }` 유지** — 빈 공간이 시각적으로 투명하게 보이도록 (가장 보수적, placeholder UI 없음).
4. 사이드바/윙 분기는 `suppressPlaceholder` 로 명시적으로 유지.

## 사이즈 매핑 처리 방식

기존 `getReservedHeights(config)` 로직 그대로 활용:
- `config.responsive` viewport 별 max(height) 를 mobile/tablet/desktop CSS 변수로 노출
- 예: `banner-horizontal` → mobile 100px (320x100), tablet 90px (728x90), desktop 250px (970x250)
- 예: `banner-square` → 250px (300x250) 단일
- 모바일에서 빈 공간 과다 우려 X (기존 광고 size 그대로 예약하므로 광고가 들어와도 동일 영역)

## 회귀 위험

| 항목 | 영향 |
|---|---|
| 정상 광고 표시 | 영향 없음 — 광고가 들어오면 슬롯 위에 그대로 렌더 |
| 사이드바/윙 우측 | `suppressPlaceholder` 분기로 기존 collapse 동작 유지 |
| 모바일 좁은 viewport | 기존 광고 size 그대로 예약 (320x100 등) — UX 손실 없음 |
| 다크모드/AMOLED | `.ad-slot-loaded` 만 border 처리, empty 상태는 transparent 유지 |
| 홈 공감글 터치 오인식 (#11998) | 기존 `TOUCH_SAFE_POSITIONS` 가 커버하던 케이스 → 이제 모든 슬롯에 적용되어 더 안전 |

## CLS 측정 권고

### 변경 전후 Lighthouse 비교 방법

```bash
# 1. dev 서버 실행 (production preview 권장 — dev mode 는 CLS 부정확)
# 본 서버는 pnpm build 금지 → GitHub Actions canary 배포 후 실측

# 2. Lighthouse CLI (canary URL 기준)
npx lighthouse https://canary.damoang.net/ \
  --only-categories=performance \
  --form-factor=mobile \
  --throttling.cpuSlowdownMultiplier=4 \
  --output=json --output-path=./before.json

# 3. PR merge 후 동일 실행 → diff
node -e "const b=require('./before.json'),a=require('./after.json'); \
  console.log('CLS:', b.audits['cumulative-layout-shift'].numericValue, '→', \
              a.audits['cumulative-layout-shift'].numericValue)"
```

### ClickHouse `aplog.ad_events` 자동화 (TODO follow-up)

- 현재 `aplog.ad_events` 테이블이 web-vitals (LCP/FID/CLS) 이벤트도 받는지 확인 필요
- 받지 않으면 별도 `web_vitals` 테이블 생성 + 클라이언트 `web-vitals` 라이브러리 연동
- 본 PR 머지 후 1주 데이터 수집 → CLS p75 변화 확인 (목표: < 0.1 → "Good")

### 운영 모니터링

- nginx access log 에서 GAM 빈 슬롯 비율 → AdFit fallback 비율 변화 추적
- AdSense Console fill rate 변화 (Phase B-1 prebid 와 직교)

## Test plan

- [ ] dev 환경에서 광고 차단(uBlock) 활성화 후 게시판 목록 / 게시글 상세 / 홈 페이지 접근 → 슬롯 영역이 빈 공간으로 예약되어 layout shift 없음 확인
- [ ] 광고 차단 해제 → 정상 광고가 슬롯에 채워지는지 확인
- [ ] 사이드바 / 우측 윙 광고 차단 시 영역이 collapse 되는지 확인 (suppressPlaceholder 분기 검증)
- [ ] 모바일 viewport (320x568) / 태블릿 (728x1024) / 데스크톱 (1440+) 각 viewport 에서 빈 공간 높이가 광고 size 와 일치하는지 확인
- [ ] Lighthouse CLS 점수 측정 (canary 배포 후)
- [ ] `pnpm check` 통과 (이미 검증, 0 errors / 0 new warnings)

## 관련

- 관련 PR: #1350 (P0-B AdSlot watchdog), #1352 (P1-C AdFit Dantry telemetry)
- 후속 (옵션): placeholder UI (옅은 회색 박스 + "광고 영역" 텍스트) — 사용자 컨펌 필요
- 후속: web-vitals 자동 수집 → ClickHouse `web_vitals` 테이블