### PR TITLE
fix(comments): 댓글 유튜브 임베드 아래 공백 (#12526)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -2122,6 +2122,18 @@
         min-height: 1em;
     }
 
+    /* #12526: .embed-container 안의 youtube iframe specificity 보강.
+       이전엔 `.comment-body iframe[src*='youtube']` (specificity 0,0,2,1) 의
+       `height: auto !important` 가 `.embed-container iframe` (0,0,1,1) 의
+       `height: 100% !important` 를 이겨, iframe 이 intrinsic 작은 height 로
+       떨어지면서 16:9 padding-bottom placeholder 박스 안에 큰 빈 공간 발생.
+       embed-container 안에서는 placeholder 가 비율을 잡으므로 iframe 은 fill,
+       aspect-ratio 강제는 해제. */
+    :global(.comment-body .embed-container iframe) {
+        height: 100% !important;
+        aspect-ratio: unset !important;
+    }
+
     /* 댓글 코드 블록 스타일 (게시글 본문 .prose와 동일) */
     :global(.comment-body pre) {
         background-color: var(--muted);


### PR DESCRIPTION
## 증상

#12526 (ThinkMoon, 5/29): 댓글에 유튜브 영상 임베드 시 영상 아래 큰 공백.

사용자 제공 마크업:
```html
<div class="comment-body ...">
  <p>조재윤 배우인가요?</p>
  <p></p>
  <div class="embed-container" data-platform="youtube">
    <iframe src="https://www.youtube.com/embed/Jd96a_U3_mU?start=37"></iframe>
  </div>
  <p></p>
</div>
```

## Root cause (실측)

CSS specificity 충돌:

| 선언 | specificity | height |
|---|---|---|
| `.comment-body iframe[src*='youtube']` | **0,0,2,1** | `auto !important` |
| `.embed-container iframe` | 0,0,1,1 | `100% !important` |

높은 specificity 의 `height: auto` 가 우선 → iframe 이 intrinsic 작은 height 로 떨어짐. `.embed-container::before` 의 `padding-bottom: 56.25%` placeholder 박스만 큰 사이즈 남음 → iframe 아래 큰 빈 영역.

## 변경

`.comment-body .embed-container iframe` 룰 추가 (specificity 0,0,2,1 동일, 선언 순서 후순위 → 우선 적용):
- `height: 100% !important` — placeholder 박스 fill
- `aspect-ratio: unset !important` — placeholder 가 비율 잡으므로 중복 강제 제거

## Test plan

- [ ] 댓글 유튜브 영상 임베드 → 영상 박스 16:9 + 아래 공백 없음
- [ ] youtube-shorts (9:16) → 350px max-width + 정상 fill
- [ ] vimeo / 다른 platform → 정상
- [ ] embed-container 외부 직접 iframe (드물지만) → 기존 16:9 룰 그대로
- [ ] #12258 (gif/동영상 댓글 공간 에러) 도 동일 영역 — 동시 해결 가능성