### PR TITLE
fix(security): 추천/리액션 기록에 IP 보호 적용 (admin 실제 IP 노출)

### DIFF
--- a/apps/web/src/lib/server/ip-protection.ts
+++ b/apps/web/src/lib/server/ip-protection.ts
@@ -1,0 +1,37 @@
+import { env } from '$env/dynamic/private';
+
+/**
+ * IP 보호 — Go backend `internal/middleware/ip_protection.go` 와 동일 규칙.
+ *
+ * 글/댓글 작성 등 Go backend 를 경유하는 쓰기는 IPProtection 미들웨어가
+ * super admin / 지정 멤버의 실제 IP 를 치환하지만, 추천(g5_board_good.bg_ip)·
+ * 리액션(chosen_ip)처럼 SvelteKit 라우트가 DB 에 직접 기록하는 경로는
+ * 미들웨어를 거치지 않아 실제 IP 가 그대로 남는다. 기록 직전 이 헬퍼로 치환한다.
+ *
+ * - super admin (mb_level >= 10) → KG_IPPROTECT_ADMIN_IP (예: 127.0.0.1)
+ * - KG_IPPROTECT_LIST="mb_id:ip,mb_id:ip" 지정 멤버 → 지정 IP
+ * - env 미설정 시 원본 IP 그대로 (backend 미들웨어와 동일한 무동작 기준)
+ */
+export function protectClientIp(
+    user: { mb_id?: string; mb_level?: number } | null | undefined,
+    realIp: string
+): string {
+    if (!user) return realIp;
+
+    const adminIp = env.KG_IPPROTECT_ADMIN_IP;
+    if (adminIp && (user.mb_level ?? 0) >= 10) {
+        return adminIp;
+    }
+
+    const list = env.KG_IPPROTECT_LIST || '';
+    if (list && user.mb_id) {
+        for (const entry of list.split(',')) {
+            const [id, ip] = entry.split(':').map((s) => s?.trim());
+            if (id && ip && id === user.mb_id) {
+                return ip;
+            }
+        }
+    }
+
+    return realIp;
+}

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -11,6 +11,7 @@ import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
+import { protectClientIp } from '$lib/server/ip-protection';
 import { getRedis } from '$lib/server/redis';
 import {
     getCommentReactionVersion,
@@ -358,7 +359,8 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
             }
         } else {
             // 추가
-            const clientIp = getClientAddress();
+            // IP 보호: super admin/지정 멤버는 실제 IP 대신 치환 IP 기록 (Go 미들웨어와 동일 규칙)
+            const clientIp = protectClientIp(user, getClientAddress());
             await conn.query(
                 `INSERT INTO g5_board_good (bo_table, wr_id, mb_id, bg_flag, bg_datetime, bg_ip) VALUES (?, ?, ?, ?, CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?)`,
                 [safeBoardId, safeCommentId, user.mb_id, action, clientIp]

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -11,6 +11,7 @@ import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import pool from '$lib/server/db';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
+import { protectClientIp } from '$lib/server/ip-protection';
 import { getRedis } from '$lib/server/redis';
 import {
     getPostReactionVersion,
@@ -349,7 +350,8 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
             }
         } else {
             // 추가 (INSERT + 카운트 증가)
-            const clientIp = getClientAddress();
+            // IP 보호: super admin/지정 멤버는 실제 IP 대신 치환 IP 기록 (Go 미들웨어와 동일 규칙)
+            const clientIp = protectClientIp(user, getClientAddress());
             await conn.query(
                 `INSERT INTO g5_board_good (bo_table, wr_id, mb_id, bg_flag, bg_datetime, bg_ip) VALUES (?, ?, ?, ?, CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?)`,
                 [safeBoardId, safePostId, user.mb_id, action, clientIp]

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -11,6 +11,7 @@ import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
+import { protectClientIp } from '$lib/server/ip-protection';
 import { fetchReactionsByParentId } from '$lib/server/reactions';
 import { loadPluginServerLib } from '$lib/server/plugin-server-loader.js';
 
@@ -276,9 +277,10 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         );
 
         // 클라이언트 IP (PHP chosen_ip 호환)
+        // IP 보호: super admin/지정 멤버는 실제 IP 대신 치환 IP 기록 (Go 미들웨어와 동일 규칙)
         let clientIp = '';
         try {
-            clientIp = getClientAddress();
+            clientIp = protectClientIp(user, getClientAddress());
         } catch {
             // IP 가져오기 실패 시 빈 문자열
         }


### PR DESCRIPTION
## 요약
super admin 이 추천/리액션 시 `g5_board_good.bg_ip`·`chosen_ip` 에 **실제 IP 가 기록**되던 문제를 수정합니다. (IP 보호가 '플러그인이 작동 안 함'처럼 보이던 건)

## 원인
IP 보호는 **Go backend 미들웨어**(`internal/middleware/ip_protection.go`, `KG_IPPROTECT_ADMIN_IP=127.0.0.1`) 인데, 추천/리액션은 **SvelteKit 라우트가 DB 직접 기록** → 미들웨어 미경유 → 실제 IP 노출. (frontend pod 에 env 는 이미 존재함을 실측 확인 — 코드만 누락)

## 변경
- `$lib/server/ip-protection.ts` 신규 — Go 미들웨어와 동일 규칙 (level≥10 → ADMIN_IP, LIST 지정 멤버 → 지정 IP, env 미설정 시 무동작)
- 적용 3곳: 글 추천 / 댓글 추천 / 리액션
- 로그인 IP 는 감사·rate limit 목적이라 대상 외 (기존 유지)

## 검증
- svelte-check 0 errors
- prod 반영 후 admin 추천 → bg_ip=127.0.0.1 확인 예정