### PR TITLE
feat(post): 본문 상단 네비에 글쓰기 버튼 추가

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1571,6 +1571,29 @@
         <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
 
+        <!-- 상단에도 글쓰기 버튼 (하단 네비와 동일 권한/실명인증 로직) -->
+        {#if authStore.isAuthenticated && checkPermission(data.board, 'can_write', authStore.user ?? null)}
+            <Button
+                variant="default"
+                size="sm"
+                href={canUseCertifiedAction(authStore.user, boardId)
+                    ? `/${boardId}/write`
+                    : undefined}
+                onclick={(e) => {
+                    if (!canUseCertifiedAction(authStore.user, boardId)) {
+                        e.preventDefault();
+                        goToCertification();
+                    }
+                }}
+                title={!canUseCertifiedAction(authStore.user, boardId)
+                    ? getCertificationBlockedMessage(boardId)
+                    : undefined}
+                class="shrink-0"
+            >
+                {#if !canUseCertifiedAction(authStore.user, boardId)}실명인증{:else}글쓰기{/if}
+            </Button>
+        {/if}
+
         <div class="flex-1"></div>
 
         <div class="flex shrink-0 gap-2">


### PR DESCRIPTION
## 배경
글쓰기 버튼이 본문 **하단 네비** + 모바일 FAB 에만 있어, 긴 글을 끝까지 스크롤하지 않으면 글쓰기 진입이 번거로움.

## 변경
`[boardId]/[postId]/+page.svelte` — 상단 네비(`목록으로` 라인)에도 글쓰기 버튼 추가:
- 배치: `← 목록으로 [글쓰기] … 스크랩 수정 삭제`
- 하단 글쓰기 버튼과 **동일 로직 재사용**: `authStore.isAuthenticated && checkPermission(data.board, 'can_write', …)`, 실명인증 미인증 시 `실명인증` 라벨 + `goToCertification()`, URL `/{boardId}/write`
- 추가 import 없음 (기존 하단 버튼이 쓰던 헬퍼 그대로)