### PR TITLE
fix(ad-free): plugin.json 스키마 정합성 (dependencies 객체 + pluginType 제거)

### DIFF
--- a/plugins/ad-free/plugin.json
+++ b/plugins/ad-free/plugin.json
@@ -8,11 +8,10 @@
     },
     "license": "MIT",
     "category": "plugin",
-    "pluginType": "MEMBERSHIP",
     "main": "index.ts",
     "description": "회원 구독으로 사이트 광고를 제거하는 멤버십 플러그인. payment 플러그인과 연동하여 네이버페이/PayPal/토스 결제를 통한 정기구독을 제공합니다.",
     "tags": ["membership", "ad-free", "subscription", "광고제거", "멤버십"],
-    "dependencies": [{ "id": "payment", "version": "^0.1" }],
+    "dependencies": { "payment": "^0.1" },
     "migrations": [
         {
             "version": "001",


### PR DESCRIPTION
brickang 동일 원인 (premium PR damoang/angple-premium#63 fix). scanner 의 Zod safeValidateExtensionManifest 가 다음을 reject:

- `dependencies: [{id, version}]` 배열 → `z.record(string, string)` 위반
- `pluginType: 'MEMBERSHIP'` → PluginType enum (소문자 value) 비매칭

## 수정
- dependencies: `{ "payment": "^0.1" }` 객체 형식
- pluginType 제거 (optional 필드, 미지정 허용)

## 검증
- `python -m json.tool` 통과
- `pnpm check` 0 errors (회귀 없음)
- 머지 + canary 재배포 후 `/api/plugins/ad-free/me` 401 (인증 필요, 정상) 회복 예상

Related: damoang/angple-premium#63