### PR TITLE
Block negative reactions (❌, ❓) from new use

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -11,7 +11,8 @@
     import {
         REACTION_CATEGORIES,
         REACTION_EMOTICONS,
-        REACTION_REPLACE
+        REACTION_REPLACE,
+        isReactionBlocked
     } from '$lib/config/reaction-config.js';
     import SmilePlus from '@lucide/svelte/icons/smile-plus';
     import {
@@ -49,7 +50,9 @@
 
     // 현재 카테고리의 이모티콘
     const categoryEmoticons = $derived(
-        REACTION_EMOTICONS.filter((e) => e.category === activeCategory)
+        REACTION_EMOTICONS.filter(
+            (e) => e.category === activeCategory && !isReactionBlocked(e.reaction)
+        )
     );
 
     // 리액션 로드
@@ -87,6 +90,10 @@
 
         // 교체 맵 적용
         const finalReaction = REACTION_REPLACE[reaction] || reaction;
+        if (isReactionBlocked(finalReaction)) {
+            isReacting = false;
+            return;
+        }
 
         try {
             const res = await fetch('/api/reactions', {
@@ -113,6 +120,7 @@
 
     // 기존 리액션 클릭 (토글)
     function handleReactionClick(reaction: string): void {
+        if (isReactionBlocked(reaction)) return;
         react(reaction, 'toggle');
     }
 
@@ -164,15 +172,18 @@
     <!-- 기존 리액션 배지 -->
     {#each reactions as item (item.reaction)}
         {@const display = getReactionDisplay(item.reaction)}
+        {@const blocked = isReactionBlocked(item.reaction)}
         <button
             type="button"
             onclick={() => handleReactionClick(item.reaction)}
-            disabled={isReacting}
+            disabled={isReacting || blocked}
             class="da-reaction-badge group inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-sm transition-all
-				{item.choose
-                ? 'border-primary/50 bg-primary/10 text-primary ring-primary/20 ring-1'
-                : 'border-border bg-muted/50 text-muted-foreground hover:border-primary/30 hover:bg-primary/5'}"
-            title={display.label}
+				{blocked
+                ? 'border-border bg-muted/30 text-muted-foreground/70 cursor-not-allowed opacity-70'
+                : item.choose
+                  ? 'border-primary/50 bg-primary/10 text-primary ring-primary/20 ring-1'
+                  : 'border-border bg-muted/50 text-muted-foreground hover:border-primary/30 hover:bg-primary/5'}"
+            title={blocked ? '현재 사용할 수 없는 리액션입니다.' : display.label}
         >
             {#if display.renderType === 'image' && display.url}
                 <img src={display.url} alt={display.label} class="h-5 w-5 object-scale-down" />

--- a/apps/web/src/lib/config/reaction-config.ts
+++ b/apps/web/src/lib/config/reaction-config.ts
@@ -180,6 +180,13 @@ export const REACTION_REPLACE: Record<string, string> = {
     'emoji:1f389': 'import-image:ezgif-55990bc446328e'
 };
 
+/** 운영 정책상 신규 사용을 막는 리액션. 기존 DB 집계 표시는 유지한다. */
+export const BLOCKED_REACTIONS = new Set(['emoji:274c', 'emoji:2753']);
+
+export function isReactionBlocked(reaction: string): boolean {
+    return BLOCKED_REACTIONS.has(reaction);
+}
+
 /** 전체 이모티콘 목록 */
 export const REACTION_EMOTICONS: EmoticonDef[] = [...EMOJIS, ...ANGTICONS, ...NOTO_ANIMOJI];
 

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -12,6 +12,7 @@ import pool from '$lib/server/db';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 import { fetchReactionsByParentId } from '$lib/server/reactions';
+import { isReactionBlocked } from '$lib/config/reaction-config.js';
 
 const REACTION_LIMIT = 20;
 const VALID_REACTION_PATTERN = /^[a-zA-Z0-9:_-]+$/;
@@ -151,6 +152,13 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         const safeReaction = sanitizeId(reaction);
         const safeTargetId = sanitizeId(targetId);
         const safeParentId = parentId ? sanitizeId(parentId) : safeTargetId;
+
+        if (isReactionBlocked(safeReaction)) {
+            return json(
+                { status: 'error', message: '현재 사용할 수 없는 리액션입니다.' },
+                { status: 400 }
+            );
+        }
 
         if (safeReaction.length > 250 || safeTargetId.length > 250) {
             return json({ status: 'error', message: 'ID가 너무 깁니다.' }, { status: 400 });


### PR DESCRIPTION
## 배경

`❌` (emoji:274c) 와 `❓` (emoji:2753) 리액션이 신고 절차를 우회한 **소프트 비추** 도구로 악용되는 패턴이 관찰되었습니다. 리액션 기능의 본래 의도와 충돌해 운영 정책상 신규 사용을 차단합니다.

기존 DB 레코드는 보존하여 과거 집계 표시는 유지되며, **신규 클릭만** 거절합니다.

## 변경

- `apps/web/src/lib/config/reaction-config.ts`
  - `BLOCKED_REACTIONS` Set 도입: `emoji:274c`, `emoji:2753`
  - `isReactionBlocked(reaction)` helper export
- `apps/web/src/routes/api/reactions/+server.ts`
  - POST 핸들러에서 차단 reaction 즉시 400 응답
- `apps/web/src/lib/components/features/reaction/reaction-bar.svelte`
  - 이모티콘 picker 에서 차단 이모지 숨김
  - 기존 배지 클릭 시 토글 무시
  - 신규 키보드/replace 경로에서도 차단 적용

## 향후 (별도 PR)

- 알림 발송 단계에서도 `isReactionBlocked()` 필터 적용 (방어층 추가)
- admin 페이지에서 차단 이모지 누적 클릭자 통계 — 압박 수단/검토용
- DB cleanup (옵션 C) 은 별도 의사결정 필요

## Test Plan

- [ ] 이모티콘 picker 에서 ❌, ❓ 미노출
- [ ] 기존 배지 (❌ 카운트) 클릭 시 토글 무반응 + 백엔드 400
- [ ] 다른 이모지 (👍, ❤️ 등) 정상 동작
- [ ] 차단 reaction 직접 API POST 시 400 응답
- [ ] 기존 집계 표시 유지 (배지 카운트 그대로)