### PR TITLE
fix(cls): 본문 이미지 로드 전 aspect-ratio placeholder 예약

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -132,8 +132,11 @@
                 const withoutDecoding = withoutLoading.replace(/\sdecoding=(["']).*?\1/gi, '');
                 const withoutSrcset = withoutDecoding.replace(/\ssrcset=(["']).*?\1/gi, '');
                 const withoutSizes = withoutSrcset.replace(/\ssizes=(["']).*?\1/gi, '');
+                // 기존 style 제거 후 aspect-ratio 주입 (중복 style 속성 방지)
+                const withoutStyle = withoutSizes.replace(/\sstyle=(["']).*?\1/gi, '');
                 // srcset에 썸네일, src에 원본 — srcset 실패 시 src fallback
-                return `<img${withoutSizes} src=${quote}${src}${quote} srcset=${quote}${srcset}${quote} sizes=${quote}${sizes}${quote} data-original=${quote}${src}${quote} loading=${quote}lazy${quote} decoding=${quote}async${quote}>`;
+                // CLS 방지: aspect-ratio 'auto 4 / 3'로 로드 전 4:3 박스 예약, 로드 후 intrinsic 비율 적용
+                return `<img${withoutStyle} src=${quote}${src}${quote} srcset=${quote}${srcset}${quote} sizes=${quote}${sizes}${quote} data-original=${quote}${src}${quote} loading=${quote}lazy${quote} decoding=${quote}async${quote} style=${quote}aspect-ratio: auto 4 / 3${quote}>`;
             }
         );
 


### PR DESCRIPTION
## Summary

- `markdown.svelte` `optimizeMediaHtml()`이 변환하는 본문 `<img>`에 `style=\"aspect-ratio: auto 4 / 3\"` 주입
- `auto` 키워드로 image 로드 후엔 intrinsic 비율이 우선 적용 (distortion 없음)
- `4 / 3` fallback으로 **로드 전 placeholder 박스 예약** → CLS 제거
- 기존 `style` attr 은 strip 후 재주입 (중복 attribute 방지)

## 배경 (#1354 후속)

AdSlot CLS는 #1354 로 fix됐으나, 본문/댓글/목록 3 영역 추가 audit에서 발견한 **High** 우선순위 이슈.

## 영향 영역

- 게시글 상세 페이지 본문 (`Markdown` 컴포넌트 렌더링)
- damoang storage thumbnail (cdn/s3.damoang.net) 이미지에 한정 (`isTransformableMediaImage` 통과 시)
- 외부 이미지·이미 `data-original` 가진 이미지에는 영향 없음

## 회귀 위험

- **매우 낮음**: \`aspect-ratio: auto N / N\` 은 W3C CLS placeholder 권장 패턴
- intrinsic ratio 가 있으면 그쪽이 우선 → 이미지 비율 왜곡 없음
- DOMPurify ALLOWED_ATTR 에 \`'style'\` 이미 포함됨 (markdown.svelte:206)

## Test plan

- [ ] 로컬 dev 서버에서 본문에 4:3, 16:9, 1:1 이미지 각각 포함된 글 렌더 확인 (왜곡 없음)
- [ ] Lighthouse / DevTools Performance > Layout shifts 패널에서 본문 이미지 로드 시 shift 0 확인
- [ ] DOMPurify sanitize 통과 확인 (style 속성 유지)
- [ ] 모바일/PC 둘 다에서 시각적 회귀 없음
- [ ] 다국어 / 다양한 image source (jpg/png/webp) regression 없음

## Audit 보고서

\`/home/angple/docs/2026-05-02-cls-3-areas-audit.md\` — 3 영역 (목록/상세/댓글) audit + 보류된 이슈 정리

## 보류 (별도 처리)

- **Critical**: 본문 임베드(YouTube/Twitter/Bluesky) SSR processEmbeds 미실행 → client 변환 시 200~470px shift. 별도 design doc 필요.
- **High**: 댓글 SSR vs client embed 차이 동일 패턴.