### PR TITLE
fix(header): 아이패드 세로 상단 메뉴 한글 글자 세로 줄바꿈 (#12499)

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -309,7 +309,9 @@
         </div>
 
         <!-- 데스크톱 네비게이션 (show_in_header 메뉴 동적 렌더링) -->
-        <nav class="hidden items-center space-x-8 md:flex">
+        <!-- #12499: md(아이패드 세로) 구간에서 항목 폭 부족 시 한글 라벨이 글자 단위로
+             세로 줄바꿈되던 문제 — 간격 축소(md) + 라벨 whitespace-nowrap 으로 해결 -->
+        <nav class="hidden items-center space-x-4 md:flex lg:space-x-8">
             {#if menuStore.headerMenus.length > 0}
                 {#each menuStore.headerMenus as headerMenu (headerMenu.id)}
                     {@const IconComp = getIcon(headerMenu.icon)}
@@ -319,7 +321,7 @@
                         href={headerMenu.url}
                         target={headerMenu.target === '_blank' ? '_blank' : undefined}
                         rel={headerMenu.target === '_blank' || isExternal ? 'noopener' : undefined}
-                        class="text-foreground hover:text-primary flex items-center transition-all duration-200 ease-out"
+                        class="text-foreground hover:text-primary flex items-center whitespace-nowrap transition-all duration-200 ease-out"
                         onclick={isHome
                             ? (e: MouseEvent) => {
                                   if (window.location.pathname === '/') {
@@ -337,7 +339,7 @@
                 <!-- headerMenus가 비어있으면 홈 링크만 기본 표시 -->
                 <a
                     href="/"
-                    class="text-foreground hover:text-primary flex items-center transition-all duration-200 ease-out"
+                    class="text-foreground hover:text-primary flex items-center whitespace-nowrap transition-all duration-200 ease-out"
                     onclick={(e: MouseEvent) => {
                         if (window.location.pathname === '/') {
                             e.preventDefault();


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12499 — 아이패드 11" Pro (M2) 세로 화면에서 헤더 데스크톱 메뉴의 한글 라벨이 글자 단위로 세로 줄바꿈되는 UI 버그 수정.

원본 보고: https://damoang.net/bug/12499 (House님, 아이패드 11" Pro M2 세로)

## 증상 (스샷 확인)
| 정상 | 아이패드 세로 (버그) |
|---|---|
| 모아보기 | 모아 / 보기 |
| 공감글 | 공 / 감 / 글 (세로 3줄) |
| 소모임 | 소 / 모 / 임 |
| 위키앙 | 위 / 키 / 앙 |

PC(넓음)·모바일(md 미만 → 햄버거) 정상, 아이패드 세로의 애매한 폭에서만 발생.

## Root cause
- `header.svelte:312` 데스크톱 nav `class="hidden items-center space-x-8 md:flex"` — md(768px)+ 표시
- 아이패드 11" 세로 (~768~834px) 가 md 구간 → 메뉴 6~7개 + 로고 + 우측 아이콘이 `space-x-8`(2rem) 간격으로 배치되며 폭 부족
- 메뉴 `<a>` 에 `whitespace-nowrap` 없어 한글 라벨이 글자 단위 wrap

## Fix (1 파일)
- nav 간격: `space-x-8` → `space-x-4 md:flex lg:space-x-8` (md 구간 간격 축소로 폭 여유)
- 메뉴 `<a>` (each 항목 + else 홈링크) 에 `whitespace-nowrap` 추가 (라벨 한 줄 유지)

## 변경 파일
- `apps/web/src/lib/components/layout/header.svelte` (+5 -3)

## 검증
- `pnpm check` — 0 errors
- `pnpm test:unit` — 402 tests pass

## canary 검증 (머지 후)
- [ ] 아이패드 11" 세로 (또는 768~834px 폭 브라우저) → 상단 메뉴 한 줄 표시 (글자 세로쪼개짐 없음)
- [ ] PC (lg+) → 기존 간격 (space-x-8) 유지
- [ ] 모바일 (md 미만) → 햄버거 메뉴 정상 (회귀 없음)
- [ ] 메뉴 항목 많을 때 가로 overflow 없이 표시