### PR TITLE
fix(ad-slot): dm-display-frame Tailwind overflow-hidden → x-only (윙 광고 잘림 해소)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -347,7 +347,7 @@
 {#if !suppressAds}
     <div
         bind:this={containerEl}
-        class="dm-display-frame relative overflow-hidden rounded-lg {className}"
+        class="dm-display-frame relative overflow-x-hidden overflow-y-visible rounded-lg {className}"
         class:ad-slot-loaded={isLoaded && hasAd}
         class:ad-slot-empty={isEmpty}
         class:ad-slot-empty-collapsed={isEmpty}


### PR DESCRIPTION
## 배경

PR #1539 (Math.max + .dm-display-slot overflow 분리) 머지 후에도 사용자 보고: 윙 광고 (canary) 높이가 여전히 잘림.

## Root cause

ad-slot.svelte:350

```svelte
<div class="dm-display-frame relative overflow-hidden rounded-lg {className}">
                                ^^^^^^^^^^^^^^^^
```

`.dm-display-frame` element 에 **Tailwind `overflow-hidden` 클래스가 직접 적용** → 부모 자체에서 광고 잘림. PR #1539 가 fix 한 `.dm-display-slot` 의 overflow-y:visible 는 부모 overflow:hidden 에 막혀 효과 없음.

윙: 컨테이너 600px + GAM iframe (광고 600 + Ad 라벨/padding) > 600 → 부모 overflow-hidden 으로 세로 잘림.

## 변경

```diff
- class="dm-display-frame relative overflow-hidden rounded-lg {className}"
+ class="dm-display-frame relative overflow-x-hidden overflow-y-visible rounded-lg {className}"
```

## 안전

- 가로 clip 유지 → 모바일 320 광고가 container 100% 보다 가로 넘어가는 케이스 보호
- 세로 clip 제거 → AdSense "Ad Clipping" 정책 준수
- `.dm-display-slot` 자식의 동일 패턴과 일치
- rounded-lg 시각적 영향 0 (자식 iframe 이 corner 밖 안 나옴)