### PR TITLE
feat(slot): board list mounts (Sprint 2c — 3 slots)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -914,6 +914,9 @@
                 </div>
             {/if}
 
+            <!-- 플러그인 슬롯: 필터 영역 직전 — Slot Catalog Sprint 2c -->
+            <PluginSlot name="board-list-filter-before" {boardId} />
+
             <!-- 검색 폼 (토글 or 검색 중 or 핀 고정) -->
             {#if showSearch || isSearching || uiSettingsStore.pinSearch}
                 <div class="mb-3" transition:slide={{ duration: 200 }}>
@@ -1085,6 +1088,9 @@
                 </div>
             {/if}
 
+            <!-- 플러그인 슬롯: 필터 영역 직후 (목록 시작 전) — Slot Catalog Sprint 2c -->
+            <PluginSlot name="board-list-filter-after" {boardId} />
+
             <!-- 게시글 목록 -->
             <div class={wrapperClass}>
                 {#if listLayoutId === 'classic' && uiSettingsStore.listView !== 'modern'}
@@ -1248,6 +1254,8 @@
                             {:else}
                                 <p class="text-secondary-foreground">게시글이 없습니다.</p>
                             {/if}
+                            <!-- 플러그인 슬롯: 빈 목록 (대체 CTA/추천 표시) — Slot Catalog Sprint 2c -->
+                            <PluginSlot name="board-list-empty" {boardId} />
                         </CardContent>
                     </Card>
                 {:else if LayoutComponent}


### PR DESCRIPTION
## Summary
- 게시판 목록 페이지 `[boardId]/+page.svelte` 에 3개 PluginSlot 마운트
- Slot Catalog Sprint 2c — 마켓플레이스 plugin 이 목록 페이지에 core PR 없이 컴포넌트 추가 가능

## 마운트 슬롯 (3 / 5)
| Slot | 위치 |
|---|---|
| `board-list-filter-before` | 검색 폼 위 (필터 영역 시작 전) |
| `board-list-filter-after` | 게시글 목록 wrapper 직전 (필터 영역 직후) |
| `board-list-empty` | empty Card 안, "게시글이 없습니다" 메시지 직후 |

`boardId` prop 자동 전달.

## 미마운트 (별도 sprint)
- `board-list-item-prepend` / `board-list-item-append` — `{#each filteredPosts}` 안 마운트. 변수 (post) prop 전달 위해 별도 PR.

## Test plan
- [ ] `pnpm check` 통과
- [ ] plugin 미설치 상태: 게시판 목록 페이지 SSR/CSR 영향 없음
- [ ] empty 상태 (검색 결과 없음 등) 에서 `board-list-empty` 슬롯 노출
- [ ] 더미 plugin 으로 3개 슬롯 각각 등록 → 해당 위치 렌더링 확인