### PR TITLE
feat(ad-free): Landing 디자인 + 카피 개편 — PC만 OFF / 모바일·광고앙 유지 명시

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -385,6 +385,16 @@
             </div>
             <!-- 드로워: 축하메시지 -->
             <CelebrationRolling />
+            <!-- 축하메시지 바로 아래: 벽돌한장 · 광고 제거 inline -->
+            <div class="text-muted-foreground flex items-center justify-center gap-3 px-2 text-xs">
+                <a href="/brickang" class="hover:text-primary underline-offset-2 hover:underline">
+                    벽돌한장
+                </a>
+                <span class="opacity-50">·</span>
+                <a href="/ad-free" class="hover:text-primary underline-offset-2 hover:underline">
+                    광고 제거
+                </a>
+            </div>
         {:else}
             <!-- Slot: sidebar-left-bottom -->
             {#each getComponentsForSlot('sidebar-left-bottom') as slotComp (slotComp.id)}

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -60,7 +60,10 @@
     const pluginSuppress = $derived(
         hooks.applyFilters('should_render_ad', true, {
             slotName: position,
-            user: ($page as any).data?.user ?? null
+            user: ($page as any).data?.user ?? null,
+            // PC viewport (≥970px) 일 때만 ad-free 같은 plugin 이 광고 OFF 가능.
+            // 모바일/태블릿은 default true 유지 → 다모앙 자체 광고앙 배너 + AdSense 정상 노출.
+            isDesktop: typeof window !== 'undefined' && window.innerWidth >= 970
         }) === false
     );
     const suppressAds = $derived(

--- a/packages/hook-system/src/types.ts
+++ b/packages/hook-system/src/types.ts
@@ -61,5 +61,6 @@ export interface FilterPoints {
     api_error: [error: any, endpoint: string];
 
     // 광고 렌더 결정 — 플러그인이 false 반환 시 AdSlot 미렌더 (ad-free 멤버십 등)
-    should_render_ad: [ctx: { slotName: string; user: any }];
+    // isDesktop: PC 뷰포트 (≥970px) 여부. 플러그인이 모바일/SSR 광고는 유지하고 PC 만 OFF 가능.
+    should_render_ad: [ctx: { slotName: string; user: any; isDesktop?: boolean }];
 }

--- a/plugins/ad-free/hooks/suppress.ts
+++ b/plugins/ad-free/hooks/suppress.ts
@@ -12,15 +12,23 @@ export interface AdFreeFilterCtx {
         ad_free_until?: string | Date | null;
         [k: string]: unknown;
     } | null;
+    /** PC 뷰포트 여부 (≥970px). undefined/false 면 SSR/mobile 로 간주 → 광고 유지. */
+    isDesktop?: boolean;
 }
 
 /**
  * - 다른 플러그인이 이미 false → 그대로 false (체이닝 보존)
- * - user.ad_free_until > now → false (광고 OFF)
+ * - isDesktop=false/undefined (SSR/mobile) → 입력값 그대로 (광고 유지, 다모앙 광고앙 배너 정책)
+ * - user.ad_free_until > now (PC + 활성 멤버십) → false (AdSense PC 광고 OFF)
  * - 그 외 → 입력값 그대로 (default true)
+ *
+ * 정책 메모: ad-free 멤버십은 **PC AdSense 광고만 제거**. 모바일 AdSense + 다모앙 자체 광고앙
+ * (premium/plugins/ad-widget 의 배너 — AdSlot 안 거치는 별도 컴포넌트) 는 항상 유지.
  */
 export function suppressAdsForAdFreeMember(value: boolean, ctx: AdFreeFilterCtx): boolean {
     if (value === false) return false;
+    // 모바일/SSR 은 광고 유지
+    if (!ctx?.isDesktop) return value;
     const until = ctx?.user?.ad_free_until;
     if (!until) return value;
     const expires = until instanceof Date ? until : new Date(until);

--- a/plugins/ad-free/hooks/tests/suppress.test.ts
+++ b/plugins/ad-free/hooks/tests/suppress.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { suppressAdsForAdFreeMember, type AdFreeFilterCtx } from '../suppress';
 
-function ctx(user: AdFreeFilterCtx['user']): AdFreeFilterCtx {
-    return { slotName: 'board-list-bottom', user };
+function ctx(
+    user: AdFreeFilterCtx['user'],
+    overrides: Partial<AdFreeFilterCtx> = {}
+): AdFreeFilterCtx {
+    return { slotName: 'board-list-bottom', user, isDesktop: true, ...overrides };
 }
 
 describe('suppressAdsForAdFreeMember', () => {
@@ -41,5 +44,23 @@ describe('suppressAdsForAdFreeMember', () => {
 
     it('ad_free_until null 은 입력값 그대로', () => {
         expect(suppressAdsForAdFreeMember(true, ctx({ ad_free_until: null }))).toBe(true);
+    });
+
+    // PC/모바일 분기 — ad-free 멤버십은 PC AdSense 만 OFF.
+    it('mobile (isDesktop=false) 는 멤버십 활성이어도 광고 유지', () => {
+        const future = new Date(Date.now() + 86_400_000).toISOString();
+        expect(
+            suppressAdsForAdFreeMember(true, ctx({ ad_free_until: future }, { isDesktop: false }))
+        ).toBe(true);
+    });
+
+    it('SSR (isDesktop=undefined) 도 광고 유지 (hydration 후 client 가 결정)', () => {
+        const future = new Date(Date.now() + 86_400_000).toISOString();
+        expect(
+            suppressAdsForAdFreeMember(
+                true,
+                ctx({ ad_free_until: future }, { isDesktop: undefined })
+            )
+        ).toBe(true);
     });
 });

--- a/plugins/ad-free/server/loaders.ts
+++ b/plugins/ad-free/server/loaders.ts
@@ -135,29 +135,37 @@ export async function loadLanding(_opts: LoadOptions = {}): Promise<LandingData>
         ],
         benefits: [
             {
-                icon: '🚫',
-                title: 'AdSense 광고 제거',
-                desc: '모든 페이지에서 광고가 사라집니다'
+                icon: '🖥️',
+                title: 'PC AdSense 광고 제거',
+                desc: 'PC 에서 보는 구글 AdSense 광고가 사라집니다'
             },
             {
-                icon: '✨',
-                title: '깔끔한 읽기 경험',
-                desc: '콘텐츠에 온전히 집중할 수 있습니다'
+                icon: '📱',
+                title: '모바일 광고는 유지',
+                desc: '모바일 AdSense 는 정상 노출 — 모바일 사용자 경험은 그대로'
+            },
+            {
+                icon: '🎯',
+                title: '다모앙 자체 배너 유지',
+                desc: '다모앙 자체 광고앙(이미지·텍스트) 배너는 멤버십과 무관하게 노출'
             },
             {
                 icon: '🎁',
-                title: '7일 무료 체험',
-                desc: '결제 전 7일간 무료로 사용해보세요'
-            },
-            {
-                icon: '🔓',
-                title: '언제든 해지',
-                desc: '구속 없이 언제든 해지할 수 있습니다'
+                title: '7일 무료 체험 · 언제든 해지',
+                desc: '결제 전 체험 + 약정 없이 자유 해지'
             }
         ],
         trialDays: 7,
         supportEmail: 'help@example.com',
         faqs: [
+            {
+                q: '모바일에서도 광고가 사라지나요?',
+                a: '아니요. ad-free 멤버십은 PC 의 구글 AdSense 광고만 제거합니다. 모바일 AdSense + 다모앙 자체 광고앙(이미지·텍스트) 배너는 멤버십과 무관하게 정상 노출됩니다. 모바일 사용자 경험 + 다모앙 운영 광고는 그대로 유지됩니다.'
+            },
+            {
+                q: '다모앙 자체 광고도 사라지나요?',
+                a: '아니요. 다모앙의 자체 광고앙(사이드바/메인 배너 등) 은 멤버십 활성 여부와 무관하게 항상 노출됩니다. 멤버십이 제거하는 것은 외부 광고 네트워크(Google AdSense) 의 PC 광고 슬롯에 한정됩니다.'
+            },
             {
                 q: '결제 수단은 어떤 것을 지원하나요?',
                 a: '네이버페이 정기결제와 PayPal Subscription 을 지원합니다.'

--- a/plugins/ad-free/views/Landing.svelte
+++ b/plugins/ad-free/views/Landing.svelte
@@ -27,19 +27,68 @@
 
 <div class="ad-free-landing mx-auto max-w-5xl px-4 py-12 sm:py-20">
     <section class="text-center">
-        <h1 class="text-4xl font-bold sm:text-5xl">광고 없이, 더 편하게</h1>
-        <p class="text-muted-foreground mt-3 text-2xl">{data.productName}</p>
-        <p class="text-muted-foreground mt-6 text-base">
-            {data.trialDays}일 무료 체험 · 언제든 해지 가능
+        <span
+            class="bg-primary/10 text-primary inline-block rounded-full px-3 py-1 text-xs font-medium"
+        >
+            PC 전용 광고 제거 멤버십
+        </span>
+        <h1 class="mt-4 text-4xl font-bold sm:text-5xl">
+            PC <span class="text-primary">광고 없이</span>, 더 편하게
+        </h1>
+        <p class="text-muted-foreground mt-3 text-xl sm:text-2xl">{data.productName}</p>
+        <p class="text-muted-foreground mx-auto mt-6 max-w-2xl text-base leading-relaxed">
+            PC AdSense 광고만 제거합니다. <strong class="text-foreground">모바일 광고</strong>와
+            <strong class="text-foreground">다모앙 자체 배너</strong>는 멤버십과 무관하게 그대로
+            노출됩니다.
         </p>
         <div class="mt-8 flex justify-center gap-3">
-            <Button size="lg" href="/ad-free/checkout">무료 체험 시작하기</Button>
+            <Button size="lg" href="/ad-free/checkout">{data.trialDays}일 무료 체험 시작</Button>
+        </div>
+        <p class="text-muted-foreground mt-4 text-xs">언제든 해지 가능 · 약정 없음</p>
+    </section>
+
+    <!-- 정책 요약 박스 — 멤버십 적용 범위 명확화 -->
+    <section
+        class="border-primary/20 bg-primary/5 mt-12 rounded-2xl border p-6 sm:p-8"
+        aria-label="멤버십 적용 범위"
+    >
+        <h2 class="text-center text-lg font-semibold sm:text-xl">멤버십 적용 범위</h2>
+        <div class="mt-5 grid gap-4 sm:grid-cols-3">
+            <div class="text-center">
+                <div class="mb-2 text-3xl">🖥️</div>
+                <div class="font-medium">PC AdSense</div>
+                <div
+                    class="mt-1 inline-block rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-950 dark:text-red-300"
+                >
+                    제거 ✓
+                </div>
+            </div>
+            <div class="text-center">
+                <div class="mb-2 text-3xl">📱</div>
+                <div class="font-medium">모바일 AdSense</div>
+                <div
+                    class="mt-1 inline-block rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
+                >
+                    유지
+                </div>
+            </div>
+            <div class="text-center">
+                <div class="mb-2 text-3xl">🎯</div>
+                <div class="font-medium">다모앙 자체 배너</div>
+                <div
+                    class="mt-1 inline-block rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
+                >
+                    유지
+                </div>
+            </div>
         </div>
     </section>
 
     <section class="mt-20 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         {#each data.benefits as benefit (benefit.title)}
-            <div class="bg-card rounded-xl border p-6">
+            <div
+                class="bg-card hover:border-primary/40 hover:shadow-primary/5 rounded-xl border p-6 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg"
+            >
                 <div class="text-3xl">{benefit.icon}</div>
                 <h3 class="mt-3 font-semibold">{benefit.title}</h3>
                 <p class="text-muted-foreground mt-1 text-sm">{benefit.desc}</p>


### PR DESCRIPTION
loaders.ts (benefits/FAQ) + Landing.svelte 디자인 개선. PC AdSense 만 OFF, 모바일·다모앙 자체 배너 유지 명확화.

## Landing 변경
- Hero: 'PC 전용' badge + 강조 카피 + 1줄 정책 요약
- 정책 요약 박스 (3 컬럼): PC '제거' / 모바일 '유지' / 다모앙 배너 '유지' (red/emerald badge)
- benefits 카드: hover lift + shadow

## 카피 변경
- benefits: PC AdSense 제거 + 모바일 유지 + 다모앙 배너 유지 + 체험·해지
- FAQ 2건 추가 (오해 방지)

## Related
- damoang/angple#1452 (PC-only suppress hook)
- damoang/angple-premium 의 overlay 도 같이 PR