### PR TITLE
Vary HTML responses on User-Agent so PC and mobile get distinct CDN caches

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -757,6 +757,10 @@ export const handle: Handle = async ({ event, resolve }) => {
     // 30s + stale 60s 였을 때 사용자가 새 글을 최대 90s 동안 못 보거나, 글 상세에 들어갔다 돌아왔을 때
     // 1~2분 전 list 가 그대로 노출되는 신고가 누적됨. s-maxage 와 stale 시간을 모두 단축한다.
     const publicHtmlCacheControl = 'public, s-maxage=10, stale-while-revalidate=5, max-age=0';
+    // Vary 헤더: 같은 URL 이라도 User-Agent (PC vs 모바일) / Accept-Encoding / 인증 쿠키별로
+    // CDN 이 다른 응답을 캐시하도록 명시. 이전엔 Cookie 만 vary 해서 PC 사용자가 모바일 캐시를
+    // 받거나 그 반대인 신고 (gouryella 2026-05-07) 가 발생했다.
+    const publicVaryHeader = 'Cookie, User-Agent, Accept-Encoding';
 
     // OPTIONS 요청 (CORS preflight) 처리
     if (event.request.method === 'OPTIONS') {
@@ -990,17 +994,20 @@ export const handle: Handle = async ({ event, resolve }) => {
     } else if (event.url.pathname.startsWith('/_app/immutable')) {
         // SvelteKit이 이미 설정 → 그대로 유지
     } else if (!event.locals.user && isPublicCacheablePath(pathname)) {
-        // 비로그인 사용자의 공개 페이지: CDN 캐시 30초, stale 60초
+        // 비로그인 사용자의 공개 페이지
         response.headers.set('Cache-Control', publicHtmlCacheControl);
+        response.headers.set('Vary', publicVaryHeader);
     } else if (!event.locals.user && isBoardListPath(pathname, event.url.searchParams)) {
-        // 비로그인 사용자의 게시판 목록: CDN 캐시 30초, stale 60초
+        // 비로그인 사용자의 게시판 목록
         response.headers.set('Cache-Control', publicHtmlCacheControl);
+        response.headers.set('Vary', publicVaryHeader);
     } else if (!event.locals.user && isPostDetailPath(pathname)) {
-        // 비로그인 사용자의 글 상세: CDN 캐시 30초, stale 60초
+        // 비로그인 사용자의 글 상세
         response.headers.set('Cache-Control', publicHtmlCacheControl);
+        response.headers.set('Vary', publicVaryHeader);
     } else {
         response.headers.set('Cache-Control', 'private, max-age=2, must-revalidate');
-        response.headers.set('Vary', 'Cookie');
+        response.headers.set('Vary', publicVaryHeader);
     }
 
     // SvelteKit modulepreload Link 헤더 제거 (8KB+ → 응답 헤더 축소)


### PR DESCRIPTION
## 배경

gouryella 신고 (2026-05-07): PC 와 모바일 글목록 업데이트 속도 차이.

## 진단

`hooks.server.ts:1003` 의 fallback 만 `Vary: Cookie` 를 설정하고, public HTML path (line 992/995/998) 는 Vary 헤더를 아예 안 보냈음. 결과: CloudFront/Cloudflare 가 PC/모바일 동일 캐시 키로 같은 HTML 을 전달 → 디바이스 간 동기화 차이.

## 변경

`apps/web/src/hooks.server.ts`

- `publicVaryHeader = 'Cookie, User-Agent, Accept-Encoding'` 헬퍼 추가
- public HTML path 4곳 (공개 / list / detail / fallback) 에 일관 `Vary` 응답 헤더 set

## 효과

- **Cookie**: 로그인 / 비로그인 분리 (기존)
- **User-Agent**: PC / 모바일 분리 — 디바이스 간 캐시 격리
- **Accept-Encoding**: br / gzip variant 분리

## 후속

- nginx `damoang.net.conf` 의 `proxy_cache_key` 도 동일하게 mobile/desktop 분리 검토 (별도 PR)