### PR TITLE
fix(board): RecentPosts(본문 하단 목록) layout fallback 을 board list 와 동기화

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -66,8 +66,14 @@
         displaySettings
     }: Props = $props();
 
-    // 게시판 레이아웃 설정에 따라 레이아웃 컴포넌트 resolve
-    const listLayoutId = $derived(displaySettings?.list_layout || 'compact');
+    // 게시판 레이아웃 설정에 따라 레이아웃 컴포넌트 resolve.
+    // board list 페이지(`[boardId]/+page.svelte:614`) 와 동일한 fallback 사용:
+    //   list_layout → list_style (legacy) → 'classic'.
+    // 이전엔 fallback 'compact' + list_style 무시여서 같은 게시판에서 본문 하단
+    // 목록과 게시판 목록이 다른 layout 으로 표시되었음.
+    const listLayoutId = $derived(
+        displaySettings?.list_layout || displaySettings?.list_style || 'classic'
+    );
     const layoutEntry = $derived(layoutRegistry.resolveList(listLayoutId));
     const LayoutComponent = $derived(layoutEntry?.component || CompactLayout);
     const wrapperClass = $derived(layoutEntry?.manifest.wrapperClass || 'space-y-1');


### PR DESCRIPTION
## 증상

같은 게시판인데 본문 하단의 RecentPosts(글 상세 페이지) 와 게시판 목록 페이지(`/{boardId}`) 가 서로 다른 layout 으로 표시.

## 원인 (실측)

| 위치 | `listLayoutId` 결정 |
|---|---|
| `[boardId]/+page.svelte:614` (board list) | `list_layout` → `list_style` (legacy) → **`'classic'`** |
| `recent-posts.svelte:70` (post 하단) | `list_layout` → **`'compact'`** (단일 fallback, list_style 무시) |

영향 받는 board:
1. `list_style` 만 설정 + `list_layout` 미설정 → board list 는 list_style 적용, RecentPosts 는 무시
2. 둘 다 미설정 → board list = classic, RecentPosts = compact (완전히 다른 모습)

## 변경

`recent-posts.svelte:70` 1 곳, board list 와 동일 fallback 적용:

```diff
- const listLayoutId = $derived(displaySettings?.list_layout || 'compact');
+ const listLayoutId = $derived(
+     displaySettings?.list_layout || displaySettings?.list_style || 'classic'
+ );
```

## 비용/트래픽 영향

- API / DB query: **0**
- CDN: **0** (응답 schema 동일)
- bundle 크기: **0** (두 layout 모두 이미 import)

## Test plan

- [ ] `list_layout` 명시 설정한 board: 회귀 없음 (display_settings 값 그대로 사용)
- [ ] `list_style` 만 설정한 board: 본문 하단 목록 = board list 페이지 layout 동일
- [ ] 둘 다 미설정 board: 양쪽 모두 classic
- [ ] uiSettingsStore.listView modern/classic 토글 정상 동작

## 후속 (별도 PR)

- 두 컴포넌트가 동일 helper(`resolveBoardListLayout(displaySettings)`) 공유하도록 refactor