### PR TITLE
fix(editor): auto-embed bare image URLs on paste — gif et al. (#12262)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -439,6 +439,10 @@
     // 자체 paste handler 에서 YouTube URL 감지 시 명시적으로 setYoutubeVideo 호출.
     const YOUTUBE_PASTE_PATTERN =
         /^https?:\/\/(?:www\.|m\.)?(?:youtube(?:-nocookie)?\.com\/(?:watch\?v=|embed\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})(?:[?&][^\s]*)?$/;
+    // #12262: gif 등 이미지 확장자 단독 URL 붙여넣기 시 이미지 임베드.
+    // 모바일 일부 브라우저(스타곤 등) 에서 LinkedImage 의 자동 paste 변환이
+    // 트리거되지 않아 URL 이 plain text 로 들어가던 회귀 대응.
+    const IMAGE_URL_PASTE_PATTERN = /^https?:\/\/[^\s]+\.(gif|jpe?g|png|webp|avif)(\?[^\s]*)?$/i;
 
     function handlePaste(e: ClipboardEvent): void {
         if (disabled) return;
@@ -469,6 +473,13 @@
             const timeMatch = text.match(/[?&]t=(\d+)/);
             const start = timeMatch ? parseInt(timeMatch[1], 10) : 0;
             editor?.chain().focus().setYoutubeVideo({ src: text, start }).run();
+            return;
+        }
+
+        // 단독 이미지 URL (gif/png/jpg/webp/avif) 붙여넣기 → 이미지 임베드 (#12262)
+        if (text && IMAGE_URL_PASTE_PATTERN.test(text)) {
+            e.preventDefault();
+            editor?.chain().focus().setImage({ src: text }).run();
             return;
         }
     }


### PR DESCRIPTION
## 배경

bug #12262: "댓글 gif 입력시 버그 — gif 주소와 텍스트를 같이 넣으니 gif 주소가 텍스트로 들어가네요" (스타곤, 모바일).

## 진단

`apps/web/src/lib/components/features/editor/tiptap-editor.svelte` 의 `handlePaste` 가 이미지 MIME 우선 처리 후 YouTube URL 만 명시 임베드. **단독 이미지 URL (gif/png 등)** 은 LinkedImage extension 의 자동 paste 변환에 의존했는데, 일부 모바일 브라우저에서 자동 변환이 트리거 안 됨 → URL 이 plain text 로 들어감.

#12065 (YouTube 동일 패턴) 과 같은 종류의 버그.

## 변경

`tiptap-editor.svelte` 의 `handlePaste` 에 `IMAGE_URL_PASTE_PATTERN` 추가 (gif/jpg/jpeg/png/webp/avif). 단독 URL 일 때만 `editor.setImage({ src: text })` 명시 호출. 텍스트와 같이 paste 된 경우는 기본 처리 (사용자 텍스트 손실 방지).

## 검증

- `sudo pnpm svelte-check` — 0 errors

## Test Plan

- [ ] 모바일 댓글 editor 에 `https://example.com/cat.gif` 단독 paste → 이미지 임베드
- [ ] PC 에서도 동일 단독 URL paste → 이미지 임베드
- [ ] gif/png/webp 모두 동작
- [ ] 텍스트 + URL 같이 paste → 기존 동작 유지 (plain text)
- [ ] YouTube URL 회귀 없음 (#12065)
- [ ] 이미지 파일 직접 paste 회귀 없음 (image MIME 우선 분기)