### PR TITLE
fix(comments-ssr): SvelteKit proxy 에 is_discipline_related enrich 추가

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -73,6 +73,11 @@ interface CommentResponseItem {
     link1_affiliate?: boolean;
     link2_affiliate?: boolean;
     report_count?: string | number;
+    is_discipline_related?: boolean;
+}
+
+interface DisciplineRow extends RowDataPacket {
+    sg_id: number;
 }
 
 function maskIp(ip: string): string {
@@ -178,6 +183,23 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             }
         }
 
+        // 이용제한 처분 근거 댓글 식별 (g5_na_singo.discipline_log_id IS NOT NULL)
+        // INDEX hit: (sg_table, sg_id) — idx_singo_table_id / idx_table_id_time.
+        // 실패 무시 (defensive, slow query 차단).
+        const disciplineSet = new Set<number>();
+        if (commentIds.length > 0) {
+            try {
+                const [dRows] = await pool.query<DisciplineRow[]>(
+                    `SELECT DISTINCT sg_id FROM g5_na_singo
+                     WHERE sg_table = ? AND sg_id IN (?) AND discipline_log_id IS NOT NULL`,
+                    [safeBoardId, commentIds]
+                );
+                for (const d of dRows) disciplineSet.add(d.sg_id);
+            } catch (e) {
+                console.warn('[discipline] enrich(comments) failed:', e);
+            }
+        }
+
         const comments: CommentResponseItem[] = rows.map((row) => ({
             id: row.wr_id,
             content: row.wr_deleted_at ? (isAdmin ? row.wr_content : '') : row.wr_content,
@@ -215,6 +237,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             deleted_at: row.wr_deleted_at || null,
             deleted_by: row.wr_deleted_by || null,
             edit_count: editCountMap.get(row.wr_id) || 0,
+            ...(disciplineSet.has(row.wr_id) ? { is_discipline_related: true } : {}),
             ...(isAdmin && row.wr_7
                 ? {
                       report_count:


### PR DESCRIPTION
## 배경

SSR 댓글 로드는 SvelteKit proxy `/api/boards/[boardId]/posts/[postId]/comments` 를 거침. 이 proxy 가 g5_write_{slug} 를 직접 SELECT 하므로 Go backend 의 `enrichWithDisciplineRelated` (PR #484) 가 적용되지 않아 `is_discipline_related` 필드 누락.

→ frontend `comment-list.svelte` 의 분기 (PR #1533) 가 진입하지 않아 이용제한 근거 댓글이 그대로 노출.

## 변경

- `CommentResponseItem` 에 `is_discipline_related?: boolean` 추가
- `g5_na_singo` batch IN 쿼리 (INDEX `(sg_table, sg_id)` 사용)
- 실패 시 silent skip (slow query 차단, defensive)

## 안전

- 1 batch query, INDEX hit 보장
- N+1 없음, `discipline_log_id IS NOT NULL` 은 IN clause 결과 (≤200 row) 안에서만 filter
- 캐시 영향 없음