### PR TITLE
fix(comments): 댓글 자동 링크 시각 표시 강제 (#12439)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-editor.svelte
+++ b/apps/web/src/lib/components/features/board/comment-editor.svelte
@@ -68,7 +68,15 @@
                     }
                 }),
                 Image.configure({ inline: true, allowBase64: false }),
-                Link.configure({ openOnClick: false }),
+                // #12439: 댓글 자동 링크에 시각 표시 강제 — 사용자가 selected text 에
+                // URL 을 paste 했을 때 링크화된 텍스트가 외형 변화 없이 들어가는 케이스를 차단.
+                Link.configure({
+                    openOnClick: false,
+                    HTMLAttributes: {
+                        class: 'text-primary underline decoration-primary/60 underline-offset-2',
+                        'data-comment-autolink': 'true'
+                    }
+                }),
                 Placeholder.configure({ placeholder }),
                 Mention.configure({
                     HTMLAttributes: { class: 'mention' },

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -2009,6 +2009,15 @@
     :global(.comment-body a) {
         overflow-wrap: anywhere;
         word-break: break-all;
+        /* #12439: 자동 링크/사용자 링크 모두 시각 표시 강제 — 텍스트만 보이고 링크가
+           숨어 있는 케이스를 차단 (paste 시 selected text 가 anchor 로 wrap 되는 케이스). */
+        color: var(--primary);
+        text-decoration: underline;
+        text-decoration-color: color-mix(in oklch, var(--primary) 60%, transparent);
+        text-underline-offset: 2px;
+    }
+    :global(.comment-body a:hover) {
+        text-decoration-color: var(--primary);
     }
 
     /* 댓글 본문 문단 간격 */


### PR DESCRIPTION
## Summary
- 사용자 호소: 댓글에 텍스트 선택 후 URL paste 하면 텍스트 외형 변화 없이 링크가 걸리는 케이스 — 악용 소지 (#12439).
- 원인: TipTap Link extension 이 selected text 를 `<a href>` 로 wrap 만 하고 시각 스타일 부착 안 함. prose 영역의 `<a>` 도 기본 underline/color 가 적용 안 됨.
- Fix: 두 곳 모두 명시적 시각 표시 강제.

## 변경
- `apps/web/src/lib/components/features/board/comment-editor.svelte:71`
  - `Link.configure` 에 `HTMLAttributes` 추가: `text-primary underline decoration-primary/60 underline-offset-2` + `data-comment-autolink` 부착
- `apps/web/src/lib/components/features/board/comment-list.svelte:2009`
  - `:global(.comment-body a)` 에 `color: var(--primary)`, `text-decoration: underline`, hover 색상 강조 추가

## Test plan
- [ ] 댓글 입력 시 텍스트 선택 후 URL paste → 선택 텍스트가 primary 색상 + underline 으로 보임
- [ ] 사용자가 직접 `https://...` 입력한 URL 도 자동 링크 + 시각 표시
- [ ] 기존 댓글 본문 (DB 의 `<a>` 태그 포함) 도 동일하게 표시 (회귀 없음)
- [ ] hover 시 underline 색상 짙어짐