### PR TITLE
feat: add past celebration message tab

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -177,15 +177,18 @@ export const load: PageServerLoad = async ({
     const searchSort = url.searchParams.get('sort') || null;
     const tag = url.searchParams.get('tag') || null;
     const category = url.searchParams.get('category') || null;
+    const rawMessagePeriod = boardId === 'message' ? url.searchParams.get('period') : null;
+    const messagePeriod =
+        boardId === 'message' &&
+        (rawMessagePeriod === 'month' ||
+            rawMessagePeriod === 'upcoming' ||
+            rawMessagePeriod === 'past')
+            ? rawMessagePeriod
+            : boardId === 'message'
+              ? 'today'
+              : null;
     const isSearching = Boolean(searchField && searchQuery);
     const isTagFiltering = Boolean(tag);
-    const rawMessagePeriod = url.searchParams.get('period') || 'today';
-    const messagePeriod =
-        boardId === 'message' && !isSearching && !isTagFiltering && !category
-            ? rawMessagePeriod === 'month' || rawMessagePeriod === 'upcoming'
-                ? rawMessagePeriod
-                : 'today'
-            : null;
     const includeNotices = !isSearching && page === 1 && !messagePeriod;
 
     if (isSearching && !locals.user) {
@@ -278,15 +281,15 @@ export const load: PageServerLoad = async ({
         if (category) {
             queryParams.set('category', category);
         }
+        if (messagePeriod) {
+            queryParams.set('celebration_period', messagePeriod);
+        }
         if (isTagFiltering && !isSearching) {
             queryParams.set('sfl', 'title_content');
             queryParams.set('stx', '');
         }
         if (useSummaryListResponse) {
             queryParams.set('summary', '1');
-        }
-        if (messagePeriod) {
-            queryParams.set('celebration_period', messagePeriod);
         }
         return `/api/v1/boards/${boardId}/posts?${queryParams.toString()}`;
     };

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -585,13 +585,12 @@
 
     // 현재 선택된 카테고리 (URL 쿼리에서 가져오기)
     const selectedCategory = $derived($page.url.searchParams.get('category') || '전체');
-    const isMessageBoard = $derived(boardId === 'message');
-    const messagePeriod = $derived.by(() => {
+    type MessagePeriod = 'today' | 'month' | 'upcoming' | 'past';
+    const messagePeriod = $derived.by<MessagePeriod>(() => {
         const period = $page.url.searchParams.get('period');
-        if (period === 'month' || period === 'upcoming') return period;
+        if (period === 'month' || period === 'upcoming' || period === 'past') return period;
         return 'today';
     });
-    type MessagePeriod = 'today' | 'month' | 'upcoming';
 
     function buildMessagePeriodHref(period: MessagePeriod): string {
         const url = new URL($page.url.href);
@@ -609,32 +608,7 @@
         return url.pathname + url.search;
     }
 
-    const messagePeriodHref = $derived.by(() => ({
-        today: buildMessagePeriodHref('today'),
-        month: buildMessagePeriodHref('month'),
-        upcoming: buildMessagePeriodHref('upcoming')
-    }));
-
-    type MessagePeriod = 'today' | 'month' | 'upcoming' | 'past';
-
-    const selectedMessagePeriod = $derived.by<MessagePeriod>(() => {
-        if (!isMessageBoard) return 'today';
-        const period = $page.url.searchParams.get('period');
-        if (period === 'month' || period === 'upcoming' || period === 'past') return period;
-        return 'today';
-    });
-
-    function buildMessagePeriodHref(period: MessagePeriod): string {
-        const url = new URL($page.url.href);
-        url.searchParams.set('period', period);
-        url.searchParams.set('page', '1');
-        url.searchParams.delete('category');
-        url.searchParams.delete('tag');
-        url.searchParams.delete('sfl');
-        url.searchParams.delete('stx');
-        url.searchParams.delete('sort');
-        return url.pathname + url.search;
-    }
+    const selectedMessagePeriod = $derived(messagePeriod);
 
     // 카테고리 변경
     function changeCategory(category: string): void {
@@ -918,35 +892,6 @@
                     {/if}
                 </div>
             </div>
-
-            {#if isMessageBoard && !isSearching}
-                <div class="mb-4 flex flex-wrap gap-2">
-                    <Button
-                        variant={messagePeriod === 'today' ? 'default' : 'outline'}
-                        size="sm"
-                        href={messagePeriodHref.today}
-                        aria-current={messagePeriod === 'today' ? 'page' : undefined}
-                    >
-                        오늘 축하메시지
-                    </Button>
-                    <Button
-                        variant={messagePeriod === 'month' ? 'default' : 'outline'}
-                        size="sm"
-                        href={messagePeriodHref.month}
-                        aria-current={messagePeriod === 'month' ? 'page' : undefined}
-                    >
-                        이번달 축하메시지
-                    </Button>
-                    <Button
-                        variant={messagePeriod === 'upcoming' ? 'default' : 'outline'}
-                        size="sm"
-                        href={messagePeriodHref.upcoming}
-                        aria-current={messagePeriod === 'upcoming' ? 'page' : undefined}
-                    >
-                        다가올 축하메시지
-                    </Button>
-                </div>
-            {/if}
 
             <!-- 최상단 자체 배너 (자체 배너 없으면 안 보임) -->
             {#if widgetLayoutStore.hasEnabledAds}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -149,6 +149,7 @@
     });
     const isAngmapBoard = $derived(boardType === 'angmap');
     const isEconomyBoard = $derived(boardType === 'economy');
+    const isMessageBoard = $derived(boardId === 'message');
 
     // 플러그인 레지스트리에서 특수 게시판 컴포넌트 resolve
     const boardTypeComponent = $derived(boardTypeRegistry.resolve(boardType));
@@ -614,6 +615,27 @@
         upcoming: buildMessagePeriodHref('upcoming')
     }));
 
+    type MessagePeriod = 'today' | 'month' | 'upcoming' | 'past';
+
+    const selectedMessagePeriod = $derived.by<MessagePeriod>(() => {
+        if (!isMessageBoard) return 'today';
+        const period = $page.url.searchParams.get('period');
+        if (period === 'month' || period === 'upcoming' || period === 'past') return period;
+        return 'today';
+    });
+
+    function buildMessagePeriodHref(period: MessagePeriod): string {
+        const url = new URL($page.url.href);
+        url.searchParams.set('period', period);
+        url.searchParams.set('page', '1');
+        url.searchParams.delete('category');
+        url.searchParams.delete('tag');
+        url.searchParams.delete('sfl');
+        url.searchParams.delete('stx');
+        url.searchParams.delete('sort');
+        return url.pathname + url.search;
+    }
+
     // 카테고리 변경
     function changeCategory(category: string): void {
         const url = new URL(window.location.href);
@@ -990,6 +1012,48 @@
                             <X class="h-3.5 w-3.5" />
                         </Button>
                     {/if}
+                </div>
+            {/if}
+
+            <!-- 축하메시지 기간 탭 -->
+            {#if isMessageBoard && !isSearching}
+                <div class="mb-6 flex flex-wrap gap-2">
+                    <Button
+                        href={buildMessagePeriodHref('today')}
+                        variant={selectedMessagePeriod === 'today' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'today' ? 'page' : undefined}
+                    >
+                        오늘 축하메시지
+                    </Button>
+                    <Button
+                        href={buildMessagePeriodHref('month')}
+                        variant={selectedMessagePeriod === 'month' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'month' ? 'page' : undefined}
+                    >
+                        이번달 축하메시지
+                    </Button>
+                    <Button
+                        href={buildMessagePeriodHref('upcoming')}
+                        variant={selectedMessagePeriod === 'upcoming' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'upcoming' ? 'page' : undefined}
+                    >
+                        다가올 축하메시지
+                    </Button>
+                    <Button
+                        href={buildMessagePeriodHref('past')}
+                        variant={selectedMessagePeriod === 'past' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'past' ? 'page' : undefined}
+                    >
+                        추억의 축하메시지
+                    </Button>
                 </div>
             {/if}
 


### PR DESCRIPTION
## Summary\n- Add the "추억의 축하메시지" tab to the message board.\n- Wire the message board UI to the new past period.\n\n## Notes\n- Existing today/month/upcoming tabs remain unchanged.\n- Search and category behavior stay the same.