### PR TITLE
fix(ad-slot): 광고 확장 시 오클릭 가드 + Safari 스크롤 보정 (#12632)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot-registry.ts
@@ -168,11 +168,36 @@ function ensureSlotListener() {
                 }
                 if (container && creativeHeight > 1) {
                     const frame = container.closest('.dm-display-frame') as HTMLElement | null;
+                    // #12632: 확장은 layout shift 를 만든다. Chrome/FF 는 scroll anchoring 으로
+                    // 시야를 자동 보정하지만 Safari 는 미지원이라, 확장 순간 누르려던 글 행이
+                    // 아래로 밀리며 클릭 좌표가 광고를 때리는 오클릭이 발생(무효 클릭 = AdSense
+                    // 정책 리스크). 2중 가드:
+                    //  (a) 슬롯이 viewport 에 보이는 상태에서 실제로 늘어났으면 잠시(400ms)
+                    //      광고 프레임의 pointer-events 를 차단 — 반사 클릭이 광고로 가지 않음
+                    //  (b) 슬롯이 viewport 보다 위에 있으면 늘어난 만큼 scrollBy 보정
+                    //      (Safari 수동 anchoring — 읽던 위치 유지)
+                    const rectBefore = (frame ?? container).getBoundingClientRect();
+                    let grewBy = 0;
                     for (const el of [container, frame]) {
                         if (!el) continue;
                         const current = parseFloat(getComputedStyle(el).minHeight) || 0;
                         if (creativeHeight > current) {
                             el.style.minHeight = `${creativeHeight}px`;
+                            grewBy = Math.max(grewBy, creativeHeight - current);
+                        }
+                    }
+                    if (grewBy > 0 && frame) {
+                        const inViewport =
+                            rectBefore.bottom > 0 && rectBefore.top < window.innerHeight;
+                        if (rectBefore.bottom <= 0) {
+                            // (b) viewport 위에서 확장 → 보이는 콘텐츠가 밀리지 않게 보정
+                            window.scrollBy(0, grewBy);
+                        } else if (inViewport) {
+                            // (a) 확장 직후 반사 클릭 차단
+                            frame.style.pointerEvents = 'none';
+                            window.setTimeout(() => {
+                                frame.style.pointerEvents = '';
+                            }, 400);
                         }
                     }
                 }


### PR DESCRIPTION
## 요약
게시판 목록에서 **광고 아래 게시물을 누르면 위 광고가 클릭되는** 문제를 수정합니다. (버그게시판 #12632, 맥/아이맥 사파리 반복 재현)

## 원인
#1583 의 min-height 확장(slotRenderEnded, 비동기)이 **클릭이 진행되는 순간 layout shift** 를 일으킴 → 누르려던 글 행이 아래로 밀리고 클릭 좌표가 광고를 때림. Chrome/FF 는 scroll anchoring 으로 시야를 자동 보정하지만 **Safari 는 미지원**이라 사파리에서 집중 재현. 무효 클릭은 AdSense 정책 리스크.

## 수정 (2중 가드)
- **(a) 오클릭 차단**: viewport 에 보이는 슬롯이 실제로 확장된 직후 400ms 간 광고 프레임 `pointer-events: none` — 반사 클릭이 광고에 떨어지지 않음 (클릭은 무효화되고 사용자는 다시 누르면 됨)
- **(b) Safari 수동 anchoring**: 슬롯이 viewport 위에서 확장되면 `scrollBy(grewBy)` 로 읽던 위치 유지

## 검증
- svelte-check 0 errors
- canary 배포 후 사파리 실기기: 목록 스크롤 중 광고 렌더 직후 아래 글 연타 → 광고 클릭 미발생 확인 예정