### PR TITLE
feat(theme): 오픈코어 기본 테마 generic 화 (Phase 1a, hardcode 0)

### DIFF
--- a/apps/web/src/lib/server/auth/auto-promotion.ts
+++ b/apps/web/src/lib/server/auth/auto-promotion.ts
@@ -7,6 +7,7 @@
  * - 등급3 → 등급4: 14일 이상 + 6,000 XP
  */
 import pool, { readPool } from '$lib/server/db.js';
+import { DEFAULT_THEME } from '$lib/themes/constants';
 import type { ResultSetHeader, RowDataPacket } from 'mysql2';
 import type { QueryError } from 'mysql2';
 import {
@@ -97,8 +98,8 @@ export async function savePromotionRules(rules: PromotionRule[]): Promise<void> 
 
     if (rows.length === 0) {
         await pool.query(
-            `INSERT INTO site_settings (site_id, settings_json, active_theme) VALUES ('default', ?, 'damoang-official')`,
-            [jsonStr]
+            `INSERT INTO site_settings (site_id, settings_json, active_theme) VALUES ('default', ?, ?)`,
+            [jsonStr, DEFAULT_THEME]
         );
     } else {
         await pool.query(`UPDATE site_settings SET settings_json = ? WHERE site_id = 'default'`, [

--- a/apps/web/src/lib/server/install/check-installed.ts
+++ b/apps/web/src/lib/server/install/check-installed.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { DEFAULT_THEME } from '$lib/themes/constants';
 
 /**
  * 설치 상태 체크
@@ -76,7 +77,7 @@ export function updateSettings(updates: Partial<Settings>): boolean {
     try {
         const current = getSettings() || {
             installed: false,
-            activeTheme: 'damoang-default',
+            activeTheme: DEFAULT_THEME,
             themes: {},
             version: '1.0.0'
         };

--- a/apps/web/src/lib/themes/constants.ts
+++ b/apps/web/src/lib/themes/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * 테마 관련 공용 상수 (클라이언트/서버 공용)
+ */
+
+/**
+ * 오픈코어 기본 테마 ID.
+ *
+ * 신규 설치 및 시드(seed) 시 사용하는 중립(generic) 기본 테마.
+ * 운영 사이트의 활성 테마는 DB(`site_settings.active_theme`)에서 읽으므로,
+ * 이 상수를 바꿔도 이미 활성 테마가 지정된 기존 사이트에는 영향이 없다.
+ *
+ * 다모앙 등 특정 사이트 전용 테마(`damoang-*`)는 코어 기본값으로 두지 않는다
+ * (open-core hardcode 0 원칙).
+ */
+export const DEFAULT_THEME = 'minimal-light';

--- a/apps/web/src/routes/install/+page.server.ts
+++ b/apps/web/src/routes/install/+page.server.ts
@@ -2,6 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { isInstalled, updateSettings } from '$lib/server/install/check-installed';
 import { scanThemes, getThemePath } from '$lib/server/themes/scanner';
+import { DEFAULT_THEME } from '$lib/themes/constants';
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 
@@ -44,10 +45,10 @@ export const load: PageServerLoad = async () => {
         });
     }
 
-    // damoang-default를 첫 번째로 정렬
+    // 기본 테마를 첫 번째로 정렬
     themes.sort((a, b) => {
-        if (a.id === 'damoang-default') return -1;
-        if (b.id === 'damoang-default') return 1;
+        if (a.id === DEFAULT_THEME) return -1;
+        if (b.id === DEFAULT_THEME) return 1;
         return a.name.localeCompare(b.name);
     });
 
@@ -77,7 +78,7 @@ export const actions: Actions = {
             siteDescription: siteDescription?.trim() || '',
             siteUrl: siteUrl?.trim() || '',
             language: language || 'ko',
-            activeTheme: activeTheme || 'damoang-default'
+            activeTheme: activeTheme || DEFAULT_THEME
         });
 
         if (!updated) {

--- a/apps/web/src/routes/install/+page.svelte
+++ b/apps/web/src/routes/install/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { enhance } from '$app/forms';
+    import { DEFAULT_THEME } from '$lib/themes/constants';
     import { Button } from '$lib/components/ui/button';
     import { Input } from '$lib/components/ui/input';
     import { Label } from '$lib/components/ui/label';
@@ -38,7 +39,7 @@
 
     let { data, form } = $props();
     let isSubmitting = $state(false);
-    let selectedTheme = $state('damoang-default');
+    let selectedTheme = $state(DEFAULT_THEME);
 
     // 테마 목록 (서버에서 전달)
     const themes: Theme[] = data.themes ?? [];


### PR DESCRIPTION
## 배경
core↔premium 분리(WordPress 모델) 1단계. open-core 설치/시드 경로에 `damoang-*` 테마가 하드코딩돼 있어, 제3자가 코어를 받으면 다모앙 테마로 부팅됨. "open-core hardcode 0" 원칙에 맞게 generic 기본 테마로 교체.

## 변경
- 신규 `$lib/themes/constants.ts` → `DEFAULT_THEME = 'minimal-light'` (클라/서버 공용)
- `auth/auto-promotion.ts`: site_settings seed INSERT 의 `'damoang-official'` → `DEFAULT_THEME` (파라미터화)
- `install/check-installed.ts`: updateSettings fallback `activeTheme`
- `install/+page.server.ts`: 테마 정렬 우선순위 + 폴백
- `install/+page.svelte`: 기본 선택 테마

## 기본 테마 = minimal-light
중립(Angple Team 저작·범용·가독성). damoang 좌사이드바/우패널 레이아웃(`damoang-default`)은 **공개 코어 기본값에서 제외**(다모앙 전용으로 유지).

## 운영 영향 0
활성 테마는 `site_settings.active_theme`(DB)에서 읽음. 변경 대상은 **설치/시드 경로뿐**:
- auto-promotion INSERT = site_settings row 없을 때만 → 운영은 row 존재 → UPDATE 분기(active_theme 미변경)
- 나머지는 설치 위저드 전용 → 이미 설치된 사이트 무관

## 검증
- [x] 수정 파일 `damoang-*` 잔존 0
- [x] `pnpm check` 0 errors
- [ ] (후속) board 전용 중립 기본테마 `angple-default` 신설 검토
- [ ] (후속 Phase 1b) damoang-* 테마 premium repo 물리 이전