### PR TITLE
fix(memory): apiClient AbortSignal + Promise.race hang accumulation 제거 (P0)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -186,6 +186,11 @@ class ApiClient {
     }
 
     // HTTP 요청 헬퍼
+    //
+    // `options.signal` (AbortSignal) 을 받으면 underlying fetch 까지 전달되어
+    // 호출 측 컴포넌트 unmount 등 cleanup 시 in-flight 요청이 즉시 정리된다.
+    // (P0 leak fix 2026-05-02: Promise.race(timeout, apiClient.x) 패턴이
+    //  timeout reject 후에도 fetch closure 를 leak 하던 문제 제거)
     private async request<T>(
         endpoint: string,
         options: RequestInit = {},
@@ -224,7 +229,9 @@ class ApiClient {
                 {
                     ...options,
                     headers,
-                    credentials: 'include'
+                    credentials: 'include',
+                    // 외부 signal 은 fetchWithTimeout 에서 합성되어 전달
+                    signal: options.signal
                 },
                 config,
                 fetchFn
@@ -296,17 +303,26 @@ class ApiClient {
     }
 
     // 게시판 공지사항 조회
-    async getBoardNotices(boardId: string): Promise<FreePost[]> {
+    async getBoardNotices(
+        boardId: string,
+        options?: { signal?: AbortSignal }
+    ): Promise<FreePost[]> {
         interface BackendResponse {
             data: FreePost[];
         }
 
         try {
-            const response = await this.request<BackendResponse>(`/boards/${boardId}/notices`);
+            const response = await this.request<BackendResponse>(`/boards/${boardId}/notices`, {
+                signal: options?.signal
+            });
 
             const backendData = response as unknown as BackendResponse;
             return backendData.data || [];
         } catch (error) {
+            // 호출 측이 abort 시킨 경우는 그대로 전파 (위젯 unmount 등 cleanup)
+            if (error instanceof ApiRequestError && error.type === 'aborted') {
+                throw error;
+            }
             // 공지사항 API가 없거나 에러 시 빈 배열 반환
             return [];
         }
@@ -336,7 +352,7 @@ class ApiClient {
         boardId: string,
         page = 1,
         limit = 10,
-        options?: { summary?: boolean }
+        options?: { summary?: boolean; signal?: AbortSignal }
     ): Promise<PaginatedResponse<FreePost>> {
         interface BackendResponse {
             data: FreePost[];
@@ -357,7 +373,9 @@ class ApiClient {
             params.set('summary', '1');
         }
 
-        const response = await this.request<BackendResponse>(`/boards/${boardId}/posts?${params}`);
+        const response = await this.request<BackendResponse>(`/boards/${boardId}/posts?${params}`, {
+            signal: options?.signal
+        });
 
         const backendData = response as unknown as BackendResponse;
         const meta = backendData.meta;
@@ -499,8 +517,13 @@ class ApiClient {
     }
 
     // 추천 글 데이터 가져오기 (AI 분석 포함)
-    async getRecommendedPostsWithAI(period: RecommendedPeriod): Promise<RecommendedDataWithAI> {
-        const response = await this.request<RecommendedDataWithAI>(`/recommended/ai/${period}`);
+    async getRecommendedPostsWithAI(
+        period: RecommendedPeriod,
+        options?: { signal?: AbortSignal }
+    ): Promise<RecommendedDataWithAI> {
+        const response = await this.request<RecommendedDataWithAI>(`/recommended/ai/${period}`, {
+            signal: options?.signal
+        });
         // API가 직접 데이터를 반환하는지 { data: ... }로 감싸는지 확인
         const data = response as unknown as RecommendedDataWithAI;
         if (data?.sections !== undefined) {

--- a/apps/web/src/lib/api/errors.ts
+++ b/apps/web/src/lib/api/errors.ts
@@ -5,6 +5,7 @@
 export type ApiErrorType =
     | 'network' // 네트워크 연결 실패
     | 'timeout' // 요청 타임아웃
+    | 'aborted' // 호출 측 AbortSignal 로 인한 취소 (재시도 금지)
     | 'auth' // 인증 실패 (401)
     | 'forbidden' // 권한 없음 (403)
     | 'not_found' // 리소스 없음 (404)
@@ -39,6 +40,10 @@ export class ApiRequestError extends Error {
 
     static timeout(message = '요청 시간이 초과되었습니다.'): ApiRequestError {
         return new ApiRequestError(message, 'timeout');
+    }
+
+    static aborted(message = '요청이 취소되었습니다.'): ApiRequestError {
+        return new ApiRequestError(message, 'aborted');
     }
 }
 

--- a/apps/web/src/lib/api/retry.test.ts
+++ b/apps/web/src/lib/api/retry.test.ts
@@ -1,0 +1,164 @@
+/**
+ * retry.ts AbortSignal composition 테스트
+ *
+ * P0 leak fix (2026-05-02) 검증:
+ *  - 외부 signal abort 시 underlying fetch 도 즉시 abort (closure 정리)
+ *  - aborted 에러는 retryable=false → 재시도 안 함
+ *  - 내부 timeout 은 별개 경로
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithTimeout, fetchWithRetry } from './retry';
+import { ApiRequestError } from './errors';
+
+describe('fetchWithTimeout — AbortSignal composition', () => {
+    const realFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        globalThis.fetch = realFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('외부 signal 이 이미 abort → 즉시 ApiRequestError(aborted)', async () => {
+        const fetchSpy = vi.fn();
+        globalThis.fetch = fetchSpy;
+
+        const ctrl = new AbortController();
+        ctrl.abort();
+
+        let caught: unknown;
+        try {
+            await fetchWithTimeout('/api/x', { signal: ctrl.signal }, 5000);
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeInstanceOf(ApiRequestError);
+        expect((caught as ApiRequestError).type).toBe('aborted');
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('외부 signal 이 도중에 abort → underlying fetch 도 abort, aborted 에러', async () => {
+        let innerSignal: AbortSignal | undefined;
+        globalThis.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+            innerSignal = init.signal as AbortSignal;
+            return new Promise((_resolve, reject) => {
+                innerSignal?.addEventListener('abort', () => {
+                    const e = new Error('aborted');
+                    e.name = 'AbortError';
+                    reject(e);
+                });
+            });
+        });
+
+        const ctrl = new AbortController();
+        const promise = fetchWithTimeout('/api/x', { signal: ctrl.signal }, 10_000);
+        promise.catch(() => undefined);
+
+        await vi.advanceTimersByTimeAsync(0);
+        ctrl.abort();
+        await vi.advanceTimersByTimeAsync(10);
+
+        let caught: unknown;
+        try {
+            await promise;
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeInstanceOf(ApiRequestError);
+        expect((caught as ApiRequestError).type).toBe('aborted');
+        // underlying fetch 의 signal 도 abort 됐는지 확인 (closure 정리 보장)
+        expect(innerSignal?.aborted).toBe(true);
+    });
+
+    it('내부 timeout — ApiRequestError(timeout)', async () => {
+        globalThis.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+            return new Promise((_resolve, reject) => {
+                init.signal?.addEventListener('abort', () => {
+                    const e = new Error('aborted');
+                    e.name = 'AbortError';
+                    reject(e);
+                });
+            });
+        });
+
+        const promise = fetchWithTimeout('/api/x', {}, 100);
+        promise.catch(() => undefined);
+        await vi.advanceTimersByTimeAsync(150);
+
+        let caught: unknown;
+        try {
+            await promise;
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeInstanceOf(ApiRequestError);
+        expect((caught as ApiRequestError).type).toBe('timeout');
+    });
+
+    it('정상 응답 — 외부 signal abort 리스너 정리', async () => {
+        const ok = new Response('{}', { status: 200 });
+        globalThis.fetch = vi.fn().mockResolvedValue(ok);
+
+        const ctrl = new AbortController();
+        const removeSpy = vi.spyOn(ctrl.signal, 'removeEventListener');
+
+        const res = await fetchWithTimeout('/api/x', { signal: ctrl.signal }, 5000);
+        expect(res.status).toBe(200);
+        expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+});
+
+describe('fetchWithRetry — aborted 는 재시도 금지', () => {
+    const realFetch = globalThis.fetch;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        globalThis.fetch = realFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('외부 abort → 재시도 없이 ApiRequestError(aborted) 1회만', async () => {
+        const fetchSpy = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+            return new Promise((_resolve, reject) => {
+                init.signal?.addEventListener('abort', () => {
+                    const e = new Error('aborted');
+                    e.name = 'AbortError';
+                    reject(e);
+                });
+            });
+        });
+        globalThis.fetch = fetchSpy;
+
+        const ctrl = new AbortController();
+        const promise = fetchWithRetry(
+            '/api/x',
+            { signal: ctrl.signal },
+            { maxRetries: 3, baseDelay: 10, timeout: 10_000 }
+        );
+        promise.catch(() => undefined);
+
+        // microtask flush (fetch promise 진입) 후 abort
+        await vi.advanceTimersByTimeAsync(0);
+        ctrl.abort();
+        await vi.advanceTimersByTimeAsync(50);
+
+        let caught: unknown;
+        try {
+            await promise;
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeInstanceOf(ApiRequestError);
+        expect((caught as ApiRequestError).type).toBe('aborted');
+        // 재시도 없이 정확히 1번만 호출
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/src/lib/api/retry.ts
+++ b/apps/web/src/lib/api/retry.ts
@@ -25,7 +25,16 @@ function getDelay(attempt: number, baseDelay: number): number {
     return baseDelay * Math.pow(2, attempt) + Math.random() * 500;
 }
 
-/** 타임아웃이 적용된 fetch */
+/** 타임아웃이 적용된 fetch
+ *
+ * 외부 `options.signal` 이 들어오면 내부 timeout controller 와 합성한다.
+ * - 외부 abort → 내부 fetch 도 즉시 abort (호출 측 'aborted' 처리)
+ * - 내부 timeout → 외부 호출 측 abort 와 무관 (timeout 전파)
+ *
+ * 이 합성은 P0 leak fix (2026-05-02): 호출 측이 widget unmount 등으로
+ * abort 하면 underlying fetch closure 가 즉시 정리된다 (Promise.race 가
+ * timeout reject 후에도 fetch promise 가 살아남던 패턴 제거).
+ */
 export async function fetchWithTimeout(
     url: string,
     options: RequestInit,
@@ -33,21 +42,45 @@ export async function fetchWithTimeout(
     fetchFn: typeof fetch = fetch
 ): Promise<Response> {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const externalSignal = options.signal as AbortSignal | undefined;
+
+    // 외부 signal 이 이미 abort 상태면 즉시 종료
+    if (externalSignal?.aborted) {
+        throw ApiRequestError.aborted();
+    }
+
+    const onExternalAbort = () => controller.abort();
+    externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+
+    let timedOut = false;
+    const timeoutId = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+    }, timeoutMs);
 
     try {
+        // signal 은 합성된 controller.signal 을 사용 (외부 옵션 signal 은 위에서 listener 로 위임)
+        const { signal: _ignore, ...rest } = options;
         const response = await fetchFn(url, {
-            ...options,
+            ...rest,
             signal: controller.signal
         });
         return response;
     } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-            throw ApiRequestError.timeout();
+        // AbortError: DOMException (브라우저) 또는 name='AbortError' Error (테스트/일부 런타임)
+        const isAbort =
+            (error instanceof DOMException && error.name === 'AbortError') ||
+            (error instanceof Error && error.name === 'AbortError') ||
+            controller.signal.aborted;
+        if (isAbort) {
+            if (timedOut) throw ApiRequestError.timeout();
+            // 외부 abort — retry 금지
+            throw ApiRequestError.aborted();
         }
         throw ApiRequestError.network();
     } finally {
         clearTimeout(timeoutId);
+        externalSignal?.removeEventListener('abort', onExternalAbort);
     }
 }
 

--- a/widgets/ai-analysis/index.svelte
+++ b/widgets/ai-analysis/index.svelte
@@ -7,8 +7,9 @@
      */
     import type { WidgetProps } from '$lib/types/widget-props';
     import type { RecommendedDataWithAI, RecommendedPeriod, AIAnalysis } from '$lib/api/types.js';
-    import { onMount } from 'svelte';
+    import { onMount, onDestroy } from 'svelte';
     import { apiClient } from '$lib/api';
+    import { ApiRequestError } from '$lib/api/errors';
     import { AITrendCard } from '$lib/components/features/recommended/components/ai-trend';
 
     let { config, slot, isEditMode = false }: WidgetProps = $props();
@@ -22,24 +23,11 @@
     let loading = $state(true);
     let error = $state<string | null>(null);
 
-    // apiClient 는 자체 abort 를 노출하지 않으므로 Promise.race 타임가드 적용.
-    // (audit 2026-05-01 §3-1)
+    // P0 leak fix (2026-05-02): Promise.race(timeout, apiClient.x) 패턴 제거.
+    // apiClient 가 AbortSignal 을 받으므로 AbortController 로 통합 관리.
     const FETCH_TIMEOUT_MS = 12_000;
-    function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
-        return new Promise((resolve, reject) => {
-            const timer = setTimeout(() => reject(new Error('timeout')), ms);
-            p.then(
-                (v) => {
-                    clearTimeout(timer);
-                    resolve(v);
-                },
-                (e) => {
-                    clearTimeout(timer);
-                    reject(e);
-                }
-            );
-        });
-    }
+    let controller: AbortController | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     function calculateStats(data: RecommendedDataWithAI) {
         let total_recommends = 0;
@@ -62,25 +50,49 @@
     async function loadAnalysis() {
         loading = true;
         error = null;
+
+        // 이전 in-flight 요청 정리 (period 재호출 등 대비)
+        controller?.abort();
+        if (timeoutId !== null) clearTimeout(timeoutId);
+
+        controller = new AbortController();
+        const signal = controller.signal;
+        timeoutId = setTimeout(() => controller?.abort(), FETCH_TIMEOUT_MS);
+
         try {
-            const data = await withTimeout(
-                apiClient.getRecommendedPostsWithAI(period),
-                FETCH_TIMEOUT_MS
-            );
+            const data = await apiClient.getRecommendedPostsWithAI(period, { signal });
             analysis = data.ai_analysis ?? null;
             if (analysis && showStats) {
                 stats = calculateStats(data);
             }
         } catch (err) {
-            const msg = err instanceof Error ? err.message : '분석 데이터 로드 실패';
-            error = msg === 'timeout' ? '응답이 늦어지고 있어요. 잠시 후 다시 시도해 주세요.' : msg;
+            // unmount/재호출 abort 는 사용자에게 노출하지 않음
+            if (err instanceof ApiRequestError && err.type === 'aborted') return;
+            if (err instanceof ApiRequestError && err.type === 'timeout') {
+                error = '응답이 늦어지고 있어요. 잠시 후 다시 시도해 주세요.';
+            } else {
+                error = err instanceof Error ? err.message : '분석 데이터 로드 실패';
+            }
         } finally {
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId);
+                timeoutId = null;
+            }
             loading = false;
         }
     }
 
     onMount(() => {
         loadAnalysis();
+    });
+
+    onDestroy(() => {
+        if (timeoutId !== null) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+        }
+        controller?.abort();
+        controller = null;
     });
 </script>
 

--- a/widgets/notice/index.svelte
+++ b/widgets/notice/index.svelte
@@ -6,7 +6,8 @@
     import type { WidgetProps } from '$lib/types/widget-props';
     import type { FreePost } from '$lib/api/types';
     import { apiClient } from '$lib/api';
-    import { onMount } from 'svelte';
+    import { ApiRequestError } from '$lib/api/errors';
+    import { onMount, onDestroy } from 'svelte';
     import { Info, Eye } from '../lucide.js';
 
     let { config, slot, isEditMode = false, prefetchData }: WidgetProps = $props();
@@ -16,24 +17,13 @@
     let loading = $state(true);
     let error = $state(false);
 
-    // apiClient 는 자체 abort 를 노출하지 않으므로 Promise.race 타임가드로 skeleton 무한 대기 방지.
-    // (audit 2026-05-01 §3-1)
+    // P0 leak fix (2026-05-02): Promise.race(timeout, apiClient.x) 패턴은
+    // timeout reject 후에도 underlying fetch closure 가 살아남아 SSR/CSR 양쪽에서
+    // ~50 MiB/h 누적. apiClient 가 이제 AbortSignal 을 받으므로
+    // AbortController 로 timeout + unmount 통합 abort.
     const FETCH_TIMEOUT_MS = 12_000;
-    function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
-        return new Promise((resolve, reject) => {
-            const timer = setTimeout(() => reject(new Error('timeout')), ms);
-            p.then(
-                (v) => {
-                    clearTimeout(timer);
-                    resolve(v);
-                },
-                (e) => {
-                    clearTimeout(timer);
-                    reject(e);
-                }
-            );
-        });
-    }
+    let controller: AbortController | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     onMount(async () => {
         if (prefetchData) {
@@ -42,23 +32,44 @@
             return;
         }
 
+        controller = new AbortController();
+        const signal = controller.signal;
+        timeoutId = setTimeout(() => controller?.abort(), FETCH_TIMEOUT_MS);
+
         try {
-            const [noticesData, latestData] = await withTimeout(
-                Promise.all([
-                    apiClient.getBoardNotices('free'),
-                    apiClient.getBoardPosts('notice', 1, 1).catch(() => null)
-                ]),
-                FETCH_TIMEOUT_MS
-            );
+            const [noticesData, latestData] = await Promise.all([
+                apiClient.getBoardNotices('free', { signal }),
+                apiClient.getBoardPosts('notice', 1, 1, { signal }).catch((e) => {
+                    // abort 는 위로 전파, 그 외는 silently null
+                    if (e instanceof ApiRequestError && e.type === 'aborted') throw e;
+                    return null;
+                })
+            ]);
             notices = noticesData.slice(0, 5);
             if (latestData?.items?.length) {
                 latestNotice = latestData.items[0];
             }
         } catch (e) {
+            // unmount 로 인한 abort 면 state 업데이트 무의미
+            if (e instanceof ApiRequestError && e.type === 'aborted') return;
             error = true;
         } finally {
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId);
+                timeoutId = null;
+            }
             loading = false;
         }
+    });
+
+    onDestroy(() => {
+        // unmount 시 in-flight fetch 즉시 정리 → closure leak 방지
+        if (timeoutId !== null) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+        }
+        controller?.abort();
+        controller = null;
     });
 </script>
 


### PR DESCRIPTION
## Summary

PR #1353 의 `Promise.race(withTimeout, apiClient.x)` 패턴은 timeout reject 이후에도 underlying fetch closure 가 살아있어 (apiClient 가 abort 를 노출하지 않음), SSR prefetch + CSR onMount 양 경로에서 **시간당 ~50 MiB heap 누적**의 주요 원인으로 지목됨 (2026-05-02 메모리 진단 P0 root cause #1, `/home/angple/docs/2026-05-02-memory-leak-diagnosis.md`).

## 변경 전/후 동작

**변경 전** (PR #1353 `widgets/notice`, `widgets/ai-analysis`):
```ts
const data = await Promise.race([
  apiClient.getBoardNotices('free'),    // ← timeout 후에도 closure 살아있음
  new Promise((_, rj) => setTimeout(() => rj(new Error('timeout')), 12_000))
]);
```
- timeout reject 후에도 `apiClient.getBoardNotices` 의 underlying `fetch` 는 진행 중
- response body 까지 온전히 받아 GC 안 되는 state
- widget unmount → 재마운트 사이클마다 누적

**변경 후**:
```ts
const ctrl = new AbortController();
const timer = setTimeout(() => ctrl.abort(), 12_000);
try {
  const data = await apiClient.getBoardNotices('free', { signal: ctrl.signal });
  ...
} finally { clearTimeout(timer); }

onDestroy(() => ctrl.abort());  // unmount 시 in-flight 정리
```
- timeout / unmount 모두 `controller.abort()` → underlying fetch 즉시 abort
- closure / response body 즉시 GC 대상

## 근본 변경 사항

| 파일 | 변경 |
|---|---|
| `apps/web/src/lib/api/client.ts` | `request()` 가 `options.signal` 전달, `getBoardNotices` / `getBoardPosts` / `getRecommendedPostsWithAI` 가 `{ signal?: AbortSignal }` 옵션 수용 |
| `apps/web/src/lib/api/retry.ts` | `fetchWithTimeout` 외부 signal + 내부 timeout controller 합성 (외부 abort → fetch 즉시 abort) |
| `apps/web/src/lib/api/errors.ts` | `'aborted'` 타입 신설 (retryable=false → fetchWithRetry 가 재시도 안 함) |
| `widgets/notice/index.svelte` | `Promise.race` 제거 → AbortController 패턴 + onDestroy cleanup |
| `widgets/ai-analysis/index.svelte` | 동일 패턴 적용 |
| `apps/web/src/lib/api/retry.test.ts` (신규) | 5 케이스: pre-abort / 도중 abort / 내부 timeout / 정상 응답 listener 정리 / fetchWithRetry 가 aborted 재시도 안 함 |

## 회귀 위험 평가

- **apiClient.request 시그니처**: 변경 없음. `options.signal` 은 `RequestInit` 표준 필드라 기존 호출처 무영향.
- **신규 메서드 옵션**: 모두 optional. signal 미사용 호출처 동작 동일.
- **`'aborted'` 타입 추가**: retryable=false 라 fetchWithRetry 의 기존 retry 분기에서 자연 통과 (기존 'network' 분류와 의미만 분리).
- **백엔드 영향 없음**: AbortSignal 은 client-side fetch 만 정리. 백엔드에서는 connection drop 으로 이미 처리되는 케이스.
- **테스트**: retry.test.ts 5건 + 기존 timed-fetch.test.ts 6건 모두 통과. svelte-check 0 errors.

## 후속 PR 권고

1. **다른 Promise.race 패턴 위젯 audit**: `apps/web/src/hooks.server.ts` 및 라이브러리 fetch 직접 호출 위젯 일괄 정리
2. **다른 apiClient 메서드도 점진적 signal 옵션 확장** — 사이드바/광고/리액션 등 SSR-heavy 메서드부터
3. **TimedFetchError → ApiRequestError 통합** 검토 (현재 두 개 에러 클래스 공존)

## Test plan

- [x] `pnpm test:unit src/lib/api/retry.test.ts` — 5건 pass
- [x] `pnpm test:unit src/lib/utils/timed-fetch.test.ts` — 회귀 없음 (6건 pass)
- [x] `svelte-check` — 0 errors (97 warnings 기존)
- [ ] dev 환경 widget 마운트/언마운트 반복 시 heap snapshot 비교 (수동)
- [ ] **ClickHouse `heap_metrics` 1주 모니터링** — pod 별 hourly RSS delta, 변경 전 baseline 대비 50 MiB/h 감소 확인 권고
- [ ] **heap-watch worker** 임계 트리거 빈도 추이 — Telegram per-pod alert 발생 빈도 감소 확인

## 측정 권고 (배포 후)

```sql
-- ClickHouse: 변경 전후 hourly RSS delta 비교
SELECT
  toStartOfHour(ts) AS h,
  pod,
  max(rss_bytes) - min(rss_bytes) AS delta_bytes
FROM heap_metrics
WHERE ts >= now() - INTERVAL 7 DAY
GROUP BY h, pod
ORDER BY h DESC;
```

heap-watch 워커 trigger snapshot 간격 변화 (현재 `snapshot=heap*0.44`, 헤드룸 ≥150 Mi) 도 같이 관찰.