### PR TITLE
Read RecentPosts initialPage from URL before server default (#12367)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2036,8 +2036,8 @@
                 {boardTitle}
                 currentPostId={data.post.id}
                 limit={20}
-                initialPage={data.recentPosts?.page ||
-                    Number($page.url.searchParams.get('page')) ||
+                initialPage={Number($page.url.searchParams.get('page')) ||
+                    data.recentPosts?.page ||
                     1}
                 {promotionPosts}
                 displaySettings={data.board?.display_settings}


### PR DESCRIPTION
## 배경

bug #12367 (갤럭시 폴드7 삼성인터넷): 게시글 상세 하단 RecentPosts 가 항상 1페이지로 고정.

## Root cause

`[boardId]/[postId]/+page.svelte:2039` 의 fallback 우선순위:

```svelte
initialPage = data.recentPosts?.page || urlSearchParams.get('page') || 1
```

서버 load (line 588~595) 가 `recentPosts.page = 1` 으로 항상 고정 (#12315 fix 의도). 따라서:
- `data.recentPosts.page = 1` (truthy) → URL의 ?page=N fallback 무시
- `initialPage = 1` → #1407 `$effect` 가 `currentPage = 1` sync → 1페이지 고정

## Fix

URL의 ?page=N 을 우선 fallback:

```svelte
initialPage = Number(urlSearchParams.get('page')) || data.recentPosts?.page || 1
```

- URL에 ?page=N 있으면 그 값 사용 (사용자가 list 의 N페이지에서 진입한 경우)
- 없으면 server default (1)

## 검증

- svelte-check 0 errors
- `/free?page=3` → 글 클릭 → 하단 RecentPosts 3페이지부터 시작 ✅
- RecentPosts에서 다른 글 클릭 (URL에 ?page=3 유지) → 3페이지 유지 ✅
- 직접 `/free/{id}` 진입 (URL에 ?page 없음) → 1페이지 (정상)

## 관련 PR

- #1407 (currentPage props sync) — 본 fix 와 함께 동작