### PR TITLE
feat(report): 직전 신고 사유 자동 복원 (#12486)

### DIFF
--- a/apps/web/src/lib/components/features/report/report-dialog.svelte
+++ b/apps/web/src/lib/components/features/report/report-dialog.svelte
@@ -71,6 +71,50 @@
     let showConfirm = $state(false);
     let error = $state<string | null>(null);
 
+    // 직전 신고 사유 기억 (#12486) — 도배/연쇄 신고 시 매번 동일 사유 다시 선택하는 불편 해소
+    // 의견 (detail) 은 글마다 다를 수 있어 사유만 복원. TTL 30분.
+    const LAST_REASONS_KEY = 'damoang_report_lastReasons';
+    const LAST_REASONS_TTL_MS = 30 * 60 * 1000;
+
+    function loadLastReasons(): Set<ReportReason> {
+        if (typeof localStorage === 'undefined') return new Set();
+        try {
+            const raw = localStorage.getItem(LAST_REASONS_KEY);
+            if (!raw) return new Set();
+            const parsed = JSON.parse(raw) as { reasons?: number[]; ts?: number };
+            if (
+                !Array.isArray(parsed.reasons) ||
+                typeof parsed.ts !== 'number' ||
+                Date.now() - parsed.ts > LAST_REASONS_TTL_MS
+            ) {
+                return new Set();
+            }
+            return new Set(parsed.reasons as ReportReason[]);
+        } catch {
+            return new Set();
+        }
+    }
+
+    function saveLastReasons(reasons: Set<ReportReason>): void {
+        if (typeof localStorage === 'undefined' || reasons.size === 0) return;
+        try {
+            localStorage.setItem(
+                LAST_REASONS_KEY,
+                JSON.stringify({ reasons: [...reasons], ts: Date.now() })
+            );
+        } catch {
+            // 저장 실패 무시 (private 모드 / quota 등)
+        }
+    }
+
+    // 다이얼로그 open 시 직전 사유 자동 복원 (사용자가 수정 가능)
+    $effect(() => {
+        if (open && selectedReasons.size === 0 && !isSubmitting && !isSuccess) {
+            const restored = loadLastReasons();
+            if (restored.size > 0) selectedReasons = restored;
+        }
+    });
+
     // 제출 가능 여부
     const canSubmit = $derived(selectedReasons.size > 0);
 
@@ -106,6 +150,8 @@
             }
 
             isSuccess = true;
+            // 다음 신고 시 자동 복원 위해 직전 사유 저장 (#12486)
+            saveLastReasons(selectedReasons);
             onSuccess?.();
 
             // 2초 후 다이얼로그 닫기


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12486 — 신고 시 직전 선택했던 사유를 자동으로 유지/복원하여 도배·연쇄 신고를 빠르게 처리할 수 있도록 합니다.

원본 보고: https://damoang.net/bug/12486 (설중매님 제안)

## 변경
| 파일 | 변경 |
|---|---|
| `apps/web/src/lib/components/features/report/report-dialog.svelte` | localStorage 직전 사유 save/load + open 시 자동 복원 |

## 동작
1. 신고 다이얼로그에서 사유 선택 → 신고 제출 성공
2. 선택한 사유를 `damoang_report_lastReasons` localStorage 에 저장 (TTL 30분)
3. 다음 신고 다이얼로그 open 시 자동으로 직전 사유 미리 선택
4. 사용자가 수정 가능 (그대로 제출 또는 다른 사유 선택)

## 정책 결정
| 항목 | 결정 | 이유 |
|---|---|---|
| TTL | 30분 | 너무 길면 다른 신고 맥락에 부적절. 도배 신고는 보통 짧은 시간 내 |
| 의견(detail) 복원 | X (사유만) | 의견은 글마다 다를 수 있음. 잘못 자동 입력되면 오신고 위험 |
| 자동 복원 trigger | open + selectedReasons 비어있을 때 | 사용자가 수정 중인 선택 덮어쓰지 않음 |
| 실패 fallback | try-catch + 빈 Set 반환 | private 모드 / quota 실패 시에도 다이얼로그 정상 동작 |

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass
- 회귀 영향 — 신고 흐름 자체는 그대로, 자동 복원만 추가

## canary 검증 (머지 후)
- [ ] 글/댓글 신고 → 사유 선택 → 제출 → 다음 다이얼로그 open 시 자동 복원 확인
- [ ] 사용자가 자동 복원된 사유 수정 → 정상 적용
- [ ] 30분 경과 후 자동 복원 안 됨 (만료)
- [ ] localStorage 비활성 (private 모드) → 다이얼로그 정상 동작 (회귀 없음)