### PR TITLE
fix(post-detail): auto-detect RecentPosts page for external entry (#12430)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -211,7 +211,30 @@
         if (posts.length > 0) return;
 
         try {
-            const startPage = Math.max(1, initialPage);
+            let startPage = Math.max(1, initialPage);
+
+            // #12430: URL 에 ?page 가 없고 글 상세 페이지인 경우 — 외부 진입 (검색/알림/직접 URL)
+            // 자기 글이 어느 페이지인지 자동 감지해서 그 페이지로 fetch. SSR 가 항상 1 로
+            // 고정한 부분을 클라이언트가 보강. PR #1431 의 SPA 재마운트 fix 와 함께 동작.
+            if (
+                isOnPostDetail &&
+                currentPostId > 0 &&
+                !$pageStore.url.searchParams.has('page') &&
+                startPage === 1
+            ) {
+                try {
+                    const r = await fetch(
+                        `/api/boards/${boardId}/posts/${currentPostId}/page-index`
+                    );
+                    if (r.ok) {
+                        const body = (await r.json()) as { page?: number };
+                        if (body.page && body.page > 1) startPage = body.page;
+                    }
+                } catch {
+                    // page-index 실패 시 1 유지 (사용자 흐름 방해 X)
+                }
+            }
+
             const response = await apiClient.getBoardPosts(boardId, startPage, limit, {
                 summary: useSummaryListResponse
             });

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/page-index/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/page-index/+server.ts
@@ -1,0 +1,56 @@
+/**
+ * GET /api/boards/[boardId]/posts/[postId]/page-index
+ *
+ * 해당 글이 자유게시판 등에서 N페이지에 위치하는지 계산.
+ * RecentPosts (글 상세 하단 목록) 가 URL `?page` 없이 진입했을 때
+ * 자기 글이 속한 페이지로 자동 이동하기 위한 endpoint (#12430).
+ *
+ * 페이지 계산: 더 최신 (wr_id 가 더 큰) 정상 글 개수 / page_rows + 1.
+ *   - prior = COUNT(wr_id > targetId, wr_is_comment=0, wr_deleted_at IS NULL)
+ *   - page  = floor(prior / page_rows) + 1
+ *
+ * page_rows 는 g5_board.bo_page_rows (게시판 설정), 미설정 시 25 default.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import pool from '$lib/server/db';
+import type { RowDataPacket } from 'mysql2';
+
+const BOARD_ID_RE = /^[a-zA-Z0-9_]{1,40}$/;
+
+export const GET: RequestHandler = async ({ params, setHeaders }) => {
+    const boardId = params.boardId ?? '';
+    const postId = parseInt(params.postId ?? '0', 10);
+
+    if (!BOARD_ID_RE.test(boardId) || !Number.isFinite(postId) || postId <= 0) {
+        return json({ page: 1, page_rows: 25 }, { status: 400 });
+    }
+
+    try {
+        // 게시판 page_rows 조회
+        const [boardRows] = await pool.query<RowDataPacket[]>(
+            'SELECT bo_page_rows FROM g5_board WHERE bo_table = ? LIMIT 1',
+            [boardId]
+        );
+        const pageRows = Math.max(1, (boardRows[0]?.bo_page_rows as number | null) ?? 25);
+
+        // 해당 글보다 최신인 정상 글 개수 (1페이지에 최신 글이 옴)
+        const tableName = `g5_write_${boardId}`;
+        const [countRows] = await pool.query<RowDataPacket[]>(
+            `SELECT COUNT(*) AS c FROM \`${tableName}\`
+             WHERE wr_is_comment = 0 AND wr_id > ? AND wr_deleted_at IS NULL`,
+            [postId]
+        );
+        const prior = (countRows[0]?.c as number) ?? 0;
+        const page = Math.floor(prior / pageRows) + 1;
+
+        // 짧은 캐시 (1분) — 페이지 번호가 자주 바뀌지 않음
+        setHeaders({ 'Cache-Control': 'public, max-age=60' });
+
+        return json({ page, page_rows: pageRows, prior });
+    } catch (err) {
+        // DB 오류 시 1페이지 fallback (사용자 흐름 방해 X)
+        console.error('[page-index] DB error:', err);
+        return json({ page: 1, page_rows: 25 });
+    }
+};


### PR DESCRIPTION
## Summary
페이징 회귀 1주일 11건 누적 (#12302/12315/12363/12367/12383/12389/12409/12413/12430). T윤실장 #12430 호소: PC + 모바일 다양한 환경에서 어디 페이지의 글을 조회해도 하단 RecentPosts 가 1페이지 고정.

직전 5건 fix (PR #1407/1423/1426/1427/1431) 는 SPA 재마운트 + 캐시 우회 보강. 그러나 **외부 진입 (알림/검색/직접 URL/SNS 공유) 시 URL 에 ?page 가 없어서 SSR `data.recentPosts.page=1` (의도적 고정, #12315) 로 떨어져 항상 1페이지** 라는 근본 시나리오 미해결.

## Changes
- 신설 `routes/api/boards/[boardId]/posts/[postId]/page-index/+server.ts`
  - 해당 글이 N페이지에 위치하는지 계산: `COUNT(wr_id > target, wr_is_comment=0, deleted IS NULL) / bo_page_rows + 1`
  - 1분 캐시, DB 오류 시 page=1 fallback
- 수정 `recent-posts.svelte` onMount
  - 글 상세 + currentPostId 있음 + URL ?page 없음 + initialPage=1 일 때만 page-index 호출 → 자동으로 그 페이지 startPage
  - 실패 시 1 유지 (사용자 흐름 보호)

## 효과
- 알림/검색/SNS 공유 진입 시 RecentPosts 가 글이 속한 페이지로 시작 (사용자 기대)
- URL ?page=N 정상 흐름 (목록→글 클릭) 그대로 유지
- 클라이언트 동적 호출이라 SSR 응답 캐시 무관

## ⚠️ 운영 배포 lag (별도)
운영 ASSET_RELEASE_ID = `sha-26dbcbd` = PR #1420 시점. PR #1431 포함 5/15~5/17 사이 15개 PR **모두 운영 미배포**. 본 PR 머지 + workflow_dispatch 재가동 시 함께 적용.

## Test plan
- [ ] 자유게시판 5페이지 글 ID 를 URL 직접 입력 (`/free/{id}` 없이 ?page=) → 하단 RecentPosts 가 5페이지 표시
- [ ] 1페이지 글 직접 진입 → 1페이지 (page-index 가 1 반환)
- [ ] 목록 → 글 클릭 (?page=N 포함) → 기존 흐름 그대로 N페이지
- [ ] page-index API 실패 시뮬레이션 → 1페이지 fallback, 에러 노출 X
- [ ] CI: build + lint 통과

Refs #12430