### PR TITLE
Loosen CSRF cookie SameSite to lax + default COOKIE_DOMAIN to .damoang.net (#12260, #12179)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -106,8 +106,9 @@ import {
  * 5. CSP 설정: XSS 및 데이터 인젝션 공격 방지
  */
 
-// 쿠키 도메인: 서브도메인 간 공유 (예: ".damoang.net")
-const COOKIE_DOMAIN = env.COOKIE_DOMAIN || '';
+// 쿠키 도메인: 서브도메인 간 공유 (예: ".damoang.net").
+// 미설정 시 prod 에선 ".damoang.net" 으로 폴백 — host-only 쿠키 시 새 탭/PWA 세션 격리 (#12260, #12179).
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? '' : '.damoang.net');
 
 // CORS 허용 origin (credentials 포함 요청만 제한)
 function isAllowedOrigin(origin: string): boolean {

--- a/apps/web/src/routes/api/auth/login/+server.ts
+++ b/apps/web/src/routes/api/auth/login/+server.ts
@@ -16,7 +16,8 @@ import { checkAndPromoteMember } from '$lib/server/auth/auto-promotion.js';
 import { grantLoginXP } from '$lib/server/auth/xp-grant.js';
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
-const COOKIE_DOMAIN = env.COOKIE_DOMAIN || '';
+// 미설정 시 .damoang.net 으로 폴백 — host-only 쿠키 시 새 탭/PWA 세션 격리 (#12260, #12179).
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || '.damoang.net';
 
 /**
  * POST /api/auth/login

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -42,7 +42,8 @@ import {
     findExistingTempAccount
 } from '$lib/server/auth/register.js';
 
-const COOKIE_DOMAIN = env.COOKIE_DOMAIN || undefined;
+// 미설정 시 .damoang.net 으로 폴백 — host-only 쿠키가 되면 새 탭/PWA 에서 세션이 격리됨 (#12260, #12179).
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
 
 const AUTH_EVENT_COOKIE = 'ga4_auth_event';
 
@@ -319,10 +320,13 @@ async function handleCallback(
         });
 
         // CSRF 토큰 쿠키 (non-httpOnly, JS에서 읽어 헤더로 전송)
+        // sameSite=strict 는 OAuth cross-site 콜백에서 쿠키 설정을 차단해 검증 실패를
+        // 야기했음 (#12260, #12179). 'lax' 로 완화해도 GET 외 요청은 여전히
+        // 차단되며, 본 토큰은 항상 헤더로 명시 전송되므로 CSRF 보호는 유지된다.
         cookies.set(CSRF_COOKIE_NAME, session.csrfToken, {
             path: '/',
             httpOnly: false,
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: !dev,
             maxAge: SESSION_COOKIE_MAX_AGE,
             ...domainOpt

--- a/apps/web/src/routes/plugin/social/+server.ts
+++ b/apps/web/src/routes/plugin/social/+server.ts
@@ -24,7 +24,8 @@ import { TwitterProvider } from '$lib/server/auth/oauth/providers/twitter.js';
 import type { OAuthUserProfile } from '$lib/server/auth/oauth/types.js';
 import { runSocialLoginPostProcess } from '$lib/server/auth/social-login-postprocess.js';
 
-const COOKIE_DOMAIN = env.COOKIE_DOMAIN || undefined;
+// 미설정 시 prod 에서 .damoang.net 으로 폴백 — host-only 쿠키 시 새 탭/PWA 세션 격리 (#12260, #12179).
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
 const AUTH_EVENT_COOKIE = 'ga4_auth_event';
 
 /** 공통 콜백 처리 로직 */
@@ -157,10 +158,12 @@ async function handleCallback(
         });
 
         // CSRF 토큰 쿠키 (non-httpOnly, JS에서 읽어 헤더로 전송)
+        // 'strict' 는 OAuth/cross-site 진입 시 토큰 미전송으로 검증 실패를 야기함.
+        // 토큰은 헤더로 명시 전송되므로 'lax' 로도 CSRF 보호가 유지됨 (#12260, #12179).
         cookies.set(CSRF_COOKIE_NAME, session.csrfToken, {
             path: '/',
             httpOnly: false,
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: !dev,
             maxAge: SESSION_COOKIE_MAX_AGE,
             ...domainOpt

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -38,7 +38,8 @@ import { grantLoginPoint } from '$lib/server/auth/point-grant.js';
 import { env } from '$env/dynamic/private';
 import { safeRedirectUrl } from '$lib/server/safe-redirect.js';
 
-const COOKIE_DOMAIN = env.COOKIE_DOMAIN || undefined;
+// 미설정 시 prod 에서 .damoang.net 으로 폴백 — host-only 쿠키 시 새 탭/PWA 세션 격리 (#12260, #12179).
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
 const AUTH_EVENT_COOKIE = 'ga4_auth_event';
 
 function buildInviteTempNickname(provider: string): string {
@@ -269,10 +270,12 @@ export const actions: Actions = {
                 ...domainOpt
             });
 
+            // CSRF 토큰 쿠키: 'strict' 는 OAuth/외부 콜백 후 cross-site 진입 시
+            // 미전송으로 검증 실패를 야기함. 토큰은 헤더로 명시 전송되므로 'lax' 로 충분 (#12260, #12179).
             cookies.set(CSRF_COOKIE_NAME, session.csrfToken, {
                 path: '/',
                 httpOnly: false,
-                sameSite: 'strict',
+                sameSite: 'lax',
                 secure: !dev,
                 maxAge: SESSION_COOKIE_MAX_AGE,
                 ...domainOpt


### PR DESCRIPTION
## 요약

iOS Safari PWA + Opera 새 탭에서 로그인 세션이 풀리는 버그 (#12260, #12179) 의 root cause 수정.

## 진단

두 제보 모두 OAuth 콜백 경로에서 같은 root cause:
1. `angple_csrf` 쿠키가 `SameSite=Strict` 로 발급됨 — OAuth 콜백은 cross-site navigation 이므로 strict cookie 가 다음 요청에 첨부되지 않아 CSRF 검증 실패 → SSR 세션 무효 처리
2. `COOKIE_DOMAIN` 이 미설정 시 host-only 쿠키 → `damoang.net` vs `www.damoang.net` 격리 + iOS PWA 의 standalone 컨텍스트도 별도 jar → 새 탭/창 간 세션 미공유

## 변경

| 파일 | 변경 |
|------|------|
| `auth/callback/[provider]/+server.ts` | CSRF `sameSite`: strict → lax |
| `plugin/social/+server.ts` | CSRF `sameSite`: strict → lax |
| `register/+page.server.ts` | CSRF `sameSite`: strict → lax |
| 위 3 파일 + `hooks.server.ts` + `api/auth/login/+server.ts` | `COOKIE_DOMAIN` 폴백: `undefined/\'\'` → prod 에서 `.damoang.net` (`dev` 환경은 기존 동작 유지) |

## 보안 영향

- CSRF 토큰은 항상 **헤더로 명시 전송** 되므로 `SameSite=Lax` 로도 cross-site state-changing 요청 (POST/PUT/DELETE) 은 차단됨
- `Lax` 는 GET-only top-level navigation 만 쿠키 첨부 — OAuth 콜백 진입 직후 첫 hop 에 cookie 가 전달되어 검증 가능

## Test Plan

- [ ] iOS Safari 홈화면 PWA → Google 로그인 → 창 닫기/재오픈 → 세션 유지
- [ ] Opera 메인 → 새 탭으로 글 열기 → 로그인 상태 공유
- [ ] DevTools Cookies: `angple_csrf` Domain=`.damoang.net`, SameSite=Lax 확인
- [ ] 4 provider (Google/Naver/Kakao/Apple) 콜백 모두 회귀 없음
- [ ] 일반 로그인 (`/api/auth/login`) + 회원가입 (`/register`) 정상 동작
- [ ] 로그아웃 시 쿠키 삭제 정상 (Domain 일치 — `.damoang.net`)