### PR TITLE
Drop duplicate MessagePeriod declaration in [boardId]/+page.svelte

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -610,27 +610,6 @@
 
     const selectedMessagePeriod = $derived(messagePeriod);
 
-    type MessagePeriod = 'today' | 'month' | 'upcoming' | 'past';
-
-    const selectedMessagePeriod = $derived.by<MessagePeriod>(() => {
-        if (!isMessageBoard) return 'today';
-        const period = $page.url.searchParams.get('period');
-        if (period === 'month' || period === 'upcoming' || period === 'past') return period;
-        return 'today';
-    });
-
-    function buildMessagePeriodHref(period: MessagePeriod): string {
-        const url = new URL($page.url.href);
-        url.searchParams.set('period', period);
-        url.searchParams.set('page', '1');
-        url.searchParams.delete('category');
-        url.searchParams.delete('tag');
-        url.searchParams.delete('sfl');
-        url.searchParams.delete('stx');
-        url.searchParams.delete('sort');
-        return url.pathname + url.search;
-    }
-
     // 카테고리 변경
     function changeCategory(category: string): void {
         const url = new URL(window.location.href);


### PR DESCRIPTION
## 요약

PR #1393 의 main 머지 conflict 해결 시 `MessagePeriod` 타입 선언 + `selectedMessagePeriod` + `buildMessagePeriodHref` 가 두 번 들어가 빌드 실패.

```
src/routes/[boardId]/+page.svelte:613:9 type 'MessagePeriod' has already been declared.
```

첫 번째 선언 블록 (L588~611) 만 남기고 두 번째 사본 (L613~632) 통째로 제거.

## 영향

기능 동작 동일 — 두 선언 모두 같은 타입/로직. URL canonicalization (`today` 시 query 제거) 가 들어 있는 첫 번째 버전을 채택.