### PR TITLE
feat(comments): 이용제한 댓글 본문 뒤 Badge

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -101,6 +101,8 @@ export interface FreePost {
 export interface FreeComment {
     id: number | string; // v2 API는 number, v1은 string
     content: string;
+    /** 이용제한된 댓글 (wr_7='lock'). damoang-backend PR #482 응답 필드. */
+    is_restricted?: boolean;
     link1?: string;
     link2?: string;
     link1_display?: string;

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -8,6 +8,7 @@
         DialogHeader,
         DialogTitle
     } from '$lib/components/ui/dialog/index.js';
+    import { RestrictedBadge } from '$lib/components/ui/restricted-badge/index.js';
     import type { FreeComment } from '$lib/api/types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
@@ -1607,6 +1608,9 @@
                                 {@html processedComments.get(comment.id) ??
                                     ssrCommentHtml.get(comment.id) ??
                                     ''}
+                                {#if comment.is_restricted}
+                                    <RestrictedBadge class="ml-1" />
+                                {/if}
                             </div>
                             {#if comment.link1 || comment.link2}
                                 <div class="mt-3 space-y-1.5">


### PR DESCRIPTION
## Context

damoang/angple-backend PR #482 (#084c30b0) 머지 — 댓글 응답에 `is_restricted: true` 필드 추가 (`wr_7='lock'` 댓글).

frontend PR #1529 의 RestrictedBadge 컴포넌트 재사용.

## 변경

- `FreeComment` 타입에 `is_restricted?: boolean` 추가
- `comment-list.svelte` 댓글 본문 뒤 Badge 분기

```svelte
{#if comment.is_restricted}
    <RestrictedBadge class="ml-1" />
{/if}
```

## 비용

- 0 (backend 응답 필드만 활용, 추가 fetch 없음)

## Test plan

- [ ] backend canary 배포 후 댓글 `is_restricted: true` 응답
- [ ] frontend canary 의 wr_7='lock' 댓글 본문 뒤 작은 Badge 표시
- [ ] 일반 댓글 영향 없음 (is_restricted=undefined → 분기 미진입)
- [ ] PR #1529 글 목록 Badge 와 디자인 일관