### PR TITLE
fix(post-detail): RecentPosts limit 20 → 24 통일 (#12571)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2114,7 +2114,7 @@
                 {boardId}
                 {boardTitle}
                 currentPostId={data.post.id}
-                limit={20}
+                limit={24}
                 initialPage={Number($page.url.searchParams.get('page')) ||
                     data.recentPosts?.page ||
                     1}


### PR DESCRIPTION
## 배경

[#12571 지미니쓰](https://damoang.net/bug/12571) — '기본으로 표시되는 목록'과 '게시물 하단에 표시되는 목록' 개수 다름. 페이지 넘길수록 차이 누적되어 글 누락.

## 원인

- board list `[boardId]/+page.server.ts:173` default limit = **24**
- post detail 하단 `[boardId]/[postId]/+page.svelte:2117` RecentPosts limit = **20**

## 변경

`limit={20}` → `limit={24}` (1줄)