### PR TITLE
feat(payment): 네이버페이 PG 승인 전 임시 UI — 결제 버튼 disable + 안내 (#12598 #12600)

### DIFF
--- a/apps/web/src/routes/shop/[productId]/+page.svelte
+++ b/apps/web/src/routes/shop/[productId]/+page.svelte
@@ -235,20 +235,16 @@
             </div>
 
             <!-- 구매 버튼 -->
+            <!-- #12598 임시: 네이버페이 PG 승인 전까지 결제 비활성화. 승인 완료 후 disabled 제거. -->
             <div class="mt-6 space-y-2">
                 <Button
                     class="w-full"
                     size="lg"
                     onclick={handleBuy}
-                    disabled={isOrdering || product.stock_status === 'out_of_stock'}
+                    disabled={true}
+                    title="네이버페이 PG 승인 대기 중"
                 >
-                    {#if product.stock_status === 'out_of_stock'}
-                        품절
-                    {:else if isOrdering}
-                        주문 생성 중...
-                    {:else}
-                        바로 구매하기
-                    {/if}
+                    🚧 네이버페이 승인 대기 중 (곧 오픈)
                 </Button>
                 {#if product.stock_status !== 'out_of_stock'}
                     <Button

--- a/plugins/ad-free/views/Checkout.svelte
+++ b/plugins/ad-free/views/Checkout.svelte
@@ -311,15 +311,21 @@
                 </p>
             {/if}
 
+            <!-- #12600 임시: 가맹점 심사 (네이버페이 PG 승인) 진행 중에는 결제 버튼 disable. 승인 후 자동 활성화. -->
             <Button
                 class="mt-5 w-full"
                 size="lg"
-                disabled={submitting || !guestFormValid}
+                disabled={submitting || !guestFormValid || !data.isMerchantApproved}
                 onclick={handleSubmit}
+                title={!data.isMerchantApproved ? '네이버페이 PG 승인 대기 중' : undefined}
             >
-                {submitting
-                    ? '진행 중…'
-                    : `${formatPrice(currentPlan.price, data.currency)} 결제하기`}
+                {#if !data.isMerchantApproved}
+                    🚧 네이버페이 승인 대기 중 (곧 오픈)
+                {:else if submitting}
+                    진행 중…
+                {:else}
+                    {formatPrice(currentPlan.price, data.currency)} 결제하기
+                {/if}
             </Button>
 
             {#if stubMessage}


### PR DESCRIPTION
## 변경
결제 모듈 (네이버페이) 이 PG 승인 대기 중인데 buy 버튼이 active 라 사용자가 클릭 후 멈춤 화면을 봄. 승인 전까지 임시 UI 로 명확한 안내.

## 파일
| File | 변경 |
|---|---|
| \`apps/web/src/routes/shop/[productId]/+page.svelte\` | '구매하기' 버튼 disable + label "🚧 네이버페이 승인 대기 중 (곧 오픈)" |
| \`plugins/ad-free/views/Checkout.svelte\` | 기존 \`isMerchantApproved\` flag 를 disabled 조건에 추가 + 버튼 label '승인 대기' 안내. 기존 가맹점 심사 banner 그대로 유지 |

## Pair
- bug #12598 (앙크래프트 벽돌 구매 안 됨) AI 후속 안내 댓글 = wr_id 12602
- bug #12600 (광고제거 구독 구매 안 됨) AI 후속 안내 댓글 = wr_id 12603

## 승인 후 원복
- \`/shop/[productId]\`: 기존 \`disabled={isOrdering || stock_status==='out_of_stock'}\` 복원
- \`/ad-free Checkout.svelte\`: \`isMerchantApproved\` 가 server 에서 true 반환 시 자동 활성화 (코드 변경 불필요)

## Test plan
- [ ] canary 의 /shop/[any] 진입 → 구매 버튼 disabled + 안내 노출
- [ ] /ad-free 결제 페이지 진입 (guest, plan 선택) → 결제 버튼 disabled + 안내 노출
- [ ] 가맹점 심사 banner (amber) 도 함께 표시 (이중 안내)