### PR TITLE
fix(multi-tenant): 홈/SEO 사이트명을 런타임 per-site 로 ('다모앙' 고정 해결)

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -184,8 +184,11 @@
         return origin;
     });
 
+    // multi-tenant: host 로 resolve 된 site.title 우선 (VITE_SITE_NAME 은 빌드타임 상수).
+    // NOTE: siteDefaults 는 meta-helper 의 module-level 전역 — SSR 동시요청 간 이론상 race
+    // 가능. 단일 render 는 동기라 실무상 안전. 향후 per-request context 로 이전 권장.
     configureSeo({
-        siteName: import.meta.env.VITE_SITE_NAME || '다모앙 - 종합 커뮤니티',
+        siteName: data.site?.title || import.meta.env.VITE_SITE_NAME || 'Angple',
         siteUrl
     });
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -25,11 +25,16 @@
         });
     });
 
-    // SEO 설정 (홈페이지)
-    const siteName = import.meta.env.VITE_SITE_NAME || '다모앙';
-    const siteTagline = '종합 포털 커뮤니티';
-    const homeTitle = `${siteName} | ${siteTagline}`;
-    const homeDescription = `${siteName} ${siteTagline} - 자유로운 소통의 공간 | Damoang Community Portal`;
+    // SEO 설정 (홈페이지) — multi-tenant: host 로 resolve 된 site 의 title/description 우선.
+    // VITE_SITE_NAME 은 빌드타임 상수라 공유 이미지에선 모든 사이트가 같은 값이 됨 → 런타임 우선.
+    // site.title 이 있으면 완성형 제목으로 그대로 사용(태그라인 중복 append 방지),
+    // 없으면 기존 damoang 기본 포맷 유지(회귀 0).
+    const fallbackName = import.meta.env.VITE_SITE_NAME || '다모앙';
+    const siteName = $derived(page.data.site?.title || fallbackName);
+    const homeTitle = $derived(page.data.site?.title || `${fallbackName} | 종합 포털 커뮤니티`);
+    const homeDescription = $derived(
+        page.data.site?.description || `${siteName} - 자유로운 소통의 공간`
+    );
 
     const seoConfig: SeoConfig = $derived({
         meta: {


### PR DESCRIPTION
## Summary

공유 `angple-web` 이미지를 쓰는 사이트(ipyang.com 등)가 **홈에서 '다모앙'으로 표시**되는 문제. 사이트명이 빌드타임 `import.meta.env.VITE_SITE_NAME || '다모앙'` 으로 박혀 host 무관하게 동일했음. host 로 resolve 된 `page.data.site`(= `angple_sites.site_title/description`, 이미 `+layout.server.ts` 가 전달 중)를 런타임 우선 사용하도록 수정.

`provision-site.sh`(사일로) + 공유 이미지 멀티테넌트의 마지막 브랜딩 조각. og:title/description/logo/favicon 은 이미 `+layout.svelte` 가 `data.site` 사용 중 — 홈 `<title>` 와 SEO 기본값만 빌드타임 상수였음.

## 변경 (2 files)

- `+page.svelte`: 홈 title/description → `page.data.site.title/description` 우선 (`$derived`). site.title 이 완성형이면 그대로(태그라인 중복 방지), 없으면 기존 damoang 포맷 유지.
- `+layout.svelte`: `configureSeo` siteName → `data.site.title` 우선 (og:site_name + 하위 페이지 `buildTitle`). `meta-helper` 의 `siteDefaults` 가 module-level 전역이라 SSR race 가능성은 주석으로 남김(향후 per-request context).

## 영향

`page.data.site` 없는 단일 host 사이트(damoang)는 기존 포맷 그대로 → **회귀 0**. site_title 설정된 사이트(ipyang: "입양닷컴 - 국내 입양 가족 커뮤니티")는 그 값 노출.

## Test plan

- [ ] CI (svelte-check/build/eslint/typescript)
- [ ] damoang.net 홈 title = "다모앙 | 종합 포털 커뮤니티" (회귀 없음)
- [ ] ipyang.com 홈 title = "입양닷컴 - 국내 입양 가족 커뮤니티" (재배포 후)

## 후속(별도)

manifest.json / 인증 이메일의 `VITE_SITE_NAME`, `meta-helper` siteDefaults 의 per-request 화.