### PR TITLE
style(celebration): 마음메시지 닉네임을 우측 하단으로 이동

### DIFF
--- a/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
+++ b/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
@@ -219,9 +219,9 @@
                                                 </Label>
                                                 <Switch
                                                     id={`${category}-${key}`}
-                                                    bind:checked={settings[category][
-                                                        key
-                                                    ] as boolean}
+                                                    bind:checked={
+                                                        settings[category][key] as boolean
+                                                    }
                                                 />
                                             </div>
                                         {/if}

--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -63,7 +63,7 @@
                     {/each}
                     {#if current?.target_member_nick}
                         <div
-                            class="absolute inset-x-0 bottom-0 truncate px-1.5 py-0.5 text-center text-xs font-bold text-white [text-shadow:_-1px_-1px_0_rgba(0,0,0,0.6),_1px_-1px_0_rgba(0,0,0,0.6),_-1px_1px_0_rgba(0,0,0,0.6),_1px_1px_0_rgba(0,0,0,0.6)]"
+                            class="absolute bottom-0 right-0 max-w-[90%] truncate px-1.5 py-0.5 text-right text-xs font-bold text-white [text-shadow:_-1px_-1px_0_rgba(0,0,0,0.6),_1px_-1px_0_rgba(0,0,0,0.6),_-1px_1px_0_rgba(0,0,0,0.6),_1px_1px_0_rgba(0,0,0,0.6)]"
                         >
                             {current.target_member_nick}
                         </div>


### PR DESCRIPTION
## 변경
사이드바 마음메시지 widget 의 닉네임 오버레이를 가로 전체 중앙 정렬 → 우측 하단으로 변경.

**Before**: \`absolute inset-x-0 bottom-0 ... text-center\` — 가로 전체 + 중앙
**After**: \`absolute right-0 bottom-0 max-w-[90%] ... text-right\` — 우측 하단 + 90% 폭 제한 + truncate

## 파일
- \`widgets/celebration/index.svelte:66\`

## Test plan
- [ ] canary 에서 사이드바 마음메시지 위젯 닉네임이 우측 하단에 표시
- [ ] 긴 닉네임 (예: "배추도사무도사") 도 max-w-[90%] + truncate 로 깨지지 않음
- [ ] 이미지 letterbox 영역 (aspect-[77/9]) 안에서 정상 위치