### PR TITLE
fix(api): ad-blocker EasyList 회피 — /api/sidebar/items + /api/celebration/today alias

### DIFF
--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -140,7 +140,7 @@
 
         try {
             const response = await fetch(
-                `/api/ads/banners?position=${encodeURIComponent(adsPosition)}&limit=10`
+                `/api/sidebar/items?position=${encodeURIComponent(adsPosition)}&limit=10`
             );
 
             if (!response.ok) return [];

--- a/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
+++ b/apps/web/src/lib/components/ui/image-text-banner/image-text-banner.svelte
@@ -131,7 +131,7 @@
             // timedFetch: 각 시도마다 12s timeout 보장 → fetch hang 시 retry 무한 누적 방지.
             // (audit 2026-05-01 §3-2). retries=0 으로 두고 외부 MAX_SIDE_RETRIES 로 상위 제어.
             const response = await timedFetch(
-                `/api/ads/banners?position=${position}&limit=4`,
+                `/api/sidebar/items?position=${position}&limit=4`,
                 {},
                 { retries: 0 }
             );

--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -70,7 +70,7 @@ async function doFetch(): Promise<void> {
     if (!browser) return;
 
     try {
-        const response = await fetch('/api/ads/celebration/today', {
+        const response = await fetch('/api/celebration/today', {
             method: 'GET',
             headers: { Accept: 'application/json' }
         });

--- a/apps/web/src/routes/api/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/celebration/today/+server.ts
@@ -1,0 +1,4 @@
+// Ad-blocker 회피 alias — EasyList `||*/ads/*` 매칭 회피용.
+// 본체 핸들러는 `/api/ads/celebration/today/+server.ts` 와 동일.
+// 30일 후 기존 path 제거 시 본체를 여기로 이동.
+export { GET } from '../../ads/celebration/today/+server';

--- a/apps/web/src/routes/api/sidebar/items/+server.ts
+++ b/apps/web/src/routes/api/sidebar/items/+server.ts
@@ -1,0 +1,4 @@
+// Ad-blocker 회피 alias — EasyList `||*/ads/*` 매칭 회피용.
+// 본체 핸들러는 `/api/ads/banners/+server.ts` 와 동일.
+// 30일 후 기존 path 제거 시 본체를 여기로 이동.
+export { GET } from '../../ads/banners/+server';


### PR DESCRIPTION
## 증상

prod 사이드바 마음메시지(celebration) 큰 이미지 + 광고 배너가 일부 사용자에게 미표시. 시크릿 모드도 동일.

## 원인 (실측 데이터)

EasyList / EasyList-Korea generic 룰 `||*/ads/*` 가 fetch URL 자체를 브라우저 네트워크 스택에서 차단. ad blocker 확장(uBlock / AdGuard) 사용자한테서 SSR placeholder 가 영원히 유지됨.

| 측정 | 결과 |
|---|---|
| prod SSR HTML | `loading=true` invisible placeholder 만 렌더 (정상 SSR) |
| otel 1H `/api/ads/banners?position=sidebar` | **0 건** |
| otel 1H `/api/ads/celebration/today` | **4 건** (`/api/auth/me` 290 건 대비 70× 적음) |

선례:
- `3b7dd23c` (#1469) + `c266a8eb` (#1490) — **CSS class 만** 회피 (`damoang-banner` → `dm-card`, `media-banner` → `dm-media-card`). **URL path 회피는 미적용**.

## 변경

신규 path 2 개 추가 + 클라 fetch 3 줄 갱신:

| 기존 | 신규 |
|---|---|
| `/api/ads/banners?position=...` | `/api/sidebar/items?position=...` |
| `/api/ads/celebration/today` | `/api/celebration/today` |

- 핸들러 본체는 **그대로 두고** 신규 path 에서 재export (5 줄짜리 shim).
- 클라 fetch URL 3 곳 갱신: `damoang-banner.svelte:143`, `image-text-banner.svelte:134`, `celebration.svelte.ts:73`.
- 기존 `/api/ads/*` path 는 **30 일 후 별도 PR** 에서 제거 — 외부 호출자/SSR cache/CDN rule 위험 최소화.

명명 원칙: EasyList common 키워드(`ads`/`banner`/`promo`/`affiliate`/`sponsor`) 회피 + 도메인 중립어(`sidebar`, `celebration`).

## Test plan

- [ ] canary 배포 후 DevTools Network + ad blocker ON 상태:
  - [ ] `GET /api/sidebar/items?position=sidebar&limit=10` 200
  - [ ] `GET /api/celebration/today` 200
- [ ] 우측 패널 마음메시지 영역 실제 이미지 표시 (invisible placeholder 아님)
- [ ] otel `otel.traces` 신규 path 호출량 정상 자릿수 도달
- [ ] 사용자 본인 브라우저 + 시크릿 모드 모두 표시 확인
- [ ] 기존 `/api/ads/banners` `/api/ads/celebration/today` 도 200 응답 (alias 유지)

## 후속 (별도 PR)

- `/api/ads/promotion-posts` 동일 패턴 마이그
- `/api/v1/expose|click` (aplog 외부 도메인) 차단 여부 측정 후 결정
- 30 일 후 deprecated `/api/ads/*` 제거 PR
- CDN(Cloudflare/CloudFront) cache rule 신규 path 적용 검토 (별도, 사용자 승인 후)