### PR TITLE
Tighten public HTML CDN cache to 10s/5s for fresher lists (#gouryella)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -753,7 +753,10 @@ export const handle: Handle = async ({ event, resolve }) => {
         }
     }
 
-    const publicHtmlCacheControl = 'public, s-maxage=30, stale-while-revalidate=60, max-age=0';
+    // CDN 캐시 정책: 게시판 목록·홈처럼 새 글이 즉시 반영돼야 하는 페이지에서
+    // 30s + stale 60s 였을 때 사용자가 새 글을 최대 90s 동안 못 보거나, 글 상세에 들어갔다 돌아왔을 때
+    // 1~2분 전 list 가 그대로 노출되는 신고가 누적됨. s-maxage 와 stale 시간을 모두 단축한다.
+    const publicHtmlCacheControl = 'public, s-maxage=10, stale-while-revalidate=5, max-age=0';
 
     // OPTIONS 요청 (CORS preflight) 처리
     if (event.request.method === 'OPTIONS') {


### PR DESCRIPTION
## 배경

사용자 신고 (gouryella, 2026-05-07 19:19):
- PC 와 모바일 글목록 업데이트 속도 차이
- 글 상세 진입 후 다시 list 진입 시 "몇 시간 전" 데이터로 점프

## 진단

`hooks.server.ts:756` 의 `publicHtmlCacheControl` 정책이 `s-maxage=30, stale-while-revalidate=60` 으로 — CDN edge 가 같은 HTML 을 **최대 90초** 동안 stale 응답 가능 → 새 글이 즉시 반영 안 되는 체감 + 디바이스/edge 간 갱신 시점 차이 → 보고된 두 증상의 핵심 원인.

## 변경

`apps/web/src/hooks.server.ts` line 756

```
- 'public, s-maxage=30, stale-while-revalidate=60, max-age=0'
+ 'public, s-maxage=10, stale-while-revalidate=5, max-age=0'
```

영향:
- CDN 캐시 30s → **10s** (새 글이 ~10s 안에 반영)
- stale-while-revalidate 60s → **5s** (옛 데이터 노출 시간 90s → 15s)
- `max-age=0` 유지 — 브라우저는 항상 검증

## 트레이드오프

- 캐시 hit ratio 약간 감소 (CDN 비용 ↑) — 그러나 30s/60s 도 thundering-herd window 내라 큰 차이 없을 가능성. 영향 모니터링 필요
- 신고된 사용자 체감은 즉시 개선

## 대안 (별도 PR 검토)

- list / detail 별도 cache 정책 (list 짧게, detail 길게)
- nginx `ssr_cache` 30s 단축 (#23 task — 운영 nginx config 변경)
- SvelteKit `onNavigate` 에서 list 진입 시 `invalidateAll()`

## 검증

- canary 진입 → 새 글 작성 → list 에 ~10s 안에 반영
- 글 상세 → 뒤로가기 → list 가 최신 상태
- PC/모바일 동시 접속 시 차이가 ~10s 내로 좁아짐