### PR TITLE
fix(cache): TieredCache Redis 키 CACHE_NAMESPACE 환경 격리

### DIFF
--- a/apps/web/src/lib/server/cache.ts
+++ b/apps/web/src/lib/server/cache.ts
@@ -184,6 +184,15 @@ export class TieredCache<T> {
         this.pendingMaxSize = pendingMaxSize;
     }
 
+    /**
+     * Redis(L2) 키 생성. CACHE_NAMESPACE 환경변수가 있으면 `{ns}:{prefix}:{key}` 로 격리,
+     * 없으면 기존 `{prefix}:{key}`. canary/prod 가 공유 Redis 를 써도 환경 간 캐시 오염 방지.
+     */
+    private redisKey(key: string): string {
+        const ns = process.env.CACHE_NAMESPACE;
+        return ns ? `${ns}:${this.prefix}:${key}` : `${this.prefix}:${key}`;
+    }
+
     /** L1 → L2 조회 */
     async get(key: string): Promise<T | null> {
         const l1Entry = this.l1.get(key);
@@ -193,7 +202,7 @@ export class TieredCache<T> {
 
         try {
             const redis = getRedis();
-            const val = await redis.get(`${this.prefix}:${key}`);
+            const val = await redis.get(this.redisKey(key));
             if (val) {
                 const data = JSON.parse(val) as T;
                 this.setL1(key, data);
@@ -213,7 +222,7 @@ export class TieredCache<T> {
 
         try {
             const redis = getRedis();
-            await redis.setex(`${this.prefix}:${key}`, this.l2TtlSec, JSON.stringify(data));
+            await redis.setex(this.redisKey(key), this.l2TtlSec, JSON.stringify(data));
         } catch {
             // Redis 장애 무시 (L1에는 있음)
         }
@@ -225,7 +234,7 @@ export class TieredCache<T> {
 
         try {
             const redis = getRedis();
-            await redis.del(`${this.prefix}:${key}`);
+            await redis.del(this.redisKey(key));
         } catch {
             // Redis 장애 무시
         }


### PR DESCRIPTION
## 문제
canary/prod 가 공유 Redis 캐시(`plugins:active:list` 등)를 환경 구분 없이 사용. prod(archive 비활성)가 canary 캐시를 오염시켜, canary 에서 archive 를 켜도 plugin active 목록에 반영되지 않아 보존 버튼이 노출되지 않음.

## 변경
`TieredCache` 에 `redisKey()` 헬퍼 추가:
- `CACHE_NAMESPACE` 환경변수 있으면 `{ns}:{prefix}:{key}`
- 없으면 기존 `{prefix}:{key}` (prod 영향 0)

`get`/`set`/`delete` 의 Redis 키 생성 3곳을 `redisKey()` 로 교체.

## 범위
- `createCache()`(인메모리 전용)는 Redis 미사용 → 격리 불필요, 미변경
- canary deployment 에 `CACHE_NAMESPACE=canary` env 추가는 별도 k8s PR

## 영향
- prod: env 없음 → 기존 키 유지, 동작 변화 없음
- canary: 첫 요청들 cold start(캐시 miss → 재조회), single-pod 검증 환경이라 acceptable