### PR TITLE
fix(footer): '바이럴 신고' 라벨 명확화 → '광고/바이럴 신고' (#12461)

### DIFF
--- a/apps/web/src/lib/components/layout/footer.svelte
+++ b/apps/web/src/lib/components/layout/footer.svelte
@@ -30,7 +30,7 @@
         { name: '앙리포트', href: '/report' },
         { name: '소명게시판', href: '/claim' },
         { name: '회원 신고', href: '/truthroom' },
-        { name: '바이럴 신고', href: '/nope' },
+        { name: '광고/바이럴 신고', href: '/nope' },
         { name: '이용제한 기록', href: '/disciplinelog' }
     ];
 


### PR DESCRIPTION
## Summary
- 사용자 호소: 푸터의 '바이럴 신고' 클릭 시 '광고 앙대앙' 게시판 도착 → 어떤 신고 채널인지 혼란 (#12461).
- Fix: 라벨을 **'광고/바이럴 신고'** 로 변경 — 도착 페이지의 광고/홍보 신고 의미를 사용자가 사전 인지.
- `href: '/nope'` 는 운영 의도 그대로 유지.

## 변경 파일
- `apps/web/src/lib/components/layout/footer.svelte:33`

## Test plan
- [ ] 푸터 안내 영역에 '광고/바이럴 신고' 라벨 표시
- [ ] 클릭 시 `/nope` (광고 앙대앙) 로 이동 (회귀 없음)

## 추가 고려
- 운영자 영역: 별도 신고 양식이 필요하다면 후속 PR (현재는 광고게시판 안내 유지)