### PR TITLE
feat(slot): member-profile-stats slot for plugin-driven profile stats [Sprint 0]

### DIFF
--- a/apps/web/src/lib/components/slot-manager.ts
+++ b/apps/web/src/lib/components/slot-manager.ts
@@ -45,7 +45,8 @@ export type SlotName =
     | 'board-view-banner' // 게시글 상세 상단 배너
     | 'board-view-rolling' // 게시글 상세 롤링 메시지
     | 'sidebar-banner' // 사이드바 배너
-    | 'board-list-promotion'; // 게시판 목록 인라인 홍보글
+    | 'board-list-promotion' // 게시판 목록 인라인 홍보글
+    | 'member-profile-stats'; // 회원 프로필 통계 영역 (plugin 통계 배지 등)
 
 /**
  * Component 슬롯 레지스트리

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import { Button } from '$lib/components/ui/button/index.js';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import { Progress } from '$lib/components/ui/progress/index.js';
@@ -418,6 +419,10 @@
                         <div class="mt-1 flex items-center gap-1.5">
                             <LevelBadge level={p.as_level} />
                             <span class="text-sm">{getGradeName(p.mb_level)}</span>
+                        </div>
+                        <!-- 플러그인 슬롯: 회원 프로필 통계 (예: archive plugin 의 "보존됨 N") -->
+                        <div class="mt-2">
+                            <PluginSlot name="member-profile-stats" mbId={p.mb_id} />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
archive plugin (premium #62) 의 회원 프로필 통계 표시용 slot 신설. WordPress `add_action` 패턴 — core 가 slot 사전 제공, plugin 이 등록.

## Changes
- `apps/web/src/lib/components/slot-manager.ts` — SlotName 에 `'member-profile-stats'` 추가
- `apps/web/src/routes/member/[id]/+page.svelte` — `PluginSlot` import + 등급 배지 줄 아래 `<PluginSlot name="member-profile-stats" mbId={p.mb_id} />` 마운트

## 동작
- archive plugin 활성 + 회원이 보존된 적 있으면 → "보존됨 N" amber 배지 노출
- plugin 미설치 사이트 → `components.length=0` → DOM 미렌더
- 기존 페이지 영향 0

## 후속 — Slot Catalog Expansion Sprint
본 PR = 단발 slot 추가. 다음 sprint 에서 50+ 표준 slot 일괄 정의 + 페이지 사전 배치 → 마켓플레이스 plugin 들이 core 손대지 않고 확장 가능하게 함.

분석 docs: `/home/damoang/docs/2026-05-17-plugin-slot-architecture-research.md`

## Test plan
- [ ] `pnpm check` 신규 에러 0
- [ ] archive plugin 미설치 사이트: 회원 프로필 페이지 정상 (DOM 변동 없음)
- [ ] archive plugin 설치 + 회원 1회 이상 보존 받음: 등급 줄 아래 "보존됨 N" 배지
- [ ] hydration mismatch 0

Refs damoang-premium#62