### PR TITLE
chore(footer): 통신판매업 번호 갱신 + 패밀리 사이트 인라인 링크

### DIFF
--- a/apps/web/src/lib/components/layout/footer.svelte
+++ b/apps/web/src/lib/components/layout/footer.svelte
@@ -173,10 +173,44 @@
                 </li>
             </ul>
 
+            <div
+                class="text-muted-foreground mt-3 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-xs"
+            >
+                <span class="font-medium">패밀리 사이트</span>
+                <span class="text-border">·</span>
+                <a
+                    href="https://angple.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="hover:text-primary transition-colors">angple.com</a
+                >
+                <span class="text-border">·</span>
+                <a
+                    href="https://muzia.net"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="hover:text-primary transition-colors">muzia.net</a
+                >
+                <span class="text-border">·</span>
+                <a
+                    href="https://ipyang.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="hover:text-primary transition-colors">ipyang.com</a
+                >
+                <span class="text-border">·</span>
+                <a
+                    href="https://dokdo.page"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="hover:text-primary transition-colors">dokdo.page</a
+                >
+            </div>
+
             <div class="text-muted-foreground mt-3 text-xs leading-relaxed">
                 <p>
                     주식회사 에스디케이(SDK) | 대표: 김선도 | 사업자등록번호: 871-81-03242 |
-                    통신판매업신고: 2024-고양일산서-1820
+                    통신판매업신고: 2026-삼도1동-0015
                 </p>
                 <p>
                     제주특별자치도 제주시 남성로 127, 4층 | contact@damoang.net | 제보:

--- a/apps/web/src/routes/shop/[productId]/+page.svelte
+++ b/apps/web/src/routes/shop/[productId]/+page.svelte
@@ -455,7 +455,7 @@
             <div><span class="font-medium">상호명:</span> 주식회사 에스디케이</div>
             <div><span class="font-medium">대표:</span> SDK</div>
             <div><span class="font-medium">사업자등록번호:</span> 871-81-03242</div>
-            <div><span class="font-medium">통신판매업:</span> 2024-고양일산서-1820</div>
+            <div><span class="font-medium">통신판매업:</span> 2026-삼도1동-0015</div>
             <div><span class="font-medium">주소:</span> 제주특별자치도 제주시 남성로 127, 4층</div>
             <div><span class="font-medium">이메일:</span> contact@damoang.net</div>
             <div><span class="font-medium">고객센터:</span> contact@damoang.net</div>


### PR DESCRIPTION
## 요약
1. **통신판매업신고 번호 갱신** — `2024-고양일산서-1820` → `2026-삼도1동-0015`
2. **패밀리 사이트 인라인 링크 추가** — `angple.com / muzia.net / ipyang.com / dokdo.page`

## 변경 파일
| 파일 | 변경 |
|---|---|
| `apps/web/src/lib/components/layout/footer.svelte` | 통신판매업 번호 + 패밀리 사이트 인라인 4링크 |
| `apps/web/src/routes/shop/[productId]/+page.svelte` | shop 상세 페이지 통신판매업 번호 동기 변경 |

## 패밀리 사이트 배치
법적 링크 영역 (사이트 소개 / 이용약관 / 개인정보 등) 과 사업자 정보 사이에 **한 줄 인라인**으로 배치 — 한국 footer 표준 패턴. 모바일 좁은 화면에서는 `flex-wrap` 으로 자연스럽게 줄바꿈.

```
패밀리 사이트  ·  angple.com  ·  muzia.net  ·  ipyang.com  ·  dokdo.page
```

- 4개 사이트 모두 `target="_blank" rel="noopener noreferrer"` — 새 탭, tabnabbing 방지
- `text-muted-foreground hover:text-primary transition-colors` — 기존 footer 일관성

## 검증
- `pnpm check` — 0 errors
- `grep -rn "2024-고양일산서-1820"` — 0건 (잔재 없음)

## 검증 (canary 후)
- [ ] footer 의 통신판매업 번호 `2026-삼도1동-0015` 노출
- [ ] 패밀리 사이트 4 링크 정상 (PC 한 줄, 모바일 wrap 정상)
- [ ] 각 링크 클릭 → 해당 사이트 새 탭으로 열림
- [ ] shop 상세 페이지 (`/shop/<id>`) 통신판매업 번호도 갱신