### PR TITLE
feat(slot): post detail mounts (Sprint 2c — 4 core slots)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1528,6 +1528,9 @@
      - clip 미지원 브라우저: hidden 적용 (이 wrapper 내부에는 position:sticky 가 없어 안전)
      - clip 지원 브라우저: clip 이 hidden 을 덮어 기존 동작 유지 -->
 <div class="mx-auto pt-2" style="overflow-x: hidden; overflow-x: clip;">
+    <!-- 플러그인 슬롯: 글 상세 페이지 시작 — Slot Catalog Sprint 2c -->
+    <PluginSlot name="post-detail-before" {boardId} postId={data.post.id} />
+
     <!-- 최상단 자체 배너 (없으면 GAM 폴백) -->
     {#if widgetLayoutStore.hasEnabledAds && !data.post.deleted_at}
         <div class="mb-3">
@@ -1911,6 +1914,12 @@
                     {#if !commentsLoaded}
                         <p class="text-muted-foreground text-sm">댓글을 불러오는 중입니다.</p>
                     {/if}
+                    <!-- 플러그인 슬롯: 댓글 영역 직전 — Slot Catalog Sprint 2c -->
+                    <PluginSlot
+                        name="post-detail-comments-before"
+                        {boardId}
+                        postId={data.post.id}
+                    />
                     {#if !data.post.is_comments_disabled}
                         <CommentList
                             {comments}
@@ -1932,6 +1941,8 @@
                             isRestricted={data.isRestricted}
                         />
                     {/if}
+                    <!-- 플러그인 슬롯: 댓글 영역 직후 — Slot Catalog Sprint 2c -->
+                    <PluginSlot name="post-detail-comments-after" {boardId} postId={data.post.id} />
 
                     <div class="border-border border-t pt-6">
                         <div class="mb-3 flex justify-end">
@@ -2024,6 +2035,9 @@
 
         <!-- GA4 Scroll Depth 센티넬 (100%) -->
         <div data-scroll-depth="100" aria-hidden="true"></div>
+
+        <!-- 플러그인 슬롯: 글 상세 페이지 끝 — Slot Catalog Sprint 2c -->
+        <PluginSlot name="post-detail-after" {boardId} postId={data.post.id} />
     {/if}
     <!-- /canRead -->
 </div>


### PR DESCRIPTION
## Summary
- 글 상세 페이지 `[boardId]/[postId]/+page.svelte` 에 4개 핵심 PluginSlot 마운트
- Slot Catalog Sprint 2c — 마켓플레이스 plugin 이 글 상세 페이지에 core PR 없이 컴포넌트 추가 가능

## 마운트 슬롯 (4 / 12)
| Slot | 위치 |
|---|---|
| `post-detail-before` | 페이지 main `<div>` 시작 직후, 배너 위 |
| `post-detail-comments-before` | CommentList 직전 (댓글 영역 시작 전) |
| `post-detail-comments-after` | CommentList `{/if}` 직후 (댓글 새로고침 영역 직전) |
| `post-detail-after` | GA4 센티넬 직후, `{/if}` (canRead 영역 끝) 직전 |

`boardId`, `postId` props 자동 전달.

## 미마운트 (별도 sprint 분리)
다음 8개는 페이지 구조가 component 화 / 변수명 다양해서 별도 follow-up:
- `post-detail-header-after` (제목/메타 다음)
- `post-detail-content-before` / `content-after` (본문 영역)
- `post-detail-extra` (기존 슬롯 영역)
- `post-detail-actions` (수정/삭제 버튼)
- `post-detail-tags` (태그 영역)
- `post-detail-reactions-after` (리액션 직후)
- `post-detail-related` (관련 글)

## Test plan
- [ ] \`pnpm check\` 통과
- [ ] plugin 미설치 상태: 글 상세 페이지 SSR/CSR 영향 없음
- [ ] 댓글 비활성 글 (\`is_comments_disabled=true\`) 에서도 \`comments-before/after\` 슬롯 노출
- [ ] 더미 plugin 으로 4개 슬롯 각각 등록 → 해당 위치 렌더링 확인
- [ ] boardId/postId prop 전달 확인