### PR TITLE
feat(comments): 댓글 수정 confirm window.confirm → shadcn Dialog (모바일 호환성)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
     import { Button } from '$lib/components/ui/button/index.js';
+    import {
+        Dialog,
+        DialogContent,
+        DialogDescription,
+        DialogFooter,
+        DialogHeader,
+        DialogTitle
+    } from '$lib/components/ui/dialog/index.js';
     import type { FreeComment } from '$lib/api/types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
@@ -167,6 +175,9 @@
     // 수정 상태 관리
     let editingCommentId = $state<string | null>(null);
     let editContent = $state('');
+    // 수정 확인 dialog — 대댓글 있는 댓글 수정 시 차감 안내 (모바일 window.confirm 호환성 #12511)
+    let editConfirmOpen = $state(false);
+    let pendingEditTarget = $state<FreeComment | null>(null);
     let isUpdating = $state(false);
     let LazyCommentEditor = $state<Component | null>(null);
     let isDeleting = $state<string | null>(null);
@@ -474,19 +485,31 @@
         const replyExists = !isAdmin() && hasReplies(target);
 
         if (replyExists && editPolicy.cost > 0) {
-            const costFmt = editPolicy.cost.toLocaleString('ko-KR');
-            const msg =
-                `⚠️ 이 댓글에는 대댓글이 달려 있습니다.\n` +
-                `대화 맥락이 바뀔 수 있어 수정 시 ${costFmt} 포인트가 차감되며,\n` +
-                `수정 시각과 수정 횟수가 모든 사용자에게 표시됩니다.\n\n` +
-                `계속 진행하시겠습니까?`;
-            if (!window.confirm(msg)) return;
+            // 모바일 호환성을 위해 shadcn Dialog 사용 (window.confirm 대체, #12511).
+            pendingEditTarget = target;
+            editConfirmOpen = true;
+            return;
         }
 
+        enterEdit(target);
+    }
+
+    function enterEdit(target: FreeComment): void {
         editingCommentId = String(target.id);
         editContent = target.content;
         replyingToCommentId = null;
         ensureEditEditorLoaded();
+    }
+
+    function handleEditConfirm(): void {
+        if (pendingEditTarget) enterEdit(pendingEditTarget);
+        pendingEditTarget = null;
+        editConfirmOpen = false;
+    }
+
+    function handleEditCancel(): void {
+        pendingEditTarget = null;
+        editConfirmOpen = false;
     }
 
     // 수정 취소
@@ -1871,6 +1894,31 @@
         onClose={closeLikersDialog}
     />
 {/if}
+
+<!-- 대댓글 있는 댓글 수정 확인 dialog (모바일 호환성, window.confirm 대체 — #12511) -->
+<Dialog
+    bind:open={editConfirmOpen}
+    onOpenChange={(o) => {
+        if (!o) handleEditCancel();
+    }}
+>
+    <DialogContent>
+        <DialogHeader>
+            <DialogTitle>댓글 수정 안내</DialogTitle>
+            <DialogDescription>
+                이 댓글에는 대댓글이 달려 있습니다. 대화 맥락이 바뀔 수 있어 수정 시 <strong
+                    >{editPolicy.cost.toLocaleString('ko-KR')} 포인트</strong
+                >가 차감되며, 수정 시각과 수정 횟수가 모든 사용자에게 표시됩니다.
+            </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+            <Button variant="outline" onclick={handleEditCancel}>취소</Button>
+            <Button variant="destructive" onclick={handleEditConfirm}>
+                {editPolicy.cost.toLocaleString('ko-KR')} P 차감하고 수정
+            </Button>
+        </DialogFooter>
+    </DialogContent>
+</Dialog>
 
 <style>
     /* 댓글 내 iframe/video 폭 제한 (인라인 width/height 속성 오버라이드) */


### PR DESCRIPTION
## 증상

- #12511 (5/25, 모바일/스타곤): "댓글 작성 후 바로 수정 눌렀는데 안 됨"
- #12534 (5/30): "댓글 수정이 되지 않습니다"

## 조사 결과

backend / revisions 모두 정상 작동 (revisions 527K + 5/30 11:37까지 update/create 활발). 신고자(슈니, 사자바람연꽃) 모두 신고 후 정상 사용 회복.

가설: `startEdit` 의 `window.confirm` 다이얼로그가 모바일 일부 브라우저(WebView/스타곤 등) 에서 미작동/무시되는 호환성 문제 가능성. native confirm 은 PWA/in-app browser 에서 차단되거나 무시되는 사례 존재.

## 변경

`comment-list.svelte`:
- shadcn-svelte `Dialog` 시리즈 import
- state: `editConfirmOpen` + `pendingEditTarget`
- `startEdit` — `window.confirm` 제거, 조건 충족 시 dialog open
- 신규 함수: `enterEdit` (공통 진입), `handleEditConfirm`, `handleEditCancel`
- Dialog 마크업 ("댓글 수정 안내" + 차감액 명시 + 취소/destructive 차감 버튼)

## 효과

- 모든 브라우저(특히 모바일) 에서 일관된 dialog UX
- destructive 버튼 + 차감액 명시로 사용자 인지 강화
- PR #1522 single-source 정책과 일관된 메시지

## Test plan

- [ ] PC: 5분 외 + 대댓글 있는 댓글 수정 → dialog 표시, 취소/차감 동작 정상
- [ ] **모바일 브라우저(스타곤, in-app browser)** : 동일 dialog 표시 확인
- [ ] dialog 외부 클릭 → onOpenChange 통해 cancel 처리 확인
- [ ] 대댓글 없는 댓글 / 5분 이내 / 관리자 → dialog 없이 즉시 수정 진입
- [ ] 차감액 표시 = backend env 정책 (50,000P default)

## 후속

- #12511 / #12534 후속 안내 댓글 (별도)