### PR TITLE
Show leave reason on public member profile page

### DIFF
--- a/apps/web/src/routes/admin/members/[mbId]/+page.svelte
+++ b/apps/web/src/routes/admin/members/[mbId]/+page.svelte
@@ -45,7 +45,7 @@
         { value: 'self', label: '본인 탈퇴' },
         { value: 'admin', label: '관리자 처리' },
         { value: 'terms_violation', label: '약관 위반' },
-        { value: 'contract_withdrawal', label: '계약 철회 (개인정보보호법)' },
+        { value: 'contract_withdrawal', label: '약관에 의한 계약 철회' },
         { value: 'account_abuse', label: '계정 도용/악용' },
         { value: 'other', label: '기타' }
     ];

--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -25,6 +25,7 @@ interface MemberRow extends RowDataPacket {
     mb_image_updated_at: string;
     mb_certify: string;
     mb_leave_date: string;
+    mb_leave_reason: string;
     as_level: number;
     as_exp: number;
 }
@@ -110,7 +111,7 @@ export const GET: RequestHandler = async ({ params }) => {
             `SELECT mb_id, mb_name, mb_nick, mb_level, mb_point,
                     mb_signature, mb_homepage, mb_profile,
                     mb_datetime, mb_today_login, mb_nick_date,
-                    mb_image_url, mb_image_updated_at, mb_certify, mb_leave_date,
+                    mb_image_url, mb_image_updated_at, mb_certify, mb_leave_date, mb_leave_reason,
                     as_level, as_exp
              FROM g5_member
              WHERE mb_id = ?`,
@@ -239,6 +240,7 @@ export const GET: RequestHandler = async ({ params }) => {
                 mb_certify: !!member.mb_certify,
                 is_left: isLeft,
                 mb_leave_date: member.mb_leave_date || '',
+                mb_leave_reason: member.mb_leave_reason || '',
                 reg_days: regDays,
                 // 경험치 (levelThresholds 기반 계산)
                 as_level: calculateLevelInfo(member.as_exp || 0).currentLevel,

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -544,7 +544,7 @@
                                     self: '본인 탈퇴',
                                     admin: '관리자 처리',
                                     terms_violation: '약관 위반',
-                                    contract_withdrawal: '가입 철회',
+                                    contract_withdrawal: '약관에 의한 계약 철회',
                                     account_abuse: '계정 도용/악용',
                                     other: '기타'
                                 }}

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -540,9 +540,22 @@
                                 </span>
                             </div>
                             {#if p.is_left && p.mb_leave_date}
+                                {@const LEAVE_REASON_LABELS: Record<string, string> = {
+                                    self: '본인 탈퇴',
+                                    admin: '관리자 처리',
+                                    terms_violation: '약관 위반',
+                                    contract_withdrawal: '가입 철회',
+                                    account_abuse: '계정 도용/악용',
+                                    other: '기타'
+                                }}
                                 <div class="flex items-center gap-2">
                                     <Calendar class="h-4 w-4 shrink-0" />
-                                    <span>{formatDate(p.mb_leave_date)} 탈퇴</span>
+                                    <span>
+                                        {formatDate(p.mb_leave_date)} 탈퇴{p.mb_leave_reason &&
+                                        p.mb_leave_reason !== 'self'
+                                            ? ` · ${LEAVE_REASON_LABELS[p.mb_leave_reason] ?? p.mb_leave_reason}`
+                                            : ''}
+                                    </span>
                                 </div>
                             {/if}
                             {#if p.mb_nick_date}


### PR DESCRIPTION
## 요약

공개 회원 프로필 페이지 (/member/[id]) 의 탈퇴 정보에 **사유**를 추가 표시.

기존: `2026.05.11 탈퇴`
변경: `2026.05.11 탈퇴 · 가입 철회`

본인 탈퇴(self)는 표시 없음, 나머지 사유는 한국어 라벨로 표시.

## 변경

- `/api/members/[id]/profile/+server.ts` — SELECT + response 에 `mb_leave_reason` 포함
- `/member/[id]/+page.svelte` — 탈퇴 표시에 reason 라벨 추가

## 의존

- angple-backend #464 (mb_leave_reason 컬럼) 머지 + migration 실행 완료 필요