### PR TITLE
fix(member-settings): 소셜 계정 해제 CSRF 헤더 누락 (#12298/#12545)

### DIFF
--- a/apps/web/src/routes/member/settings/+page.svelte
+++ b/apps/web/src/routes/member/settings/+page.svelte
@@ -153,10 +153,20 @@
         disconnecting = mpNo;
         error = null;
 
+        // CSRF: hooks.server.ts 가 모든 state-changing POST 에서 검증 (#12298/#12545).
+        // angple_csrf cookie 값을 X-CSRF-Token 헤더로 전송해야 403 안 남.
+        const csrfToken = document.cookie
+            .split('; ')
+            .find((c) => c.startsWith('angple_csrf='))
+            ?.split('=')[1];
+
         try {
             const response = await fetch('/member/settings/social', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {})
+                },
                 body: JSON.stringify({ mp_no: mpNo })
             });
 


### PR DESCRIPTION
## 증상

3주간 미해결 신고:
- **#12298** (5/10, 확인중): "csrf 토큰 유효하지 않음" 에러로 소셜 계정 해제 실패
- **#12545** (5/30, 미처리): 동일 증상 재신고 — 처리 지연으로 사용자 불만

## Root cause (실측)

`member/settings/+page.svelte:157` 의 fetch 호출이 `X-CSRF-Token` 헤더를 보내지 않음:

```ts
fetch('/member/settings/social', {
    method: 'POST',
    headers: { 'Content-Type': 'application/json' },  // ← CSRF 헤더 누락
    body: JSON.stringify({ mp_no: mpNo })
});
```

`hooks.server.ts:762` 가 모든 state-changing POST 에 `X-CSRF-Token` header 또는 `_csrf` form value 검증 → 둘 다 없으면 403.

## 변경

`document.cookie` 에서 `angple_csrf` 쿠키 값을 읽어 `X-CSRF-Token` 헤더로 전송. 이미 `apiClient.client.ts:175` 가 같은 패턴 사용 중 (이번 호출은 apiClient 우회하는 직접 fetch).

## Test plan

- [ ] 로그인 후 `/member/settings` 진입
- [ ] 연결된 소셜 계정 2개 이상 보유 상태
- [ ] '해제' 버튼 클릭 → 성공 응답 + 목록에서 제거
- [ ] 마지막 1개 남은 소셜 → "마지막 소셜 계정은 해제할 수 없습니다" (기존 동작)
- [ ] CSRF cookie 없을 때 (드문 케이스) 기존과 동일하게 동작 (헤더만 미포함)

## 후속

- 다른 직접 fetch 호출자 점검 (grep 결과 이 endpoint 만 해당)
- 장기 — apiClient 통일 시 자동 CSRF 헤더 적용