### PR TITLE
fix(author-link): 모바일 list 작성자 dropdown 오터치 차단 (#12480)

### DIFF
--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -116,7 +116,13 @@
     }
 </script>
 
-{#if !authorId}
+{#if !authorId || !authStore.isAuthenticated}
+    <!--
+      #12480: 비회원에게는 작성자 dropdown 비활성 (단순 텍스트).
+      모바일 list 에서 제목 영역과 인접한 작성자 영역이 자주 잘못 터치되어 dropdown 모달이
+      뜨는 문제를 해소. 비회원에겐 프로필/팔로우/쪽지 같은 dropdown 메뉴가 무의미하므로
+      클릭 영역 자체를 없애 부모 anchor (글 링크) 로 자연스럽게 propagate.
+    -->
     <span class="{className} {isWithdrawn ? 'line-through opacity-60' : ''}">
         {#if children}
             {@render children()}
@@ -137,9 +143,13 @@
               만 잡혀 글자 사이 빈 공간이나 점 주변을 누르면 트리거가 활성화 안 되는 문제.
               inline-block + min-width(2ch) + 좌우 padding 으로 클릭 영역을 보장한다.
               negative margin 으로 시각적 layout 영향은 0.
+
+              #12480: 모바일 list 에서 위 클릭 영역 보장이 인접 제목/메타 영역까지 침범하여
+              제목 터치 시 dropdown 이 뜨는 문제 발생. PC(md:) 에만 적용하도록 제한.
+              모바일은 기본 텍스트 너비만큼만 클릭 영역 — 제목 의도 터치 보호.
             -->
             <DropdownMenu.Trigger
-                class="-mx-0.5 inline-block min-w-[2ch] cursor-pointer px-0.5 text-left hover:underline focus:outline-none {className} {isWithdrawn
+                class="inline-block cursor-pointer text-left hover:underline focus:outline-none md:-mx-0.5 md:min-w-[2ch] md:px-0.5 {className} {isWithdrawn
                     ? 'line-through opacity-60'
                     : ''}"
             >


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12480 — 모바일 글 list 에서 제목 터치 시 자주 인접한 작성자 영역이 잡혀 dropdown 모달(프로필/전체게시물/게시판검색)이 뜨는 문제 해결.

원본 보고: https://damoang.net/bug/12480

## Root cause
PR #1463 (#12444 — 짧은 닉네임 클릭 영역 보장) 의 `-mx-0.5 inline-block min-w-[2ch] cursor-pointer px-0.5` class 가 PC 에선 의도대로 작동하나, **모바일 좁은 list 에서 인접 제목/메타 영역까지 클릭 영역이 침범**. 사용자가 제목 의도로 터치해도 작성자 dropdown 이 trigger 됨.

## Fix
| # | 변경 | 효과 |
|---|---|---|
| 1 | **비회원 → dropdown 자체 비활성** (`authStore.isAuthenticated === false` 분기) | 비회원에겐 프로필/팔로우/쪽지 dropdown 이 무의미. 단순 텍스트로 부모 `<a>` 글 링크로 propagate |
| 2 | **회원 → 클릭 영역 보장 코드 `md:` prefix 로 PC 만 적용** | PC 의 짧은 닉네임 클릭 보장 유지 (#12444 의도). 모바일은 텍스트 너비만큼만 클릭 — 제목 의도 터치 보호 |

## 변경 파일 (1)
- `apps/web/src/lib/components/ui/author-link/author-link.svelte` (+12 -2)

## 사용자 제안 반영
원본 보고의 사용자 제안:
- ✅ **"비회원은 목록에서 이 기능이 활성화 될 필요가 없다고 볼 수 있습니다"** → Fix #1 로 반영
- 🔜 **"옵션에서 on/off 요청"** → 회원도 토글 원하면 별도 settings UI 추가 (다음 작업)

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass
- 회귀 영향:
  - PC 회원: 짧은 닉네임 클릭 영역 보장 그대로 (#12444 유지)
  - PC 비회원: 작성자 단순 텍스트 (글 링크 propagate)
  - 모바일 회원: 작성자 텍스트 너비만큼만 클릭 (overlap 차단)
  - 모바일 비회원: 작성자 단순 텍스트 (글 링크 propagate)

## canary 검증 (머지 후)
- [ ] 모바일 비회원: list 에서 제목 터치 → 글 상세 진입 (dropdown 안 뜸)
- [ ] 모바일 회원: list 에서 작성자 텍스트 정확히 터치 → dropdown 노출 (의도된 동작)
- [ ] 모바일 회원: 제목 터치 → 글 상세 진입 (dropdown 안 뜸)
- [ ] PC 회원: 짧은 닉네임 (1~2 글자) 클릭 영역 보장 작동 (#12444 회귀 없음)