### PR TITLE
feat(plugins): archive(보존) plugin 활성화

### DIFF
--- a/apps/web/data/plugin-settings.json
+++ b/apps/web/data/plugin-settings.json
@@ -6,7 +6,8 @@
         "member-memo",
         "interaction-analysis",
         "da-reaction",
-        "affiliate-link-private"
+        "affiliate-link-private",
+        "archive"
     ],
     "plugins": {
         "ad-widget": {
@@ -48,6 +49,10 @@
                 "enabled": true
             },
             "activatedAt": "2026-03-22T13:50:00.000Z"
+        },
+        "archive": {
+            "settings": {},
+            "activatedAt": "2026-05-24T00:00:00.000Z"
         }
     },
     "version": "1.0.0"

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1459,14 +1459,16 @@
                                                 </Button>
                                             {/if}
 
-                                            <!-- 플러그인 슬롯: 댓글 액션 (보존 버튼 등) -->
-                                            <PluginSlot
-                                                name="comments-item-actions"
-                                                {boardId}
-                                                {postId}
-                                                commentId={comment.id}
-                                                commentAuthorId={comment.author_id}
-                                            />
+                                            <!-- 플러그인 슬롯: 댓글 액션 (보존 버튼 등) — chat 레이아웃은 별도 컴팩트 액션 영역에서 렌더 -->
+                                            {#if commentLayout !== 'chat'}
+                                                <PluginSlot
+                                                    name="comments-item-actions"
+                                                    {boardId}
+                                                    {postId}
+                                                    commentId={comment.id}
+                                                    commentAuthorId={comment.author_id}
+                                                />
+                                            {/if}
                                         </div>
                                     {/if}
                                 </div>
@@ -1805,6 +1807,15 @@
                                     <Flag class="h-3.5 w-3.5" />
                                 </Button>
                             {/if}
+
+                            <!-- 플러그인 슬롯: 댓글 액션 (보존 버튼 등) -->
+                            <PluginSlot
+                                name="comments-item-actions"
+                                {boardId}
+                                {postId}
+                                commentId={comment.id}
+                                commentAuthorId={comment.author_id}
+                            />
                         </div>
                     {/if}
 

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1458,6 +1458,15 @@
                                                     <span class="ml-1 text-xs">신고</span>
                                                 </Button>
                                             {/if}
+
+                                            <!-- 플러그인 슬롯: 댓글 액션 (보존 버튼 등) -->
+                                            <PluginSlot
+                                                name="comments-item-actions"
+                                                {boardId}
+                                                {postId}
+                                                commentId={comment.id}
+                                                commentAuthorId={comment.author_id}
+                                            />
                                         </div>
                                     {/if}
                                 </div>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2049,7 +2049,12 @@
         <div data-scroll-depth="100" aria-hidden="true"></div>
 
         <!-- 플러그인 슬롯: 글 상세 페이지 끝 — Slot Catalog Sprint 2c -->
-        <PluginSlot name="post-detail-after" {boardId} postId={data.post.id} />
+        <PluginSlot
+            name="post-detail-after"
+            {boardId}
+            postId={data.post.id}
+            postAuthorId={data.post.author_id}
+        />
     {/if}
     <!-- /canRead -->
 </div>


### PR DESCRIPTION
## 배경

archive(보존, 앙카이브) plugin v0.1.0 은 premium 레포(PR #55~#64)에 머지 완료되어 canary image(`p346bf26`)에 코드가 포함돼 있으나, `activePlugins` 미등록으로 `/api/plugins/archive/*` 가 `Plugin not active: archive` (404) 반환 중. MVP 동작 확인을 위해 활성화합니다.

## 변경

- `apps/web/data/plugin-settings.json` 의 `activePlugins` 에 `archive` 추가
- `plugins.archive` 항목 추가 (settings 비움 → plugin.json default 적용)

da-reaction / member-memo / interaction-analysis / affiliate-link-private 등 기존 premium plugin 활성화와 동일한 방식입니다.

## 활성화 시 영향

- canary pod 의 archive plugin 로드 → `/api/plugins/archive/*` 응답 시작
- 운영 MySQL 에 `g5_da_archive` + `g5_da_archive_report` 테이블 **자동 생성** (신규 테이블, 기존 데이터 무영향)
- post-detail 슬롯에 [보존] 버튼 노출

## 적용 정책 (default)

| 항목 | 값 |
|---|---|
| 비용 | 50,000P (환불 없음) |
| 권한 | 가입 365일 + 레벨 5 (admin bypass) |
| 검색엔진 | noindex |
| rate limit | 10/h, 50/d |

> ⚠️ 알려진 drift (canary 검증 항목): 가입 365일(spec 30일 대비 상향), 이미지 미보존, HTML sanitize 미적용(XSS), cost 클라이언트 하드코드. 상세: `/home/damoang/docs/archive-plugin/01-current-state.html`

## 검증 계획

1. 머지 → `deploy.yml` (canary_only) 자동 trigger → canary 반영
2. canary 검증: `/api/plugins/archive/archives/count` 200, migration 실행, [보존] 버튼 노출, noindex meta
3. 이상 없으면 prod 승격(`full`)은 **새벽 4시** 윈도우에서 별도 승인 후 진행

## 롤백

`activePlugins` 에서 `archive` 제거 후 재배포. 생성된 테이블은 신규라 잔존해도 무영향.