### PR TITLE
fix(message): 축하메시지 게시판 soft-deleted 글 숨김

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -575,10 +575,14 @@ export const load: PageServerLoad = async ({
             }
         }
 
-        // 축하메시지(message) 게시판: 익명 글 프로필 정보 숨김
-        // PublishToGnuboard()에서 익명 시 wr_name=""으로 설정 → author가 빈 문자열
+        // 축하메시지(message) 게시판:
+        //   1) soft-deleted(wr_deleted_at) 글 완전 숨김 — 프라이빗 영역이라 placeholder 미표시
+        //   2) 익명 글 프로필 정보 숨김 (PublishToGnuboard에서 익명 시 wr_name=""로 author가 빈 문자열)
+        // 페이지네이션 total은 백엔드 값을 그대로 두므로 페이지마다 표시 글 수가 1~2개 적을 수 있음 (허용)
         if (boardId === 'message') {
+            posts = posts.filter((p) => !p.deleted_at);
             for (const p of allPosts) {
+                if (p.deleted_at) continue;
                 if (!p.author) {
                     p.author_image = undefined;
                     p.author_image_updated_at = undefined;


### PR DESCRIPTION
## Summary
- 축하메시지(`/message`) 게시판에서 soft-deleted (`wr_deleted_at`) 글이 목록에 노출되던 문제 수정
- 다른 보드와 달리 message는 프라이빗 영역(축하)이라 placeholder 미표시 — SSR 단계에서 완전히 숨김
- 사례: 사용자 #1893 soft-delete 후에도 `/message?page=3`에 노출되던 케이스

## Changes
`apps/web/src/routes/[boardId]/+page.server.ts` (+6 / -2)

`boardId === 'message'` 분기에 다음을 추가:
1. `posts = posts.filter((p) => !p.deleted_at)` — soft-deleted 완전 숨김
2. 익명 처리 루프에 `if (p.deleted_at) continue;` 가드 (방어적 안전장치)

`notices`는 공지글이라 soft-delete 가능성이 거의 없어 미터치. 회귀 위험 최소화.

## 회귀 위험 평가
- **다른 보드**: 영향 없음 (`if (boardId === 'message')` 분기 내부 변경)
- **페이지네이션**: 백엔드 `total`은 deleted 포함 값을 그대로 사용 — 페이지마다 표시 글 수가 1~2개 적을 수 있으나 의도된 동작 (이슈 본문에 명시)
- **익명 처리**: 기존 로직 유지, deleted_at 가드만 추가
- **타입 안전성**: `FreePost.deleted_at?: string | null` (이미 정의되어 있음, types.ts:68)
- **캐시**: `postsCache`는 SSR 이후 결과를 저장하므로 필터 결과가 캐시됨 (정상 동작)

## Test plan
- [ ] `/message` 목록에서 soft-deleted 글이 보이지 않음 확인
- [ ] `/message` 익명 글의 프로필/이름 처리(`익명`)가 기존대로 동작 확인
- [ ] 다른 보드(`/free`, `/giving` 등) 정상 동작 (soft-deleted placeholder 표시) 확인
- [ ] `pnpm check` 통과 (svelte-check 0 errors, 기존 97 warnings 유지)