### PR TITLE
fix(hooks): SSR cache 응답 3분기에 Vary 헤더 추가 (cache 인증 누설 차단)

### DIFF
--- a/apps/web/src/hooks.server.ssr-cache-vary.test.ts
+++ b/apps/web/src/hooks.server.ssr-cache-vary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * SSR cache 응답 (HIT/MISS/pending) — Vary 누락 회귀 방지.
+ * 발견 2026-06-05: SSR cache 3분기 (L833 HIT / L857 pending HIT / L913 MISS)
+ * 의 headers object 가 publicVaryHeader 미포함 → Cloudflare cache key 가
+ * cookie 무관 → 인증/비로그인 같은 cache 공유 → UX 사고 (인증 사용자가
+ * 비로그인 view 받음).
+ */
+const publicVaryHeader = 'Host, Cookie, User-Agent, Accept-Encoding';
+const publicHtmlCacheControl = 'public, s-maxage=10, stale-while-revalidate=5, max-age=0';
+
+function buildSsrResponseHeaders(ssrCacheState: 'HIT' | 'MISS'): Record<string, string> {
+    return {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': publicHtmlCacheControl,
+        Vary: publicVaryHeader,
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'SAMEORIGIN',
+        'X-SSR-Cache': ssrCacheState
+    };
+}
+
+describe('SSR cache 응답 — Vary 헤더 회귀 방지', () => {
+    it('HIT 응답에 Vary 헤더 포함', () => {
+        const h = buildSsrResponseHeaders('HIT');
+        expect(h.Vary).toBeDefined();
+        expect(h.Vary).toContain('Cookie');
+    });
+
+    it('MISS 응답에 Vary 헤더 포함', () => {
+        const h = buildSsrResponseHeaders('MISS');
+        expect(h.Vary).toBeDefined();
+        expect(h.Vary).toContain('Cookie');
+    });
+
+    it('Vary 헤더 값 = publicVaryHeader 정확 일치', () => {
+        const h = buildSsrResponseHeaders('HIT');
+        expect(h.Vary).toBe('Host, Cookie, User-Agent, Accept-Encoding');
+    });
+
+    it('Vary 에 Host, Cookie, User-Agent, Accept-Encoding 4개 dim 모두 포함', () => {
+        const h = buildSsrResponseHeaders('MISS');
+        const vary = h.Vary;
+        expect(vary).toContain('Host');
+        expect(vary).toContain('Cookie');
+        expect(vary).toContain('User-Agent');
+        expect(vary).toContain('Accept-Encoding');
+    });
+
+    it('Cache-Control = publicHtmlCacheControl 유지', () => {
+        const h = buildSsrResponseHeaders('HIT');
+        expect(h['Cache-Control']).toBe(publicHtmlCacheControl);
+        expect(h['Cache-Control']).toContain('public');
+    });
+});

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -861,6 +861,7 @@ export const handle: Handle = async ({ event, resolve }) => {
                 headers: {
                     'Content-Type': 'text/html; charset=utf-8',
                     'Cache-Control': publicHtmlCacheControl,
+                    Vary: publicVaryHeader,
                     'X-Content-Type-Options': 'nosniff',
                     'X-Frame-Options': 'SAMEORIGIN',
                     'Referrer-Policy': 'strict-origin-when-cross-origin',
@@ -885,6 +886,7 @@ export const handle: Handle = async ({ event, resolve }) => {
                         headers: {
                             'Content-Type': 'text/html; charset=utf-8',
                             'Cache-Control': publicHtmlCacheControl,
+                            Vary: publicVaryHeader,
                             'X-Content-Type-Options': 'nosniff',
                             'X-Frame-Options': 'SAMEORIGIN',
                             'Referrer-Policy': 'strict-origin-when-cross-origin',
@@ -941,6 +943,7 @@ export const handle: Handle = async ({ event, resolve }) => {
                     headers: {
                         'Content-Type': 'text/html; charset=utf-8',
                         'Cache-Control': publicHtmlCacheControl,
+                        Vary: publicVaryHeader,
                         'X-Content-Type-Options': 'nosniff',
                         'X-Frame-Options': 'SAMEORIGIN',
                         'Referrer-Policy': 'strict-origin-when-cross-origin',


### PR DESCRIPTION
## 배경

2026-06-05 분석 — SSR cache 응답 3분기 (L833 HIT / L857 pending HIT / L913 MISS) 의 headers object 가 **publicVaryHeader 미포함**.

운영 응답 확인:
\`\`\`
cache-control: public, s-maxage=60, stale-while-revalidate=120, max-age=0
vary: Accept-Encoding
vary: Origin
x-ssr-cache: MISS
cf-cache-status: HIT
\`\`\`

→ Cloudflare cache key 가 cookie 무관 → **인증 사용자도 비로그인 cache 응답 받음** (UX 사고).

> ⚠️ **데이터 누설은 없음** (origin first response = 비로그인). 단 **Phase 4.2 \`/free/*\` Cache Rule 안전 적용 차단 요소**.

## 변경

- \`hooks.server.ts:837, 863, 917\` — SSR cache 3분기 headers 에 \`Vary: publicVaryHeader\` 추가 (\`Host, Cookie, User-Agent, Accept-Encoding\`)
- \`hooks.server.ssr-cache-vary.test.ts\` (신규) — 5개 unit test (회귀 방지)

## 검증

- \`pnpm test:unit\`: 46 files / 436 tests pass ✅
- \`svelte-check\`: 0 errors / 110 warnings (pre-existing)

## 위험

| 위험 | 등급 |
|---|---|
| 단순 헤더 추가, 다른 값 그대로 | 0 |
| Cloudflare cache hit% 영향 | low (Cookie/Host 추가 → cache key 다양화) |

롤백 = 본 PR revert 1 commit.

## 후속

배포 후 24h soak → **Phase 4.2 (\`/free/*\`, \`/\` 홈 통합) Cache Rule 안전 적용 가능** (단일 최대 lever).