### PR TITLE
fix: 이모지 리액션 알림 비활성화

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -45,7 +45,9 @@
     const isSecretPost = $derived(!!($page as any).data?.post?.is_secret);
     const isAdultPost = $derived(!!($page as any).data?.post?.is_adult);
     const isSuppressedAuthor = $derived(!!($page as any).data?.post?.suppress_ads);
-    const suppressAds = $derived(isDeletedPost || isSecretPost || isAdultPost || isSuppressedAuthor);
+    const suppressAds = $derived(
+        isDeletedPost || isSecretPost || isAdultPost || isSuppressedAuthor
+    );
 
     interface Props {
         position: string;

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -286,54 +286,6 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         if (!existing[0]) {
             // 리액션 추가
             await addReaction(user.mb_id, safeReaction, safeTargetId, safeParentId, clientIp);
-
-            // 리액션 알림 (비동기, fire-and-forget)
-            if (targetParts.length >= 3) {
-                const boardTable = targetParts[1].replace(/[^a-zA-Z0-9_]/g, '');
-                const wrId = parseInt(targetParts[2], 10);
-                if (!isNaN(wrId)) {
-                    pool.query<RowDataPacket[]>(
-                        `SELECT mb_id, wr_parent, wr_subject FROM g5_write_${boardTable} WHERE wr_id = ?`,
-                        [wrId]
-                    )
-                        .then(async ([rows]) => {
-                            const authorId = rows[0]?.mb_id;
-                            const wrParent = rows[0]?.wr_parent ?? wrId;
-                            if (authorId && authorId !== user.mb_id) {
-                                const userNick = user.mb_nick || user.mb_name || user.mb_id;
-                                const isComment = targetParts[0] === 'comment';
-                                const targetLabel = isComment ? '댓글' : '글';
-                                const urlHash = isComment ? `#c_${wrId}` : '';
-                                const postId = isComment ? wrParent : wrId;
-                                // 부모 글 제목
-                                let parentSubject = rows[0]?.wr_subject || '';
-                                if (isComment && wrParent !== wrId) {
-                                    const [parentRows] = await pool.query<RowDataPacket[]>(
-                                        `SELECT wr_subject FROM g5_write_${boardTable} WHERE wr_id = ?`,
-                                        [wrParent]
-                                    );
-                                    parentSubject = parentRows[0]?.wr_subject || '';
-                                }
-                                pool.query(
-                                    `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
-                                     VALUES ('reaction', 'reaction', ?, ?, ?, ?, ?, ?, ?, 'N', CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?, ?)`,
-                                    [
-                                        boardTable,
-                                        wrId,
-                                        authorId,
-                                        user.mb_id,
-                                        userNick,
-                                        `${userNick}님이 회원님의 ${targetLabel}에 리액션을 남겼습니다.`,
-                                        `/${boardTable}/${postId}${urlHash}`,
-                                        parentSubject,
-                                        postId
-                                    ]
-                                ).catch(() => {});
-                            }
-                        })
-                        .catch(() => {});
-                }
-            }
         } else if (reactionMode !== 'add') {
             // 리액션 취소 (add 모드가 아닐 때만)
             await revokeReaction(user.mb_id, safeReaction, safeTargetId);


### PR DESCRIPTION
## Summary
- 이모지 리액션 시 글/댓글 작성자에게 발송되던 알림 제거
- 리액션은 가볍게 누르는 기능이므로 매번 알림 발송 시 알림 피로도가 높아짐
- `addReaction()` 호출 후 `g5_na_noti` 테이블에 INSERT하던 fire-and-forget 블록 삭제

## 영향 범위
- 추천(좋아요) 알림은 Go 백엔드(`good_service.go`)에서 별도 처리되므로 영향 없음
- 리액션 추가/취소 기능 자체는 변경 없음
- 기존 리액션 알림 데이터는 삭제하지 않음 (자연 소멸)

## Test plan
- [ ] 글/댓글에 이모지 리액션 클릭 → 알림 미발생 확인
- [ ] 글 추천(좋아요) → 알림 정상 발생 확인
- [ ] 리액션 추가/취소 기능 정상 동작 확인