### PR TITLE
feat(web): 게시글 액션바에 post-detail-actions slot 렌더

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -41,6 +41,7 @@
     import Info from '@lucide/svelte/icons/info';
     import Pin from '@lucide/svelte/icons/pin';
     import ShareButton from '$lib/components/post/share-button.svelte';
+    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import type { ViewLayoutProps } from '../types.js';
 
     const FONT_SIZES: Record<ContentFontSize, string> = {
@@ -650,6 +651,12 @@
                             <span>신고</span>
                         </Button>
                     {/if}
+                    <PluginSlot
+                        name="post-detail-actions"
+                        {boardId}
+                        postId={post.id}
+                        postAuthorId={post.author_id}
+                    />
                 </div>
             </div>
 

--- a/apps/web/src/lib/components/slot-manager.ts
+++ b/apps/web/src/lib/components/slot-manager.ts
@@ -79,7 +79,7 @@ export type StandardSlotName =
     | 'post-detail-content-before'
     | 'post-detail-content-after'
     | 'post-detail-extra' // 본문 아래 추가 영역 (기존, archive/giving 등 사용 중)
-    | 'post-detail-actions' // 공유/신고/보존 등 액션 묶음
+    | 'post-detail-actions' // 게시글 액션바(스크랩/공유/신고 옆)
     | 'post-detail-tags'
     | 'post-detail-reactions-after'
     | 'post-detail-related'


### PR DESCRIPTION
## 개요
게시글 보존(앙카이브) 버튼 등 플러그인 액션을 게시글 액션바(스크랩/공유/신고 옆)에 노출할 수 있도록 `post-detail-actions` slot 을 basic 뷰 액션바에 렌더한다.

## 변경
- `slot-manager.ts`: `post-detail-actions` slot 주석 정비 (slot 자체는 기존부터 존재)
- `basic.svelte`: 액션바 신고 버튼 직후, 액션 컨테이너 div 닫히기 직전에 `<PluginSlot name="post-detail-actions" />` 추가
  - props: `boardId`, `postId={post.id}`, `postAuthorId={post.author_id}` (ArchiveButton props 와 일치)
  - PluginSlot import 신규 추가

## 연계
- premium: archive plugin `archive-button` slot 을 `post-detail-after` → `post-detail-actions` 로 이동 (별도 PR)

## 범위
버튼 위치만. 본문 보존의 글+댓글 일괄 로직은 이번 범위 아님.