### PR TITLE
Support env-based cache paths + CDN Cache-Control for empathy/recommended

### DIFF
--- a/apps/web/src/lib/server/index-widgets-builder.ts
+++ b/apps/web/src/lib/server/index-widgets-builder.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'fs/promises';
+import { env } from '$env/dynamic/private';
 import type {
     IndexWidgetsData,
     NewsPost,
@@ -41,7 +42,9 @@ interface BackendBoardResponse {
     };
 }
 
-const JSON_PATH = '/home/damoang/www/data/cache/recommended/index-widgets.json';
+const JSON_PATH =
+    env.INDEX_WIDGETS_CACHE_PATH ||
+    '/home/damoang/legacy-data/data/cache/recommended/index-widgets.json';
 const CACHE_TTL_MS = 60_000; // 60초 (파일은 5분마다 갱신)
 
 const EMPTY_RESULT: IndexWidgetsData = {

--- a/apps/web/src/routes/api/empathy/+server.ts
+++ b/apps/web/src/routes/api/empathy/+server.ts
@@ -31,7 +31,9 @@ export const GET: RequestHandler = async ({ url }) => {
 
     return json(dataWithoutComments, {
         headers: {
-            'Cache-Control': 'public, max-age=60'
+            // CDN s-maxage=300 (5분) — cron 갱신 주기(1h)의 1/12.
+            // stale-while-revalidate=86400 으로 갱신 중에도 옛 데이터 노출 허용.
+            'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=86400, max-age=60'
         }
     });
 };

--- a/apps/web/src/routes/empathy/+page.server.ts
+++ b/apps/web/src/routes/empathy/+page.server.ts
@@ -5,7 +5,9 @@ import {
     getTodayKST
 } from '$lib/server/daily-recommended-loader';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ setHeaders }) => {
+    // 오늘 공감글: 비로그인 60초 CDN 캐시. cron 갱신(1h) 주기 대비 짧게 설정.
+    setHeaders({ 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=3600, max-age=0' });
     const today = getTodayKST();
 
     const [calendar, dailyData] = await Promise.all([

--- a/apps/web/src/routes/empathy/[date]/+page.server.ts
+++ b/apps/web/src/routes/empathy/[date]/+page.server.ts
@@ -6,7 +6,11 @@ import {
     isValidDate
 } from '$lib/server/daily-recommended-loader';
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, setHeaders }) => {
+    // 과거 날짜 공감글은 불변 → 1시간 CDN 캐시, stale 7일 허용.
+    setHeaders({
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=604800, max-age=0'
+    });
     const { date } = params;
 
     if (!isValidDate(date)) {


### PR DESCRIPTION
## 배경

추천글 캐시 데이터가 `/home/damoang/www/` → `/home/damoang/legacy-data/` 로 이동됨. 환경변수 없으면 하드코딩된 `www/` 경로를 읽어 파일 없음 에러 발생.

## 변경

### 1. `index-widgets-builder.ts`
- `JSON_PATH` 하드코딩 → `INDEX_WIDGETS_CACHE_PATH` 환경변수 지원 추가
- 기본값: `/home/damoang/legacy-data/data/cache/recommended/index-widgets.json`

### 2. Cache-Control 헤더 추가 (CDN 모범 설계)

| 경로 | s-maxage | stale-while-revalidate | 근거 |
|------|---------|----------------------|------|
| `/api/empathy` | 300s | 86400s | cron 1h의 1/12 |
| `/empathy` (오늘) | 60s | 3600s | 오늘 데이터 자주 갱신 |
| `/empathy/[date]` (과거) | 3600s | 604800s | 과거 데이터 불변 |

Cloudflare/CloudFront 가 응답 헤더 존중하므로 별도 cache rule 불필요.

## 연관

- angple-k8s PR #96 — hostPath 경로 보정 + 환경변수 3개 추가 (먼저 배포 필요)

## 검증

- svelte-check 0 errors