### PR TITLE
fix(web): SSR activePlugins에 plugin components 포함 (archive 버튼 미노출 수정)

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -100,7 +100,8 @@ export const load: LayoutServerLoad = async ({
                   name: p.manifest.name,
                   version: p.manifest.version,
                   hooks: [],
-                  components: [],
+                  // components는 클라이언트 slot 등록(loadAllPluginComponents)에 필요하므로 SSR에 포함한다
+                  components: p.manifest.components ?? [],
                   settings: isAdminPath ? p.currentSettings || null : null
               }))
             : [];


### PR DESCRIPTION
## 문제
canary에서 archive(보존) 플러그인의 버튼(post-detail-after, comments-item-actions 등)이 slot에 등록되지 않아 노출되지 않음.

## 근본 원인
`apps/web/src/routes/+layout.server.ts`가 SSR `activePlugins`를 만들 때 `components`를 빈 배열 `[]`로 보냄.

흐름:
1. SSR `data.activePlugins`(components=[]) → `pluginStore.initFromServer` → `state.components` 빈 상태
2. 이후 `/api/layout/init`(components 포함)이 와도 같은 plugin id라 `initFromServer`가 skip (`plugin.svelte.ts:49` `if (currentIds === newIds && !isLoading) return`)
3. `loadAllPluginComponents`가 components 빈 채로 종료 (`plugin-component-loader.ts:70`)
4. archive 컴포넌트 미등록 → 버튼 미노출

archive는 svelte 컴포넌트를 가진 첫 active plugin (다른 active plugin은 hook이 server-side라 드러나지 않았음).

## 수정
- `components: []` → `components: p.manifest.components ?? []` (SSR에 plugin 컴포넌트 메타 포함)
- `hooks`는 그대로 `[]` 유지 (hook은 server-side plugin loader가 처리, archive는 hook 없음)
- `p.manifest.components` 타입은 `ExtensionComponent[] | undefined`이므로 `?? []`로 방어

## 영향 범위
- SSR `data.activePlugins[].components`가 채워짐 → `+layout.svelte` effect(line 332) 첫 실행 시 `loadAllPluginComponents`에 components 전달 → `registerComponent` → slot 렌더