### PR TITLE
fix(plugins): route-dispatcher 가 handler 에러의 status 를 보존

### DIFF
--- a/apps/web/src/lib/server/plugins/route-dispatcher.ts
+++ b/apps/web/src/lib/server/plugins/route-dispatcher.ts
@@ -134,7 +134,16 @@ export async function dispatchPluginRoute(input: DispatchInput): Promise<Respons
         return await fn(input.event);
     } catch (err) {
         console.error(`${LOG_PREFIX} handler error in ${input.pluginId}${input.rest}:`, err);
-        return new Response(`Plugin handler error`, { status: 500 });
+        // plugin handler 가 status 를 가진 에러(ApiError 등)를 throw 하면 그 코드로 응답한다.
+        // plugin 은 별도 모듈 그래프에서 동적 import 되므로 instanceof 로 식별할 수 없어
+        // duck-typing 으로 .status 를 확인한다.
+        const status =
+            err && typeof (err as { status?: unknown }).status === 'number'
+                ? (err as { status: number }).status
+                : 500;
+        const message =
+            status !== 500 && err instanceof Error ? err.message : 'Plugin handler error';
+        return new Response(message, { status });
     }
 }
 


### PR DESCRIPTION
## 문제

plugin route handler 가 status 를 가진 에러를 throw 해도 route-dispatcher 의 catch 가 무조건 500 으로 응답했다. archive plugin 이 `@sveltejs/kit` 의 `error()` 의존을 제거하고 자체 `ApiError`(`.status` 보유)로 전환하면서, dispatcher 가 그 status 를 응답 코드로 반영해야 한다.

## 수정

`apps/web/src/lib/server/plugins/route-dispatcher.ts` handler 실행 catch:

- `err.status` 가 number 면 그 값을 응답 코드로 사용 (duck-typing)
- plugin 은 별도 모듈 그래프에서 동적 import 되므로 `instanceof` 로 식별 불가 → property check
- 4xx 등 비-500 은 `err.message` 를 본문으로 노출, 500/비-Error 는 기존대로 `'Plugin handler error'` 로 마스킹

## 동반 PR

damoang/angple-premium#68 — archive plugin route handler 들의 `@sveltejs/kit` 런타임 의존 제거 (`ApiError`/`json` 헬퍼 도입). 두 PR 함께 배포되어야 archive API 의 4xx 가 정상 코드로 응답된다.