### PR TITLE
fix(member): avatar fallback a11y — split interactive button vs static div

### DIFF
--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -341,17 +341,17 @@
                                     profileIconFailed = true;
                                 }}
                             />
+                        {:else if isOwnProfile}
+                            <button
+                                type="button"
+                                class="bg-muted text-muted-foreground flex size-16 cursor-pointer items-center justify-center rounded-full text-xl font-bold"
+                                onclick={handleImageClick}
+                            >
+                                {p.mb_name.charAt(0).toUpperCase()}
+                            </button>
                         {:else}
                             <div
                                 class="bg-muted text-muted-foreground flex size-16 items-center justify-center rounded-full text-xl font-bold"
-                                class:cursor-pointer={isOwnProfile}
-                                onclick={handleImageClick}
-                                role={isOwnProfile ? 'button' : undefined}
-                                tabindex={isOwnProfile ? 0 : undefined}
-                                onkeydown={(e) => {
-                                    if (isOwnProfile && (e.key === 'Enter' || e.key === ' '))
-                                        handleImageClick();
-                                }}
                             >
                                 {p.mb_name.charAt(0).toUpperCase()}
                             </div>


### PR DESCRIPTION
## 요약

premium repo CI `Install & Build` 가 다음 svelte a11y 위반으로 fail 되어 main 빌드가 깨진 상태입니다 (ad-free PR #1434 머지 직후 rebuild trigger 로 노출):

```
src/routes/member/[id]/+page.svelte:345:28
noninteractive element cannot have nonnegative tabIndex value
```

## 원인

avatar fallback `<div>` 가 동적 `role`/`tabindex` 를 갖는 패턴인데, svelte 5 vite plugin 의 strict a11y rule `a11y_no_noninteractive_tabindex` 가 동적 `role` 값을 정적 추론하지 못해 noninteractive 로 판정 → `tabindex≥0` 위반 → vite build 실패.

기존 코드:
\`\`\`svelte
<div
    onclick={handleImageClick}
    role={isOwnProfile ? 'button' : undefined}
    tabindex={isOwnProfile ? 0 : undefined}
    onkeydown={...}
>
\`\`\`

## 수정

`isOwnProfile` 분기로 element 자체를 교체합니다. a11y 정통 + linter 정적 추론 통과.

- `isOwnProfile=true` → `<button>` (네이티브 interactive, 키보드 Enter/Space 자동)
- 그 외 → 일반 `<div>` (role/tabindex 모두 제거)

`onkeydown` 핸들러는 `<button>` 의 기본 키보드 동작으로 대체되어 불필요합니다.

## 검증

- `pnpm check`: **0 errors, 99 warnings** (이전 100 → 99, a11y warning 1건 해소)
- 머지 후 premium main `Install & Build` 회복 예상

## 후속 (별 PR 분리)

이전 premium fail 로그에 보였던 추가 svelte 5 `state_referenced_locally` warning (build fail 안 시키는 WARN):
- `let avatarError = $state(...)` (member/[id]/+page.svelte:63)
- `let errors = $state(...)` (다른 파일들)

이번 fix 의 scope 에 포함하지 않습니다 (build fail 원인 1건만 정확히 처리).

## Test plan

- [ ] CI Build (web) 통과
- [ ] 자기 프로필 페이지: avatar Tab 포커스 + Enter/Space 로 이미지 업로드 모달 동작
- [ ] 타인 프로필 페이지: avatar 클릭/포커스 비활성 (회귀 없음)
- [ ] 머지 후 `gh run -R damoang/angple-premium list --branch main --limit 1` → success