### PR TITLE
fix(celebration): /api/ads/celebration/today KST 파라미터화 (사이드바 배너 회귀 #12516 후속)

### DIFF
--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -29,6 +29,17 @@ interface Banner {
 const CDN_BASE = (env.CDN_URL || env.VITE_S3_URL || 'https://s3.damoang.net').replace(/\/$/, '');
 
 /**
+ * KST(Asia/Seoul) 기준 오늘 YYYY-MM-DD.
+ *
+ * RDS time_zone=SYSTEM(UTC) 라 MySQL CURDATE()/NOW() 가 KST 새벽 0~9시 동안 어제
+ * 날짜를 반환 → 마음메시지가 KST 자정~오전에 미표시되는 #12516 동일 원인.
+ * `$lib/server/celebration.ts` 와 일치하는 KST 파라미터화 (#12516 fix).
+ */
+function getTodayKST(): string {
+    return new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
+}
+
+/**
  * 회원 프로필 이미지 URL 생성
  */
 function getMemberPhotoUrl(mbImageUrl: string | null | undefined): string | undefined {
@@ -60,7 +71,8 @@ export const GET: RequestHandler = async () => {
         const banners: Banner[] = [];
 
         // 1차: celebration_banners 테이블 (신규) — g5_member JOIN으로 닉네임/사진 가져옴
-        // KST 기준 날짜 비교: MySQL CONVERT_TZ 사용 (서버 UTC → KST 변환)
+        // #12516: CURDATE() (RDS UTC) → KST today 파라미터화. yearly_repeat 도 KST 기준 MONTH/DAY 비교.
+        const todayKST = getTodayKST(); // 'YYYY-MM-DD'
         try {
             const [rows] = await pool.execute<RowDataPacket[]>(
                 `SELECT cb.id, cb.title, cb.content, cb.image_url, cb.link_url,
@@ -77,11 +89,12 @@ export const GET: RequestHandler = async () => {
                  LEFT JOIN g5_write_message wm
                    ON cb.source_wr_id = wm.wr_id AND wm.wr_is_comment = 0
                  WHERE cb.is_active = 1
-                   AND (cb.display_date = CURDATE()
+                   AND (cb.display_date = ?
                         OR (cb.yearly_repeat = 1
-                            AND MONTH(cb.display_date) = MONTH(CURDATE())
-                            AND DAY(cb.display_date) = DAY(CURDATE())))
-                 ORDER BY cb.sort_order ASC, cb.id DESC`
+                            AND MONTH(cb.display_date) = MONTH(?)
+                            AND DAY(cb.display_date) = DAY(?)))
+                 ORDER BY cb.sort_order ASC, cb.id DESC`,
+                [todayKST, todayKST, todayKST]
             );
 
             for (const row of rows as RowDataPacket[]) {
@@ -127,18 +140,26 @@ export const GET: RequestHandler = async () => {
         }
 
         // 2차: g5_write_message fallback (마이그레이션 전까지) — g5_member JOIN
+        // #12516: NOW() (RDS UTC) 대신 KST today 4종 포맷을 파라미터로.
         if (banners.length === 0) {
+            const [yStr, mStr, dStr] = todayKST.split('-');
+            const mNum = String(Number(mStr));
+            const dNum = String(Number(dStr));
+            const legacyFormats = [
+                `${yStr}.${mStr}.${dStr}`,
+                todayKST,
+                `${yStr}.${mNum}.${dNum}`,
+                `${yStr}-${mNum}-${dNum}`
+            ];
             const [rows] = await pool.execute<RowDataPacket[]>(
                 `SELECT wm.wr_id, wm.wr_subject, wm.wr_content, wm.wr_link2, wm.mb_id,
                         wm.wr_name, m.mb_nick, m.mb_image_url
                  FROM g5_write_message wm
                  LEFT JOIN g5_member m ON wm.mb_id = m.mb_id
                  WHERE wm.wr_is_comment = 0
-                   AND (wm.wr_subject = DATE_FORMAT(NOW(), '%Y.%m.%d')
-                        OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y-%m-%d')
-                       OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y.%c.%e')
-                       OR wm.wr_subject = DATE_FORMAT(NOW(), '%Y-%c-%e'))
-                 ORDER BY wm.wr_id DESC`
+                   AND wm.wr_subject IN (?, ?, ?, ?)
+                 ORDER BY wm.wr_id DESC`,
+                legacyFormats
             );
 
             for (const row of rows as RowDataPacket[]) {


### PR DESCRIPTION
## 배경
어제 #12516 fix(PR #1510) 는 `$lib/server/celebration.ts` 의 `getCachedCelebrations()` 만 KST 보정. 그러나 사이드바의 `celebration.svelte.ts` store 는 별도 endpoint **`/api/ads/celebration/today/+server.ts`** 호출. 이 endpoint 는 자체 SQL(`CURDATE()/NOW()`) 사용 → KST 자정~오전 미표시 + 사이드바 배너 누락 잔존.

## 수정
- `getTodayKST()` helper 추가 (Asia/Seoul YYYY-MM-DD)
- 1차 SQL: `display_date = CURDATE()` 및 yearly_repeat `MONTH(CURDATE())/DAY(CURDATE())` → `?` 파라미터 (3곳)
- 2차 fallback: `DATE_FORMAT(NOW(), ...)` 4종 → KST today 4 포맷 `IN (?,?,?,?)`

## 영향
- 운영 사이드바 마음메시지 배너 정상화 (KST 자정~오전 + 일반 시간대)
- CDN 캐시(`public, max-age=60, stale-while-revalidate=300`)는 별도 핀셋 무효화 필요