### PR TITLE
fix(author-link): 짧은 닉네임 클릭 영역 보장 (#12444)

### DIFF
--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -132,8 +132,14 @@
                 if (open) checkFollowStatus();
             }}
         >
+            <!--
+              #12444: 짧은 닉네임(예: "M.M.", "ㅇㅇ", "•") 의 클릭 영역이 텍스트 너비만큼
+              만 잡혀 글자 사이 빈 공간이나 점 주변을 누르면 트리거가 활성화 안 되는 문제.
+              inline-block + min-width(2ch) + 좌우 padding 으로 클릭 영역을 보장한다.
+              negative margin 으로 시각적 layout 영향은 0.
+            -->
             <DropdownMenu.Trigger
-                class="cursor-pointer text-left hover:underline focus:outline-none {className} {isWithdrawn
+                class="-mx-0.5 inline-block min-w-[2ch] cursor-pointer px-0.5 text-left hover:underline focus:outline-none {className} {isWithdrawn
                     ? 'line-through opacity-60'
                     : ''}"
             >


### PR DESCRIPTION
## Summary
- 사용자 호소: 특정 닉네임 (예: `M.M.` 점 두 개) 선택/클릭 안 됨 (#12444).
- 원인 분석: DB 데이터는 정상 (mb_id=`naver_8d6b08cb1`, mb_nick=`M.M.` 4bytes, 글 deleted=null, 회원 leave/intercept 비어 있음). 빈 공간/특수문자 없음.
- 실제 원인: DropdownMenu Trigger 의 클릭 영역이 텍스트 너비만큼만 잡혀, 짧은 닉네임의 글자 사이 점/빈 공간을 누르면 trigger 가 활성화 안 됨.

## 변경
- `apps/web/src/lib/components/ui/author-link/author-link.svelte`
  - Trigger class 에 `inline-block min-w-[2ch] -mx-0.5 px-0.5` 추가.
  - negative margin 으로 시각적 layout 영향 0, 실질 클릭 영역만 확보.

## Test plan
- [ ] 짧은 닉네임 (`M.M.`, `ㅇㅇ`, 한 글자) 클릭 시 DropdownMenu 정상 열림
- [ ] 점 사이 빈 공간 클릭 시에도 trigger 활성화
- [ ] 긴 닉네임 (10자+) layout 변화 없음
- [ ] hover 시 underline 동작 (회귀 없음)
- [ ] 모바일 터치 클릭 영역 개선