### PR TITLE
fix(home): 추천/탐색 위젯 캐시 JSON 이미지도 CDN_URL(r2) 정규화

### DIFF
--- a/apps/web/src/lib/server/cdn-rewrite.ts
+++ b/apps/web/src/lib/server/cdn-rewrite.ts
@@ -1,0 +1,19 @@
+/**
+ * 캐시 JSON 등 raw 문자열의 /data/ 이미지 host 를 CDN_URL 로 치환하는 서버 전용 유틸.
+ *
+ * 배경: Go/PHP 백엔드가 생성하는 cache JSON(index-widgets, recommended, explore 등)에
+ * s3/cdn.damoang.net URL 이 박혀 오는데, 이 경로들은 normalizeMediaUrl 을 거치지 않아
+ * R2 read cutover(CDN_URL=r2.damoang.net) 후에도 s3 로 빠짐.
+ * → readFile 직후 raw 단계에서 host 만 치환한다.
+ *
+ * multi-tenant: 테넌트별 CDN_URL env 사용. 미설정(기본 s3) 시 no-op.
+ */
+import { env } from '$env/dynamic/private';
+
+const CDN_BASE = (env.CDN_URL || 'https://s3.damoang.net').replace(/\/$/, '');
+
+/** raw JSON/HTML 문자열의 /data/ 이미지 host 를 CDN_BASE 로 치환. 기본값이면 no-op. */
+export function rewriteImageHosts(raw: string): string {
+    if (CDN_BASE === 'https://s3.damoang.net') return raw;
+    return raw.replace(/https:\/\/(?:s3|cdn)\.damoang\.net\/data\//g, `${CDN_BASE}/data/`);
+}

--- a/apps/web/src/lib/server/daily-recommended-loader.ts
+++ b/apps/web/src/lib/server/daily-recommended-loader.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { rewriteImageHosts } from '$lib/server/cdn-rewrite';
 import { existsSync } from 'node:fs';
 import type { DailyCalendar, DailyRecommendedData } from '$lib/api/types';
 import { env } from '$env/dynamic/private';
@@ -56,7 +57,7 @@ export async function loadDailyCalendar(): Promise<DailyCalendar | null> {
 
     try {
         const content = await readFile(filePath, 'utf-8');
-        const data: DailyCalendar = JSON.parse(content);
+        const data: DailyCalendar = JSON.parse(rewriteImageHosts(content));
         setCacheBounded(cacheKey, data, Date.now());
         return data;
     } catch (err) {
@@ -84,7 +85,7 @@ export async function loadDailyRecommended(date: string): Promise<DailyRecommend
 
     try {
         const content = await readFile(filePath, 'utf-8');
-        const data: DailyRecommendedData = JSON.parse(content);
+        const data: DailyRecommendedData = JSON.parse(rewriteImageHosts(content));
         cache.set(date, { data, timestamp: Date.now() });
         return data;
     } catch (err) {

--- a/apps/web/src/lib/server/explore-loader.ts
+++ b/apps/web/src/lib/server/explore-loader.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { rewriteImageHosts } from '$lib/server/cdn-rewrite';
 import { existsSync } from 'node:fs';
 import type { ExploreData, ExploreModeData } from '$lib/api/types';
 import { env } from '$env/dynamic/private';
@@ -48,7 +49,7 @@ export async function loadExploreData(): Promise<ExploreData | null> {
 
     try {
         const content = await readFile(filePath, 'utf-8');
-        const data: ExploreData = JSON.parse(content);
+        const data: ExploreData = JSON.parse(rewriteImageHosts(content));
         cache = { data, timestamp: Date.now() };
         return data;
     } catch (err) {

--- a/apps/web/src/lib/server/index-widgets-builder.ts
+++ b/apps/web/src/lib/server/index-widgets-builder.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'fs/promises';
+import { rewriteImageHosts } from '$lib/server/cdn-rewrite';
 import { env } from '$env/dynamic/private';
 import type {
     IndexWidgetsData,
@@ -46,20 +47,6 @@ const JSON_PATH =
     env.INDEX_WIDGETS_CACHE_PATH ||
     '/home/damoang/legacy-data/data/cache/recommended/index-widgets.json';
 const CACHE_TTL_MS = 60_000; // 60초 (파일은 5분마다 갱신)
-
-/**
- * 이미지 read CDN base (CDN_URL). Go 생성기가 index-widgets.json 의 thumbnail/content 를
- * s3/cdn.damoang.net 으로 박아 보내는데, 이 위젯 경로는 normalizeMediaUrl 을 거치지 않아
- * 홈에서만 s3 URL 이 노출됨 (게시판 목록은 정규화됨). 여기서 raw 단계에 host 를 치환한다.
- * multi-tenant: 테넌트별 CDN_URL env 사용. 미설정(기본 s3) 시 no-op.
- */
-const CDN_BASE = (env.CDN_URL || 'https://s3.damoang.net').replace(/\/$/, '');
-
-/** index-widgets.json 의 /data/ 이미지 host 를 CDN_BASE 로 치환 (R2 read cutover). */
-function rewriteImageHosts(rawJson: string): string {
-    if (CDN_BASE === 'https://s3.damoang.net') return rawJson; // 기본값 = 치환 불필요
-    return rawJson.replace(/https:\/\/(?:s3|cdn)\.damoang\.net\/data\//g, `${CDN_BASE}/data/`);
-}
 
 const EMPTY_RESULT: IndexWidgetsData = {
     news_tabs: [],

--- a/apps/web/src/lib/server/recommended-loader.ts
+++ b/apps/web/src/lib/server/recommended-loader.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { rewriteImageHosts } from '$lib/server/cdn-rewrite';
 import { existsSync, statSync } from 'node:fs';
 import type { RecommendedDataWithAI, RecommendedPeriod } from '$lib/api/types';
 import { env } from '$env/dynamic/private';
@@ -75,7 +76,7 @@ export async function loadRecommendedData(
 
     try {
         const content = await readFile(filePath, 'utf-8');
-        const data: RecommendedDataWithAI = JSON.parse(content);
+        const data: RecommendedDataWithAI = JSON.parse(rewriteImageHosts(content));
 
         cache.set(period, { data, timestamp: Date.now() });
         return data;


### PR DESCRIPTION
## 배경
#1572(index-widgets) 후에도 홈에 s3 이미지 7개 잔존. 출처 = **recommended/explore/daily 캐시 JSON** (`image_url` 에 s3 박힘)을 loader 가 정규화 없이 파싱 (실측: recommended cache 디렉토리에 s3 67회).

## 변경
- `lib/server/cdn-rewrite.ts` 공용 유틸 신설 (`rewriteImageHosts` — /data/ host 를 CDN_URL 로, 미설정 시 no-op)
- 적용: recommended-loader, explore-loader, daily-recommended-loader(2곳), index-widgets-builder(자체구현→공용 교체)

## 검증
- canary 실측으로 발견 (홈 s3 21→7, 잔존 7=recommended image_url)
- 배포 후 canary 홈에서 s3 0 확인 예정

## 위험
low. 치환 실패해도 s3 URL 정상 작동. CDN_URL 미설정 테넌트 no-op.