### PR TITLE
feat(board): 이용제한 글 목록 작은 Badge 표시

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import {
+        RestrictedBadge,
+        isRestrictedTitle
+    } from '$lib/components/ui/restricted-badge/index.js';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
@@ -116,6 +120,9 @@
                                         {@html highlightQuery(post.title, searchQuery)}
                                     {:else}
                                         {post.title}
+                                    {/if}
+                                    {#if isRestrictedTitle(post.title)}
+                                        <RestrictedBadge class="ml-1" />
                                     {/if}
                                 </CardTitle>
                                 <div

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import {
+        RestrictedBadge,
+        isRestrictedTitle
+    } from '$lib/components/ui/restricted-badge/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
     import ImageIcon from '@lucide/svelte/icons/image';
@@ -223,6 +227,9 @@
                                 {post.title}
                             {/if}
                         </span>
+                        {#if isRestrictedTitle(post.title)}
+                            <RestrictedBadge class="ml-1 shrink-0" />
+                        {/if}
                         {#if isNew}
                             <span class="text-liked shrink-0 text-[10px] font-bold">N</span>
                         {/if}

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import {
+        RestrictedBadge,
+        isRestrictedTitle
+    } from '$lib/components/ui/restricted-badge/index.js';
     import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
@@ -100,6 +104,9 @@
                         {@html highlightQuery(post.title, searchQuery)}
                     {:else}
                         {post.title}
+                    {/if}
+                    {#if isRestrictedTitle(post.title)}
+                        <RestrictedBadge class="ml-1" />
                     {/if}
                 </h3>
                 <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-sm">

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import {
+        RestrictedBadge,
+        isRestrictedTitle
+    } from '$lib/components/ui/restricted-badge/index.js';
     import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
@@ -72,6 +76,9 @@
                                 {@html highlightQuery(post.title, searchQuery)}
                             {:else}
                                 {post.title}
+                            {/if}
+                            {#if isRestrictedTitle(post.title)}
+                                <RestrictedBadge class="ml-1" />
                             {/if}
                         </CardTitle>
                         <div

--- a/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import {
+        RestrictedBadge,
+        isRestrictedTitle
+    } from '$lib/components/ui/restricted-badge/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
@@ -101,6 +105,9 @@
                 style="font-size: var(--list-font-size);"
             >
                 {post.title}
+                {#if isRestrictedTitle(post.title)}
+                    <RestrictedBadge class="ml-1" />
+                {/if}
             </h3>
             <div class="text-muted-foreground flex items-center gap-1.5 text-xs">
                 <span>👍 {post.likes}</span>

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import {
+        RestrictedBadge,
+        isRestrictedTitle
+    } from '$lib/components/ui/restricted-badge/index.js';
     import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
@@ -117,6 +121,9 @@
                             {@html highlightQuery(post.title, searchQuery)}
                         {:else}
                             {post.title}
+                        {/if}
+                        {#if isRestrictedTitle(post.title)}
+                            <RestrictedBadge class="ml-1" />
                         {/if}
                     </h3>
 

--- a/apps/web/src/lib/components/ui/restricted-badge/index.ts
+++ b/apps/web/src/lib/components/ui/restricted-badge/index.ts
@@ -1,0 +1,2 @@
+export { default as RestrictedBadge } from './restricted-badge.svelte';
+export { isRestrictedTitle } from './is-restricted.js';

--- a/apps/web/src/lib/components/ui/restricted-badge/is-restricted.ts
+++ b/apps/web/src/lib/components/ui/restricted-badge/is-restricted.ts
@@ -1,0 +1,7 @@
+/**
+ * 이용제한 글/댓글 식별 — wr_subject 또는 wr_content 가 `[신고잠김]` prefix 로 시작.
+ * damoang-backend UnlockPostContent 가 잠금 시 prefix 추가, 해제 시 prefix 제거.
+ */
+export function isRestrictedTitle(title: string | undefined | null): boolean {
+    return typeof title === 'string' && title.startsWith('[신고잠김]');
+}

--- a/apps/web/src/lib/components/ui/restricted-badge/restricted-badge.svelte
+++ b/apps/web/src/lib/components/ui/restricted-badge/restricted-badge.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import Lock from '@lucide/svelte/icons/lock';
+
+    interface Props {
+        class?: string;
+    }
+    let { class: className = '' }: Props = $props();
+</script>
+
+<span
+    class="text-destructive bg-destructive/10 inline-flex items-center gap-0.5 rounded px-1 py-0 align-middle text-[10px] {className}"
+    title="이용제한 글/댓글"
+>
+    <Lock class="h-2.5 w-2.5" />
+    이용제한
+</span>


### PR DESCRIPTION
## Context

이용제한 처분 시 damoang-backend (`UnlockPostContent`) 가 글 제목에 `[신고잠김]` prefix 적용. 모든 이용제한 글에 prefix 보장 (해제 시 제거).

사용자 요청: 글 목록에서도 시각 신호. 위치 = 글 제목 뒤 (닉네임 옆 X — 낙인 우려).

## 변경

### 신규 컴포넌트 (`$lib/components/ui/restricted-badge/`)

- `restricted-badge.svelte` — 작은 Badge (Lock icon + "이용제한", text-[10px], destructive 색)
- `is-restricted.ts` — `isRestrictedTitle(title)` helper (prefix `[신고잠김]` 검사)
- `index.ts` — re-export

### 6 list layouts patch

`classic / compact / card / detailed / webzine / gallery` — 각 layout 의 `post.title` 표시 직후:

```svelte
{#if isRestrictedTitle(post.title)}
    <RestrictedBadge class="ml-1" />
{/if}
```

## 비용 (memory feedback_no_slow_queries.md 준수)

- 추가 DB query: **0** (frontend prefix 검사만)
- 추가 API 응답 필드: **0** (`wr_subject` 그대로 사용)
- bundle 크기: +~1KB
- N+1 / slow query 위험: **0**

## Test plan

- [ ] 글 목록 (`/free`, `/notice` 등) `[신고잠김]` 시작 글의 제목 뒤 작은 Badge 표시
- [ ] PC + 모바일 모두 Badge 크기 자연 (10-12px)
- [ ] 검색 highlight 영역에서도 정상 표시
- [ ] tooltip "이용제한 글/댓글" hover 동작

## 후속 (별도 PR)

- 댓글 영역 — backend `is_restricted` flag 응답 추가 + comment-list Badge
- 다른 board layout (archive 등) — 필요시 추가