### PR TITLE
feat(brickang): Phase 2 — 3D + 하이브리드 자유 배치

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
         "@types/node": "^25.0.3",
         "@types/nodemailer": "^7.0.9",
         "@types/tar": "^6.1.13",
+        "@types/three": "^0.171.0",
         "@vitest/browser": "^3.2.3",
         "@vitest/coverage-v8": "^3.2.4",
         "bits-ui": "^2.15.4",
@@ -124,6 +125,7 @@
         "svelte-sonner": "^1.0.7",
         "svelte-tiptap": "^3.0.1",
         "tar": "^7.5.11",
+        "three": "^0.171.0",
         "turndown": "^7.2.2",
         "zod": "^4.2.1"
     }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -53,6 +53,16 @@ export default defineConfig(({ mode }) => {
                 {
                     find: '$premium-plugins',
                     replacement: path.resolve(__dirname, '../../../premium/plugins')
+                },
+                // brickang Phase 2: plugins/ 트리는 workspace 외부라 'three' resolve 가
+                // apps/web/node_modules 까지 올라오지 못한다. 명시 alias 로 강제 매핑.
+                {
+                    find: /^three$/,
+                    replacement: path.resolve(__dirname, 'node_modules/three')
+                },
+                {
+                    find: /^three\/(.+)$/,
+                    replacement: path.resolve(__dirname, 'node_modules/three/$1')
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     },
     "devDependencies": {
         "@changesets/cli": "^2.26.2",
+        "@types/three": "^0.171.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "concurrently": "^8.2.0",
@@ -31,6 +32,7 @@
         "prettier": "3.3.3",
         "prettier-plugin-svelte": "3.2.8",
         "prettier-plugin-tailwindcss": "^0.5.6",
+        "three": "^0.171.0",
         "typescript": "^5.0.0"
     },
     "engines": {

--- a/plugins/brickang/components/Building3D.svelte
+++ b/plugins/brickang/components/Building3D.svelte
@@ -1,0 +1,216 @@
+<!--
+  Building3D.svelte — Three.js 3D 뷰어.
+  - mode='view': InstancedMesh 등급별 5종 + OrbitControls
+  - mode='place': Raycaster + ghost preview, 클릭 시 onPositionPick 콜백
+  - Three.js 는 dynamic import 로만 로드 → 메인 번들에 포함되지 않음.
+  - 모바일/저성능 환경: WebGL 미지원 시 자식 컴포넌트가 2D fallback.
+-->
+<script lang="ts">
+    import { onMount, onDestroy } from 'svelte';
+    import type { BrickDto, BuildingDto } from '../lib/api.js';
+    import type { BrickTypeSlug } from '../types/index.js';
+
+    interface Props {
+        building: BuildingDto;
+        bricks: BrickDto[];
+        mode?: 'view' | 'place';
+        placingType?: BrickTypeSlug;
+        onPositionPick?: (pos: { x: number; y: number; z: number }) => void;
+    }
+
+    let {
+        building,
+        bricks,
+        mode = 'view',
+        placingType = 'silver',
+        onPositionPick
+    }: Props = $props();
+
+    let container = $state<HTMLDivElement | null>(null);
+    let loadError = $state<string | null>(null);
+    let loaded = $state(false);
+
+    let cleanup: (() => void) | null = null;
+
+    onMount(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const [
+                    { createScene, attachControls },
+                    { createInstancedMesh, applyInstances, createGhostMesh }
+                ] = await Promise.all([
+                    import('../lib/three-scene.js'),
+                    import('../lib/brick-geometry.js')
+                ]);
+
+                if (cancelled || !container) return;
+                const w = container.clientWidth || 600;
+                const h = container.clientHeight || 400;
+                const handles = await createScene({ container, width: w, height: h });
+                const { THREE, scene, camera, renderer } = handles;
+
+                // bbox 가이드 wireframe
+                const bboxGeo = new THREE.BoxGeometry(
+                    building.dimension?.x ?? 20,
+                    building.dimension?.y ?? 30,
+                    building.dimension?.z ?? 20
+                );
+                const bboxEdges = new THREE.EdgesGeometry(bboxGeo);
+                const bboxLine = new THREE.LineSegments(
+                    bboxEdges,
+                    new THREE.LineBasicMaterial({
+                        color: 0x6688ff,
+                        transparent: true,
+                        opacity: 0.3
+                    })
+                );
+                bboxLine.position.set(
+                    (building.dimension?.x ?? 20) / 2,
+                    (building.dimension?.y ?? 30) / 2,
+                    (building.dimension?.z ?? 20) / 2
+                );
+                scene.add(bboxLine);
+
+                const controls = await attachControls(camera, renderer.domElement);
+                controls.target.set(
+                    (building.dimension?.x ?? 20) / 2,
+                    (building.dimension?.y ?? 30) / 4,
+                    (building.dimension?.z ?? 20) / 2
+                );
+
+                const types: BrickTypeSlug[] = ['anonymous', 'normal', 'silver', 'gold', 'diamond'];
+                const meshes = new Map<BrickTypeSlug, import('three').InstancedMesh>();
+                const cap = Math.max(1024, bricks.length + 256);
+                for (const t of types) {
+                    const mesh = await createInstancedMesh(THREE, t, cap);
+                    scene.add(mesh);
+                    meshes.set(t, mesh);
+                }
+
+                const updateBricks = () => {
+                    applyInstances(
+                        THREE,
+                        meshes,
+                        bricks.map((b) => ({
+                            id: b.id,
+                            typeSlug: (b.brick_type_slug as BrickTypeSlug) ?? 'normal',
+                            x: b.position?.x ?? 0,
+                            y: b.position?.y ?? 0,
+                            z: b.position?.z ?? 0,
+                            color: b.color
+                        }))
+                    );
+                };
+                updateBricks();
+
+                // place 모드 ghost + raycaster
+                let ghost: import('three').Mesh | null = null;
+                let raycaster: import('three').Raycaster | null = null;
+                let pointer: import('three').Vector2 | null = null;
+                if (mode === 'place') {
+                    ghost = await createGhostMesh(THREE, placingType);
+                    scene.add(ghost);
+                    raycaster = new THREE.Raycaster();
+                    pointer = new THREE.Vector2();
+                }
+
+                function onPointerMove(ev: PointerEvent) {
+                    if (mode !== 'place' || !raycaster || !pointer || !ghost) return;
+                    const rect = renderer.domElement.getBoundingClientRect();
+                    pointer.x = ((ev.clientX - rect.left) / rect.width) * 2 - 1;
+                    pointer.y = -((ev.clientY - rect.top) / rect.height) * 2 + 1;
+                    raycaster.setFromCamera(pointer, camera);
+                    // 가상 평면(y=0) 교차 → 격자 좌표
+                    const planeY = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+                    const target = new THREE.Vector3();
+                    if (raycaster.ray.intersectPlane(planeY, target)) {
+                        const gx = Math.floor(target.x);
+                        const gz = Math.floor(target.z);
+                        if (
+                            gx >= 0 &&
+                            gx < (building.dimension?.x ?? 20) &&
+                            gz >= 0 &&
+                            gz < (building.dimension?.z ?? 20)
+                        ) {
+                            ghost.position.set(gx + 0.5, 0.5, gz + 0.5);
+                            ghost.visible = true;
+                            return;
+                        }
+                    }
+                    ghost.visible = false;
+                }
+
+                function onClick() {
+                    if (mode !== 'place' || !ghost || !ghost.visible || !onPositionPick) return;
+                    const x = Math.floor(ghost.position.x);
+                    const y = Math.floor(ghost.position.y);
+                    const z = Math.floor(ghost.position.z);
+                    onPositionPick({ x, y, z });
+                }
+
+                renderer.domElement.addEventListener('pointermove', onPointerMove);
+                renderer.domElement.addEventListener('click', onClick);
+
+                let raf = 0;
+                const tick = () => {
+                    controls.update();
+                    renderer.render(scene, camera);
+                    raf = requestAnimationFrame(tick);
+                };
+                raf = requestAnimationFrame(tick);
+                loaded = true;
+
+                cleanup = () => {
+                    cancelAnimationFrame(raf);
+                    renderer.domElement.removeEventListener('pointermove', onPointerMove);
+                    renderer.domElement.removeEventListener('click', onClick);
+                    handles.dispose();
+                };
+            } catch (err) {
+                console.error('[Building3D] init failed', err);
+                loadError = (err as Error).message;
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    });
+
+    onDestroy(() => {
+        if (cleanup) cleanup();
+    });
+</script>
+
+<div class="building-3d" bind:this={container}>
+    {#if loadError}
+        <p class="error">3D 뷰어 로드 실패: {loadError}</p>
+    {/if}
+    {#if !loaded && !loadError}
+        <p class="loading">3D 로딩 중...</p>
+    {/if}
+</div>
+
+<style>
+    .building-3d {
+        position: relative;
+        width: 100%;
+        height: 480px;
+        background: #1a1a2e;
+        border-radius: 8px;
+        overflow: hidden;
+    }
+    .error,
+    .loading {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: #fff;
+        font-size: 14px;
+    }
+    .error {
+        color: #f88;
+    }
+</style>

--- a/plugins/brickang/components/BuildingViewer.svelte
+++ b/plugins/brickang/components/BuildingViewer.svelte
@@ -1,0 +1,95 @@
+<!--
+  BuildingViewer.svelte — 2D ↔ 3D 토글 뷰어.
+  - 데스크톱 기본: 3D
+  - 모바일 (touch + 작은 화면): 2D 자동 fallback (Three.js 부담 회피)
+  - props.mode='place' 시 onPositionPick 콜백을 자식에 전달 (3D 만 지원, 2D 는 read-only)
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import Building2D from './Building2D.svelte';
+    import type { BrickDto, BuildingDto } from '../lib/api.js';
+    import type { BrickTypeSlug } from '../types/index.js';
+
+    interface Props {
+        building: BuildingDto;
+        bricks: BrickDto[];
+        mode?: 'view' | 'place';
+        placingType?: BrickTypeSlug;
+        onPositionPick?: (pos: { x: number; y: number; z: number }) => void;
+    }
+
+    let {
+        building,
+        bricks,
+        mode = 'view',
+        placingType = 'silver',
+        onPositionPick
+    }: Props = $props();
+
+    let viewerKind = $state<'2d' | '3d'>('2d');
+    let isMobile = $state(false);
+
+    onMount(() => {
+        // 모바일/저사양 감지: 좁은 화면 OR coarse pointer
+        const mql = window.matchMedia('(max-width: 768px), (pointer: coarse)');
+        isMobile = mql.matches;
+        // 데스크톱 기본 3D, 모바일 기본 2D
+        viewerKind = isMobile ? '2d' : '3d';
+    });
+
+    function toggle() {
+        viewerKind = viewerKind === '2d' ? '3d' : '2d';
+    }
+</script>
+
+<div class="viewer-wrap">
+    <div class="toolbar">
+        <button class="toggle" onclick={toggle} aria-label="뷰 전환">
+            {viewerKind === '2d' ? '3D 보기' : '2D 보기'}
+        </button>
+        {#if mode === 'place' && viewerKind === '2d'}
+            <span class="hint">자유 배치는 3D 모드에서만 가능합니다</span>
+        {/if}
+    </div>
+
+    {#if viewerKind === '3d'}
+        {#await import('./Building3D.svelte') then mod}
+            <mod.default {building} {bricks} {mode} {placingType} {onPositionPick} />
+        {:catch err}
+            <p class="error">3D 로드 실패: {err.message}</p>
+        {/await}
+    {:else}
+        <Building2D {building} {bricks} />
+    {/if}
+</div>
+
+<style>
+    .viewer-wrap {
+        width: 100%;
+    }
+    .toolbar {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        margin-bottom: 8px;
+    }
+    .toggle {
+        padding: 4px 10px;
+        background: #283050;
+        color: #fff;
+        border: 1px solid #4060a0;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+    }
+    .toggle:hover {
+        background: #344070;
+    }
+    .hint {
+        font-size: 12px;
+        color: #888;
+    }
+    .error {
+        color: #c33;
+    }
+</style>

--- a/plugins/brickang/components/PaymentModal.svelte
+++ b/plugins/brickang/components/PaymentModal.svelte
@@ -8,31 +8,104 @@
     import { brickStore } from '../stores/brick.svelte.js';
     import { paymentStore } from '../stores/payment.svelte.js';
     import BrickCard from './BrickCard.svelte';
+    import { brickangApi } from '../lib/api.js';
+    import type { BrickDto, BuildingDto } from '../lib/api.js';
 
     interface Props {
         buildingId: number;
         open: boolean;
+        building?: BuildingDto | null;
+        bricks?: BrickDto[];
         onclose?: () => void;
         oncomplete?: (
             bricks: Array<{ id: number; position: { x: number; y: number; z: number } }>
         ) => void;
     }
-    let { buildingId, open = $bindable(false), onclose, oncomplete }: Props = $props();
+    let {
+        buildingId,
+        open = $bindable(false),
+        building = null,
+        bricks = [],
+        onclose,
+        oncomplete
+    }: Props = $props();
 
     let provider = $state<'toss' | 'naver' | 'paypal'>('toss');
     let busy = $state(false);
 
-    let allowedProviders = $derived.by(() => {
-        const types = brickStore.selected;
-        if (!types) return ['toss', 'naver'] as const;
-        const list: Array<'toss' | 'naver' | 'paypal'> = ['toss', 'naver'];
-        if (types.price_krw >= 1000) list.push('paypal');
-        return list;
+    // Phase 2: 자유 배치 (silver/gold/diamond)
+    let isFreePlacement = $derived(
+        brickStore.selected
+            ? ['silver', 'gold', 'diamond'].includes(brickStore.selected.slug)
+            : false
+    );
+    let lockId = $state<number | null>(null);
+    let lockedPosition = $state<{ x: number; y: number; z: number } | null>(null);
+    let lockExpiresAt = $state<number | null>(null);
+    let lockCountdown = $state<number>(0);
+    let placeMode = $state(false);
+    let placeError = $state<string | null>(null);
+
+    // 카운트다운 갱신 (1s)
+    let countdownTimer: ReturnType<typeof setInterval> | null = null;
+    $effect(() => {
+        if (lockExpiresAt) {
+            countdownTimer = setInterval(() => {
+                const remain = Math.max(0, Math.floor((lockExpiresAt! - Date.now()) / 1000));
+                lockCountdown = remain;
+                if (remain <= 0) {
+                    placeError = '위치 lock 이 만료되었습니다. 다시 선택해 주세요.';
+                    lockId = null;
+                    lockedPosition = null;
+                    lockExpiresAt = null;
+                    if (countdownTimer) clearInterval(countdownTimer);
+                }
+            }, 1000);
+        }
+        return () => {
+            if (countdownTimer) clearInterval(countdownTimer);
+        };
     });
+
+    async function handlePositionPick(pos: { x: number; y: number; z: number }) {
+        const sel = brickStore.selected;
+        if (!sel) return;
+        placeError = null;
+        try {
+            // 기존 lock 이 있으면 해제 (UI 상 다른 좌표로 다시 클릭한 경우)
+            if (lockId) {
+                try {
+                    await brickangApi.releaseLock(lockId);
+                } catch {
+                    /* 무시 */
+                }
+            }
+            const r = await brickangApi.acquireLock({
+                building_id: buildingId,
+                brick_type_slug: sel.slug,
+                position: pos
+            });
+            lockId = r.lock_id;
+            lockedPosition = r.position;
+            lockExpiresAt = new Date(r.expires_at).getTime();
+            placeMode = false;
+        } catch (err) {
+            const msg = (err as Error).message;
+            if (msg.includes('409') || msg.includes('position_locked')) {
+                placeError = '이 좌표는 다른 사용자가 선점했습니다. 다른 좌표를 선택해 주세요.';
+            } else {
+                placeError = msg;
+            }
+        }
+    }
 
     async function handlePay() {
         const sel = brickStore.selected;
         if (!sel) return;
+        if (isFreePlacement && !lockId) {
+            placeError = '먼저 위치를 선택해 주세요.';
+            return;
+        }
         busy = true;
         try {
             const start = await paymentStore.start({
@@ -42,7 +115,9 @@
                 building_id: buildingId,
                 provider,
                 returnUrl: `${window.location.origin}/brickang/payment/return`,
-                cancelUrl: `${window.location.origin}/brickang/payment/cancel`
+                cancelUrl: `${window.location.origin}/brickang/payment/cancel`,
+                lock_id: isFreePlacement ? lockId : null,
+                position: isFreePlacement ? lockedPosition : null
             });
 
             if (start.payment.redirectUrl) {
@@ -60,6 +135,14 @@
                 pg_order_id: start.payment.pgOrderId,
                 amount: start.amount
             });
+            if (confirm.lock_fallback) {
+                placeError =
+                    '선택한 위치 lock 이 만료되어 자동 배치되었습니다. 다음번엔 더 빨리 결제해 주세요.';
+            }
+            // lock 행은 confirm 단일 tx 안에서 삭제되므로 별도 release 불필요
+            lockId = null;
+            lockedPosition = null;
+            lockExpiresAt = null;
             oncomplete?.(confirm.bricks);
             open = false;
             onclose?.();
@@ -134,6 +217,54 @@
                         {/each}
                     </div>
                 </div>
+
+                {#if isFreePlacement}
+                    <div class="modal__row modal__free-placement">
+                        <span>위치 선택</span>
+                        <div class="free-info">
+                            {#if lockedPosition}
+                                <p class="locked">
+                                    선택 좌표: ({lockedPosition.x}, {lockedPosition.y}, {lockedPosition.z})
+                                    {#if lockCountdown > 0}
+                                        <span class="countdown">남은 시간: {lockCountdown}초</span>
+                                    {/if}
+                                </p>
+                            {:else}
+                                <p class="hint">자유 배치 등급은 위치를 직접 선택해야 합니다.</p>
+                            {/if}
+                            <button
+                                type="button"
+                                class="place-btn"
+                                onclick={() => (placeMode = !placeMode)}
+                            >
+                                {placeMode
+                                    ? '위치 선택 종료'
+                                    : lockedPosition
+                                      ? '다시 선택'
+                                      : '위치 선택'}
+                            </button>
+                        </div>
+                    </div>
+
+                    {#if placeMode && building}
+                        {#await import('./BuildingViewer.svelte') then mod}
+                            <mod.default
+                                {building}
+                                {bricks}
+                                mode="place"
+                                placingType={brickStore.selected.slug as
+                                    | 'silver'
+                                    | 'gold'
+                                    | 'diamond'}
+                                onPositionPick={handlePositionPick}
+                            />
+                        {/await}
+                    {/if}
+
+                    {#if placeError}
+                        <p class="modal__error">{placeError}</p>
+                    {/if}
+                {/if}
 
                 <div class="modal__total">
                     합계: {brickStore.totalAmountKrw.toLocaleString()} 원
@@ -233,5 +364,38 @@
     .modal__error {
         color: #c00;
         margin-top: 0.5rem;
+    }
+    .modal__free-placement {
+        align-items: flex-start;
+    }
+    .free-info {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+    .free-info .locked {
+        margin: 0;
+        color: #2962ff;
+        font-weight: 500;
+    }
+    .free-info .countdown {
+        margin-left: 8px;
+        color: #c33;
+        font-size: 0.9em;
+    }
+    .free-info .hint {
+        margin: 0;
+        color: #666;
+        font-size: 0.9em;
+    }
+    .place-btn {
+        align-self: flex-start;
+        padding: 0.4rem 0.8rem;
+        background: #2962ff;
+        color: #fff;
+        border: 0;
+        border-radius: 4px;
+        cursor: pointer;
     }
 </style>

--- a/plugins/brickang/lib/api.ts
+++ b/plugins/brickang/lib/api.ts
@@ -59,8 +59,27 @@ export const brickangApi = {
     },
     getMyStats: () => request('/me/stats'),
     getRankingsAll: (limit = 50) => request(`/rankings/all?limit=${limit}`),
-    getRankingsMonthly: (limit = 50) => request(`/rankings/monthly?limit=${limit}`)
+    getRankingsMonthly: (limit = 50) => request(`/rankings/monthly?limit=${limit}`),
+    acquireLock: (body: AcquireLockBody) =>
+        request<AcquireLockResponse>('/locks/acquire', {
+            method: 'POST',
+            body: JSON.stringify(body)
+        }),
+    releaseLock: (lockId: number) =>
+        request<{ released: boolean }>(`/locks/${lockId}`, { method: 'DELETE' })
 };
+
+export interface AcquireLockBody {
+    building_id: number;
+    brick_type_slug: string;
+    position: { x: number; y: number; z: number };
+}
+
+export interface AcquireLockResponse {
+    lock_id: number;
+    expires_at: string;
+    position: { x: number; y: number; z: number };
+}
 
 export interface BrickTypeDto {
     id: number;
@@ -107,6 +126,10 @@ export interface StartOrderBody {
     provider: 'toss' | 'naver' | 'paypal';
     returnUrl: string;
     cancelUrl: string;
+    /** Phase 2: 자유 배치 lock id */
+    lock_id?: number | null;
+    /** Phase 2: 자유 배치 좌표 */
+    position?: { x: number; y: number; z: number } | null;
 }
 
 export interface StartOrderResponse {
@@ -142,4 +165,6 @@ export interface ConfirmOrderResponse {
         type: string;
         nickname: string;
     }>;
+    /** Phase 2: 자유 배치 lock 만료 등으로 자동 배치 fallback 발생 시 true */
+    lock_fallback?: boolean;
 }

--- a/plugins/brickang/lib/brick-geometry.ts
+++ b/plugins/brickang/lib/brick-geometry.ts
@@ -1,0 +1,93 @@
+/**
+ * brick InstancedMesh 헬퍼 — 등급별로 1 mesh, 위치는 setMatrixAt 으로 갱신.
+ *
+ * Three.js dynamic import 를 사용하므로 호출자는 await 필요.
+ */
+
+import type * as THREE from 'three';
+import type { BrickTypeSlug } from '../types/index.js';
+
+export interface BrickInstance {
+    id: number;
+    typeSlug: BrickTypeSlug;
+    x: number;
+    y: number;
+    z: number;
+    color?: string | null;
+}
+
+/**
+ * 등급별 색상 + glow 매핑.
+ */
+const TYPE_STYLE: Record<BrickTypeSlug, { color: number; emissive: number; opacity: number }> = {
+    anonymous: { color: 0xa0a0a0, emissive: 0x000000, opacity: 0.7 },
+    normal: { color: 0xc89060, emissive: 0x000000, opacity: 1 },
+    silver: { color: 0xc0c8e0, emissive: 0x223344, opacity: 1 },
+    gold: { color: 0xffd060, emissive: 0x553300, opacity: 1 },
+    diamond: { color: 0x88e0ff, emissive: 0x004488, opacity: 0.95 }
+};
+
+export async function createInstancedMesh(
+    THREE: typeof import('three'),
+    slug: BrickTypeSlug,
+    capacity: number = 1024
+) {
+    const geo = new THREE.BoxGeometry(0.95, 0.95, 0.95);
+    const style = TYPE_STYLE[slug];
+    const mat = new THREE.MeshStandardMaterial({
+        color: style.color,
+        emissive: style.emissive,
+        emissiveIntensity: style.emissive === 0 ? 0 : 0.4,
+        metalness: slug === 'gold' || slug === 'silver' ? 0.7 : 0.2,
+        roughness: 0.4,
+        transparent: style.opacity < 1,
+        opacity: style.opacity
+    });
+    const mesh = new THREE.InstancedMesh(geo, mat, capacity);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    mesh.count = 0;
+    return mesh;
+}
+
+/**
+ * bricks 배열을 등급별 InstancedMesh 그룹에 분배해서 setMatrixAt.
+ */
+export function applyInstances(
+    THREE: typeof import('three'),
+    meshesBySlug: Map<BrickTypeSlug, THREE.InstancedMesh>,
+    bricks: BrickInstance[]
+) {
+    const counts = new Map<BrickTypeSlug, number>();
+    const dummy = new THREE.Object3D();
+    for (const b of bricks) {
+        const mesh = meshesBySlug.get(b.typeSlug);
+        if (!mesh) continue;
+        const idx = counts.get(b.typeSlug) ?? 0;
+        dummy.position.set(b.x + 0.5, b.y + 0.5, b.z + 0.5);
+        dummy.updateMatrix();
+        mesh.setMatrixAt(idx, dummy.matrix);
+        counts.set(b.typeSlug, idx + 1);
+    }
+    for (const [slug, mesh] of meshesBySlug) {
+        mesh.count = counts.get(slug) ?? 0;
+        mesh.instanceMatrix.needsUpdate = true;
+    }
+}
+
+/**
+ * Ghost preview 메시 (place 모드에서 hover 시 반투명 표시).
+ */
+export async function createGhostMesh(THREE: typeof import('three'), slug: BrickTypeSlug) {
+    const geo = new THREE.BoxGeometry(0.96, 0.96, 0.96);
+    const style = TYPE_STYLE[slug];
+    const mat = new THREE.MeshBasicMaterial({
+        color: style.color,
+        transparent: true,
+        opacity: 0.4,
+        wireframe: false
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.visible = false;
+    return mesh;
+}

--- a/plugins/brickang/lib/three-scene.ts
+++ b/plugins/brickang/lib/three-scene.ts
@@ -1,0 +1,87 @@
+/**
+ * Three.js Scene 초기화 헬퍼.
+ *
+ * 중요: 이 파일을 import 만 해도 three 모듈이 즉시 로드되므로
+ * **Building3D.svelte 안에서 dynamic import (`await import('./three-scene.ts')`) 로만 사용**.
+ */
+
+import type * as THREE from 'three';
+
+export interface SceneHandles {
+    THREE: typeof THREE;
+    scene: THREE.Scene;
+    camera: THREE.PerspectiveCamera;
+    renderer: THREE.WebGLRenderer;
+    canvas: HTMLCanvasElement;
+    dispose: () => void;
+}
+
+export interface SceneOptions {
+    container: HTMLElement;
+    width: number;
+    height: number;
+    background?: number;
+}
+
+/**
+ * Scene + Camera + Renderer + 기본 조명 셋업. OrbitControls 는 별도로 attach.
+ */
+export async function createScene(opts: SceneOptions): Promise<SceneHandles> {
+    const THREE = await import('three');
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(opts.background ?? 0x1a1a2e);
+
+    const camera = new THREE.PerspectiveCamera(50, opts.width / opts.height, 0.1, 1000);
+    camera.position.set(15, 12, 15);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(opts.width, opts.height);
+    renderer.shadowMap.enabled = true;
+    opts.container.appendChild(renderer.domElement);
+
+    // 조명: ambient + directional (그림자) + hemisphere
+    const ambient = new THREE.AmbientLight(0xffffff, 0.5);
+    scene.add(ambient);
+
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+    dir.position.set(20, 30, 10);
+    dir.castShadow = true;
+    dir.shadow.mapSize.set(1024, 1024);
+    scene.add(dir);
+
+    const hemi = new THREE.HemisphereLight(0x88aaff, 0x442200, 0.3);
+    scene.add(hemi);
+
+    // 바닥 grid (가이드)
+    const grid = new THREE.GridHelper(20, 20, 0x444466, 0x222244);
+    scene.add(grid);
+
+    return {
+        THREE,
+        scene,
+        camera,
+        renderer,
+        canvas: renderer.domElement,
+        dispose: () => {
+            renderer.dispose();
+            opts.container.removeChild(renderer.domElement);
+        }
+    };
+}
+
+/**
+ * OrbitControls dynamic import 헬퍼.
+ */
+export async function attachControls(camera: THREE.Camera, dom: HTMLElement) {
+    const { OrbitControls } = await import('three/examples/jsm/controls/OrbitControls.js');
+    const controls = new OrbitControls(camera, dom);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.minDistance = 3;
+    controls.maxDistance = 60;
+    controls.maxPolarAngle = Math.PI / 2;
+    return controls;
+}

--- a/plugins/brickang/migrations/006_brickang_position_locks.down.sql
+++ b/plugins/brickang/migrations/006_brickang_position_locks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS brickang_position_locks

--- a/plugins/brickang/migrations/006_brickang_position_locks.up.sql
+++ b/plugins/brickang/migrations/006_brickang_position_locks.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS brickang_position_locks (
+    id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    building_id     INT UNSIGNED NOT NULL,
+    position_x      INT NOT NULL,
+    position_y      INT NOT NULL,
+    position_z      INT NOT NULL,
+    user_id         BIGINT UNSIGNED NOT NULL,
+    expires_at      DATETIME(6) NOT NULL,
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uk_position_lock (building_id, position_x, position_y, position_z),
+    KEY ix_user (user_id),
+    KEY ix_expires (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/plugins/brickang/plugin.json
+++ b/plugins/brickang/plugin.json
@@ -43,6 +43,12 @@
             "description": "brickang_events: 마일스톤/시즌 이벤트",
             "up": "migrations/005_brickang_events.up.sql",
             "down": "migrations/005_brickang_events.down.sql"
+        },
+        {
+            "version": "006",
+            "description": "brickang_position_locks: 자유 배치 5분 lock",
+            "up": "migrations/006_brickang_position_locks.up.sql",
+            "down": "migrations/006_brickang_position_locks.down.sql"
         }
     ],
     "api": {
@@ -126,6 +132,24 @@
                     "method": "GET",
                     "path": "/brick-types/:slug",
                     "handler": "routes/brick-types/detail.ts"
+                },
+                {
+                    "method": "POST",
+                    "path": "/locks/acquire",
+                    "handler": "routes/locks/acquire.ts",
+                    "authenticated": true
+                },
+                {
+                    "method": "DELETE",
+                    "path": "/locks/:lock_id",
+                    "handler": "routes/locks/release.ts",
+                    "authenticated": true
+                },
+                {
+                    "method": "POST",
+                    "path": "/locks/cleanup-expired",
+                    "handler": "routes/locks/cleanup.ts",
+                    "authenticated": true
                 }
             ]
         }

--- a/plugins/brickang/routes/locks/acquire.ts
+++ b/plugins/brickang/routes/locks/acquire.ts
@@ -1,0 +1,84 @@
+/**
+ * POST /api/plugins/brickang/locks/acquire
+ *
+ * 자유 배치(silver/gold/diamond)용 위치 lock 획득.
+ *
+ * Body: { building_id, brick_type_slug, position: {x,y,z} }
+ *
+ * 검증:
+ *   - 사용자 인증 필수
+ *   - brick_type 이 자유 배치 등급(silver/gold/diamond)
+ *   - building active
+ *   - 좌표가 strategy.validate() 통과
+ *   - UNIQUE 충돌(다른 사용자 점유) → 409
+ *
+ * 응답: 200 { lock_id, expires_at }  /  409 { error: 'position_locked' }
+ */
+
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { requireUser } from '../../server/auth.js';
+import { getBrickTypeBySlug } from '../../server/brick-types.js';
+import { getBuildingById, getOccupiedSet } from '../../server/buildings.js';
+import { validateFreePosition, pickStrategy } from '../../server/placement.js';
+import { acquireLock } from '../../server/locks.js';
+import type { BrickPosition, BrickTypeSlug } from '../../types/index.js';
+
+interface AcquireBody {
+    building_id: number;
+    brick_type_slug: BrickTypeSlug;
+    position: BrickPosition;
+}
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    const user = requireUser(event);
+
+    let body: AcquireBody;
+    try {
+        body = (await event.request.json()) as AcquireBody;
+    } catch {
+        throw error(400, 'invalid json');
+    }
+
+    if (!body.building_id) throw error(400, 'building_id required');
+    if (!body.brick_type_slug) throw error(400, 'brick_type_slug required');
+    if (
+        !body.position ||
+        !Number.isFinite(body.position.x) ||
+        !Number.isFinite(body.position.y) ||
+        !Number.isFinite(body.position.z)
+    ) {
+        throw error(400, 'position required');
+    }
+
+    const picked = pickStrategy(body.brick_type_slug);
+    if (picked.kind !== 'free') {
+        throw error(400, 'brick_type does not support free placement');
+    }
+
+    const brickType = await getBrickTypeBySlug(body.brick_type_slug);
+    if (!brickType || !brickType.isActive) {
+        throw error(400, `unknown brick_type: ${body.brick_type_slug}`);
+    }
+
+    const building = await getBuildingById(body.building_id);
+    if (!building) throw error(404, 'building not found');
+    if (building.status !== 'active') throw error(400, 'building not active');
+
+    const occupied = await getOccupiedSet(body.building_id);
+    const reason = validateFreePosition(body.brick_type_slug, building, body.position, occupied);
+    if (reason) {
+        throw error(400, reason);
+    }
+
+    const lock = await acquireLock(user.userId, body.building_id, body.position);
+    if (!lock) {
+        // 다른 사용자가 이미 lock 점유
+        return json({ error: 'position_locked' }, { status: 409 });
+    }
+
+    return json({
+        lock_id: lock.id,
+        expires_at: lock.expiresAt.toISOString(),
+        position: lock.position
+    });
+}

--- a/plugins/brickang/routes/locks/cleanup.ts
+++ b/plugins/brickang/routes/locks/cleanup.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /api/plugins/brickang/locks/cleanup-expired
+ *
+ * 만료된 lock 행을 일괄 삭제. admin (mb_level >= 10) 전용.
+ * cron 시스템이 없으면 외부에서 주기적으로 호출 (K8s CronJob 등).
+ *
+ * 응답: { deleted: <count> }
+ */
+
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { requireUser } from '../../server/auth.js';
+import { cleanExpiredLocks } from '../../server/locks.js';
+
+interface AdminLocals {
+    user?: { mb_level?: number | null };
+}
+
+export async function POST(event: RequestEvent): Promise<Response> {
+    requireUser(event);
+    const locals = event.locals as AdminLocals;
+    const level = locals.user?.mb_level ?? 0;
+    if (level < 10) {
+        throw error(403, 'admin only');
+    }
+    const deleted = await cleanExpiredLocks(1000);
+    return json({ deleted });
+}

--- a/plugins/brickang/routes/locks/release.ts
+++ b/plugins/brickang/routes/locks/release.ts
@@ -1,0 +1,25 @@
+/**
+ * DELETE /api/plugins/brickang/locks/:lock_id
+ *
+ * 사용자 본인의 위치 lock 해제. 다른 사람 lock 이면 404 (의도적으로 owner 노출 안 함).
+ *
+ * 응답: { released: true }
+ */
+
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { requireUser } from '../../server/auth.js';
+import { releaseLock } from '../../server/locks.js';
+
+export async function DELETE(event: RequestEvent): Promise<Response> {
+    const user = requireUser(event);
+    const lockId = Number(event.params.lock_id);
+    if (!Number.isFinite(lockId) || lockId <= 0) {
+        throw error(400, 'invalid lock_id');
+    }
+    const affected = await releaseLock(user.userId, lockId);
+    if (affected === 0) {
+        // 본인 lock 아니거나 이미 만료/소비됨 — 멱등 처리
+        return json({ released: false });
+    }
+    return json({ released: true });
+}

--- a/plugins/brickang/routes/orders/confirm.ts
+++ b/plugins/brickang/routes/orders/confirm.ts
@@ -23,10 +23,11 @@ import {
     getOccupiedSet
 } from '../../server/buildings.js';
 import { getBrickTypeBySlug } from '../../server/brick-types.js';
-import { findNextPositions, posKey, WallFirstStrategy } from '../../server/placement.js';
+import { posKey, WallFirstStrategy, pickStrategy } from '../../server/placement.js';
+import { consumeLockInTx } from '../../server/locks.js';
 import { upsertUserStats, checkAndRecordMilestones } from '../../server/stats-aggregator.js';
 import { invalidateBuildingSnapshot, pushRecentBrick } from '../../server/snapshot.js';
-import type { BrickangOrderMetadata } from '../../types/index.js';
+import type { BrickangOrderMetadata, BrickPosition } from '../../types/index.js';
 
 interface ConfirmRequestBody {
     order_uid: string;
@@ -118,6 +119,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
         type: string;
         nickname: string;
     }> = [];
+    let lockFallback = false;
 
     try {
         await conn.beginTransaction();
@@ -129,12 +131,40 @@ export async function POST(event: RequestEvent): Promise<Response> {
         // race-safe placement: building.currentBricks 는 FOR UPDATE 로 잠긴 최신값
         const occupied = await getOccupiedSet(buildingId);
         let cursor = building.currentBricks;
-        const strategy = new WallFirstStrategy();
+        const autoStrategy = new WallFirstStrategy();
+
+        // Phase 2: 자유 배치 lock 처리. lock_id 가 있으면 그 좌표 사용 + 행 삭제.
+        // lock 만료/없음 → 자동 배치(WallFirst) 로 fallback (결제는 이미 완료되어 환불 회피).
+        const picked = pickStrategy(metadata.brick_type_slug);
+        let lockedPosition: BrickPosition | null = null;
+        if (picked.kind === 'free' && metadata.lock_id) {
+            const lockReason = await consumeLockInTx(conn, user.userId, metadata.lock_id);
+            if (lockReason) {
+                console.warn(
+                    `[brickang/confirm] lock fallback for order=${body.order_uid} reason=${lockReason}`
+                );
+                lockFallback = true;
+            } else if (metadata.position) {
+                // lock 행 삭제 OK + 좌표 점유 검증 (race: 누가 같은 자리 INSERT 했을 가능성 차단)
+                const key = posKey(metadata.position.x, metadata.position.y, metadata.position.z);
+                if (occupied.has(key)) {
+                    lockFallback = true;
+                    console.warn(`[brickang/confirm] lock position already occupied — fallback`);
+                } else {
+                    lockedPosition = metadata.position;
+                }
+            }
+        }
 
         for (let i = 0; i < quantity; i++) {
             let inserted = false;
             for (let attempt = 0; attempt < MAX_INSERT_RETRY && !inserted; attempt++) {
-                const pos = strategy.nextPosition(building, occupied, cursor + attempt);
+                let pos: BrickPosition;
+                if (lockedPosition && i === 0 && attempt === 0) {
+                    pos = lockedPosition;
+                } else {
+                    pos = autoStrategy.nextPosition(building, occupied, cursor + attempt);
+                }
                 try {
                     const [result] = await conn.query<ResultSetHeader>(
                         `INSERT INTO brickang_bricks
@@ -169,6 +199,11 @@ export async function POST(event: RequestEvent): Promise<Response> {
                     if (e.code === 'ER_DUP_ENTRY') {
                         // race: 다음 슬롯으로 이동
                         occupied.add(posKey(pos.x, pos.y, pos.z));
+                        // lock 좌표가 race 충돌 시 즉시 자동 fallback 으로 전환
+                        if (lockedPosition && i === 0) {
+                            lockedPosition = null;
+                            lockFallback = true;
+                        }
                         continue;
                     }
                     throw err;
@@ -178,7 +213,6 @@ export async function POST(event: RequestEvent): Promise<Response> {
                 throw error(500, 'placement retry exhausted (UNIQUE conflict)');
             }
         }
-
         // 6) buildings.current_bricks 증가
         await incrementCurrentBricks(conn, buildingId, quantity);
 
@@ -217,5 +251,5 @@ export async function POST(event: RequestEvent): Promise<Response> {
         });
     }
 
-    return json({ success: true, bricks: insertedBricks });
+    return json({ success: true, bricks: insertedBricks, lock_fallback: lockFallback });
 }

--- a/plugins/brickang/routes/orders/start.ts
+++ b/plugins/brickang/routes/orders/start.ts
@@ -16,7 +16,9 @@ import { readPool } from '../../server/db.js';
 import { getBrickTypeBySlug } from '../../server/brick-types.js';
 import { getBuildingById } from '../../server/buildings.js';
 import { requireUser } from '../../server/auth.js';
-import type { BrickTypeSlug } from '../../types/index.js';
+import { getLockById } from '../../server/locks.js';
+import { pickStrategy } from '../../server/placement.js';
+import type { BrickPosition, BrickTypeSlug } from '../../types/index.js';
 
 const DEFAULT_ANONYMOUS_DAILY_CAP = 100;
 
@@ -62,6 +64,10 @@ interface StartRequestBody {
     provider: 'toss' | 'naver' | 'paypal';
     returnUrl: string;
     cancelUrl: string;
+    /** Phase 2: 자유 배치(silver/gold/diamond) 시 사전 acquire 한 lock_id */
+    lock_id?: number | null;
+    /** Phase 2: 자유 배치 좌표 — lock 의 좌표와 일치해야 함 */
+    position?: BrickPosition | null;
 }
 
 function generateOrderUid(): string {
@@ -128,6 +134,40 @@ export async function POST(event: RequestEvent): Promise<Response> {
         throw error(400, 'PayPal not available for this brick type');
     }
 
+    // Phase 2: 자유 배치 등급은 lock_id + position 필수, 자동 배치 등급은 사용 금지
+    const picked = pickStrategy(brickType.slug);
+    let lockId: number | null = null;
+    let position: BrickPosition | null = null;
+    if (picked.kind === 'free') {
+        if (quantity !== 1) {
+            throw error(400, 'free placement supports quantity=1 only');
+        }
+        if (!body.lock_id || !body.position) {
+            throw error(400, 'lock_id and position required for free placement');
+        }
+        const lock = await getLockById(body.lock_id);
+        if (!lock) throw error(404, 'lock not found');
+        if (lock.userId !== user.userId) throw error(403, 'lock not owner');
+        if (lock.buildingId !== body.building_id) throw error(400, 'lock building mismatch');
+        if (
+            lock.position.x !== body.position.x ||
+            lock.position.y !== body.position.y ||
+            lock.position.z !== body.position.z
+        ) {
+            throw error(400, 'lock position mismatch');
+        }
+        if (lock.expiresAt.getTime() < Date.now()) {
+            throw error(410, 'lock expired');
+        }
+        lockId = lock.id;
+        position = lock.position;
+    } else {
+        // 자동 배치 등급은 lock 사용 금지 (오용 방지)
+        if (body.lock_id || body.position) {
+            throw error(400, 'this brick_type uses auto placement; remove lock_id/position');
+        }
+    }
+
     const orderUid = generateOrderUid();
     const amount = brickType.priceKrw * quantity;
     const currency = body.provider === 'paypal' ? 'USD' : 'KRW';
@@ -140,7 +180,9 @@ export async function POST(event: RequestEvent): Promise<Response> {
         message,
         building_id: body.building_id,
         is_anonymous: brickType.isAnonymous,
-        nickname_snapshot: nicknameSnapshot
+        nickname_snapshot: nicknameSnapshot,
+        lock_id: lockId,
+        position
     };
 
     // plugins/payment/checkout/start 위임 호출 (서버 내부 fetch)

--- a/plugins/brickang/server/locks.ts
+++ b/plugins/brickang/server/locks.ts
@@ -1,0 +1,149 @@
+/**
+ * brickang 위치 lock 헬퍼 (Phase 2).
+ *
+ * 자유 배치(silver/gold/diamond) 흐름:
+ *   1. 사용자가 좌표 클릭 → POST /locks/acquire → INSERT brickang_position_locks (5분 TTL)
+ *   2. 결제 진행 (lock_id 를 metadata 에 보관)
+ *   3. /orders/confirm 시 lock 행 삭제 + brick INSERT (단일 tx)
+ *   4. 만료 lock 은 cron / manual cleanup 으로 정리
+ *
+ * NOTE: `@sveltejs/kit` 직접 import 금지 (auth.ts 동일 함정).
+ */
+
+import type { PoolConnection, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import { pool, readPool } from './db.js';
+import type { BrickPosition, PositionLock } from '../types/index.js';
+
+const LOCK_TTL_MS = 5 * 60 * 1000; // 5분
+
+interface LockRow extends RowDataPacket {
+    id: number;
+    building_id: number;
+    position_x: number;
+    position_y: number;
+    position_z: number;
+    user_id: number;
+    expires_at: Date;
+    created_at: Date;
+}
+
+function rowToLock(r: LockRow): PositionLock {
+    return {
+        id: r.id,
+        buildingId: r.building_id,
+        position: { x: r.position_x, y: r.position_y, z: r.position_z },
+        userId: r.user_id,
+        expiresAt: r.expires_at,
+        createdAt: r.created_at
+    };
+}
+
+/**
+ * 위치 lock 획득. UNIQUE 충돌(다른 사용자 점유) 시 null 반환.
+ * 만료된 lock 행이 있으면 사전 cleanup 한 후 재시도한다.
+ */
+export async function acquireLock(
+    userId: number,
+    buildingId: number,
+    pos: BrickPosition
+): Promise<PositionLock | null> {
+    const conn = await pool.getConnection();
+    try {
+        await conn.beginTransaction();
+
+        // 만료된 lock 사전 정리 (해당 좌표만)
+        await conn.query(
+            `DELETE FROM brickang_position_locks
+             WHERE building_id = ? AND position_x = ? AND position_y = ? AND position_z = ?
+               AND expires_at < NOW(6)`,
+            [buildingId, pos.x, pos.y, pos.z]
+        );
+
+        const expiresAt = new Date(Date.now() + LOCK_TTL_MS);
+        try {
+            const [result] = await conn.query<ResultSetHeader>(
+                `INSERT INTO brickang_position_locks
+                    (building_id, position_x, position_y, position_z, user_id, expires_at)
+                 VALUES (?, ?, ?, ?, ?, ?)`,
+                [buildingId, pos.x, pos.y, pos.z, userId, expiresAt]
+            );
+            await conn.commit();
+            return {
+                id: result.insertId,
+                buildingId,
+                position: pos,
+                userId,
+                expiresAt,
+                createdAt: new Date()
+            };
+        } catch (err) {
+            await conn.rollback();
+            const e = err as { code?: string };
+            if (e.code === 'ER_DUP_ENTRY') return null;
+            throw err;
+        }
+    } finally {
+        conn.release();
+    }
+}
+
+/**
+ * lock 조회 (id 기반).
+ */
+export async function getLockById(lockId: number): Promise<PositionLock | null> {
+    const [rows] = await readPool.query<LockRow[]>(
+        'SELECT * FROM brickang_position_locks WHERE id = ? LIMIT 1',
+        [lockId]
+    );
+    return rows[0] ? rowToLock(rows[0]) : null;
+}
+
+/**
+ * 사용자 본인 lock 만 삭제. 다른 사람 lock 이면 0 반환.
+ */
+export async function releaseLock(userId: number, lockId: number): Promise<number> {
+    const [result] = await pool.query<ResultSetHeader>(
+        'DELETE FROM brickang_position_locks WHERE id = ? AND user_id = ?',
+        [lockId, userId]
+    );
+    return result.affectedRows;
+}
+
+/**
+ * 트랜잭션 내에서 lock 사용 + 삭제. 만료/소유주 불일치 시 예외 사유 반환.
+ *
+ * @returns null = 통과 (행 삭제됨), string = 거절 사유
+ */
+export async function consumeLockInTx(
+    conn: PoolConnection,
+    userId: number,
+    lockId: number
+): Promise<string | null> {
+    const [rows] = await conn.query<LockRow[]>(
+        'SELECT * FROM brickang_position_locks WHERE id = ? FOR UPDATE',
+        [lockId]
+    );
+    const lock = rows[0];
+    if (!lock) return 'lock_not_found';
+    if (lock.user_id !== userId) return 'lock_not_owner';
+    if (lock.expires_at.getTime() < Date.now()) {
+        // 만료된 lock 행은 삭제만 하고 caller 가 fallback 하도록 사유 반환
+        await conn.query('DELETE FROM brickang_position_locks WHERE id = ?', [lockId]);
+        return 'lock_expired';
+    }
+    await conn.query('DELETE FROM brickang_position_locks WHERE id = ?', [lockId]);
+    return null;
+}
+
+/**
+ * 만료된 모든 lock 정리. cron 또는 admin 트리거가 호출.
+ *
+ * @returns 삭제된 행 수
+ */
+export async function cleanExpiredLocks(limit: number = 100): Promise<number> {
+    const [result] = await pool.query<ResultSetHeader>(
+        'DELETE FROM brickang_position_locks WHERE expires_at < NOW(6) LIMIT ?',
+        [limit]
+    );
+    return result.affectedRows;
+}

--- a/plugins/brickang/server/placement.ts
+++ b/plugins/brickang/server/placement.ts
@@ -154,3 +154,162 @@ export function findNextPositions(
     }
     return result;
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase 2: 자유 배치 전략
+// ─────────────────────────────────────────────────────────────────────
+
+import type { BrickTypeSlug } from '../types/index.js';
+
+/**
+ * 좌표 기반 검증 전략 (자유 배치).
+ *
+ * 사용자가 클릭한 좌표가 유효한지 검증한다. 유효하지 않으면 string 으로 사유 반환,
+ * 유효하면 null 반환.
+ */
+export interface FreePlacementStrategy {
+    /**
+     * @param building   현재 건축물
+     * @param pos        사용자가 지정한 좌표
+     * @param occupied   이미 점유된 좌표 세트
+     * @returns null = 통과, string = 거절 사유
+     */
+    validate(building: Building, pos: BrickPosition, occupied: Set<string>): string | null;
+}
+
+/**
+ * 좌표가 building 의 dimension 내부인지.
+ */
+function inBoundingBox(building: Building, pos: BrickPosition): boolean {
+    return (
+        pos.x >= 0 &&
+        pos.x < building.dimensionX &&
+        pos.y >= 0 &&
+        pos.y < building.dimensionY &&
+        pos.z >= 0 &&
+        pos.z < building.dimensionZ
+    );
+}
+
+/**
+ * 가장 위 미완성 층(active layer)을 반환한다. 모두 완성됐으면 dimensionY-1 반환.
+ *
+ * 활성 층 계산 규칙:
+ *   - currentBricks 가 0 이면 → y=0
+ *   - 누적 슬롯 카운트가 currentBricks 를 초과하는 첫 번째 층이 active
+ */
+export function activeLayer(building: Building): number {
+    const dimX = building.dimensionX;
+    const dimZ = building.dimensionZ;
+    const dimY = building.dimensionY;
+    let cumulative = 0;
+    for (let y = 0; y < dimY; y++) {
+        const f = getFloorConfig(building.blueprintData, y);
+        const slots = generateFloorSlots(dimX, dimZ, f?.holes ?? []);
+        cumulative += slots.length;
+        if (building.currentBricks < cumulative) {
+            return y;
+        }
+    }
+    return dimY - 1;
+}
+
+/**
+ * 6 방향 인접 1면 지지 검증 (뜬 벽돌 금지).
+ *
+ *  - y === 0  → 바닥에 닿음 → OK
+ *  - 6 방향 (+/-x, +/-y, +/-z) 중 1개라도 occupied 면 OK
+ *  - 그 외 → reject
+ */
+export function hasSupport(pos: BrickPosition, occupied: Set<string>): boolean {
+    if (pos.y === 0) return true;
+    const neighbors: BrickPosition[] = [
+        { x: pos.x + 1, y: pos.y, z: pos.z },
+        { x: pos.x - 1, y: pos.y, z: pos.z },
+        { x: pos.x, y: pos.y + 1, z: pos.z },
+        { x: pos.x, y: pos.y - 1, z: pos.z },
+        { x: pos.x, y: pos.y, z: pos.z + 1 },
+        { x: pos.x, y: pos.y, z: pos.z - 1 }
+    ];
+    return neighbors.some((n) => occupied.has(posKey(n.x, n.y, n.z)));
+}
+
+/**
+ * 좌표가 hole 인지 (배치 불가).
+ */
+function isHolePosition(building: Building, pos: BrickPosition): boolean {
+    const f = getFloorConfig(building.blueprintData, pos.y);
+    if (!f?.holes) return false;
+    return f.holes.some(
+        (h) => pos.x >= h.x_start && pos.x <= h.x_end && pos.z >= h.z && pos.z <= (h.z_end ?? h.z)
+    );
+}
+
+/**
+ * 은 등급: 활성 층 안에서만 자유 배치. 인접 1면 지지 필수.
+ */
+export class LayerFreeStrategy implements FreePlacementStrategy {
+    validate(building: Building, pos: BrickPosition, occupied: Set<string>): string | null {
+        if (!inBoundingBox(building, pos)) return 'position out of bounds';
+        if (isHolePosition(building, pos)) return 'position is a hole';
+        if (occupied.has(posKey(pos.x, pos.y, pos.z))) return 'position already occupied';
+        const active = activeLayer(building);
+        if (pos.y !== active) return `position must be on active layer (y=${active})`;
+        if (!hasSupport(pos, occupied)) return 'position has no adjacent support (floating brick)';
+        return null;
+    }
+}
+
+/**
+ * 금/다이아 등급: 건물 bbox 내 자유 배치. 인접 1면 지지 필수.
+ */
+export class BboxFreeStrategy implements FreePlacementStrategy {
+    validate(building: Building, pos: BrickPosition, occupied: Set<string>): string | null {
+        if (!inBoundingBox(building, pos)) return 'position out of bounds';
+        if (isHolePosition(building, pos)) return 'position is a hole';
+        if (occupied.has(posKey(pos.x, pos.y, pos.z))) return 'position already occupied';
+        if (!hasSupport(pos, occupied)) return 'position has no adjacent support (floating brick)';
+        return null;
+    }
+}
+
+/**
+ * 등급별 strategy 선택.
+ *
+ *   anonymous, normal → WallFirstStrategy (auto 배치)
+ *   silver            → LayerFreeStrategy (활성 층 내 자유)
+ *   gold, diamond     → BboxFreeStrategy (전체 bbox 자유)
+ */
+export type AnyStrategy =
+    | { kind: 'auto'; strategy: PlacementStrategy }
+    | { kind: 'free'; strategy: FreePlacementStrategy };
+
+export function pickStrategy(slug: BrickTypeSlug): AnyStrategy {
+    switch (slug) {
+        case 'silver':
+            return { kind: 'free', strategy: new LayerFreeStrategy() };
+        case 'gold':
+        case 'diamond':
+            return { kind: 'free', strategy: new BboxFreeStrategy() };
+        case 'anonymous':
+        case 'normal':
+        default:
+            return { kind: 'auto', strategy: new WallFirstStrategy() };
+    }
+}
+
+/**
+ * 자유 배치 검증 헬퍼 — slug + position 조합으로 1회 검증.
+ *
+ * @returns null = 통과, string = 사유
+ */
+export function validateFreePosition(
+    slug: BrickTypeSlug,
+    building: Building,
+    pos: BrickPosition,
+    occupied: Set<string>
+): string | null {
+    const picked = pickStrategy(slug);
+    if (picked.kind !== 'free') return 'brick_type does not support free placement';
+    return picked.strategy.validate(building, pos, occupied);
+}

--- a/plugins/brickang/tests/locks.test.ts
+++ b/plugins/brickang/tests/locks.test.ts
@@ -1,0 +1,199 @@
+/**
+ * locks.test.ts — Phase 2 위치 lock 흐름 단위 테스트.
+ *
+ * 시나리오:
+ *  - acquireLock 성공 → INSERT 호출 + lock 객체 반환
+ *  - 동일 좌표 동시 acquireLock → 1명만 성공, 다른 1명 ER_DUP_ENTRY → null
+ *  - releaseLock: 본인 lock 만 삭제
+ *  - consumeLockInTx: 만료된 lock 은 'lock_expired' 반환 + 행 삭제
+ *  - cleanExpiredLocks: DELETE 쿼리 호출
+ *
+ * mysql2 풀을 mock 으로 대체.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPoolQuery = vi.fn();
+const mockReadPoolQuery = vi.fn();
+const mockConnQuery = vi.fn();
+const mockConnBegin = vi.fn();
+const mockConnCommit = vi.fn();
+const mockConnRollback = vi.fn();
+const mockConnRelease = vi.fn();
+
+vi.mock('../server/db.js', () => ({
+    pool: {
+        query: (...args: unknown[]) => mockPoolQuery(...args),
+        getConnection: vi.fn(async () => ({
+            query: (...args: unknown[]) => mockConnQuery(...args),
+            beginTransaction: () => mockConnBegin(),
+            commit: () => mockConnCommit(),
+            rollback: () => mockConnRollback(),
+            release: () => mockConnRelease()
+        }))
+    },
+    readPool: {
+        query: (...args: unknown[]) => mockReadPoolQuery(...args)
+    }
+}));
+
+beforeEach(() => {
+    mockPoolQuery.mockReset();
+    mockReadPoolQuery.mockReset();
+    mockConnQuery.mockReset();
+    mockConnBegin.mockReset();
+    mockConnCommit.mockReset();
+    mockConnRollback.mockReset();
+    mockConnRelease.mockReset();
+});
+
+describe('acquireLock', () => {
+    it('성공: INSERT 후 lock 객체 반환', async () => {
+        // DELETE expired (no-op), then INSERT success
+        mockConnQuery
+            .mockResolvedValueOnce([{ affectedRows: 0 }])
+            .mockResolvedValueOnce([{ insertId: 42 }]);
+
+        const { acquireLock } = await import('../server/locks.js');
+        const lock = await acquireLock(7, 1, { x: 2, y: 3, z: 4 });
+        expect(lock).not.toBeNull();
+        expect(lock?.id).toBe(42);
+        expect(lock?.userId).toBe(7);
+        expect(lock?.position).toEqual({ x: 2, y: 3, z: 4 });
+        expect(mockConnCommit).toHaveBeenCalledOnce();
+    });
+
+    it('UNIQUE 충돌(다른 사용자 점유) → null', async () => {
+        mockConnQuery
+            .mockResolvedValueOnce([{ affectedRows: 0 }]) // DELETE expired
+            .mockRejectedValueOnce({ code: 'ER_DUP_ENTRY' }); // INSERT 충돌
+
+        const { acquireLock } = await import('../server/locks.js');
+        const lock = await acquireLock(7, 1, { x: 2, y: 3, z: 4 });
+        expect(lock).toBeNull();
+        expect(mockConnRollback).toHaveBeenCalledOnce();
+    });
+
+    it('만료 lock 사전 정리 후 INSERT', async () => {
+        mockConnQuery
+            .mockResolvedValueOnce([{ affectedRows: 1 }]) // 만료 lock 1개 삭제
+            .mockResolvedValueOnce([{ insertId: 100 }]);
+
+        const { acquireLock } = await import('../server/locks.js');
+        const lock = await acquireLock(8, 1, { x: 0, y: 0, z: 0 });
+        expect(lock?.id).toBe(100);
+    });
+});
+
+describe('releaseLock', () => {
+    it('본인 lock 삭제 → 1', async () => {
+        mockPoolQuery.mockResolvedValueOnce([{ affectedRows: 1 }]);
+        const { releaseLock } = await import('../server/locks.js');
+        const n = await releaseLock(7, 42);
+        expect(n).toBe(1);
+        const sqlArg = mockPoolQuery.mock.calls[0][0] as string;
+        expect(sqlArg).toContain('user_id = ?');
+    });
+
+    it('다른 사람 lock → 0', async () => {
+        mockPoolQuery.mockResolvedValueOnce([{ affectedRows: 0 }]);
+        const { releaseLock } = await import('../server/locks.js');
+        const n = await releaseLock(99, 42);
+        expect(n).toBe(0);
+    });
+});
+
+describe('consumeLockInTx', () => {
+    it('정상 lock → 행 삭제 + null', async () => {
+        const fakeConn = {
+            query: vi.fn()
+        };
+        const future = new Date(Date.now() + 60_000);
+        fakeConn.query
+            .mockResolvedValueOnce([
+                [
+                    {
+                        id: 1,
+                        building_id: 1,
+                        position_x: 0,
+                        position_y: 0,
+                        position_z: 0,
+                        user_id: 7,
+                        expires_at: future,
+                        created_at: new Date()
+                    }
+                ]
+            ])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+        const { consumeLockInTx } = await import('../server/locks.js');
+        const reason = await consumeLockInTx(fakeConn as never, 7, 1);
+        expect(reason).toBeNull();
+        expect(fakeConn.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('lock 없음 → lock_not_found', async () => {
+        const fakeConn = { query: vi.fn().mockResolvedValueOnce([[]]) };
+        const { consumeLockInTx } = await import('../server/locks.js');
+        const reason = await consumeLockInTx(fakeConn as never, 7, 1);
+        expect(reason).toBe('lock_not_found');
+    });
+
+    it('소유주 불일치 → lock_not_owner', async () => {
+        const fakeConn = {
+            query: vi.fn().mockResolvedValueOnce([
+                [
+                    {
+                        id: 1,
+                        building_id: 1,
+                        position_x: 0,
+                        position_y: 0,
+                        position_z: 0,
+                        user_id: 99,
+                        expires_at: new Date(Date.now() + 60_000),
+                        created_at: new Date()
+                    }
+                ]
+            ])
+        };
+        const { consumeLockInTx } = await import('../server/locks.js');
+        const reason = await consumeLockInTx(fakeConn as never, 7, 1);
+        expect(reason).toBe('lock_not_owner');
+    });
+
+    it('만료 lock → lock_expired + 행 삭제', async () => {
+        const past = new Date(Date.now() - 60_000);
+        const fakeConn = { query: vi.fn() };
+        fakeConn.query
+            .mockResolvedValueOnce([
+                [
+                    {
+                        id: 1,
+                        building_id: 1,
+                        position_x: 0,
+                        position_y: 0,
+                        position_z: 0,
+                        user_id: 7,
+                        expires_at: past,
+                        created_at: new Date()
+                    }
+                ]
+            ])
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);
+        const { consumeLockInTx } = await import('../server/locks.js');
+        const reason = await consumeLockInTx(fakeConn as never, 7, 1);
+        expect(reason).toBe('lock_expired');
+        expect(fakeConn.query).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('cleanExpiredLocks', () => {
+    it('DELETE 쿼리 실행 → affectedRows 반환', async () => {
+        mockPoolQuery.mockResolvedValueOnce([{ affectedRows: 5 }]);
+        const { cleanExpiredLocks } = await import('../server/locks.js');
+        const n = await cleanExpiredLocks(100);
+        expect(n).toBe(5);
+        const sql = mockPoolQuery.mock.calls[0][0] as string;
+        expect(sql).toContain('expires_at < NOW(6)');
+    });
+});

--- a/plugins/brickang/tests/placement-phase2.test.ts
+++ b/plugins/brickang/tests/placement-phase2.test.ts
@@ -1,0 +1,206 @@
+/**
+ * placement-phase2.test.ts — 자유 배치 전략(LayerFree / BboxFree) + 지지 규칙 단위 테스트.
+ *
+ * DB 호출 없음 — 순수 알고리즘 테스트.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    LayerFreeStrategy,
+    BboxFreeStrategy,
+    activeLayer,
+    hasSupport,
+    pickStrategy,
+    validateFreePosition,
+    posKey
+} from '../server/placement.js';
+import type { Building } from '../types/index.js';
+
+function makeBuilding(overrides: Partial<Building> = {}): Building {
+    return {
+        id: 1,
+        name: 'test',
+        description: null,
+        targetBricks: 100,
+        currentBricks: 0,
+        status: 'active',
+        blueprintData: null,
+        dimensionX: 5,
+        dimensionY: 3,
+        dimensionZ: 5,
+        season: 1,
+        createdAt: new Date(),
+        completedAt: null,
+        ...overrides
+    };
+}
+
+describe('activeLayer', () => {
+    it('빈 건물(currentBricks=0) → y=0', () => {
+        expect(activeLayer(makeBuilding())).toBe(0);
+    });
+
+    it('1층 25개 채워진 5x5x3 → y=1', () => {
+        const b = makeBuilding({ currentBricks: 25 });
+        expect(activeLayer(b)).toBe(1);
+    });
+
+    it('1층 24개만 채워진 5x5x3 → y=0', () => {
+        const b = makeBuilding({ currentBricks: 24 });
+        expect(activeLayer(b)).toBe(0);
+    });
+});
+
+describe('hasSupport (지지 규칙)', () => {
+    it('y=0 (바닥) → 항상 OK', () => {
+        expect(hasSupport({ x: 5, y: 0, z: 5 }, new Set())).toBe(true);
+    });
+
+    it('y>0 + 6방향 모두 비어있음 → reject', () => {
+        expect(hasSupport({ x: 2, y: 2, z: 2 }, new Set())).toBe(false);
+    });
+
+    it('y>0 + 아래(-y) 점유 → OK', () => {
+        const occupied = new Set([posKey(2, 1, 2)]);
+        expect(hasSupport({ x: 2, y: 2, z: 2 }, occupied)).toBe(true);
+    });
+
+    it('y>0 + 옆(+x) 점유 → OK', () => {
+        const occupied = new Set([posKey(3, 2, 2)]);
+        expect(hasSupport({ x: 2, y: 2, z: 2 }, occupied)).toBe(true);
+    });
+});
+
+describe('LayerFreeStrategy (은 등급)', () => {
+    it('활성 층 안 + 바닥 → 통과', () => {
+        const s = new LayerFreeStrategy();
+        const b = makeBuilding();
+        expect(s.validate(b, { x: 2, y: 0, z: 2 }, new Set())).toBeNull();
+    });
+
+    it('비활성 층(y=2) → 거절', () => {
+        const s = new LayerFreeStrategy();
+        const b = makeBuilding(); // active=0
+        const reason = s.validate(b, { x: 2, y: 2, z: 2 }, new Set());
+        expect(reason).toMatch(/active layer/);
+    });
+
+    it('bbox 밖 좌표 → 거절', () => {
+        const s = new LayerFreeStrategy();
+        const b = makeBuilding();
+        expect(s.validate(b, { x: 99, y: 0, z: 0 }, new Set())).toMatch(/out of bounds/);
+    });
+
+    it('이미 occupied 좌표 → 거절', () => {
+        const s = new LayerFreeStrategy();
+        const b = makeBuilding();
+        const occ = new Set([posKey(0, 0, 0)]);
+        expect(s.validate(b, { x: 0, y: 0, z: 0 }, occ)).toMatch(/already occupied/);
+    });
+
+    it('1층 활성 시 y=1 좌표 + 아래 지지 있으면 통과', () => {
+        const s = new LayerFreeStrategy();
+        const b = makeBuilding({ currentBricks: 25 }); // active=1
+        const occ = new Set([posKey(2, 0, 2)]);
+        expect(s.validate(b, { x: 2, y: 1, z: 2 }, occ)).toBeNull();
+    });
+
+    it('1층 활성 시 지지 없으면 거절 (뜬 벽돌)', () => {
+        const s = new LayerFreeStrategy();
+        const b = makeBuilding({ currentBricks: 25 });
+        // y=1 + 6방향 모두 비어있음
+        const reason = s.validate(b, { x: 2, y: 1, z: 2 }, new Set());
+        expect(reason).toMatch(/floating brick/);
+    });
+});
+
+describe('BboxFreeStrategy (금/다이아 등급)', () => {
+    it('bbox 안 + y=0 → 통과', () => {
+        const s = new BboxFreeStrategy();
+        expect(s.validate(makeBuilding(), { x: 2, y: 0, z: 3 }, new Set())).toBeNull();
+    });
+
+    it('bbox 밖 → 거절', () => {
+        const s = new BboxFreeStrategy();
+        expect(s.validate(makeBuilding(), { x: -1, y: 0, z: 0 }, new Set())).toMatch(
+            /out of bounds/
+        );
+    });
+
+    it('y>0 지지 없음 → 거절 (뜬 벽돌)', () => {
+        const s = new BboxFreeStrategy();
+        expect(s.validate(makeBuilding(), { x: 2, y: 2, z: 2 }, new Set())).toMatch(
+            /floating brick/
+        );
+    });
+
+    it('y>0 옆 지지 있음 → 통과', () => {
+        const s = new BboxFreeStrategy();
+        const occ = new Set([posKey(1, 2, 2)]);
+        expect(s.validate(makeBuilding(), { x: 2, y: 2, z: 2 }, occ)).toBeNull();
+    });
+
+    it('hole 좌표 → 거절', () => {
+        const s = new BboxFreeStrategy();
+        const b = makeBuilding({
+            blueprintData: {
+                floors: [
+                    { y: 0, pattern: 'full', holes: [{ x_start: 1, x_end: 1, z: 1, z_end: 1 }] }
+                ]
+            }
+        });
+        expect(s.validate(b, { x: 1, y: 0, z: 1 }, new Set())).toMatch(/hole/);
+    });
+});
+
+describe('pickStrategy', () => {
+    it('anonymous → auto', () => {
+        expect(pickStrategy('anonymous').kind).toBe('auto');
+    });
+    it('normal → auto', () => {
+        expect(pickStrategy('normal').kind).toBe('auto');
+    });
+    it('silver → free (Layer)', () => {
+        const r = pickStrategy('silver');
+        expect(r.kind).toBe('free');
+        if (r.kind === 'free') expect(r.strategy).toBeInstanceOf(LayerFreeStrategy);
+    });
+    it('gold → free (Bbox)', () => {
+        const r = pickStrategy('gold');
+        expect(r.kind).toBe('free');
+        if (r.kind === 'free') expect(r.strategy).toBeInstanceOf(BboxFreeStrategy);
+    });
+    it('diamond → free (Bbox)', () => {
+        const r = pickStrategy('diamond');
+        expect(r.kind).toBe('free');
+        if (r.kind === 'free') expect(r.strategy).toBeInstanceOf(BboxFreeStrategy);
+    });
+});
+
+describe('validateFreePosition (헬퍼)', () => {
+    it('normal 등급은 자유 배치 거절', () => {
+        const reason = validateFreePosition(
+            'normal',
+            makeBuilding(),
+            { x: 0, y: 0, z: 0 },
+            new Set()
+        );
+        expect(reason).toMatch(/free placement/);
+    });
+
+    it('silver 등급 + 활성 층 + 통과', () => {
+        expect(
+            validateFreePosition('silver', makeBuilding(), { x: 2, y: 0, z: 2 }, new Set())
+        ).toBeNull();
+    });
+
+    it('diamond 등급 + 뜬 벽돌 → 거절', () => {
+        const reason = validateFreePosition(
+            'diamond',
+            makeBuilding(),
+            { x: 2, y: 2, z: 2 },
+            new Set()
+        );
+        expect(reason).toMatch(/floating/);
+    });
+});

--- a/plugins/brickang/types/index.ts
+++ b/plugins/brickang/types/index.ts
@@ -95,6 +95,19 @@ export interface BrickangOrderMetadata {
     building_id: number;
     is_anonymous: boolean;
     nickname_snapshot: string;
+    /** Phase 2: 자유 배치용 position lock id (silver/gold/diamond 자유 배치 시) */
+    lock_id?: number | null;
+    /** Phase 2: 사용자 지정 위치 (silver/gold/diamond 만) */
+    position?: BrickPosition | null;
+}
+
+export interface PositionLock {
+    id: number;
+    buildingId: number;
+    position: BrickPosition;
+    userId: number;
+    expiresAt: Date;
+    createdAt: Date;
 }
 
 export const MILESTONES = [100, 500, 1000, 5000, 10000] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       tar:
         specifier: '>=7.5.8'
         version: 7.5.11
+      three:
+        specifier: ^0.171.0
+        version: 0.171.0
       turndown:
         specifier: ^7.2.2
         version: 7.2.2
@@ -298,6 +301,9 @@ importers:
       '@types/tar':
         specifier: ^6.1.13
         version: 6.1.13
+      '@types/three':
+        specifier: ^0.171.0
+        version: 0.171.0
       '@vitest/browser':
         specifier: ^3.2.3
         version: 3.2.4(playwright@1.58.0)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)
@@ -2599,6 +2605,9 @@ packages:
       '@tiptap/core': ^3.20.0
       '@tiptap/pm': ^3.20.0
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/adm-zip@0.5.7':
     resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
 
@@ -2697,11 +2706,17 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/tar@6.1.13':
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+
+  '@types/three@0.171.0':
+    resolution: {integrity: sha512-oLuT1SAsT+CUg/wxUTFHo0K3NtJLnx9sJhZWQJp/0uXqFpzSk1hRHmvWvpaAWSfvx2db0lVKZ5/wV0I0isD2mQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2711,6 +2726,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@6.21.0':
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -2884,6 +2902,9 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   '@wolfy1339/lru-cache@11.0.2-patch.1':
     resolution: {integrity: sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==}
@@ -3572,6 +3593,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4239,6 +4263,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5147,6 +5174,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  three@0.171.0:
+    resolution: {integrity: sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==}
 
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
@@ -8462,6 +8492,8 @@ snapshots:
       '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/adm-zip@0.5.7':
     dependencies:
       '@types/node': 25.0.10
@@ -8565,6 +8597,8 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/tar@6.1.13':
     dependencies:
       '@types/node': 25.0.10
@@ -8574,11 +8608,22 @@ snapshots:
     dependencies:
       '@types/node': 25.0.10
 
+  '@types/three@0.171.0':
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.69
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
+
   '@types/trusted-types@2.0.7': {}
 
   '@types/turndown@5.0.6': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -8840,6 +8885,8 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@webgpu/types@0.1.69': {}
 
   '@wolfy1339/lru-cache@11.0.2-patch.1': {}
 
@@ -9540,6 +9587,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.2: {}
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -10203,6 +10252,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meshoptimizer@0.18.1: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -11101,6 +11152,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  three@0.171.0: {}
 
   throttle-debounce@5.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.2
         version: 2.29.8(@types/node@25.0.10)
+      '@types/three':
+        specifier: ^0.171.0
+        version: 0.171.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.0.0
         version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -60,6 +63,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.5.6
         version: 0.5.14(prettier-plugin-svelte@3.2.8(prettier@3.3.3)(svelte@5.53.6))(prettier@3.3.3)
+      three:
+        specifier: ^0.171.0
+        version: 0.171.0
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Three.js 3D 뷰어 (lazy import)
- 등급별 자유 배치: 은=층 내 / 금/다이아=건물 내 (지지 규칙)
- 위치 lock 5분 + 동시성 race 보호 + 만료 cleanup
- 다이아 인접 1면 필수 (뜬 벽돌 금지)

## Test plan
- [x] pnpm check 무회귀
- [x] pnpm test:unit --run (placement-phase2 / locks 테스트 포함)
- [ ] sandbox 결제 → 자유 배치 → 정확한 좌표 INSERT 확인 (사용자 환경)

## Phase 3 예고
- WS/SSE 실시간 피드
- Redis 스냅샷 바이너리 압축
- payment.complete hook 구독으로 마이그레이션