### PR TITLE
fix(disciplined-content): 비로그인 children 미렌더 (봇 추출 차단) — #12590

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1597,7 +1597,7 @@
                                 비밀댓글입니다.
                             </div>
                         {:else if comment.is_discipline_related}
-                            <DisciplinedContent isComment>
+                            <DisciplinedContent isComment isLoggedIn={authStore.isAuthenticated}>
                                 <div
                                     class="comment-body text-foreground overflow-hidden whitespace-pre-wrap break-words {isFeed
                                         ? 'leading-snug'

--- a/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
+++ b/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
@@ -1,29 +1,60 @@
 <script lang="ts">
     import Scale from '@lucide/svelte/icons/scale';
     import Eye from '@lucide/svelte/icons/eye';
+    import Lock from '@lucide/svelte/icons/lock';
 
     interface Props {
         children: import('svelte').Snippet;
         isComment?: boolean;
+        // 비로그인 사용자는 children 자체를 렌더하지 않아 봇 추출 차단.
+        // 로그인 사용자만 blur + 보기 토글 동작.
+        isLoggedIn?: boolean;
         class?: string;
     }
-    let { children, isComment = false, class: className = '' }: Props = $props();
+    let {
+        children,
+        isComment = false,
+        isLoggedIn = false,
+        class: className = ''
+    }: Props = $props();
 
     let revealed = $state(false);
 </script>
 
 <div class="relative {className}">
-    <div
-        class={revealed
-            ? ''
-            : 'pointer-events-none select-none blur-md transition-[filter] duration-200'}
-        aria-hidden={!revealed}
-    >
-        {@render children()}
-    </div>
-    {#if !revealed}
+    {#if isLoggedIn}
         <div
-            class="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-amber-500/5 p-4 backdrop-blur-sm"
+            class={revealed
+                ? ''
+                : 'pointer-events-none select-none blur-md transition-[filter] duration-200'}
+            aria-hidden={!revealed}
+        >
+            {@render children()}
+        </div>
+        {#if !revealed}
+            <div
+                class="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-amber-500/5 p-4 backdrop-blur-sm"
+            >
+                <div
+                    class="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400"
+                >
+                    <Scale class="h-3.5 w-3.5" />
+                    이용제한 근거 {isComment ? '댓글' : '글'}
+                </div>
+                <button
+                    type="button"
+                    onclick={() => (revealed = true)}
+                    class="bg-background inline-flex items-center gap-1 rounded border border-amber-500/40 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
+                >
+                    <Eye class="h-3.5 w-3.5" />
+                    보기
+                </button>
+            </div>
+        {/if}
+    {:else}
+        <!-- 비로그인: children 자체 미렌더 → 페이지 소스에 본문 노출 0 (봇 추출 차단). -->
+        <div
+            class="flex flex-col items-center justify-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-4"
         >
             <div
                 class="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400"
@@ -31,14 +62,10 @@
                 <Scale class="h-3.5 w-3.5" />
                 이용제한 근거 {isComment ? '댓글' : '글'}
             </div>
-            <button
-                type="button"
-                onclick={() => (revealed = true)}
-                class="bg-background inline-flex items-center gap-1 rounded border border-amber-500/40 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
-            >
-                <Eye class="h-3.5 w-3.5" />
-                보기
-            </button>
+            <div class="text-muted-foreground inline-flex items-center gap-1 text-xs">
+                <Lock class="h-3 w-3" />
+                회원만 열람 가능
+            </div>
         </div>
     {/if}
 </div>


### PR DESCRIPTION
## 배경 (bug [#12590](https://damoang.net/bug/12590))

운영자 (사용자) 타당 인정:
- 비로그인 사용자도 '보기' 버튼 작동 → 봇 (구글 광고/스크래퍼) 가려진 본문 추출 가능
- 페이지 소스에 본문 미리 로드 (시각만 blur)

## 변경

`disciplined-content.svelte`:
- `isLoggedIn?: boolean` prop 추가
- **비로그인 (false)**: `children` 자체 미렌더 → 페이지 소스에 본문 0. '회원만 열람 가능' placeholder 표시
- **로그인 (true)**: 현재 동작 그대로 (blur + 보기 토글)

`comment-list.svelte`:
- DisciplinedContent 호출 시 `isLoggedIn={authStore.isAuthenticated}` 전달

## 효과

| 상태 | 이전 | 변경 후 |
|---|---|---|
| 비회원 | blur + 보기 가능 → 봇 추출 가능 | placeholder + 본문 미렌더 → 추출 0 |
| 회원 | blur + 보기 → reveal | 변화 없음 |

## 후속 (별도 PR)

**Phase 2 — lazy load** (회원도 SSR HTML 에 미포함):
- backend (Go) comment list endpoint: disciplined 댓글 content 마스킹
- SvelteKit proxy 도 동일
- DisciplinedContent 에 `commentId` prop + 클릭 시 `/api/comments/[id]/disciplined` fetch

## 참고

- angple `/disciplinelog/[id]/+page.svelte:95` 의 `getReportedItemLabel` 는 **이미 게시글/댓글 조건부** 처리됨. #12588 의 "(댓글 #...)" suffix 부분은 추가 코드 변경 불필요. damoang-ops admin 측은 별도 확인.