### PR TITLE
fix(memory): /api/image + index-widgets-builder fetch timeout (Round 3 Critical)

### DIFF
--- a/apps/web/src/lib/server/index-widgets-builder.ts
+++ b/apps/web/src/lib/server/index-widgets-builder.ts
@@ -95,29 +95,49 @@ export async function buildIndexWidgets(_backendUrl: string): Promise<IndexWidge
     }
 }
 
+/** 홈 SSR 위젯 백엔드 fetch timeout — 빠르게 fail-fast 해야 홈이 깨지지 않음 */
+const WIDGET_FETCH_TIMEOUT_MS = 3000;
+
 /**
  * 단일 게시판 데이터 조회 (post-list 위젯용)
+ *
+ * 백엔드 hang 시 3s 후 AbortSignal 로 강제 중단 → SSR pending closure heap retain 방지.
+ * 실패 시 빈 배열 fallback — 홈 페이지가 한 위젯 때문에 깨지지 않도록.
  */
 export async function fetchBoardPostsForWidget(
     backendUrl: string,
     boardId: string,
     limit: number
 ): Promise<BackendPost[]> {
-    const response = await fetch(
-        `${backendUrl}/api/v1/boards/${boardId}/posts?limit=${limit}&page=1`,
-        {
-            headers: {
-                Accept: 'application/json',
-                'User-Agent': 'Angple-Web-SSR/1.0'
+    try {
+        const response = await fetch(
+            `${backendUrl}/api/v1/boards/${boardId}/posts?limit=${limit}&page=1`,
+            {
+                headers: {
+                    Accept: 'application/json',
+                    'User-Agent': 'Angple-Web-SSR/1.0'
+                },
+                signal: AbortSignal.timeout(WIDGET_FETCH_TIMEOUT_MS)
             }
-        }
-    );
+        );
 
-    if (!response.ok) {
-        console.error('[index-widgets-builder]', boardId, 'API error:', response.status);
+        if (!response.ok) {
+            console.error('[index-widgets-builder]', boardId, 'API error:', response.status);
+            return [];
+        }
+
+        const result: BackendBoardResponse = await response.json();
+        return result.data ?? [];
+    } catch (err) {
+        // timeout 또는 network 에러 — 홈이 깨지지 않도록 빈 결과 fallback
+        const isTimeout =
+            err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
+        console.error(
+            '[index-widgets-builder]',
+            boardId,
+            isTimeout ? 'fetch timeout' : 'fetch failed:',
+            err
+        );
         return [];
     }
-
-    const result: BackendBoardResponse = await response.json();
-    return result.data ?? [];
 }

--- a/apps/web/src/routes/api/image/+server.ts
+++ b/apps/web/src/routes/api/image/+server.ts
@@ -15,6 +15,8 @@ import type { RequestHandler } from './$types';
 const ALLOWED_ORIGINS = ['localhost', '127.0.0.1', 'damoang.net', 'angple.com'];
 const MAX_WIDTH = 2560;
 const CACHE_MAX_AGE = 60 * 60 * 24 * 7; // 7일
+const FETCH_TIMEOUT_MS = 5000; // 5s — hang 시 heap retain 방지
+const MAX_BYTES = 10 * 1024 * 1024; // 10 MB — 외부 이미지 최대 크기 cap
 
 export const GET: RequestHandler = async ({ url, fetch }) => {
     const imageUrl = url.searchParams.get('url');
@@ -39,13 +41,62 @@ export const GET: RequestHandler = async ({ url, fetch }) => {
     }
 
     try {
-        const response = await fetch(imageUrl);
+        // AbortSignal.timeout: 외부 이미지 hang 시 5s 후 강제 중단 → heap body retain 방지
+        const response = await fetch(imageUrl, {
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+        });
         if (!response.ok) {
             return new Response('Image fetch failed', { status: response.status });
         }
 
+        // Content-Length 사전 검증 — 헤더만으로 큰 응답 거부 (1차 방어)
+        const contentLengthHeader = response.headers.get('content-length');
+        if (contentLengthHeader) {
+            const declaredLength = Number(contentLengthHeader);
+            if (Number.isFinite(declaredLength) && declaredLength > MAX_BYTES) {
+                return new Response('Image too large', { status: 413 });
+            }
+        }
+
         const contentType = response.headers.get('content-type') || 'image/jpeg';
-        const body = await response.arrayBuffer();
+
+        // 스트리밍 다운로드 + 누적 size 추적 — Content-Length 가 없거나 거짓말일 때 2차 방어
+        const reader = response.body?.getReader();
+        if (!reader) {
+            return new Response('Image fetch failed', { status: 502 });
+        }
+
+        const chunks: Uint8Array[] = [];
+        let received = 0;
+        try {
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value) {
+                    received += value.byteLength;
+                    if (received > MAX_BYTES) {
+                        // 이후 body 다운로드 중단 → heap 누적 차단
+                        await reader.cancel().catch(() => {});
+                        return new Response('Image too large', { status: 413 });
+                    }
+                    chunks.push(value);
+                }
+            }
+        } finally {
+            // 어떤 경로로든 reader 가 release 되도록 보장 (closure retain 방지)
+            try {
+                reader.releaseLock();
+            } catch {
+                /* noop */
+            }
+        }
+
+        const body = new Uint8Array(received);
+        let offset = 0;
+        for (const chunk of chunks) {
+            body.set(chunk, offset);
+            offset += chunk.byteLength;
+        }
 
         // TODO: sharp로 리사이즈 및 포맷 변환
         // const sharp = (await import('sharp')).default;
@@ -62,7 +113,13 @@ export const GET: RequestHandler = async ({ url, fetch }) => {
                 Vary: 'Accept'
             }
         });
-    } catch {
+    } catch (err) {
+        // AbortError (timeout) 와 일반 fetch 실패 구분 — 운영 디버깅용
+        const isTimeout =
+            err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
+        if (isTimeout) {
+            return new Response('Image fetch timeout', { status: 504 });
+        }
         return new Response('Image processing failed', { status: 500 });
     }
 };


### PR DESCRIPTION
## Summary

Round 3 P1 audit (`docs/2026-05-02-memory-round3-p1-audit.md`) Critical 2건 fix.
시간당 ~50 MiB leak 패턴 추가 진압 시도 — 서버 raw `fetch` 에 AbortSignal + size cap 추가.

### Critical 1 — `/api/image` 외부 이미지 프록시
**파일**: `apps/web/src/routes/api/image/+server.ts`

- `AbortSignal.timeout(5000)` 추가: 외부 이미지 hang 시 5s 후 강제 중단 → body heap retain 차단
- **Content-Length 사전 검사** (1차 방어): 10 MB 초과 시 즉시 `413`
- **Stream reader 누적 size 추적** (2차 방어): Content-Length 누락/거짓 대응 — 다운로드 중 10 MB 초과 시 `reader.cancel()` 후 `413`
- `finally` 에서 `reader.releaseLock()` 보장 → closure retain 차단
- `AbortError`/`TimeoutError` 분리 → `504 Image fetch timeout` (운영 디버깅용)

### Critical 2 — 홈 SSR 위젯 빌드 fetch
**파일**: `apps/web/src/lib/server/index-widgets-builder.ts`

- `fetchBoardPostsForWidget` 에 `AbortSignal.timeout(3000)` 추가
- 홈 SSR 컨텍스트라 짧은 timeout — 백엔드 hang 시 pending closure heap retain 방지
- `try/catch` 로 timeout/network 에러 시 **빈 배열 fallback** — 홈 페이지가 한 위젯 때문에 깨지지 않도록 fail-fast

## 회귀 위험 평가

| 영향 | 평가 |
|---|---|
| `/api/image` 정상 사용자 | **무영향** — 5s 면 일반 이미지에 충분, 10 MB cap 은 프로필/썸네일 용도에 충분 (대용량 이미지 프록시 사용 사례 없음) |
| 홈 위젯 백엔드 hang | **fail-fast 로 개선** — 기존: SSR 무한 hang → 메모리 누적, 변경: 3s 후 빈 결과 fallback (한 위젯만 빈 상태, 홈 자체는 정상 렌더) |
| 신규 timeout 응답 코드 | `504` (image), `413` (image too large) — 클라이언트 처리 영향 미미 |

## 검증

- [x] `pnpm check`: 0 errors (변경 파일 신규 경고 없음)
- [ ] 운영 적용 후 ClickHouse `heap_metrics` 1주 RSS delta 비교
- [ ] heap snapshot 확보되면 (PR k8s#59 적용 후) 효과 검증

## Test plan

- [ ] 로컬 `pnpm dev` 에서 `/api/image?url=https://damoang.net/...` 정상 이미지 응답 확인
- [ ] 일부러 큰 이미지 (>10 MB) URL 로 `413` 확인
- [ ] 위젯 백엔드 timeout 시 홈 페이지가 빈 위젯과 함께 정상 렌더되는지 확인
- [ ] 운영 적용 후 1주 RSS delta 추이 확인 (ClickHouse `heap_metrics`)