### PR TITLE
feat(ad-free): 광고 제거 멤버십 플러그인 + should_render_ad hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ plugins/*
 !plugins/affiliate-link-private/
 !plugins/auto-embed/
 !plugins/payment/
+!plugins/ad-free/
 !apps/web/src/routes/api/plugins/
 !apps/web/src/routes/admin/plugins/
 !apps/web/src/lib/plugins/

--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -1,5 +1,10 @@
 import type { HandleClientError } from '@sveltejs/kit';
 import { replaceState } from '$app/navigation';
+import { loadAllPluginClientHooks } from '$lib/client/plugin-client-loader';
+
+// Phase 11 (open-core plugin loader) — client hooks 자동 활성화.
+// Fire-and-forget: 실패해도 앱 부팅에 영향 없음. 모듈 load 시점 1회 실행.
+void loadAllPluginClientHooks();
 
 const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
 

--- a/apps/web/src/lib/client/plugin-client-loader.ts
+++ b/apps/web/src/lib/client/plugin-client-loader.ts
@@ -1,0 +1,46 @@
+/**
+ * Plugin Client Hook Loader — WP `add_filter`/`add_action` 클라이언트 측 자동 활성화.
+ *
+ * `plugins/&#42;&#42;/hooks/*.client.{ts,js}` 글로브 매칭 파일을 브라우저 부팅 시 1회
+ * 동적 import → 각 파일의 top-level addFilter/addAction side-effect 가 실행된다.
+ * server 측 `plugin-server-loader.ts` 의 client 짝.
+ *
+ * 호출 시점: `hooks.client.ts` 모듈 load 직후 (앱 최초 hydration 전).
+ */
+
+// Vite glob — `.client.ts` 만 (서버 번들 유입 차단).
+const clientHooks = import.meta.glob('../../../../../plugins/**/hooks/*.client.{ts,js}');
+const customClientHooks = import.meta.glob(
+    '../../../../../custom-plugins/**/hooks/*.client.{ts,js}'
+);
+
+const allClientHooks = { ...clientHooks, ...customClientHooks };
+
+/** Idempotency — 한번 로드된 경로는 재import 안 함 (singleton registry 중복 방지). */
+const loadedPaths = new Set<string>();
+
+/**
+ * 모든 plugin client hooks 자동 로드.
+ * 호출 시점: hooks.client.ts 모듈 load 직후 (최초 hydration 전).
+ */
+export async function loadAllPluginClientHooks(): Promise<void> {
+    for (const [path, loader] of Object.entries(allClientHooks)) {
+        if (loadedPaths.has(path)) continue;
+        try {
+            await loader();
+            loadedPaths.add(path);
+        } catch (err) {
+            console.error(`[Plugin Client Loader] Failed: ${path}`, err);
+        }
+    }
+}
+
+/** 로드된 hook 파일 수 (모니터링/디버깅용). */
+export function getLoadedClientHookCount(): number {
+    return loadedPaths.size;
+}
+
+/** 로드된 hook 파일 경로 리스트 (디버깅용). */
+export function getLoadedClientHookPaths(): string[] {
+    return Array.from(loadedPaths);
+}

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -31,6 +31,7 @@
     import { ensureGAMPreload } from './ad-slot-registry.js';
     import { trackAdEvent, isAdSdkBlocked } from '$lib/services/ad-telemetry.js';
     import { page } from '$app/stores';
+    import { hooks } from '@angple/hook-system';
 
     /**
      * Watchdog: `attachSlot` 후 N ms 내 `slotRenderEnded` 가 도착하지 않으면
@@ -39,15 +40,6 @@
      * 12s 는 audit 권장값. lazyLoad fetchMargin=400% 이라 일반 광고는 충분히 먼저 응답.
      */
     const AD_WATCHDOG_MS = 12_000;
-
-    /** 삭제된 글/비밀글/성인 키워드 글/차단 작가 글 상세 페이지에서는 모든 광고를 숨김 (애드센스 정책) */
-    const isDeletedPost = $derived(!!($page as any).data?.post?.deleted_at);
-    const isSecretPost = $derived(!!($page as any).data?.post?.is_secret);
-    const isAdultPost = $derived(!!($page as any).data?.post?.is_adult);
-    const isSuppressedAuthor = $derived(!!($page as any).data?.post?.suppress_ads);
-    const suppressAds = $derived(
-        isDeletedPost || isSecretPost || isAdultPost || isSuppressedAuthor
-    );
 
     interface Props {
         position: string;
@@ -58,6 +50,22 @@
     }
 
     let { position, height = '90px', class: className = '', sizes, slotKey }: Props = $props();
+
+    /** 삭제된 글/비밀글/성인 키워드 글/차단 작가 글 상세 페이지에서는 모든 광고를 숨김 (애드센스 정책) */
+    const isDeletedPost = $derived(!!($page as any).data?.post?.deleted_at);
+    const isSecretPost = $derived(!!($page as any).data?.post?.is_secret);
+    const isAdultPost = $derived(!!($page as any).data?.post?.is_adult);
+    const isSuppressedAuthor = $derived(!!($page as any).data?.post?.suppress_ads);
+    // WP 모델: 플러그인이 should_render_ad filter 에 등록 → false 반환 시 광고 OFF (ad-free 멤버십 등)
+    const pluginSuppress = $derived(
+        hooks.applyFilters('should_render_ad', true, {
+            slotName: position,
+            user: ($page as any).data?.user ?? null
+        }) === false
+    );
+    const suppressAds = $derived(
+        isDeletedPost || isSecretPost || isAdultPost || isSuppressedAuthor || pluginSuppress
+    );
 
     const BTF_POSITIONS = new Set([
         'board-list-bottom',

--- a/apps/web/src/routes/ad-free/+page.server.ts
+++ b/apps/web/src/routes/ad-free/+page.server.ts
@@ -1,0 +1,7 @@
+import type { PageServerLoad } from './$types';
+import { loadLanding } from '$plugins/ad-free/server/loaders';
+
+// Shim — 모든 로직은 $plugins/ad-free/ 안. 이 파일은 라우트 마운트 슬롯.
+export const load: PageServerLoad = async () => {
+    return await loadLanding({ siteId: 'default' });
+};

--- a/apps/web/src/routes/ad-free/+page.svelte
+++ b/apps/web/src/routes/ad-free/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    // Shim — 본문은 $plugins/ad-free/views/Landing.svelte
+    import Landing from '$plugins/ad-free/views/Landing.svelte';
+    let { data } = $props();
+</script>
+
+<Landing {data} />

--- a/apps/web/src/routes/ad-free/checkout/+page.server.ts
+++ b/apps/web/src/routes/ad-free/checkout/+page.server.ts
@@ -1,0 +1,21 @@
+import type { PageServerLoad } from './$types';
+import { loadCheckout } from '$plugins/ad-free/server/loaders';
+
+// Shim — 비회원도 진입 가능. 회원이면 user 정보 prefill, 비회원이면 guest 폼.
+export const load: PageServerLoad = async ({ locals, url }) => {
+    const planParam = url.searchParams.get('plan');
+    const initialPlan: 'monthly' | 'half_yearly' =
+        planParam === 'monthly' || planParam === 'half_yearly' ? planParam : 'monthly';
+    const data = await loadCheckout({ siteId: 'default', initialPlan });
+    const user = (locals as any).user;
+    return {
+        ...data,
+        isGuest: !user?.mb_id,
+        prefill: user
+            ? {
+                  email: user.mb_email ?? '',
+                  nickname: user.mb_nickname ?? user.mb_nick ?? user.mb_id ?? ''
+              }
+            : { email: '', nickname: '' }
+    };
+};

--- a/apps/web/src/routes/ad-free/checkout/+page.svelte
+++ b/apps/web/src/routes/ad-free/checkout/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    // Shim — 본문은 $plugins/ad-free/views/Checkout.svelte
+    import Checkout from '$plugins/ad-free/views/Checkout.svelte';
+    let { data } = $props();
+</script>
+
+<Checkout {data} />

--- a/apps/web/src/routes/ad-free/refund-policy/+page.svelte
+++ b/apps/web/src/routes/ad-free/refund-policy/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+    // Shim — 본문은 $plugins/ad-free/views/RefundPolicy.svelte
+    import RefundPolicy from '$plugins/ad-free/views/RefundPolicy.svelte';
+</script>
+
+<RefundPolicy />

--- a/apps/web/src/routes/api/plugins/ad-free/guest-checkout/+server.ts
+++ b/apps/web/src/routes/api/plugins/ad-free/guest-checkout/+server.ts
@@ -1,0 +1,19 @@
+import type { RequestHandler } from './$types';
+import { json } from '@sveltejs/kit';
+import {
+    handleGuestCheckout,
+    type GuestCheckoutInput
+} from '$plugins/ad-free/server/guest-checkout';
+
+// Shim — 본문은 $plugins/ad-free/server/guest-checkout.ts
+export const POST: RequestHandler = async ({ request }) => {
+    let body: GuestCheckoutInput;
+    try {
+        body = (await request.json()) as GuestCheckoutInput;
+    } catch {
+        return json({ status: 'error', message: '잘못된 요청 형식입니다.' }, { status: 400 });
+    }
+    const result = await handleGuestCheckout(body);
+    const status = result.status === 'error' ? 400 : 200;
+    return json(result, { status });
+};

--- a/apps/web/src/routes/api/plugins/ad-free/me/+server.ts
+++ b/apps/web/src/routes/api/plugins/ad-free/me/+server.ts
@@ -1,0 +1,13 @@
+import type { RequestHandler } from './$types';
+import { json } from '@sveltejs/kit';
+import { getMembership } from '$plugins/ad-free/server/membership-api';
+
+// Shim — 본문은 $plugins/ad-free/server/membership-api.ts
+export const GET: RequestHandler = async ({ locals }) => {
+    const user = (locals as any).user;
+    if (!user?.mb_id) {
+        return json({ error: 'unauthorized' }, { status: 401 });
+    }
+    const membership = await getMembership(user.mb_id, 'default');
+    return json(membership);
+};

--- a/packages/hook-system/src/types.ts
+++ b/packages/hook-system/src/types.ts
@@ -59,4 +59,7 @@ export interface FilterPoints {
     // API 응답
     api_response: [response: any, endpoint: string];
     api_error: [error: any, endpoint: string];
+
+    // 광고 렌더 결정 — 플러그인이 false 반환 시 AdSlot 미렌더 (ad-free 멤버십 등)
+    should_render_ad: [ctx: { slotName: string; user: any }];
 }

--- a/plugins/ad-free/hooks/suppress.client.ts
+++ b/plugins/ad-free/hooks/suppress.client.ts
@@ -1,0 +1,12 @@
+/**
+ * Client-side register — plugin-client-loader 의 import.meta.glob 가 자동 import.
+ * 브라우저 부팅 (hooks.client.ts) 시 module load → top-level addFilter 실행.
+ * 이로써 CSR hydration 후 reactive 재평가에서도 광고 OFF 가 유지된다.
+ */
+import { hooks } from '@angple/hook-system';
+import { suppressAdsForAdFreeMember } from './suppress';
+
+hooks.addFilter('should_render_ad', suppressAdsForAdFreeMember as never, 10);
+
+export { suppressAdsForAdFreeMember };
+export type { AdFreeFilterCtx } from './suppress';

--- a/plugins/ad-free/hooks/suppress.server.ts
+++ b/plugins/ad-free/hooks/suppress.server.ts
@@ -1,0 +1,11 @@
+/**
+ * Server-side register — plugin-server-loader 의 import.meta.glob 가 자동 import.
+ * SSR 부팅 시 module load → top-level addFilter 실행 (WP add_filter 동치).
+ */
+import { hooks } from '@angple/hook-system';
+import { suppressAdsForAdFreeMember } from './suppress';
+
+hooks.addFilter('should_render_ad', suppressAdsForAdFreeMember as never, 10);
+
+export { suppressAdsForAdFreeMember };
+export type { AdFreeFilterCtx } from './suppress';

--- a/plugins/ad-free/hooks/suppress.ts
+++ b/plugins/ad-free/hooks/suppress.ts
@@ -1,0 +1,29 @@
+/**
+ * should_render_ad filter — pure callback + 타입 정의 (DRY).
+ *
+ * `.server.ts` / `.client.ts` 두 register 파일이 이 모듈을 import 한 뒤 각자
+ * server / client hook instance 에 addFilter 한다. SvelteKit 규약상 `.server.ts`
+ * 는 client 번들에 들어가지 않으므로 callback 자체는 plain 모듈로 둔다.
+ */
+
+export interface AdFreeFilterCtx {
+    slotName: string;
+    user: {
+        ad_free_until?: string | Date | null;
+        [k: string]: unknown;
+    } | null;
+}
+
+/**
+ * - 다른 플러그인이 이미 false → 그대로 false (체이닝 보존)
+ * - user.ad_free_until > now → false (광고 OFF)
+ * - 그 외 → 입력값 그대로 (default true)
+ */
+export function suppressAdsForAdFreeMember(value: boolean, ctx: AdFreeFilterCtx): boolean {
+    if (value === false) return false;
+    const until = ctx?.user?.ad_free_until;
+    if (!until) return value;
+    const expires = until instanceof Date ? until : new Date(until);
+    if (Number.isNaN(expires.getTime())) return value;
+    return expires.getTime() > Date.now() ? false : value;
+}

--- a/plugins/ad-free/hooks/tests/suppress.test.ts
+++ b/plugins/ad-free/hooks/tests/suppress.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { suppressAdsForAdFreeMember, type AdFreeFilterCtx } from '../suppress';
+
+function ctx(user: AdFreeFilterCtx['user']): AdFreeFilterCtx {
+    return { slotName: 'board-list-bottom', user };
+}
+
+describe('suppressAdsForAdFreeMember', () => {
+    it('user 없으면 입력값 그대로 (default true 통과)', () => {
+        expect(suppressAdsForAdFreeMember(true, ctx(null))).toBe(true);
+    });
+
+    it('user 있지만 ad_free_until 없으면 입력값 그대로', () => {
+        expect(suppressAdsForAdFreeMember(true, ctx({}))).toBe(true);
+    });
+
+    it('ad_free_until 가 미래이면 false (광고 OFF)', () => {
+        const future = new Date(Date.now() + 86_400_000).toISOString();
+        expect(suppressAdsForAdFreeMember(true, ctx({ ad_free_until: future }))).toBe(false);
+    });
+
+    it('ad_free_until 가 과거이면 입력값 그대로 (만료된 멤버십)', () => {
+        const past = new Date(Date.now() - 86_400_000).toISOString();
+        expect(suppressAdsForAdFreeMember(true, ctx({ ad_free_until: past }))).toBe(true);
+    });
+
+    it('Date 객체 직접도 처리', () => {
+        const future = new Date(Date.now() + 86_400_000);
+        expect(suppressAdsForAdFreeMember(true, ctx({ ad_free_until: future }))).toBe(false);
+    });
+
+    it('invalid date string 은 입력값 그대로 (안전 fallback)', () => {
+        expect(suppressAdsForAdFreeMember(true, ctx({ ad_free_until: 'not-a-date' }))).toBe(true);
+    });
+
+    it('다른 플러그인이 이미 false 면 항상 false (체이닝 보존)', () => {
+        const future = new Date(Date.now() + 86_400_000).toISOString();
+        expect(suppressAdsForAdFreeMember(false, ctx({ ad_free_until: future }))).toBe(false);
+        expect(suppressAdsForAdFreeMember(false, ctx(null))).toBe(false);
+    });
+
+    it('ad_free_until null 은 입력값 그대로', () => {
+        expect(suppressAdsForAdFreeMember(true, ctx({ ad_free_until: null }))).toBe(true);
+    });
+});

--- a/plugins/ad-free/index.ts
+++ b/plugins/ad-free/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Ad-Free Membership Plugin — 메타데이터 진입점.
+ *
+ * 자동 활성화는 `hooks/suppress.server.ts` 에서 top-level side-effect 로 처리
+ * (plugin-server-loader 의 import.meta.glob 패턴 매칭). 이 파일은 plugin metadata
+ * 와 향후 admin 수동 활성/비활성 토글용 진입점.
+ *
+ * payment 플러그인 의존 (네이버페이/PayPal/토스 정기결제). dependencies 는
+ * plugin.json 에 선언.
+ */
+import { hooks } from '@angple/hook-system';
+import { suppressAdsForAdFreeMember } from './hooks/suppress.server';
+
+export const meta = {
+    id: 'ad-free',
+    version: '0.1.0'
+} as const;
+
+/** 수동 활성화 (admin UI 의 토글). 자동 활성화는 .server.ts side-effect 가 처리. */
+export function activate(): void {
+    if (hooks.getHookCount('should_render_ad', 'filter') === 0) {
+        hooks.addFilter('should_render_ad', suppressAdsForAdFreeMember as never, 10);
+    }
+}
+
+/** 비활성화 — admin 에서 플러그인 OFF 시. */
+export function deactivate(): void {
+    hooks.removeFilter('should_render_ad', suppressAdsForAdFreeMember as never);
+}

--- a/plugins/ad-free/migrations/001_ad_free_membership.down.sql
+++ b/plugins/ad-free/migrations/001_ad_free_membership.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS ad_free_membership;

--- a/plugins/ad-free/migrations/001_ad_free_membership.up.sql
+++ b/plugins/ad-free/migrations/001_ad_free_membership.up.sql
@@ -1,0 +1,20 @@
+-- ad-free 플러그인: 사용자 광고 제거 멤버십 상태
+-- (mb_id, site_id) 복합 PK — 멀티사이트 (#1287) 대비.
+-- payment_order_id 는 payment_orders.id 참조이나, 플러그인 의존성 가정상
+-- FK 제약은 두지 않음 (payment 플러그인 비활성화 시에도 행 유지).
+
+CREATE TABLE IF NOT EXISTS ad_free_membership (
+    mb_id              VARCHAR(20)  NOT NULL,
+    site_id            VARCHAR(64)  NOT NULL DEFAULT 'default',
+    plan               ENUM('monthly', 'yearly') NOT NULL,
+    status             ENUM('trialing', 'active', 'past_due', 'canceled', 'expired') NOT NULL DEFAULT 'trialing',
+    current_period_end DATETIME     NULL,
+    trial_end          DATETIME     NULL,
+    payment_provider   ENUM('naverpay', 'paypal', 'toss', 'manual') NULL,
+    payment_order_id   VARCHAR(64)  NULL COMMENT 'payment_orders.id 참조 (느슨한 결합)',
+    created_at         DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (mb_id, site_id),
+    INDEX idx_status_period (status, current_period_end),
+    INDEX idx_site_id (site_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='광고 제거 멤버십 (ad-free 플러그인)';

--- a/plugins/ad-free/plugin.json
+++ b/plugins/ad-free/plugin.json
@@ -1,0 +1,91 @@
+{
+    "id": "ad-free",
+    "name": "광고 제거 멤버십",
+    "version": "0.1.0",
+    "author": {
+        "name": "Angple",
+        "url": "https://angple.com"
+    },
+    "license": "MIT",
+    "category": "plugin",
+    "pluginType": "MEMBERSHIP",
+    "main": "index.ts",
+    "description": "회원 구독으로 사이트 광고를 제거하는 멤버십 플러그인. payment 플러그인과 연동하여 네이버페이/PayPal/토스 결제를 통한 정기구독을 제공합니다.",
+    "tags": ["membership", "ad-free", "subscription", "광고제거", "멤버십"],
+    "dependencies": [{ "id": "payment", "version": "^0.1" }],
+    "migrations": [
+        {
+            "version": "001",
+            "description": "ad_free_membership: 사용자 광고 제거 멤버십 상태",
+            "up": "migrations/001_ad_free_membership.up.sql",
+            "down": "migrations/001_ad_free_membership.down.sql"
+        }
+    ],
+    "hooks": [
+        {
+            "name": "should_render_ad",
+            "type": "filter",
+            "callback": "hooks/suppress.server.ts",
+            "priority": 10,
+            "comment": ".server.ts suffix → plugin-server-loader 의 import.meta.glob 패턴 매칭, 자동 활성화"
+        }
+    ],
+    "api": {
+        "rest": {
+            "prefix": "/api/plugins/ad-free",
+            "routes": [
+                {
+                    "method": "GET",
+                    "path": "/me",
+                    "handler": "server/membership-api.ts",
+                    "authenticated": true
+                }
+            ]
+        }
+    },
+    "settings": {
+        "enabled": {
+            "label": "활성화",
+            "type": "boolean",
+            "default": true
+        },
+        "monthly_price": {
+            "label": "월간 가격",
+            "type": "number",
+            "default": 4700,
+            "description": "월 구독 가격. 통화의 최소 단위 (KRW=원, USD=센트 ÷ 100)."
+        },
+        "yearly_price": {
+            "label": "연간 가격",
+            "type": "number",
+            "default": 47000,
+            "description": "연 구독 가격. 월 ×10 권장 (2개월 무료)."
+        },
+        "currency": {
+            "label": "통화",
+            "type": "select",
+            "default": "KRW",
+            "options": [
+                { "label": "원 (KRW)", "value": "KRW" },
+                { "label": "달러 (USD)", "value": "USD" }
+            ]
+        },
+        "trial_days": {
+            "label": "무료 체험 일수",
+            "type": "number",
+            "default": 7
+        },
+        "support_email": {
+            "label": "고객 지원 이메일",
+            "type": "string",
+            "default": "help@example.com",
+            "description": "환불/문의 안내에 표시"
+        },
+        "product_name": {
+            "label": "상품 표시명",
+            "type": "string",
+            "default": "광고 제거 멤버십",
+            "description": "랜딩/체크아웃 페이지 상품명 (사이트별 브랜딩 가능)"
+        }
+    }
+}

--- a/plugins/ad-free/server/guest-checkout.ts
+++ b/plugins/ad-free/server/guest-checkout.ts
@@ -1,0 +1,65 @@
+/**
+ * 비회원 결제 → 자동 회원 생성 + 결제 시작 (옵션 B).
+ *
+ * 현재는 stub: 가맹점 심사 진행 중이라 실제 g5_member INSERT 와 결제 PG 호출은
+ * 일어나지 않는다. 사용자 입력 검증 + 가맹 통과 후 진행 안내 메시지 응답.
+ *
+ * 가맹 통과 후 활성화 시:
+ *   1. g5_member 이메일 중복 점검 → 있으면 "기존 회원" 응답 (로그인 유도)
+ *   2. mb_id 자동 생성 (timestamp + random hex)
+ *   3. 임시 비번 + bcrypt → g5_member INSERT (mb_level=1)
+ *   4. payment 플러그인 /checkout/start 호출 (메타에 mb_id 포함)
+ *   5. 결제 webhook 성공 시 환영 메일 + 비번 재설정 토큰 발송 → ad_free_membership 활성화
+ */
+
+export type AdFreePlanCode = 'ad_free_monthly' | 'ad_free_half_yearly';
+
+export interface GuestCheckoutInput {
+    plan: AdFreePlanCode;
+    provider: 'naverpay' | 'paypal';
+    email: string;
+    nickname: string;
+    agreements: Record<string, boolean>;
+}
+
+const VALID_PLANS: readonly AdFreePlanCode[] = ['ad_free_monthly', 'ad_free_half_yearly'];
+
+export interface GuestCheckoutResult {
+    status: 'pending_merchant_review' | 'redirect' | 'error';
+    message?: string;
+    redirect_url?: string;
+}
+
+const REQUIRED_AGREEMENTS = ['terms', 'privacy', 'recurring', 'auto_signup'];
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateGuestInput(input: GuestCheckoutInput): string | null {
+    if (!input.email || !EMAIL_RE.test(input.email)) return '올바른 이메일 형식이 아닙니다.';
+    const nick = (input.nickname ?? '').trim();
+    if (nick.length < 2 || nick.length > 20) return '닉네임은 2~20자로 입력해주세요.';
+    if (!VALID_PLANS.includes(input.plan)) return '잘못된 요금제입니다.';
+    if (!['naverpay', 'paypal'].includes(input.provider)) return '잘못된 결제 수단입니다.';
+    for (const a of REQUIRED_AGREEMENTS) {
+        if (input.agreements?.[a] !== true) return `필수 약관 동의가 누락되었습니다: ${a}`;
+    }
+    return null;
+}
+
+export async function handleGuestCheckout(input: GuestCheckoutInput): Promise<GuestCheckoutResult> {
+    const err = validateGuestInput(input);
+    if (err) return { status: 'error', message: err };
+
+    // 가맹점 심사 진행 중 — 실제 회원 생성/결제 호출 X.
+    // 가맹 통과 후 isMerchantApproved=true 로 전환되면 아래 stub 을 실제 흐름으로 교체:
+    //   1. checkExistingMember(input.email)
+    //   2. createGuestMember(input)
+    //   3. paymentPluginStartCheckout({ plan, provider, mb_id })
+    //   4. sendWelcomeEmail(input.email, resetToken)
+    return {
+        status: 'pending_merchant_review',
+        message:
+            '가맹점 심사 진행 중입니다. 입력해주신 이메일(' +
+            input.email +
+            ')로 가맹 통과 후 결제 안내를 보내드립니다. 감사합니다.'
+    };
+}

--- a/plugins/ad-free/server/loaders.ts
+++ b/plugins/ad-free/server/loaders.ts
@@ -1,0 +1,183 @@
+/**
+ * Ad-Free 페이지 데이터 로더.
+ * 향후 사이트 settings (멀티사이트 #1287) 또는 plugin.json default 를 동적 로드하도록 확장.
+ * 지금은 plugin.json default 와 동일한 정적 값.
+ */
+
+export type PlanId = 'monthly' | 'half_yearly';
+
+export interface Plan {
+    id: PlanId;
+    label: string;
+    price: number;
+    period: string;
+    /** 결제 주기 (개월 수). 정기결제 webhook 에서 다음 결제일 계산에 사용. */
+    billingMonths: number;
+    badge?: string;
+    recommended?: boolean;
+}
+
+export interface Benefit {
+    icon: string;
+    title: string;
+    desc: string;
+}
+
+export interface Faq {
+    q: string;
+    a: string;
+}
+
+export interface LandingData {
+    productName: string;
+    currency: 'KRW' | 'USD';
+    plans: Plan[];
+    benefits: Benefit[];
+    trialDays: number;
+    supportEmail: string;
+    faqs: Faq[];
+}
+
+export interface LoadOptions {
+    siteId?: string;
+}
+
+export interface ProviderOption {
+    id: 'naverpay' | 'paypal';
+    label: string;
+    description?: string;
+}
+
+export interface CheckoutData {
+    productName: string;
+    currency: 'KRW' | 'USD';
+    plans: Plan[];
+    providers: ProviderOption[];
+    initialPlan: PlanId;
+    trialDays: number;
+    supportEmail: string;
+    /**
+     * 가맹점 심사 통과 여부. false 이면 결제 버튼 클릭 시 안내 모달만 노출,
+     * 실제 PG 호출은 일어나지 않는다. 가맹 통과 후 plugin.json settings 또는
+     * 서버 환경변수로 true 전환 → 정상 결제 흐름 진입.
+     */
+    isMerchantApproved: boolean;
+    /** 비회원 결제 정책 (옵션 B 자동 회원 생성) */
+    guestPolicy: GuestPolicy;
+}
+
+export interface GuestPolicy {
+    /** 비회원 결제 허용 여부 (사이트 settings) */
+    enabled: boolean;
+    /** 결제 완료 후 자동 회원 생성 (옵션 B). 환영 메일로 비번 재설정 링크 전송. */
+    autoCreateMember: boolean;
+    /** 약관 동의 필수 항목 */
+    requiredAgreements: Array<{ id: string; label: string; required: boolean }>;
+}
+
+export async function loadCheckout(opts: {
+    siteId?: string;
+    initialPlan: PlanId;
+}): Promise<CheckoutData> {
+    const landing = await loadLanding({ siteId: opts.siteId });
+    return {
+        productName: landing.productName,
+        currency: landing.currency,
+        plans: landing.plans,
+        providers: [
+            { id: 'naverpay', label: '네이버페이', description: '국내 카드 · 계좌 정기결제' },
+            { id: 'paypal', label: 'PayPal', description: '해외 결제 Subscription' }
+        ],
+        initialPlan: opts.initialPlan,
+        trialDays: landing.trialDays,
+        supportEmail: landing.supportEmail,
+        isMerchantApproved: false,
+        guestPolicy: {
+            enabled: true,
+            autoCreateMember: true,
+            requiredAgreements: [
+                { id: 'terms', label: '이용약관 동의', required: true },
+                { id: 'privacy', label: '개인정보 수집·이용 동의', required: true },
+                {
+                    id: 'recurring',
+                    label: '정기결제 자동 갱신 안내 동의',
+                    required: true
+                },
+                {
+                    id: 'auto_signup',
+                    label: '결제 완료 시 자동 회원 가입 (이메일로 비밀번호 안내) 동의',
+                    required: true
+                }
+            ]
+        }
+    };
+}
+
+export async function loadLanding(_opts: LoadOptions = {}): Promise<LandingData> {
+    return {
+        productName: '광고 제거 멤버십',
+        currency: 'KRW',
+        plans: [
+            {
+                id: 'monthly',
+                label: '월간 정기결제',
+                price: 4700,
+                period: '월',
+                billingMonths: 1
+            },
+            {
+                id: 'half_yearly',
+                label: '6개월 정기결제',
+                price: 28200,
+                period: '6개월',
+                billingMonths: 6
+            }
+        ],
+        benefits: [
+            {
+                icon: '🚫',
+                title: 'AdSense 광고 제거',
+                desc: '모든 페이지에서 광고가 사라집니다'
+            },
+            {
+                icon: '✨',
+                title: '깔끔한 읽기 경험',
+                desc: '콘텐츠에 온전히 집중할 수 있습니다'
+            },
+            {
+                icon: '🎁',
+                title: '7일 무료 체험',
+                desc: '결제 전 7일간 무료로 사용해보세요'
+            },
+            {
+                icon: '🔓',
+                title: '언제든 해지',
+                desc: '구속 없이 언제든 해지할 수 있습니다'
+            }
+        ],
+        trialDays: 7,
+        supportEmail: 'help@example.com',
+        faqs: [
+            {
+                q: '결제 수단은 어떤 것을 지원하나요?',
+                a: '네이버페이 정기결제와 PayPal Subscription 을 지원합니다.'
+            },
+            {
+                q: '7일 무료 체험 후 자동으로 결제되나요?',
+                a: '체험 기간 종료 전 해지하시면 결제되지 않습니다. 체험 종료 시 선택하신 요금제로 자동 결제됩니다.'
+            },
+            {
+                q: '환불은 어떻게 받을 수 있나요?',
+                a: '환불 정책 페이지에 자세한 절차가 안내되어 있습니다. 영업일 기준 3~5일 이내 처리됩니다.'
+            },
+            {
+                q: '구독 후 광고가 즉시 사라지나요?',
+                a: '결제 완료 직후 로그인 상태에서 광고가 사라집니다. 다른 기기는 재로그인 시 반영됩니다.'
+            },
+            {
+                q: '6개월 요금제는 어떤 점이 다른가요?',
+                a: '6개월 요금제는 6개월치 정가를 한 번에 결제합니다 (월 ×6, 별도 할인 없음). 결제 주기를 줄여 결제 빈도를 낮출 수 있습니다.'
+            }
+        ]
+    };
+}

--- a/plugins/ad-free/server/membership-api.ts
+++ b/plugins/ad-free/server/membership-api.ts
@@ -1,0 +1,36 @@
+/**
+ * 사용자의 광고 제거 멤버십 상태 조회 API.
+ *
+ * 현재는 stub: 실제 ad_free_membership 테이블 조회는 코어/백엔드 인프라가
+ * 안정화된 후 (Sprint 7+) 연결한다. 그때까지는 inactive 응답을 반환하여
+ * 회귀 없이 라우트만 노출.
+ *
+ * 향후 통합 옵션:
+ *   - mysql2 풀을 코어에서 노출 → 여기서 직접 SELECT
+ *   - Go 백엔드에 GET /api/v1/ad-free/me 추가 → 여기서 fetch
+ *   - locals.user 가 ad_free_until 을 이미 포함하면 그대로 반환
+ */
+
+export interface MembershipState {
+    mb_id: string;
+    site_id: string;
+    plan: 'monthly' | 'yearly' | null;
+    status: 'trialing' | 'active' | 'past_due' | 'canceled' | 'expired' | 'inactive';
+    current_period_end: string | null;
+    trial_end: string | null;
+    payment_provider: 'naverpay' | 'paypal' | 'toss' | 'manual' | null;
+    ad_free_until: string | null;
+}
+
+export async function getMembership(mbId: string, siteId = 'default'): Promise<MembershipState> {
+    return {
+        mb_id: mbId,
+        site_id: siteId,
+        plan: null,
+        status: 'inactive',
+        current_period_end: null,
+        trial_end: null,
+        payment_provider: null,
+        ad_free_until: null
+    };
+}

--- a/plugins/ad-free/server/tests/guest-checkout.test.ts
+++ b/plugins/ad-free/server/tests/guest-checkout.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { validateGuestInput, handleGuestCheckout } from '../guest-checkout';
+import type { GuestCheckoutInput } from '../guest-checkout';
+
+function base(overrides: Partial<GuestCheckoutInput> = {}): GuestCheckoutInput {
+    return {
+        plan: 'ad_free_half_yearly',
+        provider: 'naverpay',
+        email: 'guest@example.com',
+        nickname: 'guest',
+        agreements: { terms: true, privacy: true, recurring: true, auto_signup: true },
+        ...overrides
+    };
+}
+
+describe('validateGuestInput', () => {
+    it('모든 필드 정상 → null', () => {
+        expect(validateGuestInput(base())).toBeNull();
+    });
+
+    it('이메일 형식 오류 → 에러 메시지', () => {
+        expect(validateGuestInput(base({ email: 'not-an-email' }))).toMatch(/이메일/);
+    });
+
+    it('닉네임 1자 → 에러', () => {
+        expect(validateGuestInput(base({ nickname: 'a' }))).toMatch(/닉네임/);
+    });
+
+    it('닉네임 21자 → 에러', () => {
+        expect(validateGuestInput(base({ nickname: 'a'.repeat(21) }))).toMatch(/닉네임/);
+    });
+
+    it('잘못된 plan → 에러', () => {
+        expect(validateGuestInput(base({ plan: 'invalid' as never }))).toMatch(/요금제/);
+    });
+
+    it('잘못된 provider → 에러', () => {
+        expect(validateGuestInput(base({ provider: 'kakaopay' as never }))).toMatch(/결제 수단/);
+    });
+
+    it('필수 약관 누락 (privacy) → 에러', () => {
+        const input = base();
+        input.agreements = { ...input.agreements, privacy: false };
+        expect(validateGuestInput(input)).toMatch(/privacy/);
+    });
+
+    it('자동 회원 가입 동의 누락 → 에러', () => {
+        const input = base();
+        input.agreements = { ...input.agreements, auto_signup: false };
+        expect(validateGuestInput(input)).toMatch(/auto_signup/);
+    });
+});
+
+describe('handleGuestCheckout', () => {
+    it('정상 입력 → pending_merchant_review + 이메일 echo', async () => {
+        const res = await handleGuestCheckout(base());
+        expect(res.status).toBe('pending_merchant_review');
+        expect(res.message).toContain('guest@example.com');
+    });
+
+    it('유효성 실패 → status=error', async () => {
+        const res = await handleGuestCheckout(base({ email: '' }));
+        expect(res.status).toBe('error');
+        expect(res.message).toMatch(/이메일/);
+    });
+});

--- a/plugins/ad-free/views/Checkout.svelte
+++ b/plugins/ad-free/views/Checkout.svelte
@@ -1,0 +1,356 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button';
+    import {
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle
+    } from '$lib/components/ui/card';
+    import type { CheckoutData } from '$plugins/ad-free/server/loaders';
+    import PaymentDemoModal from './PaymentDemoModal.svelte';
+
+    interface ExtendedCheckoutData extends CheckoutData {
+        isGuest: boolean;
+        prefill: { email: string; nickname: string };
+    }
+
+    let { data }: { data: ExtendedCheckoutData } = $props();
+
+    let selectedPlan = $state<'monthly' | 'half_yearly'>(data.initialPlan);
+    let selectedProvider = $state<'naverpay' | 'paypal'>('naverpay');
+    let submitting = $state(false);
+    let stubMessage = $state<string | null>(null);
+    let demoOpen = $state(false);
+
+    // 비회원 폼 state
+    let email = $state(data.prefill.email);
+    let nickname = $state(data.prefill.nickname);
+    let agreements = $state<Record<string, boolean>>({});
+
+    const currentPlan = $derived(data.plans.find((p) => p.id === selectedPlan) ?? data.plans[0]);
+    const allRequiredAgreed = $derived(
+        data.guestPolicy.requiredAgreements
+            .filter((a) => a.required)
+            .every((a) => agreements[a.id] === true)
+    );
+    const emailValid = $derived(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email));
+    const nicknameValid = $derived(nickname.trim().length >= 2 && nickname.trim().length <= 20);
+    const guestFormValid = $derived(
+        !data.isGuest || (emailValid && nicknameValid && allRequiredAgreed)
+    );
+
+    function formatPrice(amount: number, currency: 'KRW' | 'USD'): string {
+        if (currency === 'KRW') return `₩${amount.toLocaleString('ko-KR')}`;
+        return `$${(amount / 100).toFixed(2)}`;
+    }
+
+    function toggleAgreement(id: string, checked: boolean) {
+        agreements = { ...agreements, [id]: checked };
+    }
+
+    function toggleAllAgreements(checked: boolean) {
+        const next: Record<string, boolean> = {};
+        for (const a of data.guestPolicy.requiredAgreements) next[a.id] = checked;
+        agreements = next;
+    }
+
+    // 1단계: 유효성 검증 + 데모 모달 표시 (가맹 통과 전/후 동일)
+    function handleSubmit() {
+        if (submitting) return;
+        if (!guestFormValid) {
+            stubMessage = '비회원 결제를 위해 이메일, 닉네임, 약관 동의를 모두 완료해주세요.';
+            return;
+        }
+        stubMessage = null;
+        demoOpen = true;
+    }
+
+    // 2단계: 데모 모달 "결제 진행" 클릭 → 실 API 호출 (가맹 미통과 시 stub, 통과 시 PG redirect)
+    async function handleDemoConfirm() {
+        demoOpen = false;
+        submitting = true;
+        try {
+            const endpoint = data.isGuest
+                ? '/api/plugins/ad-free/guest-checkout'
+                : '/api/plugins/payment/checkout/start';
+            const body = data.isGuest
+                ? {
+                      plan: `ad_free_${selectedPlan}`,
+                      provider: selectedProvider,
+                      email,
+                      nickname: nickname.trim(),
+                      agreements
+                  }
+                : {
+                      plan: `ad_free_${selectedPlan}`,
+                      provider: selectedProvider
+                  };
+            const res = await fetch(endpoint, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+            const json = await res.json().catch(() => null);
+            if (!res.ok) {
+                stubMessage =
+                    json?.message ?? `결제 시작 실패 (${res.status}). 잠시 후 다시 시도해주세요.`;
+                return;
+            }
+            if (json?.redirect_url) {
+                window.location.href = json.redirect_url;
+            } else if (json?.message) {
+                stubMessage = json.message;
+            } else {
+                stubMessage = '결제창을 여는 중입니다…';
+            }
+        } catch (err) {
+            stubMessage = '결제 시작 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+            console.error('[ad-free checkout]', err);
+        } finally {
+            submitting = false;
+        }
+    }
+
+    function handleDemoCancel() {
+        demoOpen = false;
+    }
+</script>
+
+<svelte:head>
+    <title>구독 결제 | {data.productName}</title>
+    <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="ad-free-checkout mx-auto max-w-3xl px-4 py-12 sm:py-16">
+    <header class="text-center">
+        <p class="text-muted-foreground text-sm">광고 제거 멤버십</p>
+        <h1 class="mt-2 text-3xl font-bold sm:text-4xl">{data.productName} 구독</h1>
+        <p class="text-muted-foreground mt-3 text-sm">
+            {data.trialDays}일 무료 체험 후 자동 결제됩니다. 체험 중 언제든 해지 가능합니다.
+        </p>
+        {#if data.isGuest}
+            <p class="text-muted-foreground mt-2 text-xs">
+                <strong>비회원도 결제 가능</strong> — 결제 완료 시 자동으로 회원 가입되며, 입력하신
+                이메일로 비밀번호 안내가 전송됩니다.
+                <a href="/login?redirect=/ad-free/checkout" class="text-primary underline">
+                    이미 회원이신가요?
+                </a>
+            </p>
+        {/if}
+    </header>
+
+    <section class="mt-10">
+        <h2 class="text-base font-semibold">요금제 선택</h2>
+        <div class="mt-3 grid gap-3 sm:grid-cols-2">
+            {#each data.plans as plan (plan.id)}
+                <button
+                    type="button"
+                    class="bg-card hover:border-primary rounded-xl border p-5 text-left transition"
+                    class:border-primary={selectedPlan === plan.id}
+                    class:ring-primary={selectedPlan === plan.id}
+                    class:ring-2={selectedPlan === plan.id}
+                    onclick={() => (selectedPlan = plan.id)}
+                >
+                    <div class="flex items-baseline justify-between">
+                        <span class="font-semibold">{plan.label}</span>
+                        {#if plan.badge}
+                            <span
+                                class="bg-primary/10 text-primary rounded-full px-2 py-0.5 text-xs font-medium"
+                            >
+                                {plan.badge}
+                            </span>
+                        {/if}
+                    </div>
+                    <p class="mt-2">
+                        <span class="text-2xl font-bold"
+                            >{formatPrice(plan.price, data.currency)}</span
+                        >
+                        <span class="text-muted-foreground"> / {plan.period}</span>
+                    </p>
+                </button>
+            {/each}
+        </div>
+    </section>
+
+    <section class="mt-8">
+        <h2 class="text-base font-semibold">결제 수단</h2>
+        <div class="mt-3 grid gap-3 sm:grid-cols-2">
+            {#each data.providers as provider (provider.id)}
+                <button
+                    type="button"
+                    class="bg-card hover:border-primary rounded-xl border p-5 text-left transition"
+                    class:border-primary={selectedProvider === provider.id}
+                    class:ring-primary={selectedProvider === provider.id}
+                    class:ring-2={selectedProvider === provider.id}
+                    onclick={() => (selectedProvider = provider.id)}
+                >
+                    <p class="font-semibold">{provider.label}</p>
+                    {#if provider.description}
+                        <p class="text-muted-foreground mt-1 text-xs">{provider.description}</p>
+                    {/if}
+                </button>
+            {/each}
+        </div>
+    </section>
+
+    {#if data.isGuest}
+        <section class="mt-8">
+            <h2 class="text-base font-semibold">구매자 정보 (비회원)</h2>
+            <div class="mt-3 space-y-3">
+                <label class="block">
+                    <span class="text-sm font-medium">이메일</span>
+                    <input
+                        type="email"
+                        bind:value={email}
+                        placeholder="you@example.com"
+                        autocomplete="email"
+                        class="bg-card focus:border-primary focus:ring-primary/20 mt-1 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                    />
+                    {#if email && !emailValid}
+                        <span class="mt-1 block text-xs text-red-600"
+                            >올바른 이메일 형식이 아닙니다</span
+                        >
+                    {/if}
+                    <span class="text-muted-foreground mt-1 block text-xs">
+                        결제 영수증 + 자동 회원 가입 안내 발송에 사용됩니다.
+                    </span>
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium">닉네임 (2~20자)</span>
+                    <input
+                        type="text"
+                        bind:value={nickname}
+                        placeholder="홍길동"
+                        autocomplete="nickname"
+                        maxlength="20"
+                        class="bg-card focus:border-primary focus:ring-primary/20 mt-1 w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                    />
+                    {#if nickname && !nicknameValid}
+                        <span class="mt-1 block text-xs text-red-600">2~20자로 입력해주세요</span>
+                    {/if}
+                </label>
+            </div>
+        </section>
+
+        <section class="mt-8">
+            <h2 class="text-base font-semibold">약관 동의</h2>
+            <div class="mt-3 space-y-2 rounded-lg border p-4">
+                <label class="flex cursor-pointer items-center gap-2 border-b pb-2">
+                    <input
+                        type="checkbox"
+                        checked={data.guestPolicy.requiredAgreements.every((a) => agreements[a.id])}
+                        onchange={(e) =>
+                            toggleAllAgreements((e.target as HTMLInputElement).checked)}
+                        class="h-4 w-4"
+                    />
+                    <span class="text-sm font-semibold">모두 동의</span>
+                </label>
+                {#each data.guestPolicy.requiredAgreements as agreement (agreement.id)}
+                    <label class="flex cursor-pointer items-start gap-2">
+                        <input
+                            type="checkbox"
+                            checked={agreements[agreement.id] === true}
+                            onchange={(e) =>
+                                toggleAgreement(
+                                    agreement.id,
+                                    (e.target as HTMLInputElement).checked
+                                )}
+                            class="mt-0.5 h-4 w-4"
+                        />
+                        <span class="text-sm">
+                            {#if agreement.required}<span class="text-red-600">(필수)</span
+                                >{:else}<span class="text-muted-foreground">(선택)</span>{/if}
+                            {agreement.label}
+                        </span>
+                    </label>
+                {/each}
+            </div>
+        </section>
+    {/if}
+
+    <Card class="mt-10">
+        <CardHeader>
+            <CardTitle>주문 요약</CardTitle>
+            <CardDescription>
+                {data.productName} · {currentPlan.label}
+            </CardDescription>
+        </CardHeader>
+        <CardContent>
+            <dl class="space-y-2 text-sm">
+                <div class="flex justify-between">
+                    <dt class="text-muted-foreground">요금</dt>
+                    <dd class="font-medium">
+                        {formatPrice(currentPlan.price, data.currency)} / {currentPlan.period}
+                    </dd>
+                </div>
+                <div class="flex justify-between">
+                    <dt class="text-muted-foreground">무료 체험</dt>
+                    <dd>{data.trialDays}일</dd>
+                </div>
+                <div class="flex justify-between">
+                    <dt class="text-muted-foreground">결제 수단</dt>
+                    <dd>{data.providers.find((p) => p.id === selectedProvider)?.label}</dd>
+                </div>
+                {#if data.isGuest}
+                    <div class="flex justify-between">
+                        <dt class="text-muted-foreground">구매자</dt>
+                        <dd class="text-xs">
+                            {email || '(이메일 미입력)'}
+                        </dd>
+                    </div>
+                {/if}
+            </dl>
+
+            {#if !data.isMerchantApproved}
+                <p
+                    class="mt-5 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-700/40 dark:bg-amber-900/20 dark:text-amber-200"
+                >
+                    ⚠ 가맹점 심사 진행 중입니다. 결제 버튼을 누르셔도 실제 결제는 일어나지 않으며,
+                    심사 통과 후 안내드릴 예정입니다.
+                </p>
+            {/if}
+
+            <Button
+                class="mt-5 w-full"
+                size="lg"
+                disabled={submitting || !guestFormValid}
+                onclick={handleSubmit}
+            >
+                {submitting
+                    ? '진행 중…'
+                    : `${formatPrice(currentPlan.price, data.currency)} 결제하기`}
+            </Button>
+
+            {#if stubMessage}
+                <p
+                    class="bg-muted text-muted-foreground mt-4 rounded-lg p-3 text-sm"
+                    role="status"
+                    aria-live="polite"
+                >
+                    {stubMessage}
+                </p>
+            {/if}
+
+            <p class="text-muted-foreground mt-4 text-center text-xs">
+                결제를 진행하시면
+                <a href="/ad-free/refund-policy" class="underline">환불 정책</a>
+                에 동의하는 것으로 간주됩니다.
+            </p>
+        </CardContent>
+    </Card>
+</div>
+
+<PaymentDemoModal
+    open={demoOpen}
+    productName={data.productName}
+    planLabel={currentPlan.label}
+    amountText={formatPrice(currentPlan.price, data.currency)}
+    period={currentPlan.period}
+    provider={selectedProvider}
+    providerLabel={data.providers.find((p) => p.id === selectedProvider)?.label ?? selectedProvider}
+    buyerEmail={data.isGuest ? email : data.prefill.email}
+    supportEmail={data.supportEmail}
+    onConfirm={handleDemoConfirm}
+    onCancel={handleDemoCancel}
+/>

--- a/plugins/ad-free/views/Landing.svelte
+++ b/plugins/ad-free/views/Landing.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button';
+    import {
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle
+    } from '$lib/components/ui/card';
+    import type { LandingData } from '$plugins/ad-free/server/loaders';
+
+    let { data }: { data: LandingData } = $props();
+
+    function formatPrice(amount: number, currency: 'KRW' | 'USD'): string {
+        if (currency === 'KRW') return `₩${amount.toLocaleString('ko-KR')}`;
+        return `$${(amount / 100).toFixed(2)}`;
+    }
+</script>
+
+<svelte:head>
+    <title>{data.productName} | 광고 없이 깔끔한 경험</title>
+    <meta
+        name="description"
+        content="{data.productName} — AdSense 광고 없이 콘텐츠에 집중하세요. {data.trialDays}일 무료 체험."
+    />
+</svelte:head>
+
+<div class="ad-free-landing mx-auto max-w-5xl px-4 py-12 sm:py-20">
+    <section class="text-center">
+        <h1 class="text-4xl font-bold sm:text-5xl">광고 없이, 더 편하게</h1>
+        <p class="text-muted-foreground mt-3 text-2xl">{data.productName}</p>
+        <p class="text-muted-foreground mt-6 text-base">
+            {data.trialDays}일 무료 체험 · 언제든 해지 가능
+        </p>
+        <div class="mt-8 flex justify-center gap-3">
+            <Button size="lg" href="/ad-free/checkout">무료 체험 시작하기</Button>
+        </div>
+    </section>
+
+    <section class="mt-20 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {#each data.benefits as benefit (benefit.title)}
+            <div class="bg-card rounded-xl border p-6">
+                <div class="text-3xl">{benefit.icon}</div>
+                <h3 class="mt-3 font-semibold">{benefit.title}</h3>
+                <p class="text-muted-foreground mt-1 text-sm">{benefit.desc}</p>
+            </div>
+        {/each}
+    </section>
+
+    <section class="mt-20">
+        <h2 class="text-center text-2xl font-bold">합리적인 가격</h2>
+        <div class="mt-8 grid gap-6 sm:grid-cols-2">
+            {#each data.plans as plan (plan.id)}
+                <Card class={plan.recommended ? 'border-primary ring-primary/20 ring-2' : ''}>
+                    <CardHeader>
+                        <CardTitle class="flex items-baseline justify-between">
+                            <span>{plan.label}</span>
+                            {#if plan.badge}
+                                <span
+                                    class="bg-primary/10 text-primary rounded-full px-3 py-1 text-xs font-medium"
+                                >
+                                    {plan.badge}
+                                </span>
+                            {/if}
+                        </CardTitle>
+                        <CardDescription>
+                            <span class="text-foreground text-3xl font-bold">
+                                {formatPrice(plan.price, data.currency)}
+                            </span>
+                            <span class="text-muted-foreground"> / {plan.period}</span>
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <Button
+                            class="w-full"
+                            variant={plan.recommended ? 'default' : 'outline'}
+                            href="/ad-free/checkout?plan={plan.id}"
+                        >
+                            {plan.recommended ? '시작하기 (추천)' : '시작하기'}
+                        </Button>
+                    </CardContent>
+                </Card>
+            {/each}
+        </div>
+    </section>
+
+    <section class="mt-20">
+        <h2 class="text-center text-2xl font-bold">자주 묻는 질문</h2>
+        <div class="mx-auto mt-8 max-w-2xl space-y-4">
+            {#each data.faqs as faq (faq.q)}
+                <details class="bg-card rounded-lg border p-4">
+                    <summary class="cursor-pointer font-medium">{faq.q}</summary>
+                    <p class="text-muted-foreground mt-2 text-sm">{faq.a}</p>
+                </details>
+            {/each}
+            <p class="text-muted-foreground text-center text-sm">
+                추가 문의는
+                <a href="mailto:{data.supportEmail}" class="underline">{data.supportEmail}</a>
+                으로 보내주세요.
+            </p>
+            <p class="text-center text-sm">
+                <a href="/ad-free/refund-policy" class="text-primary underline">환불 정책 보기</a>
+            </p>
+        </div>
+    </section>
+</div>

--- a/plugins/ad-free/views/PaymentDemoModal.svelte
+++ b/plugins/ad-free/views/PaymentDemoModal.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button';
+
+    interface Props {
+        open: boolean;
+        productName: string;
+        planLabel: string;
+        amountText: string;
+        period: string;
+        provider: 'naverpay' | 'paypal';
+        providerLabel: string;
+        buyerEmail?: string;
+        supportEmail: string;
+        onConfirm: () => void;
+        onCancel: () => void;
+    }
+
+    let {
+        open,
+        productName,
+        planLabel,
+        amountText,
+        period,
+        provider,
+        providerLabel,
+        buyerEmail,
+        supportEmail,
+        onConfirm,
+        onCancel
+    }: Props = $props();
+
+    // 네이버페이/PayPal 의 대표 컬러로 결제창 분위기 시뮬레이션
+    const accent = $derived(provider === 'naverpay' ? '#03c75a' : '#0070ba');
+
+    function handleBackdrop(e: MouseEvent) {
+        if (e.target === e.currentTarget) onCancel();
+    }
+</script>
+
+{#if open}
+    <div
+        class="payment-demo-backdrop fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+        onclick={handleBackdrop}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="payment-demo-title"
+        tabindex="-1"
+        onkeydown={(e) => e.key === 'Escape' && onCancel()}
+    >
+        <div
+            class="bg-card relative w-full max-w-md overflow-hidden rounded-2xl shadow-xl"
+            role="document"
+        >
+            <!-- 결제창 헤더 (provider 컬러) -->
+            <header
+                class="flex items-center justify-between px-5 py-4"
+                style:background-color={accent}
+            >
+                <div class="flex items-center gap-2 text-white">
+                    <span class="text-lg font-bold">{providerLabel}</span>
+                    <span class="rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-medium">
+                        DEMO
+                    </span>
+                </div>
+                <button
+                    type="button"
+                    onclick={onCancel}
+                    class="text-white/80 hover:text-white"
+                    aria-label="결제 취소"
+                >
+                    ✕
+                </button>
+            </header>
+
+            <!-- 상단 안내 -->
+            <div
+                class="border-b border-amber-200 bg-amber-50 px-5 py-3 dark:border-amber-800 dark:bg-amber-900/20"
+            >
+                <p class="text-xs leading-snug text-amber-900 dark:text-amber-200">
+                    ⚠️ <strong>가맹점 심사 진행 중</strong>입니다. 이 화면은 결제 흐름 시각화이며
+                    실제 결제는 일어나지 않습니다.
+                </p>
+            </div>
+
+            <!-- 결제 정보 -->
+            <div class="p-5">
+                <h2 id="payment-demo-title" class="text-lg font-bold">결제 정보 확인</h2>
+                <dl class="mt-4 space-y-2 text-sm">
+                    <div class="flex justify-between border-b pb-2">
+                        <dt class="text-muted-foreground">상품명</dt>
+                        <dd class="text-right font-medium">{productName}</dd>
+                    </div>
+                    <div class="flex justify-between border-b pb-2">
+                        <dt class="text-muted-foreground">요금제</dt>
+                        <dd class="text-right">{planLabel}</dd>
+                    </div>
+                    <div class="flex items-baseline justify-between border-b pb-2">
+                        <dt class="text-muted-foreground">결제 금액</dt>
+                        <dd class="text-right">
+                            <span class="text-xl font-bold" style:color={accent}>{amountText}</span>
+                            <span class="text-muted-foreground text-xs"> / {period}</span>
+                        </dd>
+                    </div>
+                    <div class="flex justify-between border-b pb-2">
+                        <dt class="text-muted-foreground">결제 수단</dt>
+                        <dd>{providerLabel} 정기결제</dd>
+                    </div>
+                    {#if buyerEmail}
+                        <div class="flex justify-between">
+                            <dt class="text-muted-foreground">구매자</dt>
+                            <dd class="text-xs">{buyerEmail}</dd>
+                        </div>
+                    {/if}
+                </dl>
+
+                <!-- 약관 재확인 -->
+                <p class="text-muted-foreground mt-4 text-xs leading-relaxed">
+                    다음 결제일에 동일 금액이 등록된 결제수단으로 자동 청구됩니다. 해지는 마이페이지
+                    또는 <a href="mailto:{supportEmail}" class="underline">{supportEmail}</a> 에서
+                    가능하며, 환불 정책은
+                    <a href="/ad-free/refund-policy" class="underline">여기</a>를 참고하세요.
+                </p>
+
+                <!-- 액션 -->
+                <div class="mt-5 flex gap-2">
+                    <Button variant="outline" class="flex-1" onclick={onCancel}>취소</Button>
+                    <button
+                        type="button"
+                        onclick={onConfirm}
+                        class="ring-offset-background focus-visible:ring-ring inline-flex h-10 flex-1 items-center justify-center rounded-md px-4 text-sm font-medium text-white shadow transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+                        style:background-color={accent}
+                    >
+                        {amountText} 결제 진행
+                    </button>
+                </div>
+
+                <!-- 보조 안내 -->
+                <p class="text-muted-foreground mt-4 text-center text-[10px]">
+                    이 데모는 가맹점 심사 통과 후 실제 PG 결제창으로 자동 전환됩니다.
+                </p>
+            </div>
+        </div>
+    </div>
+{/if}
+
+<style>
+    .payment-demo-backdrop {
+        animation: fadeIn 0.15s ease-out;
+    }
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+</style>

--- a/plugins/ad-free/views/RefundPolicy.svelte
+++ b/plugins/ad-free/views/RefundPolicy.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+    interface Props {
+        supportEmail?: string;
+    }
+    let { supportEmail = 'help@example.com' }: Props = $props();
+</script>
+
+<svelte:head>
+    <title>환불 정책 | 광고 제거 멤버십</title>
+    <meta name="description" content="광고 제거 멤버십의 환불 정책 안내." />
+</svelte:head>
+
+<div class="ad-free-refund mx-auto max-w-3xl px-4 py-12 sm:py-16">
+    <header class="border-b pb-6">
+        <p class="text-muted-foreground text-sm">광고 제거 멤버십</p>
+        <h1 class="mt-2 text-3xl font-bold sm:text-4xl">환불 정책</h1>
+        <p class="text-muted-foreground mt-3 text-sm">
+            아래 안내는 본 멤버십(정기구독)에 적용되며, 결제대행사 약관 및 관련 법령 (전자상거래법
+            제17조 등) 을 따릅니다.
+        </p>
+    </header>
+
+    <section class="mt-8 space-y-6">
+        <article>
+            <h2 class="text-xl font-semibold">1. 7일 이내 해지 환불</h2>
+            <p class="text-muted-foreground mt-2">
+                결제일로부터 7일 이내, 그리고 멤버십 혜택을 사용한 이력이 없는 경우 전액 환불을 받을
+                수 있습니다. 광고 제거 기능이 실제로 적용된 시점이 사용 이력으로 간주됩니다.
+            </p>
+        </article>
+
+        <article>
+            <h2 class="text-xl font-semibold">2. 정기결제 해지</h2>
+            <p class="text-muted-foreground mt-2">
+                다음 결제일 이전에 해지를 신청하시면, 다음 회차 결제가 자동으로 중지됩니다. 이미
+                결제된 회차는 환불 대상이 아니며, 해당 기간이 종료될 때까지 혜택은 계속 제공됩니다.
+            </p>
+        </article>
+
+        <article>
+            <h2 class="text-xl font-semibold">3. 무료 체험 기간 해지</h2>
+            <p class="text-muted-foreground mt-2">
+                무료 체험 기간(가입일 기준 7일) 안에 해지하시면 결제가 이루어지지 않습니다. 별도의
+                환불 절차가 필요 없습니다.
+            </p>
+        </article>
+
+        <article>
+            <h2 class="text-xl font-semibold">4. 환불 신청 방법</h2>
+            <ol
+                class="text-muted-foreground marker:text-foreground mt-2 list-decimal space-y-1 pl-5"
+            >
+                <li>마이페이지의 구독 관리 메뉴에서 해지/환불 신청</li>
+                <li>
+                    또는 이메일 <a href="mailto:{supportEmail}" class="underline">{supportEmail}</a>
+                    로 문의 (가입 이메일과 결제 수단을 함께 기재해 주세요)
+                </li>
+            </ol>
+        </article>
+
+        <article>
+            <h2 class="text-xl font-semibold">5. 환불 처리 기간</h2>
+            <p class="text-muted-foreground mt-2">
+                환불 승인 후 영업일 기준 3~5일 이내에 원 결제 수단으로 처리됩니다. 카드사/PG사
+                일정에 따라 실제 입금까지 추가 시간이 소요될 수 있습니다.
+            </p>
+        </article>
+
+        <article>
+            <h2 class="text-xl font-semibold">6. 환불 불가 사유</h2>
+            <ul class="text-muted-foreground marker:text-foreground mt-2 list-disc space-y-1 pl-5">
+                <li>약관 위반으로 멤버십이 정지/해지된 경우</li>
+                <li>혜택을 상당 기간 사용한 후 단순 변심으로 환불을 요구하는 경우</li>
+                <li>결제 후 7일이 경과한 회차분 (정기결제 해지로 다음 회차 진행 중지는 가능)</li>
+            </ul>
+        </article>
+    </section>
+
+    <footer class="text-muted-foreground mt-12 border-t pt-6 text-sm">
+        <p>
+            추가 문의는 <a href="mailto:{supportEmail}" class="underline">{supportEmail}</a> 으로 보내주시면
+            영업일 기준 1~2일 안에 답변드립니다.
+        </p>
+        <p class="mt-2">
+            <a href="/ad-free" class="text-primary underline">← 광고 제거 멤버십 안내로 돌아가기</a>
+        </p>
+    </footer>
+</div>


### PR DESCRIPTION
## 요약

다모앙 광고 제거 (Ad-Free) 멤버십 플러그인을 WordPress 모델로 도입합니다.
네이버페이 결제형 입점 재심사(5/20 예정)에 필요한 상품 페이지, 환불 정책,
체크아웃, 비회원 결제 UX 를 1차 출시합니다.

- 라우트: `/ad-free`, `/ad-free/refund-policy`, `/ad-free/checkout`
- API: `/api/plugins/ad-free/{me, guest-checkout}`
- 결제는 가맹 통과 전이라 stub. 데모 모달이 결제창 흐름을 시각화합니다.

## 설계 원칙 (WordPress 모델)

- **코어 미터치**: hook 포인트 추가 외 코어 본문 0 변경
- **플러그인 격리**: 모든 비즈니스 로직은 `web/plugins/ad-free/` 안에 한정
- **Shim 패턴**: `apps/web/src/routes/ad-free/` 는 ~10줄 thin shim (플러그인 view import + load 위임)
- **자동 활성화**: `plugins/**/hooks/*.{server,client}.ts` 패턴 매칭으로 server/client 양쪽 자동 등록

## 변경 내역

### 코어 (최소)

| 파일 | 변경 |
|---|---|
| `packages/hook-system/src/types.ts` | `FilterPoints.should_render_ad` 1줄 추가 |
| `apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte` | `pluginSuppress` derived 추가 (콜백 미등록 시 default true → 회귀 없음) |
| `apps/web/src/lib/client/plugin-client-loader.ts` (신규) | `plugins/**/hooks/*.client.{ts,js}` 자동 import — `plugin-server-loader` 의 client 짝 |
| `apps/web/src/hooks.client.ts` | `void loadAllPluginClientHooks();` 1회 호출 |
| `.gitignore` | `!plugins/ad-free/` 예외 추가 |

### 플러그인 (`web/plugins/ad-free/`)

- `plugin.json` — payment 패턴 (migrations, hooks, api.rest.routes, settings, dependencies=[payment ^0.1])
- `hooks/suppress.{ts,server.ts,client.ts}` — pure callback + server/client 양측 자동 등록 (DRY)
- `migrations/001_ad_free_membership.{up,down}.sql` — `(mb_id, site_id)` 복합 PK, 멀티사이트 대비
- `views/Landing.svelte` — YouTube Premium 톤 (Hero / 혜택 4 / 가격 카드 / FAQ)
- `views/RefundPolicy.svelte` — 환불 정책 6개 섹션
- `views/Checkout.svelte` — 회원/비회원 분기, 4종 약관 동의, 결제 데모 모달 통합
- `views/PaymentDemoModal.svelte` — NaverPay/PayPal 결제창 시각화 (DEMO 배지 + 가맹 안내)
- `server/loaders.ts` — 월간 ₩4,700 / 6개월 ₩28,200 (정가, 할인 없음)
- `server/membership-api.ts` — 멤버십 상태 조회 stub
- `server/guest-checkout.ts` — 비회원 결제 자동 회원 생성 stub
- `tests/`, `hooks/tests/` — 단위 테스트 18 케이스

### 라우트 shim (`apps/web/src/routes/`)

- `ad-free/+page.{server.ts,svelte}` — 비회원 SSR 200
- `ad-free/refund-policy/+page.svelte`
- `ad-free/checkout/+page.{server.ts,svelte}` — 회원/비회원 모두 200, isGuest prefill
- `api/plugins/ad-free/me/+server.ts`
- `api/plugins/ad-free/guest-checkout/+server.ts`

## 검증

- `pnpm check`: **0 errors, 100 warnings** (회귀 없음)
- `pnpm test:unit`: **396 tests / 41 files** (+18 tests 추가)
- 런타임 (localhost:3010):
  - `GET /ad-free` → 200, 마커: 월간 정기결제 · 6개월 정기결제 · ₩28,200 · 환불 정책
  - `GET /ad-free/refund-policy` → 200
  - `GET /ad-free/checkout?plan=half_yearly` → 200 (비회원 SSR), 마커: 비회원도 결제 가능 · 4종 약관 동의 폼
  - `POST /api/plugins/ad-free/guest-checkout` (약관 누락) → 400 + 안내
  - `POST /api/plugins/ad-free/guest-checkout` (정상) → 200 + pending_merchant_review + 이메일 echo
- `grep yearly` in `plugins/ad-free/`: 0건 (요금제 재편 깨끗)

## 일정 / 후속

| 시점 | 작업 |
|---|---|
| 5/20 | 네이버페이 1:1 재심사 신청 |
| 가맹 통과 후 (6~7월) | `guest-checkout.ts` stub → 실 자동 회원 생성 + payment 플러그인 `/checkout/start` 연동 + 환영 메일 + webhook 멤버십 활성화 |
| Sprint 후속 | 마이페이지 구독 상태/해지 UI, brickang 플러그인에도 비회원 결제 패턴 적용 |

## Test plan

- [ ] Staging 배포 후 `/ad-free` 비회원 SSR 정상 노출
- [ ] `/ad-free/refund-policy` 정상 노출
- [ ] `/ad-free/checkout` 비회원 진입 + 약관 4종 체크 + 데모 모달 동작
- [ ] 데모 모달 [결제 진행] → "가맹 심사 진행 중" stub 응답
- [ ] navertest 계정 로그인 후 광고 슬롯 미렌더 (SSR + CSR 양측)
- [ ] AdSense 광고 미멤버십 사용자에게는 정상 노출 (회귀 없음)

## 참고

- Refs: #1287 (Angple Sites SaaS 청사진 — PortOne/NaverPay 이원화, subscriptions 재활용)
- WordPress 모델: 코어 hook 추가는 확장이지 비즈니스 로직 침투가 아닙니다 (apply_filters 패턴)