### PR TITLE
fix(embed): youtube shorts 임베드 16:9 — 위아래 빈 공간 제거

### DIFF
--- a/apps/web/src/lib/plugins/auto-embed/platforms/youtube.ts
+++ b/apps/web/src/lib/plugins/auto-embed/platforms/youtube.ts
@@ -43,7 +43,10 @@ export const youtube: EmbedPlatform = {
                     platform: isShorts ? 'youtube-shorts' : 'youtube',
                     id: videoId,
                     url,
-                    aspectRatio: isShorts ? 177.78 : 56.25, // 9:16 vs 16:9
+                    // youtube /embed/ 는 shorts 도 16:9 player 로 렌더하므로 항상 16:9.
+                    // 9:16(177.78%) 컨테이너로 두면 16:9 영상 위아래에 거대한 빈 공간이 생긴다.
+                    // 폭은 maxWidth(CSS) 로 제한해 과도하게 커지지 않게 한다.
+                    aspectRatio: 56.25,
                     maxWidth: isShorts ? 400 : 560,
                     params: Object.keys(params).length > 0 ? params : undefined
                 };


### PR DESCRIPTION
## Summary
canary 에서 PR #1489 적용 후 확인: youtube shorts 임베드의 **폭은 줄었으나 높이(위아래 빈 공간)가 과도**.

## 원인
- `youtube.ts` 가 shorts 에 `aspectRatio: 177.78`(9:16) 부여
- 그러나 `youtube.com/embed/{id}` iframe 은 shorts 도 **16:9 player** 로 렌더
- → 9:16 컨테이너(350×622px) 안에 16:9 영상 → **위아래 거대한 빈 공간**

## 변경
- `apps/web/src/lib/plugins/auto-embed/platforms/youtube.ts`
  - shorts `aspectRatio` `177.78 → 56.25` (16:9)
  - 폭 제한(`maxWidth` 400 / comment-list·EmbedContainer CSS 350) 은 유지
  - `instagram-reel`/`tiktok` 은 실제 세로 player 라 9:16 유지 (영향 없음)

## 결과
shorts 임베드 = 폭 제한된 16:9 영상 (예: 350×197) → 위아래 빈 공간 없음.

## Test plan
- [ ] 댓글/본문 youtube shorts URL → 16:9 영상, 위아래 빈 공간 없음
- [ ] 일반 youtube (16:9) 회귀 없음
- [ ] instagram reel / tiktok 세로 유지 확인
- [ ] `pnpm check` 통과