### PR TITLE
feat(plugins): pwa-share plugin + header-actions-right slot (#12394)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ plugins/*
 !plugins/auto-embed/
 !plugins/payment/
 !plugins/ad-free/
+!plugins/pwa-share/
 !apps/web/src/routes/api/plugins/
 !apps/web/src/routes/admin/plugins/
 !apps/web/src/lib/plugins/

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -13,6 +13,7 @@
     import AlignJustify from '@lucide/svelte/icons/align-justify';
     import Mail from '@lucide/svelte/icons/mail';
     import Sidebar from './sidebar.svelte';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import {
         NotificationDropdown,
         LevelupCelebration,
@@ -473,6 +474,9 @@
                 <AlignJustify class="text-muted-foreground h-5 w-5" />
             </button>
             -->
+
+            <!-- 플러그인 슬롯: 헤더 우측 아이콘 그룹 끝 (pwa-share 등) -->
+            <PluginSlot name="header-actions-right" />
         </div>
     </div>
 </header>

--- a/plugins/pwa-share/components/pwa-share-button.svelte
+++ b/plugins/pwa-share/components/pwa-share-button.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { page } from '$app/stores';
+    import Share2 from '@lucide/svelte/icons/share-2';
+    import Link from '@lucide/svelte/icons/link';
+    import { toast } from 'svelte-sonner';
+    import { trackEvent } from '$lib/services/ga4.js';
+    import {
+        shareToFacebook,
+        shareToX,
+        shareToKakao,
+        shareToNaverBand,
+        shareToNaver,
+        shareToPinterest,
+        shareToTumblr,
+        copyUrl
+    } from '$lib/utils/share.js';
+
+    let isStandalone = $state(false);
+    let open = $state(false);
+
+    onMount(() => {
+        if (typeof window === 'undefined') return;
+        const mq = window.matchMedia('(display-mode: standalone)');
+        const navStandalone = (navigator as Navigator & { standalone?: boolean }).standalone;
+        isStandalone = mq.matches || navStandalone === true;
+        const onChange = (e: MediaQueryListEvent) => {
+            isStandalone = e.matches || navStandalone === true;
+        };
+        mq.addEventListener('change', onChange);
+        return () => mq.removeEventListener('change', onChange);
+    });
+
+    function getShareUrl(): string {
+        return typeof window !== 'undefined' ? window.location.href : $page.url.href;
+    }
+
+    function getShareTitle(): string {
+        return typeof document !== 'undefined' ? document.title : '다모앙';
+    }
+
+    function handleShare() {
+        open = !open;
+    }
+
+    function handleClickOutside(e: MouseEvent) {
+        const target = e.target as HTMLElement;
+        if (!target.closest('.pwa-share-dropdown')) {
+            open = false;
+        }
+    }
+
+    async function handleCopyUrl() {
+        const success = await copyUrl(getShareUrl());
+        if (success) {
+            trackEvent('share', { method: 'copy_url', source: 'pwa-header' });
+            toast.success('주소가 복사되었습니다.');
+        } else {
+            toast.error('주소 복사에 실패했습니다.');
+        }
+        open = false;
+    }
+
+    async function handleKakao() {
+        trackEvent('share', { method: 'kakao', source: 'pwa-header' });
+        const success = await shareToKakao(getShareTitle(), getShareUrl());
+        if (!success) {
+            toast.error('카카오톡 공유를 불러올 수 없습니다.');
+        }
+        open = false;
+    }
+
+    function handlePlatform(platform: string) {
+        trackEvent('share', { method: platform, source: 'pwa-header' });
+        const url = getShareUrl();
+        const title = getShareTitle();
+        switch (platform) {
+            case 'facebook':
+                shareToFacebook(url);
+                break;
+            case 'x':
+                shareToX(title, url);
+                break;
+            case 'band':
+                shareToNaverBand(title, url);
+                break;
+            case 'naver':
+                shareToNaver(title, url);
+                break;
+            case 'pinterest':
+                shareToPinterest(url, title);
+                break;
+            case 'tumblr':
+                shareToTumblr(url);
+                break;
+        }
+        open = false;
+    }
+
+    const platforms = [
+        { id: 'copy', label: 'URL 복사', color: '' },
+        { id: 'kakao', label: '카카오톡', color: 'bg-[#FEE500]' },
+        { id: 'x', label: 'X (Twitter)', color: 'bg-black dark:bg-white' },
+        { id: 'facebook', label: 'Facebook', color: 'bg-[#1877F2]' },
+        { id: 'band', label: 'Band', color: 'bg-[#06CF5E]' },
+        { id: 'naver', label: '네이버', color: 'bg-[#03C75A]' },
+        { id: 'pinterest', label: 'Pinterest', color: 'bg-[#E60023]' },
+        { id: 'tumblr', label: 'Tumblr', color: 'bg-[#35465C]' }
+    ] as const;
+</script>
+
+{#if isStandalone}
+    <svelte:window onclick={handleClickOutside} />
+
+    <div class="pwa-share-dropdown relative">
+        <button
+            type="button"
+            onclick={handleShare}
+            class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out"
+            aria-label="공유하기"
+            aria-expanded={open}
+        >
+            <span class="pointer-events-none absolute -inset-1"></span>
+            <Share2 class="text-muted-foreground h-5 w-5" />
+        </button>
+
+        {#if open}
+            <div
+                class="bg-popover absolute right-0 top-full z-50 mt-1 w-44 rounded-md border p-1 shadow-md"
+            >
+                {#each platforms as platform (platform.id)}
+                    <button
+                        class="hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-2.5 rounded-sm px-2.5 py-2 text-sm"
+                        onclick={() => {
+                            if (platform.id === 'copy') handleCopyUrl();
+                            else if (platform.id === 'kakao') handleKakao();
+                            else handlePlatform(platform.id);
+                        }}
+                    >
+                        {#if platform.id === 'copy'}
+                            <Link class="h-4 w-4 shrink-0" />
+                        {:else}
+                            <span
+                                class="inline-block h-4 w-4 shrink-0 rounded-sm {platform.color}"
+                            ></span>
+                        {/if}
+                        <span>{platform.label}</span>
+                    </button>
+                {/each}
+            </div>
+        {/if}
+    </div>
+{/if}

--- a/plugins/pwa-share/components/pwa-share-button.svelte
+++ b/plugins/pwa-share/components/pwa-share-button.svelte
@@ -109,9 +109,11 @@
     ] as const;
 </script>
 
-{#if isStandalone}
-    <svelte:window onclick={handleClickOutside} />
+<!-- Svelte 5: <svelte:window> 는 top-level 만 허용 (block 안 금지). isStandalone 가
+     false 일 때는 dropdown 자체가 미렌더라 handleClickOutside 호출돼도 open=false 라 noop. -->
+<svelte:window onclick={handleClickOutside} />
 
+{#if isStandalone}
     <div class="pwa-share-dropdown relative">
         <button
             type="button"
@@ -140,8 +142,7 @@
                         {#if platform.id === 'copy'}
                             <Link class="h-4 w-4 shrink-0" />
                         {:else}
-                            <span
-                                class="inline-block h-4 w-4 shrink-0 rounded-sm {platform.color}"
+                            <span class="inline-block h-4 w-4 shrink-0 rounded-sm {platform.color}"
                             ></span>
                         {/if}
                         <span>{platform.label}</span>

--- a/plugins/pwa-share/components/pwa-share-button.svelte
+++ b/plugins/pwa-share/components/pwa-share-button.svelte
@@ -3,7 +3,7 @@
     import { page } from '$app/stores';
     import Share2 from '@lucide/svelte/icons/share-2';
     import Link from '@lucide/svelte/icons/link';
-    import { toast } from 'svelte-sonner';
+    // svelte-sonner 는 plugin 경로에서 Rollup 이 resolve 못 함 → 단순 alert 로 대체.
     import { trackEvent } from '$lib/services/ga4.js';
     import {
         shareToFacebook,
@@ -54,9 +54,9 @@
         const success = await copyUrl(getShareUrl());
         if (success) {
             trackEvent('share', { method: 'copy_url', source: 'pwa-header' });
-            toast.success('주소가 복사되었습니다.');
+            alert('주소가 복사되었습니다.');
         } else {
-            toast.error('주소 복사에 실패했습니다.');
+            alert('주소 복사에 실패했습니다.');
         }
         open = false;
     }
@@ -65,7 +65,7 @@
         trackEvent('share', { method: 'kakao', source: 'pwa-header' });
         const success = await shareToKakao(getShareTitle(), getShareUrl());
         if (!success) {
-            toast.error('카카오톡 공유를 불러올 수 없습니다.');
+            alert('카카오톡 공유를 불러올 수 없습니다.');
         }
         open = false;
     }

--- a/plugins/pwa-share/plugin.json
+++ b/plugins/pwa-share/plugin.json
@@ -1,0 +1,22 @@
+{
+    "id": "pwa-share",
+    "name": "PWA 공유 버튼",
+    "version": "1.0.0",
+    "category": "plugin",
+    "description": "PWA standalone 모드(주소창 숨김 상태)에서 헤더에 현재 페이지를 공유/복사할 수 있는 버튼을 노출합니다.",
+    "author": {
+        "name": "Damoang Team",
+        "url": "https://damoang.net"
+    },
+    "components": [
+        {
+            "id": "pwa-share-button",
+            "name": "PWA 공유 버튼",
+            "slot": "header-actions-right",
+            "path": "components/pwa-share-button.svelte",
+            "priority": 10
+        }
+    ],
+    "tags": ["공유", "PWA", "웹앱"],
+    "marketplaceCategory": "utility"
+}


### PR DESCRIPTION
## Summary
- Adds new slot `header-actions-right` at the end of the header's right-side icon group
- Introduces `plugins/pwa-share/` — the codebase's first UI-extension plugin — which injects a Share button into that slot
- Plugin detects PWA standalone mode (`display-mode: standalone` or `navigator.standalone`) and only renders the button when the browser address bar is hidden. Non-PWA users see no UI change.
- Reuses existing share utilities (URL copy + Kakao/X/Facebook/Band/Naver/Pinterest/Tumblr); shares `window.location.href` so every route (including `/disciplinelog/[id]`, `/empathy/[date]`, `/member/[id]`) is covered without touching those pages.

## Why
Bug #12394: PWA users can't copy URL because address bar is hidden, and special detail routes (e.g. `/disciplinelog/3661`) have no share button at all.

## Why a plugin (not core)
First UI-extension plugin in the codebase. The infrastructure (`slot-manager`, `plugin-component-loader`, `+layout.svelte` plugin loader) was already in place — we only needed one new slot name and a plugin manifest. This establishes the pattern for future header/footer/sidebar UI plugins.

## Files
- `apps/web/src/lib/components/slot-manager.ts` — 1 line (new `header-actions-right` slot name)
- `apps/web/src/lib/components/layout/header.svelte` — 2 lines (import + `<PluginSlot name="header-actions-right" />`)
- `.gitignore` — 1 line (track new plugin)
- `plugins/pwa-share/plugin.json` — manifest
- `plugins/pwa-share/components/pwa-share-button.svelte` — button + dropdown UI (PWA-only render guard inside)

## Test plan
- [ ] Admin > Plugins 에서 `pwa-share` 가 목록에 노출 + 활성화 가능
- [ ] 일반 브라우저 (주소창 있음): 헤더에 공유 버튼 안 보임
- [ ] PWA standalone 시뮬레이션 (Chrome DevTools > Rendering > Emulate CSS media feature: `display-mode: standalone`): 헤더 우측에 공유 버튼 노출
- [ ] 버튼 클릭 → 드롭다운, "URL 복사" 클릭 → toast + clipboard 확인
- [ ] `/disciplinelog/3661` 같은 특수 페이지에서도 정상 동작
- [ ] `/[boardId]/[postId]` 페이지에서 기존 share-button 과 시각 충돌 없음 (역할: 헤더 = 글로벌, 포스트 푸터 = 페이지 단위)
- [ ] Plugin 토글 시 헤더 UI 즉시 반영 (slot version subscribe)
- [ ] CI: svelte-check / lint / build 통과

Refs #12394