### PR TITLE
fix(embed): 세로 영상(shorts/reels/tiktok) 폭 제한 — 거대 빈 공간 제거

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1915,12 +1915,15 @@
         border-radius: 0.375rem;
     }
 
-    /* 세로 영상 */
+    /* 세로 영상 — 9:16 이라 폭 제한 필수. max-width 가 없으면 full-width(100%)
+       × padding-bottom 177.78% 로 거대한 세로 박스가 되어 영상 주변에 큰 빈 공간이
+       생긴다 (free/6329552 댓글 youtube shorts 사례). */
     :global(.embed-container[data-platform='youtube-shorts']),
     :global(.embed-container[data-platform='instagram-reel']),
     :global(.embed-container[data-platform='tiktok']) {
         margin-left: auto;
         margin-right: auto;
+        max-width: 350px;
     }
 
     /* #12432: 댓글 내 native <video> 첨부는 자체 비율 사용 (16:9 강제 해제).

--- a/apps/web/src/lib/plugins/auto-embed/components/EmbedContainer.svelte
+++ b/apps/web/src/lib/plugins/auto-embed/components/EmbedContainer.svelte
@@ -108,12 +108,15 @@
         border-radius: 0.5rem;
     }
 
-    /* 세로 영상 (Shorts, Reels, TikTok) */
+    /* 세로 영상 (Shorts, Reels, TikTok) — 9:16 이라 폭 제한 필수.
+       max-width 가 없으면 full-width(100%) × padding-bottom 177.78% 로
+       거대한 세로 박스가 되어 영상 주변에 큰 빈 공간이 생긴다. */
     .embed-container[data-platform='youtube-shorts'],
     .embed-container[data-platform='instagram-reel'],
     .embed-container[data-platform='tiktok'] {
         margin-left: auto;
         margin-right: auto;
+        max-width: 350px;
     }
 
     /* Twitter는 높이가 가변적 */


### PR DESCRIPTION
## Summary
- 사용자 제보: 댓글에 유튜브 shorts 임베드 시 영상과 텍스트 사이 공간이 너무 넓음 (free/6329552#c_6329576).
- 원인: `youtube.ts` 가 shorts 에 `aspectRatio: 177.78`(9:16) 만 설정하고 `maxWidth` 미설정 → EmbedContainer 가 `--max-width: 100%` 적용 → 세로 영상이 full-width × 177.78% 높이 = 거대 세로 박스 → 영상 주변 큰 빈 공간.
- 세로 플랫폼 CSS 에 `margin: auto` 만 있고 **max-width 제한 없음**.

## 변경
- `apps/web/src/lib/plugins/auto-embed/components/EmbedContainer.svelte` (본문 임베드)
- `apps/web/src/lib/components/features/board/comment-list.svelte` (댓글 임베드)
  - `youtube-shorts` / `instagram-reel` / `tiktok` 에 `max-width: 350px` 추가

## Test plan
- [ ] 댓글/본문에 youtube shorts URL → 폭 350px 세로 영상으로 정상 표시 (거대 박스 없음)
- [ ] instagram reel / tiktok 도 동일하게 폭 제한 적용
- [ ] 일반 youtube (16:9) 는 영향 없음 (full-width 유지)
- [ ] 모바일에서 350px > viewport 일 때 width:100% 가 우선 (max-width 가 cap)
- [ ] `pnpm check` 통과

## 관련
PR #1458 (native video 16:9 해제) 의 후속 — 이번엔 iframe 세로 영상 폭 제한.