### PR TITLE
fix(ad-slot): creative 높이만큼 컨테이너 확장 — 광고가 제목 가림 해결 (#12628)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
@@ -155,6 +155,27 @@ function ensureSlotListener() {
                     iframe.setAttribute('scrolling', 'no');
                     iframe.style.overflow = 'hidden';
                 }
+
+                // #12628: overflow-y visible 전환(#1578) 후, 예약 높이(min-height)보다 큰
+                // creative(비디오 등)가 아래 콘텐츠 위로 흘러내려 제목을 가리는 문제.
+                // overflow 로 자르는 대신(잘림=AdSense 정책 위반, auto=스크롤바 #12595)
+                // 컨테이너 min-height 를 creative 렌더 높이만큼 올려 sizing 으로 해결한다.
+                // - 늘리기만 하고 줄이지 않음 (refresh 로 작은 creative 가 와도 layout shift 최소화)
+                // - fluid/1x1 creative 는 event.size 가 무의미 → iframe 실측 높이 fallback
+                let creativeHeight = Array.isArray(event.size) ? Number(event.size[1]) || 0 : 0;
+                if (creativeHeight <= 1 && iframe) {
+                    creativeHeight = iframe.offsetHeight || 0;
+                }
+                if (container && creativeHeight > 1) {
+                    const frame = container.closest('.dm-display-frame') as HTMLElement | null;
+                    for (const el of [container, frame]) {
+                        if (!el) continue;
+                        const current = parseFloat(getComputedStyle(el).minHeight) || 0;
+                        if (creativeHeight > current) {
+                            el.style.minHeight = `${creativeHeight}px`;
+                        }
+                    }
+                }
             } catch {
                 // best-effort: GPT iframe 없거나 권한 부족 시 silent skip
             }


### PR DESCRIPTION
## 요약
모바일에서 본문 광고(비디오 creative)가 글 제목을 덮는 문제를 수정합니다. (버그게시판 #12628, 오늘 새벽 prod 반영된 #1578의 부작용)

## 원인 — overflow 3난제
| overflow-y | 결과 |
|---|---|
| hidden/clip | 세로 잘림 → AdSense 정책 위반 + 윙 잘림(#1542) |
| auto (구현상 hidden+visible 조합) | 스크롤바 (#12595/#12616) |
| visible (#1578, 현 prod) | 예약 높이보다 큰 creative 가 아래 콘텐츠 침범 (#12628) ← 이번 제보 |

## 수정 — overflow 가 아니라 sizing
`slotRenderEnded` 에서 creative 렌더 높이(`event.size[1]`, fluid 는 iframe 실측 fallback)가 컨테이너 min-height 보다 크면 slot/frame 의 min-height 를 그만큼 올림 → 컨테이너가 creative 를 온전히 담아 **잘림·스크롤바·침범 모두 없음**.
- 늘리기만 하고 줄이지 않음 (refresh 시 layout shift 최소화)

## 검증
- 기존 #1578 의 clip/visible 은 유지 (이 PR 은 sizing 만 추가)
- canary 배포 후 board-list-infeed/인아티클에서 큰 creative 수신 시 컨테이너 확장 확인 예정