### PR TITLE
feat(editor): tiptap 에디터에 문단 정렬 (left/center/right/justify) 추가

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -99,6 +99,7 @@
         "@tiptap/extension-table-cell": "^3.19.0",
         "@tiptap/extension-table-header": "^3.19.0",
         "@tiptap/extension-table-row": "^3.19.0",
+        "@tiptap/extension-text-align": "^3.25.0",
         "@tiptap/extension-underline": "^3.17.0",
         "@tiptap/extension-youtube": "^3.20.0",
         "@tiptap/pm": "^3.20.0",

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -8,6 +8,7 @@
     import { LinkedImage } from './linked-image.js';
     import Placeholder from '@tiptap/extension-placeholder';
     import Underline from '@tiptap/extension-underline';
+    import TextAlign from '@tiptap/extension-text-align';
     import Mention from '@tiptap/extension-mention';
     import { Table } from '@tiptap/extension-table';
     import { TableRow } from '@tiptap/extension-table-row';
@@ -46,6 +47,10 @@
     import Bold from '@lucide/svelte/icons/bold';
     import Italic from '@lucide/svelte/icons/italic';
     import UnderlineIcon from '@lucide/svelte/icons/underline';
+    import AlignLeftIcon from '@lucide/svelte/icons/align-left';
+    import AlignCenterIcon from '@lucide/svelte/icons/align-center';
+    import AlignRightIcon from '@lucide/svelte/icons/align-right';
+    import AlignJustifyIcon from '@lucide/svelte/icons/align-justify';
     import Strikethrough from '@lucide/svelte/icons/strikethrough';
     import List from '@lucide/svelte/icons/list';
     import ListOrdered from '@lucide/svelte/icons/list-ordered';
@@ -212,6 +217,11 @@
                     placeholder
                 }),
                 Underline,
+                TextAlign.configure({
+                    types: ['heading', 'paragraph'],
+                    alignments: ['left', 'center', 'right', 'justify'],
+                    defaultAlignment: 'left'
+                }),
                 Mention.configure({
                     HTMLAttributes: {
                         class: 'mention-node text-primary font-medium'
@@ -1066,6 +1076,51 @@
                 title="밑줄 (Ctrl+U)"
             >
                 <UnderlineIcon class="h-4 w-4" />
+            </Button>
+            <!-- 문단 정렬 (TextAlign extension) -->
+            <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onclick={() => editor?.chain().focus().setTextAlign('left').run()}
+                {disabled}
+                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'left' }))}"
+                title="왼쪽 정렬"
+            >
+                <AlignLeftIcon class="h-4 w-4" />
+            </Button>
+            <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onclick={() => editor?.chain().focus().setTextAlign('center').run()}
+                {disabled}
+                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'center' }))}"
+                title="가운데 정렬"
+            >
+                <AlignCenterIcon class="h-4 w-4" />
+            </Button>
+            <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onclick={() => editor?.chain().focus().setTextAlign('right').run()}
+                {disabled}
+                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'right' }))}"
+                title="오른쪽 정렬"
+            >
+                <AlignRightIcon class="h-4 w-4" />
+            </Button>
+            <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onclick={() => editor?.chain().focus().setTextAlign('justify').run()}
+                {disabled}
+                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'justify' }))}"
+                title="양쪽 정렬"
+            >
+                <AlignJustifyIcon class="h-4 w-4" />
             </Button>
             <Button
                 type="button"

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -1084,7 +1084,9 @@
                 size="sm"
                 onclick={() => editor?.chain().focus().setTextAlign('left').run()}
                 {disabled}
-                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'left' }))}"
+                class="h-8 w-8 p-0 {getButtonClass(
+                    editor?.isActive({ textAlign: 'left' }) ?? false
+                )}"
                 title="왼쪽 정렬"
             >
                 <AlignLeftIcon class="h-4 w-4" />
@@ -1095,7 +1097,9 @@
                 size="sm"
                 onclick={() => editor?.chain().focus().setTextAlign('center').run()}
                 {disabled}
-                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'center' }))}"
+                class="h-8 w-8 p-0 {getButtonClass(
+                    editor?.isActive({ textAlign: 'center' }) ?? false
+                )}"
                 title="가운데 정렬"
             >
                 <AlignCenterIcon class="h-4 w-4" />
@@ -1106,7 +1110,9 @@
                 size="sm"
                 onclick={() => editor?.chain().focus().setTextAlign('right').run()}
                 {disabled}
-                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'right' }))}"
+                class="h-8 w-8 p-0 {getButtonClass(
+                    editor?.isActive({ textAlign: 'right' }) ?? false
+                )}"
                 title="오른쪽 정렬"
             >
                 <AlignRightIcon class="h-4 w-4" />
@@ -1117,7 +1123,9 @@
                 size="sm"
                 onclick={() => editor?.chain().focus().setTextAlign('justify').run()}
                 {disabled}
-                class="h-8 w-8 p-0 {getButtonClass(editor?.isActive({ textAlign: 'justify' }))}"
+                class="h-8 w-8 p-0 {getButtonClass(
+                    editor?.isActive({ textAlign: 'justify' }) ?? false
+                )}"
                 title="양쪽 정렬"
             >
                 <AlignJustifyIcon class="h-4 w-4" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@tiptap/extension-table-row':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/extension-table@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))
+      '@tiptap/extension-text-align':
+        specifier: ^3.25.0
+        version: 3.25.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extension-underline':
         specifier: ^3.17.0
         version: 3.17.1(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
@@ -2573,6 +2576,11 @@ packages:
       '@tiptap/core': ^3.20.0
       '@tiptap/pm': ^3.20.0
 
+  '@tiptap/extension-text-align@3.25.0':
+    resolution: {integrity: sha512-/VcaNtcljC4O7hOVTwwekgwef+hiAIwnx/xErYme9oHTeLjlGsN9ZKLRQxcW7kjT9A1SSD/hPGNvQSkQJ2jh3w==}
+    peerDependencies:
+      '@tiptap/core': 3.25.0
+
   '@tiptap/extension-text@3.20.0':
     resolution: {integrity: sha512-tf8bE8tSaOEWabCzPm71xwiUhyMFKqY9jkP5af3Kr1/F45jzZFIQAYZooHI/+zCHRrgJ99MQHKHe1ZNvODrKHQ==}
     peerDependencies:
@@ -2855,6 +2863,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/browser@3.2.4':
     resolution: {integrity: sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==}
@@ -8423,6 +8432,10 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
+
+  '@tiptap/extension-text-align@3.25.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
+    dependencies:
+      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
 
   '@tiptap/extension-text@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))':
     dependencies:


### PR DESCRIPTION
## 변경
\`@tiptap/extension-text-align\` 설치 + tiptap-editor 에 등록.

toolbar 의 밑줄 버튼 옆에 정렬 버튼 4개 노출:
- 왼쪽 정렬 (AlignLeft)
- 가운데 정렬 (AlignCenter)
- 오른쪽 정렬 (AlignRight)
- 양쪽 정렬 (AlignJustify)

## 파일
- \`apps/web/package.json\` — \`@tiptap/extension-text-align@^3.25.0\` 추가
- \`apps/web/src/lib/components/features/editor/tiptap-editor.svelte:11\` — import
- \`apps/web/src/lib/components/features/editor/tiptap-editor.svelte:215-219\` — extensions 등록 (heading + paragraph, default 'left')
- \`apps/web/src/lib/components/features/editor/tiptap-editor.svelte:49-52\` — lucide icon import
- \`apps/web/src/lib/components/features/editor/tiptap-editor.svelte:1077+\` — toolbar button 4개

## 사용자 피드백
"에디터에 문장 정렬 기능이 없음"

## Test plan
- [ ] canary 의 글쓰기 / 댓글 작성 폼에서 toolbar 정렬 버튼 4개 노출
- [ ] 클릭 시 해당 문단 정렬 적용 (active 표시)
- [ ] 저장 후 읽기 화면에서도 정렬 유지
- [ ] heading + paragraph 모두 적용