### PR TITLE
fix(plugins): migration-runner schema drift 자동 복구 + payment pluginType 제거

### DIFF
--- a/apps/web/src/lib/server/plugins/migration-runner.ts
+++ b/apps/web/src/lib/server/plugins/migration-runner.ts
@@ -19,6 +19,29 @@ let bootstrapped = false;
 async function ensureBootstrap(): Promise<void> {
     if (bootstrapped) return;
     await pool.query(TRACKING_TABLE_DDL);
+
+    // Schema drift repair — `CREATE TABLE IF NOT EXISTS` 가 옛 schema 테이블을 SKIP 하여
+    // 누락 column 이 추가되지 않은 운영 환경 대비 (예: 'version' / 'applied_at' 컬럼 누락).
+    // 검증: SHOW COLUMNS 로 존재 여부 확인 후 누락 시에만 ALTER. idempotent.
+    const [versionCol] = await pool.query<RowDataPacket[]>(
+        "SHOW COLUMNS FROM plugin_migrations LIKE 'version'"
+    );
+    if (versionCol.length === 0) {
+        console.warn(`${LOG_PREFIX} schema drift — adding 'version' column`);
+        await pool.query(
+            "ALTER TABLE plugin_migrations ADD COLUMN version VARCHAR(100) NOT NULL DEFAULT ''"
+        );
+    }
+    const [appliedAtCol] = await pool.query<RowDataPacket[]>(
+        "SHOW COLUMNS FROM plugin_migrations LIKE 'applied_at'"
+    );
+    if (appliedAtCol.length === 0) {
+        console.warn(`${LOG_PREFIX} schema drift — adding 'applied_at' column`);
+        await pool.query(
+            'ALTER TABLE plugin_migrations ADD COLUMN applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP'
+        );
+    }
+
     bootstrapped = true;
 }
 

--- a/plugins/payment/plugin.json
+++ b/plugins/payment/plugin.json
@@ -7,7 +7,6 @@
         "url": "https://angple.com"
     },
     "category": "plugin",
-    "pluginType": "PAYMENT",
     "license": "MIT",
     "main": "index.ts",
     "description": "다중 PG (토스/네이버페이/페이팔) 통합 결제 플러그인. 멀티사이트 키 분리.",


### PR DESCRIPTION
운영 plugin 활성화가 'Unknown column version' 으로 실패. 원인: plugin_migrations 옛 schema (version/applied_at 컬럼 누락) + CREATE TABLE IF NOT EXISTS 의 stale drift.

## 수정
1. migration-runner.ts ensureBootstrap: SHOW COLUMNS → 누락 ALTER (idempotent)
2. payment plugin.json: pluginType 'PAYMENT' enum 비매칭 → 제거

Related: premium#63/#64, angple#1439