### PR TITLE
fix(auth): 보호 페이지 ↔ /login 무한 새로고침 루프 차단 (#12621)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -345,22 +345,41 @@ function getGlobalApiRateLimitKey(
     return clientIp ? `ip:${clientIp}` : null;
 }
 
-/** 타임아웃 래퍼: 지정 시간 내 미완료 시 null 반환
- *
- * 2026-04-26: setTimeout clearTimeout 누락 수정.
- * Promise.race 가 promise winner 일 때 timer 가 살아있어 매 SSR 요청 누적
- * (12h × 수만 요청 = pod 메모리 +수백 MB). Serena Round A #2 발견.
- */
 const AUTH_TIMEOUT_MS = 3000;
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<null>((resolve) => {
-        timer = setTimeout(() => resolve(null), ms);
-        timer.unref?.();
-    });
-    return Promise.race([promise, timeoutPromise]).finally(() => {
-        if (timer) clearTimeout(timer);
-    });
+
+/**
+ * withTimeout 은 타임아웃 시 null 을 반환해 "조회 결과 없음(로그아웃)"과
+ * "일시 장애(Redis/DB 지연)"가 구분되지 않는다. 이 때문에 세션이 유효한데도
+ * 지연 한 번에 비로그인 처리되어, 보호 페이지 → /login → 복귀 → 또 지연 →
+ * 무한 왕복(#12621 쪽지함 무한 새로고침)이 생긴다.
+ * sentinel 로 타임아웃을 구분하고, 타임아웃/예외 시 1회 재시도한다.
+ */
+const AUTH_LOOKUP_TIMEOUT: unique symbol = Symbol('auth-lookup-timeout');
+async function withTimeoutRetry<T>(
+    fn: () => Promise<T>,
+    ms: number,
+    label: string
+): Promise<T | null> {
+    for (let attempt = 1; attempt <= 2; attempt++) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<typeof AUTH_LOOKUP_TIMEOUT>((resolve) => {
+            timer = setTimeout(() => resolve(AUTH_LOOKUP_TIMEOUT), ms);
+            timer.unref?.();
+        });
+        try {
+            const result = await Promise.race([fn(), timeoutPromise]).finally(() => {
+                if (timer) clearTimeout(timer);
+            });
+            if (result !== AUTH_LOOKUP_TIMEOUT) return result;
+            console.error(`[Auth] ${label} 타임아웃 (시도 ${attempt}/2)`);
+        } catch (err) {
+            console.error(
+                `[Auth] ${label} 실패 (시도 ${attempt}/2):`,
+                err instanceof Error ? err.message : err
+            );
+        }
+    }
+    return null;
 }
 
 /** SSR 인증: 서버사이드 세션 only (JWT 미사용) */
@@ -375,7 +394,11 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
 
     if (sessionId) {
         try {
-            const session = await withTimeout(getSession(sessionId), AUTH_TIMEOUT_MS);
+            const session = await withTimeoutRetry(
+                () => getSession(sessionId),
+                AUTH_TIMEOUT_MS,
+                'getSession'
+            );
             if (session) {
                 // FAST PATH: user_basic 쿠키 + JWT cache hit → DB 조회 0 (Phase B wire-up)
                 // feature flag USER_BASIC_FAST_PATH=true 시 활성화. default off.
@@ -412,7 +435,11 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                     }
                 }
 
-                const member = await withTimeout(getMemberById(session.mbId), AUTH_TIMEOUT_MS);
+                const member = await withTimeoutRetry(
+                    () => getMemberById(session.mbId),
+                    AUTH_TIMEOUT_MS,
+                    'getMemberById'
+                );
                 if (member) {
                     // 탈퇴 회원 세션 차단 (이용제한 회원은 글 열람 허용을 위해 세션 유지)
                     if (member.mb_leave_date) {

--- a/apps/web/src/lib/components/layout/message-icon.svelte
+++ b/apps/web/src/lib/components/layout/message-icon.svelte
@@ -63,12 +63,19 @@
             }
         }
 
+        // 쪽지함 다이얼로그에서 읽기 성공 시 즉시 갱신 (messages/+page.svelte 가 발행)
+        function handleMessagesRead() {
+            void loadUnreadCount();
+        }
+
         if (document.visibilityState === 'visible') startPolling();
         document.addEventListener('visibilitychange', handleVisibilityChange);
+        window.addEventListener('angple:messages-read', handleMessagesRead);
 
         return () => {
             stopPolling();
             document.removeEventListener('visibilitychange', handleVisibilityChange);
+            window.removeEventListener('angple:messages-read', handleMessagesRead);
         };
     });
 

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -43,6 +43,68 @@
     // 일반 로그인 form 노출 (iOS Safari pull-to-refresh 후 cookie 손실 시 무한 spinner 차단).
     const AUTH_POLL_TIMEOUT_MS = 5000;
 
+    // #12621: 보호 페이지(SSR 세션 판정) ↔ /login(클라이언트 판정) 무한 왕복 차단.
+    // SSR 인증이 일시 장애(Redis 지연 등)로 비로그인 판정하면 보호 페이지가 /login 으로
+    // 보내고, 여기서 클라이언트 상태만 믿고 즉시 되돌리면 무한 새로고침 루프가 된다.
+    // 가드 2중:
+    //  (1) 되돌리기 전 /api/auth/me(no-store) 로 서버 세션을 직접 확인 — 서버가
+    //      비로그인이라면 되돌리지 않고 로그인 form 노출.
+    //  (2) 같은 목적지로 60초 내 2회 이상 자동 이동 시 루프로 간주하고 form 노출.
+    const BOUNCE_STORAGE_KEY = 'angple_login_bounce_v1';
+    const BOUNCE_WINDOW_MS = 60_000;
+    const BOUNCE_MAX = 2;
+
+    function readBounce(): { target: string; count: number; ts: number } | null {
+        try {
+            const raw = sessionStorage.getItem(BOUNCE_STORAGE_KEY);
+            return raw ? JSON.parse(raw) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    function recordBounce(target: string): void {
+        try {
+            const prev = readBounce();
+            const fresh = prev && prev.target === target && Date.now() - prev.ts < BOUNCE_WINDOW_MS;
+            sessionStorage.setItem(
+                BOUNCE_STORAGE_KEY,
+                JSON.stringify({
+                    target,
+                    count: fresh ? prev.count + 1 : 1,
+                    ts: Date.now()
+                })
+            );
+        } catch {
+            // sessionStorage 불가 환경은 (1) 서버 확인 가드만으로 동작
+        }
+    }
+
+    function isBounceLooping(target: string): boolean {
+        const prev = readBounce();
+        return (
+            !!prev &&
+            prev.target === target &&
+            prev.count >= BOUNCE_MAX &&
+            Date.now() - prev.ts < BOUNCE_WINDOW_MS
+        );
+    }
+
+    /** 서버 세션 확정 확인 — 캐시 우회. 실패/비로그인 모두 false. */
+    async function confirmServerSession(): Promise<boolean> {
+        try {
+            const res = await fetch('/api/auth/me', {
+                cache: 'no-store',
+                credentials: 'same-origin'
+            });
+            if (!res.ok) return false;
+            const data = await res.json();
+            return !!data?.user;
+        } catch {
+            return false;
+        }
+    }
+
     onMount(() => {
         const oauthError = $page.url.searchParams.get('error');
         if (oauthError) {
@@ -54,7 +116,22 @@
             if (isRedirecting) return;
             if (!authStore.isLoading && authStore.isAuthenticated) {
                 isRedirecting = true;
-                window.location.href = redirectUrl;
+                void (async () => {
+                    if (isBounceLooping(redirectUrl)) {
+                        // 가드 (2): 짧은 시간 내 같은 목적지로 반복 왕복 → 루프 차단
+                        isRedirecting = false;
+                        error = '자동 이동이 반복되어 중단했습니다. 다시 로그인해 주세요.';
+                        return;
+                    }
+                    if (!(await confirmServerSession())) {
+                        // 가드 (1): 클라이언트는 로그인 상태지만 서버 세션이 없음/불안정
+                        isRedirecting = false;
+                        error = '세션이 만료되었습니다. 다시 로그인해 주세요.';
+                        return;
+                    }
+                    recordBounce(redirectUrl);
+                    window.location.href = redirectUrl;
+                })();
                 return;
             }
             // timeout: polling 5초 내 결판 안 나면 form 노출 (loop 차단)

--- a/apps/web/src/routes/messages/+page.svelte
+++ b/apps/web/src/routes/messages/+page.svelte
@@ -99,6 +99,10 @@
 
         try {
             viewingMessage = await apiClient.getMessage(message.id);
+            // 상세 조회 성공 = 서버 읽음 처리 완료. 다이얼로그에서 읽으면 네비게이션이
+            // 없어 헤더 배지가 폴링(3분)까지 안 줄어드므로, 즉시 갱신 신호를 보낸다.
+            message.is_read = true;
+            window.dispatchEvent(new CustomEvent('angple:messages-read'));
         } catch (err) {
             console.error('Failed to load message:', err);
             // 상세 조회는 읽음 처리(MarkAsRead)도 트리거하므로, 실패를 조용히 묻으면


### PR DESCRIPTION
## 요약

쪽지함(/messages) 등 보호 페이지 새로고침 시 **"로그아웃됐다 로그인되는 것처럼" 무한 새로고침** 되는 루프를 차단합니다. (버그게시판 #12621, #12586 잔존 — 공지글 댓글로 3명 동일 제보: iOS Safari / 안드 삼성인터넷 / Brave)

## 원인 — SSR 세션 ↔ 클라이언트 인증 스플릿 브레인

- SSR 인증(`hooks.server.ts`)의 `withTimeout`은 **타임아웃 시 null을 반환** → "세션 없음(로그아웃)"과 "Redis/DB 일시 지연"이 구분 불가
- Redis가 3초 한 번만 느려도 **유효한 세션이 비로그인 판정** → 보호 페이지 `redirect(302, /login)` → /login은 클라이언트 상태만 믿고 즉시 복귀 → 또 지연 → **무한 왕복**
- 쪽지 배지 도입으로 쪽지함 방문이 급증하며 발현 빈도 증가

## 수정 (다층 방어)

1. **`hooks.server.ts`** — `withTimeoutRetry` 도입: sentinel로 타임아웃과 "결과 없음"을 구분, `getSession`/`getMemberById` 일시 실패 시 **1회 재시도** (루프 원천 흡수)
2. **`login/+page.svelte`** — 자동 복귀 전 `/api/auth/me`(no-store)로 **서버 세션 확정 확인** (서버가 비로그인이라면 form 노출, 왕복 금지) + **bounce 가드** (60초 내 같은 목적지로 2회 이상 → 루프 판정, form + 안내 메시지)
3. **(동봉)** 쪽지 다이얼로그에서 읽기 성공 시 `angple:messages-read` 이벤트로 **헤더 배지 즉시 갱신** (기존엔 3분 폴링/이탈 시에만 갱신 → "읽어도 안 줄어듦" 체감의 클라이언트 측 기여분 제거)

## 검증

- `svelte-check` 0 errors (변경 파일 warning 0)
- 가드 동작: 서버 세션 null → 자동 복귀 안 함 + "세션이 만료되었습니다" / 60초 내 2회 왕복 → "자동 이동이 반복되어 중단했습니다"
- 정상 로그인 플로우: OAuth 콜백 → 세션 생성 → `/api/auth/me` 확인 통과 → 1회 복귀 (bounce 카운트 1, 영향 없음)

## 참고

- 서버측 read-marking 미동작("읽어도 배지 안 사라짐")의 근본은 angple-backend#496 (IsRead zero-date)에서 별도 수정 중 — 본 PR 범위 아님
