### PR TITLE
fix(memory): OTel BSP queue/timeout 인하 (Round 3 후속)

### DIFF
--- a/apps/web/src/lib/server/telemetry.ts
+++ b/apps/web/src/lib/server/telemetry.ts
@@ -82,7 +82,7 @@ if (OTEL_ENABLED) {
     const { NodeSDK } = await import('@opentelemetry/sdk-node');
     const { OTLPTraceExporter } = await import('@opentelemetry/exporter-trace-otlp-grpc');
     const { resourceFromAttributes } = await import('@opentelemetry/resources');
-    const { TraceIdRatioBasedSampler, ParentBasedSampler } = await import(
+    const { TraceIdRatioBasedSampler, ParentBasedSampler, BatchSpanProcessor } = await import(
         '@opentelemetry/sdk-trace-node'
     );
     const semconv = await import('@opentelemetry/semantic-conventions');
@@ -95,6 +95,23 @@ if (OTEL_ENABLED) {
         'otel-collector.observability.svc.cluster.local:4317';
     const samplerArg = parseFloat(process.env.OTEL_TRACES_SAMPLER_ARG || '0.1');
 
+    // BSP queue/timeout 인하 — Round 3 후속 (2026-05-02 audit High).
+    // OTel default: maxQueueSize=2048, maxExportBatchSize=512, scheduledDelayMillis=5000, exportTimeoutMillis=30000.
+    // collector 장애 시 2048 span queue 항시 점유 + timeout 동안 export blocking → external 메모리 ↑.
+    // queue 1/2 + batch 1/4 + delay 2.5배 빠르게 + timeout 1/3 → external 메모리 영향 완화 (4/24 RCA 정합).
+    // 손실: 정상 collector 환경에선 더 자주 flush 하므로 데이터 손실 거의 없음.
+    // 회귀: maxExportBatchSize 인하 → export 횟수 ↑ (CPU 미미 영향, 10% 샘플링 + HTTP 만 계측이라 무시 가능).
+    const traceExporter = new OTLPTraceExporter({
+        url: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`,
+        timeoutMillis: parseInt(process.env.OTEL_BSP_EXPORT_TIMEOUT_MS || '10000', 10)
+    });
+    const spanProcessor = new BatchSpanProcessor(traceExporter, {
+        maxQueueSize: parseInt(process.env.OTEL_BSP_MAX_QUEUE_SIZE || '1024', 10),
+        maxExportBatchSize: parseInt(process.env.OTEL_BSP_MAX_EXPORT_BATCH_SIZE || '128', 10),
+        scheduledDelayMillis: parseInt(process.env.OTEL_BSP_SCHEDULE_DELAY_MS || '2000', 10),
+        exportTimeoutMillis: parseInt(process.env.OTEL_BSP_EXPORT_TIMEOUT_MS || '10000', 10)
+    });
+
     const sdk = new NodeSDK({
         resource: resourceFromAttributes({
             [semconv.ATTR_SERVICE_NAME]: 'damoang-web',
@@ -104,9 +121,7 @@ if (OTEL_ENABLED) {
         sampler: new ParentBasedSampler({
             root: new TraceIdRatioBasedSampler(samplerArg)
         }),
-        traceExporter: new OTLPTraceExporter({
-            url: endpoint.startsWith('http') ? endpoint : `http://${endpoint}`
-        }),
+        spanProcessors: [spanProcessor],
         instrumentations: [
             getNodeAutoInstrumentations({
                 // 과도한 span 방지 — fs 계측 비활성
@@ -119,7 +134,10 @@ if (OTEL_ENABLED) {
 
     sdk.start();
     // eslint-disable-next-line no-console
-    console.log(`[telemetry] OTel started: endpoint=${endpoint} sampler=${samplerArg}`);
+    console.log(
+        `[telemetry] OTel started: endpoint=${endpoint} sampler=${samplerArg} ` +
+            `bsp(queue=1024 batch=128 delay=2000ms timeout=10000ms)`
+    );
 
     // Heap metrics logger — 4/22 OOM 이후 추가.
     // process.memoryUsage()를 60초마다 stdout에 JSON으로 출력 → OTel collector filelog receiver가


### PR DESCRIPTION
## 배경

Round 3 메모리 leak audit (`/home/angple/docs/2026-05-02-memory-round3-p1-audit.md` High 섹션) 후속.

OpenTelemetry **BSP (BatchSpanProcessor) 가 collector 장애 시 queue 항시 점유** → 4/24 RCA 의 `external/heap` 의심과 정합. NodeSDK 가 default 로 BSP 를 내부 생성하지만 default 값 (queue 2048) 은 메모리 부담이 큼.

## 변경 (telemetry.ts ~28 LOC)

`BatchSpanProcessor` 를 명시 구성하여 4개 파라미터 모두 인하:

| 파라미터 | OTel default | 변경 후 | 비율 |
| --- | --- | --- | --- |
| maxQueueSize | 2048 | 1024 | 1/2 |
| maxExportBatchSize | 512 | 128 | 1/4 |
| scheduledDelayMillis | 5000ms | 2000ms | 2.5배 자주 flush |
| exportTimeoutMillis | 30000ms | 10000ms | 1/3 |

모든 값 환경변수 (`OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`, `OTEL_BSP_SCHEDULE_DELAY_MS`, `OTEL_BSP_EXPORT_TIMEOUT_MS`) 로 override 가능 — 운영 중 튜닝 용이.

## 영향 분석

### Collector 정상
- `scheduledDelayMillis 5000 → 2000`: 더 자주 flush. 평소 1 batch (≤512 span) → 1 batch (≤128 span) × 4회 — **데이터 손실 없음**.
- export 횟수 ↑ → 네트워크/CPU 미미 영향. 10% 샘플링 + HTTP 계측만이라 무시 가능.

### Collector 장애
- queue 점유 메모리: 2048 span × ~1 KB → 1024 span × ~1 KB ≈ **~1 MB 절약/pod** (외부 메모리).
- `exportTimeoutMillis 30000 → 10000`: collector 응답 없을 때 3배 빠르게 drop → blocking 단축 → external 메모리 회복 빠름.
- queue overflow 시 정책: drop oldest (BSP 기본). default 환경에선 2048 까지 buffer 가능했지만 1024 로 인하 — 장애 중 더 빨리 drop, 정상 환경에선 영향 없음 (2000ms 마다 flush).

## 회귀 위험
- maxExportBatchSize 인하 → CPU/네트워크 호출 ↑: 무시 가능 (샘플링 0.1, HTTP-only 계측).
- 정상 telemetry 데이터 손실: 거의 없음 (더 자주 flush).
- API 변경: NodeSDK 의 `traceExporter` field 대신 `spanProcessors[]` 사용 (sdk-node 0.215 / sdk-trace-node 2.7 — `spanProcessor` 단수는 deprecated).

## 검증
- [x] `pnpm check` — telemetry.ts 관련 에러 0건 (잔존 2건은 packages/types 의 zod 모듈 미설치, 본 변경 무관)
- [x] prettier check pass
- [ ] 운영 배포 후 60s heap_metrics 로그의 `external` 추이 관찰 (Grafana otel.logs)
- [ ] collector 장애 시뮬레이션 (collector svc scale=0) → external 메모리 1 MB+ 절약 확인

## 출처
- audit: `/home/angple/docs/2026-05-02-memory-round3-p1-audit.md` High 섹션
- 4/24 heap leak RCA: `project_2026_04_24_heap_leak_rca.md` (external/heap 의심)