### PR TITLE
feat(post,comment): 신고잠금 글/댓글 UX — 수정·신고 가드 + 블라인드 (#12420)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -379,6 +379,22 @@
         }
     }
 
+    // #12420: 신고 누적으로 잠긴 댓글 펼침 상태 (블라인드 + 일시 해제)
+    // blockedUsersStore (영구 정책) 와 의미 분리 — lock 은 임시 운영 결정
+    let expandedLockedComments = new SvelteSet<string>();
+
+    function isLockedComment(comment: FreeComment): boolean {
+        return comment.report_count === 'lock';
+    }
+
+    function toggleLockedComment(commentId: string): void {
+        if (expandedLockedComments.has(commentId)) {
+            expandedLockedComments.delete(commentId);
+        } else {
+            expandedLockedComments.add(commentId);
+        }
+    }
+
     // 작성자 확인
     function isCommentAuthor(comment: FreeComment): boolean {
         return (
@@ -413,9 +429,11 @@
 
     // 댓글 수정/삭제 권한 (작성자 또는 관리자)
     // 대댓글이 달린 댓글도 작성자가 수정 가능. 단 startEdit 에서 별도 안내 confirm 을 띄운다 (#12437, #12451).
+    // #12420: 신고 누적으로 잠긴 댓글은 작성자 수정 차단. admin 만 운영 도구로 수정 가능.
     function canEditComment(comment: FreeComment): boolean {
         if (!authStore.user) return false;
         if (isAdmin()) return true;
+        if (isLockedComment(comment)) return false;
         return isCommentAuthor(comment);
     }
 
@@ -955,6 +973,7 @@
     {#each commentTree as comment, commentIndex (comment.id)}
         {@const isDeleted = !!comment.deleted_at}
         {@const isBlocked = isBlockedComment(comment)}
+        {@const isLocked = isLockedComment(comment)}
         {@const isAuthor = isCommentAuthor(comment)}
         {@const canEdit = !isDeleted && canEditComment(comment)}
         {@const isEditing = editingCommentId === String(comment.id)}
@@ -981,7 +1000,7 @@
               )}
 
         <!-- 차단된 사용자 댓글 (접힌 상태) -->
-        {#if isBlocked && !expandedBlockedComments.has(String(comment.id))}
+        {#if (isBlocked && !expandedBlockedComments.has(String(comment.id))) || (!isBlocked && isLocked && !expandedLockedComments.has(String(comment.id)))}
             <li
                 id="c_{comment.id}"
                 style="margin-left: {Math.min(depth, 2) * 1}rem"
@@ -997,11 +1016,14 @@
                     : ''}"
             >
                 <button
-                    onclick={() => toggleBlockedComment(String(comment.id))}
+                    onclick={() =>
+                        isBlocked
+                            ? toggleBlockedComment(String(comment.id))
+                            : toggleLockedComment(String(comment.id))}
                     class="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-xs transition-colors"
                 >
                     <EyeOff class="h-3.5 w-3.5" />
-                    차단된 사용자의 댓글입니다
+                    {isBlocked ? '차단된 사용자의 댓글입니다' : '신고 누적으로 가려진 댓글입니다'}
                 </button>
             </li>
         {:else}
@@ -1063,6 +1085,15 @@
                     >
                         <EyeOff class="h-3.5 w-3.5" />
                         차단된 사용자의 댓글 — 접기
+                    </button>
+                {:else if isLocked}
+                    <!-- #12420: 신고 누적으로 잠긴 댓글 (펼쳐진 상태) — 접기 -->
+                    <button
+                        onclick={() => toggleLockedComment(String(comment.id))}
+                        class="text-muted-foreground hover:text-foreground mb-1 flex items-center gap-1.5 text-xs transition-colors"
+                    >
+                        <EyeOff class="h-3.5 w-3.5" />
+                        신고 누적으로 가려진 댓글 — 접기
                     </button>
                 {/if}
 
@@ -1410,8 +1441,8 @@
                                                     <Trash2 class="h-4 w-4" />
                                                 </Button>
                                             {/if}
-                                            {#if !isAuthor && authStore.isAuthenticated}
-                                                <!-- 신고 버튼 (본인이 아닌 경우에만) -->
+                                            {#if !isAuthor && authStore.isAuthenticated && !isLocked}
+                                                <!-- 신고 버튼 (본인이 아닌 경우에만, #12420: 잠긴 댓글은 추가 신고 불가) -->
                                                 <Button
                                                     variant="ghost"
                                                     size="sm"
@@ -1753,8 +1784,8 @@
                                 </Button>
                             {/if}
 
-                            <!-- 신고 버튼 (본인이 아닌 경우) -->
-                            {#if !isAuthor && authStore.isAuthenticated}
+                            <!-- 신고 버튼 (본인이 아닌 경우, #12420: 잠긴 댓글은 추가 신고 불가) -->
+                            {#if !isAuthor && authStore.isAuthenticated && !isLocked}
                                 <Button
                                     variant="ghost"
                                     size="sm"

--- a/apps/web/src/lib/components/features/board/content-blur.svelte
+++ b/apps/web/src/lib/components/features/board/content-blur.svelte
@@ -11,9 +11,14 @@
         shouldBlur: boolean;
         /** 자식 요소 */
         children: import('svelte').Snippet;
+        /**
+         * 블러 사유 라벨. 지정 시 기본 "클릭하여 내용 확인" 대신 이 문구가 노출됨.
+         * 예: "신고 누적으로 가려졌습니다 — 보기는 본인 책임" (#12420)
+         */
+        blurReason?: string;
     }
 
-    let { shouldBlur, children }: Props = $props();
+    let { shouldBlur, children, blurReason }: Props = $props();
 
     let revealed = $state(false);
 
@@ -56,7 +61,9 @@
                     (e.currentTarget as HTMLImageElement).style.display = 'none';
                 }}
             />
-            <p class="text-muted-foreground text-sm font-medium">클릭하여 내용 확인</p>
+            <p class="text-muted-foreground text-sm font-medium">
+                {blurReason ?? '클릭하여 내용 확인'}
+            </p>
         </button>
     </div>
 {:else if shouldBlur && revealed}

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -384,7 +384,12 @@
         <!-- 게시글 본문 -->
         {#if canViewSecret}
             <AdultBlur isAdult={post.is_adult ?? false}>
-                <ContentBlur shouldBlur={uiSettingsStore.shouldBlurContent(post.title)}>
+                <ContentBlur
+                    shouldBlur={uiSettingsStore.shouldBlurContent(post.title) || isLockedPost}
+                    blurReason={isLockedPost
+                        ? '신고 누적으로 가려진 글입니다 — 클릭하면 본인 책임 하에 표시'
+                        : undefined}
+                >
                     <div id="economy-post-content" style="font-size: {FONT_SIZES[currentFontSize]}">
                         <Markdown content={postContent} />
                     </div>
@@ -627,7 +632,8 @@
                     {#if board?.use_sns}
                         <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}
-                    {#if !isAuthor}
+                    {#if !isAuthor && !isLockedPost}
+                        <!-- #12420: 이미 신고 누적으로 잠긴 글은 추가 신고 불가 -->
                         <Button
                             variant="ghost"
                             size="sm"

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -929,8 +929,10 @@
     );
 
     // 수정/삭제 권한 (작성자 또는 관리자)
+    // #12420: 신고 누적으로 잠긴 글은 작성자 수정 차단. admin 만 운영 도구로 수정 가능.
     const isAdmin = $derived((authStore.user?.mb_level ?? 0) >= 10);
-    const canModify = $derived(isAuthor || isAdmin);
+    const isLockedPost = $derived(data.post.extra_7 === 'lock' || postReportCount === 'lock');
+    const canModify = $derived((isAuthor && !isLockedPost) || isAdmin);
 
     // 직접홍보 게시판 만료 여부
     const promotionExpired = $derived(data.promotionExpired === true && !isAuthor);


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12420 — 신고 누적 자동 lock 글/댓글에 대한 프론트엔드 UX 개선.

원본 보고: https://damoang.net/bug/12420

## 사용자 의도 반영
- 콘텐츠 삭제 안 함 (이용제한 박제 보존)
- 본문/댓글 자동 블라인드 + 일시 펼치기 토글 (회원 책임)
- 작성자 수정 차단, 추가 신고 차단
- admin 운영 도구는 그대로 (mb_level ≥ 10 예외)

## A — 수정·신고 버튼 가드

| 위치 | 변경 |
|---|---|
| `+page.svelte:933` | `canModify = (isAuthor && !isLockedPost) \|\| isAdmin` (post.extra_7 또는 postReportCount === 'lock') |
| `basic.svelte:635` | 신고 버튼 `{#if !isAuthor && !isLockedPost}` |
| `comment-list.svelte:416` | `canEditComment` 에 `isLockedComment` 차단 |
| `comment-list.svelte:1431, 1788` | 댓글 신고 버튼 2곳 `&& !isLocked` |

## B — 블라인드 + 일시 해제

| 위치 | 변경 |
|---|---|
| `content-blur.svelte` | `blurReason?: string` prop 추가 — overlay 문구 |
| `basic.svelte:387` | `<ContentBlur shouldBlur={blur \|\| isLockedPost} blurReason="신고 누적..." />` |
| `comment-list.svelte` | `expandedLockedComments` 신규 store (차단 store 와 의미 분리) |
| `comment-list.svelte:1002` | 블라인드 분기 OR 합성 (차단 또는 lock → 접힘) |

기존 `blockedUsersStore + expandedBlockedComments + toggleBlockedComment` 패턴 그대로 차용 — 사용자에게 익숙한 UX.

## 짝꿍 PR — 필수
본 PR 단독으로는 frontend 만 막아 API 직접 호출 시 우회 가능.
**damoang/angple-backend#473** 가 진실의 원천 — 글/댓글 update + report 4 라우트에 lock 가드 추가 (admin 예외). 이미 머지 (`da486bf`).

## 변경 파일 (4)
- `apps/web/src/lib/components/features/board/content-blur.svelte` (blurReason prop)
- `apps/web/src/lib/components/features/board/layouts/view/basic.svelte`
- `apps/web/src/lib/components/features/board/comment-list.svelte`
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte`

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass

## canary 검증 (머지 후)
- [ ] lock 글: 본문 자동 blur → "신고 누적으로 가려진 글입니다 — 클릭하면 본인 책임" overlay → 클릭 시 reveal
- [ ] lock 글: 수정 버튼 숨김 (작성자), 신고 버튼 숨김
- [ ] lock 댓글: 자동 접힘 → "신고 누적으로 가려진 댓글입니다" 버튼 → 클릭 시 펼침
- [ ] lock 댓글: 수정 버튼 숨김 (작성자), 신고 버튼 숨김
- [ ] admin (mb_level≥10): lock 글/댓글 수정 가능 (운영 도구 보존)
- [ ] 일반 (lock 아닌) 글/댓글: 회귀 없음

## 후속 (별도 PR)
- `/[boardId]/[postId]/edit/+page.server.ts` SSR loader 가드 (URL 직접 진입 우회 방지)
- lock 댓글 답글 작성 차단 여부 (운영 정책 결정 후)