### PR TITLE
refactor(ad-free): 카피 건조화 — 멤버십 단어 제거 + PC 광고 제거 강조

### DIFF
--- a/plugins/ad-free/server/loaders.ts
+++ b/plugins/ad-free/server/loaders.ts
@@ -115,7 +115,7 @@ export async function loadCheckout(opts: {
 
 export async function loadLanding(_opts: LoadOptions = {}): Promise<LandingData> {
     return {
-        productName: '광고 제거 멤버십',
+        productName: 'PC 광고 제거',
         currency: 'KRW',
         plans: [
             {
@@ -136,51 +136,51 @@ export async function loadLanding(_opts: LoadOptions = {}): Promise<LandingData>
         benefits: [
             {
                 icon: '🖥️',
-                title: 'PC AdSense 광고 제거',
-                desc: 'PC 에서 보는 구글 AdSense 광고가 사라집니다'
+                title: 'PC AdSense 제거',
+                desc: 'PC 에서 구글 AdSense 광고만 제거'
             },
             {
                 icon: '📱',
-                title: '모바일 광고는 유지',
-                desc: '모바일 AdSense 는 정상 노출 — 모바일 사용자 경험은 그대로'
+                title: '모바일 광고 유지',
+                desc: '모바일 AdSense 는 그대로 노출'
             },
             {
                 icon: '🎯',
-                title: '다모앙 자체 배너 유지',
-                desc: '다모앙 자체 광고앙(이미지·텍스트) 배너는 멤버십과 무관하게 노출'
+                title: '다모앙 배너 유지',
+                desc: '다모앙 자체 광고앙 배너는 그대로 노출'
             },
             {
                 icon: '🎁',
-                title: '7일 무료 체험 · 언제든 해지',
-                desc: '결제 전 체험 + 약정 없이 자유 해지'
+                title: '7일 체험 · 언제든 해지',
+                desc: '약정 없음'
             }
         ],
         trialDays: 7,
         supportEmail: 'help@example.com',
         faqs: [
             {
-                q: '모바일에서도 광고가 사라지나요?',
-                a: '아니요. ad-free 멤버십은 PC 의 구글 AdSense 광고만 제거합니다. 모바일 AdSense + 다모앙 자체 광고앙(이미지·텍스트) 배너는 멤버십과 무관하게 정상 노출됩니다. 모바일 사용자 경험 + 다모앙 운영 광고는 그대로 유지됩니다.'
+                q: '모바일에서도 광고가 제거되나요?',
+                a: '아니요. PC 의 구글 AdSense 광고만 제거됩니다. 모바일 AdSense 와 다모앙 자체 광고앙 배너는 그대로 노출됩니다.'
             },
             {
-                q: '다모앙 자체 광고도 사라지나요?',
-                a: '아니요. 다모앙의 자체 광고앙(사이드바/메인 배너 등) 은 멤버십 활성 여부와 무관하게 항상 노출됩니다. 멤버십이 제거하는 것은 외부 광고 네트워크(Google AdSense) 의 PC 광고 슬롯에 한정됩니다.'
+                q: '다모앙 자체 광고도 제거되나요?',
+                a: '아니요. 다모앙의 자체 광고앙 배너는 제거 대상이 아닙니다. 외부 광고 네트워크(Google AdSense) 의 PC 슬롯만 제거됩니다.'
             },
             {
                 q: '결제 수단은 어떤 것을 지원하나요?',
                 a: '네이버페이 정기결제와 PayPal Subscription 을 지원합니다.'
             },
             {
-                q: '7일 무료 체험 후 자동으로 결제되나요?',
-                a: '체험 기간 종료 전 해지하시면 결제되지 않습니다. 체험 종료 시 선택하신 요금제로 자동 결제됩니다.'
+                q: '체험 후 자동 결제되나요?',
+                a: '체험 종료 전 해지하면 결제되지 않습니다. 종료 시 선택한 요금제로 자동 결제됩니다.'
             },
             {
-                q: '환불은 어떻게 받을 수 있나요?',
-                a: '환불 정책 페이지에 자세한 절차가 안내되어 있습니다. 영업일 기준 3~5일 이내 처리됩니다.'
+                q: '환불은 어떻게 받나요?',
+                a: '환불 정책 페이지의 절차 참고. 영업일 기준 3~5일 처리.'
             },
             {
-                q: '구독 후 광고가 즉시 사라지나요?',
-                a: '결제 완료 직후 로그인 상태에서 광고가 사라집니다. 다른 기기는 재로그인 시 반영됩니다.'
+                q: '결제 후 즉시 적용되나요?',
+                a: '결제 완료 직후 로그인 상태에서 적용. 다른 기기는 재로그인 시 반영.'
             },
             {
                 q: '6개월 요금제는 어떤 점이 다른가요?',

--- a/plugins/ad-free/views/Landing.svelte
+++ b/plugins/ad-free/views/Landing.svelte
@@ -27,32 +27,30 @@
 
 <div class="ad-free-landing mx-auto max-w-5xl px-4 py-12 sm:py-20">
     <section class="text-center">
-        <span
-            class="bg-primary/10 text-primary inline-block rounded-full px-3 py-1 text-xs font-medium"
-        >
-            PC 전용 광고 제거 멤버십
-        </span>
-        <h1 class="mt-4 text-4xl font-bold sm:text-5xl">
-            PC <span class="text-primary">광고 없이</span>, 더 편하게
+        <h1 class="text-4xl font-bold sm:text-5xl">
+            <span class="text-primary">PC 광고 제거</span>
         </h1>
-        <p class="text-muted-foreground mt-3 text-xl sm:text-2xl">{data.productName}</p>
-        <p class="text-muted-foreground mx-auto mt-6 max-w-2xl text-base leading-relaxed">
-            PC AdSense 광고만 제거합니다. <strong class="text-foreground">모바일 광고</strong>와
-            <strong class="text-foreground">다모앙 자체 배너</strong>는 멤버십과 무관하게 그대로
-            노출됩니다.
+        <p class="text-muted-foreground mt-6 text-base">
+            PC 에서 보이는 구글 AdSense 광고만 제거합니다.
+        </p>
+        <p class="mt-3 text-base">
+            <strong class="text-amber-700 dark:text-amber-300"
+                >모바일에서는 광고가 정상 노출됩니다.</strong
+            >
+            다모앙 자체 광고앙 배너도 그대로 노출됩니다.
         </p>
         <div class="mt-8 flex justify-center gap-3">
-            <Button size="lg" href="/ad-free/checkout">{data.trialDays}일 무료 체험 시작</Button>
+            <Button size="lg" href="/ad-free/checkout">{data.trialDays}일 무료 체험</Button>
         </div>
-        <p class="text-muted-foreground mt-4 text-xs">언제든 해지 가능 · 약정 없음</p>
+        <p class="text-muted-foreground mt-4 text-xs">언제든 해지 · 약정 없음</p>
     </section>
 
-    <!-- 정책 요약 박스 — 멤버십 적용 범위 명확화 -->
+    <!-- 정책 요약 박스 — 광고 제거 범위 명확화 -->
     <section
         class="border-primary/20 bg-primary/5 mt-12 rounded-2xl border p-6 sm:p-8"
-        aria-label="멤버십 적용 범위"
+        aria-label="광고 제거 범위"
     >
-        <h2 class="text-center text-lg font-semibold sm:text-xl">멤버십 적용 범위</h2>
+        <h2 class="text-center text-lg font-semibold sm:text-xl">광고 제거 범위</h2>
         <div class="mt-5 grid gap-4 sm:grid-cols-3">
             <div class="text-center">
                 <div class="mb-2 text-3xl">🖥️</div>
@@ -69,7 +67,7 @@
                 <div
                     class="mt-1 inline-block rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
                 >
-                    유지
+                    광고 노출
                 </div>
             </div>
             <div class="text-center">
@@ -78,7 +76,7 @@
                 <div
                     class="mt-1 inline-block rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
                 >
-                    유지
+                    광고 노출
                 </div>
             </div>
         </div>


### PR DESCRIPTION
사용자 요청: 감성 톤 제거, '광고 제거' 만 강조, 모바일 광고 노출 명시.

## 변경
- productName: 'PC 광고 제거'
- Hero: 모바일 광고 노출 amber 강조
- benefits / FAQ 짧고 건조
- 정책 박스 badge: '유지' → '광고 노출'

## 검증
- pnpm check: 0 errors / 99 warnings
- grep '멤버십': 0건