### PR TITLE
fix(auth): allow intercepted members to log in — only withdrawal blocks (소명 권리 보장)

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/member.ts
+++ b/apps/web/src/lib/server/auth/oauth/member.ts
@@ -128,15 +128,17 @@ export async function updateLoginTimestamp(
     await invalidateMemberCache(mbId);
 }
 
-/** 회원이 활성 상태인지 확인 (탈퇴 + 이용제한 모두 체크).
- *  - mb_leave_date 가 set 이면 탈퇴 → inactive.
- *  - mb_intercept_date 는 빈 문자열 '' / null / '0000-00-00' 등 레거시 sentinel 을
- *    모두 활성으로 간주 (#12386, #12383). 실제 이용제한은 YYYYMMDD 또는
- *    YYYY-MM-DD 형식의 진짜 날짜만 차단 사유.
+/** 로그인 차단 사유는 "탈퇴" 한 가지만. 이용제한(mb_intercept_date) 은 로그인 차단 사유가 아님.
+ *
+ *  운영 정책 (2026-05-15):
+ *  - **탈퇴자(mb_leave_date set)만 OAuth 로그인 차단**.
+ *  - 이용제한(mb_intercept_date 가 진짜 날짜) 회원도 로그인은 허용 — 본인이 소명할 수
+ *    있어야 하기 때문. 글/댓글 작성 같은 활동 제한은 별도 ban-check 미들웨어가 담당.
+ *  - 자발적 탈퇴(reason='self' 또는 빈 값) 의 자동 복귀는 updateLoginTimestamp 가 처리.
+ *  - 관리자 처리 탈퇴(admin / terms_violation / contract_withdrawal / account_abuse) 는
+ *    PROTECTED_REASONS 가 mb_leave_date 를 보존 → 이 함수에서 false 반환 → 로그인 차단.
  */
 export function isMemberActive(member: MemberRow): boolean {
     if (member.mb_leave_date) return false;
-    const intercept = (member.mb_intercept_date ?? '').trim();
-    if (!intercept || intercept === '0000-00-00' || intercept === '00000000') return true;
-    return false;
+    return true;
 }


### PR DESCRIPTION
## Summary
운영진 정책 (2026-05-15): **이용제한(정지) 회원도 OAuth 로그인은 허용** — 본인이 소명할 수 있어야 하기 때문. 글/댓글 작성 제한은 별도 ban-check 미들웨어 담당.

## Problem
이전 `isMemberActive()` 는 `mb_intercept_date` 가 빈 값/sentinel(`0000-00-00`,`00000000`) 이외의 진짜 날짜면 `false` 반환 → OAuth callback 에서 `account_inactive` 로 리다이렉트 → 정지된 회원이 소명조차 못 함. 정지 해제 후에도 sentinel 정규화 갭으로 잠겨있는 경우 발생.

## Fix
`isMemberActive(member)` 단순화 — **`mb_leave_date` 만 체크**:
- 자발적 탈퇴 (reason `self` 또는 빈 값): 기존 `updateLoginTimestamp` 가 다음 로그인 시 mb_leave_date 클리어 → 자동 복구
- 관리자 처리 탈퇴 (`admin` / `terms_violation` / `contract_withdrawal` / `account_abuse`): `PROTECTED_REASONS` 가 mb_leave_date 보존 → 여기서 `false` 반환 → 로그인 차단 유지
- 이용제한 (`mb_intercept_date` 진짜 날짜): **로그인 허용** (이전엔 차단)

## Behavior matrix
| 상태 | 이전 | 이후 |
|---|---|---|
| 탈퇴 (보호된 reason) | 차단 | 차단 (유지) |
| 탈퇴 (self / 빈 reason) | 자동 복구 후 통과 | 자동 복구 후 통과 (유지) |
| 이용제한 활성 (진짜 날짜) | **차단** | **허용** |
| 이용제한 해제 (빈 문자열) | 통과 | 통과 (유지) |
| 레거시 sentinel | 통과 | 통과 (유지) |

## Not in scope
- 글/댓글 작성 등 활동 제한은 backend `ban-check` 미들웨어가 그대로 처리 (`mb_intercept_date` 진짜 날짜 → 403)
- `mb_intercept_date` sentinel 데이터 정리는 별도 batch (선택)

## Test plan
- [ ] 정지된 회원 OAuth 로그인 → 성공 + 글 작성 시도 시 403 (ban-check)
- [ ] 정지 해제된 회원 (`mb_intercept_date=''`) → 로그인 + 글 작성 모두 성공
- [ ] 관리자 처리 탈퇴 회원 → 로그인 차단 유지
- [ ] 자발적 탈퇴 회원 → 자동 복구 후 로그인 성공
- [ ] svelte-check / lint 통과