### PR TITLE
Add 축하메시지 신청 button next to past tab

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -999,6 +999,14 @@
                     >
                         추억의 축하메시지
                     </Button>
+                    <Button
+                        href="/message/144"
+                        variant="outline"
+                        size="sm"
+                        class="h-8 rounded-full px-4"
+                    >
+                        축하메시지 신청
+                    </Button>
                 </div>
             {/if}
 


### PR DESCRIPTION
## 요약

message 보드 상단 period 탭 (오늘 / 이번달 / 다가올 / 추억) 옆에 "축하메시지 신청" 버튼 추가. 클릭 시 `/message/144` (축하메시지 신청 안내 글) 로 같은 창에서 이동.

## 변경

- `apps/web/src/routes/[boardId]/+page.svelte` — past 탭 Button 직후 새 Button 추가 (variant=outline, href=`/message/144`)