### PR TITLE
fix: 초대 임시 계정 닉네임 30일 잠금 방지

### DIFF
--- a/apps/web/src/lib/server/auth/register.ts
+++ b/apps/web/src/lib/server/auth/register.ts
@@ -178,6 +178,7 @@ export async function createMember(params: {
     mb_email: string;
     mb_name: string;
     mb_ip: string;
+    skipNickLock?: boolean;
 }): Promise<void> {
     const registerLevel = await getRegisterLevel();
 
@@ -197,7 +198,7 @@ export async function createMember(params: {
 			) VALUES (
 				?, ?, ?, ?, ?,
 				?, NOW(), ?, ?, NOW(),
-				CURDATE(), CURDATE(), NOW(),
+				?, CURDATE(), NOW(),
 				0, 0, 0, '', '',
 				'', '', '', '', '', '', '',
 				'', '', '', '',
@@ -211,7 +212,8 @@ export async function createMember(params: {
                 params.mb_email,
                 registerLevel,
                 params.mb_ip,
-                params.mb_ip
+                params.mb_ip,
+                params.skipNickLock ? '' : new Date().toISOString().slice(0, 10)
             ]
         );
     } catch (err: unknown) {

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -223,7 +223,8 @@ async function handleCallback(
                         mb_nick: nickname,
                         mb_email: profile.email || '',
                         mb_name: nickname,
-                        mb_ip: clientIp
+                        mb_ip: clientIp,
+                        skipNickLock: true
                     });
                 }
             } else {
@@ -284,7 +285,8 @@ async function handleCallback(
                         mb_nick: nickname,
                         mb_email: profile.email || '',
                         mb_name: nickname,
-                        mb_ip: clientIp
+                        mb_ip: clientIp,
+                        skipNickLock: true
                     });
                 }
                 member = await getMemberById(mbId);


### PR DESCRIPTION
## Summary
- `createMember()`에 `skipNickLock` 옵션 추가
- 초대 플로우에서 임시 계정 생성 시 `mb_nick_date`를 빈 문자열로 설정하여 30일 닉네임 잠금 방지
- 일반 가입 플로우는 기존 동작 유지 (`CURDATE()` 설정)

## 변경 파일
- `apps/web/src/lib/server/auth/register.ts` — `skipNickLock` 파라미터 추가, SQL에서 `CURDATE()` → `?` 파라미터로 교체
- `apps/web/src/routes/auth/callback/[provider]/+server.ts` — 초대 플로우 createMember 호출 2곳에 `skipNickLock: true` 추가

## Test plan
- [ ] 초대 링크로 소셜 로그인 → 임시 계정의 `mb_nick_date`가 빈 문자열인지 확인
- [ ] 일반 소셜 가입 → `mb_nick_date`가 당일 날짜로 설정되는지 확인