### PR TITLE
fix(board): scheduled-delete badge in compact/webzine/detailed list layouts (#12415)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/_shared/scheduled-delete-badge.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/_shared/scheduled-delete-badge.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { Badge } from '$lib/components/ui/badge/index.js';
+
+    interface Props {
+        scheduledDeleteAt?: string | null;
+    }
+
+    let { scheduledDeleteAt }: Props = $props();
+</script>
+
+{#if scheduledDeleteAt}
+    <Badge
+        variant="outline"
+        class="shrink-0 border-amber-300 bg-amber-50 px-1.5 py-0 text-[10px] text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+        title={`삭제 예정: ${scheduledDeleteAt}`}>삭제예정</Badge
+    >
+{/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
@@ -87,6 +88,7 @@
                             >19</Badge
                         >
                     {/if}
+                    <ScheduledDeleteBadge scheduledDeleteAt={post.scheduled_delete_at} />
                     {#if post.is_secret}
                         <Lock class="text-muted-foreground h-4 w-4 shrink-0" />
                     {/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
@@ -59,6 +60,7 @@
                                     class="shrink-0 px-1.5 py-0 text-[10px]">19</Badge
                                 >
                             {/if}
+                            <ScheduledDeleteBadge scheduledDeleteAt={post.scheduled_delete_at} />
                             {#if post.is_secret}
                                 <Lock class="text-muted-foreground h-4 w-4 shrink-0" />
                             {/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
@@ -99,6 +100,7 @@
                                 >19</Badge
                             >
                         {/if}
+                        <ScheduledDeleteBadge scheduledDeleteAt={post.scheduled_delete_at} />
                         {#if post.is_secret}
                             <Lock class="text-muted-foreground h-4 w-4 shrink-0" />
                         {/if}


### PR DESCRIPTION
## Summary
PR #1240 가 classic / card layout 에만 '삭제예정' 뱃지를 넣어서 다른 layout (compact 가 free 기본) 게시판에서는 표시되지 않는 누락 보강 (#12415).

## Changes
- 공통 컴포넌트 `list/_shared/scheduled-delete-badge.svelte` 신설 (amber 팔레트 + tooltip, classic/card 인라인 패턴과 동일)
- `compact.svelte` / `webzine.svelte` / `detailed.svelte` 에 import + `<ScheduledDeleteBadge scheduledDeleteAt={post.scheduled_delete_at} />` 삽입 — is_secret 잠금 아이콘 직전 위치
- gallery / poster-gallery / archive 는 이미지 중심이라 is_secret indicator 도 없음 → 별도 follow-up

## Test plan
- [ ] 자유게시판 (compact) 에서 scheduled_delete_at 있는 글 → 제목 옆에 amber '삭제예정' 뱃지
- [ ] webzine / detailed layout 사용 게시판 동일 표시
- [ ] scheduled_delete_at 없는 글 → 뱃지 미표시 (현 동작 유지)
- [ ] classic / card 기존 인라인 뱃지 변동 없음
- [ ] svelte-check / lint 통과

Refs #12415, #11825