### PR TITLE
fix(sidebar): PC 우측 마음메시지 카드 위젯 복구 (PR #1517 revert)

### DIFF
--- a/apps/web/src/lib/components/layout/panel.svelte
+++ b/apps/web/src/lib/components/layout/panel.svelte
@@ -3,7 +3,6 @@
     import { WidgetRenderer } from '$lib/components/widget-renderer';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
-    import { CelebrationRolling } from '$lib/components/ui/celebration-rolling';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
 </script>
 
@@ -17,14 +16,14 @@
     <!-- 공지사항 위젯 (가장 위) -->
     <WidgetRenderer zone="sidebar" onlyIds={['notice']} />
 
-    <!-- 마음메시지 작은 롤링 배너 (공지 아래, 사이드바 배너 위) -->
-    <CelebrationRolling />
+    <!-- 마음메시지 카드 위젯 (공지 아래, 사이드바 배너 위) -->
+    <WidgetRenderer zone="sidebar" onlyIds={['celebration']} />
 
     <!-- 사이드바 배너 (슬롯 기반) -->
     <PluginSlot name="sidebar-banner" />
 
     <!-- 나머지 사이드바 위젯 -->
-    <WidgetRenderer zone="sidebar" excludeIds={['notice']} />
+    <WidgetRenderer zone="sidebar" excludeIds={['notice', 'celebration']} />
 
     <!-- Slot: sidebar-right-bottom -->
     {#each getComponentsForSlot('sidebar-right-bottom') as slotComp (slotComp.id)}

--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -73,10 +73,11 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
 /** 기본 사이드바 위젯 레이아웃 */
 export const DEFAULT_SIDEBAR_WIDGETS: WidgetConfig[] = [
     { id: 'notice', type: 'notice', position: 0, enabled: true },
+    { id: 'celebration', type: 'celebration', position: 1, enabled: true },
     {
         id: 'sidebar-ad-2',
         type: 'ad-slot',
-        position: 1,
+        position: 2,
         enabled: true,
         settings: { position: 'sidebar-2', type: 'image-text', format: 'grid' }
     }

--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -32,7 +32,7 @@
         if (!loaded && browser) {
             // timedFetch: 12s timeout + 1회 retry. hasBanners=false 면 위젯 자체가 미표시되므로
             // silent fail 정책 유지. (audit 2026-05-01 §3-1)
-            timedFetch('/api/ads/celebration/today?mode=recent')
+            timedFetch('/api/celebration/today?mode=recent')
                 .then((r) => r.json())
                 .then((res) => {
                     if (res.success && res.data) {


### PR DESCRIPTION
## 증상

PC 우측 사이드바 공지사항 아래에 옛엔 마음메시지 **3×2 그리드 카드**(축소된 이미지 + 닉 오버레이) 가 표시되었는데 사라짐.

PR #1517 에서 임시로 `CelebrationRolling` (가로 1줄 텍스트) 을 마운트했으나 사용자 의도는 **옛 카드 그리드 형태**(`widgets/celebration/`).

## 원인

`widgets/celebration/` (PR #97 에서 추가된 `celebration-card`, 이후 rename) 이 `DEFAULT_SIDEBAR_WIDGETS` 에서 빠짐. 어느 시점 사이드바 default layout 정리하면서 누락.

## 변경

| 파일 | 변경 |
|---|---|
| `default-widgets.ts` | `DEFAULT_SIDEBAR_WIDGETS` 에 `celebration` widget 복원 (notice 다음 position=1, sidebar-ad-2 → position=2) |
| `panel.svelte` | PR #1517 의 `<CelebrationRolling />` 마운트 제거 → `<WidgetRenderer onlyIds={['celebration']} />` 로 대체. `excludeIds` 에 `'celebration'` 추가 (중복 렌더 방지) |
| `widgets/celebration/index.svelte` | fetch URL `/api/ads/celebration/today` → `/api/celebration/today` (PR #1516 ad-blocker alias 사용) |

## 결과 (PC 우측 사이드바)

- 공지사항 박스
- **마음메시지 3×2 그리드 카드** ← 옛 모습 복구
- 광고 배너 (DamoangBanner)
- 나머지 사이드바 위젯

## Test plan

- [ ] PC 브라우저 우측 패널: 공지사항 아래에 3×2 그리드 카드 (이미지 + 닉 오버레이) 표시
- [ ] DevTools Network + ad blocker ON: `GET /api/celebration/today?mode=recent` 200
- [ ] 텍스트 롤링 줄(PR #1517) 제거 확인
- [ ] 모바일 드로워(sidebar.svelte:398) CelebrationRolling 그대로 (회귀 없음)

## 후속

- 기존 사용자 layout 저장본에는 `celebration` widget 추가 안 됨 — admin 사이드바 layout 페이지에서 수동 추가 또는 reset 필요