### PR TITLE
fix(widgets): widget layout 을 +layout.server.ts 로 이전 (전역 hydration)

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -3,6 +3,8 @@ import { getActiveTheme } from '$lib/server/themes';
 import { loadMenus } from '$lib/server/menu-loader';
 import { getCachedLogoData } from '$lib/server/logo';
 import { resolveLogoRequestLocale } from '$lib/utils/logo-schedule';
+import { getWidgetLayout, getSidebarWidgetLayout } from '$lib/server/settings/index';
+import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default-widgets';
 
 import { hooks } from '@angple/hook-system';
 import { env } from '$env/dynamic/private';
@@ -61,7 +63,9 @@ export const load: LayoutServerLoad = async ({
                 requestLocale,
                 requestTimeZone: 'UTC'
             },
-            ga4MeasurementId: ''
+            ga4MeasurementId: '',
+            widgetLayout: DEFAULT_WIDGETS,
+            sidebarWidgetLayout: DEFAULT_SIDEBAR_WIDGETS
         };
 
         return hooks.applyFilters('layout_server_data', installLayoutData);
@@ -70,15 +74,32 @@ export const load: LayoutServerLoad = async ({
     // 병렬로 SSR 필수 데이터만 로드 (allSettled: 개별 실패 허용)
     // celebration, banners, ga4는 /api/layout/init에서 클라이언트 로드 (비용 절감)
     const { getActivePlugins } = await import('$lib/server/plugins/index.js');
-    const [themeResult, menusResult, logoResult, pluginsResult] = await Promise.allSettled([
+    const [
+        themeResult,
+        menusResult,
+        logoResult,
+        pluginsResult,
+        widgetLayoutResult,
+        sidebarWidgetLayoutResult
+    ] = await Promise.allSettled([
         getActiveTheme(),
         isDataRequest ? Promise.resolve([]) : loadMenus(),
         getCachedLogoData(requestLocale),
-        getActivePlugins()
+        getActivePlugins(),
+        getWidgetLayout(),
+        getSidebarWidgetLayout()
     ]);
 
     const activeTheme = themeResult.status === 'fulfilled' ? themeResult.value : null;
     const menus = menusResult.status === 'fulfilled' ? menusResult.value : [];
+    const widgetLayout =
+        widgetLayoutResult.status === 'fulfilled' && widgetLayoutResult.value
+            ? widgetLayoutResult.value
+            : DEFAULT_WIDGETS;
+    const sidebarWidgetLayout =
+        sidebarWidgetLayoutResult.status === 'fulfilled' && sidebarWidgetLayoutResult.value
+            ? sidebarWidgetLayoutResult.value
+            : DEFAULT_SIDEBAR_WIDGETS;
     const logoData =
         logoResult.status === 'fulfilled'
             ? logoResult.value
@@ -110,7 +131,9 @@ export const load: LayoutServerLoad = async ({
         ['Theme', themeResult],
         ['Menus', menusResult],
         ['Logo', logoResult],
-        ['Plugins', pluginsResult]
+        ['Plugins', pluginsResult],
+        ['WidgetLayout', widgetLayoutResult],
+        ['SidebarWidgetLayout', sidebarWidgetLayoutResult]
     ] as const) {
         if (r.status === 'rejected') {
             console.error(`[Layout] ${name} load failed:`, r.reason);
@@ -147,7 +170,11 @@ export const load: LayoutServerLoad = async ({
             requestTimeZone: logoData.requestTimeZone
         },
         // Phase 1 (Path D′): site-resolver 결과. miss 시 null. svelte:head 가 og:*/favicon 변수화에 사용.
-        site: locals.site ?? null
+        site: locals.site ?? null,
+        // 모든 페이지에서 widgetLayoutStore 초기화 (Redis 캐시 사용, SSR 비용 미미)
+        // 이전엔 +page.server.ts(홈)에서만 로드 → 글 상세/게시판 목록 등에서 사이드바 사용자 layout 미적용.
+        widgetLayout,
+        sidebarWidgetLayout
     };
 
     // 훅: 레이아웃 데이터 필터 (플러그인이 SSR 데이터를 수정/확장 가능)

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
     import { authActions, authStore } from '$lib/stores/auth.svelte';
     import { themeStore } from '$lib/stores/theme.svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
+    import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import type { ActivePlugin } from '$lib/stores/plugin.svelte';
     import { menuStore } from '$lib/stores/menu.svelte';
     import { loadThemeHooks } from '$lib/hooks/theme-loader';
@@ -197,12 +198,23 @@
         pluginStore.initFromServer(data.activePlugins);
     }
 
+    // SSR에서 받은 widget layout 으로 즉시 초기화 (사이드바 widget SSR 렌더 보장)
+    // 이전엔 +page.svelte(홈)에서만 호출 → 글 상세/게시판 목록에서 default 사용 → 사용자 layout 누락.
+    if (data.widgetLayout || data.sidebarWidgetLayout) {
+        widgetLayoutStore.initFromServer(
+            data.widgetLayout ?? null,
+            data.sidebarWidgetLayout ?? null
+        );
+    }
+
     // SSR에서 받은 테마/메뉴로 스토어 초기화 (깜박임 방지!)
     // plugins는 /api/layout/init에서 클라이언트 로드 (비용 절감)
     $effect(() => {
         const theme = data.activeTheme;
         const menus = data.menus || [];
         const plugins = data.activePlugins || [];
+        const widgetLayout = data.widgetLayout;
+        const sidebarWidgetLayout = data.sidebarWidgetLayout;
         untrack(() => {
             themeStore.initFromServer(theme);
             if (menus.length > 0) {
@@ -211,6 +223,9 @@
             }
             if (plugins.length > 0) {
                 pluginStore.initFromServer(plugins);
+            }
+            if (widgetLayout || sidebarWidgetLayout) {
+                widgetLayoutStore.initFromServer(widgetLayout ?? null, sidebarWidgetLayout ?? null);
             }
         });
     });


### PR DESCRIPTION
## 배경

신규 P0 #12580 fix (premium #75, no_image 무한 루프 차단) 후에도 사이드바 giving widget 박스 자체가 SSR HTML 에 표시 안 되는 증상 확인.

## 원인

`widgetLayoutStore.initFromServer(data.widgetLayout, data.sidebarWidgetLayout)` 가 **`+page.svelte` (홈) 에서만** 호출. SSR data 도 `+page.server.ts` (홈) 에서만 로드.

→ 글 상세 / 게시판 목록 / 기타 모든 페이지에서 store 가 default(`DEFAULT_SIDEBAR_WIDGETS = [notice, sidebar-ad-2]`) 만 사용 → admin 에서 등록한 sidebar-giving 누락.

## 변경

- `+layout.server.ts`: `Promise.allSettled` 에 `getWidgetLayout/getSidebarWidgetLayout` 추가, layoutData 에 두 필드 추가, install path 도 default 채움
- `+layout.svelte`: `widgetLayoutStore.initFromServer` 호출 (`pluginStore.initFromServer` 패턴 일치, 초기 + `$effect` 동기화 둘 다)

## 안전

- Redis 캐시 (mysql-redis-provider WIDGET_LAYOUT TTL) → SSR 비용 미미
- 홈 (`+page.svelte`) 의 기존 호출 = idempotent (그대로 두기)
- DEFAULT fallback 동일 → 회귀 0
- 다른 widget (notice/celebration/ad-slot) 도 동일 store 사용 → 영향 없음

## 검증

머지 + canary 배포 후:
- 글 상세 페이지에서 사이드바에 "진행 중 나눔" widget 박스 표시
- HTML 응답에 `lucide-gift` 클래스 포함
- premium #75 와 함께 깜박임 해소 확인