### PR TITLE
feat(multi-tenant): 빈 사이트 SSR 안전성 — widget boundary + home fallback + sourcemap (Phase 14 Tier 1)

### DIFF
--- a/apps/web/src/lib/components/widget-renderer/widget-wrapper.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-wrapper.svelte
@@ -99,7 +99,26 @@
     <!-- 위젯 콘텐츠 -->
     <div class={isEditMode ? 'pt-4' : ''}>
         {#if widget.enabled || isEditMode}
-            {@render children()}
+            <!--
+              Phase 14 Tier 1 T1.2 — widget-level error isolation (Svelte 5 boundary).
+              각 widget 의 render throw 가 다른 widget / 페이지 영향 0.
+              multi-tenant 빈 사이트 (ipyang/nuna/tektok) 의 widget data null → undefined access 방어.
+            -->
+            <svelte:boundary onerror={(err) => console.error('[Widget Boundary]', widget.type, err)}>
+                {@render children()}
+                {#snippet failed(error, reset)}
+                    <div class="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                        <p class="font-medium">위젯을 일시적으로 불러올 수 없습니다.</p>
+                        <p class="mt-1 text-xs opacity-70">
+                            {widget.type}
+                            {#if isEditMode}— {String(error)}{/if}
+                        </p>
+                        <button onclick={reset} class="mt-2 text-xs underline hover:text-amber-900">
+                            다시 시도
+                        </button>
+                    </div>
+                {/snippet}
+            </svelte:boundary>
         {/if}
     </div>
 </div>

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -69,6 +69,28 @@ async function buildHomePageData(): Promise<HomePageData> {
     };
 }
 
+/**
+ * Phase 14 Tier 1 T1.3 — multi-tenant graceful fallback.
+ *
+ * 빈 사이트 (ipyang/nuna/tektok 등 신규 도메인) 의 transitive 의존성
+ * (g5_write_message / celebration_banners / legacy-data cache file 등) 누락 시
+ * buildHomePageData 가 unexpected throw 해도 SSR 가 정상 응답하도록 보강.
+ *
+ * 모든 fail = empty defaults 로 fallback. damoang regression 0
+ * (정상 데이터는 그대로 반환).
+ */
+function emptyHomePageData(): HomePageData {
+    return {
+        indexWidgets: null,
+        widgetLayout: DEFAULT_WIDGETS,
+        sidebarWidgetLayout: DEFAULT_SIDEBAR_WIDGETS,
+        recommendedData: null,
+        recommendedPeriod: getDefaultPeriod(),
+        exploreData: null,
+        celebrationRecent: null
+    };
+}
+
 export const load: PageServerLoad = async () => {
     const now = Date.now();
     if (cachedHomePageData && now - cachedHomePageDataAt < HOME_PAGE_CACHE_TTL_MS) {
@@ -81,6 +103,14 @@ export const load: PageServerLoad = async () => {
                 cachedHomePageData = data;
                 cachedHomePageDataAt = Date.now();
                 return data;
+            })
+            .catch((err) => {
+                // Phase 14 — 빈 사이트 graceful fallback
+                console.error('[SSR Home] buildHomePageData failed, returning empty defaults:', err);
+                const fallback = emptyHomePageData();
+                cachedHomePageData = fallback;
+                cachedHomePageDataAt = Date.now();
+                return fallback;
             })
             .finally(() => {
                 pendingHomePageLoad = null;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,7 +23,11 @@ export default defineConfig(({ mode }) => {
         },
         build: {
             assetsInlineLimit: 8192,
-            chunkSizeWarningLimit: 1120
+            chunkSizeWarningLimit: 1120,
+            // server-side stack trace 가 minified chunk 대신 원본 source line 노출.
+            // 'hidden' = browser DevTools 에는 안 노출 (사용자 정보 보호), server runtime 만 사용.
+            // Phase 14 Tier 1 T1.1 — multi-tenant 빈 사이트 throw 위치 디버깅 가능화.
+            sourcemap: 'hidden'
         },
         ssr: {
             // AWS SDK를 서버 번들에 포함 (프로덕션 배포 시 node_modules 불필요)


### PR DESCRIPTION
## Summary

수백 개 사이트가 동일 core 위에서 작동하는 WordPress 식 멀티사이트 SaaS 전환의 기초 (Phase 14 Tier 1). 빈 사이트(신규 도메인 ipyang.com / nuna.gg / tektok.sd.gy 등)의 home page SSR 가 다모앙 production 자원(`g5_write_message` / `celebration_banners` / legacy cache file) 누락 시 throw → "페이지를 불러올 수 없습니다" 로 깨지는 문제 해결.

## Changes (3 files)

### 1. `widget-wrapper.svelte` — Svelte 5 `<svelte:boundary>`
각 widget render throw 가 다른 widget/페이지에 전파되지 않도록 격리. widget data null → undefined access 시 "위젯을 일시적으로 불러올 수 없습니다" fallback UI + 다시 시도 버튼. (WordPress 의 plugin 격리와 동일 효과)

### 2. `+page.server.ts` — buildHomePageData top-level catch
transitive 의존성 누락 시 `emptyHomePageData()` fallback. **damoang regression 0** (정상 데이터는 그대로 반환, fail 시에만 DEFAULT_WIDGETS).

### 3. `vite.config.ts` — `sourcemap: 'hidden'`
server stack trace 가 minified chunk 대신 원본 source line 노출 (멀티테넌트 디버깅 가능화). browser DevTools 에는 미노출 (사용자 정보 보호).

## Test plan
- [x] 빌드 통과 (angple-landing build.sh)
- [ ] CI Test + Lint + Build 통과
- [ ] damoang.net 본문 정상 (regression 0)
- [ ] ipyang.com / 신규 빈 사이트 SSR 정상 (widget fallback)

## Context
사용자 요청: "워드프레스처럼 어떻게 해야 해? 계속 사이트가 angple 로 추가될 텐데." — Tier 1 (즉시) / Tier 2 (1주, homeTemplate + 1-클릭 onboarding) / Tier 3 (1개월, plugin scope + marketplace + WP import) 중 첫 단계.