### PR TITLE
fix(notifications): 댓글 추천 알림에도 공감 알림 임계값 적용 (#12612)

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -77,11 +77,20 @@ function fireAndForgetCommentLikeSideEffects(options: {
                 if (!options.authorMbId || options.authorMbId === options.actorMbId) return;
 
                 const [prefRows] = await pool.query<RowDataPacket[]>(
-                    `SELECT noti_like FROM g5_noti_preference WHERE mb_id = ?`,
+                    `SELECT noti_like, like_threshold FROM g5_noti_preference WHERE mb_id = ?`,
                     [options.authorMbId]
                 );
                 const notiLikeEnabled = prefRows[0]?.noti_like ?? 1;
-                if (!notiLikeEnabled) return;
+                const likeThreshold = prefRows[0]?.like_threshold ?? 1;
+
+                // 공감 알림 임계값 게이트 — 글 추천 라우트(post like)와 동일한 규칙.
+                // 댓글 라우트만 이 체크가 누락되어 임계값 설정이 무시되던 버그 수정 (#12612).
+                if (
+                    !notiLikeEnabled ||
+                    (likeThreshold > 1 && options.nextLikes % likeThreshold !== 0)
+                ) {
+                    return;
+                }
 
                 await pool.query(
                     `DELETE FROM g5_na_noti WHERE bo_table = ? AND wr_id = ? AND rel_mb_id = ? AND ph_from_case = 'good'`,


### PR DESCRIPTION
## 요약

개인 설정의 **공감 알림 임계값**(`like_threshold`)이 **댓글 추천 알림**에는 적용되지 않던 버그를 수정합니다. (버그게시판 #12612)

## 원인

- 글 추천 라우트(`posts/[postId]/like`)는 알림 발송 전 `like_threshold` 게이트가 있음 ✅
- **댓글 추천 라우트**(`comments/[commentId]/like`)는 `noti_like`만 읽고 임계값 체크가 누락 ❌
- 제보자 실데이터 확인: 임계값 3 설정(5/21) 이후 수신한 공감 알림 12건 전부 "댓글을 추천했습니다" — 모두 누락 경로에서 발송

## 변경

`comments/[commentId]/like/+server.ts` 알림 발송 블록에 글 추천 라우트와 동일한 게이트 추가:

- `SELECT noti_like` → `SELECT noti_like, like_threshold`
- `likeThreshold > 1 && nextLikes % likeThreshold !== 0` 이면 알림 스킵

## 동작

| 설정 | 변경 전 | 변경 후 |
|---|---|---|
| 임계값 3 | 댓글 공감 1개부터 매번 알림 | 3, 6, 9…번째에만 알림 (글 추천과 동일) |
| 임계값 1/미설정 | 매번 알림 | 매번 알림 (변화 없음) |
| 공감 알림 끔 | 알림 없음 | 알림 없음 (변화 없음) |
