### PR TITLE
feat(search): 작성자/댓글 검색 필터 4단 분리 (닉네임/아이디 분리)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -649,13 +649,20 @@ export interface LikersResponse {
 }
 
 // 검색 필드 타입
+// - author / comment_author: mb_id + wr_name 모두 매칭 (legacy 호환 유지)
+// - author_nick / comment_nick: wr_name (닉네임)만 매칭
+// - author_id / comment_id: mb_id (아이디)만 매칭 — 정확 매칭 (false-positive 차단)
 export type SearchField =
     | 'title'
     | 'content'
     | 'title_content'
     | 'author'
+    | 'author_nick'
+    | 'author_id'
     | 'comment'
     | 'comment_author'
+    | 'comment_nick'
+    | 'comment_id'
     | 'google';
 
 // 검색 요청 파라미터

--- a/apps/web/src/lib/components/features/board/search-form.svelte
+++ b/apps/web/src/lib/components/features/board/search-form.svelte
@@ -21,13 +21,19 @@
     }: Props = $props();
 
     // 검색 필드 옵션
+    // author / comment_author: 닉네임+아이디 모두 매칭 (legacy 호환)
+    // *_nick: 닉네임만, *_id: 아이디만 (정확 매칭, false-positive 차단)
     const searchFieldOptions: { value: SearchField; label: string }[] = [
         { value: 'title_content', label: '제목+내용' },
         { value: 'title', label: '제목' },
         { value: 'content', label: '내용' },
-        { value: 'author', label: '작성자' },
-        { value: 'comment', label: '댓글' },
-        { value: 'comment_author', label: '작성자(댓글)' },
+        { value: 'author', label: '작성자(모두)' },
+        { value: 'author_nick', label: '작성자(닉네임)' },
+        { value: 'author_id', label: '작성자(아이디)' },
+        { value: 'comment', label: '댓글 내용' },
+        { value: 'comment_author', label: '댓글 작성자(모두)' },
+        { value: 'comment_nick', label: '댓글 작성자(닉네임)' },
+        { value: 'comment_id', label: '댓글 작성자(아이디)' },
         { value: 'google', label: 'Google' }
     ];
 

--- a/apps/web/src/lib/server/sphinx-search.test.ts
+++ b/apps/web/src/lib/server/sphinx-search.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { buildMatchExpr, escapeSphinxMatch, containsCJK } from './sphinx-search.js';
+
+describe('escapeSphinxMatch', () => {
+    it('escapes Sphinx special characters', () => {
+        expect(escapeSphinxMatch('hello (world)')).toBe('hello \\(world\\)');
+        expect(escapeSphinxMatch('a@b')).toBe('a\\@b');
+        expect(escapeSphinxMatch('a/b')).toBe('a\\/b');
+    });
+});
+
+describe('containsCJK', () => {
+    it('detects Korean / Chinese / Japanese characters', () => {
+        expect(containsCJK('한글')).toBe(true);
+        expect(containsCJK('日本語')).toBe(true);
+        expect(containsCJK('中文')).toBe(true);
+    });
+
+    it('returns false for ASCII-only strings', () => {
+        expect(containsCJK('hello world')).toBe(false);
+        expect(containsCJK('abc123')).toBe(false);
+    });
+});
+
+describe('buildMatchExpr — sfl 4-split (작성자/댓글 닉네임/아이디 분리)', () => {
+    // 작성자 (글)
+    it("'author' (legacy) matches both mb_id and wr_name", () => {
+        expect(buildMatchExpr('admin', 'author')).toBe('@(mb_id,wr_name) *admin*');
+    });
+
+    it("'author_nick' matches only wr_name", () => {
+        expect(buildMatchExpr('SDK', 'author_nick')).toBe('@wr_name *SDK*');
+    });
+
+    it("'author_id' matches only mb_id", () => {
+        expect(buildMatchExpr('admin', 'author_id')).toBe('@mb_id *admin*');
+    });
+
+    // 댓글 작성자
+    it("'comment_author' (legacy) matches both mb_id and wr_name", () => {
+        expect(buildMatchExpr('admin', 'comment_author')).toBe('@(mb_id,wr_name) *admin*');
+    });
+
+    it("'comment_nick' matches only wr_name", () => {
+        expect(buildMatchExpr('SDK', 'comment_nick')).toBe('@wr_name *SDK*');
+    });
+
+    it("'comment_id' matches only mb_id", () => {
+        expect(buildMatchExpr('admin', 'comment_id')).toBe('@mb_id *admin*');
+    });
+
+    // 기존 동작 회귀 보호
+    it("'title' / 'content' / 'title_content' / 'comment' unchanged", () => {
+        expect(buildMatchExpr('foo', 'title')).toBe('@wr_subject *foo*');
+        expect(buildMatchExpr('foo', 'content')).toBe('@wr_content *foo*');
+        expect(buildMatchExpr('foo', 'title_content')).toBe('@(wr_subject,wr_content) *foo*');
+        expect(buildMatchExpr('foo', 'comment')).toBe('@wr_content *foo*');
+    });
+
+    it('CJK 토큰을 구문 검색으로 wrap한다', () => {
+        // 2자 이상 CJK는 "*token*" 으로 인접 ngram 매칭 강제
+        expect(buildMatchExpr('한글', 'author_nick')).toBe('@wr_name "*한글*"');
+        expect(buildMatchExpr('한글', 'author_id')).toBe('@mb_id "*한글*"');
+    });
+});

--- a/apps/web/src/lib/server/sphinx-search.ts
+++ b/apps/web/src/lib/server/sphinx-search.ts
@@ -57,15 +57,31 @@ export function buildMatchExpr(query: string, field: string): string {
             return `@wr_content ${wildcarded}`;
         case 'author':
             return `@(mb_id,wr_name) ${wildcarded}`;
+        case 'author_nick':
+            return `@wr_name ${wildcarded}`;
+        case 'author_id':
+            return `@mb_id ${wildcarded}`;
         case 'comment':
             return `@wr_content ${wildcarded}`;
         case 'comment_author':
             return `@(mb_id,wr_name) ${wildcarded}`;
+        case 'comment_nick':
+            return `@wr_name ${wildcarded}`;
+        case 'comment_id':
+            return `@mb_id ${wildcarded}`;
         case 'title_content':
         default:
             return `@(wr_subject,wr_content) ${wildcarded}`;
     }
 }
+
+/** 댓글 인덱스(wr_is_comment=1)를 검색해야 하는 sfl 필드 집합 */
+const COMMENT_SEARCH_FIELDS = new Set<string>([
+    'comment',
+    'comment_author',
+    'comment_nick',
+    'comment_id'
+]);
 
 /**
  * 보드별 Sphinx 검색
@@ -82,7 +98,7 @@ export async function searchByBoard(
     sort: 'date' | 'relevance' = 'date'
 ): Promise<SphinxSearchResult> {
     const matchExpr = buildMatchExpr(query, field);
-    const isCommentSearch = field === 'comment' || field === 'comment_author';
+    const isCommentSearch = COMMENT_SEARCH_FIELDS.has(field);
 
     const safeMatch = matchExpr.replace(/'/g, "\\'");
     const offset = (page - 1) * limit;
@@ -148,7 +164,7 @@ export async function searchAllBoards(
     total: number;
 }> {
     const matchExpr = buildMatchExpr(query, field);
-    const isCommentSearch = field === 'comment' || field === 'comment_author';
+    const isCommentSearch = COMMENT_SEARCH_FIELDS.has(field);
     const safeMatch = matchExpr.replace(/'/g, "\\'");
 
     const sphinxSql =

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -187,21 +187,21 @@
     const listPage = $derived(Number($page.url.searchParams.get('page')) || 1);
 
     // #12012: 보드별 "내가 쓴 글/댓글" 빠른 필터
-    // 백엔드 ?sfl=author|comment_author&stx={mb_id} 재사용 (Sphinx @(mb_id,wr_name) 매칭)
+    // 4단 분리 후: ?sfl=author_id|comment_id&stx={mb_id} (mb_id 정확 매칭, false-positive 차단)
     const currentSfl = $derived($page.url.searchParams.get('sfl') || '');
     const currentStx = $derived($page.url.searchParams.get('stx') || '');
     const isMyPostsActive = $derived(
         authStore.isAuthenticated &&
-            currentSfl === 'author' &&
+            currentSfl === 'author_id' &&
             currentStx === (authStore.user?.mb_id ?? '')
     );
     const isMyCommentsActive = $derived(
         authStore.isAuthenticated &&
-            currentSfl === 'comment_author' &&
+            currentSfl === 'comment_id' &&
             currentStx === (authStore.user?.mb_id ?? '')
     );
 
-    function applyMyFilter(sfl: 'author' | 'comment_author'): void {
+    function applyMyFilter(sfl: 'author_id' | 'comment_id'): void {
         const mbId = authStore.user?.mb_id;
         if (!mbId) return;
         const url = new URL(window.location.href);
@@ -904,7 +904,7 @@
                         size="sm"
                         class="h-8"
                         onclick={() =>
-                            isMyPostsActive ? clearMyFilter() : applyMyFilter('author')}
+                            isMyPostsActive ? clearMyFilter() : applyMyFilter('author_id')}
                         title="이 게시판에서 내가 쓴 글만 보기"
                     >
                         <User class="mr-1.5 h-3.5 w-3.5" />
@@ -915,7 +915,7 @@
                         size="sm"
                         class="h-8"
                         onclick={() =>
-                            isMyCommentsActive ? clearMyFilter() : applyMyFilter('comment_author')}
+                            isMyCommentsActive ? clearMyFilter() : applyMyFilter('comment_id')}
                         title="이 게시판에서 내가 쓴 댓글만 보기"
                     >
                         <MessageSquare class="mr-1.5 h-3.5 w-3.5" />

--- a/apps/web/src/routes/api/search/+server.ts
+++ b/apps/web/src/routes/api/search/+server.ts
@@ -51,7 +51,11 @@ export const GET: RequestHandler = async ({ url, locals }) => {
     }
 
     try {
-        const isCommentSearch = field === 'comment' || field === 'comment_author';
+        const isCommentSearch =
+            field === 'comment' ||
+            field === 'comment_author' ||
+            field === 'comment_nick' ||
+            field === 'comment_id';
 
         // 1) Sphinx에서 검색 (최대 200건)
         const { rows: sphinxRows } = await searchAllBoards(field, query, 200);


### PR DESCRIPTION
## Summary

기존 작성자 검색은 `mb_id`와 `wr_name`(닉네임)을 **동시에 매칭**해서, 닉네임으로만 검색하고 싶은 경우에도 다른 회원의 mb_id 와 우연히 매칭되는 false-positive 가 발생했습니다. 이를 4단으로 분리합니다.

| sfl 값 | 매칭 필드 | 비고 |
|---|---|---|
| `author` | `@(mb_id, wr_name)` | 기존 (legacy 호환 유지) |
| `author_nick` | `@wr_name` | 신규 — 닉네임만 |
| `author_id` | `@mb_id` | 신규 — 아이디만 (정확) |
| `comment_author` | `@(mb_id, wr_name)` | 기존 |
| `comment_nick` | `@wr_name` | 신규 |
| `comment_id` | `@mb_id` | 신규 |

- "내가 쓴 글/댓글" 빠른 필터를 `author_id` / `comment_id` 로 전환 → 자기 자신만 정확히 필터링
- 검색 폼 드롭다운 6개 → 10개 옵션 ("작성자(모두/닉네임/아이디)", "댓글 작성자(모두/닉네임/아이디)")
- 기존 `?sfl=author&stx=...` URL 은 그대로 동작 (회귀 0)

## Changed Files

- `apps/web/src/lib/api/types.ts` — `SearchField` union 에 4개 추가
- `apps/web/src/lib/server/sphinx-search.ts` — `buildMatchExpr` switch 확장, `COMMENT_SEARCH_FIELDS` 집합 도입
- `apps/web/src/lib/server/sphinx-search.test.ts` — 신규 단위 테스트 (legacy 회귀 + 4-split 매칭 + CJK)
- `apps/web/src/lib/components/features/board/search-form.svelte` — 드롭다운 옵션 확장
- `apps/web/src/routes/[boardId]/+page.svelte` — `applyMyFilter('author_id'|'comment_id')` 로 정확 매칭
- `apps/web/src/routes/api/search/+server.ts` — 신규 `comment_nick`/`comment_id` 도 `isCommentSearch` 로 인식 (글로벌 검색 응답 shape 회귀 방지)

## 회귀 위험 평가

| 항목 | 평가 |
|---|---|
| 기존 `sfl=author` URL | 매칭 로직 100% 동일 → 회귀 0 |
| 기존 `sfl=comment_author` URL | 매칭 로직 100% 동일 → 회귀 0 |
| 백엔드 sphinx 빌더 | 본 PR 영향 없음 (frontend-only 필드 분리) |
| 글로벌 `/api/search` | 신규 sfl 도 comment 인덱스에서 정확 검색 |
| 빠른 필터 ("내가 쓴 글") | `author` → `author_id` 변경 — 동일한 mb_id 정확 매칭이라 결과는 더 줄지 않음 (오히려 false-positive 차단) |
| 드롭다운 라벨 변경 | "작성자" → "작성자(모두)" 로 의미 명확화 (UX 개선) |

## Test Plan

- [x] `pnpm test:unit -- --run src/lib/server/sphinx-search.test.ts` — 9 tests pass
- [x] `pnpm check` — 0 errors (warnings 모두 pre-existing)
- [ ] dev 환경에서 검색 동작 확인:
  - `?sfl=author_id&stx=admin` → mb_id 가 admin 인 회원의 글만
  - `?sfl=author_nick&stx=SDK` → 닉네임이 SDK 인 회원의 글만
  - `?sfl=comment_id&stx=admin` → admin 이 댓글 단 글만
  - `?sfl=author&stx=admin` → 기존 동작 (mb_id 또는 wr_name 매칭) 유지
- [ ] 보드 페이지에서 "내가 쓴 글" 토글 → URL 이 `?sfl=author_id&stx={mb_id}` 로 바뀌는지 확인
- [ ] 모바일 네이티브 select / 데스크톱 커스텀 Select 모두 10개 옵션 표기 확인

## Out of Scope

- `routes/search/+page.svelte` (글로벌 검색 페이지) 의 드롭다운 옵션은 추후 별도 PR
- `author-link.svelte` 클릭 시 `?sfl=author` 로 보내는 동작은 legacy 호환을 위해 유지 (필요 시 후속 PR 에서 `author_id` 로 전환 검토)