### PR TITLE
feat(slot): home page mounts (Sprint 2c — 2 slots)

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -6,6 +6,7 @@
     import { untrack } from 'svelte';
     import { SeoHead, createWebSiteJsonLd, getSiteUrl } from '$lib/seo/index.js';
     import type { SeoConfig } from '$lib/seo/types.js';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
 
     let { data } = $props();
 
@@ -61,6 +62,9 @@
     </div>
 {/if}
 
+<!-- 플러그인 슬롯: 홈 콘텐츠 직전 (위젯 영역 위) — Slot Catalog Sprint 2c -->
+<PluginSlot name="home-content-before" />
+
 <!-- 통합 위젯 렌더러로 메인 영역 렌더링 (추천글 SSR 프리페치 포함) -->
 <WidgetRenderer
     zone="main"
@@ -82,3 +86,6 @@
         celebration: { data: data.celebrationRecent ?? data.celebration ?? [] }
     }}
 />
+
+<!-- 플러그인 슬롯: 홈 콘텐츠 직후 (위젯 영역 아래) — Slot Catalog Sprint 2c -->
+<PluginSlot name="home-content-after" />


### PR DESCRIPTION
## Summary
- 홈페이지 \`+page.svelte\` 에 2개 PluginSlot 마운트
- Slot Catalog Sprint 2c

## 마운트 슬롯
| Slot | 위치 |
|---|---|
| \`home-content-before\` | WidgetRenderer 직전 |
| \`home-content-after\` | WidgetRenderer 직후 |

## Test plan
- [ ] \`pnpm check\` 통과
- [ ] plugin 미설치 상태: 홈페이지 SSR/CSR 영향 없음
- [ ] 더미 plugin 으로 2 슬롯 노출 확인