### PR TITLE
feat(multi-tenant): 사이트 관리 수정/삭제 — /super-admin/sites CRUD 완결

### DIFF
--- a/apps/web/src/routes/api/super-admin/sites/[id]/+server.ts
+++ b/apps/web/src/routes/api/super-admin/sites/[id]/+server.ts
@@ -1,0 +1,121 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { pool } from '$lib/server/db';
+import { getSingoRole } from '$lib/server/singo-role';
+import { invalidateDbSiteCache } from '$lib/server/site-resolver/db';
+import { scanThemes } from '$lib/server/themes/scanner';
+import type { ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+
+/**
+ * PATCH/DELETE /api/super-admin/sites/[id] — 사이트 수정/삭제.
+ * (생성은 형제 라우트 /create — SvelteKit 가 정적 세그먼트를 [id] 보다 우선 매칭)
+ *
+ * 권한: 최고관리자(super_admin) 전용. 변경 후 DbSiteResolver cache 즉시 무효화.
+ */
+
+async function isSuperAdmin(mbId: string | undefined): Promise<boolean> {
+    return !!mbId && (await getSingoRole(mbId)) === 'super_admin';
+}
+
+/** 사이트의 모든 host (primary + alias) — cache 무효화용 */
+async function siteHosts(id: number): Promise<string[]> {
+    const [primary] = await pool.query<RowDataPacket[]>(
+        'SELECT domain FROM angple_sites WHERE id = ? LIMIT 1',
+        [id]
+    );
+    if (primary.length === 0) return [];
+    const [aliases] = await pool.query<RowDataPacket[]>(
+        'SELECT domain FROM angple_site_aliases WHERE site_id = ?',
+        [id]
+    );
+    return [primary[0].domain as string, ...aliases.map((a) => a.domain as string)];
+}
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+    if (!(await isSuperAdmin(locals.user?.id))) {
+        return json({ success: false, message: '최고관리자 권한이 필요합니다.' }, { status: 403 });
+    }
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+        return json({ success: false, message: '잘못된 사이트 ID 입니다.' }, { status: 400 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+        body = await request.json();
+    } catch {
+        return json({ success: false, message: '잘못된 요청 본문입니다.' }, { status: 400 });
+    }
+
+    const sets: string[] = [];
+    const values: unknown[] = [];
+
+    if (body.themeId !== undefined) {
+        const themeId = String(body.themeId).trim();
+        const themes = await scanThemes();
+        if (!themes.has(themeId)) {
+            return json(
+                { success: false, message: `설치되지 않은 테마입니다: ${themeId}` },
+                { status: 400 }
+            );
+        }
+        sets.push('theme_id = ?');
+        values.push(themeId);
+    }
+    if (body.siteTitle !== undefined) {
+        const t = String(body.siteTitle).trim().slice(0, 255);
+        sets.push('site_title = ?');
+        values.push(t || null);
+    }
+    if (body.siteDescription !== undefined) {
+        const d = String(body.siteDescription).trim().slice(0, 1000);
+        sets.push('site_description = ?');
+        values.push(d || null);
+    }
+    if (body.active !== undefined) {
+        sets.push('active = ?');
+        values.push(body.active ? 1 : 0);
+    }
+
+    if (sets.length === 0) {
+        return json({ success: false, message: '변경할 항목이 없습니다.' }, { status: 400 });
+    }
+
+    const hosts = await siteHosts(id);
+    if (hosts.length === 0) {
+        return json({ success: false, message: '사이트를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    values.push(id);
+    await pool.query<ResultSetHeader>(
+        `UPDATE angple_sites SET ${sets.join(', ')} WHERE id = ?`,
+        values
+    );
+
+    // 수정 즉시 반영
+    for (const h of hosts) await invalidateDbSiteCache(h);
+
+    return json({ success: true });
+};
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+    if (!(await isSuperAdmin(locals.user?.id))) {
+        return json({ success: false, message: '최고관리자 권한이 필요합니다.' }, { status: 403 });
+    }
+    const id = Number(params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+        return json({ success: false, message: '잘못된 사이트 ID 입니다.' }, { status: 400 });
+    }
+
+    const hosts = await siteHosts(id);
+    if (hosts.length === 0) {
+        return json({ success: false, message: '사이트를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    // angple_site_aliases 는 FK ON DELETE CASCADE 로 함께 삭제됨
+    await pool.query<ResultSetHeader>('DELETE FROM angple_sites WHERE id = ?', [id]);
+
+    for (const h of hosts) await invalidateDbSiteCache(h);
+
+    return json({ success: true });
+};

--- a/apps/web/src/routes/super-admin/sites/+page.svelte
+++ b/apps/web/src/routes/super-admin/sites/+page.svelte
@@ -12,6 +12,15 @@
     let submitting = $state(false);
     let message = $state<{ type: 'success' | 'error'; text: string } | null>(null);
 
+    // 인라인 수정 상태
+    let editingId = $state<number | null>(null);
+    let editDraft = $state<{ themeId: string; siteTitle: string; active: boolean }>({
+        themeId: '',
+        siteTitle: '',
+        active: true
+    });
+    let busyId = $state<number | null>(null);
+
     async function createSite(e: Event) {
         e.preventDefault();
         if (submitting) return;
@@ -47,6 +56,60 @@
             submitting = false;
         }
     }
+
+    function startEdit(s: (typeof data.sites)[number]) {
+        editingId = s.id;
+        editDraft = { themeId: s.themeId, siteTitle: s.siteTitle, active: s.active };
+    }
+
+    function cancelEdit() {
+        editingId = null;
+    }
+
+    async function saveEdit(id: number) {
+        if (busyId) return;
+        message = null;
+        busyId = id;
+        try {
+            const res = await fetch(`/api/super-admin/sites/${id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(editDraft)
+            });
+            const result = await res.json();
+            if (res.ok && result.success) {
+                editingId = null;
+                await invalidateAll();
+            } else {
+                message = { type: 'error', text: result.message ?? '수정 실패' };
+            }
+        } catch {
+            message = { type: 'error', text: '네트워크 오류로 수정에 실패했습니다.' };
+        } finally {
+            busyId = null;
+        }
+    }
+
+    async function deleteSite(s: (typeof data.sites)[number]) {
+        if (busyId) return;
+        if (!confirm(`정말 삭제하시겠습니까?\n${s.domain} (#${s.id}) — 되돌릴 수 없습니다.`))
+            return;
+        message = null;
+        busyId = s.id;
+        try {
+            const res = await fetch(`/api/super-admin/sites/${s.id}`, { method: 'DELETE' });
+            const result = await res.json();
+            if (res.ok && result.success) {
+                await invalidateAll();
+            } else {
+                message = { type: 'error', text: result.message ?? '삭제 실패' };
+            }
+        } catch {
+            message = { type: 'error', text: '네트워크 오류로 삭제에 실패했습니다.' };
+        } finally {
+            busyId = null;
+        }
+    }
 </script>
 
 <svelte:head><title>사이트 관리 · 최고관리자</title></svelte:head>
@@ -58,19 +121,19 @@
         라이브됩니다 (콘텐츠가 없으면 환영 화면 표시).
     </p>
 
+    {#if message}
+        <div
+            class="mb-4 rounded-lg px-4 py-3 text-sm {message.type === 'success'
+                ? 'border border-green-200 bg-green-50 text-green-800'
+                : 'border border-red-200 bg-red-50 text-red-800'}"
+        >
+            {message.text}
+        </div>
+    {/if}
+
     <!-- 신규 사이트 생성 -->
     <section class="mb-10 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
         <h2 class="mb-4 text-lg font-semibold">새 사이트 만들기</h2>
-
-        {#if message}
-            <div
-                class="mb-4 rounded-lg px-4 py-3 text-sm {message.type === 'success'
-                    ? 'border border-green-200 bg-green-50 text-green-800'
-                    : 'border border-red-200 bg-red-50 text-red-800'}"
-            >
-                {message.text}
-            </div>
-        {/if}
 
         <form class="grid gap-4 sm:grid-cols-2" onsubmit={createSite}>
             <label class="flex flex-col gap-1 text-sm">
@@ -154,6 +217,7 @@
                         <th class="px-4 py-2 font-medium">제목</th>
                         <th class="px-4 py-2 font-medium">별칭</th>
                         <th class="px-4 py-2 font-medium">상태</th>
+                        <th class="px-4 py-2 text-right font-medium">작업</th>
                     </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-100">
@@ -168,26 +232,83 @@
                                     class="text-blue-600 hover:underline">{s.domain}</a
                                 >
                             </td>
-                            <td class="px-4 py-2"><code class="text-xs">{s.themeId}</code></td>
-                            <td class="px-4 py-2 text-gray-600">{s.siteTitle || '—'}</td>
-                            <td class="px-4 py-2 text-xs text-gray-500">{s.aliases || '—'}</td>
-                            <td class="px-4 py-2">
-                                {#if s.active}
-                                    <span
-                                        class="rounded bg-green-100 px-2 py-0.5 text-xs text-green-700"
-                                        >활성</span
+
+                            {#if editingId === s.id}
+                                <!-- 편집 모드 -->
+                                <td class="px-4 py-2">
+                                    <select
+                                        bind:value={editDraft.themeId}
+                                        class="rounded border border-gray-300 px-2 py-1 text-xs"
                                     >
-                                {:else}
-                                    <span
-                                        class="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500"
-                                        >비활성</span
+                                        {#each data.themes as t (t.id)}
+                                            <option value={t.id}>{t.id}</option>
+                                        {/each}
+                                    </select>
+                                </td>
+                                <td class="px-4 py-2">
+                                    <input
+                                        type="text"
+                                        bind:value={editDraft.siteTitle}
+                                        placeholder="제목"
+                                        class="w-full rounded border border-gray-300 px-2 py-1 text-xs"
+                                    />
+                                </td>
+                                <td class="px-4 py-2 text-xs text-gray-500">{s.aliases || '—'}</td>
+                                <td class="px-4 py-2">
+                                    <label class="inline-flex items-center gap-1 text-xs">
+                                        <input type="checkbox" bind:checked={editDraft.active} /> 활성
+                                    </label>
+                                </td>
+                                <td class="whitespace-nowrap px-4 py-2 text-right">
+                                    <button
+                                        onclick={() => saveEdit(s.id)}
+                                        disabled={busyId === s.id}
+                                        class="rounded bg-blue-600 px-2.5 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50"
+                                        >{busyId === s.id ? '저장 중…' : '저장'}</button
                                     >
-                                {/if}
-                            </td>
+                                    <button
+                                        onclick={cancelEdit}
+                                        class="rounded border border-gray-300 px-2.5 py-1 text-xs hover:bg-gray-100"
+                                        >취소</button
+                                    >
+                                </td>
+                            {:else}
+                                <!-- 보기 모드 -->
+                                <td class="px-4 py-2"><code class="text-xs">{s.themeId}</code></td>
+                                <td class="px-4 py-2 text-gray-600">{s.siteTitle || '—'}</td>
+                                <td class="px-4 py-2 text-xs text-gray-500">{s.aliases || '—'}</td>
+                                <td class="px-4 py-2">
+                                    {#if s.active}
+                                        <span
+                                            class="rounded bg-green-100 px-2 py-0.5 text-xs text-green-700"
+                                            >활성</span
+                                        >
+                                    {:else}
+                                        <span
+                                            class="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500"
+                                            >비활성</span
+                                        >
+                                    {/if}
+                                </td>
+                                <td class="whitespace-nowrap px-4 py-2 text-right">
+                                    <button
+                                        onclick={() => startEdit(s)}
+                                        disabled={busyId === s.id || editingId !== null}
+                                        class="rounded border border-gray-300 px-2.5 py-1 text-xs hover:bg-gray-100 disabled:opacity-50"
+                                        >수정</button
+                                    >
+                                    <button
+                                        onclick={() => deleteSite(s)}
+                                        disabled={busyId === s.id || editingId !== null}
+                                        class="rounded border border-red-200 px-2.5 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-50"
+                                        >{busyId === s.id ? '삭제 중…' : '삭제'}</button
+                                    >
+                                </td>
+                            {/if}
                         </tr>
                     {:else}
                         <tr
-                            ><td colspan="6" class="px-4 py-6 text-center text-gray-400"
+                            ><td colspan="7" class="px-4 py-6 text-center text-gray-400"
                                 >등록된 사이트가 없습니다.</td
                             ></tr
                         >


### PR DESCRIPTION
## Summary

1-클릭 사이트 생성(#1488)에 이어 **수정·삭제**를 추가해 멀티사이트 관리 CRUD 를 완성. create-only 였던 어드민이 완전한 사이트 운영 화면이 됨 (Phase 14 Tier 2 연속).

## 변경 (신규 1 + 수정 1)

- `api/super-admin/sites/[id]/+server.ts` (신규)
  - `PATCH` — theme_id/site_title/site_description/active 부분 수정 (변경 필드만 동적 SET, theme 존재 검증, 해당 host cache 무효화)
  - `DELETE` — 사이트 삭제 (`angple_site_aliases` FK ON DELETE CASCADE)
  - super_admin 게이팅, id 검증, 없는 사이트 404
- `super-admin/sites/+page.svelte` (수정)
  - 목록에 인라인 수정 모드(테마 dropdown · 제목 input · 활성 토글) + 저장/취소
  - 삭제 버튼(confirm 확인), 작업 중 버튼 비활성

## 설계 노트

- 정적 `/create` 가 동적 `[id]` 보다 우선 매칭 → 라우트 충돌 없음
- 생성 API 와 동일 패턴(`getSingoRole`·`pool`·`invalidateDbSiteCache`)
- 순수 additive — 기존 사이트 렌더/동작 **회귀 0**

## Test plan

- [ ] CI (svelte-check/build/eslint/typescript) 통과
- [ ] 테마 변경 저장 → 해당 host 가 새 테마로 즉시 반영 (cache 무효화)
- [ ] 활성 토글 off → 해당 host 가 기본 테마로 fallback (active=0)
- [ ] 삭제 → 목록에서 사라지고 alias 도 함께 제거
- [ ] 비-super_admin → 403, 없는 id → 404