### PR TITLE
fix(web): fail safe on missing site resolver tables

### DIFF
--- a/apps/web/src/lib/server/site-resolver/db.test.ts
+++ b/apps/web/src/lib/server/site-resolver/db.test.ts
@@ -71,9 +71,7 @@ describe('DbSiteResolver', () => {
     });
 
     it('miss 는 60초 negative cache 되어 같은 host 재조회 시 DB를 다시 치지 않는다', async () => {
-        mockQuery
-            .mockResolvedValueOnce([[]])
-            .mockResolvedValueOnce([[]]);
+        mockQuery.mockResolvedValueOnce([[]]).mockResolvedValueOnce([[]]);
 
         const { DbSiteResolver } = await loadModule();
         const resolver = new DbSiteResolver();

--- a/apps/web/src/lib/server/site-resolver/db.test.ts
+++ b/apps/web/src/lib/server/site-resolver/db.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+const redisGet = vi.fn();
+const redisSetex = vi.fn();
+const redisDel = vi.fn();
+
+vi.mock('$lib/server/db', () => ({
+    pool: {
+        query: mockQuery
+    }
+}));
+
+vi.mock('$lib/server/redis.js', () => ({
+    getRedis: () => ({
+        get: redisGet,
+        setex: redisSetex,
+        del: redisDel
+    })
+}));
+
+async function loadModule() {
+    vi.resetModules();
+    return import('./db.js');
+}
+
+describe('DbSiteResolver', () => {
+    beforeEach(() => {
+        mockQuery.mockReset();
+        redisGet.mockReset();
+        redisSetex.mockReset();
+        redisDel.mockReset();
+        redisGet.mockResolvedValue(null);
+        redisSetex.mockResolvedValue('OK');
+        redisDel.mockResolvedValue(1);
+    });
+
+    it('positive lookup 는 캐시되어 같은 host 재조회 시 DB를 다시 치지 않는다', async () => {
+        mockQuery.mockResolvedValueOnce([
+            [
+                {
+                    id: 7,
+                    domain: 'damoang.net',
+                    theme_id: 'default',
+                    site_title: 'Damoang',
+                    site_description: null,
+                    site_url: null,
+                    logo_url: null,
+                    favicon_url: null,
+                    keywords: '["community"]',
+                    settings: null,
+                    active: 1
+                }
+            ]
+        ]);
+
+        const { DbSiteResolver } = await loadModule();
+        const resolver = new DbSiteResolver();
+
+        await expect(resolver.resolve('damoang.net')).resolves.toMatchObject({
+            id: 'db:7',
+            numericId: 7,
+            theme_id: 'default',
+            title: 'Damoang',
+            keywords: ['community']
+        });
+        await expect(resolver.resolve('damoang.net')).resolves.toMatchObject({
+            id: 'db:7'
+        });
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('miss 는 60초 negative cache 되어 같은 host 재조회 시 DB를 다시 치지 않는다', async () => {
+        mockQuery
+            .mockResolvedValueOnce([[]])
+            .mockResolvedValueOnce([[]]);
+
+        const { DbSiteResolver } = await loadModule();
+        const resolver = new DbSiteResolver();
+
+        await expect(resolver.resolve('unknown.damoang.net')).resolves.toBeNull();
+        await expect(resolver.resolve('unknown.damoang.net')).resolves.toBeNull();
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('angple_sites 테이블 누락 시 resolver 를 일정 시간 자동 bypass 한다', async () => {
+        const tableMissing = Object.assign(new Error('missing table'), {
+            code: 'ER_NO_SUCH_TABLE',
+            errno: 1146
+        });
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockQuery.mockRejectedValueOnce(tableMissing);
+
+        const { DbSiteResolver } = await loadModule();
+        const resolver = new DbSiteResolver();
+
+        await expect(resolver.resolve('damoang.net')).resolves.toBeNull();
+        mockQuery.mockClear();
+        await expect(resolver.resolve('another.damoang.net')).resolves.toBeNull();
+
+        expect(mockQuery).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('angple_sites tables unavailable'),
+            tableMissing
+        );
+    });
+
+    it('일반 DB 오류는 숨기지 않고 상위로 전달한다', async () => {
+        const fatal = new Error('db down');
+        mockQuery.mockRejectedValueOnce(fatal);
+
+        const { DbSiteResolver } = await loadModule();
+        const resolver = new DbSiteResolver();
+
+        await expect(resolver.resolve('damoang.net')).rejects.toThrow('db down');
+    });
+});

--- a/apps/web/src/lib/server/site-resolver/db.ts
+++ b/apps/web/src/lib/server/site-resolver/db.ts
@@ -1,6 +1,6 @@
 import type { RowDataPacket } from 'mysql2/promise';
 import { pool } from '$lib/server/db';
-import { TieredCache } from '$lib/server/cache';
+import { createCache, TieredCache } from '$lib/server/cache';
 import type { SiteContext, SiteResolver } from './index.js';
 
 interface SiteRow extends RowDataPacket {
@@ -22,6 +22,19 @@ interface AliasRow extends RowDataPacket {
 }
 
 const cache = new TieredCache<SiteContext>('site:db', 60_000, 300, 200);
+const missCache = createCache<true>({ ttl: 60_000, maxSize: 2000 });
+const SCHEMA_RETRY_TTL_MS = 5 * 60_000;
+let schemaUnavailableUntil = 0;
+
+type ResolverDbError = Error & {
+    code?: string;
+    errno?: number | string;
+};
+
+function isMissingTableError(err: unknown): boolean {
+    const dbErr = err as ResolverDbError;
+    return dbErr?.code === 'ER_NO_SUCH_TABLE' || dbErr?.errno === 1146;
+}
 
 function rowToContext(row: SiteRow): SiteContext {
     let keywords: string[] | undefined;
@@ -76,15 +89,37 @@ async function lookupByHost(host: string): Promise<SiteContext | null> {
 export class DbSiteResolver implements SiteResolver {
     async resolve(host: string): Promise<SiteContext | null> {
         const key = host.toLowerCase();
+        if (missCache.get(key)) return null;
+        if (Date.now() < schemaUnavailableUntil) return null;
+
         const cached = await cache.get(key);
         if (cached) return cached;
 
-        const found = await lookupByHost(key);
-        if (found) await cache.set(key, found);
-        return found;
+        try {
+            const found = await lookupByHost(key);
+            if (found) {
+                await cache.set(key, found);
+                return found;
+            }
+
+            missCache.set(key, true);
+            return null;
+        } catch (err) {
+            if (isMissingTableError(err)) {
+                schemaUnavailableUntil = Date.now() + SCHEMA_RETRY_TTL_MS;
+                console.error(
+                    `[site-resolver] angple_sites tables unavailable, bypassing DbSiteResolver for ${SCHEMA_RETRY_TTL_MS / 1000}s`,
+                    err
+                );
+                return null;
+            }
+
+            throw err;
+        }
     }
 }
 
 export async function invalidateDbSiteCache(host: string): Promise<void> {
     await cache.delete(host.toLowerCase());
+    missCache.delete(host.toLowerCase());
 }


### PR DESCRIPTION
## Summary
- add a fail-safe to `DbSiteResolver` when `angple_sites` tables are missing
- add negative caching for unknown hosts to reduce repeated DB lookups on misses
- add regression tests for cache hits, miss caching, schema-miss bypass, and fatal DB errors

## Problem
On May 3, 2026, the remaining healthy `angple-web` pods repeatedly hit `angple_sites` lookups from `hooks.server.ts` and threw `ER_NO_SUCH_TABLE` on every request. That turned a schema rollout miss into a hot-path CPU amplifier.

## Changes
- if `angple_sites` or `angple_site_aliases` are missing, `DbSiteResolver` now returns `null` and bypasses DB resolution for 5 minutes instead of throwing on every request
- unknown hosts are negative-cached for 60 seconds to avoid repeated misses
- non-schema DB errors still bubble up so real failures are not hidden

## Verification
- `pnpm exec vitest run src/lib/server/site-resolver/db.test.ts`
- `pnpm build`

## Notes
- verification was run in the original working tree because the clean PR worktree does not have `node_modules`
