### PR TITLE
fix(ads): 자체 광고 wrapper class 차단 회피 (dm-*) — damoang-banner / image-text-banner / promo-classic-row

### DIFF
--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -187,7 +187,7 @@
     }
 </script>
 
-<div class="damoang-banner {className}" data-position={position} style:min-height={height}>
+<div class="dm-card {className}" data-position={position} style:min-height={height}>
     {#if loading}
         <div
             aria-hidden="true"

--- a/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
+++ b/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
@@ -200,9 +200,7 @@
 </script>
 
 <div
-    class="image-text-banner {className} {position === 'side-image-text-banner'
-        ? 'min-h-[164px]'
-        : ''}"
+    class="dm-grid-card {className} {position === 'side-image-text-banner' ? 'min-h-[164px]' : ''}"
     data-position={position}
 >
     {#if loading}

--- a/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
+++ b/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
@@ -42,7 +42,7 @@
     <!-- Classic variant: legacy step-pai amber bg + left accent -->
     <a
         {href}
-        class="promo-classic-row block px-4 no-underline transition-colors hover:bg-amber-100/10 dark:hover:bg-amber-950/15"
+        class="dm-list-row block px-4 no-underline transition-colors hover:bg-amber-100/10 dark:hover:bg-amber-950/15"
         style="background: rgba(255, 179, 39, 0.06); border-left: 3px solid rgba(255, 179, 39, 0.4); border-bottom: 1px solid color-mix(in oklch, var(--foreground) 8%, transparent);"
     >
         <div
@@ -116,13 +116,13 @@
 
 <style>
     /* 홍보 classic 행: regular post-row와 동일한 density-aware 패딩 */
-    .promo-classic-row {
+    .dm-list-row {
         padding-top: calc(10px + var(--row-pad-extra, 3px));
         padding-bottom: calc(10px + var(--row-pad-extra, 3px));
     }
 
     @media (min-width: 768px) {
-        .promo-classic-row {
+        .dm-list-row {
             padding-top: calc(6px + var(--row-pad-extra, 3px));
             padding-bottom: calc(6px + var(--row-pad-extra, 3px));
         }


### PR DESCRIPTION
## 요약
AdGuard / uBlock 의 EasyList Korea generic 룰에 의해 자체 광고 컴포넌트 3종이 차단되는 문제 해결. PR #1466 의 ad-slot wrapper `dm-display-*` 와 동일 패턴.

## 증상
canary 에서 AdGuard 활성 사용자가 다음 광고를 못 보고 있었습니다:
- 다모앙 직접 광고 배너 (damoang-banner)
- 사이드바 4칸 이미지/텍스트 배너 (image-text-banner)
- 직접홍보 게시판 사잇광고 (promotion-inline-post)

## 원인
AdGuard 의 generic cosmetic filter (`[class*="banner"]`, `[class*="promo"]`) 가 다음 class 들을 자동으로 hide 시킴:
- `.damoang-banner` (banner 포함)
- `.image-text-banner` (banner 포함)
- `.promo-classic-row` (promo 포함)

진단 결과 SSR / ads server / 데이터 fetch 는 모두 정상이었습니다 — 마크업이 정상 렌더링됨에도 브라우저 단에서 차단기가 hide.

## 변경
| 파일 | 기존 wrapper class | 신규 |
|---|---|---|
| `damoang-banner.svelte` | `damoang-banner` | `dm-card` |
| `image-text-banner.svelte` | `image-text-banner` | `dm-grid-card` |
| `promotion-inline-post.svelte` | `promo-classic-row` | `dm-list-row` |

`<style>` 내부 `.promo-classic-row` selector 도 `.dm-list-row` 로 동기 변경.

## 안전망 (유지)
- "광고" 텍스트 라벨 (alt, fallback) 유지 — 전자상거래법 준수
- 외부 링크 `rel="nofollow noopener"` 유지 — SEO 안전
- 광고 클릭 추적 (`use:aplogTrack`) 유지 — 텔레메트리 보존
- 외부 참조 0건 (slot-defaults.ts 의 import path 는 컴포넌트 경로지 class 명 아님)

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests 통과
- SSR HTML 마크업 정상 (PR-A 검증에서 이미 확인)

## canary 검증 (머지 후)
- [ ] AdGuard 활성 상태에서 게시판 list 진입 → damoang-banner / image-text-banner / 직접홍보 사잇광고 노출
- [ ] AdGuard 비활성 상태에서도 정상 (시각 회귀 0)
- [ ] PC 사이드바 4칸 image-text-banner 정상
- [ ] /promotion 게시판은 자체적으로 promotion-inline-post 미노출 (`isPromotionBoard` 분기 보존)
- [ ] 클릭 추적 텔레메트리 정상 (aplog `expose`/`click` 이벤트)

## 정책 경계
GAM/AdSense (외부 광고, 주 수입원) 는 광고 정책상 라벨 유지 필수 — 이 PR 범위 외. ad-slot 의 `dm-display-*` 는 PR #1466 에서 이미 처리 완료.