### PR TITLE
chore(deps): prettier-plugin-svelte 3.2.8 → 3.5.2 (SvelteBoundary 지원)

### DIFF
--- a/apps/web/src/lib/components/widget-renderer/widget-wrapper.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-wrapper.svelte
@@ -104,10 +104,14 @@
               각 widget 의 render throw 가 다른 widget / 페이지 영향 0.
               multi-tenant 빈 사이트 (ipyang/nuna/tektok) 의 widget data null → undefined access 방어.
             -->
-            <svelte:boundary onerror={(err) => console.error('[Widget Boundary]', widget.type, err)}>
+            <svelte:boundary
+                onerror={(err) => console.error('[Widget Boundary]', widget.type, err)}
+            >
                 {@render children()}
                 {#snippet failed(error, reset)}
-                    <div class="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                    <div
+                        class="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
+                    >
                         <p class="font-medium">위젯을 일시적으로 불러올 수 없습니다.</p>
                         <p class="mt-1 text-xs opacity-70">
                             {widget.type}

--- a/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
+++ b/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
@@ -219,9 +219,9 @@
                                                 </Label>
                                                 <Switch
                                                     id={`${category}-${key}`}
-                                                    bind:checked={settings[category][
-                                                        key
-                                                    ] as boolean}
+                                                    bind:checked={
+                                                        settings[category][key] as boolean
+                                                    }
                                                 />
                                             </div>
                                         {/if}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "husky": "^8.0.3",
         "lint-staged": "^15.0.0",
         "prettier": "3.3.3",
-        "prettier-plugin-svelte": "3.2.8",
+        "prettier-plugin-svelte": "3.5.2",
         "prettier-plugin-tailwindcss": "^0.5.6",
         "three": "^0.171.0",
         "typescript": "^5.0.0"

--- a/plugins/affiliate-link/components/affiliate-badge.svelte
+++ b/plugins/affiliate-link/components/affiliate-badge.svelte
@@ -23,11 +23,7 @@
     const platformName = $derived(platformNames[platform] || platform);
 </script>
 
-<span
-    class="affiliate-badge"
-    title="{platformName} 제휴 링크"
-    data-platform={platform}
->
+<span class="affiliate-badge" title="{platformName} 제휴 링크" data-platform={platform}>
     {#if showIcon}
         <span class="affiliate-badge-icon">💰</span>
     {/if}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,11 +58,11 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       prettier-plugin-svelte:
-        specifier: 3.2.8
-        version: 3.2.8(prettier@3.3.3)(svelte@5.53.6)
+        specifier: 3.5.2
+        version: 3.5.2(prettier@3.3.3)(svelte@5.53.6)
       prettier-plugin-tailwindcss:
         specifier: ^0.5.6
-        version: 0.5.14(prettier-plugin-svelte@3.2.8(prettier@3.3.3)(svelte@5.53.6))(prettier@3.3.3)
+        version: 0.5.14(prettier-plugin-svelte@3.5.2(prettier@3.3.3)(svelte@5.53.6))(prettier@3.3.3)
       three:
         specifier: ^0.171.0
         version: 0.171.0
@@ -4629,8 +4629,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-svelte@3.2.8:
-    resolution: {integrity: sha512-PAHmmU5cGZdnhW4mWhmvxuG2PVbbHIxUuPOdUKvfE+d4Qt2d29iU5VWrPdsaW5YqVEE0nqhlvN4eoKmVMpIF3Q==}
+  prettier-plugin-svelte@3.5.2:
+    resolution: {integrity: sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: '>=5.53.5'
@@ -10565,16 +10565,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.2.8(prettier@3.3.3)(svelte@5.53.6):
+  prettier-plugin-svelte@3.5.2(prettier@3.3.3)(svelte@5.53.6):
     dependencies:
       prettier: 3.3.3
       svelte: 5.53.6
 
-  prettier-plugin-tailwindcss@0.5.14(prettier-plugin-svelte@3.2.8(prettier@3.3.3)(svelte@5.53.6))(prettier@3.3.3):
+  prettier-plugin-tailwindcss@0.5.14(prettier-plugin-svelte@3.5.2(prettier@3.3.3)(svelte@5.53.6))(prettier@3.3.3):
     dependencies:
       prettier: 3.3.3
     optionalDependencies:
-      prettier-plugin-svelte: 3.2.8(prettier@3.3.3)(svelte@5.53.6)
+      prettier-plugin-svelte: 3.5.2(prettier@3.3.3)(svelte@5.53.6)
 
   prettier@2.8.8: {}
 

--- a/themes/wiki-theme/components/wiki-footer.svelte
+++ b/themes/wiki-theme/components/wiki-footer.svelte
@@ -11,8 +11,7 @@
                 <h4 class="text-foreground mb-3 text-sm font-semibold">둘러보기</h4>
                 <ul class="space-y-2">
                     <li>
-                        <a href="/" class="text-muted-foreground hover:text-primary text-sm"
-                            >대문</a
+                        <a href="/" class="text-muted-foreground hover:text-primary text-sm">대문</a
                         >
                     </li>
                     <li>

--- a/themes/wiki-theme/components/wiki-sidebar.svelte
+++ b/themes/wiki-theme/components/wiki-sidebar.svelte
@@ -58,7 +58,9 @@
                 <li>
                     <a
                         href="/"
-                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive('/') ? 'bg-primary/10 text-primary font-medium' : 'text-foreground hover:bg-muted'}"
+                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive('/')
+                            ? 'bg-primary/10 text-primary font-medium'
+                            : 'text-foreground hover:bg-muted'}"
                     >
                         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path
@@ -74,7 +76,11 @@
                 <li>
                     <a
                         href="/wiki/Special:RecentChanges"
-                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive('/wiki/Special:RecentChanges') ? 'bg-primary/10 text-primary font-medium' : 'text-foreground hover:bg-muted'}"
+                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive(
+                            '/wiki/Special:RecentChanges'
+                        )
+                            ? 'bg-primary/10 text-primary font-medium'
+                            : 'text-foreground hover:bg-muted'}"
                     >
                         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path
@@ -90,7 +96,11 @@
                 <li>
                     <a
                         href="/wiki/Special:Random"
-                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive('/wiki/Special:Random') ? 'bg-primary/10 text-primary font-medium' : 'text-foreground hover:bg-muted'}"
+                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive(
+                            '/wiki/Special:Random'
+                        )
+                            ? 'bg-primary/10 text-primary font-medium'
+                            : 'text-foreground hover:bg-muted'}"
                     >
                         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path
@@ -121,10 +131,20 @@
                         <li>
                             <a
                                 href="/wiki{recentPage.path}"
-                                class="group flex flex-col rounded-lg px-3 py-1.5 text-sm {isActive(`/wiki${recentPage.path}`) ? 'bg-primary/10' : 'hover:bg-muted'}"
+                                class="group flex flex-col rounded-lg px-3 py-1.5 text-sm {isActive(
+                                    `/wiki${recentPage.path}`
+                                )
+                                    ? 'bg-primary/10'
+                                    : 'hover:bg-muted'}"
                             >
-                                <span class="{isActive(`/wiki${recentPage.path}`) ? 'text-primary font-medium' : 'text-foreground'} truncate">{recentPage.title}</span>
-                                <span class="text-muted-foreground text-xs">{formatRelativeTime(recentPage.updated_at)}</span>
+                                <span
+                                    class="{isActive(`/wiki${recentPage.path}`)
+                                        ? 'text-primary font-medium'
+                                        : 'text-foreground'} truncate">{recentPage.title}</span
+                                >
+                                <span class="text-muted-foreground text-xs"
+                                    >{formatRelativeTime(recentPage.updated_at)}</span
+                                >
                             </a>
                         </li>
                     {/each}
@@ -145,7 +165,11 @@
                 <li>
                     <a
                         href="/wiki/Special:AllPages"
-                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive('/wiki/Special:AllPages') ? 'bg-primary/10 text-primary font-medium' : 'text-foreground hover:bg-muted'}"
+                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive(
+                            '/wiki/Special:AllPages'
+                        )
+                            ? 'bg-primary/10 text-primary font-medium'
+                            : 'text-foreground hover:bg-muted'}"
                     >
                         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path
@@ -161,7 +185,11 @@
                 <li>
                     <a
                         href="/wiki/Help:Contents"
-                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive('/wiki/Help:Contents') ? 'bg-primary/10 text-primary font-medium' : 'text-foreground hover:bg-muted'}"
+                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive(
+                            '/wiki/Help:Contents'
+                        )
+                            ? 'bg-primary/10 text-primary font-medium'
+                            : 'text-foreground hover:bg-muted'}"
                     >
                         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path
@@ -188,7 +216,11 @@
                 <li>
                     <a
                         href="/wiki/Wikiang:Portal"
-                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive('/wiki/Wikiang:Portal') ? 'bg-primary/10 text-primary font-medium' : 'text-foreground hover:bg-muted'}"
+                        class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm {isActive(
+                            '/wiki/Wikiang:Portal'
+                        )
+                            ? 'bg-primary/10 text-primary font-medium'
+                            : 'text-foreground hover:bg-muted'}"
                     >
                         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path


### PR DESCRIPTION
## 증상

매 PR 의 CI 잡 \"Prettier Suggestions\" 가 advisory fail. 원인:

```
[error] src/lib/components/widget-renderer/widget-wrapper.svelte:
Error: unknown node type: SvelteBoundary
```

prettier-plugin-svelte 3.2.8 이 Svelte 5 의 `<svelte:boundary>` 노드 미지원.

## 변경

- `package.json`: `prettier-plugin-svelte` 3.2.8 → 3.5.2 (마지막 3.x, major bump 회피)
- `pnpm-lock.yaml`: 갱신
- `prettier --write` 전수 적용 → 5 svelte 파일 long-attr wrap 등 minor 포맷:
  - `widget-renderer/widget-wrapper.svelte` (svelte:boundary 자체 + 내부 div)
  - `admin/themes/[id]-settings/+page.svelte`
  - `affiliate/components/affiliate-badge.svelte`
  - `themes/wiki-theme/components/{wiki-footer,wiki-sidebar}.svelte`

## 효과

- CI \"Prettier Suggestions\" advisory 잡 통과 가능
- 동작 변경 0 (포맷만)

## Test plan

- [ ] CI \"Prettier Suggestions\" 잡 pass
- [ ] svelte-check 0 error (43 파일 검증 통과)
- [ ] widget-wrapper.svelte 의 svelte:boundary 동작 그대로 (포맷만 변경)