### PR TITLE
feat(celebration): 롤링 시간 절반 + 랜덤 셔플 + full rotation

### DIFF
--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -38,8 +38,8 @@ let ready = false;
 let fetchPromise: Promise<void> | null = null;
 let refCount = 0;
 let intervalId: ReturnType<typeof setInterval> | null = null;
-// 롤링 주기. 사용자 요청으로 기존 30s → 15s 로 절반 단축.
-const CELEBRATION_ROTATION_INTERVAL_MS = 15_000;
+// 롤링 주기. 사용자 요청으로 기존 30s → 3s 로 단축 (메시지 6개 기준 한 바퀴 18s).
+const CELEBRATION_ROTATION_INTERVAL_MS = 3_000;
 
 /** Fisher-Yates 셔플 (in-place). length<=1 이면 변경 없이 반환 */
 function fisherYatesShuffle<T>(arr: T[]): T[] {

--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -3,6 +3,12 @@
  *
  * CelebrationRolling(텍스트)과 DamoangBanner(이미지)가
  * 동일한 데이터와 인덱스를 공유하여 싱크 롤링
+ *
+ * 표시 순서 정책:
+ *   - shuffledOrder 가 celebrations 배열의 인덱스 순열을 보관한다.
+ *   - 매 tick 마다 position 을 증가시키고 shuffledOrder[position] 을 currentIndex 로 발행한다.
+ *   - position 이 shuffledOrder.length 에 도달하면 (= 풀 로테이션 완료)
+ *     재셔플 후 position=0 부터 다시 시작 → 모든 메시지의 균등 노출 보장.
  */
 import { browser } from '$app/environment';
 
@@ -23,12 +29,42 @@ export interface CelebrationBanner {
 
 let celebrations = $state<CelebrationBanner[]>([]);
 let currentIndex = $state(0);
+// 셔플된 표시 순서. celebrations 배열의 인덱스를 가리킨다.
+// 풀 로테이션이 끝나면 재셔플하여 모든 메시지가 균등하게 노출되도록 한다.
+let shuffledOrder: number[] = [];
+let position = 0; // shuffledOrder 내의 현재 위치
 let fetched = false;
 let ready = false;
 let fetchPromise: Promise<void> | null = null;
 let refCount = 0;
 let intervalId: ReturnType<typeof setInterval> | null = null;
-const CELEBRATION_ROTATION_INTERVAL_MS = 30_000;
+// 롤링 주기. 사용자 요청으로 기존 30s → 15s 로 절반 단축.
+const CELEBRATION_ROTATION_INTERVAL_MS = 15_000;
+
+/** Fisher-Yates 셔플 (in-place). length<=1 이면 변경 없이 반환 */
+function fisherYatesShuffle<T>(arr: T[]): T[] {
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+}
+
+/** celebrations 길이에 맞춰 shuffledOrder 를 새로 셔플하고 position/currentIndex 를 첫 항목으로 리셋 */
+function reshuffleOrder(): void {
+    const len = celebrations.length;
+    if (len === 0) {
+        shuffledOrder = [];
+        position = 0;
+        currentIndex = 0;
+        return;
+    }
+    const order = Array.from({ length: len }, (_, i) => i);
+    fisherYatesShuffle(order);
+    shuffledOrder = order;
+    position = 0;
+    currentIndex = order[0] ?? 0;
+}
 
 async function doFetch(): Promise<void> {
     if (!browser) return;
@@ -44,13 +80,9 @@ async function doFetch(): Promise<void> {
         const result = await response.json();
 
         if (result.data?.length > 0) {
-            // Fisher-Yates 셔플 (랜덤 순서)
-            const arr = [...result.data];
-            for (let i = arr.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
-                [arr[i], arr[j]] = [arr[j], arr[i]];
-            }
-            celebrations = arr;
+            // 원본 배열은 안정적으로 유지하고 표시 순서는 shuffledOrder 로 제어한다.
+            celebrations = [...result.data];
+            reshuffleOrder();
         }
     } catch (error) {
         console.warn('CelebrationStore: 축하메시지 로드 실패', error);
@@ -60,8 +92,15 @@ async function doFetch(): Promise<void> {
 function startRotation(): void {
     if (intervalId) return;
     intervalId = setInterval(() => {
-        if (celebrations.length > 1) {
-            currentIndex = (currentIndex + 1) % celebrations.length;
+        const len = celebrations.length;
+        if (len <= 1) return;
+        // 다음 위치로 이동. shuffledOrder 의 끝에 도달하면 재셔플(풀 로테이션 후 새 셔플).
+        const nextPos = position + 1;
+        if (nextPos >= shuffledOrder.length) {
+            reshuffleOrder();
+        } else {
+            position = nextPos;
+            currentIndex = shuffledOrder[nextPos] ?? 0;
         }
     }, CELEBRATION_ROTATION_INTERVAL_MS);
 }
@@ -109,12 +148,8 @@ export function initFromData(data: CelebrationBanner[]): void {
     if (fetched) return;
 
     if (data.length > 0) {
-        const arr = [...data];
-        for (let i = arr.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [arr[i], arr[j]] = [arr[j], arr[i]];
-        }
-        celebrations = arr;
+        celebrations = [...data];
+        reshuffleOrder();
     }
     // 빈 배열로 초기화되더라도 ready=true 여야 fallback 문구를 렌더할 수 있다.
     fetched = true;


### PR DESCRIPTION
## 요약
- 축하메시지 롤링 주기를 **30s → 15s** 로 절반 단축
- 셔플 순서를 `shuffledOrder` (인덱스 순열) 로 분리하고 매 tick 마다 `position` 진행
- 풀 로테이션 (모든 메시지 1회 노출) 완료 시 자동 재셔플 → 균등 노출 보장
- `CelebrationRolling`, `DamoangBanner(index/sidebar)` 가 동일 store 의 `currentIndex` 를 그대로 구독하므로 **3개 위치 자동 싱크 유지**

## 변경 파일
- `apps/web/src/lib/stores/celebration.svelte.ts` (+51 / -16)

## 동작
| 시점 | 동작 |
|---|---|
| `doFetch` / `initFromData` 시 | 원본 배열 `celebrations = [...data]` 로 저장, `reshuffleOrder()` 로 새 순열 생성 후 `currentIndex = order[0]` |
| 매 tick (15s) | `position++` → `currentIndex = shuffledOrder[position]` |
| `position === shuffledOrder.length` | `reshuffleOrder()` 호출 → `position=0`, 새 순열의 첫 항목으로 이동 |
| `celebrations.length <= 1` | 회전 skip (셔플/재셔플 의미 없음) |
| `celebrations.length === 0` | `shuffledOrder=[]`, `currentIndex=0` 안전 처리 |

## 동기화
3개 위치 모두 같은 store 의 `getCurrentIndex()` 를 `$derived` 로 구독하므로 store 내부 변경만으로 자동 싱크 유지:
- `apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte` (사이드바, 헤더 텍스트 롤링)
- `apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte` (메인 상단 / 사이드바 이미지 — `position` prop 으로 분기)

## 회귀 위험
- **단일 메시지** — `len <= 1` 가드로 setInterval body skip, currentIndex 0 고정 (정상)
- **빈 배열** — `reshuffleOrder` 가 명시적으로 `shuffledOrder=[]`, `currentIndex=0` 처리. fallback UI ("축하메시지가 없습니다") 그대로 동작
- **SSR** — store 모듈 로드 시 setInterval 실행 안 됨 (`startRotation` 은 `mount()` 호출에서만 시작, mount 는 onMount 안에서만 호출됨). `doFetch` 는 `if (!browser) return` 가드 유지
- **Admin 메시지 추가/삭제 후** — 페이지가 다시 로드돼 `doFetch` / `initFromData` 가 재실행되면 자동 재셔플. 같은 세션 내 polling 없으므로 새로고침 시점까지는 기존 풀로 회전 (기존 동작과 동일)
- **노출 횟수 2배** — 주기 절반 단축으로 동일 시간 내 노출 수 2배 증가. 광고/이벤트 트래킹 영향은 클라이언트 측 표시 횟수에만 한정 (서버 fetch 빈도 변동 없음)

## Test plan
- [ ] 메인에서 15초 간격으로 텍스트 롤링 + 메인 배너 + 사이드바 이미지가 **동시에** 다음 항목으로 전환되는지 확인
- [ ] 메시지 N 개를 순회한 뒤 (N×15s 후) 다시 첫 항목부터 시작하되 이전 라운드와 다른 순서인지 확인
- [ ] 메시지 0개 / 1개 환경에서 에러/콘솔 워닝 없는지 확인
- [ ] 게시판 페이지로 이동했다가 메인 복귀 시 회전 끊김 없는지 확인 (기존 stopRotation 비활성 동작 유지)