### PR TITLE
fix(comments): refetchComments URL cache buster — 모바일 in-app webview (#12548)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1234,9 +1234,20 @@
         // 브라우저 HTTP 캐시 / SvelteKit data 캐시가 옛 응답을 반환하면 optimistic
         // update 로 추가된 새 댓글이 덮어써져 "댓글이 바로 안 보인다" (#12294) 가
         // 재현되므로 no-store 로 캐시를 우회한다.
+        //
+        // 추가 보강 (#12548): 카카오톡 등 모바일 in-app webview 는 cache 헤더를
+        // 무시하는 사례가 있어 URL cache buster (`_t=${Date.now()}`) 로 강제 우회.
+        // SW (service worker) 가 가로채는 케이스도 동일하게 URL 변화로 회피.
+        const cacheBuster = Date.now();
         const res = await fetch(
-            `/api/boards/${boardId}/posts/${data.post.id}/comments?page=1&limit=200`,
-            { cache: 'no-store', headers: { 'Cache-Control': 'no-cache' } }
+            `/api/boards/${boardId}/posts/${data.post.id}/comments?page=1&limit=200&_t=${cacheBuster}`,
+            {
+                cache: 'no-store',
+                headers: {
+                    'Cache-Control': 'no-cache, no-store, must-revalidate',
+                    Pragma: 'no-cache'
+                }
+            }
         );
         const json = await res.json();
         if (json.success) {


### PR DESCRIPTION
## 증상

#12548 (sltx, kakao_8e0f0895, 5/30 17:00): "댓글 작성 후 바로 보이지 않습니다. 새로고침해야 보입니다."

## 조사 (실측)

- prod sha = `e2c26ba-p224d575` (오늘 PR 9건 모두 반영)
- sltx 댓글 `car/137983` = 16:57:51 **DB INSERT 정상** (wr_parent=137951, 8번째 댓글)
- 신고는 16:57 작성 후 3분 30초 뒤 (17:00)
- 본인 화면만 미표시 = refetchComments 응답 stale 캐시 가능성
- 신고자 kakao_* OAuth → **카카오톡 인앱 webview 사용 가능성 매우 높음**

## 기존 fix (#12294) 한계

`refetchComments` 가 이미 `cache: 'no-store'` + `Cache-Control: no-cache` 사용 중. 그러나 카카오톡/네이버앱/페이스북 인앱 등 일부 모바일 webview 는 이 헤더를 무시.

## 변경

`refetchComments` URL 에 cache buster query 추가:
- `?page=1&limit=200&_t=${Date.now()}`
- 헤더 강화: `Cache-Control: no-cache, no-store, must-revalidate` + `Pragma: no-cache`

URL 자체가 매번 달라지므로 어떤 cache layer (browser/CDN/SW) 도 이전 응답 재사용 불가.

## Test plan

- [ ] PC: 댓글 작성 → 즉시 표시 (회귀 없음)
- [ ] 모바일 카카오톡 인앱: 댓글 작성 → 즉시 표시
- [ ] 모바일 네이버앱 인앱: 동일
- [ ] DevTools Network: `/api/boards/.../comments?...&_t=...` 매 요청 URL 다름
- [ ] CDN 부담 증가 없음 (어차피 no-store 응답)