### PR TITLE
fix(post): SSR 단계에서 RecentPosts page 자동 결정 (#12430)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -583,16 +583,35 @@ export const load: PageServerLoad = async ({
             }
         }
 
-        // 하단 게시글 목록은 클라이언트에서 로드한다.
-        // 개수(20개)는 유지하되 상세 __data.json을 줄이기 위해 SSR 프리로드는 하지 않는다.
-        // SSR 단계에서는 항상 page=1 로 고정 — URL 의 ?page 파라미터는 목록 페이지 컨텍스트이며
-        // 글 상세 하단 RecentPosts 에 그대로 전달하면 특정 날짜의 글들이 고정 노출되는 버그 발생 (#12315).
-        // 실제 page 탐색은 클라이언트 컴포넌트가 담당한다.
+        // 하단 게시글 목록은 클라이언트에서 로드한다 (items 는 비워두어 __data.json 최소화).
+        // #12430 fix: URL `?page=N` 있으면 그 값, 없으면 SSR 단계에서 page-index 호출하여
+        // 자기 글이 속한 페이지를 자동 결정. 이전에 SSR=1 로 고정 후 클라이언트 onMount 에서
+        // 보강하던 방식이 race / hydration 문제로 1페이지에 고정되는 회귀가 반복됨 (#12430).
+        // items 는 SSR 에서 비워두므로 #12315 의 "특정 날짜 글 고정 노출" 회귀와는 무관.
+        const urlPage = Number(url.searchParams.get('page')) || 0;
+        let recentPostsPage = urlPage > 0 ? urlPage : 1;
+
+        if (urlPage === 0 && !post.deleted_at) {
+            try {
+                const piRes = await svelteKitFetch(
+                    `/api/boards/${boardId}/posts/${postId}/page-index`
+                );
+                if (piRes.ok) {
+                    const body = (await piRes.json()) as { page?: number };
+                    if (body.page && body.page > 1) {
+                        recentPostsPage = body.page;
+                    }
+                }
+            } catch {
+                // page-index 실패 시 1 유지 (사용자 흐름 방해 X)
+            }
+        }
+
         let recentPosts: { items: FreePost[]; total: number; totalPages: number; page: number } = {
             items: [],
             total: 0,
             totalPages: 1,
-            page: 1
+            page: recentPostsPage
         };
 
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12430 — 게시글 진입 시 하단 list 가 항상 1페이지로 고정되는 회귀를 SSR 단계에서 page-index 호출로 근본 해결.

원본 보고: https://damoang.net/bug/12430

## Root cause
1. `+page.server.ts:591` 에서 `data.recentPosts.page = 1` 로 SSR 고정 (#12315 회귀 방지 의도)
2. 클라이언트 `recent-posts.svelte` 의 onMount 에서 `/api/boards/.../page-index` 호출로 보강 시도
3. 그러나 `$derived isOnPostDetail` 의 SSR=false stale, `$pageStore` reactive hydration race 등으로 분기 진입 실패 케이스가 존재
4. URL ?page= 없는 외부 진입 (즐겨찾기 / 검색 / 알림 / 외부 링크) 시 client 보강 실패하면 1페이지 고정

이전 fix (PR #12048, #12302, #1431) 들이 모두 클라이언트 의존이라 race 가능성 잔존 → 회귀 반복.

## Fix
SSR `+page.server.ts` 에서 직접 page-index 호출 + `recentPosts.page` 를 정확하게 결정.

```typescript
const urlPage = Number(url.searchParams.get('page')) || 0;
let recentPostsPage = urlPage > 0 ? urlPage : 1;

if (urlPage === 0 && !post.deleted_at) {
    try {
        const piRes = await svelteKitFetch(`/api/boards/${boardId}/posts/${postId}/page-index`);
        if (piRes.ok) {
            const body = await piRes.json();
            if (body.page && body.page > 1) recentPostsPage = body.page;
        }
    } catch {
        // 실패 시 1 유지
    }
}
```

| 조건 | 결과 |
|---|---|
| URL `?page=N` 있음 | N 그대로 사용 (이전 동작 유지) |
| URL `?page=` 없음 + 정상 글 | page-index API 호출 → 자기 글의 페이지 결정 |
| URL `?page=` 없음 + 삭제글 | 호출 skip (page-index 의미 없음) |
| page-index API 실패 | 1 fallback (사용자 흐름 방해 X) |

## 변경 파일 (1)
- `apps/web/src/routes/[boardId]/[postId]/+page.server.ts` (+25 -6)

## SSR latency 영향
- page-index API 는 단순 COUNT 쿼리 (~5~10ms)
- 글 상세 SSR cache (60초 TTL) 로 같은 글 진입 시 1번만 호출
- 글마다 추가 latency ~5~10ms — 허용 범위

## #12315 회귀 위험 없음
`items: []` (SSR 비움) 유지 — 특정 날짜 글 고정 노출 위험 없음. 이번 변경은 `page` 값만 결정.

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass

## canary 검증 (머지 후)
- [ ] 글 상세 직접 URL 접근 (`/free/<id>` 형태, ?page= 없이) → RecentPosts 가 자기 글이 속한 페이지로 자동 표시
- [ ] 글 상세 `?page=N` URL 접근 → RecentPosts 가 N 페이지 표시 (이전 동작 유지)
- [ ] 삭제글 진입 → page-index 호출 안 함 (불필요 latency 없음)
- [ ] 페이지네이션 클릭 → board list 로 이동 (recent-posts pageHref 동작 회귀 없음)