### PR TITLE
fix: 축하메시지 익명 표시 동기화

### DIFF
--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -61,10 +61,13 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
 					cb.link_target, cb.sort_order, cb.display_type,
 					cb.source_wr_id,
 					m.mb_nick AS target_member_nick,
-					m.mb_image_url AS target_member_image_url
+					m.mb_image_url AS target_member_image_url,
+					wm.wr_name AS source_wr_name
 			 FROM celebration_banners cb
 			 LEFT JOIN g5_member m
 			   ON cb.target_member_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
+			 LEFT JOIN g5_write_message wm
+			   ON cb.source_wr_id = wm.wr_id AND wm.wr_is_comment = 0
 			 WHERE cb.is_active = 1 ${dateFilter}
 			 ORDER BY cb.display_date DESC, cb.sort_order ASC, cb.id DESC
 			 LIMIT 8`
@@ -74,7 +77,8 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
             const linkUrl =
                 row.external_url ||
                 (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
-            const anonymous = !!row.is_anonymous;
+            const sourceWrName = (row.source_wr_name ?? '').toString().trim();
+            const anonymous = !!row.is_anonymous || (!!row.source_wr_id && sourceWrName === '');
 
             banners.push({
                 id: row.source_wr_id || row.id,
@@ -107,7 +111,7 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
                 ? ''
                 : "AND (wm.wr_subject = DATE_FORMAT(NOW(),'%Y.%m.%d') OR wm.wr_subject = DATE_FORMAT(NOW(),'%Y-%m-%d'))";
             const [rows] = await pool.query<RowDataPacket[]>(
-                `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
+                `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id, wm.wr_name,
                         m.mb_nick, m.mb_image_url
                  FROM g5_write_message wm
                  LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
@@ -119,6 +123,7 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
             for (const row of rows as RowDataPacket[]) {
                 const imageUrl = extractFirstImage(row.wr_content);
                 if (imageUrl) {
+                    const anonymous = (row.wr_name ?? '').toString().trim() === '';
                     banners.push({
                         id: row.wr_id,
                         title: row.wr_subject,
@@ -127,9 +132,11 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
                         link_url: row.wr_link2 || `/message/${row.wr_id}`,
                         display_date: row.wr_subject,
                         is_active: true,
-                        target_member_id: row.mb_id || undefined,
-                        target_member_nick: row.mb_nick || undefined,
-                        target_member_photo: getMemberPhotoUrl(row.mb_image_url),
+                        target_member_id: anonymous ? undefined : row.mb_id || undefined,
+                        target_member_nick: anonymous ? undefined : row.mb_nick || undefined,
+                        target_member_photo: anonymous
+                            ? undefined
+                            : getMemberPhotoUrl(row.mb_image_url),
                         external_link: row.wr_link2 || undefined,
                         display_type: 'image'
                     });

--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -69,7 +69,8 @@ export const GET: RequestHandler = async () => {
                         cb.source_wr_id, cb.updated_at AS cb_updated_at, cb.is_anonymous,
                         m.mb_nick AS target_member_nick,
                         m.mb_image_url AS target_member_image_url,
-                        wm.wr_content AS source_content
+                        wm.wr_content AS source_content,
+                        wm.wr_name AS source_wr_name
                  FROM celebration_banners cb
                  LEFT JOIN g5_member m
                    ON cb.target_member_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
@@ -87,7 +88,8 @@ export const GET: RequestHandler = async () => {
                 const linkUrl =
                     row.external_url ||
                     (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
-                const anonymous = !!row.is_anonymous;
+                const sourceWrName = (row.source_wr_name ?? '').toString().trim();
+                const anonymous = !!row.is_anonymous || (!!row.source_wr_id && sourceWrName === '');
 
                 // source_wr_id가 있으면 원본 게시글에서 최신 이미지 추출 (동기화)
                 let imageUrl = row.image_url || '';
@@ -128,7 +130,7 @@ export const GET: RequestHandler = async () => {
         if (banners.length === 0) {
             const [rows] = await pool.execute<RowDataPacket[]>(
                 `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
-                        m.mb_nick, m.mb_image_url
+                        wm.wr_name, m.mb_nick, m.mb_image_url
                  FROM g5_write_message wm
                  LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
                  WHERE wm.wr_is_comment = 0
@@ -140,6 +142,7 @@ export const GET: RequestHandler = async () => {
             for (const row of rows as RowDataPacket[]) {
                 const imageUrl = extractFirstImage(row.wr_content);
                 if (imageUrl) {
+                    const anonymous = (row.wr_name ?? '').toString().trim() === '';
                     banners.push({
                         id: row.wr_id,
                         title: row.wr_subject,
@@ -148,9 +151,11 @@ export const GET: RequestHandler = async () => {
                         link_url: `/message/${row.wr_id}`,
                         display_date: row.wr_subject,
                         is_active: true,
-                        target_member_id: row.mb_id || undefined,
-                        target_member_nick: row.mb_nick || undefined,
-                        target_member_photo: getMemberPhotoUrl(row.mb_image_url),
+                        target_member_id: anonymous ? undefined : row.mb_id || undefined,
+                        target_member_nick: anonymous ? undefined : row.mb_nick || undefined,
+                        target_member_photo: anonymous
+                            ? undefined
+                            : getMemberPhotoUrl(row.mb_image_url),
                         external_link: row.wr_link2 || undefined,
                         display_type: 'image'
                     });


### PR DESCRIPTION
## Summary
- celebration_banners 조회 시 원본 message 글의 wr_name을 함께 확인해 게시판 익명 기준과 동기화합니다.
- /api/ads/celebration/today 및 서버 공유 fetchCelebrations 경로 모두에서 익명 글의 닉네임/프로필 사진을 마스킹합니다.
- 레거시 g5_write_message fallback에서도 wr_name이 비어 있으면 회원 닉네임/사진을 내려주지 않습니다.

## Verification
- pnpm --dir apps/web exec svelte-check (0 errors, existing warnings)
- pnpm --dir apps/web exec eslint src/lib/server/celebration.ts src/routes/api/ads/celebration/today/+server.ts
- pnpm --dir apps/web exec prettier --check src/lib/server/celebration.ts src/routes/api/ads/celebration/today/+server.ts
- pnpm --dir apps/web build

Note: full pnpm --dir apps/web lint is currently blocked by unrelated existing formatting warnings in uncommitted files.