### PR TITLE
fix(messages-list): /messages 페이지 썸네일 object-contain (사이드바 widget 일관)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/message.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/message.svelte
@@ -85,11 +85,11 @@
         <!-- 이미지 영역 -->
         <a {href} class="block px-3 py-1">
             {#if hasImage}
-                <div class="overflow-hidden rounded">
+                <div class="bg-muted overflow-hidden rounded">
                     <img
                         src={thumbnailUrl}
                         alt={post.title}
-                        class="aspect-[6/1] w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                        class="aspect-[6/1] w-full object-contain transition-transform duration-300 group-hover:scale-[1.02]"
                         loading="lazy"
                         onerror={(e) => {
                             const target = e.target as HTMLImageElement;


### PR DESCRIPTION
## 배경

PR #1543 (사이드바 마음메시지 widget) 후속 — 사용자가 `/message?period=upcoming` page (=`/messages` 라우트) 의 list 카드 썸네일도 같은 잘림 발견.

## 변경

`apps/web/src/lib/components/features/board/layouts/list/message.svelte`:
- line 88: wrapper `overflow-hidden rounded` → `bg-muted overflow-hidden rounded`
- line 92: `object-cover` → `object-contain`
- 아바타 (line 122, h-6 w-6) 는 object-cover 유지 (작은 원형은 cover 가 자연스러움)

## 효과

| 이미지 | 이전 | 변경 후 |
|---|---|---|
| 770×90 (8.55:1) | aspect-[6/1] cover → 잘림 | bg-muted letterbox + 전체 표시 |
| 6:1 정확 비율 | full bleed | full bleed (변화 없음) |
| 다른 비율 | 잘림 | letterbox |

## 안전

- aspect 비율 유지 → CLS 0
- 호버 scale-[1.02] 동작 그대로
- 광고 아닌 자체 콘텐츠 — AdSense 정책 무관