### PR TITLE
revert: celebration 배너 벽지 패턴 롤백 (#1560 revert)

### DIFF
--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -48,19 +48,17 @@
                 <div class="bg-muted relative aspect-[77/9] w-full overflow-hidden">
                     {#each celebrations as banner, i (banner.id)}
                         {#if banner.image_url}
-                            <!-- 벽지 패턴: 규격 (770×90) 미만 이미지는 자동 반복으로 빈 공간 채움.
-                                 큰 이미지는 가운데 정렬 + 컨테이너 넘는 부분만 잘림. -->
-                            <div
-                                role="img"
-                                aria-label={banner.target_member_nick || '마음메시지'}
-                                style:background-image="url({banner.image_url})"
-                                class="absolute inset-0 h-full w-full bg-center bg-repeat transition-all duration-500 ease-in-out
+                            <img
+                                src={banner.image_url}
+                                alt={banner.target_member_nick || '마음메시지'}
+                                class="absolute inset-0 h-full w-full object-contain transition-all duration-500 ease-in-out
                                     {i === currentIndex
                                     ? 'translate-y-0 opacity-100'
                                     : i < currentIndex
                                       ? '-translate-y-full opacity-0'
                                       : 'translate-y-full opacity-0'}"
-                            ></div>
+                                loading="lazy"
+                            />
                         {/if}
                     {/each}
                     {#if current?.target_member_nick}


### PR DESCRIPTION
## 롤백 사유
PR #1560 의 \`background-repeat: repeat\` 가 모든 이미지에 적용되어 **큰 이미지가 잘림** = "확대된 것처럼 보임" 사용자 피드백.

이전 동작 (object-contain) 으로 복구:
- 큰 이미지 (770×90 매치): letterbox 없이 1회 표시 (정상)
- 작은 이미지: 가운데 작게 + 양쪽 여백 (사용자가 원래 원하지 않던 동작)

## 후속
**작은 이미지만** background-repeat 적용하는 옵션 B (JS dimension 검사) 별도 PR 진행 예정.

## Test plan
- [ ] canary 의 우측 마음메시지 위젯 — 큰 배너 이미지가 잘림 없이 정상 letterbox 표시