### PR TITLE
feat(comments): 이용제한 처분 댓글 본문 blur + 토글

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -9,6 +9,7 @@
         DialogTitle
     } from '$lib/components/ui/dialog/index.js';
     import { RestrictedBadge } from '$lib/components/ui/restricted-badge/index.js';
+    import { DisciplinedContent } from '$lib/components/ui/discipline-related/index.js';
     import type { FreeComment } from '$lib/api/types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
@@ -1595,6 +1596,25 @@
                                 <Lock class="h-4 w-4" />
                                 비밀댓글입니다.
                             </div>
+                        {:else if comment.is_discipline_related}
+                            <DisciplinedContent isComment>
+                                <div
+                                    class="comment-body text-foreground overflow-hidden whitespace-pre-wrap break-words {isFeed
+                                        ? 'leading-snug'
+                                        : commentLayout === 'bordered'
+                                          ? 'leading-snug'
+                                          : 'leading-normal'}"
+                                    style="font-size: var(--comment-font-size, 1rem);"
+                                >
+                                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                                    {@html processedComments.get(comment.id) ??
+                                        ssrCommentHtml.get(comment.id) ??
+                                        ''}
+                                    {#if comment.is_restricted}
+                                        <RestrictedBadge class="ml-1" />
+                                    {/if}
+                                </div>
+                            </DisciplinedContent>
                         {:else}
                             <div
                                 class="comment-body text-foreground overflow-hidden whitespace-pre-wrap break-words {isFeed


### PR DESCRIPTION
## Context

PR #1532 (이용제한 글 목록 Badge) + damoang/angple-backend#484 (`is_discipline_related`) 후속. 댓글 본문도 사용자 명시 정책 (가려있고 클릭 시 보임) 적용.

## 변경

`comment-list.svelte` — 비밀댓글 분기 다음에 `is_discipline_related` 분기 추가:

```svelte
{:else if comment.is_discipline_related}
    <DisciplinedContent isComment>
        <div class="comment-body ...">
            {@html ...}
        </div>
    </DisciplinedContent>
{:else}
    <div class="comment-body ...">...</div>
{/if}
```

`DisciplinedContent` (PR #1532 신규): blur(8px) + 중앙 '[보기]' 버튼 + 클릭 시 unblur.

일반 댓글 경로 (else) 는 그대로 — 회귀 0.

## Test plan

- [ ] is_discipline_related=true 댓글 → blur + '[보기]' 표시
- [ ] '[보기]' 클릭 → unblur (본문 표시)
- [ ] 일반 댓글 영향 0
- [ ] 비밀 댓글 영향 0
- [ ] 댓글 페이지 새로고침 시 다시 blur (state reset)

## 후속

- post detail 본문 동일 wrap (별도 PR — renderedPostContent prop 흐름 파악 필요)