### PR TITLE
fix(board): 게시글 공감자 아바타를 진입 시 eager 로드

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -760,6 +760,15 @@
         likersPage = 1;
         editingMemoFor = null;
         scheduledDelete = null;
+
+        // 공감자 아바타 eager 미리보기 로드.
+        // 댓글은 getCommentLikersBatch로 초기 로드 시 아바타가 뜨지만, 게시글은 기존에
+        // loadLikerAvatars가 공감 토글에서만 호출돼 "공감/공감자 목록 보기"를 누르기 전엔
+        // 아바타가 안 떴음. 좋아요가 있는 글에서만 1회 요청(상위 5명).
+        // 비로그인은 loadLikerAvatars 내부에서 early-return하므로 요청 발생 안 함.
+        if (data.post.likes > 0) {
+            loadLikerAvatars();
+        }
     });
 
     // 앵커 스크롤 + 하이라이트 헬퍼


### PR DESCRIPTION
## 요약
게시글 공감자 프로필 아바타가 **게시글 진입 직후에는 보이지 않고**, "공감" 버튼이나 "공감자 목록 보기"를 눌러야만 표시되던 문제를 수정합니다. 댓글은 초기 로드 시 아바타가 뜨던 것과 비대칭이었습니다.

## 원인
`loadLikerAvatars()`(상위 5명 아바타 미리보기)가 **공감 토글 핸들러에서만** 호출되고 초기 진입에는 연결되어 있지 않았습니다. 댓글은 `getCommentLikersBatch`로 목록 로드 시 eager 패칭합니다.

## 수정
글 이동/초기화 effect에서 좋아요가 있는 글(`data.post.likes > 0`)에 한해 `loadLikerAvatars()`를 1회 호출 → 댓글과 동일하게 진입 시 아바타 표시.
- 비로그인은 함수 내부 early-return으로 요청 발생 안 함
- 좋아요 0인 글은 호출하지 않아 불필요한 요청 없음

## 테스트
- dev DB에 공감자(`g5_board_good`) 시드 후, 게시글 진입 시 **클릭 없이** 아바타 스택이 표시됨을 확인.
- `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
