### PR TITLE
feat(shopping-banner): 쇼핑 바로가기에 KKday 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/economy-shopping-banner.svelte
+++ b/apps/web/src/lib/components/features/board/economy-shopping-banner.svelte
@@ -27,7 +27,8 @@
             name: '교보문고',
             href: 'https://click.linkprice.com/click.php?m=kbbook&a=A100694456&l=9999&l_cd2=0&tu=https%3A%2F%2Fwww.kyobobook.co.kr%2F'
         },
-        { name: '쿠팡', href: 'https://link.coupang.com/a/cSFTV0' }
+        { name: '쿠팡', href: 'https://link.coupang.com/a/cSFTV0' },
+        { name: 'KKday', href: 'https://www.kkday.com/ko?cid=20907' }
     ];
 </script>
 


### PR DESCRIPTION
## 변경
\`economy-shopping-banner.svelte\` 의 쇼핑 바로가기 리스트 마지막에 KKday 항목 추가.

- **URL**: \`https://www.kkday.com/ko?cid=20907\`
- **CID**: 20907 (다모앙 affiliate, kkday platform 의 \`AFFI_KKDAY_CID\` env 기본값)
- **위치**: 쿠팡 다음

## 노출 영역
- economy (알뜰구매) 게시판 + 동일 컴포넌트 사용하는 곳 모두

## 파일
- \`apps/web/src/lib/components/features/board/economy-shopping-banner.svelte:30-31\`

## Test plan
- [ ] canary 의 알뜰구매 게시판에서 쇼핑 바로가기 마지막에 "KKday" 표시
- [ ] 클릭 시 \`https://www.kkday.com/ko?cid=20907\` 새 탭 열림
- [ ] 다른 상점 항목 외관/순서 변경 없음