### PR TITLE
Unify list/recommend font size under a single user setting (#12365)

### DIFF
--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -155,10 +155,10 @@ function createUiSettingsStore() {
         html.style.setProperty('--content-line-height', LINE_HEIGHT_VALUES[settings.lineHeight]);
 
         html.style.setProperty('--list-font-size', LIST_FONT_SIZES[settings.listFontSize]);
-        html.style.setProperty(
-            '--recommend-font-size',
-            LIST_FONT_SIZES[settings.recommendFontSize]
-        );
+        // #12365: 공감글/추천글 컴포넌트도 동일한 listFontSize 적용 — 사용자가
+        // "리스트 글자 크기" 하나만 조정하면 모든 리스트류가 일관되게 변경됨.
+        // recommendFontSize 설정 store key 는 backward-compat 위해 유지하되 미사용.
+        html.style.setProperty('--recommend-font-size', LIST_FONT_SIZES[settings.listFontSize]);
 
         // 본문·에디터에 contentFontSize 연동
         html.style.setProperty('--content-font-size', CONTENT_FONT_SIZES[settings.contentFontSize]);

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -490,32 +490,8 @@
                 </CardContent>
             </Card>
 
-            <Card>
-                <CardHeader>
-                    <CardTitle class="flex items-center gap-2">
-                        <Type class="h-5 w-5" />
-                        공감글 글씨 크기
-                    </CardTitle>
-                    <CardDescription
-                        >메인화면 공감 컴포넌트의 글씨 크기를 조정합니다.</CardDescription
-                    >
-                </CardHeader>
-                <CardContent>
-                    <div class="flex flex-wrap gap-2">
-                        {#each listFontSizeOptions as opt (opt.value)}
-                            <button
-                                class="rounded-lg border px-4 py-2 text-sm transition-colors {uiSettingsStore.recommendFontSize ===
-                                opt.value
-                                    ? 'border-primary bg-primary/10 text-foreground'
-                                    : 'border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground'}"
-                                onclick={() => uiSettingsStore.setRecommendFontSize(opt.value)}
-                            >
-                                {opt.label}
-                            </button>
-                        {/each}
-                    </div>
-                </CardContent>
-            </Card>
+            <!-- #12365: '공감글 글씨 크기' 슬라이더 제거 — '목록 글자 크기' 하나로 통합.
+                 공감글/추천글 컴포넌트는 이제 listFontSize 를 따라간다. -->
 
             <Card>
                 <CardHeader>


### PR DESCRIPTION
## 배경

bug #12365: 메인 페이지 좌(공감글) vs 우(모아보기) 글자 크기 불일치.

"설정에서 좀 크게 보이게 설정을 했는데 모아보기만 커지네요"

사용자 추가 의견: "설정된 값이나, 그렇지 않을 경우 폰트사이즈는 일정해야 하는것이 아닌가? 이곳 다르고 저곳 다르고 뒤죽 박죽보다는?"

## 진단

설정 페이지에 두 개의 슬라이더가 존재:
- "목록 글자 크기" → `listFontSize` → `--list-font-size` (게시판 목록, ExplorePreview)
- "공감글 글씨 크기" → `recommendFontSize` → `--recommend-font-size` (RecommendedPosts, daily-recommended, post-card)

사용자 대부분 "공감글 글씨 크기" 슬라이더의 존재를 모름 → 한쪽만 커지는 체감.

## 변경

1. **`ui-settings.svelte.ts`** — `--recommend-font-size` 도 `listFontSize` 값을 사용. 사용자가 하나의 "목록 글자 크기" 슬라이더만 조정해도 모든 리스트류 컴포넌트 (목록 / 공감글 / 모아보기 / daily-recommended / post-card) 일관 변경.

2. **`member/settings/ui/+page.svelte`** — "공감글 글씨 크기" Card 제거.

3. `recommendFontSize` store key 자체는 backward-compat 위해 유지 (저장된 사용자 설정 값은 그대로 보존하되 미사용).

## 영향

- 사용자 입장에서 일관된 글자 크기 (의도)
- 기존에 두 슬라이더를 따로 설정한 사용자는 listFontSize 만 적용됨 (대부분 같은 값이거나 listFontSize만 변경한 경우라 영향 작음)

## 검증

- svelte-check 0 errors
- /설정 페이지에서 "목록 글자 크기" 변경 → 메인 좌측 공감글 + 우측 모아보기 + 게시판 목록 모두 함께 변경 확인