### PR TITLE
fix(memory): OAuth/AI/Turnstile 외부 fetch AbortSignal 일괄 (Round 3 후속)

### DIFF
--- a/apps/web/src/lib/server/ai-content.ts
+++ b/apps/web/src/lib/server/ai-content.ts
@@ -67,7 +67,9 @@ async function callOpenAI(
             ],
             max_tokens: 300,
             temperature: 0.3
-        })
+        }),
+        // OpenAI hang 시 closure heap retain 방지 (Round 3 후속) — 긴 응답 가능성 고려해 30s
+        signal: AbortSignal.timeout(30000)
     });
 
     if (!response.ok) {
@@ -98,7 +100,9 @@ async function callAnthropic(
             max_tokens: 300,
             system: systemPrompt,
             messages: [{ role: 'user', content: userPrompt }]
-        })
+        }),
+        // Anthropic hang 시 closure heap retain 방지 (Round 3 후속) — 긴 응답 가능성 고려해 30s
+        signal: AbortSignal.timeout(30000)
     });
 
     if (!response.ok) {

--- a/apps/web/src/lib/server/auth/oauth/base-provider.ts
+++ b/apps/web/src/lib/server/auth/oauth/base-provider.ts
@@ -40,7 +40,9 @@ export abstract class BaseOAuthProvider {
         const response = await fetch(this.config.tokenUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString()
+            body: body.toString(),
+            // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!response.ok) {
@@ -57,7 +59,9 @@ export abstract class BaseOAuthProvider {
     /** 액세스 토큰으로 사용자 프로필 조회 */
     async getUserProfile(accessToken: string): Promise<OAuthUserProfile> {
         const response = await fetch(this.config.profileUrl, {
-            headers: { Authorization: `Bearer ${accessToken}` }
+            headers: { Authorization: `Bearer ${accessToken}` },
+            // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!response.ok) {

--- a/apps/web/src/lib/server/auth/oauth/providers/apple.ts
+++ b/apps/web/src/lib/server/auth/oauth/providers/apple.ts
@@ -118,7 +118,9 @@ export class AppleProvider extends BaseOAuthProvider {
         const response = await fetch(this.config.tokenUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString()
+            body: body.toString(),
+            // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!response.ok) {

--- a/apps/web/src/lib/server/auth/oauth/providers/kakao.ts
+++ b/apps/web/src/lib/server/auth/oauth/providers/kakao.ts
@@ -56,7 +56,9 @@ export class KakaoProvider extends BaseOAuthProvider {
         const response = await fetch(this.config.tokenUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: new URLSearchParams(params).toString()
+            body: new URLSearchParams(params).toString(),
+            // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!response.ok) {

--- a/apps/web/src/lib/server/auth/oauth/providers/payco.ts
+++ b/apps/web/src/lib/server/auth/oauth/providers/payco.ts
@@ -85,7 +85,9 @@ export class PaycoProvider extends BaseOAuthProvider {
             body: JSON.stringify({
                 client_id: this.config.clientId,
                 access_token: accessToken
-            })
+            }),
+            // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!response.ok) {
@@ -125,7 +127,9 @@ export class PaycoProvider extends BaseOAuthProvider {
                 access_token: accessToken,
                 Authorization: `Bearer ${accessToken}`
             },
-            body: body.toString()
+            body: body.toString(),
+            // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!response.ok) {

--- a/apps/web/src/lib/server/auth/oauth/providers/twitter.ts
+++ b/apps/web/src/lib/server/auth/oauth/providers/twitter.ts
@@ -114,7 +114,9 @@ export class TwitterProvider extends BaseOAuthProvider {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 Authorization: `Basic ${credentials}`
             },
-            body: body.toString()
+            body: body.toString(),
+            // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!response.ok) {

--- a/apps/web/src/lib/server/captcha.ts
+++ b/apps/web/src/lib/server/captcha.ts
@@ -29,7 +29,9 @@ export async function verifyTurnstile(token: string, ip: string): Promise<boolea
                 secret: TURNSTILE_SECRET_KEY,
                 response: token,
                 remoteip: ip
-            })
+            }),
+            // Cloudflare Turnstile hang 시 closure heap retain 방지 (Round 3 후속)
+            signal: AbortSignal.timeout(5000)
         });
 
         if (!res.ok) {
@@ -41,7 +43,13 @@ export async function verifyTurnstile(token: string, ip: string): Promise<boolea
 
         return data.success;
     } catch (err) {
-        console.error('[Captcha] Turnstile 검증 중 예외:', err);
+        // AbortError/TimeoutError 포함 — 명확한 로그 + false 반환 (보수적)
+        const name = (err as { name?: string })?.name;
+        if (name === 'AbortError' || name === 'TimeoutError') {
+            console.error('[Captcha] Turnstile 검증 timeout (5s)');
+        } else {
+            console.error('[Captcha] Turnstile 검증 중 예외:', err);
+        }
         return false;
     }
 }

--- a/apps/web/src/lib/server/github-oauth/github-oauth.ts
+++ b/apps/web/src/lib/server/github-oauth/github-oauth.ts
@@ -73,7 +73,9 @@ export async function exchangeGitHubCode(
             client_secret: config.clientSecret,
             code,
             redirect_uri: callbackUrl
-        })
+        }),
+        // 외부 OAuth 서버 hang 시 closure heap retain 방지 (Round 3 후속)
+        signal: AbortSignal.timeout(5000)
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Round 3 P1 audit (`docs/2026-05-02-memory-round3-p1-audit.md`) High 영역 일괄 fix.
PR #1364 (Critical 2건) 패턴을 같은 영역의 8개 외부 `fetch` 호출에 적용.
외부 API hang 시 closure heap retain 차단 — 시간당 ~50 MiB leak 패턴 추가 진압.

## Changes (8 files, +40/-12 LOC)

### OAuth providers (5 files, 7 fetch sites) — 5s timeout
- `auth/oauth/base-provider.ts` — token + profile fetch (Google/Naver/Facebook 가 상속하므로 한 번에 커버)
- `auth/oauth/providers/twitter.ts` — token fetch (Basic Auth override)
- `auth/oauth/providers/apple.ts` — token fetch (id_token 서명 검증용)
- `auth/oauth/providers/kakao.ts` — token fetch (override)
- `auth/oauth/providers/payco.ts` — idNo + profile fetch (Step 1, Step 2)
- `github-oauth/github-oauth.ts` — token fetch (프리미엄 테마 인증)

### AI content (2 fetch sites) — 30s timeout
- `ai-content.ts` `callOpenAI` — gpt-4o-mini chat completion
- `ai-content.ts` `callAnthropic` — claude-haiku messages

### Cloudflare Turnstile (1 fetch site) — 5s timeout
- `captcha.ts` `verifyTurnstile` — siteverify endpoint
- catch 분기 추가: `AbortError`/`TimeoutError` 별도 로그

## Mechanism

`AbortSignal.timeout(N)` 추가만으로:
- N ms 후 fetch 강제 abort → response/headers/body closure 즉시 GC 가능
- 호출자 `await` Promise reject → 상위 catch 가 정리
- closure 가 retain 하던 cookie/locals/session 객체 모두 해제

## Timeout 값 근거

| 영역 | timeout | 근거 |
|---|---|---|
| OAuth (token/profile) | 5s | 정상 응답 100~500ms, 5s 는 10x 헤드룸 |
| OpenAI/Anthropic | 30s | LLM 응답 평균 2~5s, max 15s 가능 — 30s 보수적 |
| Turnstile | 5s | 정상 100~300ms, 5s 면 충분 |

## Regression risk: Low

- **OAuth**: 정상 flow 는 ~수백ms, 5s 는 넉넉. 5s 후 fail 은 hang 보다 나음 (사용자가 즉시 재시도 가능)
- **AI**: 30s 는 OpenAI/Anthropic 평균 응답의 6~10배. callsite (`summarizeContent`/`analyzeSpamWithAI`) 에 try/catch + `null` 반환 fallback 이 이미 존재 → 사용자 경험 영향 0
- **Turnstile**: 5s timeout 시 `false` 반환 — 기존 catch (`return false`) 와 동일 동작. 보수적 (인증 실패 처리)
- **상속 확인**: Google/Naver/Facebook provider 는 `extends BaseOAuthProvider` 만 하고 `exchangeCode`/`getUserProfile` 미오버라이드 → base 수정으로 함께 커버
- **테스트**: `pnpm check` 0 errors (97 warnings 모두 사전 존재)

## Test plan

- [ ] CI 통과 (svelte-check, vitest)
- [ ] dev/prod 배포 후 로그 모니터링: `[Captcha] Turnstile 검증 timeout` / OAuth 토큰 교환 timeout 발생 빈도 ~ 0
- [ ] 시간당 heap leak 누적 감소 확인 (PR #1364 + 본 PR 후 ~50 MiB → 측정)

## Refs

- audit: `docs/2026-05-02-memory-round3-p1-audit.md` §3 (H-FETCH-3~7)
- 선행 PR: #1364 (Critical 2건 — `/api/image`, `index-widgets-builder`)
- 4/30 OOM RCA: `project_2026_04_30_oom_incident.md`