### PR TITLE
chore(footer): 패밀리 사이트 인라인 링크 제거

### DIFF
--- a/apps/web/src/lib/components/layout/footer.svelte
+++ b/apps/web/src/lib/components/layout/footer.svelte
@@ -173,40 +173,6 @@
                 </li>
             </ul>
 
-            <div
-                class="text-muted-foreground mt-3 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-xs"
-            >
-                <span class="font-medium">패밀리 사이트</span>
-                <span class="text-border">·</span>
-                <a
-                    href="https://angple.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="hover:text-primary transition-colors">angple.com</a
-                >
-                <span class="text-border">·</span>
-                <a
-                    href="https://muzia.net"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="hover:text-primary transition-colors">muzia.net</a
-                >
-                <span class="text-border">·</span>
-                <a
-                    href="https://ipyang.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="hover:text-primary transition-colors">ipyang.com</a
-                >
-                <span class="text-border">·</span>
-                <a
-                    href="https://dokdo.page"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="hover:text-primary transition-colors">dokdo.page</a
-                >
-            </div>
-
             <div class="text-muted-foreground mt-3 text-xs leading-relaxed">
                 <p>
                     주식회사 에스디케이(SDK) | 대표: 김선도 | 사업자등록번호: 871-81-03242 |


### PR DESCRIPTION
## 요약
footer 하단의 패밀리 사이트 인라인 링크 (angple.com / muzia.net / ipyang.com / dokdo.page) 제거. PR #1471 에서 추가했던 것을 사용자 요청으로 롤백.

## 변경
- `apps/web/src/lib/components/layout/footer.svelte` (-34) — 패밀리 사이트 `<div>` 블록 제거
- 통신판매업 번호 등 사업자 정보는 그대로 유지

## 검증
- `pnpm check` — 0 errors

## canary 검증
- [ ] footer 하단에 패밀리 사이트 줄 없음
- [ ] 사업자 정보 / 법적 링크 정상