### PR TITLE
feat(comments): point-charge confirm before edit (#12401 follow-up)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -95,6 +95,8 @@
         initialDislikedCommentIds?: number[]; // SSR에서 전달된 비추천한 댓글 ID 목록
         truthroomCommentMap?: Record<number, number>; // 잠긴 댓글 → 진실의방 글 ID 매핑
         isRestricted?: boolean; // 제한된 유저 (영구정지 등)
+        // 댓글 수정 정책 (단일 진실 근원: 백엔드 env). 미전달 시 default 사용 (코드 하드코딩 금지 — 부모가 API 메타에서 받아 전달).
+        editPolicy?: { cost: number; grace_seconds: number };
     }
 
     let {
@@ -114,7 +116,8 @@
         initialLikedCommentIds = [],
         initialDislikedCommentIds = [],
         truthroomCommentMap = {},
-        isRestricted = false
+        isRestricted = false,
+        editPolicy = { cost: 50000, grace_seconds: 300 }
     }: Props = $props();
 
     function findCommentById(commentId: string): FreeComment | null {
@@ -439,9 +442,26 @@
         return editEditorLoadPromise;
     }
 
-    // 수정 모드 시작
+    // 수정 모드 시작 — 비-관리자, grace 윈도우 밖, 비용 > 0 일 때 포인트 차감 안내 confirm
     function startEdit(comment: FreeComment): void {
         const target = commentTree.find((c) => c.id === comment.id) ?? comment;
+
+        if (!isAdmin() && editPolicy.cost > 0) {
+            const createdAtMs = new Date(target.created_at).getTime();
+            const elapsedSec = (Date.now() - createdAtMs) / 1000;
+            const inGrace = elapsedSec <= editPolicy.grace_seconds;
+            if (!inGrace) {
+                const graceMin = Math.floor(editPolicy.grace_seconds / 60);
+                const costFmt = editPolicy.cost.toLocaleString('ko-KR');
+                const msg =
+                    `이 댓글을 수정하면 ${costFmt} 포인트가 차감되며,\n` +
+                    `수정 시각과 수정 횟수가 모든 사용자에게 표시됩니다.\n\n` +
+                    `(작성 후 ${graceMin}분 이내 수정은 무료입니다.)\n\n` +
+                    `계속 진행하시겠습니까?`;
+                if (!window.confirm(msg)) return;
+            }
+        }
+
         editingCommentId = String(target.id);
         editContent = target.content;
         replyingToCommentId = null;


### PR DESCRIPTION
## Summary
백엔드 PR damoang/angple-backend#468 의 "댓글 수정 50,000P 차감 + 5분 grace" 정책에 맞춰 프론트엔드에서 수정 버튼 클릭 시 **포인트 차감 안내 confirm 다이얼로그** 추가.

## Changes
`apps/web/src/lib/components/features/board/comment-list.svelte`:
- `Props.editPolicy?: { cost: number; grace_seconds: number }` 추가 (단일 진실 근원: 백엔드 env. 부모는 댓글 list API 응답의 `meta.comment_edit_policy` 전달, 미전달 시 백엔드와 동일한 default 50000/300)
- `startEdit()` 에 confirm 다이얼로그 — **관리자 / grace 윈도우 / cost=0 케이스는 스킵**
- 안내 문구: "<cost> 포인트가 차감되며, 수정 시각과 수정 횟수가 모든 사용자에게 표시됩니다. (작성 후 N분 이내 수정은 무료입니다.)"

## Behavior matrix
| 케이스 | 다이얼로그 |
|---|---|
| 관리자 (mb_level ≥ 10) | 스킵 (백엔드 면제와 일치) |
| Grace 윈도우 안 (≤300s) | 스킵 |
| Grace 윈도우 밖 + cost > 0 | 표시, 취소 시 편집 모드 진입 안 함 |
| cost = 0 (kill switch) | 스킵 |

## Follow-up
- 부모 `+page.svelte` 에서 `meta.comment_edit_policy` 받아 prop 으로 전달 — 별도 PR (이번엔 default 값만으로 동작)

## Test plan
- [ ] 자식 없는 본인 댓글, 작성 1분 후 수정 클릭 → 다이얼로그 미표시 (grace)
- [ ] 자식 없는 본인 댓글, 작성 10분 후 수정 클릭 → 다이얼로그 표시, 취소 시 편집 안 됨
- [ ] 다이얼로그 확인 클릭 → 편집 모드 진입
- [ ] 관리자 계정 → 다이얼로그 미표시
- [ ] svelte-check 신규 에러 0

Refs #12401