### PR TITLE
feat(ad-free): PC AdSense 만 OFF — 모바일·광고앙 배너는 유지

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -385,6 +385,16 @@
             </div>
             <!-- 드로워: 축하메시지 -->
             <CelebrationRolling />
+            <!-- 축하메시지 바로 아래: 벽돌한장 · 광고 제거 inline -->
+            <div class="text-muted-foreground flex items-center justify-center gap-3 px-2 text-xs">
+                <a href="/brickang" class="hover:text-primary underline-offset-2 hover:underline">
+                    벽돌한장
+                </a>
+                <span class="opacity-50">·</span>
+                <a href="/ad-free" class="hover:text-primary underline-offset-2 hover:underline">
+                    광고 제거
+                </a>
+            </div>
         {:else}
             <!-- Slot: sidebar-left-bottom -->
             {#each getComponentsForSlot('sidebar-left-bottom') as slotComp (slotComp.id)}

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -60,7 +60,10 @@
     const pluginSuppress = $derived(
         hooks.applyFilters('should_render_ad', true, {
             slotName: position,
-            user: ($page as any).data?.user ?? null
+            user: ($page as any).data?.user ?? null,
+            // PC viewport (≥970px) 일 때만 ad-free 같은 plugin 이 광고 OFF 가능.
+            // 모바일/태블릿은 default true 유지 → 다모앙 자체 광고앙 배너 + AdSense 정상 노출.
+            isDesktop: typeof window !== 'undefined' && window.innerWidth >= 970
         }) === false
     );
     const suppressAds = $derived(

--- a/packages/hook-system/src/types.ts
+++ b/packages/hook-system/src/types.ts
@@ -61,5 +61,6 @@ export interface FilterPoints {
     api_error: [error: any, endpoint: string];
 
     // 광고 렌더 결정 — 플러그인이 false 반환 시 AdSlot 미렌더 (ad-free 멤버십 등)
-    should_render_ad: [ctx: { slotName: string; user: any }];
+    // isDesktop: PC 뷰포트 (≥970px) 여부. 플러그인이 모바일/SSR 광고는 유지하고 PC 만 OFF 가능.
+    should_render_ad: [ctx: { slotName: string; user: any; isDesktop?: boolean }];
 }

--- a/plugins/ad-free/hooks/suppress.ts
+++ b/plugins/ad-free/hooks/suppress.ts
@@ -12,15 +12,23 @@ export interface AdFreeFilterCtx {
         ad_free_until?: string | Date | null;
         [k: string]: unknown;
     } | null;
+    /** PC 뷰포트 여부 (≥970px). undefined/false 면 SSR/mobile 로 간주 → 광고 유지. */
+    isDesktop?: boolean;
 }
 
 /**
  * - 다른 플러그인이 이미 false → 그대로 false (체이닝 보존)
- * - user.ad_free_until > now → false (광고 OFF)
+ * - isDesktop=false/undefined (SSR/mobile) → 입력값 그대로 (광고 유지, 다모앙 광고앙 배너 정책)
+ * - user.ad_free_until > now (PC + 활성 멤버십) → false (AdSense PC 광고 OFF)
  * - 그 외 → 입력값 그대로 (default true)
+ *
+ * 정책 메모: ad-free 멤버십은 **PC AdSense 광고만 제거**. 모바일 AdSense + 다모앙 자체 광고앙
+ * (premium/plugins/ad-widget 의 배너 — AdSlot 안 거치는 별도 컴포넌트) 는 항상 유지.
  */
 export function suppressAdsForAdFreeMember(value: boolean, ctx: AdFreeFilterCtx): boolean {
     if (value === false) return false;
+    // 모바일/SSR 은 광고 유지
+    if (!ctx?.isDesktop) return value;
     const until = ctx?.user?.ad_free_until;
     if (!until) return value;
     const expires = until instanceof Date ? until : new Date(until);

--- a/plugins/ad-free/hooks/tests/suppress.test.ts
+++ b/plugins/ad-free/hooks/tests/suppress.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { suppressAdsForAdFreeMember, type AdFreeFilterCtx } from '../suppress';
 
-function ctx(user: AdFreeFilterCtx['user']): AdFreeFilterCtx {
-    return { slotName: 'board-list-bottom', user };
+function ctx(
+    user: AdFreeFilterCtx['user'],
+    overrides: Partial<AdFreeFilterCtx> = {}
+): AdFreeFilterCtx {
+    return { slotName: 'board-list-bottom', user, isDesktop: true, ...overrides };
 }
 
 describe('suppressAdsForAdFreeMember', () => {
@@ -41,5 +44,23 @@ describe('suppressAdsForAdFreeMember', () => {
 
     it('ad_free_until null 은 입력값 그대로', () => {
         expect(suppressAdsForAdFreeMember(true, ctx({ ad_free_until: null }))).toBe(true);
+    });
+
+    // PC/모바일 분기 — ad-free 멤버십은 PC AdSense 만 OFF.
+    it('mobile (isDesktop=false) 는 멤버십 활성이어도 광고 유지', () => {
+        const future = new Date(Date.now() + 86_400_000).toISOString();
+        expect(
+            suppressAdsForAdFreeMember(true, ctx({ ad_free_until: future }, { isDesktop: false }))
+        ).toBe(true);
+    });
+
+    it('SSR (isDesktop=undefined) 도 광고 유지 (hydration 후 client 가 결정)', () => {
+        const future = new Date(Date.now() + 86_400_000).toISOString();
+        expect(
+            suppressAdsForAdFreeMember(
+                true,
+                ctx({ ad_free_until: future }, { isDesktop: undefined })
+            )
+        ).toBe(true);
     });
 });


### PR DESCRIPTION
ad-free 멤버십 정책 명확화. **PC AdSense 광고만 제거**, 모바일 AdSense + 다모앙 자체 광고앙 배너는 항상 유지.

## 변경
- `should_render_ad` filter ctx 에 `isDesktop?: boolean` 추가
- `ad-slot.svelte`: `window.innerWidth >= 970` 으로 isDesktop ctx 전달
- ad-free hook: `isDesktop=false/undefined` 면 광고 유지 (default true)
- 단위 테스트 2건 추가 (mobile / SSR)

## 정책표
| 환경 | AdSense | 다모앙 광고앙 |
|---|---|---|
| PC + ad-free 활성 | OFF | 노출 |
| PC + 비멤버 | 노출 | 노출 |
| 모바일 (멤버 무관) | 노출 | 노출 |

## 검증
- pnpm check: 0 errors / 99 warnings
- pnpm test:unit: 398 passed (+2 케이스)