### PR TITLE
feat: 후방/혐짤/NSFW 키워드 글 광고 억제

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -40,10 +40,11 @@
      */
     const AD_WATCHDOG_MS = 12_000;
 
-    /** 삭제된 글/비밀글 상세 페이지에서는 모든 광고를 숨김 (애드센스 정책) */
+    /** 삭제된 글/비밀글/성인 키워드 글 상세 페이지에서는 모든 광고를 숨김 (애드센스 정책) */
     const isDeletedPost = $derived(!!($page as any).data?.post?.deleted_at);
     const isSecretPost = $derived(!!($page as any).data?.post?.is_secret);
-    const suppressAds = $derived(isDeletedPost || isSecretPost);
+    const isAdultPost = $derived(!!($page as any).data?.post?.is_adult);
+    const suppressAds = $derived(isDeletedPost || isSecretPost || isAdultPost);
 
     interface Props {
         position: string;

--- a/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
+++ b/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
@@ -5,6 +5,10 @@
      */
     import { onMount, onDestroy } from 'svelte';
     import { browser } from '$app/environment';
+    import { page } from '$app/stores';
+
+    /** 성인 키워드 글 상세 페이지에서는 AdSense Multiplex 광고를 숨김 */
+    const suppressAds = $derived(!!($page as any).data?.post?.is_adult);
 
     interface Props {
         class?: string;
@@ -58,7 +62,7 @@
 </script>
 
 <div class="adsense-multiplex {className}">
-    {#if ready}
+    {#if ready && !suppressAds}
         <ins
             bind:this={insEl}
             class="adsbygoogle"


### PR DESCRIPTION
## Summary

- 제목에 후방/혐짤/nsfw 키워드가 포함된 글 상세 페이지에서 모든 광고(GAM, AdSense Multiplex) 숨김
- 백엔드 `is_adult` 플래그 기반 (damoang-backend#91)
- 구글 검색/비회원 접근에는 영향 없음 (광고만 비노출)

## Changes

- `ad-slot.svelte`: `isAdultPost` 체크 추가 → suppressAds에 포함
- `adsense-multiplex.svelte`: `page` import + `suppressAds` 로직 추가

## Background

후방 콘텐츠가 애드센스에 신고되어 광고 계정이 반복 정지되는 문제 대응.
오탐("후방 카메라" 등)은 소수이며 계정 정지 리스크 대비 허용.