### PR TITLE
feat(slot): comments mounts (Sprint 2c — 2 slots)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -31,6 +31,7 @@
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent, loadPluginLib } from '$lib/utils/plugin-optional-loader';
     import RevisionHistory from '$lib/components/post/revision-history.svelte';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import type { PostRevision } from '$lib/api/types.js';
     import History from '@lucide/svelte/icons/history';
     import Heart from '@lucide/svelte/icons/heart';
@@ -928,6 +929,9 @@
     });
 </script>
 
+<!-- 플러그인 슬롯: 댓글 리스트 직전 — Slot Catalog Sprint 2c -->
+<PluginSlot name="comments-list-before" {boardId} {postId} />
+
 <ul
     bind:this={commentListEl}
     class={commentLayout === 'chat'
@@ -1785,6 +1789,9 @@
         </li>
     {/each}
 </ul>
+
+<!-- 플러그인 슬롯: 댓글 리스트 직후 — Slot Catalog Sprint 2c -->
+<PluginSlot name="comments-list-after" {boardId} {postId} />
 
 <!-- 댓글 신고 다이얼로그 -->
 {#if reportingCommentId !== null}


### PR DESCRIPTION
## Summary
- 댓글 컴포넌트 \`comment-list.svelte\` 에 2개 PluginSlot 마운트
- Slot Catalog Sprint 2c

## 마운트 슬롯
| Slot | 위치 |
|---|---|
| \`comments-list-before\` | \`<ul>\` 직전 (댓글 리스트 시작 전) |
| \`comments-list-after\` | \`</ul>\` 직후 (댓글 리스트 끝 후, 다이얼로그 위) |

\`boardId\`, \`postId\` props 자동 전달.

## 미마운트 (별도 sprint)
- \`comments-header\` / \`comments-item-prepend\` / \`comments-item-append\` / \`comments-item-actions\` — 각 댓글 each loop 안 마운트
- \`comments-form-before\` / \`form-toolbar\` / \`form-after\` — CommentForm 주변 (form 변수 활용 필요)

## Test plan
- [ ] \`pnpm check\` 통과
- [ ] plugin 미설치 상태: 글 상세 + 댓글 렌더링 영향 없음
- [ ] 댓글 0건/N건 모두에서 슬롯 노출