### PR TITLE
feat(header): 2026-06-03 제21대 대선일 임시 안내 배지

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -67,6 +67,14 @@
     });
     const logoAlt = $derived(headerLogoFailed ? 'Logo' : activeLogoAlt);
 
+    // 임시: 6/3 제21대 대선일 안내 배지 (KST 기준 6/3 00:00 ~ 6/4 00:00 자동 해제)
+    const showElectionBadge = $derived.by(() => {
+        const now = logoNow; // 이미 1초마다 갱신되는 reactive 시계
+        const startUtc = new Date('2026-06-02T15:00:00Z'); // 6/3 00:00 KST
+        const endUtc = new Date('2026-06-03T15:00:00Z'); // 6/4 00:00 KST
+        return now >= startUtc && now < endUtc;
+    });
+
     // SSR 안전한 인증 상태:
     // - 서버(SSR): $page.data.user 사용 (요청별 안전, 모듈 레벨 상태 오염 없음)
     // - 클라이언트(hydration 전): $page.data.user 사용 (authStore.isLoading = true)
@@ -304,6 +312,19 @@
                     }}
                 />
             </a>
+            <!-- 임시: 2026-06-03 제21대 대선일 안내 배지 (자동 해제, 외부 출처 = 선관위) -->
+            {#if showElectionBadge}
+                <a
+                    href="https://info.nec.go.kr"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="bg-primary/10 text-primary hover:bg-primary/15 ml-2 hidden items-center gap-1 whitespace-nowrap rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors md:inline-flex"
+                    title="제21대 대통령선거 - 선관위 실시간 투표율 안내"
+                    aria-label="제21대 대통령선거 안내 (선관위)"
+                >
+                    🗳️ 6/3 대선
+                </a>
+            {/if}
             <!-- 플러그인 슬롯: 헤더 좌측 액션 (로고 옆) — Slot Catalog Sprint 2b -->
             <PluginSlot name="header-actions-left" />
         </div>


### PR DESCRIPTION
## 변경
헤더 로고 우측에 6/3 대선 안내 배지 임시 추가.

- **위치**: \`header.svelte:312\` (로고 \`</a>\` 다음, PluginSlot 위)
- **노출 조건**: KST 6/3 00:00 ~ 6/4 00:00 (\`logoNow\` reactive 시계로 1초마다 재평가)
- **외부 링크**: https://info.nec.go.kr (선관위 — 실시간 투표율 안내)
- **모바일**: md 이상에서만 표시 (\`hidden md:inline-flex\`)
- **자동 해제**: 6/4 0시 KST 부터 \`{#if showElectionBadge}\` false → DOM 미렌더

## 정치 중립성
- AI 가 생성한 콘텐츠 아님 (단순 안내 배지)
- 텍스트: "🗳️ 6/3 대선" — 정파 무관
- 실시간 % 표시는 외부 선관위 사이트로 위임 (출처 명시)

## 파일
- \`apps/web/src/lib/components/layout/header.svelte:67-74, 312-326\`

## Test plan
- [ ] canary 에서 헤더 로고 우측에 "🗳️ 6/3 대선" 배지 표시
- [ ] 클릭 시 선관위 사이트 새 탭으로 열림
- [ ] 모바일 (375px): 배지 숨김 (md 미만)
- [ ] 데스크톱: 로고와 일직선 정렬
- [ ] 자동 해제 검증: 시스템 시간 6/4 0시 이후 시뮬레이션 → 배지 사라짐