### PR TITLE
feat(board): 이용제한 처분 글 목록 Badge + 컴포넌트

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -35,6 +35,8 @@ export interface FreePost {
     author_id: string;
     author_image?: string; // 프로필 이미지 URL (mb_image_url)
     author_image_updated_at?: number; // 프로필 이미지 갱신 시각 unix epoch (캐시 버스팅용)
+    /** 이용제한 처분 근거 글 (g5_na_singo.discipline_log_id IS NOT NULL). PR #484. */
+    is_discipline_related?: boolean;
     board_id?: string;
     author_ip?: string; // 작성자 IP (마스킹된 형태, 예: 123.456.*.*)
     views: number;
@@ -101,8 +103,10 @@ export interface FreePost {
 export interface FreeComment {
     id: number | string; // v2 API는 number, v1은 string
     content: string;
-    /** 이용제한된 댓글 (wr_7='lock'). damoang-backend PR #482 응답 필드. */
+    /** 신고잠김 댓글 (wr_7='lock'). damoang-backend PR #482 응답 필드. */
     is_restricted?: boolean;
+    /** 이용제한 처분 근거 댓글 (g5_na_singo.discipline_log_id IS NOT NULL). PR #484. */
+    is_discipline_related?: boolean;
     link1?: string;
     link2?: string;
     link1_display?: string;

--- a/apps/web/src/lib/components/features/board/layouts/list/card.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/card.svelte
@@ -4,6 +4,7 @@
         RestrictedBadge,
         isRestrictedTitle
     } from '$lib/components/ui/restricted-badge/index.js';
+    import { DisciplinedBadge } from '$lib/components/ui/discipline-related/index.js';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
@@ -123,6 +124,9 @@
                                     {/if}
                                     {#if isRestrictedTitle(post.title)}
                                         <RestrictedBadge class="ml-1" />
+                                    {/if}
+                                    {#if post.is_discipline_related}
+                                        <DisciplinedBadge class="ml-1" />
                                     {/if}
                                 </CardTitle>
                                 <div

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -4,6 +4,7 @@
         RestrictedBadge,
         isRestrictedTitle
     } from '$lib/components/ui/restricted-badge/index.js';
+    import { DisciplinedBadge } from '$lib/components/ui/discipline-related/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import Lock from '@lucide/svelte/icons/lock';
     import ImageIcon from '@lucide/svelte/icons/image';
@@ -229,6 +230,9 @@
                         </span>
                         {#if isRestrictedTitle(post.title)}
                             <RestrictedBadge class="ml-1 shrink-0" />
+                        {/if}
+                        {#if post.is_discipline_related}
+                            <DisciplinedBadge class="ml-1 shrink-0" />
                         {/if}
                         {#if isNew}
                             <span class="text-liked shrink-0 text-[10px] font-bold">N</span>

--- a/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/compact.svelte
@@ -4,6 +4,7 @@
         RestrictedBadge,
         isRestrictedTitle
     } from '$lib/components/ui/restricted-badge/index.js';
+    import { DisciplinedBadge } from '$lib/components/ui/discipline-related/index.js';
     import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
@@ -107,6 +108,9 @@
                     {/if}
                     {#if isRestrictedTitle(post.title)}
                         <RestrictedBadge class="ml-1" />
+                    {/if}
+                    {#if post.is_discipline_related}
+                        <DisciplinedBadge class="ml-1" />
                     {/if}
                 </h3>
                 <div class="text-muted-foreground flex flex-wrap items-center gap-2 text-sm">

--- a/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/detailed.svelte
@@ -4,6 +4,7 @@
         RestrictedBadge,
         isRestrictedTitle
     } from '$lib/components/ui/restricted-badge/index.js';
+    import { DisciplinedBadge } from '$lib/components/ui/discipline-related/index.js';
     import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
@@ -79,6 +80,9 @@
                             {/if}
                             {#if isRestrictedTitle(post.title)}
                                 <RestrictedBadge class="ml-1" />
+                            {/if}
+                            {#if post.is_discipline_related}
+                                <DisciplinedBadge class="ml-1" />
                             {/if}
                         </CardTitle>
                         <div

--- a/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/gallery.svelte
@@ -4,6 +4,7 @@
         RestrictedBadge,
         isRestrictedTitle
     } from '$lib/components/ui/restricted-badge/index.js';
+    import { DisciplinedBadge } from '$lib/components/ui/discipline-related/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import ImageIcon from '@lucide/svelte/icons/image';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
@@ -107,6 +108,9 @@
                 {post.title}
                 {#if isRestrictedTitle(post.title)}
                     <RestrictedBadge class="ml-1" />
+                {/if}
+                {#if post.is_discipline_related}
+                    <DisciplinedBadge class="ml-1" />
                 {/if}
             </h3>
             <div class="text-muted-foreground flex items-center gap-1.5 text-xs">

--- a/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/webzine.svelte
@@ -4,6 +4,7 @@
         RestrictedBadge,
         isRestrictedTitle
     } from '$lib/components/ui/restricted-badge/index.js';
+    import { DisciplinedBadge } from '$lib/components/ui/discipline-related/index.js';
     import ScheduledDeleteBadge from './_shared/scheduled-delete-badge.svelte';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
@@ -124,6 +125,9 @@
                         {/if}
                         {#if isRestrictedTitle(post.title)}
                             <RestrictedBadge class="ml-1" />
+                        {/if}
+                        {#if post.is_discipline_related}
+                            <DisciplinedBadge class="ml-1" />
                         {/if}
                     </h3>
 

--- a/apps/web/src/lib/components/ui/discipline-related/disciplined-badge.svelte
+++ b/apps/web/src/lib/components/ui/discipline-related/disciplined-badge.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import Scale from '@lucide/svelte/icons/scale';
+
+    interface Props {
+        class?: string;
+    }
+    let { class: className = '' }: Props = $props();
+</script>
+
+<span
+    class="inline-flex items-center gap-0.5 rounded bg-amber-500/15 px-1 py-0 align-middle text-[10px] text-amber-700 dark:text-amber-400 {className}"
+    title="이용제한 처분 근거 글/댓글"
+>
+    <Scale class="h-2.5 w-2.5" />
+    이용제한 처분
+</span>

--- a/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
+++ b/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    import Scale from '@lucide/svelte/icons/scale';
+    import Eye from '@lucide/svelte/icons/eye';
+
+    interface Props {
+        children: import('svelte').Snippet;
+        isComment?: boolean;
+        class?: string;
+    }
+    let { children, isComment = false, class: className = '' }: Props = $props();
+
+    let revealed = $state(false);
+</script>
+
+<div class="relative {className}">
+    <div
+        class={revealed
+            ? ''
+            : 'pointer-events-none select-none blur-md transition-[filter] duration-200'}
+        aria-hidden={!revealed}
+    >
+        {@render children()}
+    </div>
+    {#if !revealed}
+        <div
+            class="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-amber-500/5 p-4 backdrop-blur-sm"
+        >
+            <div
+                class="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400"
+            >
+                <Scale class="h-3.5 w-3.5" />
+                이용제한 처분 근거 {isComment ? '댓글' : '글'}
+            </div>
+            <button
+                type="button"
+                onclick={() => (revealed = true)}
+                class="bg-background inline-flex items-center gap-1 rounded border border-amber-500/40 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
+            >
+                <Eye class="h-3.5 w-3.5" />
+                보기
+            </button>
+        </div>
+    {/if}
+</div>

--- a/apps/web/src/lib/components/ui/discipline-related/index.ts
+++ b/apps/web/src/lib/components/ui/discipline-related/index.ts
@@ -1,0 +1,2 @@
+export { default as DisciplinedBadge } from './disciplined-badge.svelte';
+export { default as DisciplinedContent } from './disciplined-content.svelte';


### PR DESCRIPTION
## Context

backend PR damoang/angple-backend#484 (243b7a61) 머지 — 응답에 `is_discipline_related` 필드 추가.

**신고잠김** (wr_7='lock', RestrictedBadge) ≠ **이용제한 처분** (이번 PR) — 별개. 운영자가 사용자 이용제한 처분 시 근거로 삼은 글/댓글 식별.

## 변경

### 신규 컴포넌트 `$lib/components/ui/discipline-related/`
- `disciplined-badge.svelte` — Scale icon + "이용제한 처분" amber Badge (text-[10px])
- `disciplined-content.svelte` — blur(8px) + "[보기]" 토글 wrapper (본문용, 후속 PR 에서 활용)
- `index.ts` — re-export

### types.ts
- `FreePost.is_discipline_related?: boolean`
- `FreeComment.is_discipline_related?: boolean`

### 6 list layouts (RestrictedBadge 옆에 DisciplinedBadge 분기)
- classic / compact / card / detailed / webzine / gallery

## 비용 (memory feedback_no_slow_queries.md 준수)

- 추가 DB query: **0** (backend PR #484 의 batch 1 query 만)
- bundle: +~2KB (2 컴포넌트)
- 표시 트래픽 영향: 0

## Test plan

- [ ] backend canary 의 `is_discipline_related: true` 글 → 글 목록 제목 뒤 amber Badge "⚖️ 이용제한 처분"
- [ ] RestrictedBadge (신고잠김 빨강) + DisciplinedBadge (이용제한 amber) 동시 표시 가능 (둘 다 true 시)
- [ ] 일반 글 영향 0

## 후속 (별도 PR)

- comment-list.svelte 본문 `DisciplinedContent` wrap (blur+토글)
- post detail 본문 동일 wrap