### PR TITLE
fix(sidebar): PC 우측 패널에 마음메시지 작은 롤링 배너 복구

### DIFF
--- a/apps/web/src/lib/components/layout/panel.svelte
+++ b/apps/web/src/lib/components/layout/panel.svelte
@@ -3,6 +3,7 @@
     import { WidgetRenderer } from '$lib/components/widget-renderer';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
+    import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
 </script>
 
@@ -15,6 +16,9 @@
 
     <!-- 공지사항 위젯 (가장 위) -->
     <WidgetRenderer zone="sidebar" onlyIds={['notice']} />
+
+    <!-- 마음메시지 작은 롤링 배너 (공지 아래, 사이드바 배너 위) -->
+    <CelebrationRolling />
 
     <!-- 사이드바 배너 (슬롯 기반) -->
     <PluginSlot name="sidebar-banner" />


### PR DESCRIPTION
## 증상

PC 우측 사이드바의 큰 광고 배너(`dm-media-card`) 위에 있던 작은 마음메시지(축하메시지) 가로 롤링 배너가 안 보임.

## 원인

`panel.svelte`(PC 우측 패널) 에 `CelebrationRolling` 마운트 자체가 없음. 모바일 드로워(`sidebar.svelte:398`, `compact=true` 분기) 에만 마운트되어 있어 PC 사용자한테는 표시 안 됨.

## 변경

`panel.svelte` 의 공지사항(notice widget) 과 `PluginSlot(\"sidebar-banner\")` 사이에 `<CelebrationRolling />` 1 줄 추가. 모바일 드로워와 동일 패턴.

## 위치

- 공지사항 박스
- **마음메시지 롤링 배너** ← 복구
- 큰 광고 배너 (DamoangBanner = 마음메시지 큰 이미지 OR 광고)
- 나머지 사이드바 위젯

## 함께 작동하는 fix

PR #1516 (`/api/celebration/today` ad-blocker URL 회피) 이 머지되어 `CelebrationRolling` 의 fetch 도 ad blocker 사용자에게 정상 도달.

## Test plan

- [ ] PC 브라우저 우측 패널: 공지사항 박스 바로 아래에 가로 9px h 마음메시지 롤링 배너 표시
- [ ] 그 아래 큰 광고 배너(`dm-media-card`) 자리 유지
- [ ] 모바일 드로워: 기존 마음메시지 배너 그대로 (회귀 없음)
- [ ] DevTools Network: `GET /api/celebration/today` 200
- [ ] ad blocker ON 상태에서도 표시 확인 (#1516 와 함께)