### PR TITLE
Show edit timestamp inline next to 수정됨 badge in comment list (#12252)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1198,11 +1198,11 @@
                                         {#if comment.edit_count && comment.edit_count > 0 && comment.updated_at && new Date(comment.updated_at).getTime() - new Date(comment.created_at).getTime() > 5 * 60 * 1000}
                                             <span
                                                 class="text-muted-foreground/70"
-                                                title={comment.updated_at
-                                                    ? `최종 수정: ${formatDate(comment.updated_at)}`
-                                                    : ''}
+                                                title={`최종 수정: ${formatDate(comment.updated_at)}`}
                                             >
-                                                · 수정됨 ({comment.edit_count}회)
+                                                · 수정됨{comment.edit_count > 1
+                                                    ? ` (${comment.edit_count}회)`
+                                                    : ''} · {formatDate(comment.updated_at)}
                                             </span>
                                         {/if}
                                     </p>
@@ -1574,6 +1574,15 @@
                                     {formatDate(comment.created_at)}
                                     {#if comment.author_ip}
                                         · {comment.author_ip}
+                                    {/if}
+                                    {#if comment.edit_count && comment.edit_count > 0 && comment.updated_at && new Date(comment.updated_at).getTime() - new Date(comment.created_at).getTime() > 5 * 60 * 1000}
+                                        <span
+                                            title={`최종 수정: ${formatDate(comment.updated_at)}`}
+                                        >
+                                            · 수정됨{comment.edit_count > 1
+                                                ? ` (${comment.edit_count}회)`
+                                                : ''} · {formatDate(comment.updated_at)}
+                                        </span>
                                     {/if}
                                 </span>
                             </p>


### PR DESCRIPTION
## 요약

운영 정책 (#12252) — 댓글 수정 시 "수정됨 + 시각" 을 inline 으로 명시 표시하여 transparency 강화. backend angple-backend #460 가 이미 `updated_at` + `edit_count` 를 응답에 포함시키므로 frontend UI 만 추가.

## 변경

`apps/web/src/lib/components/features/board/comment-list.svelte`

### 기본 레이아웃 (L1198~)

기존:
```
· 수정됨 (1회)
```
변경:
```
· 수정됨 · 5/6 14:32          (수정 1회)
· 수정됨 (3회) · 5/6 14:32    (수정 2회 이상)
```

### Chat 레이아웃 (L1571~)

동일 indicator 추가 — 우하단 시간 메타에 "수정됨" 도 함께 노출.

## 정책 일관성

- `edit_count > 0` + `updated_at` 존재 + 작성→수정 간격 5분 초과 (작성 직후 사소한 수정은 표시 X) — 기존 조건 유지
- 1회 수정 시 `(1회)` 접미는 제거 (가장 흔한 케이스라 노이즈)
- 시각은 `formatDate()` 재사용 — 오늘이면 HH:MM, 어제면 어제 HH:MM, 그 외 MM.DD

## 검증

- 로컬에서 새 댓글 → 5분 후 수정 → "수정됨 · 시각" 노출
- 추가 수정 → "수정됨 (2회) · 시각" 으로 카운트 증가
- 미수정 댓글 → 표시 없음
- chat 레이아웃 → 우하단 메타에 동일 표시