### PR TITLE
fix(ad-slot): 광고 iframe/img max-width 100% — 모바일 잘림 (#12411)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -377,6 +377,15 @@
         min-height: var(--ad-slot-min-height);
         /* transition은 inline style로 통일 (0ms) — CLS 방지 위해 즉시 적용 */
     }
+    /* #12411: 모바일 좁은 viewport 에서 광고 크리에이티브가 컨테이너 폭을 초과해
+       overflow-hidden 으로 좌/우 잘리는 문제 fix. 광고 iframe/img/ins 자식 요소를
+       컨테이너 폭에 맞추도록 max-width 강제 (AdSense/GAM/Adfit 공통). */
+    .dm-display-frame :global(iframe),
+    .dm-display-frame :global(img),
+    .dm-display-frame :global(ins.adsbygoogle) {
+        max-width: 100% !important;
+        height: auto;
+    }
     .dm-display-slot {
         min-height: var(--ad-slot-min-height);
     }


### PR DESCRIPTION
## 증상

#12411 (nemose, 5/15): 모바일 삼성인터넷 세로보기에서 게시글 + 댓글 사이 구글 광고 좌/우 잘림. 신고자가 5/20 정확한 URL [damoang.net/free/6303999](https://damoang.net/free/6303999) + 첨부 스크린샷 제공.

## Root cause (실측)

`ad-slot.svelte:345`:
```svelte
class="dm-display-frame relative overflow-hidden rounded-lg ..."
```

`overflow-hidden` + 모바일 좁은 viewport (~360-414px) 에서 광고 크리에이티브 (AdSense/GAM responsive) 가 컨테이너 폭 초과 시 좌/우 잘림.

## 변경

`.dm-display-frame` 의 자식 광고 요소에 `max-width: 100%` 강제:

```css
.dm-display-frame :global(iframe),
.dm-display-frame :global(img),
.dm-display-frame :global(ins.adsbygoogle) {
    max-width: 100% !important;
    height: auto;
}
```

## Test plan

- [ ] PC 데스크탑 광고: 회귀 없음 (기존 폭 그대로)
- [ ] 모바일 (~360px viewport) + 글 본문 사이 광고: 좌/우 잘림 없이 컨테이너 폭에 fit
- [ ] AdSense responsive: 광고 표시 정상 (수익 영향 0)
- [ ] CLS: min-height var 유지 → 미영향
- [ ] Adfit (카카오) 광고: 동일하게 fit

## 영향

- 광고 수익: 영향 없음 (광고는 표시됨, 크기만 fit)
- 모바일 UX: 잘림 해소