### PR TITLE
fix(api): 401 시 자동 refresh + 재시도 — 로그인 자주 해제 해소 (#12463)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -95,6 +95,8 @@ class ApiClient {
     private _accessToken: string | null = null;
     private _fetchFn: typeof fetch | null = null;
     private _idempotencyKeys = new Map<string, { key: string; expiresAt: number }>();
+    // 진행 중인 refresh 호출 캐싱 (동시 401 race 방지) — #12463
+    private _refreshInFlight: Promise<boolean> | null = null;
 
     private stableSerialize(value: unknown): string {
         if (value === null) return 'null';
@@ -191,10 +193,48 @@ class ApiClient {
     // 호출 측 컴포넌트 unmount 등 cleanup 시 in-flight 요청이 즉시 정리된다.
     // (P0 leak fix 2026-05-02: Promise.race(timeout, apiClient.x) 패턴이
     //  timeout reject 후에도 fetch closure 를 leak 하던 문제 제거)
+    /**
+     * 401 응답 시 1회 자동 refresh 시도 (동시 호출은 같은 Promise 공유 — race 방지).
+     * 성공 시 access token 갱신 + true. 실패 시 false (재시도 안 함).
+     * #12463: access token 15분 만료 후 자동 refresh 없어 사용자가 "로그인 자주 해제" 보고.
+     */
+    private async tryAutoRefresh(): Promise<boolean> {
+        if (!browser) return false;
+        if (!this._refreshInFlight) {
+            this._refreshInFlight = (async () => {
+                try {
+                    const fetchFn = this._fetchFn || fetch;
+                    const r = await fetchFn(`${API_BASE_URL}/auth/refresh`, {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                    if (!r.ok) return false;
+                    const body = await r.json();
+                    const newToken = body?.data?.access_token ?? body?.access_token ?? null;
+                    if (typeof newToken === 'string' && newToken.length > 0) {
+                        this._accessToken = newToken;
+                        return true;
+                    }
+                    return false;
+                } catch {
+                    return false;
+                } finally {
+                    // 다음 호출은 새 시도. (성공/실패 무관)
+                    queueMicrotask(() => {
+                        this._refreshInFlight = null;
+                    });
+                }
+            })();
+        }
+        return this._refreshInFlight;
+    }
+
     private async request<T>(
         endpoint: string,
         options: RequestInit = {},
-        retryConfig?: Partial<RetryConfig>
+        retryConfig?: Partial<RetryConfig>,
+        _skipAutoRefresh: boolean = false
     ): Promise<ApiResponse<T>> {
         const url = `${API_BASE_URL}${endpoint}`;
 
@@ -258,6 +298,17 @@ class ApiClient {
             }
 
             if (!response.ok) {
+                // #12463: 401 시 1회 자동 refresh 후 재시도 (auth/* endpoint 는 제외 — 무한 루프 방지)
+                if (
+                    response.status === 401 &&
+                    !_skipAutoRefresh &&
+                    !endpoint.startsWith('/auth/')
+                ) {
+                    const refreshed = await this.tryAutoRefresh();
+                    if (refreshed) {
+                        return this.request<T>(endpoint, options, retryConfig, true);
+                    }
+                }
                 let errorMessage = '요청 실패';
                 let errorCode: string | undefined;
                 if (data?.error) {


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12463 — 네이버 간편로그인 (구글/카카오 포함 추정) 사용자가 짧은 시간 안에 로그인이 자주 해제되는 문제를 client.ts 의 401 자동 refresh 로직 추가로 해결.

원본 보고: https://damoang.net/bug/12463

## Root cause
| 항목 | 상태 |
|---|---|
| Access JWT 만료 | **15분** (`config.prod.yaml: expires_in: 900`) |
| Refresh token 만료 | 7일 (HttpOnly cookie, backend 정상) |
| Backend `/api/v1/auth/refresh` endpoint | 정상 작동 (cookie 기반) |
| **client.ts `request()` 401 자동 refresh** | **부재** ← 회귀 원인 |
| `tryRefreshToken()` | `@deprecated` 표시 + `!!this._accessToken` 만 반환 (실제 refresh X) |

즉 사용자가 15분 이상 활동 시 첫 API call 에서 401 → 그대로 throw → 인식상 "로그인 해제". 재로그인해도 다시 15분 후 같은 현상 반복.

## Fix
1. `ApiClient` 에 `_refreshInFlight: Promise<boolean> | null` 추가 (동시 401 race 방지)
2. `private async tryAutoRefresh()` 메서드 추가
   - `POST /auth/refresh` + `credentials: 'include'` (cookie 자동 전송)
   - 응답에서 `access_token` 추출 → `_accessToken` 갱신 → true
   - 진행 중 호출은 같은 Promise 공유 (race 방지)
3. `request()` 안 401 분기에서:
   - `_skipAutoRefresh=false` && `!endpoint.startsWith('/auth/')` 조건일 때
   - `tryAutoRefresh()` 호출 → 성공 시 `_skipAutoRefresh=true` 재진입으로 1회 재시도
   - 실패 시 원본 401 그대로 throw (사용자가 재로그인 필요)

## 안전망
- `_skipAutoRefresh` flag: 재진입 시 무한 루프 방지
- `/auth/*` endpoint 제외: refresh 자체가 401 이면 무한 루프 방지
- `tryAutoRefresh()` 실패 시 원본 401 유지: 진짜 인증 실패 시 사용자 흐름 보존

## 변경 파일 (1)
- `apps/web/src/lib/api/client.ts` (+52 -1)

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass

## canary 검증 (머지 후)
- [ ] 네이버/구글/카카오 로그인 → 15분 이상 무활동 → 글 작성/댓글/추천 등 동작 정상 (background refresh)
- [ ] DevTools Network: 첫 401 후 `/auth/refresh` POST 자동 호출 + 원래 요청 재시도
- [ ] 7일 경과 후 자동 refresh 실패 → 정상 401 → 사용자 재로그인 (회귀 없음)
- [ ] 동시 다발 API call 중 401 발생 시 refresh 1번만 호출 (race 방지)

## 추가 follow-up (별도)
- `tryRefreshToken()` `@deprecated` 코드 정리 (deprecated 그대로 둠, 호출처 없으면 다음 cleanup PR 에서 제거)
- 세션 기반 인증 마이그레이션 완료까지 본 fix 가 임시 patch 역할