### PR TITLE
feat(slot): write form mounts (Sprint 2c — 2 slots)

### DIFF
--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -16,6 +16,7 @@
     import FileText from '@lucide/svelte/icons/file-text';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import { Button } from '$lib/components/ui/button/index.js';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
 
     let { data }: { data: PageData } = $props();
 
@@ -233,6 +234,9 @@
 
         <h1 class="text-foreground mb-4 text-xl font-bold">{boardTitle} — 새 글 작성</h1>
 
+        <!-- 플러그인 슬롯: 글쓰기 폼 직전 — Slot Catalog Sprint 2c -->
+        <PluginSlot name="write-form-before" {boardId} />
+
         {#if isPromotion}
             <div class="mb-4">
                 <Button
@@ -316,5 +320,8 @@
                 />
             {/key}
         {/if}
+
+        <!-- 플러그인 슬롯: 글쓰기 폼 직후 — Slot Catalog Sprint 2c -->
+        <PluginSlot name="write-form-after" {boardId} />
     {/if}
 </div>


### PR DESCRIPTION
## Summary
- 글쓰기 페이지 \`[boardId]/write/+page.svelte\` 에 2개 PluginSlot 마운트
- Slot Catalog Sprint 2c

## 마운트 슬롯
| Slot | 위치 |
|---|---|
| \`write-form-before\` | 페이지 제목 직후, PostForm 위 |
| \`write-form-after\` | PostForm 직후, canWrite \`{/if}\` 직전 |

\`boardId\` prop 자동 전달.

## 미마운트 (별도 sprint)
- \`write-form-title-after\` / \`toolbar\` / \`editor-after\` — PostForm 컴포넌트 내부 마운트 필요

## Test plan
- [ ] \`pnpm check\` 통과
- [ ] plugin 미설치 상태: 글쓰기 페이지 SSR/CSR 영향 없음
- [ ] 권한 없는 사용자에게는 슬롯 미노출 (canWrite \`{:else}\` 안)