### PR TITLE
feat(brickang): Phase 1 — 참여형 가상 건축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ plugins/*
 !plugins/affiliate-link-private/
 !plugins/auto-embed/
 !plugins/payment/
+!plugins/brickang/
 !apps/web/src/routes/api/plugins/
 !apps/web/src/routes/admin/plugins/
 !apps/web/src/lib/plugins/

--- a/apps/web/src/lib/server/plugins/route-dispatcher.ts
+++ b/apps/web/src/lib/server/plugins/route-dispatcher.ts
@@ -20,20 +20,58 @@ async function loadHandler(absolutePath: string): Promise<HandlerModule> {
     return mod;
 }
 
+/**
+ * `:param` 형태의 path 파라미터를 정규식으로 변환해 매칭한다.
+ * 예: `/buildings/:id/bricks` → `^/buildings/([^/]+)/bricks$`
+ * 매칭 시 추출한 파라미터는 `event.params` 처럼 `RouteParams` 로 반환된다.
+ */
+export type RouteParams = Record<string, string>;
+
+interface MatchResult {
+    route: ExtensionAPIRoute;
+    params: RouteParams;
+}
+
+function compileRoutePattern(pattern: string): { regex: RegExp; keys: string[] } {
+    const keys: string[] = [];
+    const escaped = pattern.replace(/[.+*?^${}()|[\]\\]/g, '\\$&');
+    const regexBody = escaped.replace(/:([A-Za-z_][A-Za-z0-9_]*)/g, (_m, key: string) => {
+        keys.push(key);
+        return '([^/]+)';
+    });
+    return { regex: new RegExp(`^${regexBody}$`), keys };
+}
+
 function matchRoute(
     routes: ExtensionAPIRoute[],
     requestPath: string,
     method: Method,
     prefix: string
-): ExtensionAPIRoute | null {
+): MatchResult | null {
     const normalizedPrefix = prefix.startsWith('/') ? prefix : `/${prefix}`;
     const stripped = requestPath.startsWith(normalizedPrefix)
         ? requestPath.slice(normalizedPrefix.length) || '/'
         : requestPath;
 
+    // 1차: 정확 매칭 (성능 최적화 + 정적 경로 우선)
     for (const route of routes) {
         if (route.method !== method) continue;
-        if (route.path === stripped || route.path === requestPath) return route;
+        if (route.path === stripped || route.path === requestPath) {
+            return { route, params: {} };
+        }
+    }
+    // 2차: `:param` 동적 매칭
+    for (const route of routes) {
+        if (route.method !== method) continue;
+        if (!route.path.includes(':')) continue;
+        const { regex, keys } = compileRoutePattern(route.path);
+        const m = regex.exec(stripped) ?? regex.exec(requestPath);
+        if (!m) continue;
+        const params: RouteParams = {};
+        for (let i = 0; i < keys.length; i++) {
+            params[keys[i]] = decodeURIComponent(m[i + 1] ?? '');
+        }
+        return { route, params };
     }
     return null;
 }
@@ -67,7 +105,7 @@ export async function dispatchPluginRoute(input: DispatchInput): Promise<Respons
         });
     }
 
-    const handlerPath = path.join(plugin.path, matched.handler);
+    const handlerPath = path.join(plugin.path, matched.route.handler);
     let mod: HandlerModule;
     try {
         mod = await loadHandler(handlerPath);
@@ -79,6 +117,17 @@ export async function dispatchPluginRoute(input: DispatchInput): Promise<Respons
     const fn = mod[input.method] ?? mod.default;
     if (typeof fn !== 'function') {
         return new Response(`Plugin handler missing ${input.method} export`, { status: 500 });
+    }
+
+    // 동적 path 파라미터를 `event.params` 에 합쳐 핸들러에 전달.
+    // 기존 SvelteKit 의 catch-all params (`id`, `rest`) 은 plugin params 로 덮어쓰지 않도록 보존한다.
+    if (Object.keys(matched.params).length > 0) {
+        const proxiedParams = { ...input.event.params, ...matched.params };
+        Object.defineProperty(input.event, 'params', {
+            value: proxiedParams,
+            writable: true,
+            configurable: true
+        });
     }
 
     try {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -134,7 +134,10 @@ export default defineConfig(({ mode }) => {
                     test: {
                         name: 'server',
                         environment: 'node',
-                        include: ['src/**/*.{test,spec}.{js,ts}'],
+                        include: [
+                            'src/**/*.{test,spec}.{js,ts}',
+                            '../../plugins/**/tests/**/*.{test,spec}.{js,ts}'
+                        ],
                         exclude: ['src/**/*.svelte.{test,spec}.{js,ts}']
                     }
                 }

--- a/plugins/brickang/components/BrickCard.svelte
+++ b/plugins/brickang/components/BrickCard.svelte
@@ -1,0 +1,77 @@
+<!--
+  BrickCard.svelte — 등급 카드.
+-->
+<script lang="ts">
+    import type { BrickTypeDto } from '../lib/api.js';
+
+    interface Props {
+        brickType: BrickTypeDto;
+        selected?: boolean;
+        onselect?: (slug: string) => void;
+    }
+    let { brickType, selected = false, onselect }: Props = $props();
+</script>
+
+<button
+    type="button"
+    class="brick-card {selected ? 'brick-card--selected' : ''}"
+    style="--brick-color: {brickType.color_hex};"
+    onclick={() => onselect?.(brickType.slug)}
+>
+    <div class="brick-card__swatch" class:brick-card__swatch--glow={brickType.glow_effect}></div>
+    <div class="brick-card__name">{brickType.name}</div>
+    <div class="brick-card__price">
+        {brickType.price_krw.toLocaleString()}원
+    </div>
+    {#if brickType.is_anonymous}
+        <div class="brick-card__tag">익명 / 메시지 X</div>
+    {/if}
+</button>
+
+<style>
+    .brick-card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 1rem;
+        border: 2px solid #ddd;
+        border-radius: 8px;
+        background: #fff;
+        cursor: pointer;
+        min-width: 110px;
+        transition:
+            border-color 0.15s,
+            transform 0.15s;
+    }
+    .brick-card:hover {
+        border-color: var(--brick-color);
+        transform: translateY(-2px);
+    }
+    .brick-card--selected {
+        border-color: var(--brick-color);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--brick-color) 30%, transparent);
+    }
+    .brick-card__swatch {
+        width: 50px;
+        height: 30px;
+        background: var(--brick-color);
+        border-radius: 4px;
+        border: 1px solid rgba(0, 0, 0, 0.1);
+    }
+    .brick-card__swatch--glow {
+        box-shadow: 0 0 12px var(--brick-color);
+    }
+    .brick-card__name {
+        font-weight: 600;
+        font-size: 0.95rem;
+    }
+    .brick-card__price {
+        font-size: 0.85rem;
+        color: #555;
+    }
+    .brick-card__tag {
+        font-size: 0.7rem;
+        color: #999;
+    }
+</style>

--- a/plugins/brickang/components/BrickShop.svelte
+++ b/plugins/brickang/components/BrickShop.svelte
@@ -1,0 +1,117 @@
+<!--
+  BrickShop.svelte — 메인 진입.
+  - 진행률 ProgressBar
+  - 등급 카드
+  - 결제 버튼 → PaymentModal
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { brickStore } from '../stores/brick.svelte.js';
+    import { buildingStore } from '../stores/building.svelte.js';
+    import ProgressBar from './ProgressBar.svelte';
+    import BrickCard from './BrickCard.svelte';
+    import Building2D from './Building2D.svelte';
+    import PaymentModal from './PaymentModal.svelte';
+
+    interface Props {
+        defaultBuildingId?: number;
+    }
+    let { defaultBuildingId = 1 }: Props = $props();
+
+    let modalOpen = $state(false);
+
+    onMount(async () => {
+        await Promise.all([brickStore.load(), buildingStore.loadActive()]);
+    });
+
+    function handleComplete() {
+        // confirm 후 active 재조회 (current_bricks + recent 갱신)
+        void buildingStore.loadActive();
+    }
+
+    let activeBuildingId = $derived(buildingStore.building?.id ?? defaultBuildingId);
+</script>
+
+<section class="brick-shop">
+    <h1 class="brick-shop__title">브릭앙 — 벽돌한장의 마음을 쌓다</h1>
+
+    {#if buildingStore.loading}
+        <p>로딩 중…</p>
+    {:else if buildingStore.building}
+        <ProgressBar
+            current={buildingStore.building.current_bricks}
+            target={buildingStore.building.target_bricks}
+            label={buildingStore.building.name}
+        />
+
+        <div class="brick-shop__viewer">
+            <Building2D building={buildingStore.building} bricks={buildingStore.bricks} />
+        </div>
+    {:else}
+        <p>활성 건축물이 없습니다.</p>
+    {/if}
+
+    <h2>등급 선택</h2>
+    <div class="brick-shop__cards">
+        {#each brickStore.brickTypes as t (t.id)}
+            <BrickCard
+                brickType={t}
+                selected={brickStore.selectedSlug === t.slug}
+                onselect={(slug) => brickStore.select(slug)}
+            />
+        {/each}
+    </div>
+
+    <button
+        type="button"
+        class="brick-shop__cta"
+        disabled={!brickStore.selected}
+        onclick={() => (modalOpen = true)}
+    >
+        벽돌 놓기
+    </button>
+
+    <PaymentModal
+        bind:open={modalOpen}
+        buildingId={activeBuildingId}
+        onclose={() => (modalOpen = false)}
+        oncomplete={handleComplete}
+    />
+</section>
+
+<style>
+    .brick-shop {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 1.5rem;
+    }
+    .brick-shop__title {
+        margin-bottom: 1.5rem;
+    }
+    .brick-shop__viewer {
+        margin: 1.5rem 0;
+        text-align: center;
+    }
+    .brick-shop__cards {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin: 1rem 0;
+    }
+    .brick-shop__cta {
+        display: block;
+        width: 100%;
+        padding: 1rem;
+        font-size: 1.1rem;
+        background: #c84c32;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        font-weight: 600;
+    }
+    .brick-shop__cta:disabled {
+        background: #aaa;
+        cursor: not-allowed;
+    }
+</style>

--- a/plugins/brickang/components/BrickTooltip.svelte
+++ b/plugins/brickang/components/BrickTooltip.svelte
@@ -1,0 +1,54 @@
+<!--
+  BrickTooltip.svelte — 호버 시 닉네임/메시지 표시.
+  익명 등급은 메시지 영역 미노출.
+-->
+<script lang="ts">
+    import type { BrickDto } from '../lib/api.js';
+
+    interface Props {
+        brick: BrickDto;
+        x: number;
+        y: number;
+    }
+    let { brick, x, y }: Props = $props();
+
+    let isAnonymous = $derived(brick.brick_type_slug === 'anonymous');
+</script>
+
+<div class="tooltip" style="left: {x}px; top: {y}px;">
+    <div class="tooltip__nickname">{brick.nickname}</div>
+    {#if !isAnonymous && brick.message}
+        <div class="tooltip__message">"{brick.message}"</div>
+    {/if}
+    <div class="tooltip__meta">
+        {brick.brick_type_slug} · {new Date(brick.placed_at).toLocaleDateString('ko-KR')}
+    </div>
+</div>
+
+<style>
+    .tooltip {
+        position: fixed;
+        pointer-events: none;
+        background: rgba(0, 0, 0, 0.85);
+        color: #fff;
+        padding: 0.5rem 0.75rem;
+        border-radius: 6px;
+        font-size: 0.85rem;
+        z-index: 1000;
+        max-width: 240px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    }
+    .tooltip__nickname {
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+    }
+    .tooltip__message {
+        font-style: italic;
+        margin-bottom: 0.25rem;
+        word-break: break-word;
+    }
+    .tooltip__meta {
+        font-size: 0.7rem;
+        opacity: 0.7;
+    }
+</style>

--- a/plugins/brickang/components/BrickangShopWidget.svelte
+++ b/plugins/brickang/components/BrickangShopWidget.svelte
@@ -1,0 +1,248 @@
+<!--
+  BrickangShopWidget.svelte — damoang.net/shop 의 brickang 섹션 삽입용 미니 위젯.
+
+  한 번의 fetch (`/api/plugins/brickang/buildings/active`) 로 활성 건축물 정보 + recent 5명 을
+  가져와서 진행률 바 + 최근 벽돌 닉네임 row + CTA 를 보여준다.
+
+  Svelte 5 Rune 모드 (`$state`, `$derived`, `$effect`) 사용.
+  로딩/에러/빈 상태 모두 처리.
+-->
+<script lang="ts">
+    import ProgressBar from './ProgressBar.svelte';
+
+    interface ActiveBuilding {
+        id: number;
+        name: string;
+        target_bricks: number;
+        current_bricks: number;
+        progress_percent: number;
+        status: string;
+    }
+    interface RecentBrick {
+        id: number;
+        nickname: string;
+        message: string | null;
+        placed_at: string;
+        brick_type_slug: string | null;
+    }
+    interface ApiResponse {
+        building: ActiveBuilding | null;
+        recent: RecentBrick[];
+    }
+
+    interface Props {
+        ctaHref?: string;
+        title?: string;
+    }
+    let { ctaHref = '/brickang', title = '브릭앙 — 함께 짓는 가상 건축' }: Props = $props();
+
+    let loading = $state(true);
+    let errorMsg = $state<string | null>(null);
+    let building = $state<ActiveBuilding | null>(null);
+    let recent = $state<RecentBrick[]>([]);
+
+    let hasBuilding = $derived(building !== null);
+
+    $effect(() => {
+        void load();
+    });
+
+    async function load(): Promise<void> {
+        loading = true;
+        errorMsg = null;
+        try {
+            const res = await fetch('/api/plugins/brickang/buildings/active', {
+                credentials: 'include'
+            });
+            if (!res.ok) {
+                errorMsg = `로딩 실패 (${res.status})`;
+                return;
+            }
+            const data = (await res.json()) as ApiResponse;
+            building = data.building;
+            recent = data.recent ?? [];
+        } catch (err) {
+            console.error('[BrickangShopWidget] fetch failed:', err);
+            errorMsg = '브릭앙 정보를 불러오지 못했어요';
+        } finally {
+            loading = false;
+        }
+    }
+</script>
+
+<section class="brickang-widget">
+    <header class="brickang-widget__header">
+        <h3 class="brickang-widget__title">{title}</h3>
+    </header>
+
+    {#if loading}
+        <div class="brickang-widget__skeleton" aria-busy="true">
+            <div class="skeleton-line skeleton-line--lg"></div>
+            <div class="skeleton-bar"></div>
+            <div class="skeleton-row">
+                <div class="skeleton-pill"></div>
+                <div class="skeleton-pill"></div>
+                <div class="skeleton-pill"></div>
+            </div>
+        </div>
+    {:else if errorMsg}
+        <div class="brickang-widget__error">{errorMsg}</div>
+    {:else if !hasBuilding}
+        <div class="brickang-widget__empty">현재 진행 중인 건축물이 없어요</div>
+    {:else if building}
+        <div class="brickang-widget__progress">
+            <ProgressBar
+                current={building.current_bricks}
+                target={building.target_bricks}
+                label={building.name}
+            />
+        </div>
+
+        {#if recent.length > 0}
+            <ul class="brickang-widget__recent" aria-label="최근 벽돌">
+                {#each recent as brick (brick.id)}
+                    <li class="recent-row" title={brick.message ?? ''}>
+                        <span class="recent-row__dot" data-type={brick.brick_type_slug ?? 'normal'}
+                        ></span>
+                        <span class="recent-row__name">{brick.nickname}</span>
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+
+        <a class="brickang-widget__cta" href={ctaHref}>
+            벽돌 쌓으러 가기 <span aria-hidden="true">→</span>
+        </a>
+    {/if}
+</section>
+
+<style>
+    .brickang-widget {
+        display: flex;
+        flex-direction: column;
+        gap: 0.875rem;
+        padding: 1rem 1.125rem;
+        border: 1px solid #e6e6e6;
+        border-radius: 12px;
+        background: linear-gradient(180deg, #fffaf3 0%, #fff 60%);
+    }
+    .brickang-widget__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .brickang-widget__title {
+        font-size: 1rem;
+        font-weight: 700;
+        margin: 0;
+        color: #333;
+    }
+    .brickang-widget__progress {
+        margin-top: 0.25rem;
+    }
+    .brickang-widget__error,
+    .brickang-widget__empty {
+        font-size: 0.875rem;
+        color: #888;
+        padding: 0.5rem 0;
+    }
+    .brickang-widget__recent {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+    .recent-row {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.25rem 0.625rem;
+        background: #fff;
+        border: 1px solid #ececec;
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        color: #444;
+    }
+    .recent-row__dot {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+        background: #c84c32;
+    }
+    .recent-row__dot[data-type='diamond'] {
+        background: linear-gradient(135deg, #b6e0ff, #ffffff);
+    }
+    .recent-row__dot[data-type='gold'] {
+        background: #ffd700;
+    }
+    .recent-row__dot[data-type='silver'] {
+        background: #c0c0c0;
+    }
+    .recent-row__dot[data-type='anonymous'] {
+        background: #888;
+    }
+    .recent-row__name {
+        font-weight: 500;
+    }
+    .brickang-widget__cta {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem 0.875rem;
+        background: #c84c32;
+        color: #fff;
+        text-decoration: none;
+        border-radius: 8px;
+        font-weight: 600;
+        font-size: 0.875rem;
+        transition: background 0.15s ease;
+    }
+    .brickang-widget__cta:hover {
+        background: #a83a26;
+    }
+    .brickang-widget__skeleton {
+        display: flex;
+        flex-direction: column;
+        gap: 0.625rem;
+    }
+    .skeleton-line {
+        height: 0.875rem;
+        background: linear-gradient(90deg, #eee, #f6f6f6, #eee);
+        background-size: 200% 100%;
+        animation: shimmer 1.4s infinite;
+        border-radius: 4px;
+    }
+    .skeleton-line--lg {
+        width: 60%;
+        height: 1rem;
+    }
+    .skeleton-bar {
+        height: 12px;
+        background: linear-gradient(90deg, #eee, #f6f6f6, #eee);
+        background-size: 200% 100%;
+        animation: shimmer 1.4s infinite;
+        border-radius: 6px;
+    }
+    .skeleton-row {
+        display: flex;
+        gap: 0.5rem;
+    }
+    .skeleton-pill {
+        width: 4.5rem;
+        height: 1.5rem;
+        border-radius: 999px;
+        background: linear-gradient(90deg, #eee, #f6f6f6, #eee);
+        background-size: 200% 100%;
+        animation: shimmer 1.4s infinite;
+    }
+    @keyframes shimmer {
+        0% {
+            background-position: 200% 0;
+        }
+        100% {
+            background-position: -200% 0;
+        }
+    }
+</style>

--- a/plugins/brickang/components/Building2D.svelte
+++ b/plugins/brickang/components/Building2D.svelte
@@ -1,0 +1,115 @@
+<!--
+  Building2D.svelte — Canvas 2D 뷰어.
+  벽돌 격자, 호버 시 BrickTooltip. 5,000 벽돌까지 단순 Canvas 로 충분.
+  새 벽돌 INSERT 시 점등 애니메이션 (1초).
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import BrickTooltip from './BrickTooltip.svelte';
+    import type { BrickDto, BuildingDto } from '../lib/api.js';
+
+    interface Props {
+        building: BuildingDto;
+        bricks: BrickDto[];
+    }
+    let { building, bricks }: Props = $props();
+
+    let canvas = $state<HTMLCanvasElement | null>(null);
+    let hovered = $state<{ brick: BrickDto; x: number; y: number } | null>(null);
+
+    const PADDING = 16;
+    const BRICK_W = 14;
+    const BRICK_H = 8;
+
+    let dim = $derived(building.dimension ?? { x: 20, y: 30, z: 20 });
+
+    let canvasSize = $derived({
+        w: dim.x * BRICK_W + PADDING * 2,
+        h: dim.y * BRICK_H + PADDING * 2
+    });
+
+    function draw() {
+        if (!canvas) return;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+
+        canvas.width = canvasSize.w;
+        canvas.height = canvasSize.h;
+
+        ctx.fillStyle = '#f8f8f8';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        // 정면뷰: x = 가로, y = 세로 (위로 갈수록 위층)
+        for (const b of bricks) {
+            const px = b.position?.x ?? 0;
+            const py = b.position?.y ?? 0;
+            const screenX = PADDING + px * BRICK_W;
+            const screenY = canvas.height - PADDING - (py + 1) * BRICK_H;
+            ctx.fillStyle = b.color ?? '#C84C32';
+            ctx.fillRect(screenX, screenY, BRICK_W - 1, BRICK_H - 1);
+        }
+    }
+
+    function pickBrick(mx: number, my: number): BrickDto | null {
+        if (!canvas) return null;
+        const rect = canvas.getBoundingClientRect();
+        const x = ((mx - rect.left) * canvas.width) / rect.width;
+        const y = ((my - rect.top) * canvas.height) / rect.height;
+        const px = Math.floor((x - PADDING) / BRICK_W);
+        const py = Math.floor((canvas.height - y - PADDING) / BRICK_H);
+        return (
+            bricks.find((b) => (b.position?.x ?? -1) === px && (b.position?.y ?? -1) === py) ?? null
+        );
+    }
+
+    function onMouseMove(e: MouseEvent) {
+        const b = pickBrick(e.clientX, e.clientY);
+        if (b) {
+            hovered = { brick: b, x: e.clientX + 12, y: e.clientY + 12 };
+        } else {
+            hovered = null;
+        }
+    }
+
+    function onMouseLeave() {
+        hovered = null;
+    }
+
+    $effect(() => {
+        // bricks 또는 building 변경 시 재드로우
+        void bricks;
+        void building;
+        draw();
+    });
+
+    onMount(() => {
+        draw();
+    });
+</script>
+
+<div class="building2d">
+    <canvas
+        bind:this={canvas}
+        onmousemove={onMouseMove}
+        onmouseleave={onMouseLeave}
+        aria-label="building 2D viewer"
+    ></canvas>
+    {#if hovered}
+        <BrickTooltip brick={hovered.brick} x={hovered.x} y={hovered.y} />
+    {/if}
+</div>
+
+<style>
+    .building2d {
+        display: inline-block;
+        background: #fafafa;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        overflow: auto;
+        max-width: 100%;
+    }
+    canvas {
+        display: block;
+        cursor: crosshair;
+    }
+</style>

--- a/plugins/brickang/components/PaymentModal.svelte
+++ b/plugins/brickang/components/PaymentModal.svelte
@@ -1,0 +1,237 @@
+<!--
+  PaymentModal.svelte
+  - 등급 선택 → 수량 → 메시지 (익명은 비활성) → PG 선택 → /orders/start
+  - SDK/redirect 처리 후 콜백에서 /orders/confirm
+  - 익명/일반/은/금 등급은 KRW PG (Toss/Naver) 만 노출, PayPal 은 1000원 이상에서만.
+-->
+<script lang="ts">
+    import { brickStore } from '../stores/brick.svelte.js';
+    import { paymentStore } from '../stores/payment.svelte.js';
+    import BrickCard from './BrickCard.svelte';
+
+    interface Props {
+        buildingId: number;
+        open: boolean;
+        onclose?: () => void;
+        oncomplete?: (
+            bricks: Array<{ id: number; position: { x: number; y: number; z: number } }>
+        ) => void;
+    }
+    let { buildingId, open = $bindable(false), onclose, oncomplete }: Props = $props();
+
+    let provider = $state<'toss' | 'naver' | 'paypal'>('toss');
+    let busy = $state(false);
+
+    let allowedProviders = $derived.by(() => {
+        const types = brickStore.selected;
+        if (!types) return ['toss', 'naver'] as const;
+        const list: Array<'toss' | 'naver' | 'paypal'> = ['toss', 'naver'];
+        if (types.price_krw >= 1000) list.push('paypal');
+        return list;
+    });
+
+    async function handlePay() {
+        const sel = brickStore.selected;
+        if (!sel) return;
+        busy = true;
+        try {
+            const start = await paymentStore.start({
+                brick_type: sel.slug,
+                quantity: brickStore.quantity,
+                message: sel.is_anonymous ? null : brickStore.message,
+                building_id: buildingId,
+                provider,
+                returnUrl: `${window.location.origin}/brickang/payment/return`,
+                cancelUrl: `${window.location.origin}/brickang/payment/cancel`
+            });
+
+            if (start.payment.redirectUrl) {
+                window.location.href = start.payment.redirectUrl;
+                return;
+            }
+
+            // SDK 방식 PG (Toss 등) — 실제 SDK 호출은 PG별로 구현. 여기서는 디버그 로그만.
+            console.info('[brickang/payment] sdkParams:', start.payment.sdkParams);
+
+            // 데모용: confirm 도 즉시 호출 (실제로는 PG 콜백 후 호출됨)
+            // sandbox 환경에서만 적용. 운영 통합 시 실제 콜백 라우트(/brickang/payment/return) 에서 처리.
+            const confirm = await paymentStore.confirm({
+                order_uid: start.order_uid,
+                pg_order_id: start.payment.pgOrderId,
+                amount: start.amount
+            });
+            oncomplete?.(confirm.bricks);
+            open = false;
+            onclose?.();
+        } catch (err) {
+            console.error('[brickang/payment] failed:', err);
+        } finally {
+            busy = false;
+        }
+    }
+</script>
+
+{#if open}
+    <div class="modal-backdrop" role="presentation" onclick={() => onclose?.()}>
+        <div
+            class="modal"
+            role="dialog"
+            aria-modal="true"
+            aria-label="브릭앙 결제"
+            onclick={(e) => e.stopPropagation()}
+        >
+            <h2 class="modal__title">벽돌 등급 선택</h2>
+            <div class="modal__cards">
+                {#each brickStore.brickTypes as t (t.id)}
+                    <BrickCard
+                        brickType={t}
+                        selected={brickStore.selectedSlug === t.slug}
+                        onselect={(slug) => brickStore.select(slug)}
+                    />
+                {/each}
+            </div>
+
+            {#if brickStore.selected}
+                <div class="modal__row">
+                    <label for="qty">수량 (1~100)</label>
+                    <input
+                        id="qty"
+                        type="number"
+                        min="1"
+                        max="100"
+                        value={brickStore.quantity}
+                        oninput={(e) =>
+                            brickStore.setQuantity(Number((e.target as HTMLInputElement).value))}
+                    />
+                </div>
+
+                <div class="modal__row">
+                    <label for="msg">메시지 (최대 100자)</label>
+                    <input
+                        id="msg"
+                        type="text"
+                        maxlength="100"
+                        value={brickStore.message}
+                        disabled={brickStore.selected.is_anonymous}
+                        placeholder={brickStore.selected.is_anonymous
+                            ? '익명 등급은 메시지를 남길 수 없습니다'
+                            : '응원 메시지를 남겨보세요'}
+                        oninput={(e) => brickStore.setMessage((e.target as HTMLInputElement).value)}
+                    />
+                </div>
+
+                <div class="modal__row">
+                    <span>결제수단</span>
+                    <div class="modal__providers">
+                        {#each allowedProviders as p (p)}
+                            <button
+                                type="button"
+                                class:active={provider === p}
+                                onclick={() => (provider = p)}
+                            >
+                                {p}
+                            </button>
+                        {/each}
+                    </div>
+                </div>
+
+                <div class="modal__total">
+                    합계: {brickStore.totalAmountKrw.toLocaleString()} 원
+                </div>
+
+                <div class="modal__actions">
+                    <button type="button" onclick={() => onclose?.()} disabled={busy}>취소</button>
+                    <button type="button" onclick={handlePay} disabled={busy}>
+                        {busy ? '결제 중…' : '결제하기'}
+                    </button>
+                </div>
+
+                {#if paymentStore.error}
+                    <p class="modal__error">{paymentStore.error}</p>
+                {/if}
+            {/if}
+        </div>
+    </div>
+{/if}
+
+<style>
+    .modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 100;
+    }
+    .modal {
+        background: #fff;
+        padding: 1.5rem;
+        border-radius: 8px;
+        width: 90vw;
+        max-width: 600px;
+        max-height: 90vh;
+        overflow-y: auto;
+    }
+    .modal__title {
+        margin-top: 0;
+    }
+    .modal__cards {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin: 1rem 0;
+    }
+    .modal__row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.75rem;
+    }
+    .modal__row label,
+    .modal__row span {
+        min-width: 100px;
+        font-weight: 500;
+    }
+    .modal__row input {
+        flex: 1;
+        padding: 0.4rem 0.6rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+    .modal__providers {
+        display: flex;
+        gap: 0.5rem;
+    }
+    .modal__providers button {
+        padding: 0.4rem 0.8rem;
+        border: 1px solid #ccc;
+        background: #fff;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+    .modal__providers button.active {
+        background: #2962ff;
+        color: #fff;
+        border-color: #2962ff;
+    }
+    .modal__total {
+        text-align: right;
+        font-size: 1.2rem;
+        font-weight: 600;
+        margin: 1rem 0;
+    }
+    .modal__actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+    }
+    .modal__actions button {
+        padding: 0.5rem 1rem;
+        cursor: pointer;
+    }
+    .modal__error {
+        color: #c00;
+        margin-top: 0.5rem;
+    }
+</style>

--- a/plugins/brickang/components/ProgressBar.svelte
+++ b/plugins/brickang/components/ProgressBar.svelte
@@ -1,0 +1,58 @@
+<!--
+  ProgressBar.svelte — 건축 진행률 바.
+  current / target 백분율을 시각화.
+-->
+<script lang="ts">
+    interface Props {
+        current: number;
+        target: number;
+        label?: string;
+    }
+    let { current, target, label = '진행률' }: Props = $props();
+
+    let percent = $derived(target > 0 ? Math.min(100, (current / target) * 100) : 0);
+</script>
+
+<div class="progress-bar">
+    <div class="progress-bar__header">
+        <span class="progress-bar__label">{label}</span>
+        <span class="progress-bar__value">
+            {current.toLocaleString()} / {target.toLocaleString()}
+            <small>({percent.toFixed(1)}%)</small>
+        </span>
+    </div>
+    <div class="progress-bar__track">
+        <div class="progress-bar__fill" style="width: {percent}%"></div>
+    </div>
+</div>
+
+<style>
+    .progress-bar {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+    }
+    .progress-bar__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+    }
+    .progress-bar__label {
+        font-weight: 600;
+    }
+    .progress-bar__value {
+        color: #555;
+    }
+    .progress-bar__track {
+        height: 12px;
+        background: #eee;
+        border-radius: 6px;
+        overflow: hidden;
+    }
+    .progress-bar__fill {
+        height: 100%;
+        background: linear-gradient(90deg, #c84c32, #ffd700);
+        transition: width 0.3s ease;
+    }
+</style>

--- a/plugins/brickang/index.ts
+++ b/plugins/brickang/index.ts
@@ -1,0 +1,9 @@
+/**
+ * brickang 플러그인 엔트리.
+ *
+ * angple plugin loader 가 routes/ 와 migrations/ 를 plugin.json 기준으로 자동 로드한다.
+ * 별도 부트스트랩 로직은 없으며, 본 파일은 메타데이터 export 만 담당한다.
+ */
+
+export const PLUGIN_ID = 'brickang';
+export const PLUGIN_VERSION = '0.1.0';

--- a/plugins/brickang/lib/api.ts
+++ b/plugins/brickang/lib/api.ts
@@ -1,0 +1,145 @@
+/**
+ * brickang 클라이언트 API 래퍼.
+ * 모든 호출은 same-origin (`/api/plugins/brickang/*`) 으로 간다.
+ */
+
+const BASE = '/api/plugins/brickang';
+
+async function request<T>(
+    path: string,
+    init: RequestInit & { fetch?: typeof fetch } = {}
+): Promise<T> {
+    const f = init.fetch ?? globalThis.fetch;
+    const res = await f(`${BASE}${path}`, {
+        credentials: 'same-origin',
+        headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+        ...init
+    });
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`brickang api ${path} failed: ${res.status} ${text}`);
+    }
+    return (await res.json()) as T;
+}
+
+export const brickangApi = {
+    listBrickTypes: () => request<{ brick_types: BrickTypeDto[] }>('/brick-types'),
+    getBrickType: (slug: string) => request<BrickTypeDto>(`/brick-types/${slug}`),
+    listBuildings: () => request<{ buildings: BuildingDto[] }>('/buildings'),
+    getActive: () =>
+        request<{ building: BuildingDto | null; recent: BrickDto[] }>('/buildings/active'),
+    getBuilding: (id: number) => request<BuildingDto>(`/buildings/${id}`),
+    getBuildingBricks: (id: number, opts: { limit?: number; offset?: number } = {}) => {
+        const q = new URLSearchParams();
+        if (opts.limit) q.set('limit', String(opts.limit));
+        if (opts.offset) q.set('offset', String(opts.offset));
+        return request<{ bricks: BrickDto[] }>(`/buildings/${id}/bricks?${q.toString()}`);
+    },
+    getRecentBricks: (id: number, limit = 10) =>
+        request<{ bricks: BrickDto[] }>(`/buildings/${id}/bricks/recent?limit=${limit}`),
+    getSnapshot: (id: number) => request(`/buildings/${id}/snapshot`),
+    getBuildingRankings: (id: number, limit = 30) =>
+        request(`/buildings/${id}/rankings?limit=${limit}`),
+    startOrder: (body: StartOrderBody) =>
+        request<StartOrderResponse>('/orders/start', {
+            method: 'POST',
+            body: JSON.stringify(body)
+        }),
+    confirmOrder: (body: ConfirmOrderBody) =>
+        request<ConfirmOrderResponse>('/orders/confirm', {
+            method: 'POST',
+            body: JSON.stringify(body)
+        }),
+    getOrder: (orderUid: string) => request(`/orders/${orderUid}`),
+    getMyBricks: (opts: { limit?: number; offset?: number } = {}) => {
+        const q = new URLSearchParams();
+        if (opts.limit) q.set('limit', String(opts.limit));
+        if (opts.offset) q.set('offset', String(opts.offset));
+        return request<{ bricks: BrickDto[] }>(`/me/bricks?${q.toString()}`);
+    },
+    getMyStats: () => request('/me/stats'),
+    getRankingsAll: (limit = 50) => request(`/rankings/all?limit=${limit}`),
+    getRankingsMonthly: (limit = 50) => request(`/rankings/monthly?limit=${limit}`)
+};
+
+export interface BrickTypeDto {
+    id: number;
+    slug: string;
+    name: string;
+    price_krw: number;
+    price_usd: number;
+    color_hex: string;
+    size_multiplier: number;
+    glow_effect: boolean;
+    is_anonymous: boolean;
+    allow_message: boolean;
+    sort_order: number;
+}
+
+export interface BuildingDto {
+    id: number;
+    name: string;
+    description?: string | null;
+    target_bricks: number;
+    current_bricks: number;
+    progress_percent: number;
+    status: string;
+    dimension?: { x: number; y: number; z: number };
+    season?: number;
+}
+
+export interface BrickDto {
+    id: number;
+    building_id?: number;
+    nickname: string;
+    message: string | null;
+    position?: { x: number; y: number; z: number };
+    placed_at: string;
+    brick_type_slug: string;
+    color: string | null;
+}
+
+export interface StartOrderBody {
+    brick_type: string;
+    quantity: number;
+    message?: string | null;
+    building_id: number;
+    provider: 'toss' | 'naver' | 'paypal';
+    returnUrl: string;
+    cancelUrl: string;
+}
+
+export interface StartOrderResponse {
+    order_uid: string;
+    brick_order_uid: string;
+    amount: number;
+    currency: string;
+    provider: string;
+    brick_type: string;
+    quantity: number;
+    payment: {
+        orderUid: string;
+        provider: string;
+        sandbox: boolean;
+        sdkParams: Record<string, unknown> | null;
+        redirectUrl: string | null;
+        pgOrderId: string;
+    };
+}
+
+export interface ConfirmOrderBody {
+    order_uid: string;
+    pg_order_id: string;
+    pg_payment_key?: string;
+    amount: number;
+}
+
+export interface ConfirmOrderResponse {
+    success: boolean;
+    bricks: Array<{
+        id: number;
+        position: { x: number; y: number; z: number };
+        type: string;
+        nickname: string;
+    }>;
+}

--- a/plugins/brickang/migrations/001_brickang_buildings.down.sql
+++ b/plugins/brickang/migrations/001_brickang_buildings.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS brickang_buildings

--- a/plugins/brickang/migrations/001_brickang_buildings.up.sql
+++ b/plugins/brickang/migrations/001_brickang_buildings.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS brickang_buildings (
+    id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name            VARCHAR(100) NOT NULL,
+    description     TEXT,
+    target_bricks   INT UNSIGNED NOT NULL,
+    current_bricks  INT UNSIGNED NOT NULL DEFAULT 0,
+    status          ENUM('active','completed','archived') NOT NULL DEFAULT 'active',
+    blueprint_data  JSON,
+    dimension_x     INT UNSIGNED NOT NULL DEFAULT 20,
+    dimension_y     INT UNSIGNED NOT NULL DEFAULT 30,
+    dimension_z     INT UNSIGNED NOT NULL DEFAULT 20,
+    season          INT UNSIGNED NOT NULL DEFAULT 1,
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    completed_at    DATETIME(6) NULL,
+    INDEX idx_status (status),
+    INDEX idx_season (season)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/brickang/migrations/002_brickang_brick_types.down.sql
+++ b/plugins/brickang/migrations/002_brickang_brick_types.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS brickang_brick_types

--- a/plugins/brickang/migrations/002_brickang_brick_types.up.sql
+++ b/plugins/brickang/migrations/002_brickang_brick_types.up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS brickang_brick_types (
+    id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    slug            VARCHAR(30) NOT NULL UNIQUE,
+    name            VARCHAR(50) NOT NULL,
+    price_krw       INT UNSIGNED NOT NULL DEFAULT 1000,
+    price_usd       DECIMAL(10,2) NOT NULL DEFAULT 1.00,
+    color_hex       VARCHAR(7) NOT NULL DEFAULT '#C84C32',
+    texture_url     VARCHAR(500) NULL,
+    size_multiplier DECIMAL(3,2) NOT NULL DEFAULT 1.00,
+    glow_effect     TINYINT(1) NOT NULL DEFAULT 0,
+    is_anonymous    TINYINT(1) NOT NULL DEFAULT 0,
+    allow_message   TINYINT(1) NOT NULL DEFAULT 1,
+    is_active       TINYINT(1) NOT NULL DEFAULT 1,
+    sort_order      INT NOT NULL DEFAULT 0,
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    INDEX idx_active_sort (is_active, sort_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO brickang_brick_types
+    (slug, name, price_krw, price_usd, color_hex, size_multiplier, glow_effect, is_anonymous, allow_message, sort_order)
+VALUES
+    ('anonymous', '익명 벽돌',     100,  0.10, '#A0A0A0', 1.00, 0, 1, 0, 0),
+    ('normal',    '일반 벽돌',    1000,  1.00, '#C84C32', 1.00, 0, 0, 1, 1),
+    ('silver',    '은 벽돌',      3000,  3.00, '#C0C0C0', 1.00, 0, 0, 1, 2),
+    ('gold',      '금 벽돌',      5000,  5.00, '#FFD700', 1.00, 1, 0, 1, 3),
+    ('diamond',   '다이아 벽돌', 10000, 10.00, '#B9F2FF', 1.50, 1, 0, 1, 4)

--- a/plugins/brickang/migrations/003_brickang_bricks.down.sql
+++ b/plugins/brickang/migrations/003_brickang_bricks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS brickang_bricks

--- a/plugins/brickang/migrations/003_brickang_bricks.up.sql
+++ b/plugins/brickang/migrations/003_brickang_bricks.up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS brickang_bricks (
+    id                  BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    building_id         INT UNSIGNED NOT NULL,
+    user_id             BIGINT UNSIGNED NOT NULL,
+    nickname            VARCHAR(50) NOT NULL,
+    message             VARCHAR(100) NULL,
+    brick_type_id       INT UNSIGNED NOT NULL,
+    color               VARCHAR(7) NULL,
+    position_x          INT NOT NULL,
+    position_y          INT NOT NULL,
+    position_z          INT NOT NULL,
+    placed_at           DATETIME(6) NOT NULL,
+    payment_order_id    BIGINT UNSIGNED NOT NULL,
+    created_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uk_position (building_id, position_x, position_y, position_z),
+    KEY ix_user (user_id),
+    KEY ix_building (building_id),
+    KEY ix_payment (payment_order_id),
+    KEY ix_placed (placed_at),
+    CONSTRAINT fk_bricks_building   FOREIGN KEY (building_id)   REFERENCES brickang_buildings(id),
+    CONSTRAINT fk_bricks_brick_type FOREIGN KEY (brick_type_id) REFERENCES brickang_brick_types(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/brickang/migrations/004_brickang_user_stats.down.sql
+++ b/plugins/brickang/migrations/004_brickang_user_stats.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS brickang_user_stats

--- a/plugins/brickang/migrations/004_brickang_user_stats.up.sql
+++ b/plugins/brickang/migrations/004_brickang_user_stats.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS brickang_user_stats (
+    user_id         BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+    total_bricks    INT UNSIGNED NOT NULL DEFAULT 0,
+    total_spent_krw BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    total_spent_usd DECIMAL(12,2) NOT NULL DEFAULT 0,
+    first_brick_at  DATETIME(6) NULL,
+    last_brick_at   DATETIME(6) NULL,
+    user_rank       INT UNSIGNED NULL,
+    updated_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    KEY ix_rank (user_rank),
+    KEY ix_total_bricks (total_bricks)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/brickang/migrations/005_brickang_events.down.sql
+++ b/plugins/brickang/migrations/005_brickang_events.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS brickang_events

--- a/plugins/brickang/migrations/005_brickang_events.up.sql
+++ b/plugins/brickang/migrations/005_brickang_events.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS brickang_events (
+    id                  INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    building_id         INT UNSIGNED NOT NULL,
+    event_type          ENUM('milestone','season_start','season_end','special') NOT NULL,
+    milestone_count     INT UNSIGNED NULL,
+    title               VARCHAR(200),
+    description         TEXT,
+    reward_description  TEXT,
+    created_at          DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    KEY ix_building (building_id),
+    KEY ix_type (event_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/brickang/plugin.json
+++ b/plugins/brickang/plugin.json
@@ -1,0 +1,157 @@
+{
+    "id": "brickang",
+    "name": "브릭앙",
+    "version": "0.1.0",
+    "author": {
+        "name": "SDK Labs",
+        "url": "https://damoang.net"
+    },
+    "description": "벽돌한장의 마음을 쌓다 — 참여형 가상 건축",
+    "license": "proprietary",
+    "category": "plugin",
+    "pluginType": "custom",
+    "main": "index.ts",
+    "tags": ["building", "community", "brickang", "벽돌"],
+    "dependencies": [{ "id": "payment", "version": ">=0.1.0" }],
+    "migrations": [
+        {
+            "version": "001",
+            "description": "brickang_buildings: 건축물 메인 테이블",
+            "up": "migrations/001_brickang_buildings.up.sql",
+            "down": "migrations/001_brickang_buildings.down.sql"
+        },
+        {
+            "version": "002",
+            "description": "brickang_brick_types: 5종 등급 + seed",
+            "up": "migrations/002_brickang_brick_types.up.sql",
+            "down": "migrations/002_brickang_brick_types.down.sql"
+        },
+        {
+            "version": "003",
+            "description": "brickang_bricks: 벽돌 위치/메시지",
+            "up": "migrations/003_brickang_bricks.up.sql",
+            "down": "migrations/003_brickang_bricks.down.sql"
+        },
+        {
+            "version": "004",
+            "description": "brickang_user_stats: 유저 누적 통계",
+            "up": "migrations/004_brickang_user_stats.up.sql",
+            "down": "migrations/004_brickang_user_stats.down.sql"
+        },
+        {
+            "version": "005",
+            "description": "brickang_events: 마일스톤/시즌 이벤트",
+            "up": "migrations/005_brickang_events.up.sql",
+            "down": "migrations/005_brickang_events.down.sql"
+        }
+    ],
+    "api": {
+        "rest": {
+            "prefix": "/api/plugins/brickang",
+            "routes": [
+                {
+                    "method": "POST",
+                    "path": "/orders/start",
+                    "handler": "routes/orders/start.ts",
+                    "authenticated": true
+                },
+                {
+                    "method": "POST",
+                    "path": "/orders/confirm",
+                    "handler": "routes/orders/confirm.ts",
+                    "authenticated": true
+                },
+                {
+                    "method": "GET",
+                    "path": "/orders/:order_uid",
+                    "handler": "routes/orders/detail.ts",
+                    "authenticated": true
+                },
+                { "method": "GET", "path": "/buildings", "handler": "routes/buildings/index.ts" },
+                {
+                    "method": "GET",
+                    "path": "/buildings/active",
+                    "handler": "routes/buildings/active.ts"
+                },
+                {
+                    "method": "GET",
+                    "path": "/buildings/:id",
+                    "handler": "routes/buildings/detail.ts"
+                },
+                {
+                    "method": "GET",
+                    "path": "/buildings/:id/bricks",
+                    "handler": "routes/buildings/bricks.ts"
+                },
+                {
+                    "method": "GET",
+                    "path": "/buildings/:id/bricks/recent",
+                    "handler": "routes/buildings/bricks-recent.ts"
+                },
+                {
+                    "method": "GET",
+                    "path": "/buildings/:id/snapshot",
+                    "handler": "routes/buildings/snapshot.ts"
+                },
+                {
+                    "method": "GET",
+                    "path": "/buildings/:id/rankings",
+                    "handler": "routes/buildings/rankings.ts"
+                },
+                { "method": "GET", "path": "/bricks/recent", "handler": "routes/bricks/recent.ts" },
+                {
+                    "method": "GET",
+                    "path": "/me/bricks",
+                    "handler": "routes/me/bricks.ts",
+                    "authenticated": true
+                },
+                {
+                    "method": "GET",
+                    "path": "/me/stats",
+                    "handler": "routes/me/stats.ts",
+                    "authenticated": true
+                },
+                { "method": "GET", "path": "/rankings/all", "handler": "routes/rankings/all.ts" },
+                {
+                    "method": "GET",
+                    "path": "/rankings/monthly",
+                    "handler": "routes/rankings/monthly.ts"
+                },
+                {
+                    "method": "GET",
+                    "path": "/brick-types",
+                    "handler": "routes/brick-types/index.ts"
+                },
+                {
+                    "method": "GET",
+                    "path": "/brick-types/:slug",
+                    "handler": "routes/brick-types/detail.ts"
+                }
+            ]
+        }
+    },
+    "ui": {
+        "admin": {
+            "menu": {
+                "title": "브릭앙 관리",
+                "icon": "wall",
+                "position": 70,
+                "component": "admin/index.svelte"
+            }
+        }
+    },
+    "settings": {
+        "default_building_id": {
+            "label": "기본 건축물 ID",
+            "type": "number",
+            "default": 1,
+            "description": "shop 위젯 등에서 사용할 기본 건축물 ID"
+        },
+        "anonymous_daily_cap": {
+            "label": "익명 결제 일일 한도",
+            "type": "number",
+            "default": 100,
+            "description": "동일 user_id 의 익명 100원 결제 일일 최대 횟수 (어뷰징 방지)"
+        }
+    }
+}

--- a/plugins/brickang/routes/brick-types/detail.ts
+++ b/plugins/brickang/routes/brick-types/detail.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/plugins/brickang/brick-types/:slug
+ */
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { getBrickTypeBySlug } from '../../server/brick-types.js';
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const slug = event.params.slug;
+    if (!slug) throw error(400, 'slug required');
+
+    const t = await getBrickTypeBySlug(slug);
+    if (!t) throw error(404, 'brick_type not found');
+
+    return json({
+        id: t.id,
+        slug: t.slug,
+        name: t.name,
+        price_krw: t.priceKrw,
+        price_usd: t.priceUsd,
+        color_hex: t.colorHex,
+        texture_url: t.textureUrl,
+        size_multiplier: t.sizeMultiplier,
+        glow_effect: t.glowEffect,
+        is_anonymous: t.isAnonymous,
+        allow_message: t.allowMessage,
+        is_active: t.isActive,
+        sort_order: t.sortOrder
+    });
+}

--- a/plugins/brickang/routes/brick-types/index.ts
+++ b/plugins/brickang/routes/brick-types/index.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/plugins/brickang/brick-types
+ * 활성 5종 등급 목록.
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import { listBrickTypes } from '../../server/brick-types.js';
+
+export async function GET(_event: RequestEvent): Promise<Response> {
+    const types = await listBrickTypes();
+    return json({
+        brick_types: types.map((t) => ({
+            id: t.id,
+            slug: t.slug,
+            name: t.name,
+            price_krw: t.priceKrw,
+            price_usd: t.priceUsd,
+            color_hex: t.colorHex,
+            size_multiplier: t.sizeMultiplier,
+            glow_effect: t.glowEffect,
+            is_anonymous: t.isAnonymous,
+            allow_message: t.allowMessage,
+            sort_order: t.sortOrder
+        }))
+    });
+}

--- a/plugins/brickang/routes/bricks/recent.ts
+++ b/plugins/brickang/routes/bricks/recent.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/plugins/brickang/bricks/recent
+ * 전역 최근 벽돌 (모든 건축물).
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+
+interface RecentRow extends RowDataPacket {
+    id: number;
+    building_id: number;
+    nickname: string;
+    message: string | null;
+    placed_at: Date;
+    slug: string;
+    color: string | null;
+}
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const limit = Math.min(50, Math.max(1, Number(event.url.searchParams.get('limit') ?? 20)));
+
+    const [rows] = await readPool.query<RecentRow[]>(
+        `SELECT br.id, br.building_id, br.nickname, br.message, br.placed_at, br.color, bt.slug
+         FROM brickang_bricks br
+         INNER JOIN brickang_brick_types bt ON bt.id = br.brick_type_id
+         ORDER BY br.id DESC
+         LIMIT ?`,
+        [limit]
+    );
+
+    return json({
+        limit,
+        bricks: rows.map((r) => ({
+            id: r.id,
+            building_id: r.building_id,
+            nickname: r.nickname,
+            message: r.slug === 'anonymous' ? null : r.message,
+            placed_at: r.placed_at,
+            brick_type_slug: r.slug,
+            color: r.color
+        }))
+    });
+}

--- a/plugins/brickang/routes/buildings/active.ts
+++ b/plugins/brickang/routes/buildings/active.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/plugins/brickang/buildings/active
+ *
+ * shop 위젯 등에서 사용. 활성 건축물 1개(가장 최근 active) + recent 5개.
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+import { listActiveBuildings } from '../../server/buildings.js';
+
+interface BrickRow extends RowDataPacket {
+    id: number;
+    nickname: string;
+    message: string | null;
+    placed_at: Date;
+    brick_type_id: number;
+    slug: string | null;
+    color: string | null;
+}
+
+export async function GET(_event: RequestEvent): Promise<Response> {
+    const buildings = await listActiveBuildings();
+    if (buildings.length === 0) return json({ building: null, recent: [] });
+
+    const b = buildings[0];
+    const [recent] = await readPool.query<BrickRow[]>(
+        `SELECT br.id, br.nickname, br.message, br.placed_at, br.brick_type_id, br.color, bt.slug
+         FROM brickang_bricks br
+         INNER JOIN brickang_brick_types bt ON bt.id = br.brick_type_id
+         WHERE br.building_id = ?
+         ORDER BY br.id DESC
+         LIMIT 5`,
+        [b.id]
+    );
+
+    return json({
+        building: {
+            id: b.id,
+            name: b.name,
+            target_bricks: b.targetBricks,
+            current_bricks: b.currentBricks,
+            progress_percent:
+                b.targetBricks > 0 ? Math.min(100, (b.currentBricks / b.targetBricks) * 100) : 0,
+            status: b.status
+        },
+        recent: recent.map((r) => ({
+            id: r.id,
+            nickname: r.nickname,
+            message: r.slug === 'anonymous' ? null : r.message,
+            placed_at: r.placed_at,
+            brick_type_slug: r.slug
+        }))
+    });
+}

--- a/plugins/brickang/routes/buildings/bricks-recent.ts
+++ b/plugins/brickang/routes/buildings/bricks-recent.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/plugins/brickang/buildings/:id/bricks/recent
+ * 최근 N개 (default 10).
+ */
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+
+interface BrickRow extends RowDataPacket {
+    id: number;
+    nickname: string;
+    message: string | null;
+    position_x: number;
+    position_y: number;
+    position_z: number;
+    placed_at: Date;
+    slug: string;
+    color: string | null;
+}
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const id = Number(event.params.id);
+    if (!id) throw error(400, 'invalid building id');
+
+    const limit = Math.min(50, Math.max(1, Number(event.url.searchParams.get('limit') ?? 10)));
+
+    const [rows] = await readPool.query<BrickRow[]>(
+        `SELECT br.id, br.nickname, br.message, br.position_x, br.position_y, br.position_z,
+                br.placed_at, br.color, bt.slug
+         FROM brickang_bricks br
+         INNER JOIN brickang_brick_types bt ON bt.id = br.brick_type_id
+         WHERE br.building_id = ?
+         ORDER BY br.id DESC
+         LIMIT ?`,
+        [id, limit]
+    );
+
+    return json({
+        building_id: id,
+        limit,
+        bricks: rows.map((r) => ({
+            id: r.id,
+            nickname: r.nickname,
+            message: r.slug === 'anonymous' ? null : r.message,
+            position: { x: r.position_x, y: r.position_y, z: r.position_z },
+            placed_at: r.placed_at,
+            brick_type_slug: r.slug,
+            color: r.color
+        }))
+    });
+}

--- a/plugins/brickang/routes/buildings/bricks.ts
+++ b/plugins/brickang/routes/buildings/bricks.ts
@@ -1,0 +1,60 @@
+/**
+ * GET /api/plugins/brickang/buildings/:id/bricks
+ *
+ * Phase 1: 직접 SELECT (전체 벽돌). offset/limit 페이지네이션.
+ * Phase 2 에서는 snapshot 우선 + 닉네임/메시지 lazy-load 로 마이그레이션.
+ */
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+
+interface BrickRow extends RowDataPacket {
+    id: number;
+    nickname: string;
+    message: string | null;
+    position_x: number;
+    position_y: number;
+    position_z: number;
+    placed_at: Date;
+    brick_type_id: number;
+    slug: string;
+    color: string | null;
+}
+
+const MAX_LIMIT = 5000;
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const id = Number(event.params.id);
+    if (!id) throw error(400, 'invalid building id');
+
+    const url = event.url;
+    const limit = Math.min(MAX_LIMIT, Math.max(1, Number(url.searchParams.get('limit') ?? 1000)));
+    const offset = Math.max(0, Number(url.searchParams.get('offset') ?? 0));
+
+    const [rows] = await readPool.query<BrickRow[]>(
+        `SELECT br.id, br.nickname, br.message, br.position_x, br.position_y, br.position_z,
+                br.placed_at, br.brick_type_id, br.color, bt.slug
+         FROM brickang_bricks br
+         INNER JOIN brickang_brick_types bt ON bt.id = br.brick_type_id
+         WHERE br.building_id = ?
+         ORDER BY br.id ASC
+         LIMIT ? OFFSET ?`,
+        [id, limit, offset]
+    );
+
+    return json({
+        building_id: id,
+        limit,
+        offset,
+        bricks: rows.map((r) => ({
+            id: r.id,
+            nickname: r.nickname,
+            // 익명 등급은 메시지 미노출
+            message: r.slug === 'anonymous' ? null : r.message,
+            position: { x: r.position_x, y: r.position_y, z: r.position_z },
+            placed_at: r.placed_at,
+            brick_type_slug: r.slug,
+            color: r.color
+        }))
+    });
+}

--- a/plugins/brickang/routes/buildings/detail.ts
+++ b/plugins/brickang/routes/buildings/detail.ts
@@ -1,0 +1,31 @@
+/**
+ * GET /api/plugins/brickang/buildings/:id
+ */
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { getBuildingById } from '../../server/buildings.js';
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const id = Number(event.params.id);
+    if (!id) throw error(400, 'invalid building id');
+
+    const b = await getBuildingById(id);
+    if (!b) throw error(404, 'building not found');
+
+    const progress =
+        b.targetBricks > 0 ? Math.min(100, (b.currentBricks / b.targetBricks) * 100) : 0;
+
+    return json({
+        id: b.id,
+        name: b.name,
+        description: b.description,
+        target_bricks: b.targetBricks,
+        current_bricks: b.currentBricks,
+        progress_percent: progress,
+        status: b.status,
+        blueprint_data: b.blueprintData,
+        dimension: { x: b.dimensionX, y: b.dimensionY, z: b.dimensionZ },
+        season: b.season,
+        created_at: b.createdAt,
+        completed_at: b.completedAt
+    });
+}

--- a/plugins/brickang/routes/buildings/index.ts
+++ b/plugins/brickang/routes/buildings/index.ts
@@ -1,0 +1,26 @@
+/**
+ * GET /api/plugins/brickang/buildings
+ * 활성 건축물 목록.
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import { listActiveBuildings } from '../../server/buildings.js';
+
+export async function GET(_event: RequestEvent): Promise<Response> {
+    const buildings = await listActiveBuildings();
+    return json({
+        buildings: buildings.map((b) => ({
+            id: b.id,
+            name: b.name,
+            description: b.description,
+            target_bricks: b.targetBricks,
+            current_bricks: b.currentBricks,
+            progress_percent:
+                b.targetBricks > 0 ? Math.min(100, (b.currentBricks / b.targetBricks) * 100) : 0,
+            status: b.status,
+            dimension: { x: b.dimensionX, y: b.dimensionY, z: b.dimensionZ },
+            season: b.season,
+            created_at: b.createdAt,
+            completed_at: b.completedAt
+        }))
+    });
+}

--- a/plugins/brickang/routes/buildings/rankings.ts
+++ b/plugins/brickang/routes/buildings/rankings.ts
@@ -1,0 +1,46 @@
+/**
+ * GET /api/plugins/brickang/buildings/:id/rankings
+ * 건축물별 사용자 기여도 랭킹 (벽돌 수 기준).
+ */
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+
+interface RankRow extends RowDataPacket {
+    user_id: number;
+    nickname: string;
+    bricks: number;
+    spent_krw: number;
+}
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const id = Number(event.params.id);
+    if (!id) throw error(400, 'invalid building id');
+
+    const limit = Math.min(100, Math.max(1, Number(event.url.searchParams.get('limit') ?? 30)));
+
+    // 익명 행은 user_id 별로도 모이지만 닉네임은 '익명' 으로 통일하므로 group by user_id + nickname
+    const [rows] = await readPool.query<RankRow[]>(
+        `SELECT br.user_id, br.nickname,
+                COUNT(*) AS bricks,
+                COALESCE(SUM(po.amount), 0) AS spent_krw
+         FROM brickang_bricks br
+         INNER JOIN payment_orders po ON po.id = br.payment_order_id
+         WHERE br.building_id = ?
+         GROUP BY br.user_id, br.nickname
+         ORDER BY bricks DESC
+         LIMIT ?`,
+        [id, limit]
+    );
+
+    return json({
+        building_id: id,
+        rankings: rows.map((r, idx) => ({
+            rank: idx + 1,
+            user_id: r.user_id,
+            nickname: r.nickname,
+            bricks: Number(r.bricks),
+            spent_krw: Number(r.spent_krw)
+        }))
+    });
+}

--- a/plugins/brickang/routes/buildings/snapshot.ts
+++ b/plugins/brickang/routes/buildings/snapshot.ts
@@ -1,0 +1,14 @@
+/**
+ * GET /api/plugins/brickang/buildings/:id/snapshot
+ * Redis 캐시 우선.
+ */
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { getBuildingSnapshot } from '../../server/snapshot.js';
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const id = Number(event.params.id);
+    if (!id) throw error(400, 'invalid building id');
+
+    const snap = await getBuildingSnapshot(id);
+    return json(snap);
+}

--- a/plugins/brickang/routes/me/bricks.ts
+++ b/plugins/brickang/routes/me/bricks.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/plugins/brickang/me/bricks
+ * 내 벽돌 목록.
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+import { requireUser } from '../../server/auth.js';
+
+interface MyBrickRow extends RowDataPacket {
+    id: number;
+    building_id: number;
+    nickname: string;
+    message: string | null;
+    position_x: number;
+    position_y: number;
+    position_z: number;
+    placed_at: Date;
+    slug: string;
+    color: string | null;
+}
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const user = requireUser(event);
+    const limit = Math.min(500, Math.max(1, Number(event.url.searchParams.get('limit') ?? 100)));
+    const offset = Math.max(0, Number(event.url.searchParams.get('offset') ?? 0));
+
+    const [rows] = await readPool.query<MyBrickRow[]>(
+        `SELECT br.id, br.building_id, br.nickname, br.message,
+                br.position_x, br.position_y, br.position_z,
+                br.placed_at, br.color, bt.slug
+         FROM brickang_bricks br
+         INNER JOIN brickang_brick_types bt ON bt.id = br.brick_type_id
+         WHERE br.user_id = ?
+         ORDER BY br.id DESC
+         LIMIT ? OFFSET ?`,
+        [user.userId, limit, offset]
+    );
+
+    return json({
+        limit,
+        offset,
+        bricks: rows.map((r) => ({
+            id: r.id,
+            building_id: r.building_id,
+            nickname: r.nickname,
+            message: r.message, // 본인 행이므로 익명도 노출 (어뷰징 추적 차원에서 본인은 볼 수 있음)
+            position: { x: r.position_x, y: r.position_y, z: r.position_z },
+            placed_at: r.placed_at,
+            brick_type_slug: r.slug,
+            color: r.color
+        }))
+    });
+}

--- a/plugins/brickang/routes/me/stats.ts
+++ b/plugins/brickang/routes/me/stats.ts
@@ -1,0 +1,49 @@
+/**
+ * GET /api/plugins/brickang/me/stats
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+import { requireUser } from '../../server/auth.js';
+
+interface StatsRow extends RowDataPacket {
+    user_id: number;
+    total_bricks: number;
+    total_spent_krw: number;
+    total_spent_usd: string | number;
+    first_brick_at: Date | null;
+    last_brick_at: Date | null;
+    user_rank: number | null;
+}
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const user = requireUser(event);
+
+    const [rows] = await readPool.query<StatsRow[]>(
+        'SELECT * FROM brickang_user_stats WHERE user_id = ? LIMIT 1',
+        [user.userId]
+    );
+
+    if (!rows[0]) {
+        return json({
+            user_id: user.userId,
+            total_bricks: 0,
+            total_spent_krw: 0,
+            total_spent_usd: 0,
+            first_brick_at: null,
+            last_brick_at: null,
+            user_rank: null
+        });
+    }
+
+    const r = rows[0];
+    return json({
+        user_id: r.user_id,
+        total_bricks: r.total_bricks,
+        total_spent_krw: Number(r.total_spent_krw),
+        total_spent_usd: Number(r.total_spent_usd),
+        first_brick_at: r.first_brick_at,
+        last_brick_at: r.last_brick_at,
+        user_rank: r.user_rank
+    });
+}

--- a/plugins/brickang/routes/orders/confirm.ts
+++ b/plugins/brickang/routes/orders/confirm.ts
@@ -1,0 +1,221 @@
+/**
+ * POST /api/plugins/brickang/orders/confirm
+ *
+ * 단일 트랜잭션:
+ *   1. plugins/payment/checkout/complete 내부 호출 (PG 승인)
+ *   2. payment_orders 행 조회 → metadata.kind='brickang' 검증
+ *   3. building_id FOR UPDATE 잠금
+ *   4. quantity 만큼 placement.nextPosition() → (x,y,z)
+ *   5. brickang_bricks INSERT × quantity (UNIQUE 충돌 시 재시도)
+ *   6. brickang_buildings.current_bricks += quantity
+ *   7. brickang_user_stats UPSERT
+ *   8. milestone 도달 시 brickang_events INSERT
+ *   9. Redis snapshot 무효화
+ */
+
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import { pool } from '../../server/db.js';
+import { requireUser } from '../../server/auth.js';
+import {
+    getBuildingForUpdate,
+    incrementCurrentBricks,
+    getOccupiedSet
+} from '../../server/buildings.js';
+import { getBrickTypeBySlug } from '../../server/brick-types.js';
+import { findNextPositions, posKey, WallFirstStrategy } from '../../server/placement.js';
+import { upsertUserStats, checkAndRecordMilestones } from '../../server/stats-aggregator.js';
+import { invalidateBuildingSnapshot, pushRecentBrick } from '../../server/snapshot.js';
+import type { BrickangOrderMetadata } from '../../types/index.js';
+
+interface ConfirmRequestBody {
+    order_uid: string;
+    pg_order_id: string;
+    pg_payment_key?: string;
+    amount: number;
+}
+
+interface PaymentOrderRow extends RowDataPacket {
+    id: number;
+    user_id: number;
+    order_uid: string;
+    amount: string | number;
+    currency: string;
+    status: string;
+    metadata_json: string | null;
+}
+
+const MAX_INSERT_RETRY = 3;
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    const user = requireUser(event);
+    let body: ConfirmRequestBody;
+    try {
+        body = (await event.request.json()) as ConfirmRequestBody;
+    } catch {
+        throw error(400, 'invalid json');
+    }
+
+    if (!body.order_uid || !body.pg_order_id || !body.amount) {
+        throw error(400, 'order_uid/pg_order_id/amount required');
+    }
+
+    // 1) plugins/payment/checkout/complete 위임 호출 (PG 승인)
+    const completeRes = await event.fetch('/api/plugins/payment/checkout/complete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            orderUid: body.order_uid,
+            pgOrderId: body.pg_order_id,
+            pgPaymentKey: body.pg_payment_key,
+            amount: body.amount
+        })
+    });
+    if (!completeRes.ok) {
+        const text = await completeRes.text();
+        console.error('[brickang/confirm] payment complete failed:', completeRes.status, text);
+        throw error(completeRes.status, `payment complete failed: ${text}`);
+    }
+
+    // 2) payment_orders 행 조회 (raw SQL — payment plugin 의 store 를 dynamic import 하지 않고 동일 풀 사용)
+    const [orderRows] = await pool.query<PaymentOrderRow[]>(
+        'SELECT * FROM payment_orders WHERE order_uid = ? LIMIT 1',
+        [body.order_uid]
+    );
+    const orderRow = orderRows[0];
+    if (!orderRow) throw error(404, 'order not found');
+    if (orderRow.status !== 'paid') throw error(400, `order not paid: ${orderRow.status}`);
+    if (orderRow.user_id !== user.userId) throw error(403, 'order does not belong to user');
+
+    let metadata: BrickangOrderMetadata;
+    try {
+        const parsed = orderRow.metadata_json
+            ? (JSON.parse(orderRow.metadata_json) as Record<string, unknown>)
+            : null;
+        if (!parsed || parsed.kind !== 'brickang') {
+            throw new Error('not a brickang order');
+        }
+        metadata = parsed as unknown as BrickangOrderMetadata;
+    } catch (err) {
+        console.error('[brickang/confirm] metadata parse failed:', err);
+        throw error(400, 'order metadata invalid');
+    }
+
+    const brickType = await getBrickTypeBySlug(metadata.brick_type_slug);
+    if (!brickType) throw error(400, 'unknown brick_type in metadata');
+
+    const buildingId = metadata.building_id;
+    const quantity = metadata.quantity;
+    const message = metadata.message;
+    const nickname = brickType.isAnonymous ? '익명' : metadata.nickname_snapshot;
+    const placedAt = new Date();
+
+    // 3) 트랜잭션 시작 — building 잠금 후 placement → INSERT
+    const conn = await pool.getConnection();
+    const insertedBricks: Array<{
+        id: number;
+        position: { x: number; y: number; z: number };
+        type: string;
+        nickname: string;
+    }> = [];
+
+    try {
+        await conn.beginTransaction();
+
+        const building = await getBuildingForUpdate(conn, buildingId);
+        if (!building) throw error(404, 'building not found');
+        if (building.status !== 'active') throw error(400, 'building not active');
+
+        // race-safe placement: building.currentBricks 는 FOR UPDATE 로 잠긴 최신값
+        const occupied = await getOccupiedSet(buildingId);
+        let cursor = building.currentBricks;
+        const strategy = new WallFirstStrategy();
+
+        for (let i = 0; i < quantity; i++) {
+            let inserted = false;
+            for (let attempt = 0; attempt < MAX_INSERT_RETRY && !inserted; attempt++) {
+                const pos = strategy.nextPosition(building, occupied, cursor + attempt);
+                try {
+                    const [result] = await conn.query<ResultSetHeader>(
+                        `INSERT INTO brickang_bricks
+                            (building_id, user_id, nickname, message, brick_type_id, color,
+                             position_x, position_y, position_z, placed_at, payment_order_id)
+                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                        [
+                            buildingId,
+                            user.userId,
+                            nickname,
+                            message,
+                            brickType.id,
+                            brickType.colorHex,
+                            pos.x,
+                            pos.y,
+                            pos.z,
+                            placedAt,
+                            orderRow.id
+                        ]
+                    );
+                    occupied.add(posKey(pos.x, pos.y, pos.z));
+                    insertedBricks.push({
+                        id: result.insertId,
+                        position: pos,
+                        type: brickType.slug,
+                        nickname
+                    });
+                    cursor++;
+                    inserted = true;
+                } catch (err) {
+                    const e = err as { code?: string };
+                    if (e.code === 'ER_DUP_ENTRY') {
+                        // race: 다음 슬롯으로 이동
+                        occupied.add(posKey(pos.x, pos.y, pos.z));
+                        continue;
+                    }
+                    throw err;
+                }
+            }
+            if (!inserted) {
+                throw error(500, 'placement retry exhausted (UNIQUE conflict)');
+            }
+        }
+
+        // 6) buildings.current_bricks 증가
+        await incrementCurrentBricks(conn, buildingId, quantity);
+
+        // 7) user_stats UPSERT
+        const totalSpentKrw = orderRow.currency === 'KRW' ? Number(orderRow.amount) : 0;
+        const totalSpentUsd = orderRow.currency === 'USD' ? Number(orderRow.amount) : 0;
+        await upsertUserStats(conn, {
+            userId: user.userId,
+            deltaBricks: quantity,
+            deltaSpentKrw: totalSpentKrw,
+            deltaSpentUsd: totalSpentUsd,
+            placedAt
+        });
+
+        // 8) milestone 검사
+        const previousCount = building.currentBricks;
+        const newCount = previousCount + quantity;
+        await checkAndRecordMilestones(conn, buildingId, previousCount, newCount);
+
+        await conn.commit();
+    } catch (err) {
+        await conn.rollback();
+        throw err;
+    } finally {
+        conn.release();
+    }
+
+    // 9) 캐시 무효화 + recent push (트랜잭션 밖)
+    await invalidateBuildingSnapshot(buildingId);
+    for (const b of insertedBricks) {
+        await pushRecentBrick(buildingId, {
+            id: b.id,
+            nickname: b.nickname,
+            brickTypeSlug: b.type,
+            placedAt: placedAt.toISOString()
+        });
+    }
+
+    return json({ success: true, bricks: insertedBricks });
+}

--- a/plugins/brickang/routes/orders/detail.ts
+++ b/plugins/brickang/routes/orders/detail.ts
@@ -1,0 +1,75 @@
+/**
+ * GET /api/plugins/brickang/orders/:order_uid
+ *
+ * payment_orders + brickang_bricks 조인하여 주문 상태 + 놓인 벽돌 반환.
+ */
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+import { requireUser } from '../../server/auth.js';
+
+interface OrderRow extends RowDataPacket {
+    id: number;
+    user_id: number;
+    order_uid: string;
+    provider: string;
+    amount: string | number;
+    currency: string;
+    status: string;
+    metadata_json: string | null;
+    paid_at: Date | null;
+    created_at: Date;
+}
+
+interface BrickRow extends RowDataPacket {
+    id: number;
+    building_id: number;
+    nickname: string;
+    message: string | null;
+    position_x: number;
+    position_y: number;
+    position_z: number;
+    placed_at: Date;
+    brick_type_id: number;
+    color: string | null;
+}
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const user = requireUser(event);
+    const orderUid = event.params.order_uid;
+    if (!orderUid) throw error(400, 'order_uid required');
+
+    const [orderRows] = await readPool.query<OrderRow[]>(
+        'SELECT * FROM payment_orders WHERE order_uid = ? LIMIT 1',
+        [orderUid]
+    );
+    const order = orderRows[0];
+    if (!order) throw error(404, 'order not found');
+    if (order.user_id !== user.userId) throw error(403, 'forbidden');
+
+    const [brickRows] = await readPool.query<BrickRow[]>(
+        'SELECT * FROM brickang_bricks WHERE payment_order_id = ? ORDER BY id ASC',
+        [order.id]
+    );
+
+    return json({
+        order_uid: order.order_uid,
+        provider: order.provider,
+        amount: Number(order.amount),
+        currency: order.currency,
+        status: order.status,
+        metadata: order.metadata_json ? JSON.parse(order.metadata_json) : null,
+        paid_at: order.paid_at,
+        created_at: order.created_at,
+        bricks: brickRows.map((b) => ({
+            id: b.id,
+            building_id: b.building_id,
+            nickname: b.nickname,
+            message: b.message,
+            position: { x: b.position_x, y: b.position_y, z: b.position_z },
+            placed_at: b.placed_at,
+            brick_type_id: b.brick_type_id,
+            color: b.color
+        }))
+    });
+}

--- a/plugins/brickang/routes/orders/start.ts
+++ b/plugins/brickang/routes/orders/start.ts
@@ -1,0 +1,190 @@
+/**
+ * POST /api/plugins/brickang/orders/start
+ *
+ * 흐름:
+ *   1. body 검증 (brick_type, quantity 1~100, message ≤100자, building_id, provider, returnUrl, cancelUrl)
+ *   2. brick_type 조회 → server-side 가격 산정 (클라 입력 신뢰 X)
+ *   3. is_anonymous=1 이면 message=null, nickname='익명' 강제
+ *   4. orderUid 생성 (BRK-YYYYMMDD-XXXXXX)
+ *   5. 내부 fetch 로 plugins/payment/checkout/start 호출 → metadata.kind='brickang' 저장
+ *   6. 응답 { order_uid, amount, currency, provider, payment }
+ */
+
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+import { getBrickTypeBySlug } from '../../server/brick-types.js';
+import { getBuildingById } from '../../server/buildings.js';
+import { requireUser } from '../../server/auth.js';
+import type { BrickTypeSlug } from '../../types/index.js';
+
+const DEFAULT_ANONYMOUS_DAILY_CAP = 100;
+
+interface CountRow extends RowDataPacket {
+    cnt: number;
+}
+
+/**
+ * 익명 등급 일일 한도 검사 — 동일 user_id 가 오늘 결제한 익명 벽돌 INSERT 카운트 기준.
+ *
+ * `payment_orders.metadata->>'$.brick_type_slug'='anonymous'` 로 익명 주문만 카운트.
+ * brickang_bricks.placed_at 가 오늘 (서버 로컬 시간) 인 행 수.
+ *
+ * @returns 현재 카운트 (cap 미초과 시) — 호출자가 cap 비교
+ */
+export async function countAnonymousBricksToday(userId: number): Promise<number> {
+    const [rows] = await readPool.query<CountRow[]>(
+        `SELECT COUNT(*) AS cnt
+         FROM brickang_bricks b
+         INNER JOIN payment_orders po ON b.payment_order_id = po.id
+         WHERE b.user_id = ?
+           AND JSON_UNQUOTE(JSON_EXTRACT(po.metadata, '$.brick_type_slug')) = 'anonymous'
+           AND DATE(b.placed_at) = CURDATE()`,
+        [userId]
+    );
+    return rows[0]?.cnt ?? 0;
+}
+
+/**
+ * settings.anonymous_daily_cap (plugin.json) 또는 DEFAULT 반환.
+ * 현재 plugin settings 동적 로드 인프라가 brickang 에 없어서 default 만 사용.
+ * Phase 2 에서 settings store 연동 예정.
+ */
+export function getAnonymousDailyCap(): number {
+    return DEFAULT_ANONYMOUS_DAILY_CAP;
+}
+
+interface StartRequestBody {
+    brick_type: BrickTypeSlug;
+    quantity: number;
+    message?: string | null;
+    building_id: number;
+    provider: 'toss' | 'naver' | 'paypal';
+    returnUrl: string;
+    cancelUrl: string;
+}
+
+function generateOrderUid(): string {
+    const now = new Date();
+    const yyyymmdd = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(
+        now.getDate()
+    ).padStart(2, '0')}`;
+    const rand = Math.random().toString(36).slice(2, 8).toUpperCase();
+    return `BRK-${yyyymmdd}-${rand}`;
+}
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    const user = requireUser(event);
+
+    let body: StartRequestBody;
+    try {
+        body = (await event.request.json()) as StartRequestBody;
+    } catch {
+        throw error(400, 'invalid json');
+    }
+
+    if (!body.brick_type) throw error(400, 'brick_type required');
+    if (!body.building_id) throw error(400, 'building_id required');
+    if (!body.provider) throw error(400, 'provider required');
+    if (!body.returnUrl || !body.cancelUrl) throw error(400, 'returnUrl/cancelUrl required');
+
+    const quantity = Math.floor(Number(body.quantity ?? 1));
+    if (!Number.isFinite(quantity) || quantity < 1 || quantity > 100) {
+        throw error(400, 'quantity must be between 1 and 100');
+    }
+
+    const brickType = await getBrickTypeBySlug(body.brick_type);
+    if (!brickType || !brickType.isActive) {
+        throw error(400, `unknown brick_type: ${body.brick_type}`);
+    }
+
+    const building = await getBuildingById(body.building_id);
+    if (!building) throw error(404, 'building not found');
+    if (building.status !== 'active') throw error(400, 'building not active');
+
+    // 익명 등급 일일 한도 검사 (어뷰징 방지)
+    if (brickType.slug === 'anonymous') {
+        const cap = getAnonymousDailyCap();
+        const todayCount = await countAnonymousBricksToday(user.userId);
+        if (todayCount + quantity > cap) {
+            throw error(400, 'anonymous_daily_cap_exceeded');
+        }
+    }
+
+    // 익명 등급 정책: 메시지 강제 null + 닉네임 '익명'
+    let message: string | null = body.message?.trim() || null;
+    let nicknameSnapshot = user.nickname;
+    if (brickType.isAnonymous) {
+        message = null;
+        nicknameSnapshot = '익명';
+    } else if (!brickType.allowMessage) {
+        message = null;
+    } else if (message && message.length > 100) {
+        throw error(400, 'message too long (max 100 chars)');
+    }
+
+    // PayPal 은 1000원 이상에서만 활성 (요구사항)
+    if (body.provider === 'paypal' && brickType.priceKrw < 1000) {
+        throw error(400, 'PayPal not available for this brick type');
+    }
+
+    const orderUid = generateOrderUid();
+    const amount = brickType.priceKrw * quantity;
+    const currency = body.provider === 'paypal' ? 'USD' : 'KRW';
+    const finalAmount = currency === 'USD' ? brickType.priceUsd * quantity : amount;
+
+    const metadata = {
+        kind: 'brickang',
+        brick_type_slug: brickType.slug,
+        quantity,
+        message,
+        building_id: body.building_id,
+        is_anonymous: brickType.isAnonymous,
+        nickname_snapshot: nicknameSnapshot
+    };
+
+    // plugins/payment/checkout/start 위임 호출 (서버 내부 fetch)
+    const paymentRes = await event.fetch('/api/plugins/payment/checkout/start', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            provider: body.provider,
+            amount: finalAmount,
+            currency,
+            description: `브릭앙 ${brickType.name} ${quantity}개`,
+            returnUrl: body.returnUrl,
+            cancelUrl: body.cancelUrl,
+            metadata: { ...metadata, order_uid: orderUid }
+        })
+    });
+
+    if (!paymentRes.ok) {
+        const text = await paymentRes.text();
+        console.error(
+            '[brickang/orders/start] payment delegation failed:',
+            paymentRes.status,
+            text
+        );
+        throw error(paymentRes.status, `payment start failed: ${text}`);
+    }
+
+    const payment = (await paymentRes.json()) as {
+        orderUid: string;
+        provider: string;
+        sandbox: boolean;
+        sdkParams: Record<string, unknown> | null;
+        redirectUrl: string | null;
+        pgOrderId: string;
+    };
+
+    return json({
+        order_uid: payment.orderUid,
+        brick_order_uid: orderUid,
+        amount: finalAmount,
+        currency,
+        provider: body.provider,
+        brick_type: brickType.slug,
+        quantity,
+        payment
+    });
+}

--- a/plugins/brickang/routes/rankings/all.ts
+++ b/plugins/brickang/routes/rankings/all.ts
@@ -1,0 +1,60 @@
+/**
+ * GET /api/plugins/brickang/rankings/all
+ * 전체 누적 랭킹 (Redis 1시간 캐시).
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+import { getRedis } from '$lib/server/redis';
+
+interface RankRow extends RowDataPacket {
+    user_id: number;
+    total_bricks: number;
+    total_spent_krw: number;
+    last_brick_at: Date | null;
+    nickname: string | null;
+}
+
+const CACHE_KEY = 'brickang:ranking:all';
+const CACHE_TTL_SEC = 60 * 60;
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const limit = Math.min(100, Math.max(1, Number(event.url.searchParams.get('limit') ?? 50)));
+
+    try {
+        const cached = await getRedis().get(CACHE_KEY);
+        if (cached) return json(JSON.parse(cached));
+    } catch {
+        // ignore — fallback to DB
+    }
+
+    const [rows] = await readPool.query<RankRow[]>(
+        `SELECT us.user_id, us.total_bricks, us.total_spent_krw, us.last_brick_at,
+                (SELECT br.nickname FROM brickang_bricks br
+                 WHERE br.user_id = us.user_id ORDER BY br.id DESC LIMIT 1) AS nickname
+         FROM brickang_user_stats us
+         ORDER BY us.total_bricks DESC
+         LIMIT ?`,
+        [limit]
+    );
+
+    const payload = {
+        scope: 'all',
+        rankings: rows.map((r, idx) => ({
+            rank: idx + 1,
+            user_id: r.user_id,
+            nickname: r.nickname ?? `user-${r.user_id}`,
+            total_bricks: r.total_bricks,
+            total_spent_krw: Number(r.total_spent_krw),
+            last_brick_at: r.last_brick_at
+        }))
+    };
+
+    try {
+        await getRedis().set(CACHE_KEY, JSON.stringify(payload), 'EX', CACHE_TTL_SEC);
+    } catch {
+        // ignore
+    }
+
+    return json(payload);
+}

--- a/plugins/brickang/routes/rankings/monthly.ts
+++ b/plugins/brickang/routes/rankings/monthly.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/plugins/brickang/rankings/monthly
+ * 월간 랭킹 (당월 1일 ~ 현재). Redis 10분 캐시.
+ */
+import { json, type RequestEvent } from '@sveltejs/kit';
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '../../server/db.js';
+import { getRedis } from '$lib/server/redis';
+
+interface MonthRow extends RowDataPacket {
+    user_id: number;
+    nickname: string;
+    bricks: number;
+    spent_krw: number;
+}
+
+const CACHE_TTL_SEC = 10 * 60;
+
+export async function GET(event: RequestEvent): Promise<Response> {
+    const limit = Math.min(100, Math.max(1, Number(event.url.searchParams.get('limit') ?? 50)));
+
+    const now = new Date();
+    const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const cacheKey = `brickang:ranking:monthly:${month}`;
+
+    try {
+        const cached = await getRedis().get(cacheKey);
+        if (cached) return json(JSON.parse(cached));
+    } catch {
+        // ignore
+    }
+
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    const [rows] = await readPool.query<MonthRow[]>(
+        `SELECT br.user_id, br.nickname,
+                COUNT(*) AS bricks,
+                COALESCE(SUM(po.amount), 0) AS spent_krw
+         FROM brickang_bricks br
+         INNER JOIN payment_orders po ON po.id = br.payment_order_id
+         WHERE br.placed_at >= ?
+         GROUP BY br.user_id, br.nickname
+         ORDER BY bricks DESC
+         LIMIT ?`,
+        [startOfMonth, limit]
+    );
+
+    const payload = {
+        scope: 'monthly',
+        month,
+        rankings: rows.map((r, idx) => ({
+            rank: idx + 1,
+            user_id: r.user_id,
+            nickname: r.nickname,
+            bricks: Number(r.bricks),
+            spent_krw: Number(r.spent_krw)
+        }))
+    };
+
+    try {
+        await getRedis().set(cacheKey, JSON.stringify(payload), 'EX', CACHE_TTL_SEC);
+    } catch {
+        // ignore
+    }
+
+    return json(payload);
+}

--- a/plugins/brickang/server/auth.ts
+++ b/plugins/brickang/server/auth.ts
@@ -1,0 +1,45 @@
+/**
+ * brickang 인증 헬퍼.
+ *
+ * angple plugin dispatcher 가 `event.locals.user` 에 다모앙 세션 사용자를 주입한다 (giving 패턴).
+ * brickang 라우트는 `requireUser(event)` 로 401 처리 + user_id 추출.
+ */
+
+import { error, type RequestEvent } from '@sveltejs/kit';
+
+interface AuthUser {
+    userId: number;
+    nickname: string;
+}
+
+interface LocalsUser {
+    mb_no?: number | null;
+    id?: number | null;
+    mb_id?: string | null;
+    mb_nick?: string | null;
+    mb_nickname?: string | null;
+    nickname?: string | null;
+}
+
+export function requireUser(event: RequestEvent): AuthUser {
+    const u = event.locals.user as LocalsUser | undefined;
+    if (!u) throw error(401, 'authentication required');
+
+    const userId = u.mb_no ?? u.id ?? 0;
+    if (!userId) throw error(401, 'authentication required (no user id)');
+
+    const nickname = u.mb_nickname ?? u.mb_nick ?? u.nickname ?? u.mb_id ?? 'user';
+    return { userId, nickname };
+}
+
+/**
+ * 로그인 안 한 사용자도 허용 (조회 API 용).
+ */
+export function getOptionalUser(event: RequestEvent): AuthUser | null {
+    const u = event.locals.user as LocalsUser | undefined;
+    if (!u) return null;
+    const userId = u.mb_no ?? u.id ?? 0;
+    if (!userId) return null;
+    const nickname = u.mb_nickname ?? u.mb_nick ?? u.nickname ?? u.mb_id ?? 'user';
+    return { userId, nickname };
+}

--- a/plugins/brickang/server/auth.ts
+++ b/plugins/brickang/server/auth.ts
@@ -3,9 +3,16 @@
  *
  * angple plugin dispatcher 가 `event.locals.user` 에 다모앙 세션 사용자를 주입한다 (giving 패턴).
  * brickang 라우트는 `requireUser(event)` 로 401 처리 + user_id 추출.
+ *
+ * NOTE: `@sveltejs/kit` 직접 import 금지. plugin-server-loader 의 import.meta.glob
+ * (`plugins/**\/server/*.{ts,js}`) 가 server/ 파일을 build 에 포함시키는데,
+ * `@sveltejs/kit` 는 plugins/ 트리에서 resolve 되지 않아 Rollup 이 실패한다.
+ * 401 응답은 표준 `Response` throw 로 대체 (SvelteKit 이 자동 처리).
  */
 
-import { error, type RequestEvent } from '@sveltejs/kit';
+interface RequestEventLike {
+    locals: { user?: unknown };
+}
 
 interface AuthUser {
     userId: number;
@@ -21,12 +28,19 @@ interface LocalsUser {
     nickname?: string | null;
 }
 
-export function requireUser(event: RequestEvent): AuthUser {
+function authResponse(status: number, message: string): Response {
+    return new Response(JSON.stringify({ message }), {
+        status,
+        headers: { 'content-type': 'application/json' }
+    });
+}
+
+export function requireUser(event: RequestEventLike): AuthUser {
     const u = event.locals.user as LocalsUser | undefined;
-    if (!u) throw error(401, 'authentication required');
+    if (!u) throw authResponse(401, 'authentication required');
 
     const userId = u.mb_no ?? u.id ?? 0;
-    if (!userId) throw error(401, 'authentication required (no user id)');
+    if (!userId) throw authResponse(401, 'authentication required (no user id)');
 
     const nickname = u.mb_nickname ?? u.mb_nick ?? u.nickname ?? u.mb_id ?? 'user';
     return { userId, nickname };
@@ -35,7 +49,7 @@ export function requireUser(event: RequestEvent): AuthUser {
 /**
  * 로그인 안 한 사용자도 허용 (조회 API 용).
  */
-export function getOptionalUser(event: RequestEvent): AuthUser | null {
+export function getOptionalUser(event: RequestEventLike): AuthUser | null {
     const u = event.locals.user as LocalsUser | undefined;
     if (!u) return null;
     const userId = u.mb_no ?? u.id ?? 0;

--- a/plugins/brickang/server/brick-types.ts
+++ b/plugins/brickang/server/brick-types.ts
@@ -1,0 +1,92 @@
+/**
+ * 벽돌 등급(5종) 캐시.
+ *
+ * 등급 정보는 거의 변하지 않으므로 프로세스 메모리에 5분 캐시한다.
+ * 가격 산정은 항상 서버 측에서 DB 조회 결과(또는 캐시)로 수행한다 — 클라 입력 신뢰 X.
+ */
+
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from './db.js';
+import type { BrickType, BrickTypeSlug } from '../types/index.js';
+
+interface BrickTypeRow extends RowDataPacket {
+    id: number;
+    slug: string;
+    name: string;
+    price_krw: number;
+    price_usd: string | number;
+    color_hex: string;
+    texture_url: string | null;
+    size_multiplier: string | number;
+    glow_effect: number;
+    is_anonymous: number;
+    allow_message: number;
+    is_active: number;
+    sort_order: number;
+}
+
+const TTL_MS = 5 * 60 * 1000;
+
+let cache: BrickType[] | null = null;
+let cachedAt = 0;
+
+function rowToType(r: BrickTypeRow): BrickType {
+    return {
+        id: r.id,
+        slug: r.slug as BrickTypeSlug,
+        name: r.name,
+        priceKrw: r.price_krw,
+        priceUsd:
+            typeof r.price_usd === 'string' ? parseFloat(r.price_usd) : (r.price_usd as number),
+        colorHex: r.color_hex,
+        textureUrl: r.texture_url,
+        sizeMultiplier:
+            typeof r.size_multiplier === 'string'
+                ? parseFloat(r.size_multiplier)
+                : (r.size_multiplier as number),
+        glowEffect: r.glow_effect === 1,
+        isAnonymous: r.is_anonymous === 1,
+        allowMessage: r.allow_message === 1,
+        isActive: r.is_active === 1,
+        sortOrder: r.sort_order
+    };
+}
+
+export async function listBrickTypes(force = false): Promise<BrickType[]> {
+    const now = Date.now();
+    if (!force && cache && now - cachedAt < TTL_MS) return cache;
+    const [rows] = await readPool.query<BrickTypeRow[]>(
+        'SELECT * FROM brickang_brick_types WHERE is_active = 1 ORDER BY sort_order ASC, id ASC'
+    );
+    cache = rows.map(rowToType);
+    cachedAt = now;
+    return cache;
+}
+
+export async function getBrickTypeBySlug(slug: string): Promise<BrickType | null> {
+    const all = await listBrickTypes();
+    const found = all.find((t) => t.slug === slug);
+    if (found) return found;
+    // 캐시에 없는 경우 DB 직접 조회 (비활성 등급도 조회 가능)
+    const [rows] = await readPool.query<BrickTypeRow[]>(
+        'SELECT * FROM brickang_brick_types WHERE slug = ? LIMIT 1',
+        [slug]
+    );
+    return rows[0] ? rowToType(rows[0]) : null;
+}
+
+export async function getBrickTypeById(id: number): Promise<BrickType | null> {
+    const all = await listBrickTypes();
+    const found = all.find((t) => t.id === id);
+    if (found) return found;
+    const [rows] = await readPool.query<BrickTypeRow[]>(
+        'SELECT * FROM brickang_brick_types WHERE id = ? LIMIT 1',
+        [id]
+    );
+    return rows[0] ? rowToType(rows[0]) : null;
+}
+
+export function invalidateBrickTypeCache(): void {
+    cache = null;
+    cachedAt = 0;
+}

--- a/plugins/brickang/server/buildings.ts
+++ b/plugins/brickang/server/buildings.ts
@@ -1,0 +1,109 @@
+/**
+ * 건축물 조회/갱신 헬퍼.
+ */
+import type { PoolConnection, RowDataPacket } from 'mysql2/promise';
+import { readPool, pool } from './db.js';
+import type { Building, BuildingStatus, Blueprint } from '../types/index.js';
+
+interface BuildingRow extends RowDataPacket {
+    id: number;
+    name: string;
+    description: string | null;
+    target_bricks: number;
+    current_bricks: number;
+    status: string;
+    blueprint_data: string | object | null;
+    dimension_x: number;
+    dimension_y: number;
+    dimension_z: number;
+    season: number;
+    created_at: Date;
+    completed_at: Date | null;
+}
+
+function rowToBuilding(r: BuildingRow): Building {
+    let blueprint: Blueprint | null = null;
+    if (r.blueprint_data) {
+        if (typeof r.blueprint_data === 'string') {
+            try {
+                blueprint = JSON.parse(r.blueprint_data) as Blueprint;
+            } catch {
+                blueprint = null;
+            }
+        } else {
+            blueprint = r.blueprint_data as Blueprint;
+        }
+    }
+    return {
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        targetBricks: r.target_bricks,
+        currentBricks: r.current_bricks,
+        status: r.status as BuildingStatus,
+        blueprintData: blueprint,
+        dimensionX: r.dimension_x,
+        dimensionY: r.dimension_y,
+        dimensionZ: r.dimension_z,
+        season: r.season,
+        createdAt: r.created_at,
+        completedAt: r.completed_at
+    };
+}
+
+export async function listActiveBuildings(): Promise<Building[]> {
+    const [rows] = await readPool.query<BuildingRow[]>(
+        `SELECT * FROM brickang_buildings WHERE status = 'active' ORDER BY created_at DESC`
+    );
+    return rows.map(rowToBuilding);
+}
+
+export async function getBuildingById(id: number): Promise<Building | null> {
+    const [rows] = await readPool.query<BuildingRow[]>(
+        'SELECT * FROM brickang_buildings WHERE id = ? LIMIT 1',
+        [id]
+    );
+    return rows[0] ? rowToBuilding(rows[0]) : null;
+}
+
+/**
+ * 트랜잭션 내에서 building 조회 (FOR UPDATE).
+ */
+export async function getBuildingForUpdate(
+    conn: PoolConnection,
+    id: number
+): Promise<Building | null> {
+    const [rows] = await conn.query<BuildingRow[]>(
+        'SELECT * FROM brickang_buildings WHERE id = ? FOR UPDATE',
+        [id]
+    );
+    return rows[0] ? rowToBuilding(rows[0]) : null;
+}
+
+export async function incrementCurrentBricks(
+    conn: PoolConnection,
+    id: number,
+    delta: number
+): Promise<void> {
+    await conn.query(
+        'UPDATE brickang_buildings SET current_bricks = current_bricks + ? WHERE id = ?',
+        [delta, id]
+    );
+}
+
+/**
+ * 점유된 좌표 Set 조회 (placement.ts 가 사용).
+ */
+export async function getOccupiedSet(buildingId: number): Promise<Set<string>> {
+    const [rows] = await readPool.query<RowDataPacket[]>(
+        'SELECT position_x, position_y, position_z FROM brickang_bricks WHERE building_id = ?',
+        [buildingId]
+    );
+    const set = new Set<string>();
+    for (const r of rows) {
+        set.add(`${r.position_x},${r.position_y},${r.position_z}`);
+    }
+    return set;
+}
+
+export { pool };

--- a/plugins/brickang/server/db.ts
+++ b/plugins/brickang/server/db.ts
@@ -1,0 +1,10 @@
+/**
+ * brickang DB 헬퍼.
+ *
+ * angple-web 의 공용 mysql2 풀(`$lib/server/db`)을 그대로 재사용한다.
+ * brickang 전용 풀은 만들지 않는다 — 동일 damoang DB 를 사용하므로 connection limit 공유가 더 안전.
+ */
+import { pool, readPool } from '$lib/server/db';
+
+export { pool, readPool };
+export default pool;

--- a/plugins/brickang/server/placement.ts
+++ b/plugins/brickang/server/placement.ts
@@ -1,0 +1,156 @@
+/**
+ * Phase 1 자동 배치 — `WallFirstStrategy`.
+ *
+ * 알고리즘:
+ *   1. 같은 층(y) 내에서 테두리(perimeter) → 안쪽으로 채운다.
+ *   2. blueprint_data.floors[].holes 좌표는 skip.
+ *   3. 이미 occupied (Set 으로 전달) 또는 hole 좌표면 다음 슬롯으로 이동.
+ *   4. UNIQUE(x,y,z) DB 충돌은 호출자(`/orders/confirm`)가 catch 후 다시 nextPosition 호출하여 재시도.
+ *
+ * 단순/결정적 알고리즘이므로 단위 테스트로 100% 커버 가능.
+ */
+
+import type { Blueprint, BlueprintFloor, Building, BrickPosition } from '../types/index.js';
+
+export interface PlacementStrategy {
+    /**
+     * 다음 빈 위치 1개를 반환. 더 이상 빈 위치가 없으면 throw.
+     * @param building   현재 건축물
+     * @param occupied   이미 점유된 좌표 (`"x,y,z"` 문자열)
+     * @param startCount placement 시작 시점의 currentBricks. 같은 confirm tx 안에서 여러 벽돌을 놓을 때 카운터를 증가시켜 호출.
+     */
+    nextPosition(building: Building, occupied: Set<string>, startCount: number): BrickPosition;
+}
+
+const MAX_SCAN = 10_000;
+
+export function posKey(x: number, y: number, z: number): string {
+    return `${x},${y},${z}`;
+}
+
+/**
+ * 한 층의 valid 좌표 시퀀스를 생성한다 (테두리 → 안쪽).
+ *
+ * 정사각형/직사각형 층에서 가장자리부터 시계방향으로 한 바퀴 → 한 칸 안쪽으로 들어가서 다시 한 바퀴…
+ * holes 에 포함되는 좌표는 skip.
+ */
+export function generateFloorSlots(
+    dimX: number,
+    dimZ: number,
+    holes: Array<{ x_start: number; x_end: number; z: number; z_end?: number }> = []
+): Array<{ x: number; z: number }> {
+    const result: Array<{ x: number; z: number }> = [];
+    const isHole = (x: number, z: number): boolean =>
+        holes.some((h) => x >= h.x_start && x <= h.x_end && z >= h.z && z <= (h.z_end ?? h.z));
+
+    const layers = Math.ceil(Math.min(dimX, dimZ) / 2);
+    for (let layer = 0; layer < layers; layer++) {
+        const xMin = layer;
+        const xMax = dimX - 1 - layer;
+        const zMin = layer;
+        const zMax = dimZ - 1 - layer;
+        if (xMin > xMax || zMin > zMax) break;
+
+        if (xMin === xMax && zMin === zMax) {
+            // 가운데 한 점
+            if (!isHole(xMin, zMin)) result.push({ x: xMin, z: zMin });
+            continue;
+        }
+
+        // 위쪽 가로
+        for (let x = xMin; x <= xMax; x++) if (!isHole(x, zMin)) result.push({ x, z: zMin });
+        // 오른쪽 세로
+        for (let z = zMin + 1; z <= zMax; z++) if (!isHole(xMax, z)) result.push({ x: xMax, z });
+        if (zMin !== zMax) {
+            // 아래쪽 가로 (역순)
+            for (let x = xMax - 1; x >= xMin; x--)
+                if (!isHole(x, zMax)) result.push({ x, z: zMax });
+        }
+        if (xMin !== xMax) {
+            // 왼쪽 세로 (역순)
+            for (let z = zMax - 1; z >= zMin + 1; z--)
+                if (!isHole(xMin, z)) result.push({ x: xMin, z });
+        }
+    }
+    return result;
+}
+
+function getFloorConfig(blueprint: Blueprint | null, y: number): BlueprintFloor | null {
+    if (!blueprint?.floors) return null;
+    for (const f of blueprint.floors) {
+        const start = f.y;
+        const end = f.y_end ?? f.y;
+        if (y >= start && y <= end) return f;
+    }
+    return null;
+}
+
+export class WallFirstStrategy implements PlacementStrategy {
+    nextPosition(building: Building, occupied: Set<string>, startCount: number): BrickPosition {
+        const dimX = building.dimensionX;
+        const dimZ = building.dimensionZ;
+        const dimY = building.dimensionY;
+
+        // 층별 가용 슬롯 캐시
+        const floorSlotsCache = new Map<number, Array<{ x: number; z: number }>>();
+
+        const getSlots = (y: number): Array<{ x: number; z: number }> => {
+            const cached = floorSlotsCache.get(y);
+            if (cached) return cached;
+            const f = getFloorConfig(building.blueprintData, y);
+            const holes = f?.holes ?? [];
+            const slots = generateFloorSlots(dimX, dimZ, holes);
+            floorSlotsCache.set(y, slots);
+            return slots;
+        };
+
+        let count = startCount;
+        let scanned = 0;
+        while (scanned < MAX_SCAN) {
+            // 현재 count 가 가리키는 (floor, posInFloor) 계산
+            // floor 별 slot 개수가 다를 수 있으므로 누적해서 찾는다
+            let remaining = count;
+            for (let y = 0; y < dimY; y++) {
+                const slots = getSlots(y);
+                if (remaining < slots.length) {
+                    const pos = slots[remaining];
+                    const key = posKey(pos.x, y, pos.z);
+                    if (!occupied.has(key)) {
+                        return { x: pos.x, y, z: pos.z };
+                    }
+                    // 이미 점유 → 다음 슬롯으로 이동
+                    count++;
+                    scanned++;
+                    break;
+                }
+                remaining -= slots.length;
+                // 마지막 층까지 다 채운 경우
+                if (y === dimY - 1) {
+                    throw new Error('No empty position available in building');
+                }
+            }
+        }
+        throw new Error('Placement scan limit exceeded');
+    }
+}
+
+/**
+ * 단일 호출 헬퍼 — 트랜잭션 안에서 여러 벽돌을 차례로 배치할 때 사용.
+ */
+export function findNextPositions(
+    building: Building,
+    occupied: Set<string>,
+    count: number
+): BrickPosition[] {
+    const strategy = new WallFirstStrategy();
+    const result: BrickPosition[] = [];
+    const localOccupied = new Set(occupied);
+    let cursor = building.currentBricks;
+    for (let i = 0; i < count; i++) {
+        const pos = strategy.nextPosition(building, localOccupied, cursor);
+        result.push(pos);
+        localOccupied.add(posKey(pos.x, pos.y, pos.z));
+        cursor++;
+    }
+    return result;
+}

--- a/plugins/brickang/server/snapshot.ts
+++ b/plugins/brickang/server/snapshot.ts
@@ -1,0 +1,109 @@
+/**
+ * 건축물 스냅샷 (Redis 캐시).
+ *
+ * 키 패턴:
+ *   brickang:building:{id}:snapshot   → 5분 TTL, 위치+등급 요약
+ *   brickang:building:{id}:recent     → 최근 10개 (LIST)
+ *   brickang:ranking:all              → 1시간 TTL
+ *   brickang:ranking:monthly          → 10분 TTL
+ *
+ * Redis 미가용 환경에서도 동작하도록 try/catch 로 감싸 fallback (DB 직접 조회) 처리.
+ */
+
+import { getRedis } from '$lib/server/redis';
+import { readPool } from './db.js';
+import type { RowDataPacket } from 'mysql2/promise';
+
+const SNAPSHOT_TTL_SEC = 5 * 60;
+
+interface SnapshotRow extends RowDataPacket {
+    total: number;
+    by_type: string | null;
+}
+
+export interface BuildingSnapshot {
+    buildingId: number;
+    snapshotVersion: number;
+    generatedAt: string;
+    metadata: {
+        total: number;
+        byType: Record<string, number>;
+    };
+}
+
+function snapshotKey(buildingId: number): string {
+    return `brickang:building:${buildingId}:snapshot`;
+}
+
+export async function invalidateBuildingSnapshot(buildingId: number): Promise<void> {
+    try {
+        const redis = getRedis();
+        await redis.del(snapshotKey(buildingId));
+    } catch (err) {
+        console.warn('[brickang/snapshot] redis del failed:', (err as Error).message);
+    }
+}
+
+export async function getBuildingSnapshot(buildingId: number): Promise<BuildingSnapshot> {
+    // 1) Redis 캐시 hit
+    try {
+        const redis = getRedis();
+        const cached = await redis.get(snapshotKey(buildingId));
+        if (cached) {
+            return JSON.parse(cached) as BuildingSnapshot;
+        }
+    } catch (err) {
+        // Redis 없으면 DB 로 fallback
+        console.warn('[brickang/snapshot] redis get failed:', (err as Error).message);
+    }
+
+    // 2) DB 직접 조회 → 새 snapshot 빌드
+    const [rows] = await readPool.query<RowDataPacket[]>(
+        `SELECT bt.slug AS slug, COUNT(*) AS cnt
+         FROM brickang_bricks b
+         INNER JOIN brickang_brick_types bt ON bt.id = b.brick_type_id
+         WHERE b.building_id = ?
+         GROUP BY bt.slug`,
+        [buildingId]
+    );
+
+    const byType: Record<string, number> = {};
+    let total = 0;
+    for (const r of rows) {
+        const slug = r.slug as string;
+        const cnt = Number(r.cnt);
+        byType[slug] = cnt;
+        total += cnt;
+    }
+
+    const snapshot: BuildingSnapshot = {
+        buildingId,
+        snapshotVersion: Date.now(),
+        generatedAt: new Date().toISOString(),
+        metadata: { total, byType }
+    };
+
+    try {
+        const redis = getRedis();
+        await redis.set(snapshotKey(buildingId), JSON.stringify(snapshot), 'EX', SNAPSHOT_TTL_SEC);
+    } catch (err) {
+        console.warn('[brickang/snapshot] redis set failed:', (err as Error).message);
+    }
+
+    return snapshot;
+}
+
+export async function pushRecentBrick(
+    buildingId: number,
+    brick: { id: number; nickname: string; brickTypeSlug: string; placedAt: string }
+): Promise<void> {
+    try {
+        const redis = getRedis();
+        const key = `brickang:building:${buildingId}:recent`;
+        await redis.lpush(key, JSON.stringify(brick));
+        await redis.ltrim(key, 0, 9);
+        await redis.expire(key, 60 * 60); // 1시간
+    } catch (err) {
+        console.warn('[brickang/snapshot] redis recent push failed:', (err as Error).message);
+    }
+}

--- a/plugins/brickang/server/stats-aggregator.ts
+++ b/plugins/brickang/server/stats-aggregator.ts
@@ -1,0 +1,73 @@
+/**
+ * 사용자 누적 통계(`brickang_user_stats`) UPSERT + 마일스톤 검사.
+ *
+ * `confirm.ts` 의 트랜잭션 안에서 호출되므로 conn(트랜잭션 connection)을 인자로 받는다.
+ */
+
+import type { PoolConnection, RowDataPacket } from 'mysql2/promise';
+import { MILESTONES } from '../types/index.js';
+
+export async function upsertUserStats(
+    conn: PoolConnection,
+    input: {
+        userId: number;
+        deltaBricks: number;
+        deltaSpentKrw: number;
+        deltaSpentUsd: number;
+        placedAt: Date;
+    }
+): Promise<void> {
+    await conn.query(
+        `INSERT INTO brickang_user_stats
+            (user_id, total_bricks, total_spent_krw, total_spent_usd, first_brick_at, last_brick_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+            total_bricks = total_bricks + VALUES(total_bricks),
+            total_spent_krw = total_spent_krw + VALUES(total_spent_krw),
+            total_spent_usd = total_spent_usd + VALUES(total_spent_usd),
+            first_brick_at = COALESCE(first_brick_at, VALUES(first_brick_at)),
+            last_brick_at = VALUES(last_brick_at)`,
+        [
+            input.userId,
+            input.deltaBricks,
+            input.deltaSpentKrw,
+            input.deltaSpentUsd,
+            input.placedAt,
+            input.placedAt
+        ]
+    );
+}
+
+export async function checkAndRecordMilestones(
+    conn: PoolConnection,
+    buildingId: number,
+    previousCount: number,
+    newCount: number
+): Promise<number[]> {
+    const reached: number[] = [];
+    for (const m of MILESTONES) {
+        if (previousCount < m && newCount >= m) {
+            reached.push(m);
+            await conn.query(
+                `INSERT INTO brickang_events
+                    (building_id, event_type, milestone_count, title, description)
+                 VALUES (?, 'milestone', ?, ?, ?)`,
+                [
+                    buildingId,
+                    m,
+                    `${m.toLocaleString()}개 벽돌 달성!`,
+                    `${m.toLocaleString()}번째 벽돌이 놓였습니다.`
+                ]
+            );
+        }
+    }
+    return reached;
+}
+
+export async function getUserStats(conn: PoolConnection, userId: number): Promise<unknown> {
+    const [rows] = await conn.query<RowDataPacket[]>(
+        'SELECT * FROM brickang_user_stats WHERE user_id = ?',
+        [userId]
+    );
+    return rows[0] ?? null;
+}

--- a/plugins/brickang/stores/brick.svelte.ts
+++ b/plugins/brickang/stores/brick.svelte.ts
@@ -1,0 +1,44 @@
+/**
+ * 벽돌 등급/구매 컨텍스트.
+ */
+import { brickangApi, type BrickTypeDto } from '../lib/api.js';
+
+class BrickStore {
+    brickTypes = $state<BrickTypeDto[]>([]);
+    selectedSlug = $state<string | null>(null);
+    quantity = $state(1);
+    message = $state('');
+
+    selected = $derived(
+        this.selectedSlug
+            ? (this.brickTypes.find((t) => t.slug === this.selectedSlug) ?? null)
+            : null
+    );
+
+    totalAmountKrw = $derived(this.selected ? this.selected.price_krw * this.quantity : 0);
+
+    async load(): Promise<void> {
+        const res = await brickangApi.listBrickTypes();
+        this.brickTypes = res.brick_types;
+    }
+
+    select(slug: string): void {
+        this.selectedSlug = slug;
+        const t = this.brickTypes.find((x) => x.slug === slug);
+        if (t?.is_anonymous) this.message = '';
+    }
+
+    setQuantity(q: number): void {
+        this.quantity = Math.max(1, Math.min(100, q));
+    }
+
+    setMessage(m: string): void {
+        if (this.selected?.is_anonymous) {
+            this.message = '';
+            return;
+        }
+        this.message = m.slice(0, 100);
+    }
+}
+
+export const brickStore = new BrickStore();

--- a/plugins/brickang/stores/building.svelte.ts
+++ b/plugins/brickang/stores/building.svelte.ts
@@ -1,0 +1,54 @@
+/**
+ * 건축물 상태 (Svelte 5 Rune).
+ */
+import { brickangApi, type BuildingDto, type BrickDto } from '../lib/api.js';
+
+class BuildingStore {
+    building = $state<BuildingDto | null>(null);
+    bricks = $state<BrickDto[]>([]);
+    loading = $state(false);
+    error = $state<string | null>(null);
+
+    progress = $derived(this.building?.progress_percent ?? 0);
+
+    async loadActive(): Promise<void> {
+        this.loading = true;
+        this.error = null;
+        try {
+            const res = await brickangApi.getActive();
+            this.building = res.building;
+            this.bricks = res.recent;
+        } catch (err) {
+            this.error = (err as Error).message;
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    async loadBuilding(id: number): Promise<void> {
+        this.loading = true;
+        this.error = null;
+        try {
+            const b = await brickangApi.getBuilding(id);
+            this.building = b;
+            const res = await brickangApi.getBuildingBricks(id, { limit: 5000 });
+            this.bricks = res.bricks;
+        } catch (err) {
+            this.error = (err as Error).message;
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    addBricks(newBricks: BrickDto[]): void {
+        this.bricks = [...newBricks, ...this.bricks];
+        if (this.building) {
+            this.building = {
+                ...this.building,
+                current_bricks: this.building.current_bricks + newBricks.length
+            };
+        }
+    }
+}
+
+export const buildingStore = new BuildingStore();

--- a/plugins/brickang/stores/payment.svelte.ts
+++ b/plugins/brickang/stores/payment.svelte.ts
@@ -1,0 +1,57 @@
+/**
+ * 결제 진행 상태.
+ */
+import {
+    brickangApi,
+    type StartOrderResponse,
+    type ConfirmOrderResponse,
+    type StartOrderBody,
+    type ConfirmOrderBody
+} from '../lib/api.js';
+
+type PaymentStatus = 'idle' | 'starting' | 'awaiting_pg' | 'confirming' | 'success' | 'error';
+
+class PaymentStore {
+    status = $state<PaymentStatus>('idle');
+    error = $state<string | null>(null);
+    startResponse = $state<StartOrderResponse | null>(null);
+    confirmResponse = $state<ConfirmOrderResponse | null>(null);
+
+    async start(body: StartOrderBody): Promise<StartOrderResponse> {
+        this.status = 'starting';
+        this.error = null;
+        try {
+            const res = await brickangApi.startOrder(body);
+            this.startResponse = res;
+            this.status = 'awaiting_pg';
+            return res;
+        } catch (err) {
+            this.status = 'error';
+            this.error = (err as Error).message;
+            throw err;
+        }
+    }
+
+    async confirm(body: ConfirmOrderBody): Promise<ConfirmOrderResponse> {
+        this.status = 'confirming';
+        try {
+            const res = await brickangApi.confirmOrder(body);
+            this.confirmResponse = res;
+            this.status = 'success';
+            return res;
+        } catch (err) {
+            this.status = 'error';
+            this.error = (err as Error).message;
+            throw err;
+        }
+    }
+
+    reset(): void {
+        this.status = 'idle';
+        this.error = null;
+        this.startResponse = null;
+        this.confirmResponse = null;
+    }
+}
+
+export const paymentStore = new PaymentStore();

--- a/plugins/brickang/tests/orders.test.ts
+++ b/plugins/brickang/tests/orders.test.ts
@@ -1,0 +1,406 @@
+/**
+ * orders.test.ts — `routes/orders/start.ts` + `confirm.ts` 핵심 흐름 통합 테스트 (모킹).
+ *
+ * 시나리오:
+ *  start.ts:
+ *   - anonymous 등급: message=null + nickname='익명' 강제 → metadata 에 반영
+ *   - 일반 등급: 사용자 nickname 보존 + message 유지
+ *   - 클라 amount 무시 + 서버 산정 (priceKrw * quantity)
+ *   - anonymous_daily_cap 초과 시 400
+ *
+ *  confirm.ts:
+ *   - payment_orders.metadata.kind !== 'brickang' 시 400
+ *   - 트랜잭션 rollback 시 brick INSERT 0건 (실제 DB 호출 0건 확인)
+ *   - milestone 100 도달 시 events 행 INSERT 호출됨
+ *
+ * fetch + mysql2 + brickang 의존성 모듈을 모두 mock.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---- 1. 모킹: brickang server modules ----
+const mockGetBrickTypeBySlug = vi.fn();
+const mockGetBuildingById = vi.fn();
+const mockCountAnonymousToday = vi.fn();
+const mockReadPoolQuery = vi.fn();
+const mockPoolQuery = vi.fn();
+const mockGetBuildingForUpdate = vi.fn();
+const mockGetOccupiedSet = vi.fn();
+const mockIncrementCurrentBricks = vi.fn();
+const mockUpsertUserStats = vi.fn();
+const mockCheckAndRecordMilestones = vi.fn();
+const mockInvalidateBuildingSnapshot = vi.fn();
+const mockPushRecentBrick = vi.fn();
+const mockConnQuery = vi.fn();
+const mockConnBegin = vi.fn();
+const mockConnCommit = vi.fn();
+const mockConnRollback = vi.fn();
+const mockConnRelease = vi.fn();
+
+vi.mock('../server/db.js', () => ({
+    pool: {
+        query: (...args: unknown[]) => mockPoolQuery(...args),
+        getConnection: vi.fn(async () => ({
+            query: (...args: unknown[]) => mockConnQuery(...args),
+            beginTransaction: () => mockConnBegin(),
+            commit: () => mockConnCommit(),
+            rollback: () => mockConnRollback(),
+            release: () => mockConnRelease()
+        }))
+    },
+    readPool: {
+        query: (...args: unknown[]) => mockReadPoolQuery(...args)
+    }
+}));
+
+vi.mock('../server/brick-types.js', () => ({
+    getBrickTypeBySlug: (...args: unknown[]) => mockGetBrickTypeBySlug(...args)
+}));
+
+vi.mock('../server/buildings.js', () => ({
+    getBuildingById: (...args: unknown[]) => mockGetBuildingById(...args),
+    getBuildingForUpdate: (...args: unknown[]) => mockGetBuildingForUpdate(...args),
+    getOccupiedSet: (...args: unknown[]) => mockGetOccupiedSet(...args),
+    incrementCurrentBricks: (...args: unknown[]) => mockIncrementCurrentBricks(...args)
+}));
+
+vi.mock('../server/stats-aggregator.js', () => ({
+    upsertUserStats: (...args: unknown[]) => mockUpsertUserStats(...args),
+    checkAndRecordMilestones: (...args: unknown[]) => mockCheckAndRecordMilestones(...args)
+}));
+
+vi.mock('../server/snapshot.js', () => ({
+    invalidateBuildingSnapshot: (...args: unknown[]) => mockInvalidateBuildingSnapshot(...args),
+    pushRecentBrick: (...args: unknown[]) => mockPushRecentBrick(...args)
+}));
+
+// ---- helpers ----
+function makeRequestEvent(body: unknown, user: { mb_no: number; mb_nickname: string } | null) {
+    const fetchMock = vi.fn();
+    return {
+        fetchMock,
+        event: {
+            request: {
+                json: async () => body
+            },
+            locals: { user },
+            fetch: fetchMock
+        } as unknown as import('@sveltejs/kit').RequestEvent
+    };
+}
+
+const ANON_TYPE = {
+    id: 1,
+    slug: 'anonymous',
+    name: '익명 100원',
+    priceKrw: 100,
+    priceUsd: 0.1,
+    colorHex: '#888',
+    textureUrl: null,
+    sizeMultiplier: 1,
+    glowEffect: false,
+    isAnonymous: true,
+    allowMessage: false,
+    isActive: true,
+    sortOrder: 1
+};
+
+const NORMAL_TYPE = {
+    id: 2,
+    slug: 'normal',
+    name: '일반',
+    priceKrw: 1000,
+    priceUsd: 1,
+    colorHex: '#c84c32',
+    textureUrl: null,
+    sizeMultiplier: 1,
+    glowEffect: false,
+    isAnonymous: false,
+    allowMessage: true,
+    isActive: true,
+    sortOrder: 2
+};
+
+const ACTIVE_BUILDING = {
+    id: 1,
+    name: 'A',
+    description: null,
+    targetBricks: 1000,
+    currentBricks: 0,
+    status: 'active' as const,
+    blueprintData: null,
+    dimensionX: 5,
+    dimensionY: 3,
+    dimensionZ: 5,
+    season: 1,
+    createdAt: new Date(),
+    completedAt: null
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    // default: anon today count = 0
+    mockReadPoolQuery.mockResolvedValue([[{ cnt: 0 }]]);
+});
+
+// ---- start.ts tests ----
+describe('orders/start.ts', () => {
+    it('일반 등급 → message + 사용자 nickname 보존, 클라 amount 무시', async () => {
+        mockGetBrickTypeBySlug.mockResolvedValue(NORMAL_TYPE);
+        mockGetBuildingById.mockResolvedValue(ACTIVE_BUILDING);
+        const { POST } = await import('../routes/orders/start.js');
+        const { event, fetchMock } = makeRequestEvent(
+            {
+                brick_type: 'normal',
+                quantity: 3,
+                message: '응원합니다',
+                building_id: 1,
+                provider: 'toss',
+                returnUrl: '/r',
+                cancelUrl: '/c',
+                amount: 99999999 // 클라가 보낸 잘못된 amount — 무시되어야 함
+            },
+            { mb_no: 42, mb_nickname: '홍길동' }
+        );
+        fetchMock.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    orderUid: 'PAY-1',
+                    provider: 'toss',
+                    sandbox: true,
+                    sdkParams: {},
+                    redirectUrl: null,
+                    pgOrderId: 'pg-1'
+                }),
+                { status: 200 }
+            )
+        );
+
+        const res = await POST(event);
+        expect(res.status).toBe(200);
+
+        const calledBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+        // 서버 산정 amount = priceKrw * quantity = 1000 * 3
+        expect(calledBody.amount).toBe(3000);
+        expect(calledBody.metadata.nickname_snapshot).toBe('홍길동');
+        expect(calledBody.metadata.message).toBe('응원합니다');
+        expect(calledBody.metadata.is_anonymous).toBe(false);
+        expect(calledBody.metadata.kind).toBe('brickang');
+    });
+
+    it('anonymous 등급 → message=null + nickname=익명 강제', async () => {
+        mockGetBrickTypeBySlug.mockResolvedValue(ANON_TYPE);
+        mockGetBuildingById.mockResolvedValue(ACTIVE_BUILDING);
+        const { POST } = await import('../routes/orders/start.js');
+        const { event, fetchMock } = makeRequestEvent(
+            {
+                brick_type: 'anonymous',
+                quantity: 1,
+                message: '비밀 메시지',
+                building_id: 1,
+                provider: 'toss',
+                returnUrl: '/r',
+                cancelUrl: '/c'
+            },
+            { mb_no: 42, mb_nickname: '홍길동' }
+        );
+        fetchMock.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    orderUid: 'PAY-2',
+                    provider: 'toss',
+                    sandbox: true,
+                    sdkParams: {},
+                    redirectUrl: null,
+                    pgOrderId: 'pg-2'
+                }),
+                { status: 200 }
+            )
+        );
+
+        await POST(event);
+        const calledBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(calledBody.metadata.nickname_snapshot).toBe('익명');
+        expect(calledBody.metadata.message).toBeNull();
+        expect(calledBody.metadata.is_anonymous).toBe(true);
+        expect(calledBody.amount).toBe(100); // priceKrw 100 * 1
+    });
+
+    it('anonymous_daily_cap 초과 시 400', async () => {
+        mockGetBrickTypeBySlug.mockResolvedValue(ANON_TYPE);
+        mockGetBuildingById.mockResolvedValue(ACTIVE_BUILDING);
+        // 오늘 이미 100개 카운트
+        mockReadPoolQuery.mockResolvedValue([[{ cnt: 100 }]]);
+        const { POST } = await import('../routes/orders/start.js');
+        const { event } = makeRequestEvent(
+            {
+                brick_type: 'anonymous',
+                quantity: 1,
+                building_id: 1,
+                provider: 'toss',
+                returnUrl: '/r',
+                cancelUrl: '/c'
+            },
+            { mb_no: 42, mb_nickname: '홍길동' }
+        );
+
+        await expect(POST(event)).rejects.toMatchObject({
+            status: 400
+        });
+    });
+
+    it('anonymous_daily_cap 미초과 시 정상 진행', async () => {
+        mockGetBrickTypeBySlug.mockResolvedValue(ANON_TYPE);
+        mockGetBuildingById.mockResolvedValue(ACTIVE_BUILDING);
+        mockReadPoolQuery.mockResolvedValue([[{ cnt: 50 }]]); // 50 < 100
+        const { POST } = await import('../routes/orders/start.js');
+        const { event, fetchMock } = makeRequestEvent(
+            {
+                brick_type: 'anonymous',
+                quantity: 1,
+                building_id: 1,
+                provider: 'toss',
+                returnUrl: '/r',
+                cancelUrl: '/c'
+            },
+            { mb_no: 42, mb_nickname: '홍길동' }
+        );
+        fetchMock.mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    orderUid: 'PAY-3',
+                    provider: 'toss',
+                    sandbox: true,
+                    sdkParams: {},
+                    redirectUrl: null,
+                    pgOrderId: 'pg-3'
+                }),
+                { status: 200 }
+            )
+        );
+        const res = await POST(event);
+        expect(res.status).toBe(200);
+    });
+});
+
+// ---- confirm.ts tests ----
+describe('orders/confirm.ts', () => {
+    it('payment_orders.metadata.kind !== brickang 시 400', async () => {
+        // payment complete OK
+        const { POST } = await import('../routes/orders/confirm.js');
+        const { event, fetchMock } = makeRequestEvent(
+            { order_uid: 'PAY-X', pg_order_id: 'pg-x', amount: 1000 },
+            { mb_no: 42, mb_nickname: '홍길동' }
+        );
+        fetchMock.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+        // payment_orders 행: metadata.kind = 'subscription' (다른 플러그인)
+        mockPoolQuery.mockResolvedValueOnce([
+            [
+                {
+                    id: 99,
+                    user_id: 42,
+                    order_uid: 'PAY-X',
+                    amount: 1000,
+                    currency: 'KRW',
+                    status: 'paid',
+                    metadata_json: JSON.stringify({ kind: 'subscription' })
+                }
+            ]
+        ]);
+
+        await expect(POST(event)).rejects.toMatchObject({ status: 400 });
+        // brick INSERT 0건 (트랜잭션 시작도 안 함)
+        expect(mockConnBegin).not.toHaveBeenCalled();
+    });
+
+    it('트랜잭션 안에서 INSERT 실패 → rollback 호출 + 외부 캐시 무효화 호출 X', async () => {
+        const { POST } = await import('../routes/orders/confirm.js');
+        const { event, fetchMock } = makeRequestEvent(
+            { order_uid: 'PAY-Y', pg_order_id: 'pg-y', amount: 1000 },
+            { mb_no: 42, mb_nickname: '홍길동' }
+        );
+        fetchMock.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+        mockPoolQuery.mockResolvedValueOnce([
+            [
+                {
+                    id: 100,
+                    user_id: 42,
+                    order_uid: 'PAY-Y',
+                    amount: 1000,
+                    currency: 'KRW',
+                    status: 'paid',
+                    metadata_json: JSON.stringify({
+                        kind: 'brickang',
+                        brick_type_slug: 'normal',
+                        quantity: 1,
+                        message: 'hi',
+                        building_id: 1,
+                        is_anonymous: false,
+                        nickname_snapshot: '홍길동'
+                    })
+                }
+            ]
+        ]);
+        mockGetBrickTypeBySlug.mockResolvedValue(NORMAL_TYPE);
+        mockGetBuildingForUpdate.mockResolvedValue(ACTIVE_BUILDING);
+        mockGetOccupiedSet.mockResolvedValue(new Set<string>());
+        // INSERT 시 알 수 없는 에러 (DUP_ENTRY 가 아닌 일반 에러) → rollback
+        mockConnQuery.mockRejectedValue(new Error('boom'));
+
+        await expect(POST(event)).rejects.toThrow();
+        expect(mockConnBegin).toHaveBeenCalled();
+        expect(mockConnRollback).toHaveBeenCalled();
+        expect(mockConnCommit).not.toHaveBeenCalled();
+        // 캐시 무효화는 트랜잭션 commit 후에만 호출됨 → rollback 시 X
+        expect(mockInvalidateBuildingSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('milestone 100 도달 시 checkAndRecordMilestones 호출됨', async () => {
+        const { POST } = await import('../routes/orders/confirm.js');
+        const { event, fetchMock } = makeRequestEvent(
+            { order_uid: 'PAY-Z', pg_order_id: 'pg-z', amount: 1000 },
+            { mb_no: 42, mb_nickname: '홍길동' }
+        );
+        fetchMock.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+        mockPoolQuery.mockResolvedValueOnce([
+            [
+                {
+                    id: 101,
+                    user_id: 42,
+                    order_uid: 'PAY-Z',
+                    amount: 1000,
+                    currency: 'KRW',
+                    status: 'paid',
+                    metadata_json: JSON.stringify({
+                        kind: 'brickang',
+                        brick_type_slug: 'normal',
+                        quantity: 1,
+                        message: null,
+                        building_id: 1,
+                        is_anonymous: false,
+                        nickname_snapshot: '홍길동'
+                    })
+                }
+            ]
+        ]);
+        mockGetBrickTypeBySlug.mockResolvedValue(NORMAL_TYPE);
+        // currentBricks=99 → quantity 1 → newCount=100 (milestone)
+        // dim 10x10x10 = 1000 slots 확보
+        mockGetBuildingForUpdate.mockResolvedValue({
+            ...ACTIVE_BUILDING,
+            dimensionX: 10,
+            dimensionY: 10,
+            dimensionZ: 10,
+            currentBricks: 99
+        });
+        mockGetOccupiedSet.mockResolvedValue(new Set<string>());
+        // INSERT 성공
+        mockConnQuery.mockResolvedValue([{ insertId: 1 } as never]);
+
+        const res = await POST(event);
+        expect(res.status).toBe(200);
+        expect(mockCheckAndRecordMilestones).toHaveBeenCalledWith(expect.anything(), 1, 99, 100);
+        expect(mockConnCommit).toHaveBeenCalled();
+        expect(mockInvalidateBuildingSnapshot).toHaveBeenCalledWith(1);
+    });
+});

--- a/plugins/brickang/tests/placement.test.ts
+++ b/plugins/brickang/tests/placement.test.ts
@@ -1,0 +1,161 @@
+/**
+ * placement.test.ts — `WallFirstStrategy` 단위 테스트.
+ *
+ * 검증 시나리오:
+ *  - 빈 건물 (0,0,0) 부터 테두리 우선 배치
+ *  - occupied set 충돌 시 다음 슬롯으로 시프트 (race 보호)
+ *  - blueprint_data.floors[].holes 좌표는 skip
+ *  - 한 층 만원 시 다음 층(y+1) 진입
+ *  - MAX_SCAN 도달 시 에러 (기능적으로는 빈 슬롯이 없을 때 throw)
+ *
+ * DB 호출 없음 — 순수 알고리즘 테스트.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    WallFirstStrategy,
+    generateFloorSlots,
+    posKey,
+    findNextPositions
+} from '../server/placement.js';
+import type { Building } from '../types/index.js';
+
+function makeBuilding(overrides: Partial<Building> = {}): Building {
+    return {
+        id: 1,
+        name: 'test',
+        description: null,
+        targetBricks: 100,
+        currentBricks: 0,
+        status: 'active',
+        blueprintData: null,
+        dimensionX: 5,
+        dimensionY: 3,
+        dimensionZ: 5,
+        season: 1,
+        createdAt: new Date(),
+        completedAt: null,
+        ...overrides
+    };
+}
+
+describe('generateFloorSlots', () => {
+    it('5x5 정사각형: 테두리(16) → 안쪽 테두리(8) → 가운데 1 = 25개', () => {
+        const slots = generateFloorSlots(5, 5);
+        expect(slots).toHaveLength(25);
+        // 첫 4개는 위쪽 가로 (z=0)
+        expect(slots[0]).toEqual({ x: 0, z: 0 });
+        expect(slots[1]).toEqual({ x: 1, z: 0 });
+        expect(slots[4]).toEqual({ x: 4, z: 0 });
+    });
+
+    it('holes 좌표는 결과에서 빠진다', () => {
+        const slots = generateFloorSlots(3, 3, [{ x_start: 1, x_end: 1, z: 1, z_end: 1 }]);
+        // 3x3 = 9, 가운데 1개 hole 제외 → 8개
+        expect(slots).toHaveLength(8);
+        const hasCenter = slots.some((s) => s.x === 1 && s.z === 1);
+        expect(hasCenter).toBe(false);
+    });
+
+    it('1x1 단일 좌표', () => {
+        const slots = generateFloorSlots(1, 1);
+        expect(slots).toEqual([{ x: 0, z: 0 }]);
+    });
+});
+
+describe('WallFirstStrategy.nextPosition', () => {
+    it('빈 건물 startCount=0 → 첫 테두리 좌표 (0,0,0)', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding();
+        const pos = strategy.nextPosition(building, new Set(), 0);
+        expect(pos).toEqual({ x: 0, y: 0, z: 0 });
+    });
+
+    it('startCount 가 첫 층 슬롯 끝 = 25 → 다음 층(y=1) 진입', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding();
+        const pos = strategy.nextPosition(building, new Set(), 25);
+        expect(pos.y).toBe(1);
+        expect(pos.x).toBe(0);
+        expect(pos.z).toBe(0);
+    });
+
+    it('occupied 충돌 시 다음 슬롯으로 시프트', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding();
+        // (0,0,0) 점유 → cursor=0 호출 시 다음 슬롯 (1,0,0)
+        const occupied = new Set<string>([posKey(0, 0, 0)]);
+        const pos = strategy.nextPosition(building, occupied, 0);
+        expect(pos).toEqual({ x: 1, y: 0, z: 0 });
+    });
+
+    it('연속 2개 슬롯이 occupied → 3번째 슬롯 반환', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding();
+        const occupied = new Set<string>([posKey(0, 0, 0), posKey(1, 0, 0)]);
+        const pos = strategy.nextPosition(building, occupied, 0);
+        expect(pos).toEqual({ x: 2, y: 0, z: 0 });
+    });
+
+    it('blueprint holes 좌표는 자동으로 skip', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding({
+            blueprintData: {
+                floors: [
+                    {
+                        y: 0,
+                        pattern: 'full',
+                        holes: [{ x_start: 0, x_end: 0, z: 0, z_end: 0 }]
+                    }
+                ]
+            }
+        });
+        // (0,0,0) 이 hole → 첫 슬롯은 (1,0,0)
+        const pos = strategy.nextPosition(building, new Set(), 0);
+        expect(pos).toEqual({ x: 1, y: 0, z: 0 });
+    });
+
+    it('한 층 가득 차면 자동으로 다음 층(y+1)', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding({ dimensionX: 2, dimensionY: 3, dimensionZ: 2 });
+        // 2x2 층은 4 슬롯 → cursor=4 → y=1 진입
+        const pos = strategy.nextPosition(building, new Set(), 4);
+        expect(pos.y).toBe(1);
+    });
+
+    it('모든 층의 모든 슬롯이 occupied 면 throw', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding({ dimensionX: 2, dimensionY: 1, dimensionZ: 2 });
+        const occupied = new Set<string>([
+            posKey(0, 0, 0),
+            posKey(1, 0, 0),
+            posKey(1, 0, 1),
+            posKey(0, 0, 1)
+        ]);
+        expect(() => strategy.nextPosition(building, occupied, 0)).toThrow();
+    });
+
+    it('마지막 층에서도 슬롯 없으면 throw', () => {
+        const strategy = new WallFirstStrategy();
+        const building = makeBuilding({ dimensionX: 1, dimensionY: 1, dimensionZ: 1 });
+        // 1x1x1 = 1 슬롯, cursor=1 → throw
+        expect(() => strategy.nextPosition(building, new Set(), 1)).toThrow();
+    });
+});
+
+describe('findNextPositions', () => {
+    it('quantity=3 → 서로 다른 3개 좌표', () => {
+        const building = makeBuilding();
+        const positions = findNextPositions(building, new Set(), 3);
+        expect(positions).toHaveLength(3);
+        const keys = new Set(positions.map((p) => posKey(p.x, p.y, p.z)));
+        expect(keys.size).toBe(3);
+    });
+
+    it('currentBricks 부터 시작', () => {
+        const building = makeBuilding({ currentBricks: 25 });
+        const positions = findNextPositions(building, new Set(), 1);
+        // 5x5 첫 층 25 슬롯 다 차서 y=1 진입
+        expect(positions[0].y).toBe(1);
+    });
+});

--- a/plugins/brickang/types/index.ts
+++ b/plugins/brickang/types/index.ts
@@ -1,0 +1,100 @@
+/**
+ * brickang 도메인 타입.
+ */
+
+export type BrickTypeSlug = 'anonymous' | 'normal' | 'silver' | 'gold' | 'diamond';
+
+export interface BrickType {
+    id: number;
+    slug: BrickTypeSlug;
+    name: string;
+    priceKrw: number;
+    priceUsd: number;
+    colorHex: string;
+    textureUrl: string | null;
+    sizeMultiplier: number;
+    glowEffect: boolean;
+    isAnonymous: boolean;
+    allowMessage: boolean;
+    isActive: boolean;
+    sortOrder: number;
+}
+
+export type BuildingStatus = 'active' | 'completed' | 'archived';
+
+export interface BlueprintFloor {
+    y: number;
+    y_end?: number;
+    pattern: 'full' | 'walls_only' | 'floor_with_hole';
+    dimensions?: { x: number; z: number };
+    wall_thickness?: number;
+    holes?: Array<{ x_start: number; x_end: number; z: number; z_end?: number }>;
+}
+
+export interface Blueprint {
+    name?: string;
+    type?: string;
+    floors?: BlueprintFloor[];
+    total_brick_slots?: number;
+}
+
+export interface Building {
+    id: number;
+    name: string;
+    description: string | null;
+    targetBricks: number;
+    currentBricks: number;
+    status: BuildingStatus;
+    blueprintData: Blueprint | null;
+    dimensionX: number;
+    dimensionY: number;
+    dimensionZ: number;
+    season: number;
+    createdAt: Date;
+    completedAt: Date | null;
+}
+
+export interface Brick {
+    id: number;
+    buildingId: number;
+    userId: number;
+    nickname: string;
+    message: string | null;
+    brickTypeId: number;
+    color: string | null;
+    positionX: number;
+    positionY: number;
+    positionZ: number;
+    placedAt: Date;
+    paymentOrderId: number;
+    createdAt: Date;
+}
+
+export interface BrickPosition {
+    x: number;
+    y: number;
+    z: number;
+}
+
+export interface UserStats {
+    userId: number;
+    totalBricks: number;
+    totalSpentKrw: number;
+    totalSpentUsd: number;
+    firstBrickAt: Date | null;
+    lastBrickAt: Date | null;
+    userRank: number | null;
+    updatedAt: Date;
+}
+
+export interface BrickangOrderMetadata {
+    kind: 'brickang';
+    brick_type_slug: BrickTypeSlug;
+    quantity: number;
+    message: string | null;
+    building_id: number;
+    is_anonymous: boolean;
+    nickname_snapshot: string;
+}
+
+export const MILESTONES = [100, 500, 1000, 5000, 10000] as const;


### PR DESCRIPTION
## Summary
- plugins/payment 어댑터 재사용으로 결제 통합
- 5종 벽돌 등급 (익명₩100 ~ 다이아₩10,000)
- 자동 배치 (WallFirstStrategy)
- 2D Canvas 뷰어 + 다모앙 shop 위젯

## Test plan
- [x] pnpm check 무회귀
- [x] pnpm test:unit --run (placement / orders 신규 테스트 포함)
- [ ] sandbox PG 키 등록 후 실제 결제 → 벽돌 INSERT 확인 (사용자 환경)

## Phase 2 예고
- Three.js 3D 뷰어
- 등급별 자유 배치 (다이아 인접 1면 필수)
- 위치 lock 5분 + 실시간 피드