### PR TITLE
feat(comments): 댓글 수정 정책 single-source — backend env 기반 응답 통합

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -122,7 +122,7 @@
         // - 대댓글 없는 댓글: 항상 무료 수정 (grace 무관)
         // - 대댓글 달린 댓글: cost 포인트 차감 + 수정 이력 카운트 표시
         // grace_seconds 는 호환을 위해 남겨두지만 신규 정책에서 사용하지 않는다.
-        editPolicy = { cost: 5000, grace_seconds: 360 }
+        editPolicy = { cost: 50000, grace_seconds: 300 }
     }: Props = $props();
 
     function findCommentById(commentId: string): FreeComment | null {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -339,7 +339,10 @@ export const load: PageServerLoad = async ({
                     total: data.total || 0,
                     page: data.page || 1,
                     limit: data.limit || initialCommentsLimit,
-                    total_pages: data.total_pages || 1
+                    total_pages: data.total_pages || 1,
+                    edit_policy: json.meta?.comment_edit_policy as
+                        | { cost: number; grace_seconds: number }
+                        | undefined
                 };
             });
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -331,6 +331,10 @@
     // 댓글/프로모션/리비전 — Streaming SSR (2단계 데이터)
     let comments = $state<FreeComment[]>(data.commentsData?.comments.items || []);
     let commentsTotal = $state<number>(data.commentsData?.comments.total || comments.length);
+    // 댓글 수정 정책 — backend 단일 출처. proxy 응답의 meta.comment_edit_policy 에서 전달.
+    let commentEditPolicy = $state<{ cost: number; grace_seconds: number } | undefined>(
+        data.commentsData?.comments.edit_policy
+    );
     let truthroomCommentMap = $state<Record<number, number>>({});
     let promotionPosts = $state<PromotionPost[]>([]);
     let revisions = $state<PostRevision[]>([]);
@@ -1974,6 +1978,7 @@
                             {initialDislikedCommentIds}
                             {truthroomCommentMap}
                             isRestricted={data.isRestricted}
+                            editPolicy={commentEditPolicy}
                         />
                     {/if}
                     <!-- 플러그인 슬롯: 댓글 영역 직후 — Slot Catalog Sprint 2c -->

--- a/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
+++ b/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
@@ -219,9 +219,9 @@
                                                 </Label>
                                                 <Switch
                                                     id={`${category}-${key}`}
-                                                    bind:checked={
-                                                        settings[category][key] as boolean
-                                                    }
+                                                    bind:checked={settings[category][
+                                                        key
+                                                    ] as boolean}
                                                 />
                                             </div>
                                         {/if}

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -297,6 +297,14 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
                 page: effectivePage,
                 limit,
                 total_pages: totalPages
+            },
+            // 댓글 수정 정책 (단일 출처: env). 프론트 confirm 다이얼로그/차감 안내에서 사용.
+            // 기본값은 backend 의 getCommentEditPolicy() 와 일치 (50000P / 300s).
+            meta: {
+                comment_edit_policy: {
+                    cost: Number(process.env.COMMENT_EDIT_COST ?? 50000),
+                    grace_seconds: Number(process.env.COMMENT_EDIT_GRACE_SECONDS ?? 300)
+                }
             }
         });
     } catch (error) {

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/angple/web/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/angple/web/node_modules


### PR DESCRIPTION
## Context

댓글 수정 정책 (operator decision 2026-05-25):
- 대댓글 없는 댓글: 자유 수정
- 대댓글 있고 5분 이내: 무료
- 대댓글 있고 5분 초과: **50,000 P 차감**
- 수정 시 수정날짜 + n회 수정 표시

## 현황

- **backend** (\`cmd/api/main.go:130-154,3424-3606\`): 정책 default \`COMMENT_EDIT_COST=50000\`, \`COMMENT_EDIT_GRACE_SECONDS=300\` 환경변수 기반으로 **이미 완전 구현** (차감 + 환불 + 이력 추적 + 관리자 면제)
- **SvelteKit proxy** (\`comments/+server.ts\`): SSR 에서 자체 DB 조회로 응답 build → backend 의 \`meta.comment_edit_policy\` 가 클라이언트까지 도달 안 함
- **프론트** \`comment-list.svelte:125\` fallback default = cost 5000, grace 360s → backend default(50000/300) 와 **불일치**
- **CommentList 호출** (\`+page.svelte:1959\`): \`editPolicy\` props 전달 0 → fallback 만 사용

## 변경

| 파일 | 변경 |
|---|---|
| \`api/boards/.../comments/+server.ts\` | 응답에 \`meta.comment_edit_policy\` 추가 (env 우선, default 50000/300) |
| \`[boardId]/[postId]/+page.server.ts\` | proxy meta 의 \`comment_edit_policy\` 를 \`commentsData.comments.edit_policy\` 로 보존 |
| \`[boardId]/[postId]/+page.svelte\` | \`commentEditPolicy\` state + \`<CommentList editPolicy={commentEditPolicy} />\` |
| \`comment-list.svelte:125\` | fallback default 5000→50000, 360→300 |

## 운영 작업 (별도, 사용자 결정)

frontend pod 의 ConfigMap 에 backend 와 동일한 env 키 설정 권장:
\`\`\`
COMMENT_EDIT_COST=50000
COMMENT_EDIT_GRACE_SECONDS=300
\`\`\`

설정 안 해도 default 가 backend 와 일치 → 동작 정상.

## Test plan

- [ ] canary 게시글 진입 → DevTools Network 댓글 응답에 \`meta.comment_edit_policy: { cost: 50000, grace_seconds: 300 }\` 포함
- [ ] 5분 이내 본인 댓글 수정 → 무료
- [ ] 5분 외 + 대댓글 없는 댓글 수정 → 무료
- [ ] 5분 외 + 대댓글 있는 댓글 수정 → 50,000P 차감 확인 dialog → 차감 후 수정 완료
- [ ] 수정 후 "수정됨 (1회) · {timestamp}" 표시
- [ ] 포인트 부족 시 403
- [ ] 관리자 면제

## 후속

- 글(post) 수정에도 동일 정책 적용 검토 (별도 PR)
- 정책 조정 admin UI (장기 과제)
- #12511 / #12534 root cause 별도 조사