### PR TITLE
fix(comments): 삭제된 글에서 '작성자' 배지 숨김 (작성자 식별 방지)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -97,6 +97,7 @@
         onDislike?: (commentId: string) => Promise<{ dislikes: number; user_disliked: boolean }>;
         onRestore?: (commentId: string) => Promise<void>;
         postAuthorId?: string; // 게시글 작성자 ID (비밀댓글 열람 권한 체크용)
+        postDeleted?: boolean; // 글이 삭제된 경우 '작성자' 배지 숨김 — 삭제글 작성자 식별 방지
         boardId?: string; // 신고 기능용
         postId?: number; // 신고 기능용
         useNogood?: boolean; // 비추천 기능 사용 여부 (게시판 설정)
@@ -119,6 +120,7 @@
         onDislike,
         onRestore,
         postAuthorId,
+        postDeleted = false,
         boardId = 'free',
         postId = 0,
         useNogood = false,
@@ -1153,7 +1155,7 @@
                         >
                             <AuthorLink authorId={comment.author_id} authorName={comment.author} />
                             <LevelBadge level={memberLevelStore.getLevel(comment.author_id)} />
-                            {#if postAuthorId && comment.author_id === postAuthorId}
+                            {#if !postDeleted && postAuthorId && comment.author_id === postAuthorId}
                                 <span
                                     class="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
                                     >작성자</span
@@ -1253,7 +1255,7 @@
                                                 >→ {replyToAuthor}</span
                                             >
                                         {/if}
-                                        {#if postAuthorId && comment.author_id === postAuthorId}
+                                        {#if !postDeleted && postAuthorId && comment.author_id === postAuthorId}
                                             <span
                                                 class="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
                                                 >작성자</span

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1992,6 +1992,7 @@
                             onLike={handleLikeComment}
                             onDislike={handleDislikeComment}
                             postAuthorId={data.post.author_id}
+                            postDeleted={!!data.post.deleted_at}
                             {boardId}
                             postId={data.post.id}
                             useNogood={!!data.board?.use_nogood}


### PR DESCRIPTION
## 요약
삭제된 게시글에 글쓴이가 댓글을 달면 **'작성자' 배지로 삭제글 작성자를 식별**할 수 있는 프라이버시 문제를 수정합니다. (free/6415335 에서 실증 — 삭제 상태 글의 본인 댓글에 배지 렌더 확인)

## 변경
- `CommentList` 에 `postDeleted` prop 추가 — 글이 삭제 상태면 '작성자' 배지 미표시 (chat/classic 레이아웃 2곳 모두)
- 글 상세에서 `!!data.post.deleted_at` 전달 (삭제 배너와 동일한 판정 기준)
- `postAuthorId` 는 그대로 유지 — 비밀댓글 열람 권한 체크에 계속 필요