### PR TITLE
Extend damoang_jwt SSO cookie lifetime from 1h to 24h

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -499,7 +499,7 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
     // 세션 없으면 잔여 JWT 쿠키 정리 (로그아웃 후 도메인 불일치로 남은 쿠키)
     const domainOpt = COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {};
     const cleanupOpts = { path: '/', secure: !dev, httpOnly: true, ...domainOpt } as const;
-    const staleNames = ['refresh_token', 'damoang_jwt', 'access_token'];
+    const staleNames = ['refresh_token', 'access_token'];
     for (const name of staleNames) {
         if (event.cookies.get(name)) {
             try {

--- a/apps/web/src/lib/server/auth/jwt.ts
+++ b/apps/web/src/lib/server/auth/jwt.ts
@@ -124,7 +124,7 @@ export async function generateDamoangJWT(user: {
     })
         .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
         .setIssuedAt()
-        .setExpirationTime('1h')
+        .setExpirationTime('24h')
         .setIssuer('damoang.net')
         .setAudience('ads.damoang.net')
         .sign(damoangSecret);

--- a/apps/web/src/lib/server/auth/sso-cookie.ts
+++ b/apps/web/src/lib/server/auth/sso-cookie.ts
@@ -6,7 +6,7 @@ import { generateDamoangJWT } from './jwt.js';
 
 const SSO_COOKIE_NAME = 'damoang_jwt';
 const SSO_COOKIE_DOMAIN = '.damoang.net';
-const SSO_COOKIE_MAX_AGE = 3600; // 1시간
+const SSO_COOKIE_MAX_AGE = 86400; // 24시간
 
 /** 로그인 성공 시 damoang_jwt 쿠키 설정 */
 export async function setDamoangSSOCookie(


### PR DESCRIPTION
## 요약

- `damoang_jwt` 는 `damoang.net` 과 `ads.damoang.net` 사이 SSO 를 담당합니다.
- 만료 1시간 정책 때문에 메인 세션이 살아있어도 광고 대시보드에서 1시간마다 로그아웃되는 현상 발생.
- JWT exp claim 과 쿠키 Max-Age 를 모두 **24시간** 으로 확장하여 일반 작업 세션 길이와 맞춥니다.
- `hooks.server.ts` 의 stale-cookie 정리 목록에서 `damoang_jwt` 를 제외 — SSR 세션이 없다는 이유만으로 SSO 토큰을 지우면 안 되기 때문.

## 변경

- `apps/web/src/lib/server/auth/jwt.ts` — `setExpirationTime('1h')` → `'24h'`
- `apps/web/src/lib/server/auth/sso-cookie.ts` — `SSO_COOKIE_MAX_AGE` 3600 → 86400
- `apps/web/src/hooks.server.ts` — `staleNames` 에서 `damoang_jwt` 제거

## 영향

- ads.damoang.net 광고 대시보드 진입 시 1시간 단위 재로그인 필요 X
- 보안 영향: 24h 는 표준 SSO 토큰 수명 범위. 로그아웃 시 명시적 cookie 삭제 경로는 그대로 유지됨

## Test Plan

- [ ] damoang.net 로그인 후 ads.damoang.net 진입 → 정상 인증
- [ ] 1시간 경과 후에도 ads 대시보드 세션 유지
- [ ] damoang.net 로그아웃 → `damoang_jwt` 쿠키 삭제 확인
- [ ] 미로그인 상태에서 SSR 진입 시 `refresh_token` / `access_token` 정리는 그대로 동작