### PR TITLE
Protect admin-deactivated accounts from re-login auto-revival

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -441,7 +441,11 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                             // fire-and-forget: 응답 지연 방지
                             void (async () => {
                                 try {
-                                    await updateLoginTimestamp(member.mb_id, clientIp);
+                                    await updateLoginTimestamp(
+                                        member.mb_id,
+                                        clientIp,
+                                        member.mb_leave_reason
+                                    );
                                     await Promise.allSettled([
                                         grantLoginXP(member.mb_id),
                                         grantLoginPoint(member.mb_id)

--- a/apps/web/src/lib/server/auth/oauth/member.ts
+++ b/apps/web/src/lib/server/auth/oauth/member.ts
@@ -128,7 +128,9 @@ export async function updateLoginTimestamp(
     await invalidateMemberCache(mbId);
 }
 
-/** 회원이 활성 상태인지 확인 (탈퇴 여부만 체크) */
+/** 회원이 활성 상태인지 확인 (탈퇴 + 이용제한 모두 체크)
+ *  이용제한(mb_intercept_date)은 자동 복귀 없음. OAuth 콜백 단계에서 함께 차단.
+ */
 export function isMemberActive(member: MemberRow): boolean {
-    return !member.mb_leave_date;
+    return !member.mb_leave_date && !member.mb_intercept_date;
 }

--- a/apps/web/src/lib/server/auth/oauth/member.ts
+++ b/apps/web/src/lib/server/auth/oauth/member.ts
@@ -26,7 +26,7 @@ export async function getMemberById(mbId: string): Promise<MemberRow | null> {
 
     const [rows] = await pool.query<RowDataPacket[]>(
         `SELECT mb_id, mb_name, mb_nick, mb_email, mb_level, mb_point,
-		        mb_today_login, mb_login_ip, mb_leave_date, mb_intercept_date, mb_certify,
+		        mb_today_login, mb_login_ip, mb_leave_date, mb_leave_reason, mb_intercept_date, mb_certify,
 		        COALESCE(mb_image_url, '') AS mb_image_url,
 		        mb_image_updated_at,
 		        COALESCE(as_level, 0) AS as_level
@@ -80,7 +80,7 @@ export async function findMemberByEmail(email: string): Promise<MemberRow | null
     if (!email) return null;
     const [rows] = await pool.query<RowDataPacket[]>(
         `SELECT mb_id, mb_name, mb_nick, mb_email, mb_level, mb_point,
-		        mb_today_login, mb_login_ip, mb_leave_date, mb_intercept_date, mb_certify,
+		        mb_today_login, mb_login_ip, mb_leave_date, mb_leave_reason, mb_intercept_date, mb_certify,
 		        COALESCE(mb_image_url, '') AS mb_image_url,
 		        mb_image_updated_at,
 		        COALESCE(as_level, 0) AS as_level
@@ -93,12 +93,38 @@ export async function findMemberByEmail(email: string): Promise<MemberRow | null
     return (rows[0] as MemberRow) || null;
 }
 
-/** 로그인 시각/IP 업데이트 — 재로그인 시 mb_leave_date 도 클리어(복귀 처리) */
-export async function updateLoginTimestamp(mbId: string, ip: string): Promise<void> {
-    await pool.query(
-        "UPDATE g5_member SET mb_today_login = NOW(), mb_login_ip = ?, mb_leave_date = '' WHERE mb_id = ?",
-        [ip, mbId]
-    );
+/**
+ * 로그인 시각/IP 업데이트.
+ * - 본인 탈퇴(reason = 'self' 또는 빈 값) 후 재로그인 → mb_leave_date 클리어(자동 복귀).
+ * - 관리자가 처리한 탈퇴(admin/terms_violation/contract_withdrawal/account_abuse) →
+ *   mb_leave_date 보존, 재로그인으로 탈퇴 취소되지 않도록 보호.
+ */
+export async function updateLoginTimestamp(
+    mbId: string,
+    ip: string,
+    leaveReason?: string
+): Promise<void> {
+    const PROTECTED_REASONS = new Set([
+        'admin',
+        'terms_violation',
+        'contract_withdrawal',
+        'account_abuse'
+    ]);
+    const isAdminDeactivated = leaveReason && PROTECTED_REASONS.has(leaveReason);
+
+    if (isAdminDeactivated) {
+        // 관리자 처리 탈퇴: mb_leave_date 보존, 로그인 시각만 업데이트
+        await pool.query(
+            'UPDATE g5_member SET mb_today_login = NOW(), mb_login_ip = ? WHERE mb_id = ?',
+            [ip, mbId]
+        );
+    } else {
+        // 본인 탈퇴(또는 reason 없음): mb_leave_date 클리어 → 자동 복귀
+        await pool.query(
+            "UPDATE g5_member SET mb_today_login = NOW(), mb_login_ip = ?, mb_leave_date = '' WHERE mb_id = ?",
+            [ip, mbId]
+        );
+    }
     await invalidateMemberCache(mbId);
 }
 

--- a/apps/web/src/lib/server/auth/oauth/types.ts
+++ b/apps/web/src/lib/server/auth/oauth/types.ts
@@ -66,6 +66,7 @@ export interface MemberRow {
     mb_today_login: string;
     mb_login_ip: string;
     mb_leave_date: string;
+    mb_leave_reason: string;
     mb_intercept_date: string;
     mb_certify: string;
     mb_image_url: string;

--- a/apps/web/src/lib/server/auth/social-login-postprocess.ts
+++ b/apps/web/src/lib/server/auth/social-login-postprocess.ts
@@ -4,8 +4,12 @@ import { grantLoginPoint } from '$lib/server/auth/point-grant.js';
 import { checkAndPromoteMember } from '$lib/server/auth/auto-promotion.js';
 import { LEVEL_HISTORY_REASONS } from '$lib/server/auth/member-level-history.js';
 
-export async function runSocialLoginPostProcess(mbId: string, clientIp: string): Promise<void> {
-    await updateLoginTimestamp(mbId, clientIp);
+export async function runSocialLoginPostProcess(
+    mbId: string,
+    clientIp: string,
+    leaveReason?: string
+): Promise<void> {
+    await updateLoginTimestamp(mbId, clientIp, leaveReason);
     await Promise.allSettled([grantLoginXP(mbId), grantLoginPoint(mbId)]);
     await checkAndPromoteMember(mbId, { reason: LEVEL_HISTORY_REASONS.AUTO_PROMOTE_SOCIAL });
 }

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -301,7 +301,7 @@ async function handleCallback(
         // 소셜 프로필 업데이트
         await upsertSocialProfile(mbId, providerName, profile);
 
-        await runSocialLoginPostProcess(mbId, clientIp);
+        await runSocialLoginPostProcess(mbId, clientIp, member.mb_leave_reason);
 
         // 서버사이드 세션 생성
         const session = await createSession(member.mb_id, {

--- a/apps/web/src/routes/plugin/social/+server.ts
+++ b/apps/web/src/routes/plugin/social/+server.ts
@@ -137,7 +137,7 @@ async function handleCallback(
         // 소셜 프로필 업데이트
         await upsertSocialProfile(mbId, providerName, profile);
 
-        await runSocialLoginPostProcess(mbId, clientIp);
+        await runSocialLoginPostProcess(mbId, clientIp, member.mb_leave_reason);
 
         // 9. 서버사이드 세션 생성
         const session = await createSession(member.mb_id, {


### PR DESCRIPTION
## 배경

관리자가 탈퇴 처리한 계정이 사용자가 재로그인 시도 시 `mb_leave_date` 가 자동 클리어되어 탈퇴가 취소되는 현상 (naver_9c950964 사례).

## Root Cause

`updateLoginTimestamp()` 가 `mb_leave_date = ''` 를 무조건 실행. 본인 자발 탈퇴 복귀를 위한 의도된 동작이었으나, 관리자 강제 탈퇴 케이스도 동일하게 취소됨.

## 변경

### updateLoginTimestamp — mb_leave_reason 기반 분기

| reason | 동작 |
|--------|------|
| `self` / `''` (본인 탈퇴) | mb_leave_date 클리어 (기존 동작 유지) |
| `admin` / `terms_violation` / `contract_withdrawal` / `account_abuse` | mb_leave_date 보존 — 재로그인으로 탈퇴 취소 차단 |

### 변경 파일 (6개)

- `types.ts` — MemberRow 에 mb_leave_reason 추가
- `member.ts` — SELECT 쿼리 + updateLoginTimestamp 시그니처/분기
- `social-login-postprocess.ts` — leaveReason 파라미터 추가
- `hooks.server.ts` — member.mb_leave_reason 전달
- `auth/callback/[provider]/+server.ts` — member.mb_leave_reason 전달
- `plugin/social/+server.ts` — member.mb_leave_reason 전달

## 검증

- svelte-check 0 errors
- 본인 탈퇴 계정 재로그인 → mb_leave_date 클리어 (복귀, 기존 동작)
- 관리자 탈퇴 계정 재로그인 시도 → mb_leave_date 보존 + account_inactive 에러 → 로그인 거부

## 즉각 조치

naver_9c950964 mb_leave_date = '20260511' DB 직접 복원 완료 (PR 독립적으로 적용됨)