### PR TITLE
fix(seo): OG image fallback when post has no image (#12417)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -16,6 +16,7 @@
 
 <script lang="ts">
     import { browser } from '$app/environment';
+    import { env as publicEnv } from '$env/dynamic/public';
     import { afterNavigate, goto } from '$app/navigation';
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
@@ -1433,10 +1434,14 @@
             ? `${siteUrl}/member/${data.post.author_id}`
             : undefined;
         // OG 이미지: 캐시버스팅으로 소셜 미디어 stale preview 방지
+        // 본문에 이미지가 없으면 PUBLIC_OG_FALLBACK_IMAGE (운영에서 사이트 로고 URL 설정) 로
+        // 대체. fallback 미설정 시 og:image 가 누락되어 크롤러가 페이지 안의 임의 이미지
+        // (작성자 프로필, 댓글자 아바타 등) 를 썸네일로 잡아가는 문제 (#12417) 발생.
         const rawOgImage = data.post.thumbnail || data.post.images?.[0];
+        const fallbackOgImage = publicEnv.PUBLIC_OG_FALLBACK_IMAGE || undefined;
         const ogImageUrl = rawOgImage
             ? `${rawOgImage}${rawOgImage.includes('?') ? '&' : '?'}v=${new Date(data.post.updated_at || data.post.created_at).getTime()}`
-            : undefined;
+            : fallbackOgImage;
 
         return {
             meta: {


### PR DESCRIPTION
## Summary
본문 이미지가 없는 글의 OG 썸네일이 작성자/댓글자 프로필 이미지로 잘못 잡히는 회귀 수정 (#12417).

## Root cause
`og:image` 가 비어있으면 카카오/페이스북 등 크롤러가 페이지 렌더링 결과에서 임의의 `<img>` 를 골라 썸네일로 사용. 다모앙 페이지 안에서 작성자 아바타 또는 (영상만 있는 글의 경우) 댓글자 아바타가 첫 이미지로 선택됨.

## Fix
`PUBLIC_OG_FALLBACK_IMAGE` env var 도입. 본문 이미지가 없을 때 이 값으로 `og.image` / `twitter.image` / JSON-LD `image` 모두 채움.

- 운영(다모앙): 환경 변수에 사이트 로고 절대 URL 설정 후 rollout → 카톡 미리보기에 로고 표시
- 코어 오픈소스: env 미설정 시 기존 동작 (og:image 누락) 유지 → angple 을 채택한 다른 사이트에 영향 없음

## Files
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` — env import + ogImageUrl fallback

## Test plan
- [ ] 본문에 이미지 있는 글: 기존 동작 (post 이미지 + 캐시버스팅)
- [ ] 본문 이미지 없음 + env 설정: og:image 가 로고 URL
- [ ] 본문 이미지 없음 + env 미설정: og:image 누락 (코어 default)
- [ ] 카톡/슬랙/디스코드 미리보기 확인 (운영 반영 후)
- [ ] svelte-check / lint 통과

Refs #12417