### PR TITLE
fix(celebration): 익명 fallback nick '축하합니다' → '앙님' + 사진 영역 숨김

### DIFF
--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -23,13 +23,17 @@
     });
 
     function getNick(banner: { target_member_nick?: string }): string {
-        return banner.target_member_nick || '축하합니다';
+        // 익명 마음메시지 fallback — '축하합니다'(구) → '앙님'(다모앙 커뮤니티 호칭).
+        return banner.target_member_nick || '앙님';
     }
 
     function getMessage(banner: { content?: string }): string {
         const raw = banner.content || '';
         return raw.replace(/<[^>]*>/g, '').trim();
     }
+
+    // 현 banner 가 사진 있는지 — 익명이면 이미지 영역 자체를 hide.
+    let showAvatar = $derived(!!celebrations[currentIndex]?.target_member_photo);
 </script>
 
 {#if celebrations.length > 0}
@@ -37,22 +41,24 @@
         href={getLink(celebrations[currentIndex])}
         class="border-border bg-background hover:bg-accent flex h-9 items-center gap-2 overflow-hidden rounded-lg border px-3 transition-colors {className}"
     >
-        <div class="relative h-6 w-6 shrink-0 overflow-hidden rounded-full">
-            {#each celebrations as banner, i (banner.id)}
-                {#if banner.target_member_photo}
-                    <img
-                        src={banner.target_member_photo}
-                        alt=""
-                        class="absolute inset-0 h-6 w-6 rounded-full object-cover transition-all duration-500 ease-in-out
-                            {i === currentIndex
-                            ? 'translate-y-0 opacity-100'
-                            : i < currentIndex
-                              ? '-translate-y-full opacity-0'
-                              : 'translate-y-full opacity-0'}"
-                    />
-                {/if}
-            {/each}
-        </div>
+        {#if showAvatar}
+            <div class="relative h-6 w-6 shrink-0 overflow-hidden rounded-full">
+                {#each celebrations as banner, i (banner.id)}
+                    {#if banner.target_member_photo}
+                        <img
+                            src={banner.target_member_photo}
+                            alt=""
+                            class="absolute inset-0 h-6 w-6 rounded-full object-cover transition-all duration-500 ease-in-out
+                                {i === currentIndex
+                                ? 'translate-y-0 opacity-100'
+                                : i < currentIndex
+                                  ? '-translate-y-full opacity-0'
+                                  : 'translate-y-full opacity-0'}"
+                        />
+                    {/if}
+                {/each}
+            </div>
+        {/if}
 
         <div class="relative h-7 min-w-0 flex-1 overflow-hidden">
             {#each celebrations as banner, i (banner.id)}


### PR DESCRIPTION
## 배경
사이드바 celebration-rolling 에서 익명 마음메시지의 fallback nick 이 `'축하합니다'` 그대로 잔존 (어제 명칭 변경 누락). 또 `target_member_photo` 없는 익명 글에서 이미지 자리가 빈 동그라미로 보임.

## 변경
`celebration-rolling.svelte`
- `getNick` fallback: `'축하합니다'` → **`'앙님'`** (커뮤니티 호칭 컨벤션)
- `showAvatar` derived 추가: 현재 banner 의 `target_member_photo` 유무로 판단
- 이미지 div 를 `{#if showAvatar}` 로 감싸 익명 시 미렌더 (flex 자동 조정 → 텍스트만 깔끔)

## 영향
우측 사이드바 마음메시지 영역만.