### PR TITLE
fix(profile): 프로필 이미지 화이트리스트에 r2.damoang.net 추가 (#12626)

### DIFF
--- a/apps/web/src/lib/server/auth/member-update.ts
+++ b/apps/web/src/lib/server/auth/member-update.ts
@@ -354,8 +354,14 @@ export async function updateProfile(
     const values: (string | number)[] = [];
 
     if (fields.mb_image_url !== undefined) {
-        // 빈 문자열(삭제) 또는 S3/CDN URL만 허용
-        const ALLOWED_CDN_PREFIXES = ['https://s3.damoang.net/', 'https://cdn.damoang.net/'];
+        // 빈 문자열(삭제) 또는 S3/CDN/R2 URL만 허용
+        // r2.damoang.net: R2 read 전환(2026-06)으로 업로드가 R2 URL 을 반환 — 누락 시
+        // 프로필 사진 변경이 전부 거절됨 (#12626)
+        const ALLOWED_CDN_PREFIXES = [
+            'https://s3.damoang.net/',
+            'https://cdn.damoang.net/',
+            'https://r2.damoang.net/'
+        ];
         if (
             fields.mb_image_url &&
             !ALLOWED_CDN_PREFIXES.some((p) => fields.mb_image_url!.startsWith(p))


### PR DESCRIPTION
## 요약
프로필 사진 변경이 '유효하지 않은 이미지 URL'로 전부 거절되던 문제를 수정합니다. (버그게시판 #12626)

## 원인 (실측 확정)
- prod `CDN_URL=https://r2.damoang.net` (R2 read 전환, pod env 확인)
- `/api/media/images` 업로드 응답 `cdn_url` 이 r2 URL 반환
- `member-update.ts` 화이트리스트는 `s3.damoang.net`/`cdn.damoang.net` 만 허용 → 거절

## 변경
화이트리스트에 `https://r2.damoang.net/` 추가 (+재발 방지 주석)