### PR TITLE
fix(recent-posts): align pagination first/last shortcuts with board list (#12234)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -362,12 +362,14 @@
     <!-- 페이지네이션 -->
     {#if totalPages > 1}
         <div class="mt-4 flex items-center justify-center gap-2">
+            <!-- #12234: 게시판 목록(#11941)과 동일한 첫/끝 페이지 단축 — 5페이지 점프 대신 처음/마지막 이동으로 통일 -->
             <Button
                 variant="outline"
                 size="sm"
-                disabled={currentPage <= 5}
-                title="5페이지 뒤로"
-                onclick={() => goToPage(Math.max(1, currentPage - 5))}
+                disabled={currentPage === 1}
+                title="처음으로"
+                aria-label="첫 페이지"
+                onclick={() => goToPage(1)}
             >
                 &laquo;
             </Button>
@@ -401,9 +403,10 @@
             <Button
                 variant="outline"
                 size="sm"
-                disabled={currentPage + 5 > totalPages}
-                title="5페이지 앞으로"
-                onclick={() => goToPage(Math.min(totalPages, currentPage + 5))}
+                disabled={currentPage === totalPages}
+                title="마지막으로"
+                aria-label="마지막 페이지"
+                onclick={() => goToPage(totalPages)}
             >
                 &raquo;
             </Button>


### PR DESCRIPTION
## 배경

bug #12234: 게시판 목록 (1) 과 글 상세 하단 목록 (2) 의 페이지네이션 동작 차이.

- (1) 게시판 목록: `«` = 첫 페이지, `»` = 마지막 페이지 (#11941 패턴)
- (2) 글 상세 하단 RecentPosts: `«` = 5페이지 뒤로, `»` = 5페이지 앞으로 (다른 의미)

사용자 체감: "4페이지 이후에서 (2) 의 맨처음 페이지 이동 버튼이 비활성/없음". UX 일관성 문제.

## 변경

`apps/web/src/lib/components/features/board/recent-posts.svelte`

5페이지 점프 패턴 (`«` = goToPage(currentPage-5), `»` = +5) 을 게시판 목록과 동일한 **첫/끝 페이지 단축** 으로 교체:

- `«` → `goToPage(1)`, `disabled={currentPage === 1}`, title='처음으로'
- `»` → `goToPage(totalPages)`, `disabled={currentPage === totalPages}`, title='마지막으로'

이전/다음 버튼은 그대로.

## Test Plan

- [ ] 글 상세 진입 → 하단 목록 페이지 4 이상에서 `«` 클릭 → 1페이지로 이동
- [ ] 마지막 페이지 미만에서 `»` 클릭 → 마지막 페이지로 이동
- [ ] 1페이지/마지막 페이지에서 각각 버튼 비활성 확인
- [ ] 게시판 목록의 페이지네이션은 변경 없음