### PR TITLE
fix(widgets): widget-renderer dynamic-first — custom-widgets overlay 우선

### DIFF
--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -99,38 +99,39 @@
     const componentCache = new SvelteMap<string, WidgetComponent | null>();
     let loadedComponents = new SvelteMap<string, WidgetComponent | null>();
 
-    // 위젯 타입이 변경될 때마다 컴포넌트 로드
+    // 위젯 타입이 변경될 때마다 컴포넌트 로드 (dynamic-first).
+    // dynamic loader 는 widgets/ + custom-widgets/ 둘 다 스캔하며 같은 id 가
+    // 있을 경우 custom-widgets/ 가 덮어쓴다 (premium overlay 패턴).
+    // STATIC 매핑은 SSR 단계의 fallback 으로만 사용 — client mount 후
+    // dynamic load 결과로 자연스럽게 swap 된다.
     $effect(() => {
         const types = new Set(widgets.map((w) => w.type));
         for (const type of types) {
-            const staticComponent = STATIC_WIDGET_COMPONENTS[type];
-            if (staticComponent) {
-                if (!componentCache.has(type)) {
-                    componentCache.set(type, staticComponent);
-                    loadedComponents.set(type, staticComponent);
-                }
-                continue;
-            }
-            if (!componentCache.has(type)) {
-                loadWidgetComponent(type)
-                    .then((component) => {
-                        componentCache.set(type, component);
-                        // SvelteMap is reactive, just copy entries to trigger updates
-                        loadedComponents.set(type, component);
-                    })
-                    .catch(() => {
+            if (componentCache.has(type)) continue;
+            loadWidgetComponent(type)
+                .then((component) => {
+                    if (!component) throw new Error('no widget');
+                    componentCache.set(type, component);
+                    loadedComponents.set(type, component);
+                })
+                .catch(() => {
+                    const staticComponent = STATIC_WIDGET_COMPONENTS[type];
+                    if (staticComponent) {
+                        componentCache.set(type, staticComponent);
+                        loadedComponents.set(type, staticComponent);
+                    } else {
                         componentCache.set(type, null);
                         loadedComponents.set(type, null);
-                    });
-            }
+                    }
+                });
         }
     });
 
     function getComponent(type: string): WidgetComponent | null {
-        // STATIC 매핑 즉시 반환 — $effect 는 client-only 라 SSR 단계에서
-        // componentCache 가 비어 있어 SSR HTML 에 widget 미렌더되는 회귀 차단.
-        // dynamic load 위젯은 client mount 후 loadedComponents 에서 받음.
-        return STATIC_WIDGET_COMPONENTS[type] ?? loadedComponents.get(type) ?? null;
+        // 우선순위: dynamic load 결과 (custom-widgets 우선) → STATIC fallback (SSR).
+        // SSR 단계에서는 client-only $effect 가 미실행 → loadedComponents 빈 →
+        // STATIC 으로 fallback 하여 SSR HTML 에 widget 미렌더 회귀 차단.
+        return loadedComponents.get(type) ?? STATIC_WIDGET_COMPONENTS[type] ?? null;
     }
 
     // 훅: 위젯 목록 필터 (플러그인이 위젯 추가/제거/순서 변경 가능)


### PR DESCRIPTION
## 배경

PR #1540 (STATIC fallthrough) 후 사이드바 giving widget SSR mount 는 성공했으나, 사용자에게 **open-source 더미 widget** (`widgets/giving/index.svelte`, 'sidebar text-only') 만 표시. 사용자가 원하는 premium widget (`custom-widgets/giving/index.svelte`, 4×grid) 가 hydration 후에도 mount 안 됨.

## 원인

widget-renderer 의 `$effect` 에서 STATIC 매핑을 우선 검사:

```ts
const staticComponent = STATIC_WIDGET_COMPONENTS[type];
if (staticComponent) { ...; continue; }   // ← static 있으면 dynamic skip
loadWidgetComponent(type).then(...)        // ← 미도달
```

`widget-component-loader` 의 `scanWidgets()` 는 builtin → custom 순서로 `Map.set` 하여 같은 id 면 custom 이 overwrite (premium overlay 패턴). 하지만 `$effect` 가 STATIC skip 으로 dynamic load 자체를 안 호출 → custom-widgets/giving 미사용.

## 변경

- `$effect`: dynamic load 우선 시도 → 실패 시 STATIC fallback
- `getComponent`: dynamic 결과 우선 → STATIC fallback (SSR)

## 동작 흐름

| 단계 | 결과 |
|---|---|
| SSR (server) | $effect 미실행 → loadedComponents 빈 → getComponent 가 STATIC 반환 → 더미 widget HTML |
| Client hydrate | $effect 실행 → loadWidgetComponent('giving') → custom-widgets/giving (premium) → loadedComponents 채움 → re-render |
| 결과 | SSR: 더미 → client mount 후: premium (자연스러운 swap, 박스 크기 동일이라 시각적 거의 무중단) |

## 안전

- 영향 widget: open-source + premium 모두 존재하는 경우만 (현재 giving 1건)
- builtin-only 위젯 (notice, celebration, ad-slot 등): dynamic load = STATIC 동일 → 변화 없음
- dynamic load 실패 시 STATIC fallback → 회귀 0