### PR TITLE
feat(slot): mount body-start / body-end PluginSlot [Sprint 2a]

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
     import '../app.css';
     import favicon from '$lib/assets/favicon.png';
     import { onMount, untrack } from 'svelte';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import type { Component } from 'svelte';
     import { browser } from '$app/environment';
     import { afterNavigate, onNavigate } from '$app/navigation';
@@ -650,6 +651,9 @@
     {/if}
 </svelte:head>
 
+<!-- 플러그인 슬롯: <body> 시작 (analytics, 모달 마운트 등) — Slot Catalog Sprint 2 -->
+<PluginSlot name="body-start" />
+
 <!-- /admin, /install 경로는 테마 레이아웃 없이 렌더링 -->
 {#if isAdminRoute || isInstallRoute}
     {@render children()}
@@ -681,3 +685,6 @@
 {#if !isAdminRoute && !isInstallRoute && LazyShortcutButtons}
     <LazyShortcutButtons />
 {/if}
+
+<!-- 플러그인 슬롯: </body> 직전 (지연 로딩 컴포넌트, fallback 등) — Slot Catalog Sprint 2 -->
+<PluginSlot name="body-end" />


### PR DESCRIPTION
## Summary
Slot Catalog Sprint 1 (#1438) 의 글로벌 layout slot 2개를 `+layout.svelte` 에 사전 배치.

## Changes
- `PluginSlot` import 추가
- `<PluginSlot name="body-start" />` — `<svelte:head>` 직후, children 분기 전
- `<PluginSlot name="body-end" />` — `LazyShortcutButtons` 다음 (페이지 끝)

## 동작
- plugin 미사용 시 `components.length=0` → DOM 미렌더 → 영향 0
- 기존 plugin (archive/ad-free) 영향 없음 (사용 slot 다름)
- 후속 plugin: page-wide analytics / modal / floating action / 지연 로딩 자유 등록

## Sprint 진행
- ✅ Sprint 1 (#1438): Catalog
- ✅ **Sprint 2a (이 PR)**: body-start/end 마운트
- ⏳ Sprint 2b: header.svelte header-actions-* (별도)
- ⏳ Sprint 2c: 사이드바/게시판/댓글/회원 프로필 (영역별)
- ✅ Sprint 3 (#1440): 카탈로그 HTML 문서

## Test plan
- [ ] plugin 미설치: 페이지 정상, DOM 변동 없음
- [ ] 더미 plugin 으로 등록 → 위치 검증
- [ ] admin/install 페이지 정상 (slot 미사용 시 영향 없음)
- [ ] CI: build + lint 통과

문서: `docs/PLUGIN_SLOTS.html` (#1440)