### PR TITLE
fix(board): 댓글 공감자 아바타를 로그인 사용자 한정으로 노출

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -935,6 +935,8 @@
     // 50개 초과 시 한 번에 보내면 뒤쪽 댓글이 조용히 잘려 나가 "특정번째 이후 댓글 공감자 미노출" 제보(#11996) 재현됨
     const COMMENT_LIKERS_BATCH_CHUNK = 50;
     async function loadCommentLikerAvatarsBatch(commentIds: string[]): Promise<void> {
+        // 공감자 신원(닉네임/ID)은 로그인 사용자에게만 노출 — 게시글 공감자(loadLikerAvatars)와 동일 정책.
+        if (!authStore.isAuthenticated) return;
         if (!boardId || !postId || commentIds.length === 0) return;
         try {
             const chunks: string[][] = [];
@@ -1384,7 +1386,7 @@
                                 </div>
 
                                 <!-- 댓글 추천자 아바타 스택 -->
-                                {#if getCommentLikes(comment) > 0 && commentLikersList.has(String(comment.id))}
+                                {#if authStore.isAuthenticated && getCommentLikes(comment) > 0 && commentLikersList.has(String(comment.id))}
                                     <AvatarStack
                                         items={commentLikersList.get(String(comment.id)) ?? []}
                                         total={commentLikersTotal.get(String(comment.id)) ?? 0}
@@ -1776,7 +1778,7 @@
                             {/if}
 
                             <!-- 댓글 추천자 아바타 스택 -->
-                            {#if getCommentLikes(comment) > 0 && commentLikersList.has(String(comment.id))}
+                            {#if authStore.isAuthenticated && getCommentLikes(comment) > 0 && commentLikersList.has(String(comment.id))}
                                 <AvatarStack
                                     items={commentLikersList.get(String(comment.id)) ?? []}
                                     total={commentLikersTotal.get(String(comment.id)) ?? 0}


### PR DESCRIPTION
## 요약
댓글 공감자 아바타가 **비로그인 사용자에게도 노출**되어, 공감자 신원(닉네임/ID)이 익명 방문자에게 보이던 비대칭을 게시글 정책에 맞춰 정렬합니다.

## 배경
- **게시글** 공감자 아바타: 로그인 사용자 한정 (`basic.svelte`의 `authStore.isAuthenticated` 게이트 + `loadLikerAvatars` early-return)
- **댓글** 공감자 아바타: 게이트 없음 → 비로그인도 노출 (백엔드/프록시는 same-origin 요청이면 로그인 무관하게 데이터를 주므로 UI 게이트만으로 결정됨)

## 수정 (`comment-list.svelte`)
- `loadCommentLikerAvatarsBatch`: 비로그인 시 early-return → fetch 자체를 하지 않음
- 아바타 스택 렌더 게이트 2곳(데스크톱/모바일)에 `authStore.isAuthenticated` 추가

## 테스트
- `svelte-check` 0 errors.
- 비로그인 상태에서 댓글 공감자 아바타 미표시 / 로그인 시 표시 확인.

## 비고

> [!note]
> 공감자 신원을 익명 방문자에게 공개할지는 정책 결정 사항입니다. 본 PR은 **게시글의 기존 정책(로그인 한정)**에 댓글을 맞추는 방향입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
