### PR TITLE
fix(celebration-widget): grid 6장 → store sync 1장 롤링 + 라벨/컴팩

### DIFF
--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -1,103 +1,75 @@
 <script lang="ts">
-    import { browser } from '$app/environment';
+    import { onMount } from 'svelte';
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
     import { PartyPopper, ChevronRight } from '../lucide.js';
     import type { WidgetConfig } from '$lib/stores/widget-layout.svelte';
-    import { timedFetch } from '$lib/utils/timed-fetch';
-
-    interface Banner {
-        id: number;
-        title: string;
-        content: string;
-        image_url: string;
-        link_url: string;
-        target_member_nick?: string;
-        target_member_photo?: string;
-        display_type: 'image' | 'text';
-    }
+    import {
+        mount,
+        getCelebrations,
+        getCurrentIndex,
+        getLink
+    } from '$lib/stores/celebration.svelte';
 
     interface Props {
         config: WidgetConfig;
         slot?: string;
         isEditMode?: boolean;
-        prefetchData?: { data: Banner[] } | null;
     }
 
-    const { prefetchData = null }: Props = $props();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _props: Props = $props();
 
-    let banners = $state<Banner[]>(prefetchData?.data ?? []);
-    let loaded = $state(!!prefetchData);
+    // 공유 store 마운트 — CelebrationRolling/DamoangBanner 와 동일 currentIndex 로 sync.
+    onMount(() => mount());
 
-    $effect(() => {
-        if (!loaded && browser) {
-            // timedFetch: 12s timeout + 1회 retry. hasBanners=false 면 위젯 자체가 미표시되므로
-            // silent fail 정책 유지. (audit 2026-05-01 §3-1)
-            timedFetch('/api/celebration/today?mode=recent')
-                .then((r) => r.json())
-                .then((res) => {
-                    if (res.success && res.data) {
-                        banners = res.data;
-                    }
-                })
-                .catch(() => {})
-                .finally(() => {
-                    loaded = true;
-                });
-        }
-    });
-
-    // 최대 6개 표시 (3x2 그리드)
-    const displayBanners = $derived(banners.slice(0, 6));
-    const hasBanners = $derived(displayBanners.length > 0);
+    let celebrations = $derived(getCelebrations());
+    let currentIndex = $derived(getCurrentIndex());
+    let current = $derived(celebrations[currentIndex]);
 </script>
 
-{#if hasBanners}
-    <Card class="gap-0">
-        <CardHeader class="flex flex-row items-center justify-between space-y-0 px-4 py-3">
-            <div class="flex items-center gap-2">
-                <PartyPopper class="text-primary h-5 w-5" />
-                <h3 class="text-base font-semibold">축하메시지</h3>
+{#if celebrations.length > 0}
+    <Card class="w-full gap-0 overflow-hidden">
+        <CardHeader class="flex flex-row items-center justify-between space-y-0 px-3 py-2">
+            <div class="flex items-center gap-1.5">
+                <PartyPopper class="text-primary h-4 w-4" />
+                <h3 class="text-sm font-semibold">마음메시지</h3>
             </div>
             <a
                 href="/message"
-                class="text-muted-foreground hover:text-foreground flex items-center gap-1 text-[15px] transition-all duration-200 ease-out"
+                class="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
             >
                 더보기
-                <ChevronRight class="h-4 w-4" />
+                <ChevronRight class="h-3.5 w-3.5" />
             </a>
         </CardHeader>
 
-        <CardContent class="px-4 pb-4">
-            <div class="grid grid-cols-3 gap-2">
-                {#each displayBanners as banner (banner.id)}
-                    <a
-                        href={banner.link_url || `/message/${banner.id}`}
-                        class="group relative overflow-hidden rounded-lg border transition-all duration-200 hover:scale-[1.03] hover:shadow-md"
-                    >
-                        <div class="bg-muted relative aspect-[4/1] overflow-hidden">
-                            {#if banner.image_url}
-                                <img
-                                    src={banner.image_url}
-                                    alt={banner.target_member_nick || '축하메시지'}
-                                    class="h-full w-full object-cover"
-                                    loading="lazy"
-                                />
-                            {:else}
-                                <div class="flex h-full w-full items-center justify-center">
-                                    <PartyPopper class="text-muted-foreground h-6 w-6" />
-                                </div>
-                            {/if}
-                            {#if banner.target_member_nick}
-                                <div
-                                    class="absolute inset-x-0 bottom-0 truncate px-1 py-0.5 text-center text-xs font-bold text-white [text-shadow:_-1px_-1px_0_rgba(0,0,0,0.6),_1px_-1px_0_rgba(0,0,0,0.6),_-1px_1px_0_rgba(0,0,0,0.6),_1px_1px_0_rgba(0,0,0,0.6)]"
-                                >
-                                    {banner.target_member_nick}
-                                </div>
-                            {/if}
+        <CardContent class="p-0">
+            <a href={current ? getLink(current) : '/message'} class="block">
+                <div class="bg-muted relative aspect-[4/1] w-full overflow-hidden">
+                    {#each celebrations as banner, i (banner.id)}
+                        {#if banner.image_url}
+                            <img
+                                src={banner.image_url}
+                                alt={banner.target_member_nick || '마음메시지'}
+                                class="absolute inset-0 h-full w-full object-cover transition-all duration-500 ease-in-out
+                                    {i === currentIndex
+                                    ? 'translate-y-0 opacity-100'
+                                    : i < currentIndex
+                                      ? '-translate-y-full opacity-0'
+                                      : 'translate-y-full opacity-0'}"
+                                loading="lazy"
+                            />
+                        {/if}
+                    {/each}
+                    {#if current?.target_member_nick}
+                        <div
+                            class="absolute inset-x-0 bottom-0 truncate px-1.5 py-0.5 text-center text-xs font-bold text-white [text-shadow:_-1px_-1px_0_rgba(0,0,0,0.6),_1px_-1px_0_rgba(0,0,0,0.6),_-1px_1px_0_rgba(0,0,0,0.6),_1px_1px_0_rgba(0,0,0,0.6)]"
+                        >
+                            {current.target_member_nick}
                         </div>
-                    </a>
-                {/each}
-            </div>
+                    {/if}
+                </div>
+            </a>
         </CardContent>
     </Card>
 {/if}


### PR DESCRIPTION
## 사용자 피드백 (#1518 후속, 누적 4건)

1. "예전엔 이미지만 나왔어 — 롤링으로 되어 있고 text 와 sync"
2. 라벨 '축하메시지' → '마음메시지' (PR #1498 통일)
3. 가로 100%
4. title 컴팩

## 변경

`widgets/celebration/index.svelte` 전면 재작성:

| 항목 | 이전 | 변경 |
|---|---|---|
| 데이터 소스 | 자체 `timedFetch` | 공유 store `\$lib/stores/celebration.svelte` (CelebrationRolling/DamoangBanner 와 sync) |
| 마크업 | grid-cols-3 (6장) | 1장 표시 + `aspect-[4/1] w-full` 큰 이미지 |
| 롤링 | 없음 | currentIndex 기준 translate-y 트랜지션 (celebration-rolling.svelte 의 아바타 sync 패턴) |
| 헤더 라벨 | "축하메시지" | "마음메시지" |
| 헤더 padding | `px-4 py-3` | `px-3 py-2` |
| 아이콘 | `h-5 w-5` | `h-4 w-4` |
| 더보기 | `text-[15px]` | `text-xs h-3.5 w-3.5` |
| Card | `gap-0` | `w-full gap-0 overflow-hidden` |

## 결과 (PC 우측 사이드바)

- 헤더 한 줄: 🎉 마음메시지 ··· 더보기 ›
- 본문: 가로 100% + aspect 4/1 큰 이미지 1장 (2초마다 store sync 롤링)
- 닉네임 외곽선 오버레이 (이미지 하단)
- 동일 시점에 모바일 드로워 CelebrationRolling 텍스트 줄도 같은 banner 표시

## Test plan

- [ ] PC 우측 패널: 가로 100% 카드 1개, 헤더 "마음메시지" + 더보기 컴팩
- [ ] 2초마다 다음 banner 로 translate-y 롤링
- [ ] 모바일 드로워 CelebrationRolling 과 banner 동기화 확인
- [ ] DevTools Network + ad blocker ON: `GET /api/celebration/today` 200
- [ ] 자체 fetch 호출 제거 확인 (`/api/celebration/today?mode=recent` 호출 0)