### PR TITLE
Broaden celebration date parsing for past tab + sync

### DIFF
--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -105,7 +105,7 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
         try {
             const legacyDateFilter = isRecent
                 ? ''
-                : "AND (wm.wr_subject = DATE_FORMAT(NOW(),'%Y.%m.%d') OR wm.wr_subject = DATE_FORMAT(NOW(),'%Y-%m-%d'))";
+                : "AND (wm.wr_subject = DATE_FORMAT(NOW(),'%Y.%m.%d') OR wm.wr_subject = DATE_FORMAT(NOW(),'%Y-%m-%d') OR wm.wr_subject = DATE_FORMAT(NOW(),'%Y.%c.%e') OR wm.wr_subject = DATE_FORMAT(NOW(),'%Y-%c-%e'))";
             const [rows] = await pool.query<RowDataPacket[]>(
                 `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
                         m.mb_nick, m.mb_image_url

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -177,9 +177,19 @@ export const load: PageServerLoad = async ({
     const searchSort = url.searchParams.get('sort') || null;
     const tag = url.searchParams.get('tag') || null;
     const category = url.searchParams.get('category') || null;
+    const rawMessagePeriod = boardId === 'message' ? url.searchParams.get('period') : null;
+    const messagePeriod =
+        boardId === 'message' &&
+        (rawMessagePeriod === 'month' ||
+            rawMessagePeriod === 'upcoming' ||
+            rawMessagePeriod === 'past')
+            ? rawMessagePeriod
+            : boardId === 'message'
+              ? 'today'
+              : null;
     const isSearching = Boolean(searchField && searchQuery);
     const isTagFiltering = Boolean(tag);
-    const includeNotices = !isSearching && page === 1;
+    const includeNotices = !isSearching && page === 1 && boardId !== 'message';
 
     if (isSearching && !locals.user) {
         return {
@@ -271,6 +281,9 @@ export const load: PageServerLoad = async ({
         if (category) {
             queryParams.set('category', category);
         }
+        if (messagePeriod) {
+            queryParams.set('celebration_period', messagePeriod);
+        }
         if (isTagFiltering && !isSearching) {
             queryParams.set('sfl', 'title_content');
             queryParams.set('stx', '');
@@ -283,7 +296,7 @@ export const load: PageServerLoad = async ({
 
     // 비로그인 + 검색/태그 필터 없는 경우: 게시글 목록 캐시 사용 (15초)
     const usePostsCache = !locals.user && !isSearching && !isTagFiltering;
-    const postsCacheKey = `${boardId}:p${page}:l${limit}${category ? `:c${category}` : ''}${useSummaryListResponse ? ':summary1' : ''}`;
+    const postsCacheKey = `${boardId}:p${page}:l${limit}${category ? `:c${category}` : ''}${messagePeriod ? `:period:${messagePeriod}` : ''}${useSummaryListResponse ? ':summary1' : ''}`;
 
     if (usePostsCache) {
         const cachedPosts = postsCache.get(postsCacheKey);

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -149,6 +149,7 @@
     });
     const isAngmapBoard = $derived(boardType === 'angmap');
     const isEconomyBoard = $derived(boardType === 'economy');
+    const isMessageBoard = $derived(boardId === 'message');
 
     // 플러그인 레지스트리에서 특수 게시판 컴포넌트 resolve
     const boardTypeComponent = $derived(boardTypeRegistry.resolve(boardType));
@@ -585,6 +586,27 @@
     // 현재 선택된 카테고리 (URL 쿼리에서 가져오기)
     const selectedCategory = $derived($page.url.searchParams.get('category') || '전체');
 
+    type MessagePeriod = 'today' | 'month' | 'upcoming' | 'past';
+
+    const selectedMessagePeriod = $derived.by<MessagePeriod>(() => {
+        if (!isMessageBoard) return 'today';
+        const period = $page.url.searchParams.get('period');
+        if (period === 'month' || period === 'upcoming' || period === 'past') return period;
+        return 'today';
+    });
+
+    function buildMessagePeriodHref(period: MessagePeriod): string {
+        const url = new URL($page.url.href);
+        url.searchParams.set('period', period);
+        url.searchParams.set('page', '1');
+        url.searchParams.delete('category');
+        url.searchParams.delete('tag');
+        url.searchParams.delete('sfl');
+        url.searchParams.delete('stx');
+        url.searchParams.delete('sort');
+        return url.pathname + url.search;
+    }
+
     // 카테고리 변경
     function changeCategory(category: string): void {
         const url = new URL(window.location.href);
@@ -932,6 +954,48 @@
                             <X class="h-3.5 w-3.5" />
                         </Button>
                     {/if}
+                </div>
+            {/if}
+
+            <!-- 축하메시지 기간 탭 -->
+            {#if isMessageBoard && !isSearching}
+                <div class="mb-6 flex flex-wrap gap-2">
+                    <Button
+                        href={buildMessagePeriodHref('today')}
+                        variant={selectedMessagePeriod === 'today' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'today' ? 'page' : undefined}
+                    >
+                        오늘 축하메시지
+                    </Button>
+                    <Button
+                        href={buildMessagePeriodHref('month')}
+                        variant={selectedMessagePeriod === 'month' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'month' ? 'page' : undefined}
+                    >
+                        이번달 축하메시지
+                    </Button>
+                    <Button
+                        href={buildMessagePeriodHref('upcoming')}
+                        variant={selectedMessagePeriod === 'upcoming' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'upcoming' ? 'page' : undefined}
+                    >
+                        다가올 축하메시지
+                    </Button>
+                    <Button
+                        href={buildMessagePeriodHref('past')}
+                        variant={selectedMessagePeriod === 'past' ? 'default' : 'outline'}
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                        aria-current={selectedMessagePeriod === 'past' ? 'page' : undefined}
+                    >
+                        추억의 축하메시지
+                    </Button>
                 </div>
             {/if}
 

--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -133,7 +133,9 @@ export const GET: RequestHandler = async () => {
                  LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
                  WHERE wm.wr_is_comment = 0
                    AND (wm.wr_subject = DATE_FORMAT(NOW(), '%Y.%m.%d')
-                        OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y-%m-%d'))
+                        OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y-%m-%d')
+                       OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y.%c.%e')
+                       OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y-%c-%e'))
                  ORDER BY wm.wr_id DESC`
             );
 

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -180,6 +180,16 @@ async function checkWriteAuthor(path: string, userId: string): Promise<Response 
     return null;
 }
 
+function normalizeLegacyCelebrationDate(subject: string | null | undefined): string | null {
+    if (!subject) return null;
+    const compact = subject.trim().replace(/\s+/g, '');
+    const normalized = compact.replace(/[./]/g, '-');
+    const match = normalized.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+    if (!match) return null;
+    const [, year, month, day] = match;
+    return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}
+
 /**
  * message 게시판 글 수정 시 celebration_banners 동기화
  * wr_subject(날짜), wr_content, wr_9(이미지) → celebration_banners
@@ -199,9 +209,8 @@ async function syncCelebrationBanner(path: string): Promise<void> {
 
     const { wr_subject, wr_content, wr_9 } = rows[0];
 
-    // wr_subject → display_date (2026.03.07 → 2026-03-07)
-    const displayDate = wr_subject?.replace(/\./g, '-');
-    if (!displayDate || !/^\d{4}-\d{2}-\d{2}$/.test(displayDate)) return;
+    const displayDate = normalizeLegacyCelebrationDate(wr_subject);
+    if (!displayDate) return;
 
     // wr_content에서 텍스트만 추출 (HTML 태그 제거)
     const textContent = wr_content


### PR DESCRIPTION
## 요약

- 추억의 축하메시지가 `wr_subject` 의 더 넓은 날짜 형식을 인식하도록 확장 — 2026.05.06 / 2026-5-6 / 2026-05-06 / 2026.5.6 등 zero-padding 없는 변형 포함.
- 메시지 수정 시 `celebration_banners` 동기화도 같은 느슨한 형식 수용.
- 오늘 endpoint 의 legacy fallback 도 동일 패턴을 허용해 backend 변경과 일관성 유지.

## 변경

- `apps/web/src/routes/api/v1/[...path]/+server.ts:176`
- `apps/web/src/routes/api/ads/celebration/today/+server.ts:130`
- `apps/web/src/lib/server/celebration.ts:100`

## 연관 PR

- Backend: damoang/angple-backend#459

## 검증

- `sudo pnpm check` — svelte-check 0 errors (기존 경고만)

## Test Plan

- [ ] `/message?period=past&page=1` 페이지네이션 정상
- [ ] `wr_subject` 다양한 변형 모두 인식
- [ ] 오늘 (period=today) 동작 회귀 없음
- [ ] 메시지 수정 시 `celebration_banners` 동기화 새 형식 동작