### PR TITLE
fix(#12592): 모바일 게시판 검색바 2개 중복 제거

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -958,8 +958,9 @@
             {/if}
 
             <!-- #12012: 내가 쓴 글/댓글 빠른 필터 (로그인 시) -->
+            <!-- #12592: 모바일에서는 상단 SearchForm 과 검색 input 중복 → PC(md+) 전용 -->
             {#if authStore.isAuthenticated}
-                <div class="mb-3 flex flex-wrap items-center gap-2">
+                <div class="mb-3 hidden flex-wrap items-center gap-2 md:flex">
                     <Button
                         variant={isMyPostsActive ? 'default' : 'outline'}
                         size="sm"


### PR DESCRIPTION
## 변경
\`[boardId]/+page.svelte:962\` 의 빠른필터 행 wrapper class 를 \`md:flex\` 로 변경 (\`hidden md:flex\` 형태).

**Before**:
- 빠른필터 행 (#12012): 모든 화면 노출
- SearchForm (#12455): 로그인 사용자 PC 에서 \`md:hidden\` → 모바일만 노출
- **결과**: 로그인 + 모바일 = 검색 input 2개 노출 (제보 #12592)

**After**:
- 빠른필터 행: PC(md+) 전용 (hidden md:flex)
- SearchForm: 모바일 (로그인) — 기존 유지
- **결과**: 모바일 검색 input 1개 (SearchForm), PC 1개 (빠른필터)

## 파일
- \`apps/web/src/routes/[boardId]/+page.svelte:960-962\`

## #12592 잔여
- "통합검색 작동 안 함" 은 별도 진단 필요 (\`/api/search/+server.ts\` 의 비로그인 401 정책 또는 다른 원인)

## Test plan
- [ ] canary 의 임의 게시판 (예: /free) 모바일 화면 (devtools 375px)
  - 검색 input 1개 (SearchForm)
  - 빠른필터 행 (내가 쓴 글/댓글, 검색 input) 미노출
- [ ] 같은 게시판 PC 화면 (1024+)
  - 빠른필터 행 노출 (내가 쓴 글/댓글 + 검색 input)
  - SearchForm 미노출
- [ ] 비로그인 모바일: SearchForm 만 노출 (기존 동작 유지)