### PR TITLE
tweak(celebration): 롤링 주기 3s → 2s

### DIFF
--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -38,8 +38,8 @@ let ready = false;
 let fetchPromise: Promise<void> | null = null;
 let refCount = 0;
 let intervalId: ReturnType<typeof setInterval> | null = null;
-// 롤링 주기. 사용자 요청으로 기존 30s → 3s 로 단축 (메시지 6개 기준 한 바퀴 18s).
-const CELEBRATION_ROTATION_INTERVAL_MS = 3_000;
+// 롤링 주기. 사용자 요청으로 3s → 2s 로 추가 단축 (메시지 6개 기준 한 바퀴 12s).
+const CELEBRATION_ROTATION_INTERVAL_MS = 2_000;
 
 /** Fisher-Yates 셔플 (in-place). length<=1 이면 변경 없이 반환 */
 function fisherYatesShuffle<T>(arr: T[]): T[] {


### PR DESCRIPTION
사용자 요청으로 축하메시지 롤링 주기를 3초에서 2초로 추가 단축. 메시지 6개 기준 한 바퀴 12s.