### PR TITLE
fix(ad-slot): GAM SafeFrame 비활성화 — in-flow 광고 iframe 내부 scrollbar 제거 (#12595)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
@@ -178,6 +178,11 @@ function ensureServices() {
         }
     });
     googletag.pubads().setCentering(true);
+    // #12595: SafeFrame 비활성화 — 게시판 목록 in-flow 광고 (board-list-infeed) 의
+    // creative height 가 reserved (90px) 보다 큰 경우 SafeFrame iframe 내부에 scrollbar 가
+    // 생성되어 사용자의 페이지 스크롤 포커스를 가로채는 문제 해결. SafeFrame off 시
+    // GAM 이 standard iframe (scrolling="no") 으로 렌더하여 내부 scroll 미발생.
+    googletag.pubads().setForceSafeFrame(false);
     googletag.pubads().setTargeting('site', GAM_SITE_NAME);
     const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
     googletag.pubads().setTargeting('theme', theme);


### PR DESCRIPTION
## 사용자 보고
**#12595 "광고구역의 스크롤 방해"** — 게시판 목록 7/17번째 글 사이 in-flow 광고 (board-list-infeed) 구역에 iframe 내부 scrollbar 가 생성되어 페이지 스크롤 시 포커스를 가로채는 문제.

## Root Cause
GAM **SafeFrame default ON** 상태에서 creative height > reserved (90px) 인 경우 SafeFrame iframe 이 자체적으로 inner scrollbar 를 노출. 컨테이너의 \`overflow:hidden\` 으로는 iframe 내부 scrollbar 차단 불가 (iframe = 독립 DOM).

## Fix
\`googletag.pubads().setForceSafeFrame(false)\` — GAM 이 standard iframe (\`scrolling="no"\`) 으로 렌더 → 내부 scroll 미발생.

## 안전성
- AdSense 정책 호환 (creative height clipping 없음 — \`ad-slot.svelte\` 의 \`overflow-x-hidden\` + \`overflow-y-visible\` 가 잘림 방지 유지)
- 모든 광고 단위에 일괄 적용 (전역 pubads 설정) — 50-60% 효과 추정 (Agent 분석)
- 일부 광고 (SafeFrame 강제 creative) 는 렌더 안 될 수 있음 — fallback (Adfit) 으로 자동 처리

## 파일
- \`apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts:180\` — \`setCentering(true)\` 다음에 \`setForceSafeFrame(false)\` 한 줄 추가

## 병행 권장 (운영 작업)
**Ad Manager UI 에서 \`board-list-infeed\` 광고 단위 설정**:
- Creative size policy = 정확한 \`728x90\` / \`320x100\` 만 허용
- 추가 fallback 으로 height max 90px 강제

운영 작업은 별도 (Claude 권한 없음). 코드 fix + Ad Manager 둘 다 적용 권장.

## Test plan
- [ ] canary \`/free\` 진입 → 7/17번째 글 사이 광고에서 iframe 내부 scrollbar 미노출
- [ ] PC + 모바일 모두 정상
- [ ] AdSense / GAM 광고 fill rate 회귀 모니터링 (1-2일)
- [ ] 다른 광고 영역 (sidebar/wing/header/footer) 동일 동작