### PR TITLE
Add mobile tap feedback for list items (#12268)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -415,3 +415,24 @@ html {
         animation: none;
     }
 }
+
+/* #12268: 모바일 터치 피드백 — 어떤 글을 눌렀는지 시각적 확인이 가능하도록 한다.
+ * iOS Safari / Chrome Mobile 등 webkit 계열에서 link/button tap 시 색조 표시.
+ * 기본 transparent 로 설정된 경우 사용자가 어디를 눌렀는지 모름 → 사이트가 느린 듯 체감. */
+html {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0.12);
+}
+
+:root.dark,
+:root.amoled {
+    -webkit-tap-highlight-color: rgba(255, 255, 255, 0.14);
+}
+
+/* 터치 디바이스에서 게시판 목록 / 공감글 / 모아보기 등 list-item 링크의 :active 강조.
+ * hover:bg-accent 클래스를 가진 모든 링크에 동일한 visual feedback 을 적용 → 13개 list
+ * layout / 모아보기 / 공감글 카드 / RecentPosts 등 일관 적용. */
+@media (hover: none) and (pointer: coarse) {
+    a[class*='hover:bg-accent']:active {
+        background-color: var(--accent);
+    }
+}


### PR DESCRIPTION
## 배경

#12268 (모바일 터치 피드백 부재):

> "다모앙을 모바일로 접속하고 보고싶은 공감글을 누르면 (터치) 어느 글을 눌렀는지에 대한 피드백이 없습니다. 네이버는 회색 잠시 번쩍이면서 어느 글을 눌렀는지 확인 가능. 이게 없으니 사이트 자체 로딩이 느린것처럼 잘못 느껴질 수 있습니다."

## 진단

- 기존 `hover:bg-accent` 는 hover-capable 디바이스에만 적용 → 모바일 터치 시 미발동
- `-webkit-tap-highlight-color` 기본 transparent

## 변경

`apps/web/src/app.css` 글로벌 룰 추가:

1. `html` 의 `-webkit-tap-highlight-color` 색조 적용 (light/dark/amoled 분리)
2. `@media (hover: none) and (pointer: coarse)` 안에서 `a[class*='hover:bg-accent']:active` → `background-color: var(--accent)`

→ 13개 list layout (compact/classic/detailed/gallery/...) + RecommendedPosts + ExplorePreview + RecentPosts 모두 자동 적용. 개별 컴포넌트 수정 X.

## 검증

- svelte-check 0 errors
- 모바일 터치 시 자유게시판 / 공감글 / 모아보기 항목에 즉시 시각적 피드백
- 데스크탑 hover 동작 회귀 없음 (`hover:bg-accent` 그대로 동작)

## 트레이드오프

- `var(--accent)` 값이 hover 와 동일 → 피드백이 더 명확해질 수도 있으나 디자인 톤 유지를 우선시