### PR TITLE
Normalize Unix timestamp inputs in format-date utility (#12266)

### DIFF
--- a/apps/web/src/lib/utils/format-date.test.ts
+++ b/apps/web/src/lib/utils/format-date.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { formatDate, formatDateCompact, isToday } from './format-date';
+
+describe('format-date — Unix timestamp 보정', () => {
+    // KST 2026-05-06 15:00 = UTC 06:00 (시각 자체는 무관, 단지 fake now 의 절대시점)
+    const NOW = new Date('2026-05-06T06:00:00Z');
+    const NOW_SEC = Math.floor(NOW.getTime() / 1000);
+    const NOW_SEC_STR = String(NOW_SEC);
+    const YESTERDAY_SEC = NOW_SEC - 86400;
+
+    beforeAll(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+    });
+
+    afterAll(() => {
+        vi.useRealTimers();
+    });
+
+    it('10자리 Unix timestamp(초 단위) 문자열을 정상 파싱한다 — #12266', () => {
+        const result = formatDate(NOW_SEC_STR);
+        // 오늘이므로 HH:MM 형식 (KST 15:00)
+        expect(result).toBe('15:00');
+    });
+
+    it('10자리 Unix timestamp 숫자도 동일하게 파싱한다', () => {
+        const result = formatDate(NOW_SEC);
+        expect(result).toBe('15:00');
+    });
+
+    it('ISO 문자열은 그대로 처리한다 (회귀 방지)', () => {
+        const result = formatDate('2026-05-06T06:00:00Z');
+        expect(result).toBe('15:00');
+    });
+
+    it('Gnuboard YYYYMMDD 8자리 형식은 그대로 변환된다 (회귀 방지)', () => {
+        const result = formatDate('20260505');
+        expect(result).toBe('05.05');
+    });
+
+    it('빈 값 / null / undefined 는 빈 문자열을 반환한다', () => {
+        expect(formatDate('')).toBe('');
+        expect(formatDate(null)).toBe('');
+        expect(formatDate(undefined)).toBe('');
+    });
+
+    it('formatDateCompact 도 동일한 정규화 규칙을 적용한다', () => {
+        expect(formatDateCompact(NOW_SEC_STR)).toBe('15:00');
+        expect(formatDateCompact(NOW_SEC)).toBe('15:00');
+    });
+
+    it('isToday 가 unix timestamp 입력에서도 정확히 판정한다', () => {
+        expect(isToday(NOW_SEC_STR)).toBe(true);
+        expect(isToday(NOW_SEC)).toBe(true);
+        expect(isToday(YESTERDAY_SEC)).toBe(false);
+    });
+});

--- a/apps/web/src/lib/utils/format-date.ts
+++ b/apps/web/src/lib/utils/format-date.ts
@@ -6,16 +6,36 @@
  * - 작년 이전: YY.MM.DD (예: 25.02.19)
  */
 
+type DateInput = string | number | null | undefined;
+
+/**
+ * 다양한 형태의 입력을 Date 가 안전하게 파싱할 수 있는 문자열로 정규화한다.
+ * - YYYYMMDD (Gnuboard 8자리)
+ * - 10자리 Unix timestamp (초 단위) — Sphinx/검색 응답이 숫자로 내려올 수 있어, 밀리초로 변환하지 않으면 1970년 또는 미래 날짜로 잘못 표시됨 (#12266)
+ * - 그 외는 원본 문자열 그대로 (ISO/RFC 형식 가정)
+ */
+function normalizeDateInput(input: DateInput): string {
+    if (input === null || input === undefined || input === '') return '';
+    const str = String(input);
+    if (/^\d{10}$/.test(str)) {
+        const seconds = Number(str);
+        if (Number.isFinite(seconds)) {
+            return new Date(seconds * 1000).toISOString();
+        }
+    }
+    if (/^\d{8}$/.test(str)) {
+        return `${str.slice(0, 4)}-${str.slice(4, 6)}-${str.slice(6, 8)}`;
+    }
+    return str;
+}
+
 /**
  * 목록용 날짜 포맷 (MM.DD HH:MM 통일)
  * 행 높이가 일정하게 유지됨
  */
-export function formatDateCompact(dateString: string): string {
-    if (!dateString) return '';
-    let normalized = dateString;
-    if (/^\d{8}$/.test(dateString)) {
-        normalized = `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
-    }
+export function formatDateCompact(dateString: DateInput): string {
+    const normalized = normalizeDateInput(dateString);
+    if (!normalized) return '';
     const date = new Date(normalized);
     if (isNaN(date.getTime())) return '';
     const now = new Date();
@@ -43,23 +63,21 @@ export function formatDateCompact(dateString: string): string {
 /**
  * 주어진 날짜가 오늘(서울 시간 기준)인지 확인
  */
-export function isToday(dateString: string): boolean {
-    const date = new Date(dateString);
+export function isToday(dateString: DateInput): boolean {
+    const normalized = normalizeDateInput(dateString);
+    if (!normalized) return false;
+    const date = new Date(normalized);
+    if (isNaN(date.getTime())) return false;
     const now = new Date();
     const toSeoulDateStr = (d: Date) => d.toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
     return toSeoulDateStr(date) === toSeoulDateStr(now);
 }
 
-export function formatDate(dateString: string): string {
+export function formatDate(dateString: DateInput): string {
     // 빈 값/무효 입력은 빈 문자열 반환. 과거 Invalid Date → toLocaleTimeString 이
     // "Invalid Date" (production minify 시 "va.id.Da" 등)로 노출되던 문제 방지.
-    if (!dateString) return '';
-
-    // Gnuboard YYYYMMDD 형식 (mb_leave_date 등) → ISO 변환
-    let normalized = dateString;
-    if (/^\d{8}$/.test(dateString)) {
-        normalized = `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
-    }
+    const normalized = normalizeDateInput(dateString);
+    if (!normalized) return '';
     const date = new Date(normalized);
     if (isNaN(date.getTime())) return '';
     const now = new Date();


### PR DESCRIPTION
## 요약

`/free?sfl=...&stx=...` 등 검색 결과/목록 페이지에서 오늘 작성된 글이 가끔 **미래 일자** 또는 1970년대로 표시되는 회귀 (#12266) 의 root cause 수정.

## 진단

Sphinx 응답 경로에서 `wr_datetime` 이 **10자리 Unix timestamp (초 단위)** 로 `format-date` 유틸로 들어오는 경우가 있습니다. `new Date("1778047200")` 또는 `new Date(1778047200)` 은 ISO 파싱 실패 또는 **밀리초 단위로 오해석** → 1970-01-21 또는 timezone 보정에 따라 미래 날짜로 보일 수 있습니다.

## 변경

- `apps/web/src/lib/utils/format-date.ts`
  - `normalizeDateInput()` 헬퍼 추가:
    - 10자리 숫자 (number / numeric string) → `* 1000` 후 ISO 변환
    - 8자리 Gnuboard YYYYMMDD 변환은 기존 그대로 유지
    - ISO/RFC 문자열은 원본 유지
  - `formatDate`, `formatDateCompact`, `isToday` 의 파라미터 타입을 `string | number | null | undefined` 로 확장 — 호출 측에서 별도 stringify 불필요
- `apps/web/src/lib/utils/format-date.test.ts` (신규)
  - `vi.useFakeTimers()` 로 KST 2026-05-06 15:00 고정
  - 7 케이스 — unix string / unix number / ISO / YYYYMMDD / 빈 값 / formatDateCompact / isToday

## 검증

- `pnpm test:unit src/lib/utils/format-date.test.ts -- --run` — 7 / 7 통과

## Test Plan

- [ ] dev 환경에서 검색 결과 (`/free?sfl=author&stx=admin`) 진입 → 오늘 작성 글이 `HH:MM` 으로 표시
- [ ] 어제/올해/작년 글의 표시 회귀 없음
- [ ] mb_leave_date 같은 8자리 input 처리 회귀 없음
- [ ] DB 검증 SQL 으로 실제 `wr_datetime` 자체가 정상인지 (= 표시 단계만 깨졌는지) 확인:
  ```sql
  SELECT wr_id, wr_subject, wr_datetime, UNIX_TIMESTAMP(wr_datetime)
  FROM g5_write_free WHERE DATE(wr_datetime) = CURDATE()
  ORDER BY wr_datetime DESC LIMIT 5;
  ```

## 후속 추적

본 fix 는 호출 측에서 unix timestamp 가 들어오는 상황을 방어합니다. 진짜 root cause (Sphinx 직렬화? backend 직렬화? client 변환?) 별도 탐색이 #12266 의 완전 해결에 필요할 수 있어 별도 issue 로 추적합니다.