### PR TITLE
fix(ad-slot): overflow-x hidden → clip — 광고 세로 스크롤바 근본 해결 (#12595, #12616)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -345,9 +345,13 @@
 </script>
 
 {#if !suppressAds}
+    <!-- overflow-x 는 hidden 이 아닌 clip 이어야 한다: CSS 스펙상 한 축이 hidden 이면
+         다른 축의 visible 이 auto 로 강제되어 스크롤 컨테이너가 생긴다 (#12595/#12616
+         광고 세로 스크롤바의 근본 원인). clip 은 스크롤 컨테이너를 만들지 않아
+         가로 clipping + 세로 visible(윙 잘림 방지, #1542)이 모두 유지된다. -->
     <div
         bind:this={containerEl}
-        class="dm-display-frame relative overflow-x-hidden overflow-y-visible rounded-lg {className}"
+        class="dm-display-frame relative overflow-x-clip overflow-y-visible rounded-lg {className}"
         class:ad-slot-loaded={isLoaded && hasAd}
         class:ad-slot-empty={isEmpty}
         class:ad-slot-empty-collapsed={isEmpty}
@@ -432,8 +436,10 @@
         justify-content: center;
         align-items: center;
         max-width: 100%;
-        /* AdSense 정책: 광고 세로 잘림 금지 (Ad Clipping). 가로만 clip — 모바일 viewport 보호용. */
-        overflow-x: hidden;
+        /* AdSense 정책: 광고 세로 잘림 금지 (Ad Clipping). 가로만 clip — 모바일 viewport 보호용.
+           주의: hidden 을 쓰면 CSS 스펙상 overflow-y: visible 이 auto 로 강제되어
+           세로 스크롤바가 생긴다 (#12595/#12616). 반드시 clip 사용. */
+        overflow-x: clip;
         overflow-y: visible;
     }
 


### PR DESCRIPTION
## 요약

게시판 인피드/디스플레이 광고에 **세로 스크롤바가 생기는 문제의 근본 원인**을 수정합니다. (버그게시판 #12595, #12616)

## 근본 원인 — CSS 스펙 함정

CSS Overflow 스펙: **한 축이 `hidden`이면 다른 축의 `visible`은 `auto`로 강제 계산**됩니다.

#1542에서 윙 광고 세로 잘림을 풀기 위해 `overflow-hidden` → `overflow-x-hidden overflow-y-visible`로 바꿨는데, 실제 computed style은 `overflow-y: auto`가 되어 — 광고 creative가 컨테이너 min-height보다 높으면 **wrapper div가 스크롤 컨테이너**가 되어 세로 스크롤바가 발생했습니다.

**canary 실측** (Playwright, 4개 슬롯 전부):
```
클래스:   overflow-x-hidden overflow-y-visible
computed: overflow-x: hidden, overflow-y: auto   ← visible 무시됨
```

이것이 #1568(SafeFrame off), #1569(iframe scrolling=no)가 효과 없던 이유입니다 — 스크롤바는 GAM iframe이 아니라 **우리 wrapper에** 있었습니다.

## 수정

`overflow-x: hidden` → **`overflow-x: clip`** (frame Tailwind 클래스 + `.dm-display-slot` CSS 둘 다)

- `clip`은 **스크롤 컨테이너를 만들지 않음** → 스크롤바 원천 불가
- `clip` + `visible` 조합은 스펙상 유효 → `overflow-y: visible` 실제 적용 → **윙 잘림 방지(#1542) 유지**
- 가로 clipping(모바일 viewport 보호)도 동일하게 유지
- 지원: Chrome 90+ / Safari 16+ / Firefox 81+
- 재발 방지 주석 추가, 동일 패턴 코드베이스 전수 검사 — 이 파일이 유일

## 검증 계획

canary 배포 후 동일 Playwright 스크립트로 computed `overflow-x: clip / overflow-y: visible` 재실측.
