### PR TITLE
fix(web): iOS Safari history 병합으로 뒤로가기가 목록 건너뛰는 문제

### DIFF
--- a/apps/web/e2e/history-merge-989.test.ts
+++ b/apps/web/e2e/history-merge-989.test.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * #989 회귀 방지: iOS Safari history 병합 버그.
+ *
+ * 증상: `/board` → 글을 빠르게 탭 → 곧바로 빠르게 뒤로가기 하면, 목록이 아니라
+ * `about:blank`(앱 로드 전 빈 문서)로 이탈. iOS WebKit이 짧은 시간 내 연속 history
+ * 쓰기(SvelteKit init `replaceState` → 내비 `pushState`)를 한 틱으로 병합해, pushState가
+ * 새 엔트리를 만드는 대신 현재(`/board`) 엔트리를 덮어쓰기 때문.
+ *
+ * 수정: `src/app.html`에서 `history.pushState`/`replaceState`를 감싸 호출 직후
+ * `history.length`를 동기 read → WebKit이 엔트리를 즉시 commit하여 병합을 막는다.
+ *
+ * 주의: 실제 병합은 iOS Safari(모바일 WebKit) 타이밍 고유 현상이라 desktop 엔진에선
+ * 결정적으로 재현되지 않는다. 따라서 1번 테스트(래퍼 설치 여부)가 핵심 회귀 가드이며,
+ * 2번은 동작 문서화 + gross regression 감지용이다. iOS/WebKit에서 돌리면 2번이 병합도 잡는다.
+ */
+test.describe('#989 history merge commit guard', () => {
+    test('history.pushState/replaceState are wrapped (commit guard installed)', async ({
+        page
+    }) => {
+        await page.goto('/');
+        const isNative = await page.evaluate(() => ({
+            push: history.pushState.toString().includes('[native code]'),
+            replace: history.replaceState.toString().includes('[native code]')
+        }));
+        // 래퍼가 제거되면 네이티브로 돌아가 이 단언이 깨진다 → #989 재발 방지.
+        expect(isNative.push, 'history.pushState must be wrapped by the #989 commit guard').toBe(
+            false
+        );
+        expect(
+            isNative.replace,
+            'history.replaceState must be wrapped by the #989 commit guard'
+        ).toBe(false);
+    });
+
+    test('rapid replaceState→pushState creates distinct entries (no merge)', async ({ page }) => {
+        await page.goto('/');
+        const result = await page.evaluate(() => {
+            const start = history.length;
+            // 같은 틱에 연속 history 쓰기 — 병합 버그 조건 재현
+            history.replaceState({ m: 989 }, '', location.href);
+            history.pushState({ m: 989 }, '', location.pathname + '?e989a');
+            history.pushState({ m: 989 }, '', location.pathname + '?e989b');
+            return { start, end: history.length };
+        });
+        // pushState 2회 → 엔트리 2개 추가. 병합되면 증가량이 부족해진다.
+        expect(result.end).toBe(result.start + 2);
+    });
+});

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -2,6 +2,32 @@
 <html lang="ko">
     <head>
         <meta charset="utf-8" />
+        <!--
+          #989 fix: iOS Safari는 짧은 시간 내 연속 history 쓰기(replaceState→pushState)를
+          한 틱으로 병합해, list→detail pushState가 새 엔트리 대신 현재 엔트리를 덮어쓴다
+          (빠른 탭→뒤로가기 시 목록을 건너뛰고 about:blank로 이탈).
+          쓰기 직후 history.length를 동기 read하면 WebKit이 엔트리를 즉시 commit하여 병합을 막는다.
+          SvelteKit은 history.pushState/replaceState를 호출 시점에 live로 참조하므로(클라이언트
+          번들보다 먼저 실행되는) 이 래퍼가 내부 내비게이션에도 적용된다.
+        -->
+        <script>
+            (function () {
+                if (typeof history === 'undefined') return;
+                var op = history.pushState;
+                var or = history.replaceState;
+                if (typeof op !== 'function' || typeof or !== 'function') return;
+                history.pushState = function () {
+                    var r = op.apply(this, arguments);
+                    void history.length; // force WebKit to flush/commit the new entry
+                    return r;
+                };
+                history.replaceState = function () {
+                    var r = or.apply(this, arguments);
+                    void history.length;
+                    return r;
+                };
+            })();
+        </script>
         <script>
             // 테마 모드 즉시 적용 (FOUC 방지 — CSS 파싱보다 먼저 실행)
             // 1순위: 쿠키 (SSR과 동일한 소스)

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -821,16 +821,19 @@
         }
     });
 
+    // afterNavigate는 컴포넌트 초기화 시점에 등록해야 destroy 시 자동 정리됨.
+    // onMount 안에서 등록하면 재마운트마다 콜백이 누적돼 추가 history 조작(replaceState)을
+    // 유발할 수 있음 (issue #989).
+    afterNavigate(() => {
+        scheduleAnchorScroll();
+    });
+
     onMount(() => {
         const onHashChange = () => {
             if (commentsLoaded) {
                 scheduleAnchorScroll();
             }
         };
-
-        afterNavigate(() => {
-            scheduleAnchorScroll();
-        });
 
         window.addEventListener('hashchange', onHashChange);
 


### PR DESCRIPTION
## 요약
iOS Safari(모바일 WebKit)에서 게시판 목록 → 글 상세로 **빠르게** 이동한 뒤 곧바로 뒤로가기를 누르면, 목록으로 돌아가지 않고 `about:blank`로 이탈하던 문제(#989)를 수정합니다.

## 원인
WebKit은 짧은 시간 내 연속 history 쓰기(SvelteKit init `replaceState` → 내비 `pushState`)를 한 틱으로 병합합니다. 그 결과 list→detail의 `pushState`가 새 히스토리 엔트리를 만들지 못하고 현재(목록) 엔트리를 덮어써, 뒤로가기 시 직전(앱 로드 전 빈 문서)인 `about:blank`로 갑니다. 천천히 이동하면 두 호출이 다른 틱으로 분리돼 정상 동작합니다.

> ⚠️ 완전한 Heisenbug — `history`/click 경로에 계측을 조금만 추가해도(스택 로깅 등 미세 지연) 레이스가 사라져 로깅으로는 못 잡습니다. 화면 동작 관측("글이 잠깐 떴다가 → about:blank")으로 메커니즘을 확정했습니다.

## 수정
`app.html`에서 `history.pushState`/`replaceState`를 감싸 호출 직후 `history.length`를 동기 read → WebKit이 엔트리를 즉시 commit하도록 강제하여 병합을 막습니다. SvelteKit은 두 메서드를 호출 시점에 live로 참조하므로 내부 내비게이션에도 적용됩니다.

## 검증
- iPhone Safari 실기기에서 빠른 탭→뒤로가기 반복으로 재현 → 수정 후 항상 목록 복귀 확인.
- `e2e/history-merge-989.test.ts`: 회귀 방지 (래퍼 설치 여부 + 연속 `pushState` 엔트리 검증). 실제 병합은 iOS 모바일 WebKit 고유라 desktop 엔진에선 결정적으로 재현되지 않으므로, 래퍼 설치 여부 단언이 핵심 가드입니다.

## 기타
- `[boardId]/[postId]/+page.svelte`: `afterNavigate`를 `onMount` 밖 컴포넌트 init로 이동 (이슈 체크리스트 항목 정리).
- stall-recovery(`+layout.svelte` 4초 워치독)는 멈춘 내비게이션용 안전장치로 정상 동작이며 본 증상과 무관 — 변경 없음.

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)
