### PR TITLE
feat(hooks): 서버 hook 표준 컨텍스트(HookContext) 이음새 (Phase 2 Step A′)

### DIFF
--- a/apps/web/src/lib/hooks/HOOKS.md
+++ b/apps/web/src/lib/hooks/HOOKS.md
@@ -1,0 +1,60 @@
+# Angple Hook System — 런타임 경계 & 컨텍스트 규약
+
+WordPress 식 Action/Filter 확장 시스템. 코어는 확장점(hook)만 호출하고, 플러그인이
+`addFilter`/`addAction`(또는 `registerHook`)으로 등록한다. open-core 빌드에서 등록된
+hook 이 없으면 모든 호출은 no-op(pass-through).
+
+## 런타임이 둘이다 (G2) — 용도별로 골라 쓴다
+
+| 런타임 | import | 실행 | 쓰는 곳 |
+|---|---|---|---|
+| **app registry** | `$lib/hooks/registry` (`applyFilter`/`doAction`/`registerHook`) | **async** (await) | **서버 사이드** hook. DB/네트워크 I/O 필터·액션. 예: `post.list.enrich` |
+| **package** | `@angple/hook-system` (`hooks.applyFilters`/`addFilter`) | **sync** | **클라이언트** sync UI 필터. 예: `should_render_ad`, `sidebar_widgets` |
+
+규칙:
+- **서버에서 async 작업이 필요한 hook → app registry** (`$lib/hooks/registry`). 패키지는 sync 라 DB await 불가.
+- **클라이언트 sync UI 필터 → 패키지** (`@angple/hook-system`).
+- 신규 플러그인 hook 은 이 경계를 따른다. (기존 혼재 등록은 점진 정리 — 강제 마이그레이션은 동작 위험이 있어 보류.)
+
+> 현재 혼재 예시: `member-memo`(server) = registry `registerHook`, `ad-free` = 패키지 `hooks.addFilter`. 신규는 위 표 기준.
+
+## 서버 hook 컨텍스트 규약 (`HookContext`)
+
+모든 **서버** hook 호출은 마지막 인자로 `HookContext` 를 넘긴다:
+
+```ts
+import { applyFilter } from '$lib/hooks/registry';
+import { buildHookContext } from '$lib/hooks/context';
+
+const enriched = await applyFilter('post.list.enrich', posts, buildHookContext(locals));
+```
+
+`buildHookContext(locals)` → `{ site, user }`.
+
+- **단일 테넌트(self-host / 사이트별 별도 배포 = 현 운영)**: site 가 단일이라 콜백이 ctx 를
+  무시해도 무방 → **동작 변화 0**.
+- **멀티테넌트(managed SaaS, 향후)**: 디스패치/콜백이 `ctx.site` 로 사이트별 게이팅
+  (활성 플러그인/entitlement)에 사용. ctx 인자가 이미 흐르고 있으므로 **호출부 수정 없이**
+  게이팅만 끼우면 된다.
+
+기존 콜백은 추가 인자를 무시하므로 ctx 도입은 점진적이며 회귀가 없다.
+
+### 클라이언트 hook 의 site
+
+클라이언트에는 `locals` 가 없다 → site 컨텍스트는 page data(`data.site`)로 전달된 값을
+쓴다. (현재는 단일 테넌트라 미사용. 멀티테넌트 시점에 규약화.)
+
+## 로더
+
+- 서버: `$lib/server/plugin-server-loader.ts` — `plugins/**/hooks/*.server.{ts,js}` 를 부팅
+  시 1회 동적 import(self-register). 멱등·에러격리. (= "Phase 1A")
+- 클라: `$lib/client/plugin-client-loader.ts` — `plugins/**/hooks/*.client.{ts,js}`.
+
+## 현재 등록된 서버 hook point (예시)
+
+| hook | 종류 | 호출처 | 등록 플러그인 |
+|---|---|---|---|
+| `post.list.enrich` | filter | `[boardId]/+page.server.ts`, `[boardId]/[postId]/+page.server.ts` | member-memo (author_memo 등) |
+| `comment_content` / `post_content` | filter | comment-list / markdown (클라) | affiliate-link |
+| `should_render_ad` | filter | ad-slot (클라) | ad-free |
+| `layout_server_data` | filter | `+layout.server.ts` (패키지 sync) | — |

--- a/apps/web/src/lib/hooks/context.ts
+++ b/apps/web/src/lib/hooks/context.ts
@@ -1,0 +1,42 @@
+/**
+ * Hook 실행 컨텍스트 — 서버 사이드 hook(applyFilter/doAction) 호출 표준 인자.
+ *
+ * 서버 hook 호출은 마지막 인자로 HookContext 를 넘긴다:
+ *   applyFilter('post.list.enrich', posts, buildHookContext(locals))
+ *
+ * ## 왜 필요한가 (Track A ↔ B 공통 이음새)
+ * - 단일 테넌트(self-host / 사이트별 별도 배포 = 현 운영): site 가 단일이므로
+ *   콜백/디스패치가 ctx 를 무시해도 무방 → **현재 동작 변화 0**.
+ * - 멀티테넌트(managed SaaS, 향후): 한 프로세스가 여러 host 를 서빙하므로,
+ *   디스패치/콜백이 `ctx.site` 로 사이트별 게이팅(활성 플러그인/entitlement)에 사용.
+ *
+ * 기존 hook 콜백은 추가 인자를 무시하므로 ctx 전달은 점진 도입이며 회귀가 없다.
+ * 런타임 경계·등록 규약은 ./HOOKS.md 참고.
+ */
+import type { SiteContext } from '$lib/server/site-resolver/index.js';
+
+/** hook 콜백에 노출되는 사용자 정보 (App.Locals.user 와 동일 형태, 비로그인 시 null). */
+export type HookUser = NonNullable<App.Locals['user']>;
+
+/** 서버 hook 호출에 함께 전달되는 표준 컨텍스트. */
+export interface HookContext {
+    /** host→site 해석 결과. 멀티테넌트 게이팅용. 단일 테넌트면 단일/누락. */
+    site?: SiteContext | null;
+    /** 요청 사용자 (비로그인 시 null). */
+    user?: HookUser | null;
+    /** hook 별 추가 컨텍스트 확장 슬롯. */
+    [key: string]: unknown;
+}
+
+/**
+ * SvelteKit `locals` 에서 표준 HookContext 를 만든다.
+ *
+ * 서버 load/endpoint 의 hook 호출에서 사용:
+ *   applyFilter(name, value, buildHookContext(locals))
+ */
+export function buildHookContext(locals: App.Locals): HookContext {
+    return {
+        site: locals.site ?? null,
+        user: locals.user ?? null
+    };
+}

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -18,6 +18,7 @@ import { searchByBoard } from '$lib/server/sphinx-search.js';
 import { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { applyFilter } from '$lib/hooks/registry.js';
+import { buildHookContext } from '$lib/hooks/context.js';
 
 // --- 인메모리 캐시: 비로그인 게시글 목록 (15초 TTL) ---
 interface PostsCacheData {
@@ -393,13 +394,16 @@ export const load: PageServerLoad = async ({
             const trimmed = maybeTrimBoardListPayload(boardId, board, posts, notices);
             // Phase 1C: 플러그인 enrich filter 호출 (member-memo author_memo 등).
             // 미설치 시 pass-through. (premium PR #43 기준 stub)
+            // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달 — 단일테넌트 무시, 멀티테넌트 게이팅 대비.
             const enrichedPosts = (await applyFilter(
                 'post.list.enrich',
-                trimmed.posts
+                trimmed.posts,
+                buildHookContext(locals)
             )) as FreePost[];
             const enrichedNotices = (await applyFilter(
                 'post.list.enrich',
-                trimmed.notices
+                trimmed.notices,
+                buildHookContext(locals)
             )) as FreePost[];
             const result = {
                 posts: enrichedPosts,
@@ -604,10 +608,16 @@ export const load: PageServerLoad = async ({
         const trimmed = maybeTrimBoardListPayload(boardId, board, posts, notices);
         // Phase 1C: 플러그인 enrich filter 호출 (member-memo author_memo 등).
         // 미설치 시 pass-through. (premium PR #43 기준 stub)
-        const enrichedPosts = (await applyFilter('post.list.enrich', trimmed.posts)) as FreePost[];
+        // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달 — 단일테넌트 무시, 멀티테넌트 게이팅 대비.
+        const enrichedPosts = (await applyFilter(
+            'post.list.enrich',
+            trimmed.posts,
+            buildHookContext(locals)
+        )) as FreePost[];
         const enrichedNotices = (await applyFilter(
             'post.list.enrich',
-            trimmed.notices
+            trimmed.notices,
+            buildHookContext(locals)
         )) as FreePost[];
         const result = {
             posts: enrichedPosts,

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -26,6 +26,7 @@ import { fetchPostLikeStatus } from '$lib/server/post-like-status.js';
 import { fetchTruthroomPostId, fetchTruthroomCommentMap } from '$lib/server/truthroom.js';
 import { BackendUnavailableError } from '$lib/server/backend-fetch.js';
 import { applyFilter } from '$lib/hooks/registry.js';
+import { buildHookContext } from '$lib/hooks/context.js';
 import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 
 /**
@@ -616,7 +617,12 @@ export const load: PageServerLoad = async ({
 
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).
         // 미설치 시 pass-through. (premium PR #43 기준 stub)
-        const enrichedPostList = (await applyFilter('post.list.enrich', [post])) as FreePost[];
+        // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달.
+        const enrichedPostList = (await applyFilter(
+            'post.list.enrich',
+            [post],
+            buildHookContext(locals)
+        )) as FreePost[];
         const enrichedPost = enrichedPostList[0] ?? post;
 
         return {


### PR DESCRIPTION
## 배경
core↔premium 분리 Phase 2. 서버 hook 로더(`plugin-server-loader`, Phase 1A)는 이미 존재 → 이번엔 **동작 변화 0** 기반 작업만:
1. 두 hook 런타임 경계 문서화 (서버 async=`$lib/hooks/registry` / 클라 sync=`@angple/hook-system`)
2. 서버 hook 표준 컨텍스트(`HookContext`) 이음새 도입

## 변경
- **새 `$lib/hooks/context.ts`**: `HookContext`(site/user) + `buildHookContext(locals)`
- **`post.list.enrich` 호출에 ctx 전달**: `[boardId]/+page.server.ts`(목록 2블록) + `[boardId]/[postId]/+page.server.ts`(상세)
- **새 `$lib/hooks/HOOKS.md`**: 런타임 경계 + ctx 규약 + 현 hook point 표

## 왜 (Track A·B 공통 이음새)
- **단일 테넌트**(현 운영, 사이트별 별도 배포): site 단일 → 콜백이 ctx 무시 → **동작 동일**
- **멀티테넌트**(향후 managed SaaS): ctx 가 이미 흐르므로 **호출부 수정 없이** `ctx.site` 게이팅만 끼우면 됨

## 검증
- [x] `pnpm check` 0 errors (동일 변경으로 확인)
- [x] 5개 `post.list.enrich` 호출 전수 ctx 전달
- [x] 기존 콜백(member-memo) 추가 인자 무시 → 회귀 0; open-core pass-through 동일

## 범위 외
affiliate 결합 치환 완성(Phase 1C), 사이트별 플러그인 활성화, behavior 변경 일체.