### PR TITLE
feat(brickang): 페이지 라우트 + 결손 컴포넌트 (Phase 2.5)

### DIFF
--- a/apps/web/src/routes/brickang/+layout.svelte
+++ b/apps/web/src/routes/brickang/+layout.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+    import { page } from '$app/stores';
+
+    interface Props {
+        children?: import('svelte').Snippet;
+    }
+    let { children }: Props = $props();
+
+    const tabs = [
+        { href: '/brickang', label: '메인' },
+        { href: '/brickang/ranking', label: '랭킹' },
+        { href: '/brickang/my', label: '내 벽돌' }
+    ];
+
+    const path = $derived($page.url.pathname);
+</script>
+
+<div class="brickang-layout">
+    <nav class="brickang-nav">
+        <div class="brickang-nav__inner">
+            <a href="/brickang" class="brickang-nav__brand">브릭앙</a>
+            <div class="brickang-nav__tabs">
+                {#each tabs as t (t.href)}
+                    <a
+                        href={t.href}
+                        class="brickang-nav__tab"
+                        class:brickang-nav__tab--active={path === t.href ||
+                            (t.href !== '/brickang' && path.startsWith(t.href))}
+                    >
+                        {t.label}
+                    </a>
+                {/each}
+            </div>
+        </div>
+    </nav>
+
+    <main class="brickang-layout__content">
+        {@render children?.()}
+    </main>
+</div>
+
+<style>
+    .brickang-layout {
+        min-height: 100vh;
+    }
+    .brickang-nav {
+        background-color: #ffffff;
+        border-bottom: 1px solid #e5e7eb;
+        position: sticky;
+        top: 0;
+        z-index: 10;
+    }
+    .brickang-nav__inner {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 0.75rem 1rem;
+        display: flex;
+        align-items: center;
+        gap: 1.5rem;
+    }
+    .brickang-nav__brand {
+        font-size: 1.125rem;
+        font-weight: 700;
+        color: #111827;
+        text-decoration: none;
+    }
+    .brickang-nav__tabs {
+        display: flex;
+        gap: 0.25rem;
+    }
+    .brickang-nav__tab {
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.375rem;
+        color: #6b7280;
+        text-decoration: none;
+        font-size: 0.875rem;
+    }
+    .brickang-nav__tab--active {
+        background-color: #eff6ff;
+        color: #1d4ed8;
+        font-weight: 600;
+    }
+    .brickang-layout__content {
+        padding-bottom: 3rem;
+    }
+</style>

--- a/apps/web/src/routes/brickang/+page.svelte
+++ b/apps/web/src/routes/brickang/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import BrickShop from '../../../../../plugins/brickang/components/BrickShop.svelte';
+</script>
+
+<svelte:head>
+    <title>브릭앙 — 다모앙</title>
+    <meta name="description" content="벽돌한장의 마음을 쌓다 — 브릭앙 참여형 가상 건축" />
+</svelte:head>
+
+<BrickShop />

--- a/apps/web/src/routes/brickang/building/[id]/+page.server.ts
+++ b/apps/web/src/routes/brickang/building/[id]/+page.server.ts
@@ -1,0 +1,10 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async ({ params }) => {
+    const id = Number(params.id);
+    if (!Number.isFinite(id) || id <= 0) {
+        error(400, 'invalid building id');
+    }
+    return { buildingId: id };
+};

--- a/apps/web/src/routes/brickang/building/[id]/+page.svelte
+++ b/apps/web/src/routes/brickang/building/[id]/+page.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import BuildingViewer from '../../../../../../../plugins/brickang/components/BuildingViewer.svelte';
+    import {
+        brickangApi,
+        type BrickDto,
+        type BuildingDto
+    } from '../../../../../../../plugins/brickang/lib/api.js';
+    import type { PageData } from './$types.js';
+
+    interface Props {
+        data: PageData;
+    }
+    let { data }: Props = $props();
+
+    let building = $state<BuildingDto | null>(null);
+    let bricks = $state<BrickDto[]>([]);
+    let loading = $state(true);
+    let error = $state<string | null>(null);
+
+    onMount(async () => {
+        try {
+            const [b, br] = await Promise.all([
+                brickangApi.getBuilding(data.buildingId),
+                brickangApi.getBuildingBricks(data.buildingId, { limit: 500 })
+            ]);
+            building = b;
+            bricks = br.bricks;
+        } catch (err) {
+            error = err instanceof Error ? err.message : '건축물 로드 실패';
+        } finally {
+            loading = false;
+        }
+    });
+</script>
+
+<svelte:head>
+    <title>건축물 #{data.buildingId} — 브릭앙</title>
+</svelte:head>
+
+<section class="brickang-building">
+    {#if loading}
+        <p class="brickang-building__msg">불러오는 중…</p>
+    {:else if error}
+        <p class="brickang-building__msg brickang-building__msg--error">에러: {error}</p>
+    {:else if building}
+        <header class="brickang-building__header">
+            <h1>{building.name}</h1>
+            {#if building.description}
+                <p class="brickang-building__desc">{building.description}</p>
+            {/if}
+            <p class="brickang-building__progress">
+                {building.current_bricks.toLocaleString('ko-KR')} /
+                {building.target_bricks.toLocaleString('ko-KR')} 장 ({building.progress_percent.toFixed(
+                    1
+                )}%)
+            </p>
+        </header>
+        <BuildingViewer {building} {bricks} mode="view" />
+    {:else}
+        <p class="brickang-building__msg">건축물을 찾을 수 없습니다.</p>
+    {/if}
+</section>
+
+<style>
+    .brickang-building {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem;
+    }
+    .brickang-building__header {
+        margin-bottom: 1rem;
+    }
+    .brickang-building__header h1 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin: 0 0 0.25rem;
+    }
+    .brickang-building__desc {
+        color: #6b7280;
+        font-size: 0.875rem;
+        margin: 0 0 0.5rem;
+    }
+    .brickang-building__progress {
+        font-size: 0.875rem;
+        color: #374151;
+        margin: 0;
+    }
+    .brickang-building__msg {
+        padding: 2rem 1rem;
+        text-align: center;
+        color: #6b7280;
+    }
+    .brickang-building__msg--error {
+        color: #dc2626;
+    }
+</style>

--- a/apps/web/src/routes/brickang/my/+page.server.ts
+++ b/apps/web/src/routes/brickang/my/+page.server.ts
@@ -1,0 +1,10 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+    if (!locals.user) {
+        redirect(302, `/login?redirect=${encodeURIComponent(url.pathname)}`);
+    }
+    const userId = Number(locals.user.id ?? 0) || 0;
+    return { userId };
+};

--- a/apps/web/src/routes/brickang/my/+page.svelte
+++ b/apps/web/src/routes/brickang/my/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    import MyBricks from '../../../../../../plugins/brickang/components/MyBricks.svelte';
+    import type { PageData } from './$types.js';
+
+    interface Props {
+        data: PageData;
+    }
+    let { data }: Props = $props();
+</script>
+
+<svelte:head>
+    <title>내 벽돌 — 브릭앙</title>
+</svelte:head>
+
+<MyBricks userId={data.userId} />

--- a/apps/web/src/routes/brickang/ranking/+page.svelte
+++ b/apps/web/src/routes/brickang/ranking/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import Ranking from '../../../../../../plugins/brickang/components/Ranking.svelte';
+</script>
+
+<svelte:head>
+    <title>브릭앙 랭킹 — 다모앙</title>
+    <meta name="description" content="브릭앙 누적 / 월간 / 건축물별 랭킹" />
+</svelte:head>
+
+<Ranking />

--- a/apps/web/src/routes/brickang/shop/+page.svelte
+++ b/apps/web/src/routes/brickang/shop/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import BrickShop from '../../../../../../plugins/brickang/components/BrickShop.svelte';
+</script>
+
+<svelte:head>
+    <title>브릭앙 상점 — 다모앙</title>
+    <meta name="description" content="벽돌을 골라 건축물에 쌓아 보세요." />
+</svelte:head>
+
+<BrickShop />

--- a/plugins/brickang/components/MyBricks.svelte
+++ b/plugins/brickang/components/MyBricks.svelte
@@ -1,0 +1,170 @@
+<!--
+  MyBricks.svelte — 내가 놓은 벽돌 목록.
+  - placed_at desc 정렬
+  - 등급 색상 표시 (BrickType.color_hex 매칭)
+  - 본인은 익명 brick 의 message 도 볼 수 있음 (어뷰징 추적용 — bricks API 가 그렇게 응답)
+  - Svelte 5 Rune 모드
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { brickangApi, type BrickDto, type BrickTypeDto } from '../lib/api.js';
+
+    interface Props {
+        userId: number;
+    }
+    // userId 는 표시 / 디버깅용. 실제 필터링은 서버 세션 기반.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let { userId }: Props = $props();
+
+    let bricks = $state<BrickDto[]>([]);
+    let brickTypes = $state<BrickTypeDto[]>([]);
+    let loading = $state(true);
+    let error = $state<string | null>(null);
+
+    const typeMap = $derived.by(() => {
+        const m = new Map<string, BrickTypeDto>();
+        for (const t of brickTypes) m.set(t.slug, t);
+        return m;
+    });
+
+    onMount(async () => {
+        try {
+            const [bricksRes, typesRes] = await Promise.all([
+                brickangApi.getMyBricks({ limit: 200 }),
+                brickangApi.listBrickTypes()
+            ]);
+            bricks = bricksRes.bricks;
+            brickTypes = typesRes.brick_types;
+        } catch (err) {
+            error = err instanceof Error ? err.message : '불러오기 실패';
+        } finally {
+            loading = false;
+        }
+    });
+
+    function fmtDate(s: string | Date): string {
+        try {
+            const d = typeof s === 'string' ? new Date(s) : s;
+            return d.toLocaleString('ko-KR', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit'
+            });
+        } catch {
+            return String(s);
+        }
+    }
+</script>
+
+<section class="my-bricks">
+    <h2 class="my-bricks__title">내가 놓은 벽돌</h2>
+
+    {#if loading}
+        <p class="my-bricks__empty">불러오는 중…</p>
+    {:else if error}
+        <p class="my-bricks__error">에러: {error}</p>
+    {:else if bricks.length === 0}
+        <p class="my-bricks__empty">아직 놓은 벽돌이 없습니다.</p>
+    {:else}
+        <p class="my-bricks__count">총 {bricks.length}장</p>
+        <div class="my-bricks__table-wrap">
+            <table class="my-bricks__table">
+                <thead>
+                    <tr>
+                        <th>일시</th>
+                        <th>등급</th>
+                        <th>건축물</th>
+                        <th>닉네임</th>
+                        <th>메시지</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each bricks as b (b.id)}
+                        {@const t = typeMap.get(b.brick_type_slug)}
+                        <tr>
+                            <td class="my-bricks__date">{fmtDate(b.placed_at)}</td>
+                            <td>
+                                <span
+                                    class="my-bricks__chip"
+                                    style="background-color: {b.color ?? t?.color_hex ?? '#9CA3AF'}"
+                                    title={t?.name ?? b.brick_type_slug}
+                                >
+                                    {t?.name ?? b.brick_type_slug}
+                                </span>
+                            </td>
+                            <td>#{b.building_id ?? '-'}</td>
+                            <td>{b.nickname}</td>
+                            <td class="my-bricks__msg">{b.message ?? ''}</td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    {/if}
+</section>
+
+<style>
+    .my-bricks {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem;
+    }
+    .my-bricks__title {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin-bottom: 1rem;
+    }
+    .my-bricks__count {
+        font-size: 0.875rem;
+        color: #6b7280;
+        margin-bottom: 0.5rem;
+    }
+    .my-bricks__empty,
+    .my-bricks__error {
+        padding: 1.5rem;
+        text-align: center;
+        color: #6b7280;
+    }
+    .my-bricks__error {
+        color: #dc2626;
+    }
+    .my-bricks__table-wrap {
+        overflow-x: auto;
+    }
+    .my-bricks__table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.875rem;
+    }
+    .my-bricks__table th,
+    .my-bricks__table td {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #e5e7eb;
+        text-align: left;
+        vertical-align: top;
+    }
+    .my-bricks__table th {
+        font-weight: 600;
+        background-color: #f9fafb;
+        color: #374151;
+    }
+    .my-bricks__date {
+        white-space: nowrap;
+        color: #6b7280;
+    }
+    .my-bricks__chip {
+        display: inline-block;
+        padding: 0.125rem 0.5rem;
+        border-radius: 9999px;
+        color: #fff;
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+    .my-bricks__msg {
+        max-width: 360px;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+</style>

--- a/plugins/brickang/components/PaymentModal.svelte
+++ b/plugins/brickang/components/PaymentModal.svelte
@@ -31,6 +31,11 @@
     }: Props = $props();
 
     let provider = $state<'toss' | 'naver' | 'paypal'>('toss');
+    const allowedProviders: ReadonlyArray<'toss' | 'naver' | 'paypal'> = [
+        'toss',
+        'naver',
+        'paypal'
+    ];
     let busy = $state(false);
 
     // Phase 2: 자유 배치 (silver/gold/diamond)

--- a/plugins/brickang/components/Ranking.svelte
+++ b/plugins/brickang/components/Ranking.svelte
@@ -1,0 +1,301 @@
+<!--
+  Ranking.svelte — 브릭앙 랭킹.
+  - 탭: 전체(all) / 월간(monthly) / 건축물별(building)
+  - 표시: 순위, 닉네임, 벽돌 수, 누적 금액
+  - Svelte 5 Rune 모드
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { brickangApi, type BuildingDto } from '../lib/api.js';
+
+    type Tab = 'all' | 'monthly' | 'building';
+
+    interface RankingRow {
+        rank: number;
+        user_id: number;
+        nickname: string;
+        bricks: number;
+        spent_krw: number;
+    }
+
+    let tab = $state<Tab>('all');
+    let buildings = $state<BuildingDto[]>([]);
+    let selectedBuildingId = $state<number | null>(null);
+
+    let allRows = $state<RankingRow[]>([]);
+    let monthlyRows = $state<RankingRow[]>([]);
+    let buildingRows = $state<RankingRow[]>([]);
+
+    let loading = $state(false);
+    let error = $state<string | null>(null);
+
+    interface AllOrMonthlyResponse {
+        rankings: Array<{
+            rank: number;
+            user_id: number;
+            nickname: string;
+            total_bricks: number;
+            total_spent_krw: number;
+        }>;
+    }
+
+    interface BuildingRankResponse {
+        building_id: number;
+        rankings: RankingRow[];
+    }
+
+    async function loadAll(): Promise<void> {
+        loading = true;
+        error = null;
+        try {
+            const res = (await brickangApi.getRankingsAll(50)) as AllOrMonthlyResponse;
+            allRows = res.rankings.map((r) => ({
+                rank: r.rank,
+                user_id: r.user_id,
+                nickname: r.nickname,
+                bricks: r.total_bricks,
+                spent_krw: r.total_spent_krw
+            }));
+        } catch (err) {
+            error = err instanceof Error ? err.message : '불러오기 실패';
+        } finally {
+            loading = false;
+        }
+    }
+
+    async function loadMonthly(): Promise<void> {
+        loading = true;
+        error = null;
+        try {
+            const res = (await brickangApi.getRankingsMonthly(50)) as AllOrMonthlyResponse;
+            monthlyRows = res.rankings.map((r) => ({
+                rank: r.rank,
+                user_id: r.user_id,
+                nickname: r.nickname,
+                bricks: r.total_bricks,
+                spent_krw: r.total_spent_krw
+            }));
+        } catch (err) {
+            error = err instanceof Error ? err.message : '불러오기 실패';
+        } finally {
+            loading = false;
+        }
+    }
+
+    async function loadBuildings(): Promise<void> {
+        try {
+            const res = await brickangApi.listBuildings();
+            buildings = res.buildings;
+            if (!selectedBuildingId && buildings.length > 0) {
+                selectedBuildingId = buildings[0].id;
+            }
+        } catch (err) {
+            error = err instanceof Error ? err.message : '건축물 로드 실패';
+        }
+    }
+
+    async function loadBuildingRanking(id: number): Promise<void> {
+        loading = true;
+        error = null;
+        try {
+            const res = (await brickangApi.getBuildingRankings(id, 30)) as BuildingRankResponse;
+            buildingRows = res.rankings;
+        } catch (err) {
+            error = err instanceof Error ? err.message : '불러오기 실패';
+        } finally {
+            loading = false;
+        }
+    }
+
+    onMount(async () => {
+        await Promise.all([loadAll(), loadBuildings()]);
+    });
+
+    function setTab(t: Tab): void {
+        tab = t;
+        if (t === 'monthly' && monthlyRows.length === 0) void loadMonthly();
+        if (t === 'building' && selectedBuildingId && buildingRows.length === 0) {
+            void loadBuildingRanking(selectedBuildingId);
+        }
+    }
+
+    function onBuildingChange(): void {
+        if (selectedBuildingId) void loadBuildingRanking(selectedBuildingId);
+    }
+
+    const currentRows = $derived(
+        tab === 'all' ? allRows : tab === 'monthly' ? monthlyRows : buildingRows
+    );
+
+    function fmtKrw(n: number): string {
+        return n.toLocaleString('ko-KR');
+    }
+</script>
+
+<section class="ranking">
+    <h2 class="ranking__title">브릭앙 랭킹</h2>
+
+    <div class="ranking__tabs" role="tablist">
+        <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'all'}
+            class="ranking__tab"
+            class:ranking__tab--active={tab === 'all'}
+            onclick={() => setTab('all')}
+        >
+            전체
+        </button>
+        <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'monthly'}
+            class="ranking__tab"
+            class:ranking__tab--active={tab === 'monthly'}
+            onclick={() => setTab('monthly')}
+        >
+            월간
+        </button>
+        <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'building'}
+            class="ranking__tab"
+            class:ranking__tab--active={tab === 'building'}
+            onclick={() => setTab('building')}
+        >
+            건축물별
+        </button>
+    </div>
+
+    {#if tab === 'building'}
+        <div class="ranking__building-select">
+            <label for="brickang-ranking-building">건축물 선택</label>
+            <select
+                id="brickang-ranking-building"
+                bind:value={selectedBuildingId}
+                onchange={onBuildingChange}
+            >
+                {#each buildings as b (b.id)}
+                    <option value={b.id}>#{b.id} — {b.name}</option>
+                {/each}
+            </select>
+        </div>
+    {/if}
+
+    {#if loading}
+        <p class="ranking__empty">불러오는 중…</p>
+    {:else if error}
+        <p class="ranking__error">에러: {error}</p>
+    {:else if currentRows.length === 0}
+        <p class="ranking__empty">랭킹 데이터가 없습니다.</p>
+    {:else}
+        <div class="ranking__table-wrap">
+            <table class="ranking__table">
+                <thead>
+                    <tr>
+                        <th class="ranking__col-rank">순위</th>
+                        <th>닉네임</th>
+                        <th class="ranking__col-num">벽돌 수</th>
+                        <th class="ranking__col-num">누적 금액</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each currentRows as r (r.user_id + ':' + r.rank)}
+                        <tr class:ranking__row--top={r.rank <= 3}>
+                            <td class="ranking__col-rank">{r.rank}</td>
+                            <td>{r.nickname}</td>
+                            <td class="ranking__col-num">{r.bricks.toLocaleString('ko-KR')}</td>
+                            <td class="ranking__col-num">₩{fmtKrw(r.spent_krw)}</td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    {/if}
+</section>
+
+<style>
+    .ranking {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 1.5rem 1rem;
+    }
+    .ranking__title {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin-bottom: 1rem;
+    }
+    .ranking__tabs {
+        display: flex;
+        gap: 0.25rem;
+        border-bottom: 1px solid #e5e7eb;
+        margin-bottom: 1rem;
+    }
+    .ranking__tab {
+        padding: 0.5rem 1rem;
+        background: transparent;
+        border: none;
+        border-bottom: 2px solid transparent;
+        cursor: pointer;
+        font-size: 0.875rem;
+        color: #6b7280;
+    }
+    .ranking__tab--active {
+        color: #111827;
+        border-bottom-color: #2563eb;
+        font-weight: 600;
+    }
+    .ranking__building-select {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        margin-bottom: 1rem;
+        font-size: 0.875rem;
+    }
+    .ranking__building-select select {
+        padding: 0.25rem 0.5rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.25rem;
+    }
+    .ranking__empty,
+    .ranking__error {
+        padding: 1.5rem;
+        text-align: center;
+        color: #6b7280;
+    }
+    .ranking__error {
+        color: #dc2626;
+    }
+    .ranking__table-wrap {
+        overflow-x: auto;
+    }
+    .ranking__table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.875rem;
+    }
+    .ranking__table th,
+    .ranking__table td {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #e5e7eb;
+        text-align: left;
+    }
+    .ranking__table th {
+        font-weight: 600;
+        background-color: #f9fafb;
+        color: #374151;
+    }
+    .ranking__col-rank {
+        width: 4rem;
+        text-align: center;
+    }
+    .ranking__col-num {
+        text-align: right;
+        white-space: nowrap;
+    }
+    .ranking__row--top td {
+        font-weight: 600;
+        background-color: #fef9c3;
+    }
+</style>


### PR DESCRIPTION
## 요약 (Phase 2.5)
Phase 1+2 (#1368, #1370) 머지 후 운영에서 사용자가 접근할 수 있는 페이지 라우트를 마운트합니다. 결손이었던 `MyBricks` / `Ranking` 컴포넌트를 추가했습니다.

## 변경
- 페이지 라우트 5개 추가 (`apps/web/src/routes/brickang/`)
  - `/brickang` — BrickShop 메인 진입
  - `/brickang/shop` — BrickShop 별칭
  - `/brickang/building/[id]` — BuildingViewer (param 검증 server-side)
  - `/brickang/my` — MyBricks (인증 가드, 비로그인 → `/login?redirect=...`)
  - `/brickang/ranking` — Ranking
- `+layout.svelte` — 공통 sticky 네비 (메인 / 랭킹 / 내 벽돌)
- 결손 컴포넌트 2개 (`plugins/brickang/components/`)
  - `MyBricks.svelte` — 내 벽돌 목록 (placed_at desc + 등급 색상 chip + 메시지). 익명 등급 행도 본인 거는 본인이 봄 (어뷰징 추적용, 서버 API `me/bricks` 가 그렇게 응답)
  - `Ranking.svelte` — 탭 전환 (전체/월간/건축물별), 순위 + 닉네임 + 벽돌 수 + 누적 금액
- 운영 reset SQL 준비 (`/home/damoang/docs/brickang/reset.sql`) — 정식 런칭 전 테스트 데이터 일괄 삭제용. `brick_types` (5종 시드) 는 유지. `payment_orders.metadata.kind='brickang'` 만 정리해 다른 플러그인 영향 없음
- sandbox PG 키 템플릿 (`/home/damoang/docs/brickang/sandbox-pg-keys.sql.template`) — admin UI 우선 권장

## 안전성
- `@sveltejs/kit` import 는 `routes/` 안에서만 (Phase 1 fix 교훈 준수)
- `+page.server.ts` 의 인증 가드는 `locals.user` 만 검사 → SSR 단계에서 차단
- 결제 컴포넌트 (`PaymentModal`) 는 변경 없음

## 검증
- [x] `pnpm check` — 신규 파일 무회귀 (기존 1 error 는 PaymentModal `allowedProviders` 로 main 의 사전 존재 이슈)
- [x] `pnpm test:unit --run` — 412 tests 모두 통과
- [x] `find apps/web/src/routes/brickang -type f` — 8개 파일 (page 5 + server 2 + layout 1)

## 사용자 테스트 시나리오
1. `/brickang` → BrickShop 표시, 등급 카드 + 진행률 + 벽돌 놓기 버튼
2. `/brickang/ranking` → 탭 전환 (전체 캐시 1h, 월간, 건축물별)
3. 비로그인 상태로 `/brickang/my` 접근 → `/login?redirect=/brickang/my` 자동 redirect
4. `/brickang/building/1` → 활성 건축물 BuildingViewer (read-only)

## 정식 런칭 후속
- 운영 테스트 데이터 정리 시 `reset.sql` 실행 (mysqldump 백업 + 새벽 4시 + 사용자 명시 승인 후)