### PR TITLE
Unify home '공감글' font size with '모아보기' via list-font-size (#12365)

### DIFF
--- a/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
@@ -81,7 +81,7 @@
                                 showReadState &&
                                     readPostsStore.isRead(getBoardId(post.url), post.id)
                             )}"
-                            style="font-size: var(--recommend-font-size, 1rem);"
+                            style="font-size: var(--list-font-size, 1rem);"
                         >
                             {post.title}
                         </span>


### PR DESCRIPTION
## 배경

bug #12365: 메인 페이지 좌우 위젯 (공감글 vs 모아보기) 글자 크기 불일치.

"설정에서 좀 크게 보이게 설정을 했는데 모아보기만 커지네요. 윈도11, 크롬"

## 진단

| 위젯 | 컴포넌트 | css variable |
|------|---------|-------------|
| 모아보기 (우) | ExplorePreview | `--list-font-size` ✅ |
| 공감글 (좌) | RecommendedPosts (post-list.svelte:84) | `--recommend-font-size` ❌ 별도 설정 |

사용자가 "리스트 글자 크기" 슬라이더 (listFontSize) 만 키워서 모아보기만 커짐. `--recommend-font-size` 는 별도 슬라이더 (recommendFontSize) — 사용자가 일반적으로 인지 안 하는 설정.

## 변경

`apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte` line 84
`var(--recommend-font-size, 1rem)` → `var(--list-font-size, 1rem)`

이제 두 위젯 모두 "리스트 글자 크기" 설정에 일관 반응.

## 검증

- svelte-check 0 errors
- 좌측 공감글 + 우측 모아보기 글자 크기 동기화