### PR TITLE
fix(ad-slot): iframe height:auto 제거 — 광고 사이즈 전반 이상 근본 해결 (#12595/#12616)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -388,10 +388,19 @@
     }
     /* #12411: 모바일 좁은 viewport 에서 광고 크리에이티브가 컨테이너 폭을 초과해
        overflow-hidden 으로 좌/우 잘리는 문제 fix. 광고 iframe/img/ins 자식 요소를
-       컨테이너 폭에 맞추도록 max-width 강제 (AdSense/GAM/Adfit 공통). */
+       컨테이너 폭에 맞추도록 max-width 강제 (AdSense/GAM/Adfit 공통).
+
+       주의: height: auto 는 img 에만 적용해야 한다. iframe 은 GPT 가 width/height
+       를 HTML 속성으로 지정하는데, CSS height:auto 가 속성 힌트를 무시하면
+       iframe(내용 기반 크기 없는 replaced element)이 150px 기본값으로 붕괴한다
+       — 2026-05-30 #1527 이 iframe 에도 height:auto 를 걸어 광고 사이즈 전반
+       이상(#12595/#12616 등)의 근본 원인이 됐던 회귀. Playwright 실측:
+       300×250 iframe + height:auto → offsetHeight 150. */
     .dm-display-frame :global(iframe),
-    .dm-display-frame :global(img),
     .dm-display-frame :global(ins.adsbygoogle) {
+        max-width: 100% !important;
+    }
+    .dm-display-frame :global(img) {
         max-width: 100% !important;
         height: auto;
     }


### PR DESCRIPTION
## 요약
"구글 광고 사이즈가 최근 너무 이상해졌다"의 **근본 원인**을 수정합니다.

## 근본 원인
**#1527 (5/30, #12411 모바일 가로 잘림 fix)** 이 iframe/img/ins 공통으로 `height: auto` 를 추가 → GPT 는 iframe 크기를 **HTML 속성**으로 지정하는데 CSS `height:auto` 가 속성을 무시 → iframe 은 내용 기반 크기가 없어 **150px 기본값으로 붕괴**.

**Playwright 실측 증명**: `<iframe width=300 height=250>` + `height:auto` → offsetHeight **150** / 규칙 제거 시 250.

**타임라인 정합**: 5/30 #1527 머지 → **5/31 #12595 첫 제보** → 이후 #12616(사이즈 이상)·텍스트만 보이는 광고 등 연쇄. SafeFrame off(#1568)·scrolling=no(#1569)·overflow 조정(#1542/#1578)이 효과 없던 이유 = 발생 지점이 iframe 박스 자체였기 때문.

## 수정
규칙을 요소별 분리 (1파일):
- `img`: `max-width:100% + height:auto` 유지 (비율 유지 — 본래 목적)
- `iframe`/`ins.adsbygoogle`: `max-width:100%` 만 — GPT/AdSense 가 지정한 height 살림
- #12411(가로 잘림)의 핵심 max-width 는 3요소 모두 유지 → 회귀 없음

## 검증
- 스펙 증명 (위 Playwright 실측)
- svelte-check 0 errors
- canary 배포 후 실브라우저: 사이드바 300×250/600, 인피드 728×90 정상 박스 + 내부 스크롤바 없음 확인 예정