### PR TITLE
feat(messages): 헤더 쪽지 아이콘에 미읽음 배지 추가

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -11,7 +11,7 @@
     import Smartphone from '@lucide/svelte/icons/smartphone';
     import DefaultLogo from '$lib/assets/logo.svg';
     import AlignJustify from '@lucide/svelte/icons/align-justify';
-    import Mail from '@lucide/svelte/icons/mail';
+    import MessageIcon from './message-icon.svelte';
     import Sidebar from './sidebar.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import {
@@ -467,15 +467,8 @@
             {/if}
 
             {#if isEffectivelyLoggedIn}
-                <!-- 쪽지 아이콘 -->
-                <button
-                    onclick={() => goto('/messages')}
-                    class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out"
-                    aria-label="쪽지"
-                >
-                    <span class="pointer-events-none absolute -inset-1"></span>
-                    <Mail class="text-muted-foreground h-5 w-5" />
-                </button>
+                <!-- 쪽지 아이콘 + 미읽음 배지 -->
+                <MessageIcon />
 
                 <!-- 알림 드롭다운 -->
                 <NotificationDropdown />

--- a/apps/web/src/lib/components/layout/message-icon.svelte
+++ b/apps/web/src/lib/components/layout/message-icon.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+    // 헤더 쪽지 아이콘 + 미읽음 배지.
+    // 알림 종(notification-dropdown.svelte)의 unread-count 폴링 패턴과 동일하게
+    // /api/v1/messages/unread-count 를 폴링해 미읽음 개수를 배지로 표시한다.
+    // 배경: 배지가 없어 사용자가 쪽지 수신을 인지하지 못해 3개월간 열람 기록 0건이었음
+    // (docs/2026-06-05-memo-read-tracking-diagnosis.md "남은 작업 2번").
+    import { onMount } from 'svelte';
+    import { goto, afterNavigate } from '$app/navigation';
+    import Mail from '@lucide/svelte/icons/mail';
+    import { apiClient } from '$lib/api/client';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+
+    // 알림 배지와 동일한 폴링 주기 (3분).
+    const POLL_INTERVAL_MS = 180_000;
+
+    let unreadCount = $state(0);
+    let inflight: Promise<void> | null = null;
+
+    async function loadUnreadCount(): Promise<void> {
+        if (!authStore.isAuthenticated) {
+            unreadCount = 0;
+            return;
+        }
+        if (inflight) return inflight;
+        inflight = (async () => {
+            try {
+                const res = await apiClient.getUnreadMessageCount();
+                unreadCount = res?.count ?? 0;
+            } catch {
+                // unread-count 실패 시 배지를 끄지 않고 기존 값 유지 (일시 오류로 깜박임 방지).
+            } finally {
+                inflight = null;
+            }
+        })();
+        return inflight;
+    }
+
+    onMount(() => {
+        // auth 초기화(layout onMount)가 완료된 뒤 호출하도록 약간 지연 (알림 패턴과 동일).
+        if (document.visibilityState === 'visible') {
+            setTimeout(() => void loadUnreadCount(), 200);
+        }
+
+        let interval: ReturnType<typeof setInterval> | null = null;
+
+        function startPolling() {
+            if (interval) return;
+            interval = setInterval(() => void loadUnreadCount(), POLL_INTERVAL_MS);
+        }
+        function stopPolling() {
+            if (interval) {
+                clearInterval(interval);
+                interval = null;
+            }
+        }
+
+        function handleVisibilityChange() {
+            if (document.visibilityState === 'visible') {
+                void loadUnreadCount();
+                startPolling();
+            } else {
+                stopPolling();
+            }
+        }
+
+        if (document.visibilityState === 'visible') startPolling();
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+
+        return () => {
+            stopPolling();
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+        };
+    });
+
+    // /messages 를 방문하고 나오면(쪽지를 읽었을 가능성) 즉시 카운트 갱신.
+    afterNavigate((nav) => {
+        const from = nav.from?.url.pathname;
+        const to = nav.to?.url.pathname;
+        if (from?.startsWith('/messages') || to?.startsWith('/messages')) {
+            void loadUnreadCount();
+        }
+    });
+</script>
+
+<button
+    onclick={() => goto('/messages')}
+    class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out"
+    aria-label={unreadCount > 0 ? `쪽지 (미읽음 ${unreadCount}개)` : '쪽지'}
+>
+    <span class="pointer-events-none absolute -inset-1"></span>
+    <Mail class="text-muted-foreground h-5 w-5" />
+    {#if unreadCount > 0}
+        <span
+            class="bg-primary noti-pulse absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold leading-none text-white"
+            >{unreadCount > 99 ? '99+' : unreadCount}</span
+        >
+    {/if}
+</button>
+
+<style>
+    /* 미읽음 인디케이터 펄스 (알림 배지와 동일) */
+    .noti-pulse {
+        animation: noti-pulse 1.25s ease-in-out infinite;
+    }
+
+    @keyframes noti-pulse {
+        0%,
+        100% {
+            opacity: 1;
+            transform: scale(1);
+        }
+        50% {
+            opacity: 0.6;
+            transform: scale(1.3);
+        }
+    }
+</style>

--- a/apps/web/src/routes/messages/+page.svelte
+++ b/apps/web/src/routes/messages/+page.svelte
@@ -11,6 +11,7 @@
     import { authStore } from '$lib/stores/auth.svelte.js';
     import type { Message, MessageListResponse, MessageKind } from '$lib/api/types.js';
     import { onMount } from 'svelte';
+    import { toast } from 'svelte-sonner';
     import Mail from '@lucide/svelte/icons/mail';
     import Send from '@lucide/svelte/icons/send';
     import Inbox from '@lucide/svelte/icons/inbox';
@@ -100,6 +101,9 @@
             viewingMessage = await apiClient.getMessage(message.id);
         } catch (err) {
             console.error('Failed to load message:', err);
+            // 상세 조회는 읽음 처리(MarkAsRead)도 트리거하므로, 실패를 조용히 묻으면
+            // 사용자가 못 읽은 채로 읽음 추적도 안 됨 → 최소한 토스트로 노출한다.
+            toast.error('쪽지를 불러오지 못했어요. 잠시 후 다시 시도해주세요.');
             viewingMessage = message;
         } finally {
             isLoadingMessage = false;


### PR DESCRIPTION
## 요약

헤더 쪽지 아이콘에 **미읽음 개수 배지**를 추가합니다. 알림 종 아이콘과 동일한 패턴으로 `/api/v1/messages/unread-count` 를 폴링합니다.

## 배경 (왜 중요한가)

- 배지가 없어 사용자가 쪽지 수신을 인지하지 못해 쪽지함 방문이 거의 없었고, **2026-03 PHP 종료 이후 3개월간 전 시스템 쪽지 열람 기록이 0건**이었습니다.
- 정보통신망법 제44조의2 임시조치 통보를 쪽지로 발송하는데, 수신자가 쪽지 존재를 알 수 없으면 **통지 도달을 주장하기 어려움** → 법적 절차 신뢰성 문제로 우선순위 높음.
- 진단 문서: `docs/2026-06-05-memo-read-tracking-diagnosis.md` 의 "남은 작업 2번".

## 변경 사항

- **`message-icon.svelte` 신규**: Mail 아이콘 + 미읽음 배지 캡슐화. 알림 종과 동일하게
  - `apiClient.getUnreadMessageCount()` (기존 존재) 연결
  - 폴링 3분(`180s`, 알림과 동일) + `visibilitychange` 시 갱신 + 마운트 직후 prime
  - `/messages` 진입/이탈 시 즉시 카운트 갱신 (읽은 직후 배지 반영)
  - 배지 디자인/펄스 애니메이션 알림 배지와 통일, `99+` 처리
- **`header.svelte`**: 기존 plain Mail 버튼 → `<MessageIcon />` 로 교체 (미사용 `Mail` import 정리).
- **`messages/+page.svelte`**: `viewMessage()` 상세 조회 실패 시 목록 데이터로 **조용히 폴백**하던 것을 `toast.error` 노출로 개선 (상세 조회 = 읽음 처리 트리거라, 실패가 묻히면 읽음 추적도 조용히 실패).

## 선행 조건

- `angple-backend#495` (unread-count 의 MySQL 8 datetime `''` 비교 에러 수정) **머지 완료**. 단, 이 백엔드 수정이 **prod 에 배포된 뒤** 프론트가 prod 반영되어야 배지 폴링이 500 을 받지 않습니다.

## 검증

- `svelte-check`: 0 errors
- dev: 미읽음 쪽지 보유 계정 → Mail 아이콘 배지 표시 / `/messages` 에서 읽은 뒤 배지 감소·소멸 / 비로그인 시 미노출
