### PR TITLE
feat(media-url): R2 prefix routing — content/ → r2.damoang.net (Phase B1)

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -70,6 +70,8 @@
         <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
         <link rel="preconnect" href="https://s3.damoang.net" crossorigin />
         <link rel="dns-prefetch" href="https://s3.damoang.net" />
+        <link rel="preconnect" href="https://r2.damoang.net" crossorigin />
+        <link rel="dns-prefetch" href="https://r2.damoang.net" />
         <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
         <link
             rel="preload"

--- a/apps/web/src/lib/utils/media-url.test.ts
+++ b/apps/web/src/lib/utils/media-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMediaUrl } from './media-url';
+
+describe('normalizeMediaUrl — R2 prefix routing (Phase B1)', () => {
+    it('routes data/content/* to r2.damoang.net (R2 prefix)', () => {
+        const result = normalizeMediaUrl('data/content/img/logo.png');
+        expect(result).toBe('https://r2.damoang.net/data/content/img/logo.png');
+    });
+
+    it('routes data/editor/* to s3.damoang.net (default, not R2 prefix yet)', () => {
+        const result = normalizeMediaUrl('data/editor/2606/abc.webp');
+        expect(result).toBe('https://s3.damoang.net/data/editor/2606/abc.webp');
+    });
+
+    it('routes data/member_image/* to s3.damoang.net (default)', () => {
+        const result = normalizeMediaUrl('data/member_image/ad/admin.webp');
+        expect(result).toBe('https://s3.damoang.net/data/member_image/ad/admin.webp');
+    });
+
+    it('rewrites s3.damoang.net/data/content/* to r2.damoang.net (absolute URL)', () => {
+        const result = normalizeMediaUrl('https://s3.damoang.net/data/content/img/banner.jpg');
+        expect(result).toBe('https://r2.damoang.net/data/content/img/banner.jpg');
+    });
+
+    it('keeps s3.damoang.net/data/editor/* on s3 (not yet R2 prefix)', () => {
+        const result = normalizeMediaUrl('https://s3.damoang.net/data/editor/2606/abc.webp');
+        expect(result).toBe('https://s3.damoang.net/data/editor/2606/abc.webp');
+    });
+
+    it('respects custom cdnBaseUrl for non-R2 prefixes', () => {
+        const result = normalizeMediaUrl('data/editor/x.webp', 'https://cdn.damoang.net');
+        expect(result).toBe('https://cdn.damoang.net/data/editor/x.webp');
+    });
+
+    it('overrides cdnBaseUrl with R2 for R2 prefix', () => {
+        const result = normalizeMediaUrl('data/content/img/x.png', 'https://cdn.damoang.net');
+        expect(result).toBe('https://r2.damoang.net/data/content/img/x.png');
+    });
+
+    it('returns null for empty input', () => {
+        expect(normalizeMediaUrl(null)).toBe(null);
+        expect(normalizeMediaUrl(undefined)).toBe(null);
+        expect(normalizeMediaUrl('')).toBe(null);
+    });
+});

--- a/apps/web/src/lib/utils/media-url.ts
+++ b/apps/web/src/lib/utils/media-url.ts
@@ -1,9 +1,23 @@
 import { normalizeWebUrl } from '$lib/utils/url-normalizer';
 
 const ABSOLUTE_MEDIA_HOST_REGEX =
-    /^https?:\/\/(?:www\.)?(?:damoang\.net|s3\.damoang\.net|cdn\.damoang\.net)(\/data\/.+)$/i;
+    /^https?:\/\/(?:www\.)?(?:damoang\.net|s3\.damoang\.net|cdn\.damoang\.net|r2\.damoang\.net)(\/data\/.+)$/i;
 
-function normalizeCdnBase(cdnBaseUrl?: string | null): string {
+// R2 origin (Cloudflare 자체 storage, egress 무료, Sippy 가 S3 fallback)
+const R2_BASE = 'https://r2.damoang.net';
+
+// R2 사용 prefix 화이트리스트 (Phase B1 시작: content/, 점진 확대 예정)
+const R2_PREFIXES: readonly string[] = ['data/content/'];
+
+function isR2Prefix(path: string): boolean {
+    const trimmed = path.replace(/^\/+/, '');
+    return R2_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
+function normalizeCdnBase(cdnBaseUrl?: string | null, path?: string): string {
+    if (path && isR2Prefix(path)) {
+        return R2_BASE;
+    }
     return (cdnBaseUrl || 'https://s3.damoang.net').replace(/\/$/, '');
 }
 
@@ -13,7 +27,6 @@ export function normalizeMediaUrl(
 ): string | null {
     if (!rawUrl) return null;
 
-    const cdnBase = normalizeCdnBase(cdnBaseUrl);
     const normalizedRawUrl = rawUrl.trim().replaceAll('&amp;', '&');
 
     if (
@@ -23,6 +36,7 @@ export function normalizeMediaUrl(
     ) {
         const sameMediaPath = normalizedRawUrl.match(ABSOLUTE_MEDIA_HOST_REGEX);
         if (sameMediaPath) {
+            const cdnBase = normalizeCdnBase(cdnBaseUrl, sameMediaPath[1]);
             return `${cdnBase}${sameMediaPath[1]}`;
         }
         return normalizeWebUrl(normalizedRawUrl);
@@ -30,6 +44,7 @@ export function normalizeMediaUrl(
 
     const trimmedPath = normalizedRawUrl.replace(/^\/+/, '');
     if (trimmedPath.startsWith('data/')) {
+        const cdnBase = normalizeCdnBase(cdnBaseUrl, trimmedPath);
         return `${cdnBase}/${trimmedPath}`;
     }
 

--- a/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
+++ b/apps/web/src/routes/admin/themes/[id]-settings/+page.svelte
@@ -219,9 +219,9 @@
                                                 </Label>
                                                 <Switch
                                                     id={`${category}-${key}`}
-                                                    bind:checked={settings[category][
-                                                        key
-                                                    ] as boolean}
+                                                    bind:checked={
+                                                        settings[category][key] as boolean
+                                                    }
                                                 />
                                             </div>
                                         {/if}


### PR DESCRIPTION
## 개요

R2 마이그 Phase B1 read ramp-up 시작. `data/content/*` 만 R2 (r2.damoang.net) 로 라우팅, 나머지 prefix 는 기존 s3.damoang.net 유지.

## 변경

| 파일 | 변경 |
|---|---|
| `apps/web/src/lib/utils/media-url.ts` | `R2_PREFIXES` 화이트리스트 + `isR2Prefix()` 분기 |
| `apps/web/src/app.html` | `r2.damoang.net` preconnect + dns-prefetch 추가 |
| `apps/web/src/lib/utils/media-url.test.ts` | 8개 테스트 신규 |

## Phase B1 결정 — content/ 만

- 5/31 측정: `data/content/` 트래픽 **0 GB/일** (사용자 영향 매우 작음)
- `data/editor/` (1.7 TB/일) 등은 6/22+ Phase B2 에서 점진 확대
- Sippy = 자동 fallback (R2 miss → S3 fetch + cache)

## 트래픽 흐름

```
변경 후 사용자 read:
  data/content/*    → r2.damoang.net (R2 직접) ⚡
  data/editor/*     → s3.damoang.net (그대로)
  data/member_image → s3.damoang.net (그대로)

R2 miss 시 Sippy 자동:
  사용자 → Cloudflare → R2 (miss) → Sippy → S3 fetch + R2 cache → 응답
```

## Fallback 4중 안전망

1. **R2 직접** (frontend 새 URL builder)
2. **Sippy 자동 S3 fetch** (R2 miss 시, Cloudflare 측)
3. **s3.damoang.net 영구 origin** (모든 객체 영구 backup)
4. **기존 hardcoded URL** = s3.damoang.net 그대로 작동 (DB 또는 SSR 안 박힌 URL)

## 검증

```
pnpm test:unit src/lib/utils/media-url.test.ts
✓ 8/8 tests passed
```

테스트 항목:
- data/content/* → r2.damoang.net ✅
- data/editor/* → s3.damoang.net (기본) ✅
- absolute URL (s3.damoang.net/data/content/*) → r2 로 rewrite ✅
- 기타 7가지

## 배포 일정

- canary apply 시점 = 4시 윈도우 (사용자 명시 승인 필요)
- 6/4 또는 6/5 04:00 KST (대선 freeze 5/31-6/4 해제 후)
- 24h soak → 6/15 04:00 Phase B2 (editor 추가)

## Rollback

- `R2_PREFIXES = []` 1줄 변경 + 재배포 (모든 prefix 가 s3.damoang.net 로 복귀)
- 또는 PR revert