### PR TITLE
fix(ad-slot): AdSense 정책 준수 — height clipping 방지 (Math.max + overflow 분리)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -160,8 +160,13 @@
         tablet: string;
         desktop: string;
     } {
+        // AdSense 정책 — 광고가 컨테이너보다 커서 잘리면 안 됨 (Ad Clipping 금지).
+        // explicit prop 가 sizes 최댓값보다 작아도 sizes 보장 = Math.max.
+        // 이전 코드 `explicitHeight ?? maxHeight(sizes)` 는 truthy fallback 으로
+        // sizes 최댓값 무시 → 윙(160×600) 광고가 90px 컨테이너에 잘리는 버그.
         const explicitHeight = parseHeightPx(height);
-        const fallback = explicitHeight ?? (config.sizes.length > 0 ? maxHeight(config.sizes) : 0);
+        const sizesMax = config.sizes.length > 0 ? maxHeight(config.sizes) : 0;
+        const fallback = Math.max(explicitHeight ?? 0, sizesMax);
         let mobileHeight = fallback;
         let tabletHeight: number | null = null;
         let desktopHeight: number | null = null;
@@ -427,7 +432,9 @@
         justify-content: center;
         align-items: center;
         max-width: 100%;
-        overflow: hidden;
+        /* AdSense 정책: 광고 세로 잘림 금지 (Ad Clipping). 가로만 clip — 모바일 viewport 보호용. */
+        overflow-x: hidden;
+        overflow-y: visible;
     }
 
     @media (min-width: 728px) {

--- a/apps/web/src/lib/config/ad-config.ts
+++ b/apps/web/src/lib/config/ad-config.ts
@@ -181,12 +181,13 @@ export const AD_CONFIGS: Record<string, AdConfig> = {
     'banner-square': {
         unit: AD_UNIT_PATHS.sub,
         sizes: [[300, 250]],
-        responsive: null
+        // 모든 viewport 에서 300×250 명시. getReservedHeights 가 viewport-별 reserved 채워 클리핑 방지.
+        responsive: [[0, [[300, 250]]]]
     },
     'banner-square-small': {
         unit: AD_UNIT_PATHS.sub,
         sizes: [[320, 100]],
-        responsive: null
+        responsive: [[0, [[320, 100]]]]
     },
     'banner-halfpage': {
         unit: AD_UNIT_PATHS.sub,
@@ -299,7 +300,8 @@ export const AD_CONFIGS: Record<string, AdConfig> = {
     'banner-vertical': {
         unit: AD_UNIT_PATHS.wing,
         sizes: [[160, 600]],
-        responsive: null
+        // wing: 160×600 단일 사이즈. responsive 명시로 viewport-별 reserved 보장.
+        responsive: [[0, [[160, 600]]]]
     }
 };
 


### PR DESCRIPTION
## 배경

사용자 보고 — GAM 광고 (특히 윙) 높이가 잘림. Google AdSense 정책 \"Ads must not be clipped or cut off\" 위반 가능.

## Root cause 2가지

### 1. \`getReservedHeights()\` 의 \`??\` fallback (ad-slot.svelte:164)

```ts
const explicitHeight = parseHeightPx(height);   // Props default '90px' → 90
const fallback = explicitHeight ?? maxHeight(sizes);  // 90 ?? 600 → 90 (sizes 무시)
```

- ad-slot 의 \`height\` prop default = \`'90px'\`
- \`??\` 는 left 가 truthy 이면 right 평가 안 함
- 윙(160×600) 광고: 컨테이너 90px → iframe 600px → **510px 잘림**

### 2. \`.dm-display-slot { overflow: hidden }\` (ad-slot.svelte:421)

가로(모바일 320 vs 100%) + 세로 모두 clip. AdSense 정책상 세로 clip 금지.

## 변경

| 파일 | 변경 |
|---|---|
| ad-slot.svelte | \`explicitHeight ?? sizesMax\` → \`Math.max(explicitHeight ?? 0, sizesMax)\` |
| ad-slot.svelte | \`overflow: hidden\` → \`overflow-x: hidden; overflow-y: visible\` |
| ad-config.ts | \`banner-vertical/square/square-small\` 의 \`responsive: null\` → 명시 \`[[0, [[w,h]]]]\` |

## 영향 슬롯 (이전 잘림 해소)

- **wing-left/right** (160×600): 90 → **600** ✅
- **sidebar-1/b2b/drawer** (300×250): 90 → **250** ✅
- **sidebar-sticky-desktop** (300×600/250): 970-1279 viewport 짤림 해소 ✅

## 안전

- **회귀 0**: \`Math.max\` 라 explicit 가 클 때 그대로 (작을 때만 sizes 보장)
- **iframe max-width:100% 유지** → 모바일 가로 overflow 보호
- **CLS 변화 없음**: min-height 늘어남만, 줄어들지 않음 (CLS = layout shift, 늘어남은 무관)
- **AdSense 정책 준수**: Ad Clipping 위반 0

## 검증

머지 + canary 배포 후:
- DevTools 로 wing 광고 컴퓨트된 height 확인 (1600+ viewport)
- sidebar 광고 잘림 해소
- GA4 ad rendering event 정상