### PR TITLE
fix: 이용제한 회원 세션 유지 (탈퇴만 세션 차단)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -4,11 +4,7 @@ import '$lib/server/telemetry.js';
 import { redirect, type Handle, type HandleServerError } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
-import {
-    getMemberById,
-    updateLoginTimestamp,
-    isMemberActive
-} from '$lib/server/auth/oauth/member.js';
+import { getMemberById, updateLoginTimestamp } from '$lib/server/auth/oauth/member.js';
 import { getSession, destroySession, SESSION_COOKIE_NAME } from '$lib/server/auth/session-store.js';
 import { grantLoginXP } from '$lib/server/auth/xp-grant.js';
 import { grantLoginPoint } from '$lib/server/auth/point-grant.js';
@@ -392,8 +388,8 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
 
                 const member = await withTimeout(getMemberById(session.mbId), AUTH_TIMEOUT_MS);
                 if (member) {
-                    // 탈퇴/이용제한 회원 세션 차단
-                    if (!isMemberActive(member)) {
+                    // 탈퇴 회원 세션 차단 (이용제한 회원은 글 열람 허용을 위해 세션 유지)
+                    if (member.mb_leave_date) {
                         await destroySession(sessionId).catch(() => {});
                         event.cookies.delete(SESSION_COOKIE_NAME, {
                             path: '/',


### PR DESCRIPTION
## Summary
- #1418 후속: `isMemberActive()` → `mb_leave_date`만 체크하도록 변경
- 이용제한(`mb_intercept_date`) 회원은 세션 유지하여 글 열람 허용
- 탈퇴(`mb_leave_date`) 회원만 세션 파괴 + 쿠키 삭제

## 배경
#1418에서 `isMemberActive()`로 탈퇴/이용제한 모두 세션 차단했으나, 이용제한 회원은 글 열람은 가능해야 함. 세션을 파괴하면 비로그인 상태가 되어 로그인 자체가 불가능해지는 문제.

## Test plan
- [ ] `pnpm check` 통과 (완료: 0 errors)
- [ ] 탈퇴 회원 → 세션 파괴 + 로그아웃
- [ ] 이용제한 회원 → 세션 유지, 글 열람 가능