### PR TITLE
feat(search): 검색 필터 단순화 — 기본 5개 + 데스크톱 고급 토글

### DIFF
--- a/apps/web/src/lib/components/features/board/search-form.svelte
+++ b/apps/web/src/lib/components/features/board/search-form.svelte
@@ -20,22 +20,43 @@
         showReset = true
     }: Props = $props();
 
-    // 검색 필드 옵션
+    // 검색 필드 옵션 — 기본/고급 분리
+    // 기본 5개: 모바일/PC 공통 노출 (UX 단순화)
+    // 고급 5개: 데스크톱-only 토글 펼침 시 노출 (닉네임/아이디 분리, 댓글 내용)
     // author / comment_author: 닉네임+아이디 모두 매칭 (legacy 호환)
     // *_nick: 닉네임만, *_id: 아이디만 (정확 매칭, false-positive 차단)
-    const searchFieldOptions: { value: SearchField; label: string }[] = [
+    const basicFieldOptions: { value: SearchField; label: string }[] = [
         { value: 'title_content', label: '제목+내용' },
         { value: 'title', label: '제목' },
         { value: 'content', label: '내용' },
-        { value: 'author', label: '작성자(모두)' },
+        { value: 'author', label: '작성자' },
+        { value: 'comment_author', label: '댓글 작성자' }
+    ];
+
+    const advancedFieldOptions: { value: SearchField; label: string }[] = [
         { value: 'author_nick', label: '작성자(닉네임)' },
         { value: 'author_id', label: '작성자(아이디)' },
-        { value: 'comment', label: '댓글 내용' },
-        { value: 'comment_author', label: '댓글 작성자(모두)' },
-        { value: 'comment_nick', label: '댓글 작성자(닉네임)' },
-        { value: 'comment_id', label: '댓글 작성자(아이디)' },
-        { value: 'google', label: 'Google' }
+        { value: 'comment_nick', label: '댓글(닉네임)' },
+        { value: 'comment_id', label: '댓글(아이디)' },
+        { value: 'comment', label: '댓글 내용' }
     ];
+
+    // Google 검색은 별도 옵션 (기본 노출 유지)
+    const googleFieldOption: { value: SearchField; label: string } = {
+        value: 'google',
+        label: 'Google'
+    };
+
+    // 전체 옵션 (라벨 조회용 — URL ?sfl=author_id 같은 직접 입력 호환)
+    const allFieldOptions: { value: SearchField; label: string }[] = [
+        ...basicFieldOptions,
+        ...advancedFieldOptions,
+        googleFieldOption
+    ];
+
+    // 데스크톱-only 고급 모드 토글
+    // URL이 고급 필드를 가리키면 자동으로 펼침 (북마크/링크 호환)
+    let showAdvanced = $state(false);
 
     // URL에서 현재 검색 파라미터 가져오기
     const currentField = $derived(
@@ -51,6 +72,13 @@
     $effect(() => {
         searchField = currentField;
         searchQuery = currentQuery;
+    });
+
+    // URL이 고급 필드를 가리키면 데스크톱에서 자동 펼침 (북마크/외부링크 호환)
+    $effect(() => {
+        if (advancedFieldOptions.some((opt) => opt.value === currentField)) {
+            showAdvanced = true;
+        }
     });
 
     // 검색 실행
@@ -111,21 +139,39 @@
         goto(url.pathname + url.search);
     }
 
-    // 현재 선택된 필드의 라벨
+    // 현재 선택된 필드의 라벨 (전체 옵션에서 조회 — 직접 URL 입력 호환)
     const selectedFieldLabel = $derived(
-        searchFieldOptions.find((opt) => opt.value === searchField)?.label || '제목+내용'
+        allFieldOptions.find((opt) => opt.value === searchField)?.label || '제목+내용'
     );
+
+    // 데스크톱 select 노출 옵션 (기본 + 고급 토글 + Google)
+    const desktopVisibleOptions = $derived([
+        ...basicFieldOptions,
+        ...(showAdvanced ? advancedFieldOptions : []),
+        googleFieldOption
+    ]);
+
+    // 모바일 select 노출 옵션 (기본 5개 + Google)
+    // 단, 현재 sfl이 고급 필드면 라벨 표시를 위해 해당 옵션 추가 (외부 링크 호환)
+    const mobileVisibleOptions = $derived.by(() => {
+        const advancedMatch = advancedFieldOptions.find((opt) => opt.value === searchField);
+        if (advancedMatch) {
+            // 현재 선택된 고급 필드를 모바일에도 노출 (URL 직접 입력 호환)
+            return [...basicFieldOptions, advancedMatch, googleFieldOption];
+        }
+        return [...basicFieldOptions, googleFieldOption];
+    });
 </script>
 
 <form onsubmit={handleSearch} class="flex items-center gap-2">
     <!-- 검색 필드 선택: 모바일=네이티브 select, 데스크톱=커스텀 Select -->
-    <!-- 모바일 네이티브 select (md 미만) -->
+    <!-- 모바일 네이티브 select (md 미만) — 기본 5개 + Google (현재 선택된 고급 필드는 노출 유지) -->
     <div class="relative shrink-0 md:hidden">
         <select
             class="border-input bg-background text-foreground focus:ring-ring h-9 w-full appearance-none rounded-md border px-2 pr-7 text-sm focus:outline-none focus:ring-1"
             bind:value={searchField}
         >
-            {#each searchFieldOptions as option (option.value)}
+            {#each mobileVisibleOptions as option (option.value)}
                 <option value={option.value}>{option.label}</option>
             {/each}
         </select>
@@ -139,19 +185,30 @@
             <path d="M6 9l6 6 6-6" />
         </svg>
     </div>
-    <!-- 데스크톱 커스텀 Select (md 이상) -->
+    <!-- 데스크톱 커스텀 Select (md 이상) — 기본 5개 + Google, 고급 토글 시 5개 추가 -->
     <div class="hidden md:block md:shrink-0">
         <Select.Root type="single" value={searchField} onValueChange={handleFieldChange}>
             <Select.Trigger class="w-[120px]">
                 {selectedFieldLabel}
             </Select.Trigger>
             <Select.Content>
-                {#each searchFieldOptions as option (option.value)}
+                {#each desktopVisibleOptions as option (option.value)}
                     <Select.Item value={option.value}>{option.label}</Select.Item>
                 {/each}
             </Select.Content>
         </Select.Root>
     </div>
+
+    <!-- 데스크톱-only 고급 토글 (md 이상) — 모바일은 노출 안 함 -->
+    <button
+        type="button"
+        onclick={() => (showAdvanced = !showAdvanced)}
+        class="border-input bg-background text-muted-foreground hover:bg-accent hover:text-foreground hidden h-9 shrink-0 items-center rounded-md border px-2 text-xs transition-colors md:inline-flex"
+        aria-expanded={showAdvanced}
+        title="작성자/댓글 닉네임·아이디 분리 검색"
+    >
+        고급 {showAdvanced ? '▴' : '▾'}
+    </button>
 
     <!-- 검색어 입력 -->
     <div class="relative min-w-0 flex-1">


### PR DESCRIPTION
## 배경

PR #1377 에서 검색 필드를 4단 분리 (작성자 닉/아이디, 댓글 닉/아이디) 하면서 옵션이 11개로 늘어나 일반 사용자에게 부담이 됨.

사용자 결정: **Option B + 데스크톱-only 고급 토글**.

## 변경 내용

`apps/web/src/lib/components/features/board/search-form.svelte` 단일 파일 수정.

### 기본 5개 (모바일 + PC 공통 노출)
- `title_content` — 제목+내용
- `title` — 제목
- `content` — 내용
- `author` — 작성자 (mb_id + wr_name 모두 매칭, legacy 호환)
- `comment_author` — 댓글 작성자 (동일)

### 고급 5개 (데스크톱-only "고급 ▾" 토글 펼침 시 노출)
- `author_nick` — 작성자(닉네임)
- `author_id` — 작성자(아이디)
- `comment_nick` — 댓글(닉네임)
- `comment_id` — 댓글(아이디)
- `comment` — 댓글 내용

### Google 옵션
- 기본 노출 유지 (모바일 + PC 모두).

### UI 동작 차이

| | 모바일 (< md) | 데스크톱 (≥ md) |
|---|---|---|
| 기본 select 옵션 | 5개 + Google | 5개 + Google |
| "고급 ▾" 토글 버튼 | **숨김** (`hidden md:inline-flex`) | 노출 |
| 토글 펼침 시 | 해당 없음 | 추가 5개 옵션 select 에 표시 |
| URL `?sfl=author_id` 직접 입력 | 해당 옵션을 모바일 select 에 임시 추가 (라벨 표시) | `$effect` 가 `showAdvanced=true` 자동 설정 |

### UI mockup (간략)

```
[모바일]
[제목+내용 ▾] [_____________🔍] [검색]

[데스크톱 — 기본]
[제목+내용 ▾] [고급 ▾] [_____________🔍] [검색]

[데스크톱 — 고급 펼침]
[작성자(닉네임) ▾] [고급 ▴] [_____________🔍] [검색]
                  ↑ select 안에 5+5+1=11개 모두 노출
```

## 호환성 / 회귀 위험 평가

- **타입 변경 없음**: `SearchField` 11개 값 그대로 (`apps/web/src/lib/api/types.ts:655-666`).
- **백엔드 변경 없음**: PR #1377 의 `sphinx-search.ts` 4개 신규 sfl (author_nick / author_id / comment_nick / comment_id) 그대로 작동.
- **URL 호환**: `?sfl=author_nick` 등 직접 입력 / 외부 링크 / 북마크 모두 호환. 데스크톱은 자동으로 고급 토글 펼침, 모바일은 해당 옵션을 select 에 임시 추가하여 라벨 정상 표시.
- **#1362 "내가 쓴 글" 토글 영향 없음**: 해당 토글은 내부적으로 `author_id` / `comment_id` 를 URL 파라미터로 set 하는데, 이는 select UI 와 독립적으로 작동.
- **회귀 위험**: **낮음**. 단일 컴포넌트 변경, 타입/백엔드/스토어 무영향. select 노출 옵션 차이만 존재.

## Test plan

- [ ] 모바일 (< 768px): "고급 ▾" 버튼 숨김, select 에 6개 옵션 (기본 5 + Google)
- [ ] 데스크톱 (≥ 768px) 기본: select 에 6개 옵션 (기본 5 + Google), "고급 ▾" 버튼 노출
- [ ] 데스크톱 "고급 ▾" 클릭: select 에 11개 옵션 (기본 5 + 고급 5 + Google), 버튼 라벨 "고급 ▴"
- [ ] URL `?sfl=author_id&stx=test` 직접 진입 (데스크톱): showAdvanced 자동 true, select 에 해당 옵션 표시
- [ ] URL `?sfl=author_nick&stx=test` 직접 진입 (모바일): 모바일 select 에 해당 옵션 임시 추가, 라벨 정상 표시
- [ ] "내가 쓴 글" 토글 (#1362) 정상 작동 확인
- [ ] `pnpm check` 통과 확인 (이미 통과 — 0 errors)