### PR TITLE
feat(multi-tenant): 최고관리자 1-클릭 신규 사이트 생성

### DIFF
--- a/apps/web/src/routes/api/super-admin/sites/create/+server.ts
+++ b/apps/web/src/routes/api/super-admin/sites/create/+server.ts
@@ -1,0 +1,116 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { pool } from '$lib/server/db';
+import { getSingoRole } from '$lib/server/singo-role';
+import { invalidateDbSiteCache } from '$lib/server/site-resolver/db';
+import { scanThemes } from '$lib/server/themes/scanner';
+import type { ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+
+/**
+ * POST /api/super-admin/sites/create — 1-클릭 신규 사이트 생성 (WordPress wpmu_create_blog 격)
+ *
+ * angple_sites row 를 추가하면 DbSiteResolver 가 해당 host 요청을 선택한 theme 으로 즉시
+ * 해석한다 (cache invalidate 로 5분 TTL 대기 없이 반영). 콘텐츠가 비어 있어도 Tier 1 의
+ * EmptySiteWelcome 이 표시되므로 사이트는 곧바로 정상 동작한다.
+ *
+ * 권한: 최고관리자(super_admin)만 — 전체 multi-tenant 네트워크에 사이트를 추가하는 작업.
+ * 주의: DNS + reverse proxy 가 해당 host 를 이 서버로 향하게 하는 것은 별도 인프라 작업.
+ */
+
+// RFC 1123 hostname (라벨 1~63, 전체 ≤253, 최소 1개 점)
+const HOST_RE =
+    /^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+    const mbId = locals.user?.id;
+    if (!mbId || (await getSingoRole(mbId)) !== 'super_admin') {
+        return json({ success: false, message: '최고관리자 권한이 필요합니다.' }, { status: 403 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+        body = await request.json();
+    } catch {
+        return json({ success: false, message: '잘못된 요청 본문입니다.' }, { status: 400 });
+    }
+
+    const domain = String(body.domain ?? '')
+        .trim()
+        .toLowerCase();
+    const themeId = String(body.themeId ?? '').trim();
+    const siteTitle = body.siteTitle ? String(body.siteTitle).trim().slice(0, 255) : null;
+    const siteDescription = body.siteDescription
+        ? String(body.siteDescription).trim().slice(0, 1000)
+        : null;
+    const aliases: string[] = Array.isArray(body.aliases)
+        ? [
+              ...new Set((body.aliases as unknown[]).map((a) => String(a).trim().toLowerCase()))
+          ].filter((a) => a && a !== domain)
+        : [];
+
+    if (!HOST_RE.test(domain)) {
+        return json({ success: false, message: '올바른 도메인 형식이 아닙니다.' }, { status: 400 });
+    }
+    for (const a of aliases) {
+        if (!HOST_RE.test(a)) {
+            return json(
+                { success: false, message: `올바르지 않은 별칭 도메인: ${a}` },
+                { status: 400 }
+            );
+        }
+    }
+
+    // 설치된 테마인지 확인
+    const themes = await scanThemes();
+    if (!themes.has(themeId)) {
+        return json(
+            { success: false, message: `설치되지 않은 테마입니다: ${themeId}` },
+            { status: 400 }
+        );
+    }
+
+    // 중복 도메인 확인 (primary + alias 전체)
+    const allHosts = [domain, ...aliases];
+    const placeholders = allHosts.map(() => '?').join(',');
+    const [dup] = await pool.query<RowDataPacket[]>(
+        `SELECT domain FROM angple_sites WHERE domain IN (${placeholders})
+         UNION SELECT domain FROM angple_site_aliases WHERE domain IN (${placeholders}) LIMIT 1`,
+        [...allHosts, ...allHosts]
+    );
+    if (dup.length > 0) {
+        return json(
+            { success: false, message: `이미 등록된 도메인입니다: ${dup[0].domain}` },
+            { status: 409 }
+        );
+    }
+
+    const conn = await pool.getConnection();
+    try {
+        await conn.beginTransaction();
+        const [res] = await conn.query<ResultSetHeader>(
+            `INSERT INTO angple_sites (domain, theme_id, site_title, site_description, active)
+             VALUES (?, ?, ?, ?, 1)`,
+            [domain, themeId, siteTitle, siteDescription]
+        );
+        const siteId = res.insertId;
+        for (const a of aliases) {
+            await conn.query('INSERT INTO angple_site_aliases (site_id, domain) VALUES (?, ?)', [
+                siteId,
+                a
+            ]);
+        }
+        await conn.commit();
+
+        // DbSiteResolver cache 즉시 무효화 — 새 사이트가 5분 TTL 대기 없이 바로 반영
+        await invalidateDbSiteCache(domain);
+        for (const a of aliases) await invalidateDbSiteCache(a);
+
+        return json({ success: true, site: { id: siteId, domain, themeId, aliases } });
+    } catch (e) {
+        await conn.rollback();
+        console.error('[super-admin/sites/create] insert 실패:', e);
+        return json({ success: false, message: '사이트 생성 실패 (서버 오류)' }, { status: 500 });
+    } finally {
+        conn.release();
+    }
+};

--- a/apps/web/src/routes/super-admin/sites/+page.server.ts
+++ b/apps/web/src/routes/super-admin/sites/+page.server.ts
@@ -1,0 +1,42 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { pool } from '$lib/server/db';
+import { getSingoRole } from '$lib/server/singo-role';
+import { scanThemes } from '$lib/server/themes/scanner';
+import type { RowDataPacket } from 'mysql2/promise';
+
+/**
+ * 최고관리자 — multi-tenant 사이트 목록 + 1-클릭 생성 화면.
+ * 사이트 생성은 /api/super-admin/sites/create (POST) 가 담당하고, 이 load 는 목록/테마만 제공.
+ */
+export const load: PageServerLoad = async ({ locals }) => {
+    const mbId = locals.user?.id;
+    if (!mbId || (await getSingoRole(mbId)) !== 'super_admin') {
+        throw error(403, '최고관리자 권한이 필요합니다.');
+    }
+
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT s.id, s.domain, s.theme_id, s.site_title, s.active, s.created_at,
+                (SELECT GROUP_CONCAT(a.domain SEPARATOR ', ')
+                   FROM angple_site_aliases a WHERE a.site_id = s.id) AS aliases
+           FROM angple_sites s ORDER BY s.id`
+    );
+
+    const themesMap = await scanThemes();
+    const themes = [...themesMap.values()]
+        .map((m) => ({ id: m.id, name: m.name, description: m.description ?? '' }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+
+    return {
+        sites: rows.map((r) => ({
+            id: r.id as number,
+            domain: r.domain as string,
+            themeId: r.theme_id as string,
+            siteTitle: (r.site_title as string | null) ?? '',
+            aliases: (r.aliases as string | null) ?? '',
+            active: !!r.active,
+            createdAt: r.created_at as string
+        })),
+        themes
+    };
+};

--- a/apps/web/src/routes/super-admin/sites/+page.svelte
+++ b/apps/web/src/routes/super-admin/sites/+page.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+    import { invalidateAll } from '$app/navigation';
+
+    let { data } = $props();
+
+    let domain = $state('');
+    let themeId = $state(data.themes[0]?.id ?? '');
+    let siteTitle = $state('');
+    let siteDescription = $state('');
+    let aliasesInput = $state('');
+
+    let submitting = $state(false);
+    let message = $state<{ type: 'success' | 'error'; text: string } | null>(null);
+
+    async function createSite(e: Event) {
+        e.preventDefault();
+        if (submitting) return;
+        message = null;
+        submitting = true;
+        try {
+            const aliases = aliasesInput
+                .split(/[\s,]+/)
+                .map((a) => a.trim())
+                .filter(Boolean);
+            const res = await fetch('/api/super-admin/sites/create', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ domain, themeId, siteTitle, siteDescription, aliases })
+            });
+            const result = await res.json();
+            if (res.ok && result.success) {
+                message = {
+                    type: 'success',
+                    text: `사이트 생성 완료: ${result.site.domain} (#${result.site.id}). DNS·리버스프록시가 이 서버를 향하면 즉시 동작합니다.`
+                };
+                domain = '';
+                siteTitle = '';
+                siteDescription = '';
+                aliasesInput = '';
+                await invalidateAll();
+            } else {
+                message = { type: 'error', text: result.message ?? '사이트 생성 실패' };
+            }
+        } catch {
+            message = { type: 'error', text: '네트워크 오류로 생성에 실패했습니다.' };
+        } finally {
+            submitting = false;
+        }
+    }
+</script>
+
+<svelte:head><title>사이트 관리 · 최고관리자</title></svelte:head>
+
+<div class="mx-auto max-w-5xl px-4 py-8">
+    <h1 class="mb-1 text-2xl font-bold">멀티사이트 관리</h1>
+    <p class="mb-6 text-sm text-gray-500">
+        angple core 하나로 운영하는 모든 사이트. 새 사이트를 추가하면 선택한 테마로 즉시
+        라이브됩니다 (콘텐츠가 없으면 환영 화면 표시).
+    </p>
+
+    <!-- 신규 사이트 생성 -->
+    <section class="mb-10 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 class="mb-4 text-lg font-semibold">새 사이트 만들기</h2>
+
+        {#if message}
+            <div
+                class="mb-4 rounded-lg px-4 py-3 text-sm {message.type === 'success'
+                    ? 'border border-green-200 bg-green-50 text-green-800'
+                    : 'border border-red-200 bg-red-50 text-red-800'}"
+            >
+                {message.text}
+            </div>
+        {/if}
+
+        <form class="grid gap-4 sm:grid-cols-2" onsubmit={createSite}>
+            <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium">도메인 <span class="text-red-500">*</span></span>
+                <input
+                    type="text"
+                    bind:value={domain}
+                    required
+                    placeholder="example.com"
+                    autocomplete="off"
+                    class="rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+                />
+            </label>
+
+            <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium">테마 <span class="text-red-500">*</span></span>
+                <select
+                    bind:value={themeId}
+                    required
+                    class="rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+                >
+                    {#each data.themes as t (t.id)}
+                        <option value={t.id}>{t.name} ({t.id})</option>
+                    {/each}
+                </select>
+            </label>
+
+            <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium">사이트 제목</span>
+                <input
+                    type="text"
+                    bind:value={siteTitle}
+                    placeholder="(선택) 사이트 이름"
+                    class="rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+                />
+            </label>
+
+            <label class="flex flex-col gap-1 text-sm">
+                <span class="font-medium">별칭 도메인</span>
+                <input
+                    type="text"
+                    bind:value={aliasesInput}
+                    placeholder="(선택) www.example.com, example.net"
+                    autocomplete="off"
+                    class="rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+                />
+            </label>
+
+            <label class="flex flex-col gap-1 text-sm sm:col-span-2">
+                <span class="font-medium">설명</span>
+                <textarea
+                    bind:value={siteDescription}
+                    rows="2"
+                    placeholder="(선택) 사이트 설명 (SEO)"
+                    class="rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+                ></textarea>
+            </label>
+
+            <div class="sm:col-span-2">
+                <button
+                    type="submit"
+                    disabled={submitting}
+                    class="rounded-lg bg-blue-600 px-5 py-2.5 font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                    {submitting ? '생성 중…' : '사이트 생성'}
+                </button>
+            </div>
+        </form>
+    </section>
+
+    <!-- 사이트 목록 -->
+    <section>
+        <h2 class="mb-3 text-lg font-semibold">등록된 사이트 ({data.sites.length})</h2>
+        <div class="overflow-x-auto rounded-xl border border-gray-200">
+            <table class="w-full text-left text-sm">
+                <thead class="bg-gray-50 text-gray-600">
+                    <tr>
+                        <th class="px-4 py-2 font-medium">#</th>
+                        <th class="px-4 py-2 font-medium">도메인</th>
+                        <th class="px-4 py-2 font-medium">테마</th>
+                        <th class="px-4 py-2 font-medium">제목</th>
+                        <th class="px-4 py-2 font-medium">별칭</th>
+                        <th class="px-4 py-2 font-medium">상태</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    {#each data.sites as s (s.id)}
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-4 py-2 text-gray-400">{s.id}</td>
+                            <td class="px-4 py-2 font-medium">
+                                <a
+                                    href="https://{s.domain}/"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    class="text-blue-600 hover:underline">{s.domain}</a
+                                >
+                            </td>
+                            <td class="px-4 py-2"><code class="text-xs">{s.themeId}</code></td>
+                            <td class="px-4 py-2 text-gray-600">{s.siteTitle || '—'}</td>
+                            <td class="px-4 py-2 text-xs text-gray-500">{s.aliases || '—'}</td>
+                            <td class="px-4 py-2">
+                                {#if s.active}
+                                    <span
+                                        class="rounded bg-green-100 px-2 py-0.5 text-xs text-green-700"
+                                        >활성</span
+                                    >
+                                {:else}
+                                    <span
+                                        class="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500"
+                                        >비활성</span
+                                    >
+                                {/if}
+                            </td>
+                        </tr>
+                    {:else}
+                        <tr
+                            ><td colspan="6" class="px-4 py-6 text-center text-gray-400"
+                                >등록된 사이트가 없습니다.</td
+                            ></tr
+                        >
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary

WordPress 멀티사이트의 `wpmu_create_blog()` 격 — 최고관리자가 **SQL 수기 INSERT 없이** 화면에서 도메인+테마만 선택해 새 사이트를 추가. PR #1485(SSR cache host-key)로 multi-tenant 기반이 견고해진 위에 올리는 첫 SaaS 운영 편의 기능 (Phase 14 Tier 2).

`angple_sites` row 가 생기면 `DbSiteResolver` 가 해당 host 요청을 선택 테마로 즉시 해석하고(`invalidateDbSiteCache` 로 5분 TTL 대기 없이 반영), 콘텐츠가 비어 있어도 Tier 1 의 `EmptySiteWelcome` 이 표시되어 곧바로 정상 동작한다.

## 변경 (신규 3 파일 — 순수 additive)

- `api/super-admin/sites/create/+server.ts` (POST)
  - `super_admin`(getSingoRole) 게이팅
  - 도메인 RFC1123 형식 + 중복(primary+alias) + 테마 존재(scanThemes) 검증
  - `angple_sites` + `angple_site_aliases` 트랜잭션 INSERT + `invalidateDbSiteCache`
- `super-admin/sites/+page.server.ts` — super_admin 가드 + 사이트 목록 + 테마 목록 load
- `super-admin/sites/+page.svelte` — 목록 테이블 + 생성 폼 (테마 dropdown)

## Test plan

- [ ] CI (svelte-check/build/eslint) 통과
- [ ] super_admin 으로 `/super-admin/sites` 접속 → 목록 표시
- [ ] 새 도메인+테마 생성 → 201, 목록 갱신
- [ ] 중복 도메인 → 409, 잘못된 형식 → 400, 미설치 테마 → 400
- [ ] 비-super_admin → 403
- [ ] 생성 직후 해당 host 요청이 선택 테마로 해석되는지 (proxy 연결 시)

## 영향

신규 라우트만 추가 — 기존 사이트 렌더/동작 **회귀 0**. DNS·리버스프록시가 해당 host 를 이 서버로 향하게 하는 것은 별도 인프라 작업(후속 자동화 대상). 백엔드 자동 시드(기본 게시판/환영 글)는 Tier 2 후속.