### PR TITLE
fix(multi-tenant): SSR cache key 에 host 포함 — subdomain 간 theme 교차 오염 해결

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -774,7 +774,10 @@ export const handle: Handle = async ({ event, resolve }) => {
     // Vary 헤더: 같은 URL 이라도 User-Agent (PC vs 모바일) / Accept-Encoding / 인증 쿠키별로
     // CDN 이 다른 응답을 캐시하도록 명시. 이전엔 Cookie 만 vary 해서 PC 사용자가 모바일 캐시를
     // 받거나 그 반대인 신고 (gouryella 2026-05-07) 가 발생했다.
-    const publicVaryHeader = 'Cookie, User-Agent, Accept-Encoding';
+    // Phase 14 — multi-tenant: Host 를 Vary 에 포함해야 CDN/proxy 가 host 별 cache entry 생성.
+    // 없으면 같은 path(/) 가 모든 subdomain (minimal/modern/official.angple.com) 에서
+    // 첫 host 응답을 공유 → 모든 사이트가 같은 theme 로 보이는 오염 발생.
+    const publicVaryHeader = 'Host, Cookie, User-Agent, Accept-Encoding';
 
     // OPTIONS 요청 (CORS preflight) 처리
     if (event.request.method === 'OPTIONS') {
@@ -814,7 +817,11 @@ export const handle: Handle = async ({ event, resolve }) => {
         // 캐시 키에 query string 포함 — pathname만 쓰면 ?page=N 요청이
         // ?page=1 캐시에 섞여 "뒤로 간 것처럼" 보이는 교차 오염 발생.
         // 2026-04-29: isHomePage 도 search 포함 (이전 '/' 만 사용 시 query 누락 버그).
-        const cacheKey = pathname + event.url.search;
+        // Phase 14 (2026-05-25): host 포함 — multi-tenant 에서 같은 path(/)가 모든
+        // subdomain (minimal/modern/official.angple.com) 에 첫 host 응답을 공유하던
+        // 교차 오염 fix. host 없으면 site-resolver/theme 가 정확해도 SSR 응답 cache 가
+        // 첫 host 결과를 다른 host 에 반환.
+        const cacheKey = event.url.host + '|' + pathname + event.url.search;
         const cacheTtl = isHomePage
             ? SSR_CACHE_TTL_HOME
             : isPostDetail

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -19,9 +19,10 @@ interface HomePageData {
     celebrationRecent: Awaited<ReturnType<typeof getCachedCelebrations>> | null;
 }
 
-let cachedHomePageData: HomePageData | null = null;
-let cachedHomePageDataAt = 0;
-let pendingHomePageLoad: Promise<HomePageData> | null = null;
+// Phase 14 — multi-tenant: cache 를 host 별로 격리 (module singleton 이 SSR 요청 간
+// 공유되어 첫 host 의 home data 가 후속 host 를 오염하는 문제 해결).
+const homeCacheByHost = new Map<string, { data: HomePageData; at: number }>();
+const pendingByHost = new Map<string, Promise<HomePageData>>();
 
 async function buildHomePageData(): Promise<HomePageData> {
     const recommendedPeriod = getDefaultPeriod();
@@ -91,31 +92,38 @@ function emptyHomePageData(): HomePageData {
     };
 }
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ url }) => {
+    // Phase 14 — host 별 cache key (multi-tenant: 사이트마다 다른 home data)
+    const host = url.host;
     const now = Date.now();
-    if (cachedHomePageData && now - cachedHomePageDataAt < HOME_PAGE_CACHE_TTL_MS) {
-        return cachedHomePageData;
+
+    const cached = homeCacheByHost.get(host);
+    if (cached && now - cached.at < HOME_PAGE_CACHE_TTL_MS) {
+        return cached.data;
     }
 
-    if (!pendingHomePageLoad) {
-        pendingHomePageLoad = buildHomePageData()
+    let pending = pendingByHost.get(host);
+    if (!pending) {
+        pending = buildHomePageData()
             .then((data) => {
-                cachedHomePageData = data;
-                cachedHomePageDataAt = Date.now();
+                homeCacheByHost.set(host, { data, at: Date.now() });
                 return data;
             })
             .catch((err) => {
                 // Phase 14 — 빈 사이트 graceful fallback
-                console.error('[SSR Home] buildHomePageData failed, returning empty defaults:', err);
+                console.error(
+                    '[SSR Home] buildHomePageData failed, returning empty defaults:',
+                    err
+                );
                 const fallback = emptyHomePageData();
-                cachedHomePageData = fallback;
-                cachedHomePageDataAt = Date.now();
+                homeCacheByHost.set(host, { data: fallback, at: Date.now() });
                 return fallback;
             })
             .finally(() => {
-                pendingHomePageLoad = null;
+                pendingByHost.delete(host);
             });
+        pendingByHost.set(host, pending);
     }
 
-    return pendingHomePageLoad;
+    return pending;
 };


### PR DESCRIPTION
## Summary

여러 사이트가 동일 angple core 위에서 각자 다른 theme 을 사용할 때 (11 테마 데모 `*.angple.com`, churchre tenant, ipyang/nuna 등), **같은 path(`/`)에 첫 요청 host 의 응답이 모든 subdomain 에 공유**되는 교차 오염을 해결.

## 근본 원인 (장시간 디버깅으로 격리)

site-resolver + `+layout.server.ts` 의 theme 결정은 **host 별로 100% 정확**했음 (cache buster `?q=` 로 입증: official→damoang-official, minimal→minimal-light 등). 그런데 같은 `/` 반복 시 첫 host theme 고정.

진짜 원인 = **angple core 자체의 in-app SSR 응답 cache (`hooks.server.ts` 의 `ssrCache`)의 cacheKey 가 `pathname + search` 만 — host 누락**:
- NPM `proxy_cache off`, Cloudflare `cf-cache-status: DYNAMIC`, 응답 `cache-control: no-store` — **외부 cache 와 전혀 무관**한 in-app cache.
- cache buster query 로만 우회되던 이유 = key 가 path+search 뿐이라 query 가 다르면 다른 entry.
- `+page.server.ts` 의 `cachedHomePageData` / `pendingHomePageLoad` 도 module-level singleton (host 무관).

## 수정 (2 files)

- `hooks.server.ts`: `cacheKey = host + '|' + pathname + search` (host 포함)
- `+page.server.ts`: `cachedHomePageData` → `Map<host>`, `pendingByHost` → `Map<host>`

## Test plan

- [x] 11 subdomain (`*.angple.com`) 각자 정확한 theme (cache buster 없이): official→damoang-official, classic→damoang-classic, ..., wiki→wiki-theme
- [x] angple.com 본체 corporate-landing showcase 정상
- [ ] damoang.net / muzia.net regression 0 (단일 host — host 포함해도 동일 key)
- [ ] CI 통과

## 영향

damoang/muzia 등 단일 host 사이트는 **영향 0** (host 포함해도 site 당 key 1개). multi-tenant (데모/tenant) 가 핵심 수혜. WordPress 식 "수백 사이트 동일 core" 의 필수 fix.