### PR TITLE
fix(ads): 자체 배너 클래스 media-banner → dm-media-card (ad block 우회)

### DIFF
--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -198,14 +198,14 @@
         <!-- 축하메시지 배너 -->
         <a
             href={getCelebrationHref(celebrationBanner)}
-            class="border-border media-banner block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
+            class="border-border dm-media-card block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
             style:min-height={height}
             style:height
         >
             <img
                 src={celebrationBanner.image_url}
                 alt={celebrationBanner.alt_text || '축하메시지'}
-                class="media-banner__image w-full object-contain"
+                class="dm-media-card__image w-full object-contain"
                 loading="lazy"
             />
         </a>
@@ -226,14 +226,14 @@
                 slotKey: `damoang-banner:${position}`,
                 adUserId: adsBanner.advertiserId ?? undefined
             }}
-            class="border-border media-banner block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
+            class="border-border dm-media-card block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
             style:min-height={height}
             style:height
         >
             <img
                 src={adsBanner.imageUrl}
                 alt={adsBanner.altText || '광고'}
-                class="media-banner__image w-full object-contain"
+                class="dm-media-card__image w-full object-contain"
                 loading="lazy"
             />
         </a>
@@ -258,14 +258,14 @@
 </div>
 
 <style>
-    .media-banner {
+    .dm-media-card {
         display: flex;
         align-items: center;
         justify-content: center;
         width: 100%;
     }
 
-    .media-banner__image {
+    .dm-media-card__image {
         display: block;
         width: 100%;
         height: 100%;


### PR DESCRIPTION
## Summary
자체 광고(다모앙 배너)의 `.media-banner` 클래스가 EasyList `[class*='banner']` 규칙에 잡힐 위험 → `dm-media-card` 로 변경.

## 배경 (사용자 결정 2026-05-25)
ad block 우회 전략 — 자체 광고만 게시글 카드와 클래스 prefix 통일:
- 자체 광고(직접홍보 사잇글/축하메시지 롤링/image-text-banner)는 이미 게시글 유사 클래스라 트리거 없음
- 유일하게 `damoang-banner` 의 `media-banner` 만 banner 키워드 보유 → 변경
- 자체 광고이므로 AdSense 정책 무관 (Google 광고 아님)

## 변경
- `apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte`
  - `.media-banner` → `.dm-media-card` (6곳, class + CSS)
  - `.media-banner__image` → `.dm-media-card__image`

## Test plan
- [ ] 다모앙 자체 배너 정상 노출 (레이아웃 회귀 없음)
- [ ] ad block(EasyList) 사용자에게 자체 배너 노출 회복
- [ ] `pnpm check` 통과

## 관련
PR #1466 (ad-slot/author-activity obfuscation, 머지 완료) 의 후속 — 자체 배너 보강.