### PR TITLE
feat(editor,board): board_type별 본문 콘텐츠 형식(markdown) 지원 — 위키 마크다운 네이티브

### DIFF
--- a/apps/web/src/lib/components/features/board/content-format-registry.test.ts
+++ b/apps/web/src/lib/components/features/board/content-format-registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { contentFormatRegistry } from './content-format-registry';
+
+describe('contentFormatRegistry', () => {
+    it("미등록 board_type 은 기본 'html'", () => {
+        expect(contentFormatRegistry.resolve('some-unregistered-board')).toBe('html');
+    });
+
+    it("undefined/null/'' 은 'html'", () => {
+        expect(contentFormatRegistry.resolve(undefined)).toBe('html');
+        expect(contentFormatRegistry.resolve(null)).toBe('html');
+        expect(contentFormatRegistry.resolve('')).toBe('html');
+    });
+
+    it('등록한 board_type 은 해당 형식 반환 (wiki → markdown)', () => {
+        contentFormatRegistry.register('cf-test-wiki', 'markdown', 'plugin');
+        expect(contentFormatRegistry.resolve('cf-test-wiki')).toBe('markdown');
+    });
+
+    it('plugin 등록이 core 등록을 오버라이드', () => {
+        contentFormatRegistry.register('cf-test-override', 'markdown', 'plugin');
+        // core 가 나중에 html 로 등록해도 plugin 우선
+        contentFormatRegistry.register('cf-test-override', 'html', 'core');
+        expect(contentFormatRegistry.resolve('cf-test-override')).toBe('markdown');
+    });
+
+    it('removeBySource 로 plugin 등록 제거 → 기본값 복귀', () => {
+        contentFormatRegistry.register('cf-test-remove', 'markdown', 'plugin');
+        expect(contentFormatRegistry.resolve('cf-test-remove')).toBe('markdown');
+        contentFormatRegistry.removeBySource('plugin');
+        expect(contentFormatRegistry.resolve('cf-test-remove')).toBe('html');
+    });
+});

--- a/apps/web/src/lib/components/features/board/content-format-registry.ts
+++ b/apps/web/src/lib/components/features/board/content-format-registry.ts
@@ -1,0 +1,83 @@
+/**
+ * Content Format Registry
+ *
+ * board_type 기반으로 본문 콘텐츠 형식(HTML | Markdown)을 결정하는 레지스트리.
+ * 플러그인이 자신의 board_type을 'markdown'으로 opt-in 하면,
+ * 글쓰기/편집 화면에서 에디터가 마크다운 소스 모드로 동작하고 마크다운 원문을 저장한다.
+ *
+ * 기본값은 'html' 이므로, 등록하지 않은 일반 게시판(damoang.net 등)은 기존 동작(WYSIWYG/HTML 저장) 그대로다.
+ *
+ * @example
+ * ```ts
+ * // 플러그인에서 등록 (예: 위키)
+ * contentFormatRegistry.register('wiki', 'markdown');
+ *
+ * // 코어에서 resolve
+ * const format = contentFormatRegistry.resolve(board.board_type);
+ * // → 'markdown' 또는 'html'(기본)
+ * ```
+ */
+
+export type ContentFormat = 'html' | 'markdown';
+
+interface ContentFormatEntry {
+    format: ContentFormat;
+    source: 'core' | 'plugin';
+}
+
+class ContentFormatRegistry {
+    private static instance: ContentFormatRegistry;
+    private formats: Map<string, ContentFormatEntry> = new Map();
+
+    private constructor() {}
+
+    static getInstance(): ContentFormatRegistry {
+        if (!ContentFormatRegistry.instance) {
+            ContentFormatRegistry.instance = new ContentFormatRegistry();
+        }
+        return ContentFormatRegistry.instance;
+    }
+
+    /**
+     * board_type 의 본문 콘텐츠 형식 등록
+     *
+     * @param boardType - 게시판 타입 (예: 'wiki')
+     * @param format - 'html' | 'markdown'
+     * @param source - 등록 소스 ('core' | 'plugin'), plugin이 core를 오버라이드
+     */
+    register(boardType: string, format: ContentFormat, source: 'core' | 'plugin' = 'plugin'): void {
+        const existing = this.formats.get(boardType);
+
+        // plugin 소스가 core를 오버라이드
+        if (existing && existing.source === 'plugin' && source === 'core') {
+            return;
+        }
+
+        this.formats.set(boardType, { format, source });
+    }
+
+    /**
+     * board_type 에 해당하는 콘텐츠 형식 resolve
+     *
+     * @param boardType - 게시판 타입 (없거나 미등록이면 'html')
+     * @returns 'html' | 'markdown'
+     */
+    resolve(boardType: string | undefined | null): ContentFormat {
+        if (!boardType) return 'html';
+        return this.formats.get(boardType)?.format ?? 'html';
+    }
+
+    /**
+     * 특정 소스의 모든 등록 제거 (플러그인 비활성화 시)
+     */
+    removeBySource(source: 'core' | 'plugin'): void {
+        for (const [key, entry] of this.formats) {
+            if (entry.source === source) {
+                this.formats.delete(key);
+            }
+        }
+    }
+}
+
+/** 싱글톤 인스턴스 */
+export const contentFormatRegistry = ContentFormatRegistry.getInstance();

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -39,6 +39,8 @@
         initialLink1?: string; // 초기 link1 값 (disciplinelog_id 등)
         initialLink2?: string; // 초기 link2 값 (다시 쓰기 등)
         initialContent?: string; // 초기 본문 (소명 등)
+        /** 본문 콘텐츠 형식 ('markdown'이면 마크다운 원문 저장/이미지=마크다운 문법). 기본 'html' */
+        contentFormat?: 'html' | 'markdown';
         onSubmit: (data: CreatePostRequest | UpdatePostRequest) => Promise<void>;
         onCancel: () => void;
         isLoading?: boolean;
@@ -55,6 +57,7 @@
         initialLink1 = '',
         initialLink2 = '',
         initialContent = '',
+        contentFormat = 'html',
         onSubmit,
         onCancel,
         isLoading = false
@@ -350,6 +353,13 @@
                 new RegExp(`<img[^>]*src=["']${escaped}["'][^>]*>`, 'g'),
                 ''
             );
+            if (contentFormat === 'markdown') {
+                // 마크다운 이미지 문법도 제거: ![alt](url)
+                finalContent = finalContent.replace(
+                    new RegExp(`!\\[[^\\]]*\\]\\(${escaped}\\)`, 'g'),
+                    ''
+                );
+            }
         }
 
         const imageFiles = uploadedFiles.filter(
@@ -357,9 +367,10 @@
         );
         if (imageFiles.length > 0) {
             const imgTags = imageFiles
-                .map(
-                    (f) =>
-                        `<img src="${f.url}" alt="${f.original_filename}" loading="lazy" class="max-w-full">`
+                .map((f) =>
+                    contentFormat === 'markdown'
+                        ? `![${f.original_filename}](${f.url})`
+                        : `<img src="${f.url}" alt="${f.original_filename}" loading="lazy" class="max-w-full">`
                 )
                 .join('\n');
             finalContent = finalContent ? `${finalContent}\n${imgTags}` : imgTags;
@@ -601,9 +612,10 @@
                 <Label for="content">내용 <span class="text-destructive">*</span></Label>
                 <TiptapEditor
                     {content}
+                    {contentFormat}
                     placeholder={`/ 를 눌러 이미지와 앙티콘을 추가하세요\n\n경어체 사용은 필수이며, 초성 비속어도 이용제한 대상입니다.${board?.insert_content ? `\n\n${board.insert_content}` : ''}`}
                     disabled={isLoading}
-                    onUpdate={(html) => (content = html)}
+                    onUpdate={(value) => (content = value)}
                     onImageUpload={handleEditorImageUpload}
                     class={errors.content ? 'border-destructive' : ''}
                 />

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -80,7 +80,14 @@
         content?: string;
         placeholder?: string;
         disabled?: boolean;
-        onUpdate?: (html: string) => void;
+        /**
+         * 본문 콘텐츠 형식.
+         * - 'html'(기본): 기존 WYSIWYG 동작. onUpdate/저장값은 HTML.
+         * - 'markdown': 마크다운 소스 모드로 시작하고, onUpdate/저장값으로 마크다운 원문을 전달.
+         *   (위키 등 마크다운 네이티브 게시판용)
+         */
+        contentFormat?: 'html' | 'markdown';
+        onUpdate?: (value: string) => void;
         onImageUpload?: (file: File) => Promise<string | null>;
         class?: string;
     }
@@ -89,6 +96,7 @@
         content = '',
         placeholder = '/ 를 눌러 이미지와 앙티콘을 추가하세요',
         disabled = false,
+        contentFormat = 'html',
         onUpdate,
         onImageUpload,
         class: className = ''
@@ -98,7 +106,8 @@
 
     // 에디터 모드 (WYSIWYG, Markdown, HTML)
     type EditorMode = 'wysiwyg' | 'markdown' | 'html';
-    let editorMode = $state<EditorMode>('wysiwyg');
+    // contentFormat='markdown' 이면 마크다운 소스 모드로 시작 (위키 등)
+    let editorMode = $state<EditorMode>(contentFormat === 'markdown' ? 'markdown' : 'wysiwyg');
     let rawContent = $state(''); // 마크다운/HTML 직접 편집용
 
     let editorElement: HTMLDivElement;
@@ -272,7 +281,9 @@
                     }
                 })
             ],
-            content,
+            // markdown 포맷이면 ProseMirror(WYSIWYG)는 비워두고 마크다운 원문은 rawContent(textarea)로 다룬다.
+            // (마크다운 텍스트를 HTML로 오해해 ProseMirror에 주입하는 것을 방지)
+            content: contentFormat === 'markdown' ? '' : content,
             editable: !disabled,
             // #9223: 편집 모드에서 링크(<a>) 클릭 시 외부 이동 방지.
             // Link extension 의 openOnClick:false 는 mark 만 처리하므로,
@@ -329,8 +340,22 @@
     let isSettingContent = false;
 
     $effect(() => {
-        if (!editor) return;
         const c = content ?? '';
+
+        // markdown 포맷: 본문 원문을 textarea(rawContent)에 시드 (ProseMirror 불필요)
+        if (contentFormat === 'markdown') {
+            if (!c || c === lastLoadedContent) return;
+            // 사용자가 이미 입력 중이면 덮어쓰지 않음
+            if (rawContent !== '' && lastLoadedContent !== '' && rawContent !== lastLoadedContent) {
+                lastLoadedContent = c;
+                return;
+            }
+            rawContent = c;
+            lastLoadedContent = c;
+            return;
+        }
+
+        if (!editor) return;
         if (!c || c === lastLoadedContent) return;
 
         // 에디터에 이미 사용자 입력이 있으면 덮어쓰지 않음
@@ -936,7 +961,12 @@
     // raw 콘텐츠 변경 시 부모에게 알림
     async function handleRawContentChange(): Promise<void> {
         if (editorMode === 'markdown') {
-            // 마크다운을 HTML로 변환하여 부모에게 전달
+            // 마크다운 네이티브 게시판(위키 등): 마크다운 원문을 그대로 저장
+            if (contentFormat === 'markdown') {
+                onUpdate?.(rawContent);
+                return;
+            }
+            // 일반 게시판의 임시 마크다운 모드: HTML로 변환해 전달 (기존 동작)
             const html = await marked.parse(rawContent);
             onUpdate?.(html);
         } else if (editorMode === 'html') {
@@ -1352,47 +1382,50 @@
             {/if}
         </div>
 
-        <div class="bg-border mx-1 h-6 w-px" role="separator"></div>
+        <!-- 마크다운 네이티브 게시판(위키 등)은 모드 전환을 숨겨 마크다운 소스 모드로 고정 -->
+        {#if contentFormat !== 'markdown'}
+            <div class="bg-border mx-1 h-6 w-px" role="separator"></div>
 
-        <!-- 에디터 모드 전환 -->
-        <div class="flex items-center gap-0.5">
-            <Button
-                type="button"
-                variant={editorMode === 'wysiwyg' ? 'secondary' : 'ghost'}
-                size="sm"
-                onclick={() => switchMode('wysiwyg')}
-                {disabled}
-                class="h-8 px-2 text-xs"
-                title="WYSIWYG 모드"
-            >
-                <PilcrowIcon class="mr-1 h-3 w-3" />
-                편집
-            </Button>
-            <Button
-                type="button"
-                variant={editorMode === 'markdown' ? 'secondary' : 'ghost'}
-                size="sm"
-                onclick={() => switchMode('markdown')}
-                {disabled}
-                class="h-8 px-2 text-xs"
-                title="마크다운 모드"
-            >
-                <HashIcon class="mr-1 h-3 w-3" />
-                MD
-            </Button>
-            <Button
-                type="button"
-                variant={editorMode === 'html' ? 'secondary' : 'ghost'}
-                size="sm"
-                onclick={() => switchMode('html')}
-                {disabled}
-                class="h-8 px-2 text-xs"
-                title="HTML 모드"
-            >
-                <FileCodeIcon class="mr-1 h-3 w-3" />
-                HTML
-            </Button>
-        </div>
+            <!-- 에디터 모드 전환 -->
+            <div class="flex items-center gap-0.5">
+                <Button
+                    type="button"
+                    variant={editorMode === 'wysiwyg' ? 'secondary' : 'ghost'}
+                    size="sm"
+                    onclick={() => switchMode('wysiwyg')}
+                    {disabled}
+                    class="h-8 px-2 text-xs"
+                    title="WYSIWYG 모드"
+                >
+                    <PilcrowIcon class="mr-1 h-3 w-3" />
+                    편집
+                </Button>
+                <Button
+                    type="button"
+                    variant={editorMode === 'markdown' ? 'secondary' : 'ghost'}
+                    size="sm"
+                    onclick={() => switchMode('markdown')}
+                    {disabled}
+                    class="h-8 px-2 text-xs"
+                    title="마크다운 모드"
+                >
+                    <HashIcon class="mr-1 h-3 w-3" />
+                    MD
+                </Button>
+                <Button
+                    type="button"
+                    variant={editorMode === 'html' ? 'secondary' : 'ghost'}
+                    size="sm"
+                    onclick={() => switchMode('html')}
+                    {disabled}
+                    class="h-8 px-2 text-xs"
+                    title="HTML 모드"
+                >
+                    <FileCodeIcon class="mr-1 h-3 w-3" />
+                    HTML
+                </Button>
+            </div>
+        {/if}
     </div>
 
     <!-- 에디터 영역 -->

--- a/apps/web/src/routes/[boardId]/[postId]/edit/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/edit/+page.svelte
@@ -2,6 +2,7 @@
     import { goto } from '$app/navigation';
     import { browser } from '$app/environment';
     import PostForm from '$lib/components/features/board/post-form.svelte';
+    import { contentFormatRegistry } from '$lib/components/features/board/content-format-registry.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { apiClient } from '$lib/api/index.js';
     import type { PageData } from './$types.js';
@@ -17,6 +18,8 @@
     const postId = $derived(data.postId);
     const boardTitle = $derived(data.board?.subject || data.board?.name || boardId);
     const scheduledDelete = $derived(data.scheduledDelete);
+    // 본문 콘텐츠 형식 (위키 등 markdown 게시판이면 마크다운 소스 모드로 편집)
+    const contentFormat = $derived(contentFormatRegistry.resolve(data.board?.board_type));
 
     let isSubmitting = $state(false);
     let error = $state<string | null>(null);
@@ -100,6 +103,7 @@
             mode="edit"
             post={data.post}
             categories={data.categories}
+            {contentFormat}
             onSubmit={handleSubmit}
             onCancel={handleCancel}
             isLoading={isSubmitting}

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -4,6 +4,7 @@
     import { page } from '$app/stores';
     import PostForm from '$lib/components/features/board/post-form.svelte';
     import { writeFormRegistry } from '$lib/components/features/board/write-form-registry.js';
+    import { contentFormatRegistry } from '$lib/components/features/board/content-format-registry.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { apiClient } from '$lib/api/index.js';
     import type { PageData } from './$types.js';
@@ -39,6 +40,9 @@
 
     // 커스텀 글쓰기 폼 resolve (없으면 기본 PostForm 사용)
     const customWriteForm = $derived(writeFormRegistry.resolve(boardType));
+
+    // 본문 콘텐츠 형식 ('markdown'이면 에디터가 마크다운 소스 모드, 마크다운 원문 저장)
+    const contentFormat = $derived(contentFormatRegistry.resolve(boardType));
 
     let isSubmitting = $state(false);
     let error = $state<string | null>(null);
@@ -292,7 +296,9 @@
             {@const CustomWriteForm = customWriteForm}
             <CustomWriteForm
                 {boardId}
+                board={data.board ?? undefined}
                 categories={data.categories}
+                {contentFormat}
                 onSubmit={handleSubmit}
                 onCancel={handleCancel}
                 isLoading={isSubmitting}
@@ -310,6 +316,7 @@
                     mode="create"
                     board={data.board ?? undefined}
                     categories={data.categories}
+                    {contentFormat}
                     initialTitle={repostTitle || claimInitialTitle}
                     initialLink1={repostLink1 || claimInitialLink1}
                     initialLink2={repostLink2}


### PR DESCRIPTION
## 배경
위키(`board_type='wiki'`, wikiang.org) 문서에서 마크다운/HTML 이 글자 그대로 노출되는 문제.

## 원인
본문이 tiptap `getHTML()` 로 **HTML 저장**되는데, 작성자가 붙여넣은 마크다운(`## 제목`, 표 등)은 `<p>` 안 평문으로 남는다. 렌더러 `markdown.svelte` 는 `marked` 를 돌리지만 HTML 블록은 통과시키므로 마크다운이 변환되지 않는다.

## 해결 — board_type별 본문 콘텐츠 형식
위키 본문을 **마크다운 네이티브**로 저장하도록 전환. 렌더러(`markdown.svelte`)는 이미 모든 콘텐츠에 `marked` 를 적용하므로 **순수 마크다운이면 그대로 정상 렌더**된다 → 렌더러 변경 불필요.

- `content-format-registry.ts` (신규): `board_type → 'html' | 'markdown'` (기본 `html`). 플러그인이 opt-in. 오픈코어 재사용 패턴.
- `TiptapEditor`: `contentFormat` prop. `'markdown'` 이면 마크다운 소스 모드로 시작하고 onUpdate/저장값을 마크다운 원문으로 전달·로드, 모드 토글 숨김. **기본 `'html'` 경로는 기존 WYSIWYG 동작 그대로(바이트 동일).**
- `PostForm`: `contentFormat` 전달 + 제출 이미지 후처리 마크다운 분기(`![]()`).
- `[boardId]/write`, `[boardId]/[postId]/edit`: `board_type` 으로 `contentFormat` 해석해 전달.

## 영향 범위
`contentFormat` 기본값이 `'html'` 이라 위키를 제외한 모든 게시판(일반 게시판 포함) 동작은 **변경 없음**.

## 이 PR 에 포함되지 않은 것 (후속)
- **위키 플러그인 변경**(`'wiki'→markdown` opt-in, write-form 재작성, toc 마크다운 헤딩): 별도 `angple/plugin-wiki` 레포 대상 (core 에서 `plugins/` 는 gitignore).
- **기존 문서 마이그레이션**(HTML→Markdown): 별도 스크립트, 백업+dry-run+off-peak 로 운영 진행.
- 배포는 운영 가드레일(새벽 4시 / canary) 준수.

## 검증
- `pnpm check`: 0 errors (신규 에러 0).
- 단위 테스트 `content-format-registry.test.ts`: 5/5 통과.
- 별도 리뷰: 기본 html 경로 불변·마크다운 emit/ingest·무한루프 없음 확인.
- 런타임 E2E(실제 위키 글 작성→렌더)는 스테이징/운영에서 확인 필요.
