### PR TITLE
fix(home): 홈 위젯 이미지 s3 → CDN_URL(r2) 정규화

### DIFF
--- a/apps/web/src/lib/components/features/board/content-blur.svelte
+++ b/apps/web/src/lib/components/features/board/content-blur.svelte
@@ -23,7 +23,7 @@
     let revealed = $state(false);
 
     const BOOKKUANG_IMAGE =
-        'https://s3.damoang.net/data/editor/b7767-664966b303898-9eea4d0b7513e8395986b5aa7c42d1854c10bc21.webp';
+        'https://r2.damoang.net/data/editor/b7767-664966b303898-9eea4d0b7513e8395986b5aa7c42d1854c10bc21.webp';
 
     const isBlurred = $derived(shouldBlur && !revealed);
 

--- a/apps/web/src/lib/server/index-widgets-builder.ts
+++ b/apps/web/src/lib/server/index-widgets-builder.ts
@@ -47,6 +47,20 @@ const JSON_PATH =
     '/home/damoang/legacy-data/data/cache/recommended/index-widgets.json';
 const CACHE_TTL_MS = 60_000; // 60초 (파일은 5분마다 갱신)
 
+/**
+ * 이미지 read CDN base (CDN_URL). Go 생성기가 index-widgets.json 의 thumbnail/content 를
+ * s3/cdn.damoang.net 으로 박아 보내는데, 이 위젯 경로는 normalizeMediaUrl 을 거치지 않아
+ * 홈에서만 s3 URL 이 노출됨 (게시판 목록은 정규화됨). 여기서 raw 단계에 host 를 치환한다.
+ * multi-tenant: 테넌트별 CDN_URL env 사용. 미설정(기본 s3) 시 no-op.
+ */
+const CDN_BASE = (env.CDN_URL || 'https://s3.damoang.net').replace(/\/$/, '');
+
+/** index-widgets.json 의 /data/ 이미지 host 를 CDN_BASE 로 치환 (R2 read cutover). */
+function rewriteImageHosts(rawJson: string): string {
+    if (CDN_BASE === 'https://s3.damoang.net') return rawJson; // 기본값 = 치환 불필요
+    return rawJson.replace(/https:\/\/(?:s3|cdn)\.damoang\.net\/data\//g, `${CDN_BASE}/data/`);
+}
+
 const EMPTY_RESULT: IndexWidgetsData = {
     news_tabs: [],
     economy_tabs: [],
@@ -70,7 +84,7 @@ export async function buildIndexWidgets(_backendUrl: string): Promise<IndexWidge
 
     try {
         const raw = await readFile(JSON_PATH, 'utf-8');
-        const json = JSON.parse(raw);
+        const json = JSON.parse(rewriteImageHosts(raw));
 
         const result: IndexWidgetsData = {
             news_tabs: (json.news_tabs ?? []) as NewsPost[],


### PR DESCRIPTION
## 배경
6/5 R2 read cutover(configmap CDN_URL=r2.damoang.net) 후, 게시판 목록(/free,/qa,/economy)은 100% r2 인데 **홈(/)에만 s3.damoang.net 이미지 ~21개 잔존**.

## 원인
홈 위젯은 `index-widgets-builder.ts`가 Go백엔드 생성 `index-widgets.json`(thumbnail/content 에 s3 URL 박힘)을 읽어 렌더하는데, 게시판과 달리 **normalizeMediaUrl 을 안 거침**.

## 변경
- `index-widgets-builder.ts`: raw JSON 의 `/data/` 이미지 host 를 CDN_URL 로 치환 (`rewriteImageHosts`). multi-tenant: CDN_URL env 사용, 미설정(기본 s3) 시 no-op.
- `content-blur.svelte`: 하드코딩 북꾸앙 placeholder s3 → r2.

## 검증
- 사전: r2.damoang.net 캐시 HIT(GET) + Sippy S3 fallback 확인됨 (cutover 시)
- CI: type check + lint
- 배포 후: 홈(/) SSR 이미지 도메인 s3 → r2 확인

## 효과
홈 위젯 이미지도 R2 egress($0) 경유 → CloudFront 절감 완성 (게시판+홈 100%)

## 위험
low. 치환 실패해도 s3 URL 은 여전히 작동(이미지 안 깨짐). CDN_URL 미설정 테넌트=no-op.