### PR TITLE
feat(sidebar): 축하메시지 아래 '벽돌한장 · 광고 제거' inline 링크

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -385,6 +385,16 @@
             </div>
             <!-- 드로워: 축하메시지 -->
             <CelebrationRolling />
+            <!-- 축하메시지 바로 아래: 벽돌한장 · 광고 제거 inline -->
+            <div class="text-muted-foreground flex items-center justify-center gap-3 px-2 text-xs">
+                <a href="/brickang" class="hover:text-primary underline-offset-2 hover:underline">
+                    벽돌한장
+                </a>
+                <span class="opacity-50">·</span>
+                <a href="/ad-free" class="hover:text-primary underline-offset-2 hover:underline">
+                    광고 제거
+                </a>
+            </div>
         {:else}
             <!-- Slot: sidebar-left-bottom -->
             {#each getComponentsForSlot('sidebar-left-bottom') as slotComp (slotComp.id)}


### PR DESCRIPTION
## 요약
좌측 sidebar drawer 의 축하메시지(CelebrationRolling) 바로 아래에 다모앙 서비스 진입 inline 링크 2개 추가.

```
[축하메시지 텍스트 롤링]
   벽돌한장  ·  광고 제거
```

## 검증
- pnpm check: 0 errors / 99 warnings (회귀 없음)
- compact drawer 영역 (PC 좌측 펼침 시) 에만 노출 — `{#if compact}` 분기 안

## Test plan
- [ ] PC 사이드바 드로워에서 축하메시지 아래 2개 링크 한 줄 노출
- [ ] 벽돌한장 → /brickang 이동
- [ ] 광고 제거 → /ad-free 이동
- [ ] hover 시 primary color + underline