### PR TITLE
feat(board): 빠른 글쓰기 버튼 — 내가 쓴 댓글 필터 줄에 추가 (#12455)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -960,6 +960,20 @@
                             <X class="h-3.5 w-3.5" />
                         </Button>
                     {/if}
+                    <!-- #12455: 빠른 글쓰기 (내가 쓴 글/댓글 필터 줄 우측) -->
+                    {#if canWrite}
+                        <Button
+                            onclick={goToWrite}
+                            size="sm"
+                            class="ml-auto h-8"
+                            title={!canUseCertifiedAction(authStore.user, boardId)
+                                ? getCertificationBlockedMessage(boardId)
+                                : '글쓰기'}
+                        >
+                            <Pencil class="mr-1.5 h-3.5 w-3.5" />
+                            {#if !canUseCertifiedAction(authStore.user, boardId)}실명인증{:else}글쓰기{/if}
+                        </Button>
+                    {/if}
                 </div>
             {/if}
 


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12455 — 게시판 목록의 글쓰기 버튼이 위쪽에만 있어 어색하다는 사용자 제안 반영. '내가 쓴 글 / 내가 쓴 댓글' 빠른 필터 같은 줄에 빠른 글쓰기 버튼 추가.

원본 보고: https://damoang.net/bug/12455

## 변경 (1 파일)
- `apps/web/src/routes/[boardId]/+page.svelte` (+14)

빠른 필터 영역 (`isMyPostsActive` / `isMyCommentsActive` 버튼 줄) 의 우측에 `canWrite` 조건부 글쓰기 버튼 추가. 기존 상단 글쓰기 버튼은 유지.

```svelte
{#if canWrite}
    <Button onclick={goToWrite} size="sm" class="ml-auto h-8">
        <Pencil class="mr-1.5 h-3.5 w-3.5" />
        {#if !canUseCertifiedAction(...)}실명인증{:else}글쓰기{/if}
    </Button>
{/if}
```

## 동작
- 로그인 + `canWrite` (서버 permissions / 클라이언트 레벨 폴백) 일 때만 노출
- `claim` 게시판은 `canWrite=false` 이므로 노출 안 됨 (이용제한 상세에서만 소명 작성)
- 실명인증 필요 시 label '실명인증' + `goToCertification()` 분기 (기존 글쓰기 흐름 재사용)
- `ml-auto` 로 줄 오른쪽 정렬 (필터 버튼과 시각 분리)

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass

## canary 검증 (머지 후)
- [ ] 로그인 + 글쓰기 가능 게시판 → 필터 줄 우측에 글쓰기 버튼 노출
- [ ] 버튼 클릭 → `/<boardId>/write` 이동 (기존 흐름)
- [ ] 실명인증 미완료 사용자 → 실명인증 모달 (기존 흐름)
- [ ] 비로그인 / `claim` 게시판 → 버튼 미노출
- [ ] 기존 상단 글쓰기 버튼 정상 (회귀 없음)

## 추가 follow-up (별도)
사용자가 본문에서 언급한:
- 검색 버튼 → 옆에 인라인 검색칸 (광고 영역 건너뛰지 않게)
- 글쓰기 버튼 목록 아래쪽에도 중복 배치
는 별도 PR 에서 검토 가능. 본 PR 은 사용자 추가 메시지 "내가 쓴 댓글과 같은 줄에 글쓰기 버튼을 추가하자" 만 반영.