### PR TITLE
feat(celebration): 마음메시지 배너 벽지 패턴 (규격 미만 이미지 반복)

### DIFF
--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -48,17 +48,19 @@
                 <div class="bg-muted relative aspect-[77/9] w-full overflow-hidden">
                     {#each celebrations as banner, i (banner.id)}
                         {#if banner.image_url}
-                            <img
-                                src={banner.image_url}
-                                alt={banner.target_member_nick || '마음메시지'}
-                                class="absolute inset-0 h-full w-full object-contain transition-all duration-500 ease-in-out
+                            <!-- 벽지 패턴: 규격 (770×90) 미만 이미지는 자동 반복으로 빈 공간 채움.
+                                 큰 이미지는 가운데 정렬 + 컨테이너 넘는 부분만 잘림. -->
+                            <div
+                                role="img"
+                                aria-label={banner.target_member_nick || '마음메시지'}
+                                style:background-image="url({banner.image_url})"
+                                class="absolute inset-0 h-full w-full bg-center bg-repeat transition-all duration-500 ease-in-out
                                     {i === currentIndex
                                     ? 'translate-y-0 opacity-100'
                                     : i < currentIndex
                                       ? '-translate-y-full opacity-0'
                                       : 'translate-y-full opacity-0'}"
-                                loading="lazy"
-                            />
+                            ></div>
                         {/if}
                     {/each}
                     {#if current?.target_member_nick}


### PR DESCRIPTION
## 변경
\`widgets/celebration/index.svelte\` 의 배너 렌더링 방식 변경:
- **Before**: \`<img>\` + \`object-contain\` → 규격 (770×90) 미만 이미지는 가운데 작게 + 양쪽 회색 여백
- **After**: \`<div>\` + \`background-image\` + \`bg-repeat\` + \`bg-center\` → 벽지 패턴

## 효과
| 이미지 사이즈 | 동작 |
|---|---|
| 작은 이미지 (예: 200×30) | **벽지처럼 반복**으로 빈 공간 채움 |
| 규격 이미지 (770×90) | 1회 표시 (이전 동작과 동일) |
| 큰 이미지 | 가운데 정렬 + 컨테이너 넘는 부분 잘림 (가이드 강제 효과) |

## 접근성
- \`role="img"\` + \`aria-label\` 으로 \`<img>\` 의 alt 대체

## 파일
- \`widgets/celebration/index.svelte:49-65\`

## Test plan
- [ ] canary 사이드바 마음메시지 위젯 — 작은 이미지 등록 → 반복 표시 확인
- [ ] 규격 이미지 (770×90) → 1회 표시 유지
- [ ] 닉네임 오버레이 (우측 하단) + transition (5초 rolling) 유지
- [ ] 스크린리더 (VoiceOver/NVDA) 로 aria-label 인식