### PR TITLE
fix(ad-slot): GAM iframe scrolling='no' 강제 (#12595 후속, PR #1568 보강)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
@@ -140,6 +140,26 @@ function ensureSlotListener() {
         state.loaded = true;
         state.empty = event.isEmpty;
         state.viewable = false;
+
+        // #12595: SafeFrame OFF (PR #1568) 후에도 일부 광고에서 iframe 내부 scrollbar
+        // 발생. 특히 in-flow 컨테이너 (728×90 reserved) 에 더 큰 creative (예: 250×250)
+        // 가 들어오면 iframe 안에 scroll 가 생겨 사용자 페이지 스크롤 포커스를 가로챔.
+        // GPT 가 만든 iframe element 의 scrolling 속성 + overflow style 강제로 차단.
+        if (!event.isEmpty) {
+            try {
+                const container = document.getElementById(slotId);
+                const iframe = container?.querySelector(
+                    'iframe[id^="google_ads_iframe"]'
+                ) as HTMLIFrameElement | null;
+                if (iframe) {
+                    iframe.setAttribute('scrolling', 'no');
+                    iframe.style.overflow = 'hidden';
+                }
+            } catch {
+                // best-effort: GPT iframe 없거나 권한 부족 시 silent skip
+            }
+        }
+
         const pageContext = getCurrentPageContext();
         trackEvent('ad_impression', {
             slot_id: slotId,


### PR DESCRIPTION
## Context
PR #1568 (setForceSafeFrame(false)) 머지 후에도 **canary 의 게시판 목록 in-flow 광고에 scroll bar 여전히 발생**. curl 분석 결과:

- 컨테이너 \`--ad-slot-min-height: 100px\` (in-flow board-list-infeed)
- 그러나 GAM 이 컨테이너 안에 더 큰 creative (예: 250×250) render
- SafeFrame OFF 해도 GPT iframe 의 \`scrolling\` default = \`auto\` → iframe 내부 scroll bar 생성
- CSS \`overflow:hidden\` 은 iframe 내부 차단 불가 (iframe = 독립 DOM)

## Fix
\`slotRenderEnded\` event 에서 해당 slot 의 iframe (\`google_ads_iframe_*\` id) 을 찾아 직접 attribute / style 강제 설정:

\`\`\`typescript
iframe.setAttribute('scrolling', 'no');
iframe.style.overflow = 'hidden';
\`\`\`

## 파일
- \`apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts:135-153\` — \`slotRenderEnded\` listener 안에 iframe 처리 블록 추가

## 효과
- iframe 내부 scrollbar 강제 차단 → 사용자 페이지 스크롤 포커스 가로채기 방지
- 큰 creative 가 들어오면 잘릴 가능성은 남음 (별도 issue — Ad Manager creative size 정책으로 해결 권장)

## 병행 권장 (운영, 사용자 직접)
**Ad Manager UI**: 광고 단위 (board-list-infeed) 의 creative size policy 를 컨테이너 reserved 와 정확히 일치 (728×90 / 320×100) 시켜 dimension mismatch 자체를 방지.

## Test plan
- [ ] canary 의 \`/free\` 진입 → 7/17번째 in-flow 광고 → iframe 내부 scrollbar 미노출
- [ ] PC + 모바일 모두 정상
- [ ] AdSense 광고 fill rate 회귀 모니터링
- [ ] devtools console 에 \`google_ads_iframe_*\` element 의 \`scrolling="no"\` attribute 확인