### PR TITLE
feat(slot): member profile mounts (Sprint 2c)

### DIFF
--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -35,6 +35,7 @@
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
     import FollowListDialog from '$lib/components/features/member/follow-list-dialog.svelte';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
 
     // 동적 플러그인 임포트: member-memo
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
@@ -422,6 +423,9 @@
                     </div>
                 </div>
 
+                <!-- 플러그인 슬롯: 회원 프로필 헤더 (이름/등급 영역 직후) — Slot Catalog Sprint 2c -->
+                <PluginSlot name="member-profile-header" mbId={p.mb_id} />
+
                 <!-- 경험치 바 -->
                 {#if p.as_level > 0}
                     <div class="mt-4">
@@ -444,6 +448,9 @@
                         </p>
                     </div>
                 {/if}
+
+                <!-- 플러그인 슬롯: 회원 통계 (경험치 직후, 팔로워 위) — Slot Catalog Sprint 2c -->
+                <PluginSlot name="member-profile-stats" mbId={p.mb_id} />
 
                 <!-- 팔로워/팔로잉 + 액션 버튼 -->
                 <div class="mt-4 flex items-center gap-3">
@@ -504,11 +511,16 @@
                         </div>
                     {/if}
                 </div>
+
+                <!-- 플러그인 슬롯: 회원 액션 (팔로워/액션 버튼 직후) — Slot Catalog Sprint 2c -->
+                <PluginSlot name="member-profile-actions" mbId={p.mb_id} />
             </CardContent>
         </Card>
 
         <!-- 탭 영역 -->
         <Card class="bg-background">
+            <!-- 플러그인 슬롯: 탭 직전 (탭 위 배너/공지 등) — Slot Catalog Sprint 2c -->
+            <PluginSlot name="member-profile-tabs-before" mbId={p.mb_id} />
             <Tabs.Root value="info" onValueChange={handleTabChange}>
                 <Tabs.List class="border-border w-full justify-start border-b">
                     <Tabs.Trigger value="info">정보</Tabs.Trigger>
@@ -930,6 +942,8 @@
                     {/if}
                 </Tabs.Content>
             </Tabs.Root>
+            <!-- 플러그인 슬롯: 탭 직후 (탭 아래 추가 카드 등) — Slot Catalog Sprint 2c -->
+            <PluginSlot name="member-profile-tabs-after" mbId={p.mb_id} />
         </Card>
 
         <!-- 상호작용 분석 (플러그인) — 본인만 -->


### PR DESCRIPTION
## Summary
- 회원 프로필 페이지 `member/[id]/+page.svelte` 에 5개 PluginSlot 마운트
- Slot Catalog Sprint 2c — 마켓플레이스 plugin 이 회원 영역에 core PR 없이 컴포넌트 추가 가능

## 마운트 위치
| Slot | 위치 |
|---|---|
| `member-profile-header` | 이름/등급 줄 직후, 경험치 바 위 |
| `member-profile-stats` | 경험치 바 직후, 팔로워/액션 위 |
| `member-profile-actions` | 팔로워/액션 줄 직후, CardContent 끝 |
| `member-profile-tabs-before` | `<Tabs.Root>` 직전 |
| `member-profile-tabs-after` | `</Tabs.Root>` 직후 |

PR #1436 (member-profile-stats 단일 마운트) 의 변경을 흡수 + 확장. #1436 머지 시 conflict 해결.

## Test plan
- [ ] `pnpm check` 통과
- [ ] plugin 미설치 상태: 회원 프로필 페이지 SSR/CSR 영향 없음 (components.length=0 → DOM 미생성)
- [ ] mb_name + 아바타 + 등급 + 팔로워 카운트 + 탭 4종 정상 렌더링
- [ ] 더미 plugin 으로 5개 slot 각각 등록 → 해당 위치 렌더링 확인
- [ ] mbId prop 전달 확인 (plugin component 가 회원 ID 수신)

archive plugin 등이 `member-profile-stats` 슬롯에 ArchiveProfileStat 등록 시 회원 프로필 통계 라인 자동 노출.