### PR TITLE
fix(reactions): load block policy from plugin

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -11,9 +11,9 @@
     import {
         REACTION_CATEGORIES,
         REACTION_EMOTICONS,
-        REACTION_REPLACE,
-        isReactionBlocked
+        REACTION_REPLACE
     } from '$lib/config/reaction-config.js';
+    import { loadPluginLib } from '$lib/utils/plugin-optional-loader';
     import SmilePlus from '@lucide/svelte/icons/smile-plus';
     import {
         canUseCertifiedAction,
@@ -30,9 +30,15 @@
         initialReactions?: ReactionItem[];
     }
 
+    interface ReactionPolicyModule {
+        getBlockedReactions?: () => string[];
+        isReactionBlocked?: (reaction: string) => boolean;
+    }
+
     let { boardId, postId, commentId, target, initialReactions }: Props = $props();
 
     let reactions = $state<ReactionItem[]>([]);
+    let blockedReactions = $state<string[]>([]);
     let isLoading = $state(false);
     let isReacting = $state(false);
     let showPicker = $state(false);
@@ -51,9 +57,31 @@
     // 현재 카테고리의 이모티콘
     const categoryEmoticons = $derived(
         REACTION_EMOTICONS.filter(
-            (e) => e.category === activeCategory && !isReactionBlocked(e.reaction)
+            (e) =>
+                e.category === activeCategory &&
+                !isReactionBlocked(REACTION_REPLACE[e.reaction] || e.reaction)
         )
     );
+
+    function isReactionBlocked(reaction: string): boolean {
+        return blockedReactions.includes(reaction);
+    }
+
+    async function loadReactionPolicy(): Promise<void> {
+        const policy = await loadPluginLib<ReactionPolicyModule>('da-reaction', 'reaction-policy');
+        if (!policy) return;
+
+        if (typeof policy.getBlockedReactions === 'function') {
+            blockedReactions = policy.getBlockedReactions();
+            return;
+        }
+
+        if (typeof policy.isReactionBlocked === 'function') {
+            blockedReactions = REACTION_EMOTICONS.map(
+                (e) => REACTION_REPLACE[e.reaction] || e.reaction
+            ).filter((reaction) => policy.isReactionBlocked?.(reaction));
+        }
+    }
 
     // 리액션 로드
     async function loadReactions(): Promise<void> {
@@ -163,6 +191,7 @@
     });
 
     onMount(() => {
+        void loadReactionPolicy();
         document.addEventListener('click', handleClickOutside);
         return () => document.removeEventListener('click', handleClickOutside);
     });

--- a/apps/web/src/lib/config/reaction-config.ts
+++ b/apps/web/src/lib/config/reaction-config.ts
@@ -180,13 +180,6 @@ export const REACTION_REPLACE: Record<string, string> = {
     'emoji:1f389': 'import-image:ezgif-55990bc446328e'
 };
 
-/** 운영 정책상 신규 사용을 막는 리액션. 기존 DB 집계 표시는 유지한다. */
-export const BLOCKED_REACTIONS = new Set(['emoji:274c', 'emoji:2753']);
-
-export function isReactionBlocked(reaction: string): boolean {
-    return BLOCKED_REACTIONS.has(reaction);
-}
-
 /** 전체 이모티콘 목록 */
 export const REACTION_EMOTICONS: EmoticonDef[] = [...EMOJIS, ...ANGTICONS, ...NOTO_ANIMOJI];
 

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -12,7 +12,7 @@ import pool from '$lib/server/db';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 import { fetchReactionsByParentId } from '$lib/server/reactions';
-import { isReactionBlocked } from '$lib/config/reaction-config.js';
+import { loadPluginServerLib } from '$lib/server/plugin-server-loader.js';
 
 const REACTION_LIMIT = 20;
 const VALID_REACTION_PATTERN = /^[a-zA-Z0-9:_-]+$/;
@@ -34,6 +34,36 @@ interface CountRow extends RowDataPacket {
 
 interface ChooseCountRow extends RowDataPacket {
     count: number;
+}
+
+interface ReactionPolicyModule {
+    getBlockedReactions?: () => string[];
+    isReactionBlocked?: (reaction: string) => boolean;
+}
+
+let reactionPolicyPromise: Promise<ReactionPolicyModule | null> | null = null;
+
+function loadReactionPolicy(): Promise<ReactionPolicyModule | null> {
+    reactionPolicyPromise ??= loadPluginServerLib<ReactionPolicyModule>(
+        'da-reaction',
+        'reaction-policy'
+    );
+    return reactionPolicyPromise;
+}
+
+async function isReactionBlockedByPolicy(reaction: string): Promise<boolean> {
+    const policy = await loadReactionPolicy();
+    if (!policy) return false;
+
+    if (typeof policy.isReactionBlocked === 'function') {
+        return policy.isReactionBlocked(reaction);
+    }
+
+    if (typeof policy.getBlockedReactions === 'function') {
+        return policy.getBlockedReactions().includes(reaction);
+    }
+
+    return false;
 }
 
 function parseReaction(reaction: string, count: number, choose: boolean) {
@@ -153,7 +183,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         const safeTargetId = sanitizeId(targetId);
         const safeParentId = parentId ? sanitizeId(parentId) : safeTargetId;
 
-        if (isReactionBlocked(safeReaction)) {
+        if (await isReactionBlockedByPolicy(safeReaction)) {
             return json(
                 { status: 'error', message: '현재 사용할 수 없는 리액션입니다.' },
                 { status: 400 }


### PR DESCRIPTION
## Summary
- remove Damoang-specific blocked reaction policy from core config
- load optional da-reaction reaction-policy module on client and server
- keep existing reaction display behavior; only new POSTs are blocked when plugin policy is installed

## Verification
- pnpm --dir /tmp/angple-core-reaction-policy.kAtIre/apps/web run check
- pnpm --dir /tmp/angple-core-reaction-policy.kAtIre/apps/web run build
- installed angple-premium into the temp core checkout, then reran check/build