### PR TITLE
feat(board): 보드별 "내글/내댓글" quick filter 추가 (#12012)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -66,6 +66,8 @@
     import Pin from '@lucide/svelte/icons/pin';
     import Tag from '@lucide/svelte/icons/tag';
     import X from '@lucide/svelte/icons/x';
+    import User from '@lucide/svelte/icons/user';
+    import MessageSquare from '@lucide/svelte/icons/message-square';
     import SearchForm from '$lib/components/features/board/search-form.svelte';
     import BulkActionsToolbar from '$lib/components/features/board/bulk-actions-toolbar.svelte';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
@@ -183,6 +185,42 @@
 
     // 현재 페이지 번호 (글 링크에 전달용)
     const listPage = $derived(Number($page.url.searchParams.get('page')) || 1);
+
+    // #12012: 보드별 "내가 쓴 글/댓글" 빠른 필터
+    // 백엔드 ?sfl=author|comment_author&stx={mb_id} 재사용 (Sphinx @(mb_id,wr_name) 매칭)
+    const currentSfl = $derived($page.url.searchParams.get('sfl') || '');
+    const currentStx = $derived($page.url.searchParams.get('stx') || '');
+    const isMyPostsActive = $derived(
+        authStore.isAuthenticated &&
+            currentSfl === 'author' &&
+            currentStx === (authStore.user?.mb_id ?? '')
+    );
+    const isMyCommentsActive = $derived(
+        authStore.isAuthenticated &&
+            currentSfl === 'comment_author' &&
+            currentStx === (authStore.user?.mb_id ?? '')
+    );
+
+    function applyMyFilter(sfl: 'author' | 'comment_author'): void {
+        const mbId = authStore.user?.mb_id;
+        if (!mbId) return;
+        const url = new URL(window.location.href);
+        url.searchParams.set('sfl', sfl);
+        url.searchParams.set('stx', mbId);
+        url.searchParams.set('page', '1');
+        url.searchParams.delete('category');
+        url.searchParams.delete('tag');
+        goto(url.pathname + url.search);
+    }
+
+    function clearMyFilter(): void {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('sfl');
+        url.searchParams.delete('stx');
+        url.searchParams.delete('sop');
+        url.searchParams.set('page', '1');
+        goto(url.pathname + url.search);
+    }
 
     // 읽은 글 표시 지연 — SSR에서는 모든 글이 "안읽음"으로 렌더링되므로,
     // 하이드레이션 직후 즉시 변경하면 깜빡임 발생. 2프레임 대기 후 부드럽게 전환.
@@ -855,6 +893,45 @@
             {#if showSearch || isSearching || uiSettingsStore.pinSearch}
                 <div class="mb-3" transition:slide={{ duration: 200 }}>
                     <SearchForm boardPath={`/${boardId}`} />
+                </div>
+            {/if}
+
+            <!-- #12012: 내가 쓴 글/댓글 빠른 필터 (로그인 시) -->
+            {#if authStore.isAuthenticated}
+                <div class="mb-3 flex flex-wrap items-center gap-2">
+                    <Button
+                        variant={isMyPostsActive ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8"
+                        onclick={() =>
+                            isMyPostsActive ? clearMyFilter() : applyMyFilter('author')}
+                        title="이 게시판에서 내가 쓴 글만 보기"
+                    >
+                        <User class="mr-1.5 h-3.5 w-3.5" />
+                        내가 쓴 글
+                    </Button>
+                    <Button
+                        variant={isMyCommentsActive ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8"
+                        onclick={() =>
+                            isMyCommentsActive ? clearMyFilter() : applyMyFilter('comment_author')}
+                        title="이 게시판에서 내가 쓴 댓글만 보기"
+                    >
+                        <MessageSquare class="mr-1.5 h-3.5 w-3.5" />
+                        내가 쓴 댓글
+                    </Button>
+                    {#if isMyPostsActive || isMyCommentsActive}
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            class="h-8 px-2"
+                            onclick={clearMyFilter}
+                            title="필터 해제"
+                        >
+                            <X class="h-3.5 w-3.5" />
+                        </Button>
+                    {/if}
                 </div>
             {/if}
 


### PR DESCRIPTION
## 사용자 제보 (#12012)

> 마이페이지 전체검색은 글이 너무 많아 느림. 자유게시판 같은 보드 안에서
> "내가 쓴 글 / 내가 쓴 댓글" 만 빠르게 보고 싶음.

## 변경 사항

- `apps/web/src/routes/[boardId]/+page.svelte` 검색 영역 아래에 로그인 사용자
  전용 quick-filter 버튼 2개 (`내가 쓴 글`, `내가 쓴 댓글`) 추가
- 활성 상태(URL `sfl/stx` 가 본인 mb_id 와 매칭) 면 버튼 강조 + X 버튼 노출
- 클릭 시 `?sfl=author|comment_author&stx={mb_id}&page=1` 로 이동, 카테고리/
  태그/sop 파라미터 정리

## 백엔드 / 인프라 — 변경 없음

기존 검색 path 100% 재사용:

| 컴포넌트 | 처리 |
|---|---|
| `[boardId]/+page.server.ts` | 이미 `?sfl=...&stx=...` 핸들링 |
| `lib/server/sphinx-search.ts` | `author` / `comment_author` → `@(mb_id,wr_name) {query}` 매칭 (mb_id 직접 매칭됨) |
| `lib/components/.../search-form.svelte` | `'author'` / `'comment_author'` option 이미 존재 |

→ 새 endpoint, 새 인덱스, 새 SQL 0건. UI wiring 만.

## 회귀 위험: 낮음

- UI-only 추가 (+77 LOC, 삭제 0)
- 기존 검색 인프라/캐시 path 그대로
- `usePostsCache` 는 `isSearching` 시 bypass → 캐시 오염 X
- 비로그인 사용자는 버튼 자체 hide

## 사전 검증

- [x] Sphinx `author` 필드 `mb_id` 매칭 확인 (`sphinx-search.ts:58-59`, `:62-63` — `@(mb_id,wr_name)` index)
- [x] `[postId]/+page.svelte:2032` 가 이미 `currentPostId={data.post.id}` 전달 → 추가 작업 불필요
- [x] svelte-check: 추가 에러 0 (기존 zod 관련 경고만 잔존)

## 테스트 플랜

- [ ] 로그인 → 자유게시판에서 "내가 쓴 글" 클릭 → URL `?sfl=author&stx={mb_id}&page=1` 이동 + 결과 정상
- [ ] "내가 쓴 댓글" 클릭 → 댓글 활동만 표시
- [ ] 동일 버튼 재클릭 → 필터 해제
- [ ] 비로그인 → 버튼 미노출
- [ ] 다른 보드(예: economy)에서도 동일 동작

Closes #12012