### PR TITLE
fix(content-market): 외래어 표기법 — 컨텐츠 → 콘텐츠 (#12448)

### DIFF
--- a/apps/web/src/routes/content-market/+page.svelte
+++ b/apps/web/src/routes/content-market/+page.svelte
@@ -3,12 +3,12 @@
 </script>
 
 <svelte:head>
-    <title>컨텐츠마켓 | 다모앙</title>
-    <meta name="description" content="다모앙 컨텐츠마켓 — 준비 중입니다." />
+    <title>콘텐츠마켓 | 다모앙</title>
+    <meta name="description" content="다모앙 콘텐츠마켓 — 준비 중입니다." />
 </svelte:head>
 
 <div class="container mx-auto max-w-2xl px-4 py-20 text-center">
     <Sparkles class="text-muted-foreground mx-auto mb-4 h-12 w-12" />
-    <h1 class="text-foreground text-2xl font-bold">컨텐츠마켓</h1>
+    <h1 class="text-foreground text-2xl font-bold">콘텐츠마켓</h1>
     <p class="text-muted-foreground mt-3 text-sm">곧 찾아뵙겠습니다. 현재 준비 중입니다.</p>
 </div>


### PR DESCRIPTION
## Summary
- `/content-market` 페이지의 라벨 '컨텐츠마켓' → '콘텐츠마켓' 으로 교체.
- 국립국어원 외래어 표기법상 'content' 의 표준 표기는 **콘텐츠**.

## 변경
- `apps/web/src/routes/content-market/+page.svelte`
  - line 6: `<title>`
  - line 7: `<meta description>`
  - line 12: `<h1>`

## Test plan
- [ ] `/content-market` 접속 시 제목/본문 모두 '콘텐츠마켓' 표시