### PR TITLE
fix: 모바일 드로워 네모배너 다모앙 광고 우선 + GAM 폴백

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -18,6 +18,7 @@
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import AdfitSlot from '$lib/components/ui/adfit-slot/adfit-slot.svelte';
     import ImageTextBanner from '$lib/components/ui/image-text-banner/image-text-banner.svelte';
+    import DamoangBanner from '$lib/components/ui/damoang-banner/damoang-banner.svelte';
     import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { boardFavoritesStore, slotLabel } from '$lib/stores/board-favorites.svelte';
@@ -376,9 +377,15 @@
             {/if}
         </div>
         {#if compact}
-            <!-- 드로워: 네모배너 (320x100) -->
+            <!-- 드로워: 네모배너 (다모앙 광고 → GAM 폴백) -->
             <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
-                <AdSlot position="sidebar-drawer" height="100px" slotKey="sidebar-drawer-main" />
+                <DamoangBanner
+                    position="sidebar"
+                    height="100px"
+                    showCelebration={false}
+                    gamPosition="sidebar-drawer"
+                    class="drawer-sidebar-banner"
+                />
             </div>
             <!-- 드로워: 이미지텍스트 배너 -->
             <div>

--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -282,4 +282,17 @@
         width: auto;
         max-width: 200px;
     }
+
+    /* 드로워 내 사이드바 배너: 320x100 크롭 (200px 제약 해제) */
+    :global(.drawer-sidebar-banner) .dm-media-card {
+        max-width: 100%;
+    }
+
+    :global(.drawer-sidebar-banner) .dm-media-card__image {
+        width: 100%;
+        max-width: 100%;
+        height: 100px;
+        object-fit: cover;
+        object-position: center;
+    }
 </style>


### PR DESCRIPTION
## Summary
- 모바일 드로워 네모배너: `AdSlot`(GAM only) → `DamoangBanner`로 교체
- 다모앙 광고 서버 배너 우선 표시, 없을 경우 GAM `sidebar-drawer` (320x100) 폴백
- 드로워 내 200x200 이미지를 320x100으로 크롭 (`object-fit: cover`)

## Changes
| 파일 | 변경 |
|------|------|
| `sidebar.svelte` | `AdSlot` → `DamoangBanner` 교체, import 추가 |
| `damoang-banner.svelte` | `.drawer-sidebar-banner` CSS 추가 (200px 제약 해제 + 320x100 크롭) |

## 동작 흐름
1. 다모앙 광고 서버에서 `sidebar` position 배너 조회
2. 배너 있으면 → 320x100 크롭하여 표시
3. 배너 없으면 → GAM `sidebar-drawer` (320x100) 폴백

## Test plan
- [ ] 모바일 드로워에서 다모앙 네모배너가 320x100으로 표시되는지 확인
- [ ] 다모앙 배너 없을 때 GAM 320x100 폴백 확인
- [ ] 광고 제거 회원: 배너 숨김 확인