### PR TITLE
feat(slot): header left/center mounts (Sprint 2b — 2 slots)

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -304,6 +304,8 @@
                     }}
                 />
             </a>
+            <!-- 플러그인 슬롯: 헤더 좌측 액션 (로고 옆) — Slot Catalog Sprint 2b -->
+            <PluginSlot name="header-actions-left" />
         </div>
 
         <!-- 데스크톱 네비게이션 (show_in_header 메뉴 동적 렌더링) -->
@@ -348,6 +350,9 @@
                 </a>
             {/if}
         </nav>
+
+        <!-- 플러그인 슬롯: 헤더 중앙 액션 (nav 와 우측 아이콘 사이) — Slot Catalog Sprint 2b -->
+        <PluginSlot name="header-actions-center" />
 
         <!-- 우측 아이콘 버튼들 -->
         <div class="flex shrink-0 items-center gap-1">


### PR DESCRIPTION
## Summary
- header.svelte 에 header-actions-left + header-actions-center PluginSlot 마운트
- header-actions-right 는 #1428 (pwa-share) 머지로 이미 main 에 존재 → header 3-slot 풀 구성 완성

## 마운트 슬롯
| Slot | 위치 |
|---|---|
| header-actions-left | 로고 영역 안 끝 (햄버거+로고 div 안, 로고 a 닫힘 직후) |
| header-actions-center | nav 닫힘 직후, 우측 아이콘 버튼 div 직전 |

## Test plan
- [ ] pnpm check 통과
- [ ] plugin 미설치 상태: 헤더 레이아웃 영향 없음 (components.length=0)
- [ ] 더미 plugin 으로 left/center 각각 등록 → 위치 렌더링 확인