### PR TITLE
feat(celebration): 작은 이미지만 벽지 패턴 (큰 이미지 letterbox 유지)

### DIFF
--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -25,6 +25,25 @@
     let celebrations = $derived(getCelebrations());
     let currentIndex = $derived(getCurrentIndex());
     let current = $derived(celebrations[currentIndex]);
+
+    // 이미지별 small 여부 (naturalWidth 기준).
+    // 기본값 = undefined → img 모드 (큰 이미지 가정, 가이드 770×90).
+    // onload 후 < 770 이면 small → 벽지(div, background-repeat) 모드.
+    let smallById = $state<Record<number, boolean>>({});
+
+    function checkSize(id: number, e: Event) {
+        const img = e.currentTarget as HTMLImageElement;
+        const isSmall = img.naturalWidth > 0 && img.naturalWidth < 770;
+        if (smallById[id] !== isSmall) {
+            smallById = { ...smallById, [id]: isSmall };
+        }
+    }
+
+    function slideClass(i: number, idx: number): string {
+        if (i === idx) return 'translate-y-0 opacity-100';
+        if (i < idx) return '-translate-y-full opacity-0';
+        return 'translate-y-full opacity-0';
+    }
 </script>
 
 {#if celebrations.length > 0}
@@ -48,17 +67,31 @@
                 <div class="bg-muted relative aspect-[77/9] w-full overflow-hidden">
                     {#each celebrations as banner, i (banner.id)}
                         {#if banner.image_url}
+                            {@const isSmall = smallById[banner.id] === true}
+                            {@const slide = slideClass(i, currentIndex)}
+                            <!--
+                                동시 렌더 (깜박임 0):
+                                - img: 큰 이미지일 때 노출 (object-contain). onload 시 dimension 검사.
+                                - div: 작은 이미지일 때 노출 (background-repeat 벽지 패턴).
+                                두 element 의 opacity 만 swap → reflow 없음.
+                            -->
                             <img
                                 src={banner.image_url}
                                 alt={banner.target_member_nick || '마음메시지'}
-                                class="absolute inset-0 h-full w-full object-contain transition-all duration-500 ease-in-out
-                                    {i === currentIndex
-                                    ? 'translate-y-0 opacity-100'
-                                    : i < currentIndex
-                                      ? '-translate-y-full opacity-0'
-                                      : 'translate-y-full opacity-0'}"
+                                onload={(e) => checkSize(banner.id, e)}
+                                class="absolute inset-0 h-full w-full object-contain transition-all duration-500 ease-in-out {slide} {isSmall
+                                    ? 'opacity-0'
+                                    : ''}"
                                 loading="lazy"
                             />
+                            {#if isSmall}
+                                <div
+                                    role="img"
+                                    aria-label={banner.target_member_nick || '마음메시지'}
+                                    style:background-image="url({banner.image_url})"
+                                    class="absolute inset-0 h-full w-full bg-center bg-repeat transition-all duration-500 ease-in-out {slide}"
+                                ></div>
+                            {/if}
                         {/if}
                     {/each}
                     {#if current?.target_member_nick}


### PR DESCRIPTION
## 재시도 — PR #1560 의 부작용 해결
PR #1560 (전체 \`background-repeat\`) → 큰 이미지가 확대/잘림 → 사용자 피드백으로 PR #1562 로 revert.

이번 PR 은 **naturalWidth 기준 분기**:
- \`naturalWidth < 770\` (가이드 폭) → **벽지 패턴** (background-repeat)
- \`naturalWidth >= 770\` (가이드 폭 만족) → **기존 letterbox** (object-contain)

## 구현 — 동시 렌더 (깜박임 0)
\`<img>\` + \`<div>\` 두 element 항상 렌더:
- \`<img object-contain>\`: onload 시 \`naturalWidth\` 검사 + \`smallById\` state 갱신
- \`isSmall=true\` 시: img \`opacity-0\` + div (\`background-image\` + \`bg-repeat\`) 노출
- \`isSmall=false\` 시: img 노출 + div 미렌더 (조건부 렌더)

opacity 만 swap → reflow 없음 → 깜박임 0.

## 동작
| 이미지 | naturalWidth | 표시 |
|---|---|---|
| 큰 이미지 (770×90) | 770 | \`<img object-contain>\` letterbox 없이 1회 |
| 작은 이미지 (200×30) | 200 | \`<div background-repeat>\` 벽지 패턴 |

## 파일
- \`widgets/celebration/index.svelte\` (1 file, +39/-6)

## 변경 안 됨
- transition (5초 rolling): 모든 element 에 동일 적용
- 닉네임 오버레이 (우측 하단)
- store / 마운트 흐름

## Test plan
- [ ] canary 사이드바 마음메시지 위젯 — 큰 배너 (예: 까망앙마 770×90): letterbox 1회 표시 (기존 정상 동작 복구)
- [ ] 작은 배너 (예: 200×30): 벽지 패턴으로 채움
- [ ] rolling 시 두 이미지 사이 깜박임 없음
- [ ] 닉네임 오버레이 우측 하단 유지
- [ ] 스크린리더 \`aria-label\` 인식

## Pair
- 이전 PR #1560 (전체 repeat) 의 revert = PR #1562 (이미 머지)