### PR TITLE
fix(post): SPA navigation race — 삭제글에 이전 글 본문 stale 노출 (#12484)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -372,8 +372,14 @@
 
     $effect(() => {
         const promise = data.streamed?.auxiliaryData;
+        // SPA 네비게이션 시 비동기 result 가 새 글에 잘못 적용되지 않도록 effect 시작 시점의 postId 캡처
+        const effectPostId = data.post.id;
 
-        // 글 변경 시 이전 스트리밍 데이터 즉시 리셋
+        // 글 변경 시 이전 스트리밍 데이터 즉시 리셋 + 본문 stale 차단 (#12484)
+        // renderedPostContent 가 이전 정상 글의 transformed content 를 그대로 유지하면
+        // 새 글(특히 삭제글) 진입 시 메타/일부 컴포넌트에 stale 본문이 노출될 수 있음.
+        renderedPostContent = data.post.content;
+        renderedPostContentPostId = data.post.id;
         postReactions = undefined;
         reactionsMap = undefined;
         lastFetchedReactionsKey = '';
@@ -400,6 +406,8 @@
 
         promise
             .then((result) => {
+                // SPA 네비게이션으로 다른 글로 이동했다면 적용하지 않음 (#12484 race condition)
+                if (data.post.id !== effectPostId) return;
                 if (cancelled) return;
                 promotionPosts = Array.isArray(result.promotionPosts)
                     ? (result.promotionPosts as PromotionPost[])
@@ -1425,7 +1433,9 @@
     }
 
     // SEO 설정
-    const postDescription = $derived(renderedPostContent.replace(/<[^>]+>/g, '').slice(0, 160));
+    const postDescription = $derived(
+        data.post.deleted_at ? '' : renderedPostContent.replace(/<[^>]+>/g, '').slice(0, 160)
+    );
 
     const seoConfig: SeoConfig = $derived.by(() => {
         const siteUrl = getSiteUrl();


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12484 — macOS Safari/Chrome 에서 정상 글 → 삭제글 SPA 이동 시 이전 글 본문이 캐시처럼 따라다니며 표시되는 간헐적 버그.

원본 보고: https://damoang.net/bug/12484
재현 경로: 정상 글 https://damoang.net/free/6319288 → 삭제글 https://damoang.net/free/6319197

## Root cause
`+page.svelte` 의 `auxiliaryData` streaming Promise race condition:

1. 정상 글 진입 시 transformedPostContent fetch 시작
2. 사용자가 빠르게 삭제글로 SPA 이동
3. 새 effect 사이클: `postContent` derived 는 `deleted_at` 분기로 `''` 반환 (정상)
4. 그러나 1번의 Promise 가 늦게 resolve → `renderedPostContent = result.transformedPostContent` (이전 글의 truthy content) 적용
5. `postContent` 는 deleted_at 으로 차단되지만 `postDescription` / og:description / 일부 view layout 경로에서 stale 노출

기존에도 `cancelled` flag 가 있었지만 같은 effect 인스턴스 내에서만 작동. SvelteKit 의 component reuse 로 인한 stale 가능성 차단 불완전.

## Fix
- effect 시작 시점의 `postId` 캡처 (`effectPostId`)
- Promise.then 진입 시 `data.post.id !== effectPostId` 면 적용 차단 (race guard)
- effect 시작 시 `renderedPostContent = data.post.content` 명시적 reset (이전 stale 즉시 제거)
- `postDescription` derived 에 `deleted_at` 분기 추가 (메타 stale 차단)

## 변경 파일 (1)
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` (12 lines)

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass
- 회귀 위험 낮음 — 가드 + reset 추가만, 기존 로직 유지

## canary 검증 시나리오
- [ ] 정상 글 → 삭제글 SPA 이동 → 삭제글 화면에 이전 글 본문 stale 노출 없음
- [ ] og:description 메타 stale 노출 없음 (View Source 확인)
- [ ] 일반 글 → 일반 글 SPA 이동 → 본문 정상 렌더 (회귀 없음)
- [ ] 첫 진입 (Cold load) → 본문 정상 렌더 (regression 없음)

## 추가 follow-up (별도)
SSR cache (hooks.server.ts) 의 post 페이지 cache key 정확성도 확인 가치 있음 — 이번 PR 외 별도 분석.