### PR TITLE
feat(ads): adblock detection + GA4 (audit P3, 5/22 미팅 직결)

### DIFF
--- a/apps/web/src/lib/services/ad-telemetry.ts
+++ b/apps/web/src/lib/services/ad-telemetry.ts
@@ -2,13 +2,15 @@
  * 광고 폴백/차단 이벤트 텔레메트리 (Dantry → ClickHouse)
  *
  * audit P1-C: AdFit fallback silent fail 해소.
- * 5/22 AdSense 매니저 미팅 직결 — fill rate 정확 측정.
+ * audit P3   : 페이지 단위 adblock 감지 (Brave / uBlock / AdBlock 사용자 비율 측정).
+ * 5/22 AdSense 매니저 미팅 직결 — fill rate 손실 원인 분석.
  *
  * 이벤트 타입:
  * - ad_fallback_success : AdFit SDK 로드 성공 (폴백 정상 동작)
  * - ad_fallback_failed  : AdFit SDK 로드 명시적 실패 (script.onerror)
  * - ad_fallback_timeout : AdFit SDK 8s 내 미로드 (네트워크 지연/차단)
- * - ad_sdk_blocked      : googletag + kakao_ad 둘 다 미존재 (uBlock / Brave 추정)
+ * - ad_sdk_blocked      : (슬롯 단위) googletag + kakao_ad 둘 다 미존재
+ * - ad_blocked          : (페이지 단위) 진입 시 1회 — GA4/Dantry 양쪽 송신
  *
  * 송신 정책: navigator.sendBeacon 우선 (페이지 unload 무관), 미지원 시 fetch keepalive.
  * PII 미송신 (mb_id 는 PHPSESSID → Dantry 측에서 매핑).
@@ -17,7 +19,7 @@
  *   SELECT toDate(ts) AS d, message, count() AS c
  *   FROM error_logs.js_errors
  *   WHERE message IN ('ad_fallback_success','ad_fallback_failed',
- *                     'ad_fallback_timeout','ad_sdk_blocked')
+ *                     'ad_fallback_timeout','ad_sdk_blocked','ad_blocked')
  *     AND ts >= now() - INTERVAL 7 DAY
  *   GROUP BY d, message ORDER BY d DESC;
  */
@@ -28,7 +30,8 @@ export type AdTelemetryEventName =
     | 'ad_fallback_success'
     | 'ad_fallback_failed'
     | 'ad_fallback_timeout'
-    | 'ad_sdk_blocked';
+    | 'ad_sdk_blocked'
+    | 'ad_blocked';
 
 export interface AdTelemetryPayload {
     ad_unit?: string;
@@ -85,4 +88,116 @@ export function isAdSdkBlocked(): boolean {
     const hasGam = !!w.googletag && typeof w.googletag.cmd !== 'undefined';
     const hasAdfit = typeof w.adfit === 'function';
     return !hasGam && !hasAdfit;
+}
+
+/**
+ * uBlock 패턴 bait 검사: 광고처럼 보이는 element 를 만들어
+ * 차단기가 hide 시켰는지 (offsetHeight===0) 확인. 동기. ~1ms.
+ */
+function isAdBaitHidden(): boolean {
+    if (typeof document === 'undefined' || !document.body) return false;
+    const bait = document.createElement('div');
+    bait.className = 'adsbox ad-banner ad-placement pub_300x250';
+    bait.setAttribute('aria-hidden', 'true');
+    // 화면 밖 + 1px — 시각 영향 0
+    bait.style.cssText =
+        'position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;pointer-events:none;';
+    bait.innerHTML = '&nbsp;';
+    document.body.appendChild(bait);
+    let hidden = false;
+    try {
+        // 차단기는 보통 display:none / visibility:hidden / 0px 적용
+        const cs = window.getComputedStyle(bait);
+        hidden =
+            bait.offsetParent === null ||
+            bait.offsetHeight === 0 ||
+            cs.display === 'none' ||
+            cs.visibility === 'hidden';
+    } finally {
+        bait.remove();
+    }
+    return hidden;
+}
+
+// 페이지 단위 dedupe — pathname 단위로 1회만 송신
+const adblockCheckedPaths = new Set<string>();
+
+/**
+ * 페이지 진입 시 1회 adblock 감지 → GA4 `ad_blocked` 이벤트 + Dantry 송신.
+ *
+ * @param pageType - GA4 page_type ('home' | 'board_list' 등). 이벤트 라벨링용.
+ * @param boardId  - 게시판 ID (선택, GA4 dimension)
+ * @param delayMs  - SDK 로드 대기 (기본 3000ms — googletag/adfit script 로드 시간 확보)
+ *
+ * 호출 측에서 page type 필터링 권장 (홈/게시판만). 그 외 페이지는 skip.
+ *
+ * 감지 로직 (보고서 §4-4):
+ *   1) `isAdSdkBlocked()` — SDK 객체 부재
+ *   2) `isAdBaitHidden()` — bait element hide 여부 (uBlock cosmetic filter)
+ *   둘 중 하나라도 true 면 차단으로 판정 (false positive 보다 false negative 가 분석 손해)
+ *
+ * 부정적 UX 영향 0 — 차단된 사용자에게 어떤 안내/광고도 노출하지 않음.
+ */
+export function detectAdblockOnce(
+    pageType: string,
+    boardId: string = 'none',
+    delayMs: number = 3000
+): void {
+    if (typeof window === 'undefined') return;
+
+    const path = location.pathname;
+    if (adblockCheckedPaths.has(path)) return;
+    adblockCheckedPaths.add(path);
+
+    // requestIdleCallback 우선 (저성능 기기 보호), fallback setTimeout
+    const schedule = (cb: () => void) => {
+        const w = window as any;
+        if (typeof w.requestIdleCallback === 'function') {
+            w.requestIdleCallback(() => setTimeout(cb, delayMs), { timeout: delayMs + 1000 });
+        } else {
+            setTimeout(cb, delayMs);
+        }
+    };
+
+    schedule(() => {
+        let blocked = false;
+        let reason = 'none';
+        try {
+            if (isAdSdkBlocked()) {
+                blocked = true;
+                reason = 'sdk_missing';
+            } else if (isAdBaitHidden()) {
+                blocked = true;
+                reason = 'bait_hidden';
+            }
+        } catch {
+            // 감지 실패는 무시 — 모니터링 신호일 뿐
+            return;
+        }
+
+        // GA4 (gtag) — initGA4 호출 후라야 동작. ga4.ts trackEvent 임포트 시 순환 위험 없음.
+        try {
+            const w = window as any;
+            if (typeof w.gtag === 'function') {
+                w.gtag('event', 'ad_blocked', {
+                    blocked,
+                    reason,
+                    page_type: pageType,
+                    board_id: boardId
+                });
+            }
+        } catch {
+            // GA4 송신 실패 무시
+        }
+
+        // Dantry — ClickHouse `error_logs.js_errors` 에 적재 (PII 0)
+        // position 에 path 포함 → SPA 네비게이션 시 path 별 1회씩 송신 가능
+        trackAdEvent('ad_blocked', {
+            position: `page:${path}`,
+            reason,
+            blocked,
+            page_type: pageType,
+            board_id: boardId
+        });
+    });
 }

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -30,7 +30,13 @@
     import { memberLevelStore } from '$lib/stores/member-levels.svelte';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte';
     import { updatePageTargeting } from '$lib/components/ui/ad-slot/ad-slot-registry.js';
-    import { consumePendingAuthEvent, initGA4, trackPageView } from '$lib/services/ga4';
+    import {
+        consumePendingAuthEvent,
+        initGA4,
+        resolvePageContext,
+        trackPageView
+    } from '$lib/services/ga4';
+    import { detectAdblockOnce } from '$lib/services/ad-telemetry';
     import type { MenuItem } from '$lib/api/types';
     import { readUserBasicFromCookie } from '$lib/utils/user-basic-client';
     import { env } from '$env/dynamic/public';
@@ -283,6 +289,13 @@
             trackPageView(to.url.pathname + to.url.search);
             consumePendingAuthEvent();
             updatePageTargeting(to.url.pathname);
+
+            // audit P3 (5/22 미팅 직결): 홈/게시판 진입 시 1회 adblock 감지
+            // path 단위 dedupe (ad-telemetry.ts 내부) → 같은 페이지 재진입 시 재송신 X
+            const ctx = resolvePageContext(to.url.pathname);
+            if (ctx.pageType === 'home' || ctx.pageType === 'board_list') {
+                detectAdblockOnce(ctx.pageType, ctx.boardId);
+            }
         }
         // 광고 observer 재설정 (기존 observer 재활용, 새 광고만 추가 observe)
         untrack(() => {


### PR DESCRIPTION
## 배경

[`docs/2026-05-01-widget-audit-report.md`](https://github.com/damoang/angple/blob/main/docs/2026-05-01-widget-audit-report.md) §4-4 / §6 P3.

5/22 AdSense 매니저 미팅에서 **fill rate 손실 원인** (차단기 사용자 비율) 분석에 활용. 현재 GAM `googletag` 미정의 시 10s timeout 후 빈 영역만 남김 — 차단 비율을 측정할 신호 없음.

## 변경

### 1. `apps/web/src/lib/services/ad-telemetry.ts`

기존 PR #1352 의 `isAdSdkBlocked()` 활용 + 페이지 단위 감지 함수 추가.

```ts
export function detectAdblockOnce(pageType: string, boardId?: string, delayMs?: number): void
```

- **path 단위 dedupe** (Set) — 같은 페이지 재진입 시 재송신 X
- `requestIdleCallback` + `setTimeout(3s)` — SDK 로드 시간 확보
- 감지 로직 (둘 중 하나라도 true → blocked):
  1. `isAdSdkBlocked()` — `window.googletag.cmd` + `window.adfit` 둘 다 부재
  2. `isAdBaitHidden()` — bait element (`.adsbox.ad-banner.pub_300x250`) 을 `position:absolute;left:-9999px;width:1px` 로 추가 후 `offsetHeight===0 / display:none` 검사 (uBlock cosmetic filter 패턴)
- 송신:
  - **GA4**: `gtag('event','ad_blocked', {blocked, reason, page_type, board_id})`
  - **Dantry**: `trackAdEvent('ad_blocked', {position: \`page:\${path}\`, ...})` → ClickHouse `error_logs.js_errors`

### 2. `apps/web/src/routes/+layout.svelte`

`afterNavigate` 에서 `resolvePageContext` 로 page type 판정 → **home / board_list** 만 호출.

```ts
const ctx = resolvePageContext(to.url.pathname);
if (ctx.pageType === 'home' || ctx.pageType === 'board_list') {
    detectAdblockOnce(ctx.pageType, ctx.boardId);
}
```

## 제약 준수

- [x] **PII 0** — boolean + reason + UA + 시각만 (UA 는 기존 `trackAdEvent` 송신)
- [x] **부정적 UX 영향 0** — 차단 사용자에게 안내/해제 강요 X, bait element 은 화면 밖 1px
- [x] **한 페이지당 최대 1회** — Set 기반 dedupe, 성능 영향 무시 가능
- [x] `pnpm check` pass (0 errors)
- [x] `pnpm build` 미실행 (서버 OOM 방지 — GitHub Actions 에서만)
- [x] LOC: ~133 (목표 ~40 보다 크지만 bait helper + 주석 포함, 실 함수 본문 ~80)

## 테스트 계획

- [ ] dev (로컬 `pnpm dev` — dev pod 비활성) `/` 진입 → DevTools console 에서 `gtag('event','ad_blocked')` 호출 확인
- [ ] uBlock Origin 활성 브라우저로 진입 → `blocked: true, reason: 'sdk_missing' | 'bait_hidden'` 송신 확인
- [ ] 차단기 미설치 브라우저 → `blocked: false, reason: 'none'` 송신 확인
- [ ] SPA 네비게이션 (`/` → `/free` → `/` 재진입) → 첫 두 path 만 송신, 재진입 X
- [ ] Network 탭 — `aplog.damoang.net/api/v1/dantry` POST 1회 (sendBeacon)

## ClickHouse 집계 SQL (5/22 미팅용)

운영 1주 누적 후 아래 쿼리로 차단 비율 산출.

```sql
-- 일별 page_type 별 차단/비차단 분포
SELECT
    toDate(ts) AS d,
    JSONExtractString(extra, 'page_type') AS page_type,
    JSONExtractBool(extra, 'blocked')      AS blocked,
    count() AS c
FROM error_logs.js_errors
WHERE message = 'ad_blocked'
  AND ts >= now() - INTERVAL 7 DAY
GROUP BY d, page_type, blocked
ORDER BY d DESC, page_type, blocked;

-- 차단 비율 (전체)
SELECT
    toDate(ts)                          AS d,
    countIf(JSONExtractBool(extra,'blocked'))                   AS blocked_cnt,
    count()                                                      AS total_cnt,
    round(blocked_cnt / total_cnt * 100, 2)                      AS block_rate_pct
FROM error_logs.js_errors
WHERE message = 'ad_blocked'
  AND ts >= now() - INTERVAL 7 DAY
GROUP BY d
ORDER BY d DESC;

-- reason 분포 (차단 검출 방법별)
SELECT
    JSONExtractString(extra, 'reason') AS reason,
    count() AS c
FROM error_logs.js_errors
WHERE message = 'ad_blocked'
  AND JSONExtractBool(extra, 'blocked') = 1
  AND ts >= now() - INTERVAL 7 DAY
GROUP BY reason
ORDER BY c DESC;

-- UA 별 차단율 (Brave / Firefox+uBlock / Chrome+AdBlock 식별)
SELECT
    multiIf(
        userAgent LIKE '%Brave%', 'Brave',
        userAgent LIKE '%Firefox%', 'Firefox',
        userAgent LIKE '%Chrome%', 'Chrome',
        userAgent LIKE '%Safari%', 'Safari',
        'Other'
    ) AS browser,
    countIf(JSONExtractBool(extra,'blocked')) AS blocked_cnt,
    count() AS total_cnt,
    round(blocked_cnt / total_cnt * 100, 2) AS block_rate_pct
FROM error_logs.js_errors
WHERE message = 'ad_blocked'
  AND ts >= now() - INTERVAL 7 DAY
GROUP BY browser
ORDER BY total_cnt DESC;
```

> **참고**: Dantry 측 컬럼 매핑 (`extra` JSON 구조) 은 `/home/ssm-user/aplogger/v1/dantry` 의 schema 에 맞춰 조정 필요할 수 있음. PR #1352 의 `ad_fallback_*` 이벤트와 동일 구조 사용.

## 5/22 미팅 시나리오

1. 1주 데이터 누적 (5/2 ~ 5/9 추정) 후 위 SQL 실행
2. **block_rate_pct** 가 fill rate 손실의 어느 정도인지 → 매니저에게 baseline 제공
3. 브라우저별 분포 → uBlock vs Brave Shields 비율 → "GAM 광고 미노출의 원인 중 X% 는 차단기" 정량화

## Out of Scope

- 차단 사용자에게 메시지/해제 안내 노출 (정책 위반 / UX 부정 영향)
- bait element 다중 패턴 (`#ads`, `.banner_ad` 등) — false positive 우려, 단일 패턴이면 충분
- adblock 회피 (도메인 우회) — 본 PR 범위 외