### PR TITLE
fix(ads): 자체 광고 클래스 명 obfuscation — ad block 우회

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -201,7 +201,7 @@
             <!-- 모바일: max-height 100px로 제한 / 데스크톱: 카드 높이에 맞춤 -->
             <div
                 bind:this={clipWrapper}
-                class="ad-clip-wrapper overflow-hidden rounded-xl"
+                class="dm-clip-wrapper overflow-hidden rounded-xl"
                 style="position: relative;"
             >
                 <!-- AdSense가 이 div의 height를 !important로 바꿔도 외부 래퍼가 잘라냄 -->
@@ -394,7 +394,7 @@
 
 <style>
     /* 모바일은 낮게, 데스크톱은 카드형 비율로 보이도록 높이를 제한합니다. */
-    .ad-clip-wrapper {
+    .dm-clip-wrapper {
         min-height: 110px;
         height: 110px;
         max-height: 110px;
@@ -402,7 +402,7 @@
         isolation: isolate;
     }
     @media (min-width: 640px) {
-        .ad-clip-wrapper {
+        .dm-clip-wrapper {
             min-height: 214px;
             height: 214px;
             max-height: 214px;

--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -342,18 +342,18 @@
 {#if !suppressAds}
     <div
         bind:this={containerEl}
-        class="ad-slot-container relative overflow-hidden rounded-lg {className}"
+        class="dm-display-frame relative overflow-hidden rounded-lg {className}"
         class:ad-slot-loaded={isLoaded && hasAd}
         class:ad-slot-empty={isEmpty}
         class:ad-slot-empty-collapsed={isEmpty}
         class:ad-slot-btf={isBTF}
-        class:ad-slot-wing={isWing}
-        class:ad-slot-sidebar={isSidebar}
-        class:ad-slot-floating={isFloating}
+        class:dm-display-wing={isWing}
+        class:dm-display-sidebar={isSidebar}
+        class:dm-display-floating={isFloating}
         style:--ad-slot-min-height={reservedHeights.base}
         style:--ad-slot-min-height-tablet={reservedHeights.tablet}
         style:--ad-slot-min-height-desktop={reservedHeights.desktop}
-        style:--ad-slot-floating-reserved={reservedHeights.desktop}
+        style:--dm-display-floating-reserved={reservedHeights.desktop}
         style:--ad-slot-intrinsic-size={reservedHeights.desktop}
         style:transition="min-height 0ms"
     >
@@ -363,7 +363,7 @@
         {#if slotId}
             <div
                 id={slotId}
-                class="gam-ad-slot w-full"
+                class="dm-display-slot w-full"
                 style:display={showAdfit ? 'none' : undefined}
             ></div>
         {/if}
@@ -371,13 +371,13 @@
 {/if}
 
 <style>
-    .ad-slot-container {
+    .dm-display-frame {
         contain: layout style;
         /* 기본 (모바일/in-flow): inline 으로 주입된 --ad-slot-min-height 사용 */
         min-height: var(--ad-slot-min-height);
         /* transition은 inline style로 통일 (0ms) — CLS 방지 위해 즉시 적용 */
     }
-    .gam-ad-slot {
+    .dm-display-slot {
         min-height: var(--ad-slot-min-height);
     }
 
@@ -413,7 +413,7 @@
         border-radius: 0.5rem;
     }
 
-    .gam-ad-slot {
+    .dm-display-slot {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -422,15 +422,15 @@
     }
 
     @media (min-width: 728px) {
-        .ad-slot-container,
-        .gam-ad-slot {
+        .dm-display-frame,
+        .dm-display-slot {
             min-height: var(--ad-slot-min-height-tablet);
         }
     }
 
     @media (min-width: 970px) {
-        .ad-slot-container,
-        .gam-ad-slot {
+        .dm-display-frame,
+        .dm-display-slot {
             min-height: var(--ad-slot-min-height-desktop);
         }
     }
@@ -446,29 +446,29 @@
      * 위 728/970 미디어쿼리(in-flow tablet/desktop)는 in-flow 슬롯 전용이고
      * floating 슬롯은 아래 규칙으로 덮어쓴다.
      */
-    .ad-slot-floating,
-    .ad-slot-floating .gam-ad-slot {
+    .dm-display-floating,
+    .dm-display-floating .dm-display-slot {
         min-height: 0;
     }
     @media (min-width: 1024px) {
-        .ad-slot-sidebar,
-        .ad-slot-sidebar .gam-ad-slot {
-            min-height: var(--ad-slot-floating-reserved);
+        .dm-display-sidebar,
+        .dm-display-sidebar .dm-display-slot {
+            min-height: var(--dm-display-floating-reserved);
         }
     }
     @media (min-width: 1600px) {
-        .ad-slot-wing,
-        .ad-slot-wing .gam-ad-slot {
-            min-height: var(--ad-slot-floating-reserved);
+        .dm-display-wing,
+        .dm-display-wing .dm-display-slot {
+            min-height: var(--dm-display-floating-reserved);
         }
     }
 
-    .gam-ad-slot :global(iframe) {
+    .dm-display-slot :global(iframe) {
         max-width: 100% !important;
     }
 
-    :global(.dark) .gam-ad-slot :global(iframe),
-    :global(.amoled) .gam-ad-slot :global(iframe) {
+    :global(.dark) .dm-display-slot :global(iframe),
+    :global(.amoled) .dm-display-slot :global(iframe) {
         filter: brightness(0.9);
     }
 </style>


### PR DESCRIPTION
## Summary
사용자 호소: ad block 확장 (uBlock Origin 등) 사용 시 자체 광고도 안 보임.

원인: 광고 컴포넌트 클래스 명이 EasyList generic 규칙에 정확히 잡힘.
- `##[class*='ad-slot']` → `ad-slot-container`, `ad-slot-floating` 등
- `##[class*='gam-ad']` → `gam-ad-slot`
- `##[class*='ad-']` → `ad-clip-wrapper`

## 변경
`apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte`
- `ad-slot-container` → `dm-display-frame`
- `gam-ad-slot` → `dm-display-slot`
- `ad-slot-floating` → `dm-display-floating`
- `ad-slot-sidebar` → `dm-display-sidebar`
- `ad-slot-wing` → `dm-display-wing`

`apps/web/src/lib/components/features/board/author-activity-panel.svelte`
- `ad-clip-wrapper` → `dm-clip-wrapper`

CSS 셀렉터도 일괄 변경 (같은 컴포넌트 `<style>` 안의 .ad-slot-container 등).

## Test plan
- [ ] ad block 미설치 사용자: 광고 정상 노출 (회귀 없음)
- [ ] ad block 설치 사용자 (uBlock Origin EasyList): 자체 광고 노출 회복
- [ ] sidebar/wing/floating 광고 위치 layout 변화 없음
- [ ] author-activity-panel 의 AdSense clip wrapper 정상 동작 (MutationObserver 높이 방어 유지)
- [ ] `pnpm check` 통과

## 주의
ad block 우회는 cat-and-mouse 게임 — EasyList Korea 가 `dm-display-*` 패턴 추가 시 6~12개월 후 재차단 가능. long-term 대응 (anti-adblock 감지 모달 등) 별도 검토 권장.