### PR TITLE
feat(board): 게시판 목록 빠른필터 행 컴팩트 검색 input (#12455)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -223,6 +223,23 @@
         goto(url.pathname + url.search);
     }
 
+    // #12455: 빠른필터 행 컴팩트 검색 (SearchForm 과 동일 sfl=title_content)
+    // '내가 쓴 글/댓글' 필터(sfl=author/comment_author) 가 아닐 때만 현재 검색어를 채운다.
+    let quickSearch = $state(
+        currentSfl === 'author' || currentSfl === 'comment_author' ? '' : currentStx
+    );
+    function runQuickSearch(): void {
+        const q = quickSearch.trim();
+        if (!q) return;
+        const url = new URL(window.location.href);
+        url.searchParams.set('sfl', 'title_content');
+        url.searchParams.set('stx', q);
+        url.searchParams.set('page', '1');
+        url.searchParams.delete('category');
+        url.searchParams.delete('tag');
+        goto(url.pathname + url.search);
+    }
+
     // 읽은 글 표시 지연 — SSR에서는 모든 글이 "안읽음"으로 렌더링되므로,
     // 하이드레이션 직후 즉시 변경하면 깜빡임 발생. 2프레임 대기 후 부드럽게 전환.
     let showSearch = $state(uiSettingsStore.pinSearch);
@@ -960,6 +977,26 @@
                             <X class="h-3.5 w-3.5" />
                         </Button>
                     {/if}
+                    <!-- #12455: 컴팩트 검색 (내가 쓴 댓글 ~ 글쓰기 사이, 상시 노출) -->
+                    <div class="relative">
+                        <Search
+                            class="text-muted-foreground pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2"
+                        />
+                        <input
+                            type="search"
+                            bind:value={quickSearch}
+                            onkeydown={(e) => {
+                                if (e.key === 'Enter') {
+                                    e.preventDefault();
+                                    runQuickSearch();
+                                }
+                            }}
+                            placeholder="검색"
+                            aria-label="게시판 내 검색 (제목+내용)"
+                            enterkeyhint="search"
+                            class="border-input bg-background focus:ring-primary h-8 w-28 rounded-md border pl-7 pr-2 text-sm focus:outline-none focus:ring-1 sm:w-40"
+                        />
+                    </div>
                     <!-- #12455: 빠른 글쓰기 (내가 쓴 글/댓글 필터 줄 우측) -->
                     {#if canWrite}
                         <Button


### PR DESCRIPTION
## Summary
게시판 목록의 '내가 쓴 글/댓글' 빠른필터 줄에 **제목+내용 검색 input 을 상시 노출**. 글쓰기 버튼 좌측에 배치.

## 배경
#12455 (버튼 레이아웃 — 검색/글쓰기 변경 제안) + 운영자 요청: "글쓰기 버튼과 내가 쓴 댓글 사이에 검색 input 있으면 좋겠다".

## 변경
- `apps/web/src/routes/[boardId]/+page.svelte`
  - `quickSearch` state + `runQuickSearch()` (SearchForm 과 동일 `sfl=title_content`, `stx`, page=1, category/tag clear)
  - 빠른필터 행(`내가 쓴 글/댓글`)에 컴팩트 `<input type=search>` + 돋보기 아이콘 (엔터/`enterkeyhint=search`)
  - 현재 검색어 자동 채움 (단 author/comment_author 필터 중엔 비움)

## 동작
- 로그인 사용자에게 빠른필터 줄에 상시 검색 input 노출 → 한 번에 검색
- 기존 상단 검색 토글 / pin(검색 고정) / SearchForm 은 그대로 유지 (중복 아님 — 빠른 접근용)

## Test plan
- [ ] `pnpm check` 통과
- [ ] 검색어 입력 + 엔터 → `?sfl=title_content&stx=...&page=1` 이동, 결과 정상
- [ ] '내가 쓴 글/댓글' 필터 활성 시 input 비워짐, 일반 검색 중엔 검색어 채워짐
- [ ] 모바일 폭에서 input(w-28) + 글쓰기 버튼 레이아웃 깨짐 없음
- [ ] 비로그인 사용자: 빠른필터 행 자체가 로그인 전용이라 미노출 (기존 상단 SearchForm 으로 검색)