### PR TITLE
feat: add message celebration period tabs

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -179,7 +179,14 @@ export const load: PageServerLoad = async ({
     const category = url.searchParams.get('category') || null;
     const isSearching = Boolean(searchField && searchQuery);
     const isTagFiltering = Boolean(tag);
-    const includeNotices = !isSearching && page === 1;
+    const rawMessagePeriod = url.searchParams.get('period') || 'today';
+    const messagePeriod =
+        boardId === 'message' && !isSearching && !isTagFiltering && !category
+            ? rawMessagePeriod === 'month' || rawMessagePeriod === 'upcoming'
+                ? rawMessagePeriod
+                : 'today'
+            : null;
+    const includeNotices = !isSearching && page === 1 && !messagePeriod;
 
     if (isSearching && !locals.user) {
         return {
@@ -278,12 +285,15 @@ export const load: PageServerLoad = async ({
         if (useSummaryListResponse) {
             queryParams.set('summary', '1');
         }
+        if (messagePeriod) {
+            queryParams.set('celebration_period', messagePeriod);
+        }
         return `/api/v1/boards/${boardId}/posts?${queryParams.toString()}`;
     };
 
     // 비로그인 + 검색/태그 필터 없는 경우: 게시글 목록 캐시 사용 (15초)
     const usePostsCache = !locals.user && !isSearching && !isTagFiltering;
-    const postsCacheKey = `${boardId}:p${page}:l${limit}${category ? `:c${category}` : ''}${useSummaryListResponse ? ':summary1' : ''}`;
+    const postsCacheKey = `${boardId}:p${page}:l${limit}${category ? `:c${category}` : ''}${messagePeriod ? `:period:${messagePeriod}` : ''}${useSummaryListResponse ? ':summary1' : ''}`;
 
     if (usePostsCache) {
         const cachedPosts = postsCache.get(postsCacheKey);
@@ -575,14 +585,10 @@ export const load: PageServerLoad = async ({
             }
         }
 
-        // 축하메시지(message) 게시판:
-        //   1) soft-deleted(wr_deleted_at) 글 완전 숨김 — 프라이빗 영역이라 placeholder 미표시
-        //   2) 익명 글 프로필 정보 숨김 (PublishToGnuboard에서 익명 시 wr_name=""로 author가 빈 문자열)
-        // 페이지네이션 total은 백엔드 값을 그대로 두므로 페이지마다 표시 글 수가 1~2개 적을 수 있음 (허용)
+        // 축하메시지(message) 게시판: 익명 글 프로필 정보 숨김
+        // PublishToGnuboard()에서 익명 시 wr_name=""으로 설정 → author가 빈 문자열
         if (boardId === 'message') {
-            posts = posts.filter((p) => !p.deleted_at);
             for (const p of allPosts) {
-                if (p.deleted_at) continue;
                 if (!p.author) {
                     p.author_image = undefined;
                     p.author_image_updated_at = undefined;

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -187,21 +187,21 @@
     const listPage = $derived(Number($page.url.searchParams.get('page')) || 1);
 
     // #12012: 보드별 "내가 쓴 글/댓글" 빠른 필터
-    // 4단 분리 후: ?sfl=author_id|comment_id&stx={mb_id} (mb_id 정확 매칭, false-positive 차단)
+    // 백엔드 ?sfl=author|comment_author&stx={mb_id} 재사용 (Sphinx @(mb_id,wr_name) 매칭)
     const currentSfl = $derived($page.url.searchParams.get('sfl') || '');
     const currentStx = $derived($page.url.searchParams.get('stx') || '');
     const isMyPostsActive = $derived(
         authStore.isAuthenticated &&
-            currentSfl === 'author_id' &&
+            currentSfl === 'author' &&
             currentStx === (authStore.user?.mb_id ?? '')
     );
     const isMyCommentsActive = $derived(
         authStore.isAuthenticated &&
-            currentSfl === 'comment_id' &&
+            currentSfl === 'comment_author' &&
             currentStx === (authStore.user?.mb_id ?? '')
     );
 
-    function applyMyFilter(sfl: 'author_id' | 'comment_id'): void {
+    function applyMyFilter(sfl: 'author' | 'comment_author'): void {
         const mbId = authStore.user?.mb_id;
         if (!mbId) return;
         const url = new URL(window.location.href);
@@ -584,6 +584,12 @@
 
     // 현재 선택된 카테고리 (URL 쿼리에서 가져오기)
     const selectedCategory = $derived($page.url.searchParams.get('category') || '전체');
+    const isMessageBoard = $derived(boardId === 'message');
+    const messagePeriod = $derived.by(() => {
+        const period = $page.url.searchParams.get('period');
+        if (period === 'month' || period === 'upcoming') return period;
+        return 'today';
+    });
 
     // 카테고리 변경
     function changeCategory(category: string): void {
@@ -593,6 +599,22 @@
         } else {
             url.searchParams.set('category', category);
         }
+        url.searchParams.set('page', '1');
+        goto(url.pathname + url.search);
+    }
+
+    function changeMessagePeriod(period: 'today' | 'month' | 'upcoming'): void {
+        const url = new URL(window.location.href);
+        if (period === 'today') {
+            url.searchParams.delete('period');
+        } else {
+            url.searchParams.set('period', period);
+        }
+        url.searchParams.delete('category');
+        url.searchParams.delete('tag');
+        url.searchParams.delete('sfl');
+        url.searchParams.delete('stx');
+        url.searchParams.delete('sop');
         url.searchParams.set('page', '1');
         goto(url.pathname + url.search);
     }
@@ -868,6 +890,32 @@
                 </div>
             </div>
 
+            {#if isMessageBoard && !isSearching}
+                <div class="mb-4 flex flex-wrap gap-2">
+                    <Button
+                        variant={messagePeriod === 'today' ? 'default' : 'outline'}
+                        size="sm"
+                        onclick={() => changeMessagePeriod('today')}
+                    >
+                        오늘 축하메시지
+                    </Button>
+                    <Button
+                        variant={messagePeriod === 'month' ? 'default' : 'outline'}
+                        size="sm"
+                        onclick={() => changeMessagePeriod('month')}
+                    >
+                        이번달 축하메시지
+                    </Button>
+                    <Button
+                        variant={messagePeriod === 'upcoming' ? 'default' : 'outline'}
+                        size="sm"
+                        onclick={() => changeMessagePeriod('upcoming')}
+                    >
+                        다가올 축하메시지
+                    </Button>
+                </div>
+            {/if}
+
             <!-- 최상단 자체 배너 (자체 배너 없으면 안 보임) -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-3">
@@ -904,7 +952,7 @@
                         size="sm"
                         class="h-8"
                         onclick={() =>
-                            isMyPostsActive ? clearMyFilter() : applyMyFilter('author_id')}
+                            isMyPostsActive ? clearMyFilter() : applyMyFilter('author')}
                         title="이 게시판에서 내가 쓴 글만 보기"
                     >
                         <User class="mr-1.5 h-3.5 w-3.5" />
@@ -915,7 +963,7 @@
                         size="sm"
                         class="h-8"
                         onclick={() =>
-                            isMyCommentsActive ? clearMyFilter() : applyMyFilter('comment_id')}
+                            isMyCommentsActive ? clearMyFilter() : applyMyFilter('comment_author')}
                         title="이 게시판에서 내가 쓴 댓글만 보기"
                     >
                         <MessageSquare class="mr-1.5 h-3.5 w-3.5" />
@@ -1158,6 +1206,18 @@
                         <CardContent class="py-12 text-center">
                             {#if isSearching}
                                 <p class="text-secondary-foreground">검색 결과가 없습니다.</p>
+                            {:else if isMessageBoard && messagePeriod === 'today'}
+                                <p class="text-secondary-foreground">
+                                    오늘 등록된 축하메시지가 없습니다.
+                                </p>
+                            {:else if isMessageBoard && messagePeriod === 'month'}
+                                <p class="text-secondary-foreground">
+                                    이번달 축하메시지가 없습니다.
+                                </p>
+                            {:else if isMessageBoard && messagePeriod === 'upcoming'}
+                                <p class="text-secondary-foreground">
+                                    다가올 축하메시지가 없습니다.
+                                </p>
                             {:else}
                                 <p class="text-secondary-foreground">게시글이 없습니다.</p>
                             {/if}


### PR DESCRIPTION
## Summary
- default /message to today celebrations in the SvelteKit loader
- pass the message period through to the Go posts API and cache key
- add Today, This Month, and Upcoming celebration tabs on the message board

## Verification
- not run per request