### PR TITLE
fix(bugs): P0/P1 3건 묶음 (#12548 댓글 새로고침 + #12526 유튜브 공백 + #12518 단축키 focus)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -289,8 +289,11 @@
                         }}
                         onImagePaste={(file: File) => handleFiles([file])}
                         onSubmitShortcut={() => {
-                            if (canSubmit && !isLoading && !isUploading)
+                            if (canSubmit && !isLoading && !isUploading) {
                                 handleSubmit(new Event('submit'));
+                                // #12518: 단축키 제출 후 에디터 focus 복귀 → 연속 입력 가능
+                                editorRef?.focus();
+                            }
                         }}
                         class={error ? 'border-destructive' : ''}
                     />

--- a/apps/web/src/lib/plugins/auto-embed/embedder.ts
+++ b/apps/web/src/lib/plugins/auto-embed/embedder.ts
@@ -99,9 +99,15 @@ export function processContent(html: string): string {
         return match;
     });
 
-    // 2단계: plain URL 처리 (기존 로직)
-    const urlPattern = /(<p>|<br\s*\/?>|\n|^)\s*(https?:\/\/[^\s<>"]+)\s*(<\/p>|<br\s*\/?>|\n|$)/gi;
+    // 2단계: plain URL 처리 (#12526 — <p>URL</p> 전체 단락을 embed 로 교체하여
+    // orphaned </p> 가 남지 않게 함. 단락이 아닌 다른 컨텍스트 (br, 줄바꿈) 는 기존대로)
+    const pUrlPattern = /<p>\s*(https?:\/\/[^\s<>"]+)\s*<\/p>/gi;
+    result = result.replace(pUrlPattern, (match, url) => {
+        const embedded = embedUrl(url.trim());
+        return embedded ?? match;
+    });
 
+    const urlPattern = /(<br\s*\/?>|\n|^)\s*(https?:\/\/[^\s<>"]+)\s*(<br\s*\/?>|\n|$)/gi;
     result = result.replace(urlPattern, (match, prefix, url, suffix) => {
         const embedded = embedUrl(url.trim());
         if (embedded) {

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -312,24 +312,30 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             }
         }
 
-        return json({
-            success: true,
-            data: {
-                comments,
-                total,
-                page: effectivePage,
-                limit,
-                total_pages: totalPages
-            },
-            // 댓글 수정 정책 (단일 출처: env). 프론트 confirm 다이얼로그/차감 안내에서 사용.
-            // 기본값은 backend 의 getCommentEditPolicy() 와 일치 (50000P / 300s).
-            meta: {
-                comment_edit_policy: {
-                    cost: Number(process.env.COMMENT_EDIT_COST ?? 50000),
-                    grace_seconds: Number(process.env.COMMENT_EDIT_GRACE_SECONDS ?? 300)
+        return json(
+            {
+                success: true,
+                data: {
+                    comments,
+                    total,
+                    page: effectivePage,
+                    limit,
+                    total_pages: totalPages
+                },
+                // 댓글 수정 정책 (단일 출처: env). 프론트 confirm 다이얼로그/차감 안내에서 사용.
+                // 기본값은 backend 의 getCommentEditPolicy() 와 일치 (50000P / 300s).
+                meta: {
+                    comment_edit_policy: {
+                        cost: Number(process.env.COMMENT_EDIT_COST ?? 50000),
+                        grace_seconds: Number(process.env.COMMENT_EDIT_GRACE_SECONDS ?? 300)
+                    }
                 }
+            },
+            {
+                // 댓글 작성 후 refetch 시 stale 응답 차단 (#12548)
+                headers: { 'Cache-Control': 'private, no-cache, no-store, must-revalidate' }
             }
-        });
+        );
     } catch (error) {
         console.error('Comments GET error:', error);
         return json({ success: false, message: '댓글 조회에 실패했습니다.' }, { status: 500 });


### PR DESCRIPTION
## 묶음 PR — 빠른 fix 3건 (각 1~수 줄)

### #12548 댓글 작성 후 안 보이는 문제 (P0)
- **Root cause**: \`GET /api/boards/{boardId}/posts/{postId}/comments\` 응답에 Cache-Control 헤더 없음 → 브라우저가 stale 응답 캐싱 → POST 후 refetch 시 새 댓글 누락
- **Fix**: \`Cache-Control: private, no-cache, no-store, must-revalidate\` 헤더 추가
- **File**: \`apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts\`

### #12526 덧글 유튜브 영상 첨부 후 하단 공백 (P1)
- **Root cause**: \`embedder.ts\` 가 \`<p>URL</p>\` 의 URL 만 \`<div class="embed-container">\` 로 교체 → orphaned \`</p>\` 남아 0.75rem 공백 노출
- **Fix**: \`<p>URL</p>\` 전체 단락을 embed 로 교체하는 새 regex 추가 (br/줄바꿈 컨텍스트는 기존 로직 유지)
- **File**: \`apps/web/src/lib/plugins/auto-embed/embedder.ts:103-115\`

### #12518 댓글 단축키 제출 후 focus 복귀 (P1, UX)
- **Root cause**: \`onSubmitShortcut\` 콜백이 \`handleSubmit\` 후 \`editorRef.focus()\` 호출 없음 → 연속 입력 불가
- **Fix**: 1줄 추가 — \`editorRef?.focus()\` 호출
- **File**: \`apps/web/src/lib/components/features/board/comment-form.svelte:291-297\`

## 묶음 정당성
세 변경 모두 file 다르고 기능 독립. 4시 prod gate 윈도우 시간 절약 위해 묶어 단일 PR 진단/CI/머지.

## Test plan
- [ ] canary 에서 댓글 작성 후 즉시 노출 (새로고침 불필요) — #12548
- [ ] canary 에서 댓글에 youtube URL 입력 + 영상 하단 공백 없음 — #12526
- [ ] canary 에서 댓글 Ctrl+Enter 제출 후 editor focus 유지, 연속 입력 가능 — #12518