### PR TITLE
fix(post-detail): re-mount RecentPosts per post.id (#12409 #12413)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2028,9 +2028,13 @@
      posts state 가 남아있다가 잘못된 URL 로 이동하는 문제 방지 -->
 <!-- #12048: 본문 wrapper 외부의 RecentPosts 가 일부 모바일 환경(Samsung Internet/다뷰)
      에서 가로 스크롤 유발. 동일한 overflow-x cascade 폴백 + clip 적용. -->
+<!-- #12409 + #12413: 같은 게시판 내 다른 글로 SPA navigation 시 key 가 변하지 않아
+     RecentPosts 가 재마운트되지 않고 onMount 가 재실행되지 않음 → 이전 글 진입 시점의
+     initialPage(보통 1) 가 stale 상태로 남아 항상 1페이지가 표시되는 회귀.
+     post.id 를 key 에 포함시켜 글 이동마다 RecentPosts 를 재마운트, URL ?page=N 반영. -->
 {#if canRead}
     <div style="overflow-x: hidden; overflow-x: clip;">
-        {#key boardId}
+        {#key `${boardId}:${data.post.id}`}
             <RecentPosts
                 {boardId}
                 {boardTitle}


### PR DESCRIPTION
## Summary
글 상세 하단의 RecentPosts 가 어떤 글에 진입해도 항상 1페이지를 표시하는 회귀 (#12409 + #12413) 수정.

## Root cause
`{#key boardId}` 만 사용해서, 같은 게시판 안에서 글 → 다른 글 SPA navigation 시 key 가 변하지 않아 RecentPosts 가 **재마운트되지 않음**. `onMount` 가 재실행되지 않으니 URL 의 `?page=N` 도 다시 읽지 않음 → 처음 글 진입 시점의 initialPage (보통 외부 진입 = 1) 가 stale 상태로 고정.

## Fix
`{#key boardId}` → `{#key `${boardId}:${data.post.id}`}` 로 변경. 글 이동마다 RecentPosts 가 새 인스턴스로 마운트되어 onMount 가 현재 URL 의 `?page=N` 으로 backend fetch.

목록 → 글 상세 링크의 `?page=N` 보존 ([boardId]/+page.svelte:1268) + 글 상세에서 RecentPosts initialPage 우선순위 (URL → SSR → 1) 는 모두 이미 정상이라, 본 PR 한 줄로 체인 복원.

## Trade-off
같은 게시판 글 → 글 이동마다 RecentPosts fetch 1회 추가. PR #1427 에서 `cache: 'no-store'` 로 이미 브라우저 캐시 우회 중이라 backend 1회만 호출. 모바일 삼성인터넷 + 데스크탑 양쪽 모두 회복.

## Test plan
- [ ] 자유게시판 5페이지 → 글 클릭 → 하단 RecentPosts 가 5페이지 표시 + 페이지 indicator 가 5
- [ ] 그 글에서 RecentPosts 의 다른 글 클릭 → 새 글의 하단 RecentPosts 도 동일 페이지 표시
- [ ] 외부 진입 (메인/검색/알림) → 하단 RecentPosts 1페이지 (기존 동작)
- [ ] 모바일 삼성인터넷 동작 확인
- [ ] svelte-check / lint 통과

Refs #12409, #12413