### PR TITLE
fix(comment): 댓글 수정 폼 Ctrl+Enter 단축키 작동 (#12518)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1495,6 +1495,9 @@
                                             editContent = html;
                                         }}
                                         onImagePaste={(file: File) => editHandleFiles([file])}
+                                        onSubmitShortcut={() => {
+                                            if (!isUpdating && editContent.trim()) saveEdit();
+                                        }}
                                         placeholder="댓글을 입력하세요..."
                                         disabled={isUpdating}
                                     />


### PR DESCRIPTION
## 버그
`#12518` 댓글 신규 작성은 Ctrl+Enter 작동, **수정은 미작동**.

## 원인
`comment-list.svelte` 의 수정 폼 `LazyCommentEditor` 호출에 `onSubmitShortcut` prop 미전달. `comment-editor.svelte:93` 의 `handleKeyDown` 은 `onSubmitShortcut?.()` 라 prop 없으면 단축키 검출은 되지만 호출은 no-op.

## 수정
수정 폼 `LazyCommentEditor` 에 `onSubmitShortcut` 전달 — `!isUpdating && editContent.trim()` 가드 후 `saveEdit()` 호출.

## 영향
댓글 수정 폼만.