### PR TITLE
feat(adblock): 차단 감지 시 안내 토스트 + ad-free CTA (Forbes 식)

### DIFF
--- a/apps/web/src/lib/components/features/adblock-notice/adblock-notice.svelte
+++ b/apps/web/src/lib/components/features/adblock-notice/adblock-notice.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+    /**
+     * AdBlock 감지 시 우측 하단 sticky toast — Forbes/WaPo 식 모범사례.
+     *
+     * 정책:
+     * - adblock-notice store 의 shouldShow 가 true 일 때만 노출 (감지 + 미dismiss)
+     * - 두 CTA: "잠시 허용 (7일)" (dismiss) / "PC 광고 제거 가입" (→ /ad-free)
+     * - role=status + aria-live=polite (스크린리더 자연 안내)
+     * - 사용자 영향 최소화: 콘텐츠 가리지 않음, 모달 아님
+     */
+    import { adblockNotice } from '$lib/stores/adblock-notice.svelte';
+    import { Button } from '$lib/components/ui/button';
+    import X from '@lucide/svelte/icons/x';
+    import Sparkles from '@lucide/svelte/icons/sparkles';
+
+    const show = $derived(adblockNotice.shouldShow);
+
+    function handleDismiss() {
+        adblockNotice.dismiss();
+    }
+</script>
+
+{#if show}
+    <div
+        class="adblock-notice fixed bottom-4 right-4 z-[100] max-w-sm rounded-xl border border-amber-200 bg-white p-4 shadow-2xl ring-1 ring-black/5 sm:bottom-6 sm:right-6 dark:border-amber-900/40 dark:bg-zinc-900 dark:ring-white/10"
+        role="status"
+        aria-live="polite"
+        aria-label="광고 차단 안내"
+    >
+        <button
+            type="button"
+            class="text-muted-foreground hover:text-foreground absolute right-2 top-2 rounded p-1 transition"
+            aria-label="닫기 (7일간 안내 끄기)"
+            onclick={handleDismiss}
+        >
+            <X class="h-4 w-4" />
+        </button>
+        <div class="flex items-start gap-3 pr-6">
+            <div class="text-2xl" aria-hidden="true">💡</div>
+            <div class="flex-1">
+                <p class="text-sm font-semibold">광고가 막혀있어요</p>
+                <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
+                    다모앙은 광고로 운영되는 공개 커뮤니티입니다. 잠시만 허용해주시거나 <strong
+                        class="text-foreground">PC 광고 제거</strong
+                    > 멤버십으로 응원해주세요.
+                </p>
+                <div class="mt-3 flex flex-wrap items-center gap-2">
+                    <Button
+                        size="sm"
+                        href="/ad-free"
+                        class="bg-amber-500 text-white hover:bg-amber-600"
+                    >
+                        <Sparkles class="mr-1 h-3.5 w-3.5" />
+                        PC 광고 제거 가입
+                    </Button>
+                    <Button size="sm" variant="ghost" onclick={handleDismiss}
+                        >잠시 허용 (7일)</Button
+                    >
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/apps/web/src/lib/components/features/adblock-notice/index.ts
+++ b/apps/web/src/lib/components/features/adblock-notice/index.ts
@@ -1,0 +1,1 @@
+export { default as AdblockNotice } from './adblock-notice.svelte';

--- a/apps/web/src/lib/services/ad-telemetry.ts
+++ b/apps/web/src/lib/services/ad-telemetry.ts
@@ -161,7 +161,7 @@ export function detectAdblockOnce(
 
     schedule(() => {
         let blocked = false;
-        let reason = 'none';
+        let reason: 'sdk_missing' | 'bait_hidden' | 'none' = 'none';
         try {
             if (isAdSdkBlocked()) {
                 blocked = true;
@@ -173,6 +173,16 @@ export function detectAdblockOnce(
         } catch {
             // 감지 실패는 무시 — 모니터링 신호일 뿐
             return;
+        }
+
+        // 안내 UI 노출용 store 갱신 — adblock-notice 컴포넌트가 구독.
+        // 동적 import 로 SSR/번들 영향 0 (browser 진입 후에만 실행됨).
+        if (blocked) {
+            void import('$lib/stores/adblock-notice.svelte')
+                .then((m) => m.adblockNotice.set(true, reason))
+                .catch(() => {
+                    // store 로드 실패 무시 — telemetry 는 그대로 진행
+                });
         }
 
         // GA4 (gtag) — initGA4 호출 후라야 동작. ga4.ts trackEvent 임포트 시 순환 위험 없음.

--- a/apps/web/src/lib/stores/adblock-notice.svelte.ts
+++ b/apps/web/src/lib/stores/adblock-notice.svelte.ts
@@ -1,0 +1,51 @@
+/**
+ * AdBlock 감지 상태 store — 진입 시 감지된 차단기 여부 + dismiss 상태.
+ *
+ * detectAdblockOnce (ad-telemetry.ts) 가 차단 판정 시 detected=true 로 set.
+ * adblock-notice 컴포넌트가 구독하여 toast 노출.
+ *
+ * dismiss 정책: localStorage `damoang_adblock_dismissed_until` 에 ts 저장,
+ * 7일간 안내 미노출. CTA 클릭 시 /ad-free 이동 후 자연스럽게 dismiss.
+ */
+
+const DISMISS_KEY = 'damoang_adblock_dismissed_until';
+const DISMISS_DAYS = 7;
+
+function loadDismissedUntil(): number {
+    if (typeof localStorage === 'undefined') return 0;
+    try {
+        const raw = localStorage.getItem(DISMISS_KEY);
+        return raw ? Number(raw) || 0 : 0;
+    } catch {
+        return 0;
+    }
+}
+
+let detected = $state(false);
+let reason = $state<'sdk_missing' | 'bait_hidden' | 'none'>('none');
+let dismissedUntil = $state(loadDismissedUntil());
+
+export const adblockNotice = {
+    get detected() {
+        return detected;
+    },
+    get reason() {
+        return reason;
+    },
+    get shouldShow() {
+        return detected && Date.now() >= dismissedUntil;
+    },
+    set(d: boolean, r: 'sdk_missing' | 'bait_hidden' | 'none'): void {
+        detected = d;
+        reason = r;
+    },
+    dismiss(days: number = DISMISS_DAYS): void {
+        const until = Date.now() + days * 24 * 60 * 60 * 1000;
+        dismissedUntil = until;
+        try {
+            localStorage.setItem(DISMISS_KEY, String(until));
+        } catch {
+            // localStorage 차단된 환경 — 메모리만 유지
+        }
+    }
+};

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -38,6 +38,7 @@
         trackPageView
     } from '$lib/services/ga4';
     import { detectAdblockOnce } from '$lib/services/ad-telemetry';
+    import { AdblockNotice } from '$lib/components/features/adblock-notice';
     import type { MenuItem } from '$lib/api/types';
     import { readUserBasicFromCookie } from '$lib/utils/user-basic-client';
     import { env } from '$env/dynamic/public';
@@ -684,6 +685,11 @@
 <!-- 단축 버튼 (지연 로딩, admin/install 제외) -->
 {#if !isAdminRoute && !isInstallRoute && LazyShortcutButtons}
     <LazyShortcutButtons />
+{/if}
+
+<!-- AdBlock 감지 시 안내 토스트 (admin/install 제외) -->
+{#if !isAdminRoute && !isInstallRoute}
+    <AdblockNotice />
 {/if}
 
 <!-- 플러그인 슬롯: </body> 직전 (지연 로딩 컴포넌트, fallback 등) — Slot Catalog Sprint 2 -->


### PR DESCRIPTION
## 요약
AdBlock/uBlock/AdGuard 감지 시 우측 하단 sticky 토스트로 안내합니다. **Forbes/Washington Post 식 모범사례** — 콘텐츠를 가리지 않는 부드러운 알림 + 두 CTA.

- **PC 광고 제거 가입** → `/ad-free` 멤버십 전환
- **잠시 허용 (7일)** → dismiss + localStorage 7일 안내 미노출

## 배경
기존 `detectAdblockOnce` (`ad-telemetry.ts`) 는 GA4 + Dantry 텔레메트리만 송신하고 안내 UI 는 없었습니다. AdGuard 활성 사용자에게 다모앙의 운영 비용 / ad-free 가입 옵션을 알릴 채널이 없었습니다. 이 PR 은 기존 감지 인프라(`isAdSdkBlocked` + `isAdBaitHidden`) 를 그대로 재사용하고 안내 토스트만 추가합니다.

## 변경 파일
| 파일 | 변경 |
|---|---|
| `apps/web/src/lib/stores/adblock-notice.svelte.ts` (신규) | rune store — detected / reason / dismissedUntil + localStorage 7일 |
| `apps/web/src/lib/components/features/adblock-notice/` (신규) | toast 컴포넌트 + index re-export |
| `apps/web/src/lib/services/ad-telemetry.ts` | `detectAdblockOnce` 가 차단 판정 시 store.set 호출 (dynamic import) |
| `apps/web/src/routes/+layout.svelte` | `AdblockNotice` mount (admin/install 제외) |

## UX 정책
- 모달 아님 — 우측 하단 small toast, 콘텐츠 가리지 않음
- 두 CTA — 가입 (`/ad-free`) / 잠시 허용 (7일)
- a11y — `role="status"` + `aria-live="polite"` + `aria-label="광고 차단 안내"` + 닫기 버튼 키보드 접근
- admin/install 경로 제외 — 운영자 작업 방해 X

## 모범사례 참고
- Forbes / Washington Post / WSJ — bait + modal 패턴
- YouTube (2023~) — adblock 감지 + 안내 (하지만 우리는 콘텐츠 차단 X)
- Bild (독일) — 적극적 안내 (법원 승소)
- 한국 사용자 친화적 — modal 대신 dismissable toast

## 테스트
- `pnpm check` — 0 errors (warnings 99 모두 사전 존재)
- `pnpm test:unit` — 398 tests 통과 (회귀 0)
- detectAdblockOnce 기존 텔레메트리 동작 보존 (Dantry/GA4 송신 그대로)

## 검증 (canary 후)
- [ ] AdGuard/uBlock 활성 + 홈/게시판 진입 → 3초 후 토스트 노출
- [ ] "잠시 허용" 클릭 → 사라짐 + 7일간 미노출 (incognito 다시 보임)
- [ ] "PC 광고 제거 가입" 클릭 → `/ad-free` 이동
- [ ] AdGuard 미설치 사용자 → 토스트 노출 안 됨 (회귀 0)
- [ ] /admin, /install 경로 → 토스트 노출 안 됨
- [ ] Dantry `ad_blocked` 이벤트 평소처럼 송신 (텔레메트리 보존)