### PR TITLE
feat(label): 축하메시지 → 마음메시지 한글 표시명 변경

### DIFF
--- a/apps/web/src/lib/components/features/admin-customizer/sections/widgets-section.svelte
+++ b/apps/web/src/lib/components/features/admin-customizer/sections/widgets-section.svelte
@@ -79,7 +79,7 @@
             'post-list': '게시글 목록',
             'ad-slot': '광고',
             recommended: '공감글',
-            celebration: '축하메시지',
+            celebration: '마음메시지',
             'latest-posts': '최신글',
             'popular-posts': '인기글',
             search: '검색',

--- a/apps/web/src/lib/components/features/widget-editor/widget-settings-dialog.svelte
+++ b/apps/web/src/lib/components/features/widget-editor/widget-settings-dialog.svelte
@@ -31,7 +31,7 @@
         { key: 'lecture', text: '강좌팁', url: '/lecture', show: true },
         { key: 'group', text: '소모임', url: '/groups', show: true },
         { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
-        { key: 'message', text: '축하메시지', url: '/message', show: true }
+        { key: 'message', text: '마음메시지', url: '/message', show: true }
     ];
 
     // 로컬 설정 상태 (게시판 필터용)

--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -383,9 +383,9 @@
                 </div>
                 <ImageTextBanner position="side-image-text-banner" />
             </div>
-            <!-- 드로워: 축하메시지 -->
+            <!-- 드로워: 마음메시지 -->
             <CelebrationRolling />
-            <!-- 축하메시지 바로 아래: 벽돌한장 · 광고 제거 inline -->
+            <!-- 마음메시지 바로 아래: 벽돌한장 · 광고 제거 inline -->
             <div class="text-muted-foreground flex items-center justify-center gap-3 px-2 text-xs">
                 <a href="/brickang" class="hover:text-primary underline-offset-2 hover:underline">
                     벽돌한장

--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -80,7 +80,7 @@
         <a
             href="/message"
             class="text-muted-foreground hover:text-foreground text-sm transition-colors"
-            >축하메시지가 없습니다</a
+            >마음메시지가 없습니다</a
         >
     </div>
 {:else}

--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -16,7 +16,7 @@
 
     interface Props {
         position: 'index' | 'board-list' | 'board-view' | 'sidebar';
-        showCelebration?: boolean; // 축하메시지 표시 여부 (메인만 true)
+        showCelebration?: boolean; // 마음메시지 표시 여부 (메인만 true)
         height?: string;
         gamPosition?: string; // GAM 폴백 시 사용할 슬롯 이름 (위젯에서 전달)
         gamFallback?: boolean; // 자체 배너 없을 때 GAM 폴백 여부 (기본 true)
@@ -46,11 +46,11 @@
         advertiserId?: string;
     }
 
-    // 공유 스토어에서 축하메시지 가져오기
+    // 공유 스토어에서 마음메시지 가져오기
     let storeCelebrations = $derived(getCelebrations());
     let storeIndex = $derived(getCurrentIndex());
     let celebrationReady = $derived(isCelebrationReady());
-    // 최종 선택된 배너 (축하메시지 or 프리미엄 광고)
+    // 최종 선택된 배너 (마음메시지 or 프리미엄 광고)
     let adsBanner = $state<AdsBanner | null>(null);
     let loading = $state(true);
     let useFallback = $state(false);
@@ -93,7 +93,7 @@
     });
 
     onMount(() => {
-        // 축하메시지: 공유 스토어에서 관리 (CelebrationRolling과 싱크)
+        // 마음메시지: 공유 스토어에서 관리 (CelebrationRolling과 싱크)
         let cleanupCelebration: (() => void) | undefined;
         if (showCelebration) {
             cleanupCelebration = celebrationMount();
@@ -110,7 +110,7 @@
         if (!browser) return;
 
         if (showCelebration) {
-            // 축하메시지는 공유 스토어에서 관리 → 광고만 fetch
+            // 마음메시지는 공유 스토어에서 관리 → 광고만 fetch
             const ads = await fetchAdsBanners();
             if (ads.length > 0) {
                 adsBanner = ads[Math.floor(Math.random() * ads.length)];
@@ -119,7 +119,7 @@
             loading = !adsBanner && !celebrationReady;
             useFallback = !adsBanner && celebrationReady && storeCelebrations.length === 0;
         } else {
-            // 게시판 페이지: 프리미엄 + 일반 배너만 (축하메시지 없음)
+            // 게시판 페이지: 프리미엄 + 일반 배너만 (마음메시지 없음)
             const ads = await fetchAdsBanners();
             if (ads.length > 0) {
                 adsBanner = ads[Math.floor(Math.random() * ads.length)];
@@ -181,7 +181,7 @@
         return raw;
     }
 
-    // 축하메시지 배너 링크: 공유 스토어의 getLink 사용
+    // 마음메시지 배너 링크: 공유 스토어의 getLink 사용
     function getCelebrationHref(banner: CelebrationBanner): string {
         return getCelebrationLink(banner);
     }
@@ -195,7 +195,7 @@
             style:min-height={height}
         ></div>
     {:else if celebrationBanner}
-        <!-- 축하메시지 배너 -->
+        <!-- 마음메시지 배너 -->
         <a
             href={getCelebrationHref(celebrationBanner)}
             class="border-border dm-media-card block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
@@ -204,7 +204,7 @@
         >
             <img
                 src={celebrationBanner.image_url}
-                alt={celebrationBanner.alt_text || '축하메시지'}
+                alt={celebrationBanner.alt_text || '마음메시지'}
                 class="dm-media-card__image w-full object-contain"
                 loading="lazy"
             />
@@ -239,7 +239,7 @@
         </a>
     {:else if useFallback}
         {#if position === 'sidebar'}
-            <!-- 사이드바: 축하메시지/광고 없으면 빈 플레이스홀더 -->
+            <!-- 사이드바: 마음메시지/광고 없으면 빈 플레이스홀더 -->
             <div
                 class="flex items-center justify-center rounded-lg border border-dashed border-slate-200 bg-slate-50/50 dark:border-slate-700 dark:bg-slate-800/30"
                 style:min-height="40px"
@@ -247,7 +247,7 @@
                 <a
                     href="/message"
                     class="text-[10px] text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
-                    >축하메시지가 없습니다</a
+                    >마음메시지가 없습니다</a
                 >
             </div>
         {:else if gamFallback}

--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -26,7 +26,7 @@
         { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
         { key: 'lecture', text: '강좌팁', url: '/lecture', show: true },
         { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
-        { key: 'message', text: '축하메시지', url: '/message', show: true }
+        { key: 'message', text: '마음메시지', url: '/message', show: true }
     ];
 
     let { menus: menusProp, class: className = '' }: Props = $props();

--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -1,5 +1,5 @@
 /**
- * 축하메시지 조회 공유 모듈
+ * 마음메시지 조회 공유 모듈
  *
  * +layout.server.ts (SSR), /api/init, /api/ads/celebration/today 에서 공유.
  * 서버 사이드 60초 인메모리 캐시 포함.
@@ -45,7 +45,7 @@ function extractFirstImage(content: string): string | null {
 const celebrationCache = createCache<CelebrationBanner[]>({ ttl: 60_000, maxSize: 10 });
 
 /**
- * 축하메시지 조회
+ * 마음메시지 조회
  * @param isRecent true면 날짜 무관 최근 8건, false면 오늘만
  */
 export async function fetchCelebrations(isRecent: boolean = false): Promise<CelebrationBanner[]> {
@@ -150,7 +150,7 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
     return banners;
 }
 
-/** 캐시된 축하메시지 조회 (60초 TTL, singleflight) */
+/** 캐시된 마음메시지 조회 (60초 TTL, singleflight) */
 export async function getCachedCelebrations(
     isRecent: boolean = false
 ): Promise<CelebrationBanner[]> {

--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -1,5 +1,5 @@
 /**
- * 축하메시지 공유 스토어
+ * 마음메시지 공유 스토어
  *
  * CelebrationRolling(텍스트)과 DamoangBanner(이미지)가
  * 동일한 데이터와 인덱스를 공유하여 싱크 롤링
@@ -85,7 +85,7 @@ async function doFetch(): Promise<void> {
             reshuffleOrder();
         }
     } catch (error) {
-        console.warn('CelebrationStore: 축하메시지 로드 실패', error);
+        console.warn('CelebrationStore: 마음메시지 로드 실패', error);
     }
 }
 

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -40,7 +40,7 @@ async function buildHomePageData(): Promise<HomePageData> {
                     sidebarWidgetLayout: sidebarWidgetLayout ?? DEFAULT_SIDEBAR_WIDGETS
                 };
             })(),
-            // 인덱스 전용: 최근 축하메시지 (오늘뿐 아니라 최근 8건)
+            // 인덱스 전용: 최근 마음메시지 (오늘뿐 아니라 최근 8건)
             getCachedCelebrations(true),
             // 공감글 SSR 프리페치 (스켈레톤 제거)
             loadRecommendedData(recommendedPeriod)

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -85,7 +85,7 @@
             explore: data.exploreData ? { data: data.exploreData } : undefined
         },
         // 홈 공감글 터치 오인식(#11998) — SSR 데이터가 빈 배열일 때 undefined 를 넘기면
-        // 클라이언트 $effect 가 재요청을 보내 축하메시지 Card 가 hydration 직후 삽입되며
+        // 클라이언트 $effect 가 재요청을 보내 마음메시지 Card 가 hydration 직후 삽입되며
         // 그 아래 위젯이 밀리는 레이아웃 shift 를 유발. 빈 배열이라도 항상 prefetchData 로
         // 넘겨서 클라이언트 재요청을 차단함.
         celebration: { data: data.celebrationRecent ?? data.celebration ?? [] }

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -588,7 +588,7 @@ export const load: PageServerLoad = async ({
             }
         }
 
-        // 축하메시지(message) 게시판: 익명 글 프로필 정보 숨김
+        // 마음메시지(message) 게시판: 익명 글 프로필 정보 숨김
         // PublishToGnuboard()에서 익명 시 wr_name=""으로 설정 → author가 빈 문자열
         if (boardId === 'message') {
             for (const p of allPosts) {

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -907,7 +907,7 @@
                 </div>
             {/if}
 
-            <!-- 축하메시지 아래 구글 광고 -->
+            <!-- 마음메시지 아래 구글 광고 -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-3">
                     <AdSlot position="board-list-head" height="90px" slotKey="board-list-head" />
@@ -977,7 +977,7 @@
                 </div>
             {/if}
 
-            <!-- 축하메시지 기간 탭 -->
+            <!-- 마음메시지 기간 탭 -->
             {#if isMessageBoard && !isSearching}
                 <div class="mb-6 flex flex-wrap gap-2">
                     <Button
@@ -987,7 +987,7 @@
                         class="h-8 rounded-full px-4"
                         aria-current={selectedMessagePeriod === 'today' ? 'page' : undefined}
                     >
-                        오늘 축하메시지
+                        오늘 마음메시지
                     </Button>
                     <Button
                         href={buildMessagePeriodHref('month')}
@@ -996,7 +996,7 @@
                         class="h-8 rounded-full px-4"
                         aria-current={selectedMessagePeriod === 'month' ? 'page' : undefined}
                     >
-                        이번달 축하메시지
+                        이번달 마음메시지
                     </Button>
                     <Button
                         href={buildMessagePeriodHref('upcoming')}
@@ -1005,7 +1005,7 @@
                         class="h-8 rounded-full px-4"
                         aria-current={selectedMessagePeriod === 'upcoming' ? 'page' : undefined}
                     >
-                        다가올 축하메시지
+                        다가올 마음메시지
                     </Button>
                     <Button
                         href={buildMessagePeriodHref('past')}
@@ -1014,7 +1014,7 @@
                         class="h-8 rounded-full px-4"
                         aria-current={selectedMessagePeriod === 'past' ? 'page' : undefined}
                     >
-                        추억의 축하메시지
+                        추억의 마음메시지
                     </Button>
                     <Button
                         href="/message/144"
@@ -1022,7 +1022,7 @@
                         size="sm"
                         class="h-8 rounded-full px-4"
                     >
-                        축하메시지 신청
+                        마음메시지 신청
                     </Button>
                 </div>
             {/if}
@@ -1255,15 +1255,15 @@
                                 <p class="text-secondary-foreground">검색 결과가 없습니다.</p>
                             {:else if isMessageBoard && messagePeriod === 'today'}
                                 <p class="text-secondary-foreground">
-                                    오늘 등록된 축하메시지가 없습니다.
+                                    오늘 등록된 마음메시지가 없습니다.
                                 </p>
                             {:else if isMessageBoard && messagePeriod === 'month'}
                                 <p class="text-secondary-foreground">
-                                    이번달 축하메시지가 없습니다.
+                                    이번달 마음메시지가 없습니다.
                                 </p>
                             {:else if isMessageBoard && messagePeriod === 'upcoming'}
                                 <p class="text-secondary-foreground">
-                                    다가올 축하메시지가 없습니다.
+                                    다가올 마음메시지가 없습니다.
                                 </p>
                             {:else}
                                 <p class="text-secondary-foreground">게시글이 없습니다.</p>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -214,7 +214,7 @@ export const load: PageServerLoad = async ({
             }
         }
 
-        // 축하메시지(message) 게시판: 익명 글 프로필 정보 숨김
+        // 마음메시지(message) 게시판: 익명 글 프로필 정보 숨김
         if (boardId === 'message' && !post.author) {
             post.author_image = undefined;
             post.author_image_updated_at = undefined;

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1671,7 +1671,7 @@
         <PluginSlot name="board-view-rolling" />
     </div>
 
-    <!-- 축하메시지 아래 구글 광고 -->
+    <!-- 마음메시지 아래 구글 광고 -->
     {#if widgetLayoutStore.hasEnabledAds && !data.post.deleted_at}
         <div class="mb-3">
             <AdSlot position="board-content" height="90px" slotKey="board-view-head-ad" />

--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -1,5 +1,5 @@
 /**
- * 축하메시지 배너 API
+ * 마음메시지 배너 API
  * 1차: celebration_banners 테이블 (신규 단일 소스)
  * 2차: g5_write_message 테이블 (레거시 fallback — 마이그레이션 전까지)
  */

--- a/apps/web/src/routes/content/advertisement/+page.svelte
+++ b/apps/web/src/routes/content/advertisement/+page.svelte
@@ -41,7 +41,7 @@
 
     const plans: PricingPlan[] = [
         {
-            title: '축하메시지',
+            title: '마음메시지',
             spec: '770 x 90px',
             price: '5',
             unit: '만원/24시간',
@@ -216,7 +216,7 @@
 
         <div class="bg-primary/10 text-primary mt-6 rounded-lg p-3 text-center text-sm font-medium">
             <Info class="mr-1 inline h-4 w-4" />
-            축하메시지를 제외한 나머지 상품은 부가세 별도입니다.
+            마음메시지를 제외한 나머지 상품은 부가세 별도입니다.
         </div>
     </section>
 
@@ -241,7 +241,7 @@
                 >
                     <Gift class="text-primary h-7 w-7" />
                 </div>
-                <h3 class="text-foreground text-lg font-semibold">축하메시지</h3>
+                <h3 class="text-foreground text-lg font-semibold">마음메시지</h3>
                 <p class="text-muted-foreground mt-1 text-sm">특별한 날을 함께 축하해요</p>
                 <span
                     class="bg-primary text-primary-foreground mt-4 inline-block rounded-full px-5 py-2 text-sm font-semibold"


### PR DESCRIPTION
## Summary
"축하메시지" 한글 표시명을 "마음메시지" 로 변경. **영어 코드 식별자(celebration, /message 라우트, CelebrationRolling, celebrations 테이블, /api/ads/celebration/*)는 유지** — 한글 UI 문자열만.

## 변경 (16파일, 41곳)
- 위젯 라벨: `widget-settings-dialog.svelte`, `admin-customizer/.../widgets-section.svelte`
- 자유게시판 상단 바로가기: `tag-nav.svelte`
- 사이드바 배너 빈 상태/alt: `celebration-rolling.svelte`, `damoang-banner.svelte`
- message 게시판 탭/신청 UI: `[boardId]/+page.svelte` (오늘/이번달/다가올/추억/신청/빈상태)
- 광고상품 페이지: `content/advertisement/+page.svelte`
- 사이드바·서버모듈·스토어·게시판 server 주석/JSDoc

## 제외 (별도 처리)
- `damoang_mail.gs` (Google 시트/Apps Script) + 구글폼 제목/안내 → 운영자가 Google 쪽에서 직접
- damoang-ads 레포 → 별도 PR

## 우측 패널 배너 class
- 축하(마음)메시지 배너(`celebration-rolling.svelte`)는 generic Tailwind class (`border-border`/`bg-background`) — ad/dm prefix 없음 → ad block obfuscation 불필요, 현 상태 유지 (변경 없음).

## Test plan
- [ ] `pnpm check` 통과
- [ ] `grep -rn 축하메시지 apps/web/src` → 0 (확인 완료)
- [ ] 메인 위젯 라벨 / 자유게시판 상단 바로가기 / 사이드바 배너 빈 상태 / message 게시판 탭·신청 / 광고상품 페이지에서 "마음메시지" 표시
- [ ] /message 라우트·API 정상 동작 (영어 코드 유지로 회귀 없음)