### PR TITLE
fix(search): comment_author 검색 0건 — Sphinx parentIds 활용 (#12012 후속)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -428,13 +428,20 @@ export const load: PageServerLoad = async ({
                     limit,
                     sort
                 );
-                if (sphinxResult.ids.length === 0) {
+                // 댓글 검색(comment / comment_author)이면 parentIds로 부모 글 fetch
+                // 한 글에 댓글 여러 개 매칭 시 dedupe 필요 (Set), 첫 등장 순서 유지
+                const refetchIds =
+                    sphinxResult.parentIds && sphinxResult.parentIds.length > 0
+                        ? Array.from(new Set(sphinxResult.parentIds))
+                        : sphinxResult.ids;
+
+                if (refetchIds.length === 0) {
                     return { data: [], meta: { page, limit, total: sphinxResult.total } };
                 }
                 // Sphinx에서 가져온 ID로 DB 직접 조회
                 // Gnuboard 스키마에는 wr_is_notice 컬럼이 없음 — g5_board.bo_notice (콤마 구분 wr_id)로 판단
                 const tableName = `g5_write_${boardId}`;
-                const ph = sphinxResult.ids.map(() => '?').join(',');
+                const ph = refetchIds.map(() => '?').join(',');
                 const [postRows, noticeRows] = await Promise.all([
                     readPool.execute<RowDataPacket[]>(
                         `SELECT wr_id AS id, wr_subject AS title, wr_content AS content,
@@ -447,7 +454,7 @@ export const load: PageServerLoad = async ({
                          FROM ${tableName}
                          WHERE wr_id IN (${ph}) AND wr_is_comment = 0
                            AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')`,
-                        sphinxResult.ids
+                        refetchIds
                     ),
                     readPool.execute<RowDataPacket[]>(
                         `SELECT bo_notice FROM g5_board WHERE bo_table = ?`,
@@ -462,11 +469,11 @@ export const load: PageServerLoad = async ({
                         .map((s) => Number(s.trim()))
                         .filter((n) => Number.isFinite(n) && n > 0)
                 );
-                // Sphinx 결과 순서 유지 + is_notice 주입
+                // Sphinx 결과 순서 유지 (refetchIds: parentIds dedupe or ids) + is_notice 주입
                 const rowMap = new Map(
                     rows.map((r) => [r.id, { ...r, is_notice: noticeIds.has(Number(r.id)) }])
                 );
-                const ordered = sphinxResult.ids
+                const ordered = refetchIds
                     .map((id) => rowMap.get(id))
                     .filter(Boolean) as RowDataPacket[];
                 return {


### PR DESCRIPTION
## Summary

damoang.net 게시판 검색에서 `sfl=comment` / `sfl=comment_author` 가 항상 0건을 반환하던 버그 수정.

## Root cause

- `apps/web/src/lib/server/sphinx-search.ts` 의 `searchByBoard()` 는 댓글 검색(`field='comment' | 'comment_author'`) 시 부모 글 wr_id 를 `parentIds` 로 별도 반환
- 그러나 `apps/web/src/routes/[boardId]/+page.server.ts` 의 `fetchPostsViaSphinx` 가 `parentIds` 를 무시하고 `sphinxResult.ids` (댓글 자체의 wr_id, `wr_is_comment=1`) 로 refetch
- refetch SQL: `WHERE wr_id IN (ids) AND wr_is_comment = 0` 조건에 댓글 wr_id 가 모두 필터링되어 0건 반환

## Fix

- 댓글 검색이면 `parentIds` 를 사용해 부모 글 fetch
- 한 글에 여러 댓글이 매칭되는 경우 dedupe (Set) 처리, 첫 등장 순서 유지
- 일반 글 검색(`sfl=author/title/content`) 시에는 `parentIds` 가 비어있으므로 기존처럼 `ids` 사용 → **동작 변경 없음 (회귀 위험 낮음)**
- 결과 순서: `refetchIds` 첫 등장 순서 유지 (date / relevance 정렬 보존)

변경 파일: `apps/web/src/routes/[boardId]/+page.server.ts` (+12 / -5)

## Test plan

- [ ] dev 환경 또는 prod canary 에서 댓글 검색 동작 확인
  - [ ] `/free?sfl=comment&stx=<keyword>` — 댓글 본문 검색 결과 표시
  - [ ] `/free?sfl=comment_author&stx=<nickname>` — 댓글 작성자 검색 결과 표시
- [ ] 일반 글 검색 회귀 없는지 확인
  - [ ] `sfl=title`, `sfl=content`, `sfl=author` — 기존과 동일 동작
- [ ] 한 글에 같은 작성자 댓글 여러 개 매칭되는 케이스에서 부모 글이 한 번만 노출되는지 확인 (dedupe)
- [ ] `pnpm check` 통과 (svelte-check 0 errors)

## Refs

- Follow-up to #12012 (보드별 "내글/내댓글" quick filter)