### PR TITLE
fix: 탈퇴/이용제한 회원 SSR 세션 차단

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -4,8 +4,12 @@ import '$lib/server/telemetry.js';
 import { redirect, type Handle, type HandleServerError } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
-import { getMemberById, updateLoginTimestamp } from '$lib/server/auth/oauth/member.js';
-import { getSession, SESSION_COOKIE_NAME } from '$lib/server/auth/session-store.js';
+import {
+    getMemberById,
+    updateLoginTimestamp,
+    isMemberActive
+} from '$lib/server/auth/oauth/member.js';
+import { getSession, destroySession, SESSION_COOKIE_NAME } from '$lib/server/auth/session-store.js';
 import { grantLoginXP } from '$lib/server/auth/xp-grant.js';
 import { grantLoginPoint } from '$lib/server/auth/point-grant.js';
 import { checkAndPromoteMember } from '$lib/server/auth/auto-promotion.js';
@@ -388,6 +392,16 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
 
                 const member = await withTimeout(getMemberById(session.mbId), AUTH_TIMEOUT_MS);
                 if (member) {
+                    // 탈퇴/이용제한 회원 세션 차단
+                    if (!isMemberActive(member)) {
+                        await destroySession(sessionId).catch(() => {});
+                        event.cookies.delete(SESSION_COOKIE_NAME, {
+                            path: '/',
+                            ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {})
+                        });
+                        return;
+                    }
+
                     event.locals.user = {
                         id: member.mb_id,
                         nickname: member.mb_nick || member.mb_name,


### PR DESCRIPTION
## Summary
- `authenticateSSR()`에서 `getMemberById()` 조회 후 `isMemberActive()` 체크 추가
- 탈퇴(`mb_leave_date`) 또는 이용제한(`mb_intercept_date`) 회원 감지 시 세션 즉시 파괴 + 쿠키 삭제
- 기존 Go 백엔드/OAuth 콜백에서는 차단했으나 SSR 세션 검증 경로에서 누락된 버그 수정

## 배경
약관 위반으로 탈퇴 처리된 회원(`naver_9c950964`)이 탈퇴 전 생성된 세션 쿠키로 계속 로그인 상태 유지. `authenticateSSR()`이 `mb_leave_date`/`mb_intercept_date`를 검사하지 않아 발생.

## 변경 내용
- `hooks.server.ts`: `isMemberActive`, `destroySession` import 추가
- `authenticateSSR()` Normal Path에서 member 조회 직후 활성 상태 체크 삽입
- 비활성 회원 → `destroySession()` + 쿠키 삭제 + early return (`event.locals.user = null`)

## 즉시 조치 (완료)
- 해당 회원의 DB 세션 7건 전부 삭제 (`DELETE FROM angple_sessions WHERE mb_id = ...`)

## Test plan
- [ ] `pnpm check` 통과 확인 (완료: 0 errors)
- [ ] 정상 회원 로그인/페이지 이동 정상 동작
- [ ] 탈퇴 회원 세션 접근 시 로그아웃 처리 확인
- [ ] Fast Path (`USER_BASIC_FAST_PATH`)는 현재 off — 영향 없음