### PR TITLE
fix: restore social invite reconnect flow

### DIFF
--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -15,8 +15,18 @@ import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/int
  */
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
+const LEGACY_BACKEND_URL =
+    env.LEGACY_BACKEND_URL || 'http://damoang-backend-svc.damoang.svc.cluster.local:8090';
 const PROXY_TIMEOUT_MS = 4_000;
 const INTERNAL_ONLY_V1_PREFIXES = ['my/', 'admin/'];
+
+function getBackendUrlForPath(path: string): string {
+    if (path.startsWith('social-invite/') || path === 'member-recovery/social-invite') {
+        return LEGACY_BACKEND_URL;
+    }
+
+    return BACKEND_URL;
+}
 
 function buildOptionalFallback(path: string): Response | null {
     if (path === 'my/favorites') {
@@ -292,7 +302,7 @@ async function proxyRequest(
 ): Promise<Response> {
     const path = params.path || '';
     const url = new URL(request.url);
-    const targetUrl = `${BACKEND_URL}/api/v1/${path}${url.search}`;
+    const targetUrl = `${getBackendUrlForPath(path)}/api/v1/${path}${url.search}`;
     const isInternalRequest = isInternalAppRequest(request);
 
     if (

--- a/apps/web/src/routes/invite/[token]/+page.svelte
+++ b/apps/web/src/routes/invite/[token]/+page.svelte
@@ -35,6 +35,13 @@
             bgClass: 'bg-white border border-border',
             textClass: 'text-gray-700',
             hoverClass: 'hover:bg-gray-50'
+        },
+        {
+            id: 'payco',
+            label: 'PAYCO로 로그인',
+            bgClass: 'bg-[#E42529]',
+            textClass: 'text-white',
+            hoverClass: 'hover:bg-[#E42529]/90'
         }
     ] as const;
 
@@ -57,7 +64,8 @@
             naver: '네이버',
             kakao: '카카오',
             google: '구글',
-            apple: '애플'
+            apple: '애플',
+            payco: 'PAYCO'
         };
         return labels[provider] || provider;
     }
@@ -77,6 +85,11 @@
             const json = await res.json();
             if (!res.ok || json.error) {
                 error = json.error?.message || json.message || '초대 정보를 불러올 수 없습니다';
+                return;
+            }
+            if (!json.data) {
+                error =
+                    '초대 링크가 만료되었거나 사용할 수 없습니다. 관리자에게 새 링크 발급을 요청해주세요.';
                 return;
             }
             inviteInfo = json.data;
@@ -219,6 +232,8 @@
                                         d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
                                     />
                                 </svg>
+                            {:else if provider.id === 'payco'}
+                                <span class="text-base font-black leading-none">P</span>
                             {/if}
                             {provider.label}
                         </button>


### PR DESCRIPTION
## Summary
- route social invite API calls to the legacy damoang-backend implementation until angple-backend owns the endpoint
- show an explicit error instead of a blank invite page when API returns an empty payload
- add PAYCO to the invite login options for PAYCO reconnect cases

## Verification
- PNPM_HOME=/tmp/pnpm-home pnpm --dir /tmp/angple-social-invite-fix --filter web check
- PNPM_HOME=/tmp/pnpm-home pnpm --dir /tmp/angple-social-invite-fix exec prettier --check 'apps/web/src/routes/api/v1/[...path]/+server.ts' 'apps/web/src/routes/invite/[token]/+page.svelte'
- PNPM_HOME=/tmp/pnpm-home pnpm --dir /tmp/angple-social-invite-fix --filter web build

## Notes
- This is the P0 fix. The P1 follow-up is to port social-invite API ownership into angple-backend and remove the legacy proxy exception.