### PR TITLE
Add /api/auth/sso/renew endpoint for damoang_jwt refresh

### DIFF
--- a/apps/web/src/routes/api/auth/sso/renew/+server.ts
+++ b/apps/web/src/routes/api/auth/sso/renew/+server.ts
@@ -1,0 +1,48 @@
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+import { getSession, SESSION_COOKIE_NAME } from '$lib/server/auth/session-store.js';
+import { getMemberById } from '$lib/server/auth/oauth/member.js';
+import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
+
+function corsHeaders(origin: string | null): HeadersInit {
+    if (!origin || !origin.endsWith('.damoang.net')) return {};
+    return {
+        'Access-Control-Allow-Origin': origin,
+        'Access-Control-Allow-Credentials': 'true',
+        Vary: 'Origin'
+    };
+}
+
+export const POST: RequestHandler = async ({ cookies, request }) => {
+    const headers = corsHeaders(request.headers.get('origin'));
+    const sessionId = cookies.get(SESSION_COOKIE_NAME);
+    if (!sessionId) {
+        return json({ success: false, message: '세션이 없습니다.' }, { status: 401, headers });
+    }
+
+    const session = await getSession(sessionId);
+    if (!session) {
+        return json(
+            { success: false, message: '세션이 만료되었습니다.' },
+            { status: 401, headers }
+        );
+    }
+
+    const member = await getMemberById(session.mbId);
+    if (!member) {
+        return json(
+            { success: false, message: '사용자 정보를 찾을 수 없습니다.' },
+            { status: 401, headers }
+        );
+    }
+
+    await setDamoangSSOCookie(cookies, {
+        mb_id: member.mb_id,
+        mb_level: member.mb_level ?? 0,
+        mb_name: member.mb_name || member.mb_nick,
+        mb_email: member.mb_email
+    });
+
+    return new Response(null, { status: 204, headers });
+};


### PR DESCRIPTION
## 요약

24h SSO cookie 확장 (#1394) 의 동반 endpoint 입니다. `*.damoang.net` 서브도메인 (예: ads.damoang.net) 이 SSR 세션이 살아있는 동안 POST 호출만으로 `damoang_jwt` 를 새로 발급받을 수 있어 full re-login 흐름을 거치지 않아도 됩니다.

## 흐름

1. `SESSION_COOKIE_NAME` 쿠키로 인증
2. 세션 store 에서 `mbId` 조회 → `getMemberById` 로 member 정보 fetch
3. `setDamoangSSOCookie()` 호출 — 표준 claim (mb_id / mb_level / mb_name / mb_email) 으로 새 `damoang_jwt` 발급
4. 204 응답 (body 없음)

## 보안

- credentialed CORS 는 `.damoang.net` 으로 끝나는 origin 에만 허용
- 세션 미존재 / 만료 / 회원 미발견 — 모두 401 (한국어 메시지)
- 새 토큰 자체는 `setDamoangSSOCookie` 의 기존 옵션 (HttpOnly, Secure, Domain, SameSite) 을 그대로 사용

## Test Plan

- [ ] damoang.net 로그인 후 ads.damoang.net 에서 `POST /api/auth/sso/renew` → 204 + 새 `damoang_jwt` 쿠키
- [ ] 미로그인 / 만료 세션 → 401
- [ ] 외부 origin (예: example.com) → CORS preflight/credentialed 거부
- [ ] 갱신 후 `damoang_jwt` 의 exp 가 24h 후로 설정됨

## 연관

- #1394 — `damoang_jwt` 24h 확장