### PR TITLE
Fix mention 404 + RecentPosts page sticking on posts from pages 1-2 (#12317 #12315)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -466,6 +466,23 @@
             }
         }
 
+        // HTML paste 에서 이미지 과다 방지 (#12300)
+        // 메모장 등에서 이미지 50개 이상 포함 글 붙여넣기 시 동시 업로드 → 504 발생.
+        // img 태그가 10개 초과이면 이미지를 제거하고 텍스트/구조만 삽입 후 안내.
+        const htmlData = e.clipboardData?.getData('text/html');
+        if (htmlData) {
+            const imgCount = (htmlData.match(/<img/gi) || []).length;
+            if (imgCount > 10) {
+                e.preventDefault();
+                const stripped = htmlData.replace(/<img[^>]*\/?>/gi, '');
+                editor?.commands.insertContent(stripped);
+                alert(
+                    `이미지가 ${imgCount}개 포함되어 있어 이미지를 제외하고 텍스트만 붙여넣었습니다.\n이미지는 한 번에 최대 10개까지 붙여넣기 가능합니다.`
+                );
+                return;
+            }
+        }
+
         // 단독 YouTube URL 붙여넣기 → 명시적으로 임베드 삽입 (#12065)
         const text = e.clipboardData?.getData('text/plain')?.trim();
         if (text && YOUTUBE_PASTE_PATTERN.test(text)) {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -585,12 +585,14 @@ export const load: PageServerLoad = async ({
 
         // 하단 게시글 목록은 클라이언트에서 로드한다.
         // 개수(20개)는 유지하되 상세 __data.json을 줄이기 위해 SSR 프리로드는 하지 않는다.
-        const listPage = Number(url.searchParams.get('page')) || 1;
+        // SSR 단계에서는 항상 page=1 로 고정 — URL 의 ?page 파라미터는 목록 페이지 컨텍스트이며
+        // 글 상세 하단 RecentPosts 에 그대로 전달하면 특정 날짜의 글들이 고정 노출되는 버그 발생 (#12315).
+        // 실제 page 탐색은 클라이언트 컴포넌트가 담당한다.
         let recentPosts: { items: FreePost[]; total: number; totalPages: number; page: number } = {
             items: [],
             total: 0,
             totalPages: 1,
-            page: listPage
+            page: 1
         };
 
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).

--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -114,8 +114,8 @@ export const GET: RequestHandler = async ({ params }) => {
                     mb_image_url, mb_image_updated_at, mb_certify, mb_leave_date, mb_leave_reason,
                     as_level, as_exp
              FROM g5_member
-             WHERE mb_id = ?`,
-            [memberId]
+             WHERE mb_id = ? OR mb_nick = ?`,
+            [memberId, memberId]
         );
 
         if (rows.length === 0) {


### PR DESCRIPTION
## #12317 — mention 클릭 → 회원 없음

**원인**: mention 링크가 mb_nick 기준으로 생성(`/member/{nick}`)되지만 profile API 는 `WHERE mb_id = ?` 만 조회. 닉네임 ≠ mb_id 인 경우 404.

**수정**: `WHERE mb_id = ? OR mb_nick = ?` 로 fallback 추가.

---

## #12315 — 자유게시판 1~2페이지 글 상세 하단에 5/7 글 고정

**원인**: SSR loader 가 URL 의 `?page` 파라미터를 `recentPosts.page` 로 전달. 1~2페이지 글은 `?page=2` 등이 URL 에 남아 RecentPosts 가 해당 날짜 글들로 고정됨. 3페이지는 `?page` 없어서 정상.

**수정**: SSR 에서 `recentPosts.page = 1` 고정. 실제 page 탐색은 클라이언트 컴포넌트가 담당.

## 검증

- svelte-check 0 errors