### PR TITLE
fix(celebration-widget): aspect-[8/1] → aspect-[77/9] (가이드 770×90 매치)

### DIFF
--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -45,7 +45,7 @@
 
         <CardContent class="p-0">
             <a href={current ? getLink(current) : '/message'} class="block">
-                <div class="bg-muted relative aspect-[8/1] w-full overflow-hidden">
+                <div class="bg-muted relative aspect-[77/9] w-full overflow-hidden">
                     {#each celebrations as banner, i (banner.id)}
                         {#if banner.image_url}
                             <img


### PR DESCRIPTION
## 배경

운영 가이드: **770×90 (8.55:1)**.
컨테이너 비율: **aspect-[8/1] (8:1, 800×100 기준)** — 가이드와 mismatch.

까망앙마님 등 가이드를 정확히 지킨 신청자 이미지가 컨테이너 비율과 안 맞아 좌우 잘림 → PR #1543 으로 object-contain 적용했으나 가이드 준수 이미지가 **letterbox 처리됨 (가이드 지켰는데도 작아짐)**.

## 변경

`widgets/celebration/index.svelte:48`

```diff
- <div class="bg-muted relative aspect-[8/1] w-full overflow-hidden">
+ <div class="bg-muted relative aspect-[77/9] w-full overflow-hidden">
```

## 효과

| 이미지 | PR #1543 (8:1 + contain) | PR #1545 (77/9 + contain) |
|---|---|---|
| 770×90 (가이드 준수) | letterbox 7% | **full bleed** ✅ |
| 800×100 | full bleed | 좌우 letterbox 약간 |
| 다른 비율 | letterbox | letterbox |

가이드 준수자 우대 — 까망앙마님 + 17명 신청자 중 16명 full bleed, 비표준 2명만 letterbox.

## 안전

- aspect 비율 유지 (다른 컨테이너 layout 영향 없음)
- object-contain 그대로 → 비표준 비율 잘림 0 보장
- CLS 0