### PR TITLE
fix(search): Manticore 25 mysql 프로토콜 호환 (database 더미 추가)

### DIFF
--- a/apps/web/src/lib/server/sphinx.ts
+++ b/apps/web/src/lib/server/sphinx.ts
@@ -3,12 +3,18 @@
  *
  * SphinxQL은 MySQL 프로토콜 호환이므로 mysql2를 그대로 사용.
  * 포트: 9306 (sphinx.conf의 listen = 9306:mysql41)
+ *
+ * `database` 더미 값 (SPHINX_DATABASE, default 'Manticore'):
+ *   Manticore 25 의 mysql 프로토콜 구현이 stricter — connection 시 database
+ *   미지정이면 ER_NO_DB_ERROR 반환 (Sphinx 2.2.11 은 lenient). Manticore 는
+ *   값 자체 무시하므로 임의 문자열 OK. Sphinx 9306 도 같은 옵션 허용 (역호환).
  */
 import mysql from 'mysql2/promise';
 
 const sphinxPool = mysql.createPool({
     host: process.env.SPHINX_HOST || '127.0.0.1',
     port: parseInt(process.env.SPHINX_PORT || '9306'),
+    database: process.env.SPHINX_DATABASE || 'Manticore',
     waitForConnections: true,
     connectionLimit: 10,
     queueLimit: 50,


### PR DESCRIPTION
Manticore 25 mysql 프로토콜 stricter — connection 시 db 미지정 → ER_NO_DB_ERROR (Sphinx 2.2.11 lenient). mysql2.createPool 에 database 더미 추가 (env override).

5/02 Phase C1.5 prod cutover (k8s#61) 후 사용자 검색 0건 사고 — 사용자 "rollback 안 함 + 근본 fix" 결정. 머지 + Deploy approve 즉시 필요.

검증 (web pod 안 mysql2 직접):
- Manticore 9307 + database:Manticore → MATCH("admin") = 19366
- Sphinx 9306 + database:Manticore → 동일 결과 (역호환)