### PR TITLE
fix(web): shorten heap watch polling interval

### DIFF
--- a/apps/web/src/lib/server/telemetry.ts
+++ b/apps/web/src/lib/server/telemetry.ts
@@ -47,7 +47,8 @@ process.on('SIGUSR2', () => {
  * HEAP_WATCH_DIR 미설정 시 비활성 (feature flag, dev/test 환경 영향 0).
  * 12h cooldown — pod 당 반복 fire 방지.
  */
-const HEAP_WATCH_INTERVAL_MS = 30_000;
+// Fast OOM spikes can cross the threshold and hit SIGKILL between 30s polls.
+const HEAP_WATCH_INTERVAL_MS = 5_000;
 const HEAP_RSS_THRESHOLD = parseInt(process.env.HEAP_RSS_THRESHOLD_MB || '1280', 10) * 1024 * 1024;
 const HEAP_HEAP_THRESHOLD = parseInt(process.env.HEAP_HEAP_THRESHOLD_MB || '935', 10) * 1024 * 1024;
 const HEAP_WATCH_COOLDOWN_MS = 12 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- reduce heap-watch polling interval from 30s to 5s
- improve chance of capturing heap snapshots before fast memory spikes hit SIGKILL
- complements damoang/angple-k8s#68, which adds V8 native near-heap-limit snapshots

## Testing
- git -C /tmp/angple-web-heap-watch-polling diff --check
- pnpm --dir /tmp/angple-web-heap-watch-polling build