### PR TITLE
fix(api): bypass browser HTTP cache in getBoardPosts (#12389, #12383)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -373,8 +373,10 @@ class ApiClient {
             params.set('summary', '1');
         }
 
+        // 브라우저 HTTP 캐시 우회 (PR #1404 캐시 정책 변경 후 RecentPosts 5/7 고정 회귀 — #12389/#12383)
         const response = await this.request<BackendResponse>(`/boards/${boardId}/posts?${params}`, {
-            signal: options?.signal
+            signal: options?.signal,
+            cache: 'no-store'
         });
 
         const backendData = response as unknown as BackendResponse;


### PR DESCRIPTION
## Summary
- `apiClient.getBoardPosts()` 가 `cache: 'no-store'` 없이 fetch 하던 탓에 브라우저 HTTP 캐시가 5/7 응답을 그대로 들고 있어 RecentPosts 위젯이 5/7 자 글로 고정되는 회귀 (#12389, #12383 #2).
- 1 라인 옵션 추가로 매 요청마다 서버 상태 반영.

## Test plan
- [ ] 5/7 이전 캐시가 남아있던 브라우저로 RecentPosts 위젯 노출 → 최신 글 갱신 확인
- [ ] 페이지 새로고침 시 RecentPosts 응답에 `Cache-Control: ...` 와 무관하게 매번 backend 호출 (Network 탭)

Refs #12389, #12383