### PR TITLE
fix(member): 비로그인 회원 프로필 열람 차단 (#12501)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -99,7 +99,12 @@ function calculateLevelInfo(totalExp: number) {
     return { currentLevel, nextLevelExp, expToNext, progress };
 }
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
+    // #12501: 비로그인 사용자의 타 회원 프로필 열람 차단 (개인정보 보호)
+    if (!locals.user) {
+        return json({ success: false, error: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
     const memberId = params.id;
 
     // mb_id (영문/숫자/_-) 또는 mb_nick (한글 포함) 둘 다 허용 (#12371).

--- a/apps/web/src/routes/member/[id]/+page.server.ts
+++ b/apps/web/src/routes/member/[id]/+page.server.ts
@@ -1,7 +1,13 @@
+import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 
-export const load: PageServerLoad = async ({ params, fetch }) => {
+export const load: PageServerLoad = async ({ params, fetch, locals, url }) => {
     const memberId = params.id;
+
+    // #12501: 비로그인 사용자는 타 회원 프로필 열람 불가 → 로그인 페이지로 유도 (개인정보 보호)
+    if (!locals.user) {
+        redirect(302, `/login?redirect=${encodeURIComponent(url.pathname)}`);
+    }
 
     try {
         const res = await fetch(`/api/members/${memberId}/profile`);


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12501 — 로그인하지 않은 상태에서 타 회원 프로필 (`/member/{id}`) 정보가 노출되는 개인정보 문제 차단.

원본 보고: https://damoang.net/bug/12501 (고물타자기님, 네이버 브라우저)

## 노출 정보 (차단 전)
member 프로필 API 가 인증 없이 다음을 반환:
가입일(mb_datetime), 포인트(mb_point), 레벨, 서명, 홈페이지, 이용제한 이력(discipline log), 게시글/댓글 통계 등.

## Root cause
SvelteKit 이 직접 DB 조회 (backend Go 무관):
- `/api/members/[id]/profile/+server.ts` GET — `locals` 미사용 (비인증 호출 가능)
- `/member/[id]/+page.server.ts` load — `locals.user` 체크 없음

## Fix (양쪽 차단)
| 위치 | 변경 |
|---|---|
| API proxy `+server.ts` | `if (!locals.user) → 401 "로그인이 필요합니다"` |
| page load `+page.server.ts` | `if (!locals.user) → redirect(302, /login?redirect=...)` |

두 곳 모두 차단하여 **SSR 페이지 진입 + API 직접 호출** 모두 방어.

## 변경 파일 (2)
- `apps/web/src/routes/api/members/[id]/profile/+server.ts` (+4)
- `apps/web/src/routes/member/[id]/+page.server.ts` (+9 -2)

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass

## canary 검증 (머지 후)
- [ ] 비로그인 + `/member/{id}` 직접 접근 → `/login?redirect=` 로 302
- [ ] 비로그인 + `/api/members/{id}/profile` 직접 호출 → 401
- [ ] 로그인 사용자 → 프로필 정상 열람 (회귀 없음)
- [ ] 멘션 링크 (@닉네임 → /member/{닉네임}) 로그인 시 정상

## 참고
공개 닉네임/아바타 같은 최소 정보까지 비로그인에 보여줄 필요가 있다면 별도 공개 엔드포인트 분리 검토 가능하나, 본 PR 은 사용자 요청("비회원은 막자") 에 따라 프로필 전체를 로그인 필요로 차단.