### PR TITLE
chore(restricted-badge): naming '이용제한' → '신고잠김'

### DIFF
--- a/apps/web/src/lib/components/ui/restricted-badge/restricted-badge.svelte
+++ b/apps/web/src/lib/components/ui/restricted-badge/restricted-badge.svelte
@@ -9,8 +9,8 @@
 
 <span
     class="text-destructive bg-destructive/10 inline-flex items-center gap-0.5 rounded px-1 py-0 align-middle text-[10px] {className}"
-    title="이용제한 글/댓글"
+    title="신고잠김 글/댓글 (신고 누적으로 자동 잠금)"
 >
     <Lock class="h-2.5 w-2.5" />
-    이용제한
+    신고잠김
 </span>


### PR DESCRIPTION
## Context

PR #1529/#482/#1530 머지된 RestrictedBadge 의 정확한 의미는 `wr_7='lock'` (신고 카운트 누적 자동 lock + truthroom 복제) 임.

"이용제한" 은 사용자 계정 활동 제한 처분 (별개 개념) — 운영 정책상 다른 단계.

## 변경

`restricted-badge.svelte` 텍스트만 정정:
- `이용제한` → `신고잠김`
- title 보강: `신고잠김 글/댓글 (신고 누적으로 자동 잠금)`

동작/색상 동일.