### PR TITLE
fix(widgets): sidebar giving widget SSR 누락 fix (STATIC 등록)

### DIFF
--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -23,6 +23,7 @@
     import ImageTextBannerWidget from '../../../../../../widgets/image-text-banner/index.svelte';
     import RecommendedWidget from '../../../../../../widgets/recommended/index.svelte';
     import ExploreWidget from '../../../../../../widgets/explore/index.svelte';
+    import GivingWidget from '../../../../../../widgets/giving/index.svelte';
 
     interface Props {
         /** 렌더링할 위젯 존 */
@@ -48,7 +49,8 @@
         notice: NoticeWidget,
         'image-text-banner': ImageTextBannerWidget,
         recommended: RecommendedWidget,
-        explore: ExploreWidget
+        explore: ExploreWidget,
+        giving: GivingWidget
     };
 
     // 존별 위젯 목록
@@ -146,7 +148,8 @@
         'post-list': 'min-h-[360px]',
         celebration: 'min-h-[120px]',
         notice: 'min-h-[240px]',
-        'image-text-banner': 'min-h-[164px]'
+        'image-text-banner': 'min-h-[164px]',
+        giving: 'min-h-[180px]'
     };
 
     function getPlaceholderClass(widget: WidgetConfig): string {


### PR DESCRIPTION
## 배경

DB `angple_settings.sidebar_widget_layout` 에 giving 등록되어 있으나, `widget-renderer.svelte` 의 `STATIC_WIDGET_COMPONENTS` 에 매핑 없음 → `loadWidgetComponent` 동적 로드가 SSR 시점에 미완료 → HTML 응답에 widget 박스 자체 누락 (사용자 시크릿창에서도 미표시).

## 변경

`widget-renderer.svelte`:
- `import GivingWidget from '../../../../../../widgets/giving/index.svelte'`
- `STATIC_WIDGET_COMPONENTS.giving = GivingWidget`
- `WIDGET_PLACEHOLDER_CLASS.giving = 'min-h-[180px]'` (CLS 방지)

## 안전

- celebration / notice / ad-slot 등 다른 widget 과 동일 패턴
- DB 변경 없음 (이미 layout 에 등록)
- 다른 widget 영향 0