### PR TITLE
feat(slot): Slot Catalog Expansion — 52 표준 slot + custom-* [Sprint 1]

### DIFF
--- a/apps/web/src/lib/components/slot-manager.ts
+++ b/apps/web/src/lib/components/slot-manager.ts
@@ -24,28 +24,111 @@ export interface SlotComponent {
 }
 
 /**
- * 사용 가능한 슬롯 포인트
+ * 사용 가능한 슬롯 포인트 — angple Plugin Slot Catalog
+ *
+ * WordPress `do_action` / Shopify Theme App Extension / Discourse Plugin Outlets
+ * 모범 사례 따라 사전 풍부한 slot 라이브러리 제공. plugin 이 매번 core PR 없이
+ * `plugin.json` `components[].slot` 으로 등록만 하면 동작.
+ *
+ * 명명 규약: `<area>-<object>-<position>`
+ *   position: before / after / prepend / append / top / middle / bottom /
+ *             left / center / right / actions / meta / toolbar / header
+ *
+ * `custom-${string}` template — plugin 끼리 자유 협업용 사용자 정의 slot.
+ * 표준 slot 이름 충돌 회피 위해 plugin 개발자는 `custom-{pluginId}-{slot}` 권장.
+ *
+ * 분석/근거: /home/damoang/docs/2026-05-17-plugin-slot-architecture-research.md
  */
-export type SlotName =
-    | 'header-before' // 헤더 상단
-    | 'header-after' // 헤더 하단
-    | 'sidebar-left-top' // 왼쪽 사이드바 상단
-    | 'sidebar-left-bottom' // 왼쪽 사이드바 하단
-    | 'sidebar-right-top' // 오른쪽 사이드바 상단
-    | 'sidebar-right-bottom' // 오른쪽 사이드바 하단
-    | 'content-before' // 메인 콘텐츠 상단
-    | 'content-after' // 메인 콘텐츠 하단
-    | 'footer-before' // 푸터 상단
-    | 'footer-after' // 푸터 하단
-    | 'background' // 배경 (테마용)
-    | 'landing-hero' // 랜딩 히어로 (테마용)
-    | 'landing-content' // 랜딩 콘텐츠 (테마용)
-    | 'board-list-banner' // 게시판 목록 상단 배너
-    | 'board-list-rolling' // 게시판 목록 헤더 아래 롤링 메시지
-    | 'board-view-banner' // 게시글 상세 상단 배너
-    | 'board-view-rolling' // 게시글 상세 롤링 메시지
-    | 'sidebar-banner' // 사이드바 배너
-    | 'board-list-promotion'; // 게시판 목록 인라인 홍보글
+export type StandardSlotName =
+    // ── 글로벌 layout (10) ──
+    | 'header-before' // 헤더 위
+    | 'header-after' // 헤더 아래
+    | 'header-actions-left' // 헤더 좌측 액션 영역
+    | 'header-actions-center' // 헤더 중앙 액션 영역
+    | 'header-actions-right' // 헤더 우측 액션 영역
+    | 'footer-before' // 푸터 위
+    | 'footer-after' // 푸터 아래
+    | 'body-start' // <body> 직후 (analytics, modal 마운트 등)
+    | 'body-end' // </body> 직전
+    | 'sidebar-banner' // 사이드바 배너 (기존)
+    // ── 사이드바 (6) ──
+    | 'sidebar-left-top'
+    | 'sidebar-left-middle'
+    | 'sidebar-left-bottom'
+    | 'sidebar-right-top'
+    | 'sidebar-right-middle'
+    | 'sidebar-right-bottom'
+    // ── 콘텐츠 영역 ──
+    | 'content-before'
+    | 'content-after'
+    | 'background'
+    // ── 게시판 목록 (8) ──
+    | 'board-list-banner' // 목록 상단 배너 (기존)
+    | 'board-list-rolling' // 목록 헤더 아래 롤링 (기존)
+    | 'board-list-promotion' // 인라인 홍보글 (기존)
+    | 'board-list-filter-before'
+    | 'board-list-filter-after'
+    | 'board-list-item-prepend' // 글 카드 좌측/위
+    | 'board-list-item-append' // 글 카드 우측/아래
+    | 'board-list-empty' // 빈 상태
+    // ── 글 상세 (12) ──
+    | 'board-view-banner' // 글 상세 상단 배너 (기존)
+    | 'board-view-rolling' // 글 상세 롤링 (기존)
+    | 'post-detail-before'
+    | 'post-detail-header-after'
+    | 'post-detail-content-before'
+    | 'post-detail-content-after'
+    | 'post-detail-extra' // 본문 아래 추가 영역 (기존, archive/giving 등 사용 중)
+    | 'post-detail-actions' // 공유/신고/보존 등 액션 묶음
+    | 'post-detail-tags'
+    | 'post-detail-reactions-after'
+    | 'post-detail-related'
+    | 'post-detail-comments-before'
+    | 'post-detail-comments-after'
+    | 'post-detail-after'
+    // ── 댓글 (9) ──
+    | 'comments-header'
+    | 'comments-form-before'
+    | 'comments-form-toolbar'
+    | 'comments-form-after'
+    | 'comments-list-before'
+    | 'comments-list-after'
+    | 'comments-item-prepend'
+    | 'comments-item-append'
+    | 'comments-item-actions'
+    // ── 회원 프로필 (5) ──
+    | 'member-profile-header'
+    | 'member-profile-stats' // 통계 영역 (archive plugin 등)
+    | 'member-profile-tabs-before'
+    | 'member-profile-tabs-after'
+    | 'member-profile-actions'
+    // ── 글쓰기 폼 (5) ──
+    | 'write-form-before'
+    | 'write-form-title-after'
+    | 'write-form-toolbar'
+    | 'write-form-editor-after'
+    | 'write-form-after'
+    // ── 메인/랜딩 (4) ──
+    | 'landing-hero' // 기존
+    | 'landing-content' // 기존
+    | 'home-content-before'
+    | 'home-content-after'
+    // ── 인증 / 검색 (3) ──
+    | 'auth-login-after'
+    | 'auth-signup-after'
+    | 'search-results-before'
+    // ── 어드민 (3) ──
+    | 'admin-sidebar-after'
+    | 'admin-dashboard-widgets'
+    | 'admin-settings-tabs';
+
+/**
+ * Plugin 끼리 자유 협업용 사용자 정의 slot.
+ * 권장 명명: `custom-{pluginId}-{slot}` (예: `custom-archive-profile-stats`).
+ */
+export type CustomSlotName = `custom-${string}`;
+
+export type SlotName = StandardSlotName | CustomSlotName;
 
 /**
  * Component 슬롯 레지스트리


### PR DESCRIPTION
## Summary
WordPress `add_action` / Shopify Theme App Extension / Discourse Plugin Outlets 모범 사례 따라 plugin 이 매번 core PR 없이 등록만으로 동작하도록 SlotName 사전 확장.

분석 docs: `/home/damoang/docs/2026-05-17-plugin-slot-architecture-research.md`

## Changes
- `apps/web/src/lib/components/slot-manager.ts`
  - `StandardSlotName` 52 항목 (기존 19 + 신규 33)
  - `CustomSlotName = `custom-${string}`` template literal type
  - `SlotName = StandardSlotName | CustomSlotName`

## Catalog 영역별 구성
| 영역 | slot 수 |
|---|---|
| 글로벌 layout | 10 |
| 사이드바 | 6 |
| 콘텐츠 | 3 |
| 게시판 목록 | 8 |
| 글 상세 | 14 |
| 댓글 | 9 |
| 회원 프로필 | 5 (member-profile-stats 포함, #1436 단발 추가 흡수) |
| 글쓰기 | 5 |
| 메인/랜딩 | 4 |
| 인증/검색 | 3 |
| 어드민 | 3 |

## 명명 규약
`<area>-<object>-<position>` (WordPress 호환). position: before / after / prepend / append / top / middle / bottom / left / center / right / actions / meta / toolbar / header

## custom-* 컨벤션
plugin 끼리 자유 협업용. 권장: `custom-{pluginId}-{slot}` (예: `custom-archive-profile-stats`)

## 호환성
- **기존 19 slot 이름 변경 없음** — giving/trade/archive 등 plugin 영향 0
- TypeScript strict mode 호환 (union + template literal type)

## Sprint 진행
- ✅ Sprint 0 #1436: archive 의 `member-profile-stats` 단발 추가 (호환)
- ✅ **Sprint 1 (이 PR)**: Catalog 확장 정의
- ⏳ Sprint 2: 페이지/컴포넌트에 `<PluginSlot>` 사전 배치 (영역별 1~3 PR)
- ⏳ Sprint 3: 문서 (`PLUGIN_SLOTS.md`) + 샘플 plugin

## 머지 순서 권장
1. #1436 (Sprint 0) 머지 → main 에 `member-profile-stats` 추가
2. 이 PR rebase 후 머지 (catalog 가 #1436 변경 흡수)

## Test plan
- [ ] `pnpm check` 신규 에러 0
- [ ] 기존 plugin (archive premium #62 / giving / trade) 등록 정상 — slot 이름 미변경
- [ ] `registerComponent('custom-foo', ...)` 호출 TypeScript 통과
- [ ] 빌드 size 영향 0 (타입 only 변경)