### PR TITLE
fix(comment): 대댓글 작성 후 즉시 반영되지 않는 문제 (#12228)

### DIFF
--- a/apps/web/src/lib/utils/comment-insert.test.ts
+++ b/apps/web/src/lib/utils/comment-insert.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { insertReplyAfterParent, type CommentLike } from './comment-insert';
+
+const root = (id: number): CommentLike => ({ id, depth: 0, parent_id: 100 });
+const reply = (id: number, depth = 1, parent_id: number = 0): CommentLike => ({
+    id,
+    depth,
+    parent_id
+});
+
+describe('insertReplyAfterParent', () => {
+    it('루트 댓글 한개에 대댓글이 처음 달릴 때 부모 바로 다음에 삽입된다', () => {
+        const list: CommentLike[] = [root(1), root(2)];
+        const newReply: CommentLike = { id: 3, depth: 1 };
+        const result = insertReplyAfterParent(list, 1, newReply);
+        expect(result.map((c) => c.id)).toEqual([1, 3, 2]);
+    });
+
+    it('이미 자식이 있는 부모에 대댓글이 추가될 때 마지막 자식 다음에 삽입된다', () => {
+        const list: CommentLike[] = [root(1), reply(11, 1), reply(12, 1), root(2)];
+        const newReply: CommentLike = { id: 99, depth: 1 };
+        const result = insertReplyAfterParent(list, 1, newReply);
+        expect(result.map((c) => c.id)).toEqual([1, 11, 12, 99, 2]);
+    });
+
+    it('대대댓글이 있는 부모 서브트리 끝에 삽입된다', () => {
+        const list: CommentLike[] = [
+            root(1),
+            reply(11, 1),
+            reply(111, 2), // 11 의 자식
+            reply(12, 1),
+            root(2)
+        ];
+        const newReply: CommentLike = { id: 99, depth: 1 };
+        const result = insertReplyAfterParent(list, 1, newReply);
+        // 99 는 1 의 마지막 자식(12) 다음, 2 직전
+        expect(result.map((c) => c.id)).toEqual([1, 11, 111, 12, 99, 2]);
+    });
+
+    it('parent_id 가 list 에 없으면 끝에 추가된다 (graceful fallback)', () => {
+        const list: CommentLike[] = [root(1)];
+        const newReply: CommentLike = { id: 99, depth: 1 };
+        const result = insertReplyAfterParent(list, 999, newReply);
+        expect(result.map((c) => c.id)).toEqual([1, 99]);
+    });
+
+    it('동일 id 가 이미 있으면 중복 추가하지 않는다', () => {
+        const list: CommentLike[] = [root(1), reply(11, 1)];
+        const result = insertReplyAfterParent(list, 1, { id: 11, depth: 1 });
+        expect(result).toBe(list);
+    });
+
+    it('parentId 가 string 이고 comments id 가 number 여도 정상 동작한다', () => {
+        const list: CommentLike[] = [root(1), root(2)];
+        const newReply: CommentLike = { id: 3, depth: 1 };
+        const result = insertReplyAfterParent(list, '1', newReply);
+        expect(result.map((c) => c.id)).toEqual([1, 3, 2]);
+    });
+
+    it('depth 가 누락된 (undefined) 부모도 depth 0 으로 간주한다', () => {
+        const list: CommentLike[] = [
+            { id: 1 }, // depth undefined
+            { id: 2 }
+        ];
+        const newReply: CommentLike = { id: 3, depth: 1 };
+        const result = insertReplyAfterParent(list, 1, newReply);
+        expect(result.map((c) => c.id)).toEqual([1, 3, 2]);
+    });
+});

--- a/apps/web/src/lib/utils/comment-insert.ts
+++ b/apps/web/src/lib/utils/comment-insert.ts
@@ -1,0 +1,41 @@
+/**
+ * 대댓글(reply) optimistic update 시 부모 댓글의 서브트리 끝 위치에
+ * 새 reply 를 끼워넣는 헬퍼.
+ *
+ * - 백엔드 v1 createComment 응답에 `parent_id` 와 `wr_comment_reply` 가 없어
+ *   단순 push 로 끝에 추가하면 commentTree 의 hasApiDepth 분기에서 부모 다음이
+ *   아닌 배열 맨 끝에 렌더되어 사용자에게는 reply 가 안 보이는 것처럼 인지된다.
+ *   (#12228)
+ * - 본 헬퍼는 부모 댓글 인덱스를 기준으로 자식들의 마지막 다음 위치
+ *   (= 부모 depth 이하 댓글 직전) 에 삽입하여 그누보드 표시 순서를 보존한다.
+ */
+export interface CommentLike {
+    id: string | number;
+    depth?: number;
+    parent_id?: string | number | null;
+    [key: string]: unknown;
+}
+
+export function insertReplyAfterParent<T extends CommentLike>(
+    comments: T[],
+    parentId: string | number,
+    optimistic: T
+): T[] {
+    // 중복 방지
+    if (comments.some((c) => c.id === optimistic.id)) {
+        return comments;
+    }
+
+    const parentIdx = comments.findIndex((c) => String(c.id) === String(parentId));
+    if (parentIdx === -1) {
+        return [...comments, optimistic];
+    }
+
+    const parentDepth = comments[parentIdx].depth ?? 0;
+    let insertIdx = parentIdx + 1;
+    while (insertIdx < comments.length && (comments[insertIdx].depth ?? 0) > parentDepth) {
+        insertIdx++;
+    }
+
+    return [...comments.slice(0, insertIdx), optimistic, ...comments.slice(insertIdx)];
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -45,6 +45,7 @@
     import type { FreeComment, FreePost, LikerInfo, PostRevision } from '$lib/api/types.js';
     import DeletedPostBanner from '$lib/components/post/deleted-post-banner.svelte';
     import { sendMentionNotifications } from '$lib/utils/mention-notify.js';
+    import { insertReplyAfterParent, type CommentLike } from '$lib/utils/comment-insert.js';
     import type { ReactionItem } from '$lib/types/reaction.js';
     import { generateParentId, generateDocumentTargetId } from '$lib/types/reaction.js';
     import { onMount } from 'svelte';
@@ -1331,16 +1332,35 @@
                 images
             });
 
-            // Optimistic update: 대댓글도 즉시 목록에 추가 (#11946)
+            // Optimistic update: 대댓글도 즉시 목록에 추가 (#11946, #12228)
+            // 백엔드 v1 createComment 응답에 parent_id / wr_comment_reply 가 없어
+            // 단순 push 시 commentTree 의 hasApiDepth 분기에서 부모 다음이 아닌
+            // 배열 맨 끝에 렌더되어 회귀로 안 보이는 것처럼 인지됨.
+            // → 프론트에서 parent_id, depth 를 명시적으로 채우고
+            //   부모 댓글의 마지막 자식 다음 위치에 삽입한다.
             if (replyComment && replyComment.id) {
+                const parentComment = comments.find((c) => String(c.id) === String(parentId));
+                const parentDepth = parentComment?.depth ?? 0;
                 const optimistic = {
                     ...replyComment,
+                    parent_id: (replyComment as Partial<FreeComment>).parent_id ?? parentId,
+                    depth:
+                        typeof (replyComment as Partial<FreeComment>).depth === 'number'
+                            ? (replyComment as Partial<FreeComment>).depth
+                            : parentDepth + 1,
                     author_id: authStore.user.mb_id || '',
                     author_image_url: authStore.user.mb_image || '',
                     author_level: authStore.user.mb_level ?? 0
                 } as unknown as FreeComment;
-                if (!comments.some((c) => c.id === optimistic.id)) {
-                    comments = [...comments, optimistic];
+
+                const before = comments as unknown as CommentLike[];
+                const next = insertReplyAfterParent(
+                    before,
+                    parentId,
+                    optimistic as unknown as CommentLike
+                );
+                if (next !== before) {
+                    comments = next as unknown as FreeComment[];
                     commentsTotal = commentsTotal + 1;
                 }
             }


### PR DESCRIPTION
## Summary
- #11946 (PR #1231) 으로 추가된 optimistic update 가 대댓글 케이스에서 회귀 발생.
- v1 `POST /boards/:slug/posts/:id/comments` 응답이 `parent_id` 와 `wr_comment_reply` 를 빠뜨려, `comment-list.svelte` 의 `commentTree`(`hasApiDepth=true` 분기)는 새 reply 를 단순히 배열 맨 끝(부모와 무관한 위치) 에 렌더 → 부모와 떨어져 보이거나 스크롤 영역 밖으로 밀려 사용자에게는 "안 보이는" 것처럼 인지됨.
- 프론트에서 `parent_id` / `depth` 를 명시적으로 채우고, 새로 만든 `insertReplyAfterParent()` 헬퍼로 부모 댓글의 서브트리 마지막 자손 다음에 삽입해 그누보드 표시 순서와 일치시킴.

## 변경 파일
- `apps/web/src/lib/utils/comment-insert.ts` (신규) — `insertReplyAfterParent` 헬퍼
- `apps/web/src/lib/utils/comment-insert.test.ts` (신규) — Vitest 7 케이스
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` — `handleReplyComment` 의 optimistic update 부분만 수정. 일반 댓글(`handleCreateComment`) 경로는 변경 없음.

## 회귀 위험 평가
- **변경 범위가 `handleReplyComment` 단 한 함수의 optimistic 블록에 한정** — 일반 댓글 작성 흐름은 손대지 않음.
- 헬퍼는 부모를 못 찾으면 기존 동작(끝에 push) 을 그대로 fallback 으로 유지.
- `await refetchComments()` 호출은 그대로 — 서버 정렬 결과가 곧 화면을 덮어씀.

## Test plan
- [x] `pnpm test:unit -- --run src/lib/utils/comment-insert.test.ts` (7/7 pass)
- [x] `pnpm test:unit` 전체 350개 테스트 통과
- [x] `pnpm check` 0 errors
- [ ] 운영 배포 전 canary 에서 다음 시나리오 수동 검증
  - [ ] 자식 없는 루트 댓글에 첫 대댓글 작성 → 즉시 부모 바로 아래에 표시
  - [ ] 이미 대댓글이 있는 루트에 추가 대댓글 작성 → 마지막 자식 다음 위치에 표시
  - [ ] 대대댓글까지 있는 트리에 새 대댓글 작성 → 서브트리 끝에 표시
  - [ ] 일반 댓글 작성 회귀 없음 확인

Refs: #12228, #11946 (이전 fix), PR #1231