### PR TITLE
fix(comments): bypass HTTP cache on refetchComments after write (#12294)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1215,8 +1215,13 @@
 
     // 서버에서 댓글 목록 다시 가져오기
     async function refetchComments(): Promise<void> {
+        // 댓글 작성 / 수정 / 삭제 직후 호출되는 경로라 항상 fresh 응답이 필요.
+        // 브라우저 HTTP 캐시 / SvelteKit data 캐시가 옛 응답을 반환하면 optimistic
+        // update 로 추가된 새 댓글이 덮어써져 "댓글이 바로 안 보인다" (#12294) 가
+        // 재현되므로 no-store 로 캐시를 우회한다.
         const res = await fetch(
-            `/api/boards/${boardId}/posts/${data.post.id}/comments?page=1&limit=200`
+            `/api/boards/${boardId}/posts/${data.post.id}/comments?page=1&limit=200`,
+            { cache: 'no-store', headers: { 'Cache-Control': 'no-cache' } }
         );
         const json = await res.json();
         if (json.success) {


### PR DESCRIPTION
## 배경

bug #12294 + 사용자 추가 신고: "댓글이 있거나, 새로 달면 바로 보이지 않는 케이스".

## 진단

`apps/web/src/routes/[boardId]/[postId]/+page.svelte:1217` 의 `refetchComments()` 가 기본 cache 모드로 `/api/boards/{slug}/posts/{id}/comments` GET 호출.

`handleCreateComment` 흐름:
1. `createComment` POST 성공 → server 응답 수신
2. **Optimistic update**: comments 배열에 새 댓글 push (사용자에게 보임)
3. `await refetchComments()` → GET 호출 — **browser HTTP cache 가 옛 응답을 반환**
4. `comments = json.data.comments` 로 옛 list 로 덮어씀 → optimistic 추가된 새 댓글 **사라짐**
5. 사용자 체감: "댓글이 바로 안 보임"

PR #1404 (s-maxage=10, swr=5) + #1405 (Vary) 적용 후 일부 edge 에서 cache hit 확률 증가로 race condition 가시화.

## 변경

`refetchComments()` 의 fetch 에 `cache: 'no-store'` + `Cache-Control: no-cache` 헤더 추가. write 직후 호출되는 단일 경로에만 적용 — CDN 캐시 정책 (#1404/#1405) 영향 없음.

## 검증

- `sudo pnpm svelte-check` — 0 errors
- 일반 fetch path 영향 없음 (refetch 1곳만)

## Test Plan

- [ ] 댓글 작성 → 즉시 표시 (optimistic + refetch 모두 새 댓글 포함)
- [ ] 댓글 수정 → 즉시 반영
- [ ] 댓글 삭제 → 즉시 사라짐
- [ ] 다른 글로 SPA 네비게이션 시 댓글 정상 갱신 (postId 기반 $effect 와 충돌 없음)