### PR TITLE
fix(recent-posts): sync currentPage with initialPage prop on SPA navigation (#12302)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -147,6 +147,16 @@
     let currentPage = $state(initialPage);
     let totalPages = $state(initialTotalPages);
     let totalItems = $state(initialTotal);
+
+    // SvelteKit SPA 네비게이션으로 같은 boardId 의 다른 글로 이동 시
+    // initial* props 가 새 값으로 들어와도 위 $state 초기화는 컴포넌트 생성 시점에 1회만 실행되어
+    // 옛 글의 page / posts / total 이 그대로 유지되던 회귀 (#12302). props 변경 시 동기화.
+    $effect(() => {
+        posts = initialPosts;
+        currentPage = initialPage;
+        totalPages = initialTotalPages;
+        totalItems = initialTotal;
+    });
     const useSummaryListResponse = $derived(boardId === 'free' || boardId === 'hello');
 
     // 목록 컨테이너 참조


### PR DESCRIPTION
## 배경

bug #12302: "자유게시판 게시물 상세 화면 아래 목록이 특정 페이지로만 나옵니다"

5/7 1단계 처리 시점에 #1404 (cache TTL 단축) + #1405 (Vary 헤더) 의 효과로 가정해 완료 처리했으나, 추가 분석 결과 진짜 root cause 가 cache 가 아닌 RecentPosts 컴포넌트의 Svelte 5 props 반응성 버그임을 확인.

## 진단 (확신도 95%)

`apps/web/src/lib/components/features/board/recent-posts.svelte:147~149`

```svelte
let currentPage = $state(initialPage);
let totalPages = $state(initialTotalPages);
let totalItems = $state(initialTotal);
```

Svelte 5 의 `$state(initialValue)` 는 컴포넌트 생성 시점에 한 번만 평가됨. SvelteKit SPA 네비게이션으로 **같은 boardId 의 다른 글** 로 이동하면 컴포넌트 인스턴스가 재사용되어 `initial*` props 가 새 값으로 들어와도 local state 가 옛 값을 유지 → 하단 RecentPosts 가 항상 동일 page 로 고정.

(`+page.svelte:2022~` 의 #12040 가드는 boardId 변경 시만 재생성 — 같은 boardId 내 navigation 은 fix 안 됨.)

## 변경

`recent-posts.svelte` line 147 직후 `$effect` 한 블록 추가:

```svelte
$effect(() => {
    posts = initialPosts;
    currentPage = initialPage;
    totalPages = initialTotalPages;
    totalItems = initialTotal;
});
```

deps 는 `initial*` props 만 자동 trace — 사용자가 컴포넌트 내 페이지네이션 클릭으로 `currentPage` 를 변경한 경우엔 `initial*` 가 안 바뀌므로 effect 미트리거 → 사용자 변경 보존.

## 검증

- `sudo pnpm svelte-check` — 신규 error 0 (기존 97 warnings)

## Test Plan

- [ ] `/free?page=3` 진입 → 글 클릭 → 하단 RecentPosts 가 page=3 표시
- [ ] RecentPosts 의 다른 글 클릭 (SPA 네비게이션) → 새 글에 맞는 page 자동 갱신
- [ ] 페이지네이션 클릭으로 page 변경 → 정상 동작 (effect 미트리거 확인)
- [ ] boardId 변경 시 (#12040) 정상 재생성 회귀 없음

## 후속

- #12273, #12290 (같은 "하단 목록" 신고들) 도 같은 root cause 일 가능성 — 본 PR 머지 + canary 검증 후 신고 잔존 여부 모니터링
- 머지 후 #12302 에 추가 "[AI 후속 안내]" 댓글로 진짜 root cause 안내