### PR TITLE
fix(celebration-widget): object-cover → object-contain (까망앙마 클레임 해소)

### DIFF
--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -51,7 +51,7 @@
                             <img
                                 src={banner.image_url}
                                 alt={banner.target_member_nick || '마음메시지'}
-                                class="absolute inset-0 h-full w-full object-cover transition-all duration-500 ease-in-out
+                                class="absolute inset-0 h-full w-full object-contain transition-all duration-500 ease-in-out
                                     {i === currentIndex
                                     ? 'translate-y-0 opacity-100'
                                     : i < currentIndex


### PR DESCRIPTION
## 배경

신고 (까망앙마, 6/5 마음메시지 신청자):
> 배너 이미지 직접 만들어 업로드 하였는데, 이미지 양쪽이 잘려보여서 문의 드립니다.
> 제작 이미지 사이즈는 770×90 으로 맞게 만들었는데, 지난달과 같이 왜 이런 현상이 생기는지 모르겠습니다.

운영자 의도: **작게라도 전체 보이게**.

## 원인

`widgets/celebration/index.svelte:48` 컨테이너 `aspect-[8/1]` (8:1 = 권장 800×100 매치) 인데, 까망앙마님 이미지가 **770×90 (8.55:1)** 비율.

`object-cover` 는 컨테이너 비율 강제 + 큰 쪽 잘림 → **가로 약 7% (좌우 ~27px씩) 잘림**.

## 변경

`widgets/celebration/index.svelte:54`

```diff
- class="absolute inset-0 h-full w-full object-cover transition-all duration-500 ease-in-out
+ class="absolute inset-0 h-full w-full object-contain transition-all duration-500 ease-in-out
```

## 효과

| 이미지 | 이전 | 변경 후 |
|---|---|---|
| 770×90 (까망앙마) | 좌우 7% 잘림 | **전체 표시 + 작은 회색 letterbox** (bg-muted) |
| 800×100 (정확 8:1) | full bleed | full bleed (변화 없음) |
| 다른 비율 | 큰 쪽 잘림 | 전체 표시 + letterbox |

## 안전

- AdSense 정책 무관 (광고 아님, 자체 콘텐츠)
- CLS 0 (aspect 비율 유지)
- 다른 widget 영향 0 (celebration-rolling, celebration-card 등은 별개 컴포넌트)
- 다크 모드 — `bg-muted` Tailwind 변수로 자연스러운 letterbox 색

## 운영자용 안내 (외부 채널)

신청자 안내 메일 등에 추가 권장:
> 권장 이미지: 800 × 100 px (8:1 비율)
> ※ 다른 비율 이미지는 좌우에 회색 여백이 표시됩니다.

(repo 안 신청 폼 부재 — 운영자가 외부 채널로 직접 안내)

## 검증

머지 + canary 배포 후:
- canary.damoang.net 사이드바 widget — 까망앙마 배너 (770×90, wr_id=2631) 전체 표시 확인
- 정확 8:1 이미지 영향 0 확인
- PC + 모바일 + 다크 모드 확인