### PR TITLE
fix(comments): 수정 grace 5분 → 6분(360s) 확장 (#12457)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -118,7 +118,9 @@
         initialDislikedCommentIds = [],
         truthroomCommentMap = {},
         isRestricted = false,
-        editPolicy = { cost: 50000, grace_seconds: 300 }
+        // #12457: 실수 엔터키로 댓글 전송 후 즉시 수정하는 케이스가 잦아 grace 를
+        // 5분 → 6분(360s) 으로 확장. 호출자가 명시적으로 전달하면 그 값을 우선 사용.
+        editPolicy = { cost: 50000, grace_seconds: 360 }
     }: Props = $props();
 
     function findCommentById(commentId: string): FreeComment | null {


### PR DESCRIPTION
## Summary
- 사용자 호소: '실수로 엔터키 눌렀는데 댓글 수정이 안 됩니다' (#12457).
- PR #1459 가 대댓글 차단 해제 + 안내 confirm 추가했지만, grace 시간(5분) 외에는 포인트 차감 confirm 이 떠서 실수 케이스 부담.
- Fix: `editPolicy.grace_seconds` default 300 → 360 (6분).
- 호출자가 명시 전달하면 그 값을 우선 사용 (props default 만 변경).

## 변경
- `apps/web/src/lib/components/features/board/comment-list.svelte:121`

## Test plan
- [ ] 댓글 작성 후 5분 30초 이내 수정 → 무료 수정 (이전엔 차감 confirm 떴음)
- [ ] 6분 30초 후 수정 → 포인트 차감 confirm (정책 유지)
- [ ] 대댓글이 있는 경우 안내 confirm 통합 동작 (PR #1459 호환)