### PR TITLE
fix(widgets): widget-renderer SSR mount — STATIC 컴포넌트 즉시 반환

### DIFF
--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -127,7 +127,10 @@
     });
 
     function getComponent(type: string): WidgetComponent | null {
-        return loadedComponents.get(type) ?? null;
+        // STATIC 매핑 즉시 반환 — $effect 는 client-only 라 SSR 단계에서
+        // componentCache 가 비어 있어 SSR HTML 에 widget 미렌더되는 회귀 차단.
+        // dynamic load 위젯은 client mount 후 loadedComponents 에서 받음.
+        return STATIC_WIDGET_COMPONENTS[type] ?? loadedComponents.get(type) ?? null;
     }
 
     // 훅: 위젯 목록 필터 (플러그인이 위젯 추가/제거/순서 변경 가능)


### PR DESCRIPTION
## 배경

PR #1536 (STATIC 등록) + PR #1538 (widgetLayoutStore 전역 hydration) 머지 후에도 SSR HTML 에 사이드바 giving widget 컴포넌트 (`lucide-gift` 등) 미렌더 증상 잔존. `sidebar-giving` id 는 들어가지만 위젯 컨텐츠 0.

## 원인

`widget-renderer.svelte` 의 `$effect` 가 STATIC 컴포넌트를 `componentCache` 에 채우는데, `$effect` 는 **client-only** 라 SSR 시점 캐시가 비어 있음. `getComponent()` 가 `loadedComponents.get()` 만 반환 → null → `{#if WidgetComponent}` 미진입.

## 변경

```ts
// before
return loadedComponents.get(type) ?? null;

// after
return STATIC_WIDGET_COMPONENTS[type] ?? loadedComponents.get(type) ?? null;
```

STATIC 매핑은 server/client 동일 → SSR 단계에 즉시 반환 가능. dynamic load 위젯 ($effect 안에서 `loadWidgetComponent` 호출) 은 그대로 client-side 만 동작.

## 안전

- 모든 STATIC 위젯 (tag-nav, notice, ad-slot, celebration, post-list, recommended, explore, giving, image-text-banner, news-economy-row, empathy-explore-row): SSR mount 보장
- dynamic load 위젯: 기존 fallback 그대로 (loadedComponents)
- 회귀 0
EOF