### PR TITLE
fix(memory): recycle server DOMPurify jsdom window

### DIFF
--- a/apps/web/src/lib/utils/dompurify.ts
+++ b/apps/web/src/lib/utils/dompurify.ts
@@ -1,18 +1,77 @@
 import * as DOMPurifyModule from 'isomorphic-dompurify';
+import { browser } from '$app/environment';
 import { filterUnsafeStyles } from './safe-css.js';
 
 type DOMPurifyLike = typeof import('isomorphic-dompurify');
+type HookEntryPoint = Parameters<DOMPurifyLike['addHook']>[0];
+type HookFunction = Parameters<DOMPurifyLike['addHook']>[1];
+type ClearWindowCapable = DOMPurifyLike & { clearWindow?: () => void };
+
 const safeCssHookRegisteredKey = Symbol.for('angple.dompurify.safeCssHookRegistered');
 const hookRegistry = globalThis as typeof globalThis & Record<symbol, boolean | undefined>;
 
-export const dompurify =
+const importedDompurify =
     typeof DOMPurifyModule.sanitize === 'function'
         ? (DOMPurifyModule as unknown as DOMPurifyLike)
         : ((DOMPurifyModule.default ?? DOMPurifyModule) as unknown as DOMPurifyLike);
 
-if (typeof dompurify.sanitize !== 'function') {
+if (typeof importedDompurify.sanitize !== 'function') {
     throw new Error('DOMPurify import did not expose sanitize()');
 }
+
+const DEFAULT_SERVER_CLEAR_WINDOW_EVERY = 100;
+const serverClearWindowEvery = Number(
+    process.env.DOMPURIFY_CLEAR_WINDOW_EVERY ?? DEFAULT_SERVER_CLEAR_WINDOW_EVERY
+);
+
+function createServerDompurify(baseDompurify: DOMPurifyLike): DOMPurifyLike {
+    const serverDompurify = baseDompurify as ClearWindowCapable;
+
+    if (typeof serverDompurify.clearWindow !== 'function') {
+        return baseDompurify;
+    }
+
+    const hooks: Array<[HookEntryPoint, HookFunction]> = [];
+    const addHook = serverDompurify.addHook.bind(serverDompurify);
+    const clearWindow = serverDompurify.clearWindow.bind(serverDompurify);
+    let sanitizeCount = 0;
+
+    return new Proxy(baseDompurify, {
+        get(target, prop, receiver) {
+            if (prop === 'addHook') {
+                return (entryPoint: HookEntryPoint, hookFunction: HookFunction) => {
+                    hooks.push([entryPoint, hookFunction]);
+                    return addHook(entryPoint, hookFunction);
+                };
+            }
+
+            if (prop === 'sanitize') {
+                return (...args: Parameters<DOMPurifyLike['sanitize']>) => {
+                    const sanitized = serverDompurify.sanitize(...args);
+                    sanitizeCount += 1;
+
+                    if (sanitizeCount >= serverClearWindowEvery) {
+                        sanitizeCount = 0;
+                        clearWindow();
+                        for (const [entryPoint, hookFunction] of hooks) {
+                            addHook(entryPoint, hookFunction);
+                        }
+                    }
+
+                    return sanitized;
+                };
+            }
+
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === 'function' ? value.bind(target) : value;
+        }
+    }) as DOMPurifyLike;
+}
+
+export const dompurify =
+    !browser && serverClearWindowEvery > 0
+        ? createServerDompurify(importedDompurify)
+        : importedDompurify;
 
 if (!hookRegistry[safeCssHookRegisteredKey]) {
     dompurify.addHook('afterSanitizeAttributes', (node) => {


### PR DESCRIPTION
## Summary
- Wrap server-side isomorphic-dompurify with a Proxy instead of mutating the ESM namespace.
- Track registered DOMPurify hooks and re-register them after recycling the underlying jsdom window.
- Call isomorphic-dompurify clearWindow() every 100 server sanitize calls by default, configurable via DOMPURIFY_CLEAR_WINDOW_EVERY.

## Root-cause evidence
- 2026-05-04 heap snapshot /data/angple-heap-snapshots/heap-angple-web-7d86df646-xzzp5-1777873760357.heapsnapshot was valid at 287MB.
- Snapshot contains jsdom@28.0.0, isomorphic-dompurify@3.0.0, and @asamuzakjp/dom-selector objects.
- Dominant pattern includes thousands of Finder objects and selector closures, plus duplicated <!doctype html> strings, matching a long-lived jsdom DOMPurify window retaining selector/DOM state.

## Testing
- pnpm --dir /tmp/angple-dompurify-fix install
- pnpm --dir /tmp/angple-dompurify-fix build
- git diff --check

Note: existing unrelated local changes in /home/angple/web were not included; this PR was created from a clean worktree at /tmp/angple-dompurify-fix.