### PR TITLE
feat(widgets): WidgetState 머신 + retry UI 표준 (audit P2-B)

### DIFF
--- a/apps/web/src/lib/components/ui/widget-state-fallback/index.ts
+++ b/apps/web/src/lib/components/ui/widget-state-fallback/index.ts
@@ -1,0 +1,1 @@
+export { default as WidgetStateFallback } from './widget-state-fallback.svelte';

--- a/apps/web/src/lib/components/ui/widget-state-fallback/widget-state-fallback.svelte
+++ b/apps/web/src/lib/components/ui/widget-state-fallback/widget-state-fallback.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+    /**
+     * WidgetStateFallback — 위젯 error 상태 표준 fallback UI
+     *
+     * 모든 위젯이 동일한 retry UX 를 제공하도록 표준화 (audit 2026-05-01 §5-B / P2-B).
+     *
+     * 사용 예:
+     *
+     *   <WidgetStateFallback message={machine.state.message} onRetry={() => machine.retry()} />
+     *
+     * compact 모드는 사이드바처럼 좁은 공간에서 단일 줄로 표시.
+     */
+    import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+    import AlertCircle from '@lucide/svelte/icons/alert-circle';
+
+    interface Props {
+        /** 사용자에게 노출할 에러 메시지. */
+        message?: string | null;
+        /** 재시도 버튼 콜백. 없으면 버튼 미표시. */
+        onRetry?: (() => void | Promise<void>) | null;
+        /** 좁은 영역(사이드바)용 컴팩트 레이아웃. */
+        compact?: boolean;
+        /** 재시도 진행 중 (외부 머신의 status === 'loading'). */
+        retrying?: boolean;
+        /** 컨테이너 추가 클래스. */
+        class?: string;
+    }
+
+    let {
+        message = '데이터를 불러오지 못했어요.',
+        onRetry = null,
+        compact = false,
+        retrying = false,
+        class: className = ''
+    }: Props = $props();
+
+    async function handleClick() {
+        if (!onRetry || retrying) return;
+        await onRetry();
+    }
+</script>
+
+{#if compact}
+    <div
+        class="text-muted-foreground flex items-center justify-between gap-2 py-2 text-xs {className}"
+        role="alert"
+    >
+        <span class="flex min-w-0 items-center gap-1.5">
+            <AlertCircle class="h-3.5 w-3.5 shrink-0 text-amber-500" />
+            <span class="truncate">{message}</span>
+        </span>
+        {#if onRetry}
+            <button
+                type="button"
+                onclick={handleClick}
+                disabled={retrying}
+                class="text-primary hover:bg-muted flex shrink-0 items-center gap-1 rounded px-2 py-0.5 font-medium transition-colors disabled:opacity-50"
+                aria-label="다시 불러오기"
+            >
+                <RefreshCw class="h-3 w-3 {retrying ? 'animate-spin' : ''}" />
+                <span>다시</span>
+            </button>
+        {/if}
+    </div>
+{:else}
+    <div
+        class="text-muted-foreground flex flex-col items-center justify-center gap-3 py-6 text-center text-sm {className}"
+        role="alert"
+    >
+        <AlertCircle class="h-6 w-6 text-amber-500" />
+        <p>{message}</p>
+        {#if onRetry}
+            <button
+                type="button"
+                onclick={handleClick}
+                disabled={retrying}
+                class="bg-muted hover:bg-muted/80 text-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+                aria-label="다시 불러오기"
+            >
+                <RefreshCw class="h-3.5 w-3.5 {retrying ? 'animate-spin' : ''}" />
+                다시 불러오기
+            </button>
+        {/if}
+    </div>
+{/if}

--- a/apps/web/src/lib/utils/widget-state.svelte.ts
+++ b/apps/web/src/lib/utils/widget-state.svelte.ts
@@ -1,0 +1,165 @@
+/**
+ * widget-state — 위젯 fetch 표준 상태 머신 (audit 2026-05-01 §5-B / P2-B)
+ *
+ * 모든 위젯이 동일한 상태 모델을 공유하도록 한다:
+ *
+ *     idle → loading → success | empty | error
+ *                              ↑          ↓ retry
+ *                              └──────────┘
+ *
+ * - `idle`: 초기 상태 (아직 load 가 한 번도 호출되지 않음)
+ * - `loading`: fetch 진행 중. skeleton 노출.
+ * - `success`: 정상 데이터 수신. `data` 가 채워져 있음.
+ * - `empty`: fetch 는 성공했으나 데이터가 비어있음 (서버 정상 응답 + 0건).
+ * - `error`: fetch 실패 (timeout/network/http). retry 액션을 노출해야 함.
+ *
+ * Svelte 5 Rune 모드에서 동작하도록 `$state` 객체 형태로 노출하고, 헬퍼는
+ * 머신 인스턴스(`createWidgetState`) 가 내부에서 직접 상태를 mutate 한다.
+ *
+ * 사용 예:
+ *
+ * ```svelte
+ * <script lang="ts">
+ *   const machine = createWidgetState<MyDto>({
+ *     fetcher: async (signal) => {
+ *       const res = await timedFetch('/api/foo', { signal });
+ *       return await res.json();
+ *     },
+ *     isEmpty: (data) => !data?.items?.length
+ *   });
+ *
+ *   onMount(() => machine.load());
+ * </script>
+ *
+ * {#if machine.state.status === 'loading' || machine.state.status === 'idle'}
+ *   <Skeleton />
+ * {:else if machine.state.status === 'error'}
+ *   <WidgetStateFallback message={machine.state.message} onRetry={() => machine.retry()} />
+ * {:else if machine.state.status === 'empty'}
+ *   <p>데이터가 없습니다.</p>
+ * {:else}
+ *   ...
+ * {/if}
+ * ```
+ */
+
+export type WidgetStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
+
+export interface WidgetStateValue<T> {
+    status: WidgetStatus;
+    data: T | null;
+    /** error 상태에서 사용자에게 노출할 메시지. */
+    message: string | null;
+    /** 시도 횟수 (load + retry). 디버깅 / Dantry 송신용. */
+    attempts: number;
+}
+
+export interface WidgetStateOptions<T> {
+    /**
+     * 실제 데이터를 가져오는 함수. `signal` 은 reset/load 호출 시 자동으로 abort 된다.
+     * timedFetch 와 함께 쓰는 경우 `timedFetch(url, { signal }, { signal })` 형태로 전달.
+     */
+    fetcher: (signal: AbortSignal) => Promise<T>;
+    /** 성공한 응답이 비어있는지 판정. true 면 status='empty'. 기본 false (항상 success). */
+    isEmpty?: (data: T) => boolean;
+    /** 초기 데이터 (SSR prefetch). 있으면 status='success' 또는 'empty' 로 시작. */
+    initialData?: T | null;
+    /** error 상태로 진입할 때 사용자 메시지. 기본 "데이터를 불러오지 못했어요. 잠시 후 다시 시도해 주세요." */
+    errorMessage?: string;
+    /** error / success 진입 시 호출되는 hook (Dantry 등). */
+    onError?: (err: unknown, attempts: number) => void;
+    onSuccess?: (data: T) => void;
+}
+
+const DEFAULT_ERROR_MESSAGE = '데이터를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
+
+export interface WidgetStateMachine<T> {
+    /** 현재 상태 (Svelte $state). 컴포넌트 템플릿에서 `machine.state.status` 처럼 사용. */
+    readonly state: WidgetStateValue<T>;
+    /** fetch 시작. 이미 loading 이면 no-op. */
+    load: () => Promise<void>;
+    /** error 상태에서 재시도. 그 외 상태에서는 load() 와 동일하게 동작. */
+    retry: () => Promise<void>;
+    /** idle 로 초기화 (진행 중 fetch 는 abort). */
+    reset: () => void;
+}
+
+/**
+ * WidgetState 머신을 생성한다. Svelte 5 Rune 컴포넌트의 `<script>` 최상단에서 한 번 호출.
+ */
+export function createWidgetState<T>(opts: WidgetStateOptions<T>): WidgetStateMachine<T> {
+    const isEmpty = opts.isEmpty ?? (() => false);
+    const errorMessage = opts.errorMessage ?? DEFAULT_ERROR_MESSAGE;
+
+    // initialData 기반 초기 상태 결정.
+    let initialStatus: WidgetStatus = 'idle';
+    let initialDataValue: T | null = opts.initialData ?? null;
+    if (opts.initialData !== undefined && opts.initialData !== null) {
+        initialStatus = isEmpty(opts.initialData) ? 'empty' : 'success';
+    }
+
+    const state: WidgetStateValue<T> = $state({
+        status: initialStatus,
+        data: initialDataValue,
+        message: null,
+        attempts: 0
+    });
+
+    let controller: AbortController | null = null;
+
+    async function run(): Promise<void> {
+        // 진행 중인 fetch 가 있으면 abort.
+        if (controller) {
+            controller.abort();
+        }
+        controller = new AbortController();
+        const signal = controller.signal;
+
+        state.status = 'loading';
+        state.message = null;
+        state.attempts += 1;
+
+        try {
+            const data = await opts.fetcher(signal);
+            if (signal.aborted) return; // 다음 호출이 이미 시작됨
+
+            state.data = data;
+            if (isEmpty(data)) {
+                state.status = 'empty';
+            } else {
+                state.status = 'success';
+                opts.onSuccess?.(data);
+            }
+        } catch (err) {
+            if (signal.aborted) return; // reset/재호출로 인한 abort 는 상태 갱신 안 함
+            state.status = 'error';
+            state.message = errorMessage;
+            opts.onError?.(err, state.attempts);
+        } finally {
+            if (controller && controller.signal === signal) {
+                controller = null;
+            }
+        }
+    }
+
+    return {
+        state,
+        load: async () => {
+            if (state.status === 'loading') return;
+            await run();
+        },
+        retry: async () => {
+            await run();
+        },
+        reset: () => {
+            if (controller) {
+                controller.abort();
+                controller = null;
+            }
+            state.status = 'idle';
+            state.data = null;
+            state.message = null;
+            state.attempts = 0;
+        }
+    };
+}

--- a/apps/web/src/lib/utils/widget-state.test.ts
+++ b/apps/web/src/lib/utils/widget-state.test.ts
@@ -1,0 +1,224 @@
+/**
+ * widget-state 테스트
+ *
+ * 검증 기준 (audit P2-B Sprint Contract):
+ * 1. 초기 상태: idle (initialData 없음)
+ * 2. initialData 가 비어있지 않으면 success 로 시작
+ * 3. initialData + isEmpty=true 면 empty 로 시작
+ * 4. load() 성공 → loading → success 전이
+ * 5. load() 실패 → loading → error 전이 + message 채움
+ * 6. retry() 가 error 상태에서 재시도하여 success 진입
+ * 7. reset() 이 idle 로 되돌리고 진행 중 fetch 를 abort
+ * 8. isEmpty 가 true 인 응답은 success 가 아닌 empty
+ * 9. 동시 load() 호출 시 중복 fetch 안 함 (loading 중 noop)
+ * 10. attempts 카운터 정확
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createWidgetState } from './widget-state.svelte';
+
+// AbortSignal 을 받는 fetcher 가 abort 됐는지 확인할 수 있도록 helper.
+function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe('createWidgetState', () => {
+    it('1. 초기 상태: initialData 없으면 idle', () => {
+        const m = createWidgetState({
+            fetcher: async () => ({ items: [] })
+        });
+        expect(m.state.status).toBe('idle');
+        expect(m.state.data).toBeNull();
+        expect(m.state.attempts).toBe(0);
+    });
+
+    it('2. initialData 가 채워져 있으면 success 로 시작', () => {
+        const m = createWidgetState({
+            fetcher: async () => ({ items: [1] }),
+            initialData: { items: [1, 2] },
+            isEmpty: (d) => !d.items.length
+        });
+        expect(m.state.status).toBe('success');
+        expect(m.state.data).toEqual({ items: [1, 2] });
+    });
+
+    it('3. initialData + isEmpty=true 면 empty 로 시작', () => {
+        const m = createWidgetState({
+            fetcher: async () => ({ items: [] }),
+            initialData: { items: [] },
+            isEmpty: (d) => !d.items.length
+        });
+        expect(m.state.status).toBe('empty');
+    });
+
+    it('4. load() 성공 → loading → success 전이', async () => {
+        const d = deferred<{ items: number[] }>();
+        const m = createWidgetState({
+            fetcher: () => d.promise
+        });
+
+        const loadPromise = m.load();
+        // 마이크로태스크 한 번 양보 → loading 진입 확인
+        await Promise.resolve();
+        expect(m.state.status).toBe('loading');
+        expect(m.state.attempts).toBe(1);
+
+        d.resolve({ items: [1, 2, 3] });
+        await loadPromise;
+
+        expect(m.state.status).toBe('success');
+        expect(m.state.data).toEqual({ items: [1, 2, 3] });
+        expect(m.state.message).toBeNull();
+    });
+
+    it('5. load() 실패 → loading → error 전이 + message 채움', async () => {
+        const onError = vi.fn();
+        const m = createWidgetState({
+            fetcher: async () => {
+                throw new Error('boom');
+            },
+            errorMessage: '실패했어요',
+            onError
+        });
+
+        await m.load();
+
+        expect(m.state.status).toBe('error');
+        expect(m.state.message).toBe('실패했어요');
+        expect(onError).toHaveBeenCalledTimes(1);
+    });
+
+    it('6. retry() 가 error 상태에서 재시도하여 success 진입', async () => {
+        let attempt = 0;
+        const m = createWidgetState({
+            fetcher: async () => {
+                attempt += 1;
+                if (attempt === 1) throw new Error('first fails');
+                return { ok: true };
+            }
+        });
+
+        await m.load();
+        expect(m.state.status).toBe('error');
+        expect(m.state.attempts).toBe(1);
+
+        await m.retry();
+        expect(m.state.status).toBe('success');
+        expect(m.state.attempts).toBe(2);
+        expect(m.state.data).toEqual({ ok: true });
+    });
+
+    it('7. reset() 이 idle 로 되돌리고 진행 중 fetch 를 abort', async () => {
+        const d = deferred<unknown>();
+        let abortedFlag = false;
+        const m = createWidgetState({
+            fetcher: (signal) => {
+                signal.addEventListener('abort', () => {
+                    abortedFlag = true;
+                });
+                return d.promise;
+            }
+        });
+
+        const p = m.load();
+        await Promise.resolve();
+        expect(m.state.status).toBe('loading');
+
+        m.reset();
+        expect(m.state.status).toBe('idle');
+        expect(m.state.data).toBeNull();
+        expect(m.state.attempts).toBe(0);
+        expect(abortedFlag).toBe(true);
+
+        // 원래 fetch 가 뒤늦게 resolve 해도 상태가 흔들리지 않는다.
+        d.resolve({ items: [99] });
+        await p;
+        expect(m.state.status).toBe('idle');
+    });
+
+    it('8. isEmpty 가 true 인 응답은 empty 상태', async () => {
+        const m = createWidgetState({
+            fetcher: async () => ({ items: [] }),
+            isEmpty: (d) => !d.items.length
+        });
+
+        await m.load();
+        expect(m.state.status).toBe('empty');
+        expect(m.state.data).toEqual({ items: [] });
+    });
+
+    it('9. loading 중 추가 load() 는 noop', async () => {
+        const d = deferred<{ ok: boolean }>();
+        let calls = 0;
+        const m = createWidgetState({
+            fetcher: () => {
+                calls += 1;
+                return d.promise;
+            }
+        });
+
+        const p1 = m.load();
+        await Promise.resolve();
+        expect(m.state.status).toBe('loading');
+
+        // loading 중 두 번째 load 는 즉시 종료 (run 호출 안 함)
+        await m.load();
+        expect(calls).toBe(1);
+        expect(m.state.attempts).toBe(1);
+
+        d.resolve({ ok: true });
+        await p1;
+        expect(m.state.status).toBe('success');
+    });
+
+    it('10. retry() 는 success 후에도 다시 실행', async () => {
+        let attempt = 0;
+        const m = createWidgetState({
+            fetcher: async () => {
+                attempt += 1;
+                return { value: attempt };
+            }
+        });
+
+        await m.load();
+        expect(m.state.data).toEqual({ value: 1 });
+        await m.retry();
+        expect(m.state.data).toEqual({ value: 2 });
+        expect(m.state.attempts).toBe(2);
+    });
+
+    it('11. abort 후 fetcher 가 throw 해도 상태 갱신 안 함', async () => {
+        const d = deferred<unknown>();
+        const m = createWidgetState({
+            fetcher: (signal) => {
+                return new Promise((_, reject) => {
+                    signal.addEventListener('abort', () => reject(new Error('aborted')));
+                    d.promise.then(reject);
+                });
+            }
+        });
+
+        const p = m.load();
+        await Promise.resolve();
+        m.reset();
+        await p; // 내부에서 swallow 됨
+        expect(m.state.status).toBe('idle');
+        expect(m.state.message).toBeNull();
+    });
+
+    it('12. onSuccess hook 호출', async () => {
+        const onSuccess = vi.fn();
+        const m = createWidgetState({
+            fetcher: async () => ({ k: 1 }),
+            onSuccess
+        });
+        await m.load();
+        expect(onSuccess).toHaveBeenCalledWith({ k: 1 });
+    });
+});

--- a/widgets/post-list/index.svelte
+++ b/widgets/post-list/index.svelte
@@ -22,6 +22,9 @@
     import TradeView from './layouts/trade-view.svelte';
     import type { EconomyPost, GalleryPost, GroupTabsData, NewsPost } from '$lib/api/types';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte';
+    import { timedFetch } from '$lib/utils/timed-fetch';
+    import { createWidgetState } from '$lib/utils/widget-state.svelte';
+    import { WidgetStateFallback } from '$lib/components/ui/widget-state-fallback';
 
     interface DefaultLayoutPost {
         id: number;
@@ -121,11 +124,41 @@
     }
 
     // API fetch 데이터 (기존 스토어에 없는 경우)
-    let fetchedPosts = $state<
-        DefaultLayoutPost[] | MessageLayoutPost[] | GivingLayoutPost[] | TradeLayoutPost[]
-    >([]);
-    let loading = $state(false);
-    let error = $state<string | null>(null);
+    // audit P2-B: 표준 WidgetState 머신 + timedFetch + retry UI 적용.
+    type FetchedPosts =
+        | DefaultLayoutPost[]
+        | MessageLayoutPost[]
+        | GivingLayoutPost[]
+        | TradeLayoutPost[];
+
+    const fetchMachine = createWidgetState<FetchedPosts>({
+        fetcher: async (signal) => {
+            const params = new URLSearchParams({
+                board: boardId,
+                sort: sortBy,
+                count: String(count),
+                filter
+            });
+            const res = await timedFetch(
+                `/api/widgets/post-list/data?${params}`,
+                { signal },
+                {
+                    signal,
+                    throwOnHTTPError: true
+                }
+            );
+            const data = await res.json();
+            return (data.posts ?? []) as FetchedPosts;
+        },
+        isEmpty: (posts) => !posts.length
+    });
+    const fetchedPosts = $derived(fetchMachine.state.data ?? ([] as FetchedPosts));
+    const loading = $derived(
+        fetchMachine.state.status === 'loading' || fetchMachine.state.status === 'idle'
+    );
+    const error = $derived(
+        fetchMachine.state.status === 'error' ? fetchMachine.state.message : null
+    );
 
     const noticePosts = $derived(
         (prefetchData as NewsPost[] | undefined) ?? indexWidgetsStore.newsTabs
@@ -153,36 +186,18 @@
         (fetchedPosts as TradeLayoutPost[]).filter((p) => !uiSettingsStore.isMuted(p.title ?? ''))
     );
 
-    // 기존 스토어 데이터가 아닌 경우 API에서 fetch
+    // 기존 스토어 데이터가 아닌 경우 API에서 fetch.
+    // useNativeComponent / boardId / sortBy / count / filter 가 변하면 머신을 다시 load.
     $effect(() => {
+        // 재실행 트리거를 위해 의존성을 명시적으로 읽는다.
+        void boardId;
+        void sortBy;
+        void count;
+        void filter;
         if (!useNativeComponent) {
-            fetchPosts();
+            void fetchMachine.load();
         }
     });
-
-    async function fetchPosts() {
-        loading = true;
-        error = null;
-        try {
-            const params = new URLSearchParams({
-                board: boardId,
-                sort: sortBy,
-                count: String(count),
-                filter
-            });
-            const res = await fetch(`/api/widgets/post-list/data?${params}`);
-            if (res.ok) {
-                const data = await res.json();
-                fetchedPosts = data.posts ?? [];
-            } else {
-                error = '데이터 로드 실패';
-            }
-        } catch (err) {
-            error = err instanceof Error ? err.message : '네트워크 오류';
-        } finally {
-            loading = false;
-        }
-    }
 </script>
 
 {#if useNativeComponent}
@@ -203,9 +218,11 @@
             <div class="text-muted-foreground text-sm">로딩 중...</div>
         </div>
     {:else if error}
-        <div class="flex items-center justify-center py-8">
-            <div class="text-sm text-red-600 dark:text-red-400">{error}</div>
-        </div>
+        <WidgetStateFallback
+            message={error}
+            onRetry={() => fetchMachine.retry()}
+            retrying={fetchMachine.state.status === 'loading'}
+        />
     {:else if layout === 'gallery'}
         <GalleryView posts={defaultPosts} {showTitle} {boardId} />
     {:else if layout === 'grid'}


### PR DESCRIPTION
## Summary

audit 2026-05-01 §5-B / P2 두 번째 PR. 위젯 fetch 상태를 표준 머신으로 통일하고 error 상태 retry UI 를 도입.

- **`createWidgetState<T>()` 팩토리** (`$lib/utils/widget-state.svelte.ts`): `idle/loading/success/empty/error` 5단계 + AbortController 자동 관리. `load/retry/reset` 액션. `isEmpty/onError/onSuccess` hook.
- **`WidgetStateFallback`** (`$lib/components/ui/widget-state-fallback/`): 표준 retry 버튼 UI. `compact` (사이드바용) + 일반 모드.
- **`post-list` 위젯 refactor**: 검증용으로 raw fetch + boolean state 를 머신 + `timedFetch` 로 치환. 에러 상태에 retry 노출. P0-A `ExplorePreview` / P1-B 위젯들은 회귀 위험 0 우선으로 이번 PR 에서 미변경 (후속 PR 점진 마이그레이션).

LOC: 핵심 250 + 테스트 224 + 위젯 refactor 51 (총 ~475, 소스 기준 ~250).

## Test plan

- [x] `pnpm test:unit src/lib/utils/widget-state.test.ts` → **12/12 passed**
  - 초기 상태 (idle, initialData success/empty)
  - load 성공/실패 전이, message 채움
  - retry (error→success, success→재실행)
  - reset (idle 복귀 + 진행 fetch abort + 늦은 resolve 무시)
  - isEmpty, loading 중 중복 load noop
  - onError/onSuccess hook 호출
- [x] `pnpm check` → 0 errors (warning 변동 없음)
- [ ] `pnpm build` 는 서버 정책상 미실행 → CI 검증 의존
- [ ] 사람 확인: `post-list` 위젯이 활성화된 페이지에서 백엔드 에러 시 retry 버튼 노출 / 클릭 시 재시도

## Out of scope (후속 PR)

- `ExplorePreview` (P0-A, 이미 timedFetch 적용) → 머신으로 마이그레이션
- P1-B 위젯들 (notice / image-text-banner / giving / ai-analysis / celebration) → 머신 점진 적용
- `RecommendedPosts` 의 "잠시 후 다시 시도해 주세요" + 재시도 버튼 (audit §2-1) → 머신 적용 시 자동 해결