### PR TITLE
feat(board): PC 로그인 시 중복 상단 검색(돋보기) 숨김 (#12455)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -876,7 +876,12 @@
                             </DropdownMenuContent>
                         </DropdownMenu>
                     {/if}
-                    <div class="relative flex shrink-0">
+                    <!-- #12455: 로그인 사용자는 PC(md+)에서 빠른필터 행 검색과 중복 → 상단 검색 토글 숨김 -->
+                    <div
+                        class="relative flex shrink-0 {authStore.isAuthenticated
+                            ? 'md:hidden'
+                            : ''}"
+                    >
                         {#if authStore.isAuthenticated}
                             <Button
                                 variant="outline"
@@ -962,8 +967,12 @@
             <PluginSlot name="board-list-filter-before" {boardId} />
 
             <!-- 검색 폼 (토글 or 검색 중 or 핀 고정) -->
+            <!-- #12455: 로그인 사용자는 PC(md+)에서 빠른필터 행 검색이 대체 → 상단 SearchForm 숨김 (비로그인/모바일은 유지) -->
             {#if showSearch || isSearching || uiSettingsStore.pinSearch}
-                <div class="mb-3" transition:slide={{ duration: 200 }}>
+                <div
+                    class="mb-3 {authStore.isAuthenticated ? 'md:hidden' : ''}"
+                    transition:slide={{ duration: 200 }}
+                >
                     <SearchForm boardPath={`/${boardId}`} />
                 </div>
             {/if}


### PR DESCRIPTION
## 배경
빠른필터 행 검색(#1499~#1501)을 추가하면서 PC 에서 **상단 우측 돋보기(검색 토글) + SearchForm** 이 빠른필터 검색과 중복됨.

## 변경
`[boardId]/+page.svelte` — 로그인 사용자에 한해 PC(md+)에서 상단 검색 숨김:
- 상단 검색 토글(돋보기) + pin 버튼 (`relative flex shrink-0` wrapper) → `md:hidden`
- 토글로 펼쳐지는 SearchForm wrapper → `md:hidden`
- 조건: `authStore.isAuthenticated ? 'md:hidden' : ''`

## 반응형 동작
| | 비로그인 | 로그인 |
|---|---|---|
| PC (md≥768) | 상단 검색 **유지** | 상단 검색 **숨김** → 빠른필터 행 검색 사용 |
| 모바일 (<768) | 상단 검색 유지 | 상단 검색 유지 (모바일은 이번 범위 외) |

비로그인은 빠른필터 행(로그인 전용)이 없으므로 상단 검색을 그대로 유지.