### PR TITLE
fix: PC 사이드바 배너 200x200 고정 + 모바일 드로워 320x100 배너 추가

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -376,6 +376,10 @@
             {/if}
         </div>
         {#if compact}
+            <!-- 드로워: 네모배너 (320x100) -->
+            <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
+                <AdSlot position="sidebar-drawer" height="100px" slotKey="sidebar-drawer-main" />
+            </div>
             <!-- 드로워: 이미지텍스트 배너 -->
             <div>
                 <div class="mb-1 flex items-center justify-between">

--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -271,4 +271,15 @@
         height: 100%;
         max-height: inherit;
     }
+
+    /* 사이드바: 200x200 이미지 원본 크기 유지 */
+    :global(.dm-card[data-position='sidebar']) .dm-media-card {
+        max-width: 200px;
+        margin: 0 auto;
+    }
+
+    :global(.dm-card[data-position='sidebar']) .dm-media-card__image {
+        width: auto;
+        max-width: 200px;
+    }
 </style>


### PR DESCRIPTION
## Summary
- PC 사이드바 DamoangBanner: `max-width: 200px`로 이미지 확대 방지 + 센터 정렬
- 모바일 드로워(compact): `AdSlot position="sidebar-drawer"` (GAM 320x100) 추가, ImageTextBanner 위에 배치

## Changes
| 파일 | 변경 |
|------|------|
| `sidebar.svelte` | compact 모드에 `AdSlot sidebar-drawer` 추가 |
| `damoang-banner.svelte` | sidebar position CSS: `max-width: 200px`, `width: auto` |

## Test plan
- [ ] PC: 오른쪽 패널 DamoangBanner가 200x200 원본 크기로 표시되는지 확인
- [ ] 모바일: 드로워 메뉴에서 320x100 GAM 배너가 미니배너 위에 표시되는지 확인
- [ ] 광고 제거 회원: 드로워에서 배너 숨김 확인 (`widgetLayoutStore.hasEnabledAds`)