### PR TITLE
fix(auth+disciplinelog): /login redirect loop 차단 + suffix 데이터 검증

### DIFF
--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -83,8 +83,15 @@
         }
     }
 
+    // 신고 항목이 댓글인지 판별. 글에도 parent>0 으로 들어오는 비정상 데이터 방어:
+    // parent == id 또는 parent == 0 또는 falsy → 글로 처리.
+    // 정상: parent = 게시글 wr_id, id = 댓글 wr_id (서로 다름)
+    function isComment(item: { id: number; parent?: number }): boolean {
+        return typeof item.parent === 'number' && item.parent > 0 && item.parent !== item.id;
+    }
+
     function getReportedItemUrl(item: { table: string; id: number; parent?: number }): string {
-        if (item.parent && item.parent > 0) {
+        if (isComment(item)) {
             // parent = 게시글 ID (wr_parent), id = 댓글 ID (wr_id)
             return `/${item.table}/${item.parent}#c_${item.id}`;
         }
@@ -92,7 +99,7 @@
     }
 
     function getReportedItemLabel(item: { table: string; id: number; parent?: number }): string {
-        if (item.parent && item.parent > 0) {
+        if (isComment(item)) {
             return `/${item.table}/${item.parent} (댓글 #${item.id})`;
         }
         return `/${item.table}/${item.id}`;

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -22,8 +22,26 @@
     let error = $state<string | null>(null);
     let isRedirecting = $state(false);
 
-    const redirectUrl = $derived($page.url.searchParams.get('redirect') || '/');
+    // redirect query sanitize — /login 자체로 redirect 시도 시 무한 루프 차단.
+    // 또 외부 도메인 등 의도하지 않은 redirect 방어 (invite 흐름 제외).
+    function sanitizeRedirect(raw: string | null): string {
+        if (!raw) return '/';
+        // 절대 URL: invite 흐름만 허용, 그 외 외부 도메인 차단
+        if (/^https?:\/\//.test(raw)) {
+            return raw.includes('ads.damoang.net/invite/') ? raw : '/';
+        }
+        // /login 시작 = 자기 자신 → 루프 차단
+        if (raw.startsWith('/login')) return '/';
+        // 상대 경로만 허용
+        return raw.startsWith('/') ? raw : '/';
+    }
+
+    const redirectUrl = $derived(sanitizeRedirect($page.url.searchParams.get('redirect')));
     const isInviteFlow = $derived(redirectUrl.includes('ads.damoang.net/invite/'));
+
+    // 인증 polling 최대 시간 — 이 시간 안에 authStore.isLoading 이 false 로 전환 안 되면
+    // 일반 로그인 form 노출 (iOS Safari pull-to-refresh 후 cookie 손실 시 무한 spinner 차단).
+    const AUTH_POLL_TIMEOUT_MS = 5000;
 
     onMount(() => {
         const oauthError = $page.url.searchParams.get('error');
@@ -31,6 +49,7 @@
             error = oauthErrorMessages[oauthError] || `로그인 오류: ${oauthError}`;
         }
 
+        const pollStart = performance.now();
         function checkAndRedirect() {
             if (isRedirecting) return;
             if (!authStore.isLoading && authStore.isAuthenticated) {
@@ -38,7 +57,8 @@
                 window.location.href = redirectUrl;
                 return;
             }
-            if (authStore.isLoading) {
+            // timeout: polling 5초 내 결판 안 나면 form 노출 (loop 차단)
+            if (authStore.isLoading && performance.now() - pollStart < AUTH_POLL_TIMEOUT_MS) {
                 setTimeout(checkAndRedirect, 100);
             }
         }


### PR DESCRIPTION
## 배경

### bug [#12586](https://damoang.net/bug/12586) — iOS Safari 쪽지함 무한로딩 (P0/P1)
- iPhone 16 Pro Max + Safari + 최신 iOS
- /messages 진입 + pull-to-refresh → /login 화면 무한 로딩

### bug [#12588](https://damoang.net/bug/12588) — disciplinelog suffix
- 게시글에도 "(댓글 #...)" suffix 붙는 데이터 케이스

## 변경

### `apps/web/src/routes/login/+page.svelte`
- `sanitizeRedirect()` 추가:
  - /login 시작 → `/` (자기 자신 redirect loop 차단)
  - 외부 절대 URL → `/` (invite 흐름만 예외)
  - 상대 경로만 허용
- polling timeout `AUTH_POLL_TIMEOUT_MS = 5000`: 5초 안에 isLoading 결판 안 나면 form 노출 → 무한 spinner 차단

### `apps/web/src/routes/disciplinelog/[id]/+page.svelte`
- `isComment(item)` helper 추가: `parent>0 AND parent!=id` 일 때만 댓글
- getReportedItemUrl/Label 둘 다 helper 사용 (일관성)
- 비정상 데이터 (parent==id 등): 글로 분류 (방어적)

## 효과

| 상황 | 이전 | 변경 후 |
|---|---|---|
| iOS Safari pull-to-refresh + cookie 손실 | 무한 spinner | 5초 후 로그인 form 표시 |
| /login 자체 redirect query | loop 가능 | / 로 sanitize |
| 외부 URL redirect | 무방어 | invite 외 차단 |
| 비정상 parent 데이터 | 글에도 (댓글 #) | 글로 정상 분류 |

## 후속 (별도 plan)

- #12586 깊은 fix: SESSION cookie SameSite 검토, pull-to-refresh 감지 (별도 PR)
- #12588 개별 신고 사유 매핑: `v2_discipline_logs.reported_items` JSON schema 변경 + admin UI (별도 plan)