### PR TITLE
fix(web): register DOMPurify CSS hook once

### DIFF
--- a/apps/web/src/lib/components/post/revision-history.svelte
+++ b/apps/web/src/lib/components/post/revision-history.svelte
@@ -14,12 +14,6 @@
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronUp from '@lucide/svelte/icons/chevron-up';
     import { dompurify as DOMPurify } from '$lib/utils/dompurify.js';
-    import { filterUnsafeStyles } from '$lib/utils/safe-css.js';
-
-    // CSS 필터 훅 등록
-    DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-        filterUnsafeStyles(node as unknown as Element);
-    });
 
     const REVISION_PURIFY_CONFIG = {
         ALLOWED_TAGS: [

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -9,17 +9,11 @@
     import { transformEscapedMedia } from '$lib/utils/content-transform';
     import { processContent as processEmbeds } from '$lib/plugins/auto-embed/embedder.js';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
-    import { filterUnsafeStyles } from '$lib/utils/safe-css.js';
     import {
         buildThumbnailSrcSet,
         isTransformableMediaImage,
         toThumbnailUrl
     } from '$lib/utils/thumbnail-url.js';
-
-    // CSS 필터 훅 등록 — style 속성에서 위험한 CSS 속성 제거
-    DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-        filterUnsafeStyles(node as unknown as Element);
-    });
 
     interface Props {
         content: string;

--- a/apps/web/src/lib/server/sanitize.ts
+++ b/apps/web/src/lib/server/sanitize.ts
@@ -4,7 +4,6 @@
  * isomorphic-dompurify 사용 — SSR 환경에서 JSDOM 기반 동작
  */
 import { dompurify as DOMPurify } from '$lib/utils/dompurify.js';
-import { filterUnsafeStyles } from '$lib/utils/safe-css.js';
 
 /**
  * URL에서 도메인 추출 (프로토콜, www, 경로 제거)
@@ -65,11 +64,6 @@ export function isLinkDomainMatch(href: string, text: string): boolean {
 
     return hrefRoot === textRoot;
 }
-
-// CSS 필터 훅 등록 — style 속성에서 위험한 CSS 속성 제거
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-    filterUnsafeStyles(node as unknown as Element);
-});
 
 /** 허용 iframe 도메인 패턴 */
 const ALLOWED_IFRAME_REGEX =

--- a/apps/web/src/lib/utils/dompurify.ts
+++ b/apps/web/src/lib/utils/dompurify.ts
@@ -1,6 +1,9 @@
 import * as DOMPurifyModule from 'isomorphic-dompurify';
+import { filterUnsafeStyles } from './safe-css.js';
 
 type DOMPurifyLike = typeof import('isomorphic-dompurify');
+const safeCssHookRegisteredKey = Symbol.for('angple.dompurify.safeCssHookRegistered');
+const hookRegistry = globalThis as typeof globalThis & Record<symbol, boolean | undefined>;
 
 export const dompurify =
     typeof DOMPurifyModule.sanitize === 'function'
@@ -9,4 +12,11 @@ export const dompurify =
 
 if (typeof dompurify.sanitize !== 'function') {
     throw new Error('DOMPurify import did not expose sanitize()');
+}
+
+if (!hookRegistry[safeCssHookRegisteredKey]) {
+    dompurify.addHook('afterSanitizeAttributes', (node) => {
+        filterUnsafeStyles(node as unknown as Element);
+    });
+    hookRegistry[safeCssHookRegisteredKey] = true;
 }


### PR DESCRIPTION
## Summary
- Move the DOMPurify safe-CSS hook registration into the shared DOMPurify wrapper.
- Guard the hook with a global Symbol so it is registered once per process.
- Remove per-component/per-module addHook calls from Markdown, revision history, and server sanitizer.

## Root-cause evidence
- 2026-05-04 web pods kept OOMKilled even after Node old-space and heap-watch thresholds were lowered.
- Kernel OOM logs show anon-rss reaching about 1293MiB inside the 1280Mi container limit.
- The only valid heap snapshot (287MB, pod xzzp5) showed selector/JSDOM/DOMPurify pressure: 7,686 Finder objects and tens of thousands of selector-related closures.
- markdown.svelte and revision-history.svelte registered DOMPurify.addHook() from normal component instance scripts, so SSR rendering repeatedly accumulated sanitizer hooks and their captured closures.

## Testing
- pnpm --dir /tmp/angple-dompurify-hook-leak/apps/web exec svelte-check --tsconfig ./tsconfig.json
- pnpm --dir /tmp/angple-dompurify-hook-leak/apps/web build
- pnpm --dir /tmp/angple-dompurify-hook-leak/apps/web format
- git diff --check
