### PR TITLE
Treat legacy mb_intercept_date sentinels as active (#12386, #12383)

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/member.ts
+++ b/apps/web/src/lib/server/auth/oauth/member.ts
@@ -128,9 +128,15 @@ export async function updateLoginTimestamp(
     await invalidateMemberCache(mbId);
 }
 
-/** 회원이 활성 상태인지 확인 (탈퇴 + 이용제한 모두 체크)
- *  이용제한(mb_intercept_date)은 자동 복귀 없음. OAuth 콜백 단계에서 함께 차단.
+/** 회원이 활성 상태인지 확인 (탈퇴 + 이용제한 모두 체크).
+ *  - mb_leave_date 가 set 이면 탈퇴 → inactive.
+ *  - mb_intercept_date 는 빈 문자열 '' / null / '0000-00-00' 등 레거시 sentinel 을
+ *    모두 활성으로 간주 (#12386, #12383). 실제 이용제한은 YYYYMMDD 또는
+ *    YYYY-MM-DD 형식의 진짜 날짜만 차단 사유.
  */
 export function isMemberActive(member: MemberRow): boolean {
-    return !member.mb_leave_date && !member.mb_intercept_date;
+    if (member.mb_leave_date) return false;
+    const intercept = (member.mb_intercept_date ?? '').trim();
+    if (!intercept || intercept === '0000-00-00' || intercept === '00000000') return true;
+    return false;
 }


### PR DESCRIPTION
## 배경

P0 인증 회귀 — PR #1414 (`isMemberActive` 가 mb_intercept_date 도 체크) 머지 후 발생.

- **#12386**: PC 크롬 구글 로그인 → 로그인된 듯하다가 즉시 로그아웃 상태로 복귀, 무한 루프
- **#12383 #1**: Android Chrome 알림 페이지 새로고침 시 로그인>목록 무한 reload

## Root cause

`isMemberActive()` 의 `!member.mb_intercept_date` 가 GNUboard 의 레거시 sentinel 값 (`'0000-00-00'`, `'00000000'`) 도 **truthy** 로 간주 → 실제로 이용제한 안 된 일반 회원도 inactive 판정 → `/login?error=account_inactive` redirect 무한 loop.

## Fix

`apps/web/src/lib/server/auth/oauth/member.ts` 의 `isMemberActive`:

```typescript
if (member.mb_leave_date) return false;
const intercept = (member.mb_intercept_date ?? '').trim();
if (!intercept || intercept === '0000-00-00' || intercept === '00000000') return true;
return false;
```

- 빈 문자열 / null / '0000-00-00' / '00000000' → 활성
- 실제 YYYYMMDD/YYYY-MM-DD 진짜 날짜만 inactive

## 검증

- svelte-check 0 errors
- 즉시 검증 SQL: `SELECT mb_intercept_date, COUNT(*) FROM g5_member WHERE mb_leave_date='' GROUP BY mb_intercept_date;` — 빈 값/sentinel 분포 확인