### PR TITLE
fix(search): wr_datetime KST 보정 — 다음날 표시 (#12522)

### DIFF
--- a/apps/web/src/routes/api/search/+server.ts
+++ b/apps/web/src/routes/api/search/+server.ts
@@ -184,7 +184,10 @@ export const GET: RequestHandler = async ({ url, locals }) => {
                             views: row.wr_hit,
                             likes: row.wr_good,
                             comments_count: row.wr_comment,
-                            created_at: new Date(row.wr_datetime * 1000).toISOString(),
+                            // #12522: Sphinx wr_datetime epoch 는 KST naive datetime 을
+                            // UTC 로 잘못 해석한 값(RDS time_zone=UTC SYSTEM). 9시간 보정 →
+                            // KST 15시 이후 글이 다음 날로 표시되던 버그 수정.
+                            created_at: new Date((row.wr_datetime - 9 * 3600) * 1000).toISOString(),
                             has_file: fileSet.has(`${boardId}:${row.wr_id}`),
                             parent_id: isCommentSearch ? row.wr_parent || 0 : undefined
                         };


### PR DESCRIPTION
## 버그
`#12522` 검색 결과 날짜가 작성일 다음 날로 표시 (KST 15시 이후 작성 글).

## 근본 원인
- RDS Aurora `time_zone=SYSTEM` (UTC).
- Gnuboard `wr_datetime` 은 KST naive datetime (e.g. `'2026-05-28 23:00:00'`).
- Sphinx 인덱싱 시 `UNIX_TIMESTAMP(wr_datetime)` 가 이를 UTC 로 해석 → epoch 가 KST 시각 그대로 UTC 로 박힘 (+9h 오차).
- 클라이언트 `toLocaleDateString('ko-KR')` 가 다시 KST 변환 → 추가 +9h → KST 15시 이후 글이 다음 날로 표시.

검증: RDS 직접 쿼리 결과 `wr_datetime='2026-05-29 00:24'` → epoch=1780014291 → `CONVERT_TZ` 'as_kst' = `2026-05-29 09:24` (즉 epoch 가 KST 시각의 UTC 표기).

## 수정
`/api/search/+server.ts:187` epoch 에 `-9*3600` 보정 후 `toISOString()`.

## 영향
검색 결과의 `created_at` 만. 게시판 목록(별 경로) 영향 없음.