### PR TITLE
feat(messages): 받은 쪽지함 '모두 읽음' 버튼

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2015,6 +2015,16 @@ class ApiClient {
         return response.data;
     }
 
+    /**
+     * 받은 쪽지 전체 읽음 처리 ('모두 읽음' 버튼)
+     */
+    async markAllMessagesRead(): Promise<{ updated: number }> {
+        const response = await this.request<{ updated: number }>('/messages/read-all', {
+            method: 'POST'
+        });
+        return response.data;
+    }
+
     // ==================== 경험치 API ====================
 
     /**

--- a/apps/web/src/routes/messages/+page.svelte
+++ b/apps/web/src/routes/messages/+page.svelte
@@ -45,6 +45,32 @@
     let viewingMessage = $state<Message | null>(null);
     let isLoadingMessage = $state(false);
 
+    // 모두 읽음 처리
+    let isMarkingAllRead = $state(false);
+
+    /** 받은 쪽지 전체 읽음 처리 — 목록/탭 배지/헤더 배지 즉시 반영 */
+    async function markAllRead(): Promise<void> {
+        if (isMarkingAllRead) return;
+        isMarkingAllRead = true;
+        try {
+            const { updated } = await apiClient.markAllMessagesRead();
+            if (messageData) {
+                messageData.items = messageData.items.map((m) => ({ ...m, is_read: true }));
+                messageData.unread_count = 0;
+            }
+            // 헤더 쪽지 배지 즉시 갱신 (message-icon.svelte 가 수신)
+            window.dispatchEvent(new CustomEvent('angple:messages-read'));
+            toast.success(
+                updated > 0 ? `쪽지 ${updated}개를 읽음 처리했어요.` : '읽지 않은 쪽지가 없어요.'
+            );
+        } catch (err) {
+            console.error('Failed to mark all messages read:', err);
+            toast.error('모두 읽음 처리에 실패했어요. 잠시 후 다시 시도해주세요.');
+        } finally {
+            isMarkingAllRead = false;
+        }
+    }
+
     // 탭 정의
     const tabs: { id: MessageKind; label: string; icon: typeof Inbox }[] = [
         { id: 'recv', label: '받은 쪽지', icon: Inbox },
@@ -231,7 +257,7 @@
     </div>
 
     <!-- 탭 네비게이션 -->
-    <div class="border-border mb-6 flex gap-2 border-b pb-2">
+    <div class="border-border mb-6 flex items-center gap-2 border-b pb-2">
         {#each tabs as tab (tab.id)}
             <Button
                 variant={data.kind === tab.id ? 'default' : 'ghost'}
@@ -249,6 +275,22 @@
                 {/if}
             </Button>
         {/each}
+
+        <!-- 모두 읽음: 받은쪽지 탭 + 미읽음 있을 때만 노출 -->
+        {#if data.kind === 'recv' && messageData?.unread_count}
+            <Button
+                variant="outline"
+                size="sm"
+                class="ml-auto"
+                disabled={isMarkingAllRead}
+                onclick={markAllRead}
+            >
+                {#if isMarkingAllRead}
+                    <Loader2 class="mr-1.5 h-4 w-4 animate-spin" />
+                {/if}
+                모두 읽음
+            </Button>
+        {/if}
     </div>
 
     {#if isLoading}


### PR DESCRIPTION
## 요약
받은 쪽지함에 **'모두 읽음'** 버튼을 추가합니다. 쪽지 배지 도입 후 누적 미열람이 한 번에 해소됩니다 (운영 공지에서 약속한 기능).

## 변경
- `client.ts`: `markAllMessagesRead()` → `POST /api/v1/messages/read-all` (**angple-backend#497 머지 완료**)
- `messages/+page.svelte`: 받은쪽지 탭 + 미읽음 >0 일 때만 우측에 노출. 처리 중 spinner/disabled. 성공 시:
  - 목록 `is_read` 일괄 반영 + 탭 미읽음 배지 0
  - `angple:messages-read` 이벤트 → 헤더 쪽지 배지 즉시 갱신 (#1580 의 리스너 재사용)
  - 처리 건수 토스트

## 선행 조건
- angple-backend#497 **머지 완료** — 프론트 prod 반영 전에 백엔드가 먼저 배포돼야 합니다 (아니면 버튼 클릭 시 404)

## 검증
- svelte-check 0 errors