### PR TITLE
Allow Hangul nicknames in /api/members/[id]/profile guard (#12371)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -102,7 +102,15 @@ function calculateLevelInfo(totalExp: number) {
 export const GET: RequestHandler = async ({ params }) => {
     const memberId = params.id;
 
-    if (!memberId || !/^[a-zA-Z0-9_-]+$/.test(memberId)) {
+    // mb_id (영문/숫자/_-) 또는 mb_nick (한글 포함) 둘 다 허용 (#12371).
+    // 멘션 링크 (@닉네임) 가 한글 닉네임으로 /member/{닉네임} 형태로 들어오므로 차단하지 않음.
+    // 경로 traversal/주입 방지 위해 길이 제한 + 위험 문자만 차단.
+    const isValidMemberId =
+        !!memberId &&
+        memberId.length > 0 &&
+        memberId.length <= 50 &&
+        !/[\\\/?#<>%\s\0]/.test(memberId);
+    if (!isValidMemberId) {
         return json({ success: false, error: '유효하지 않은 회원 ID입니다.' }, { status: 400 });
     }
 


### PR DESCRIPTION
## 배경

bug #12371: 댓글 멘션 `@한퉁` 클릭 → "유효하지 않은 회원 ID입니다." 에러.

## 진단

`mention-parser.ts:57` 가 멘션 링크를 `/member/${encodeURIComponent(nick)}` 으로 생성 → 한글 닉네임 통과. SQL 쿼리 (`WHERE mb_id = ? OR mb_nick = ?`) 도 이미 nick fallback 지원.

문제: 그 앞에 있는 ID 정규식 `^[a-zA-Z0-9_-]+$` 가 한글을 차단 → SQL 도달 전에 400 반환.

## 변경

`apps/web/src/routes/api/members/[id]/profile/+server.ts` 의 가드를 완화:

- 영문/숫자/_- (mb_id) 또는 한글 (mb_nick) 모두 허용
- 길이 ≤ 50 + 위험 문자 (`\\ / ? # < > %` whitespace null) 만 차단
- SQL fallback (`mb_id OR mb_nick`) 그대로 활용

## 검증

- svelte-check 0 errors
- /api/members/한퉁/profile → 200 + 회원 정보 (nick 매칭)
- /api/members/google_xxx/profile → 200 (mb_id 매칭, 기존 동작)
- /api/members/../etc/profile → 400 (path traversal 차단)