### PR TITLE
fix(sidebar): 게시판 선택 시 펼침 상태 리셋/전체 재렌더 수정 (#12645)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -80,8 +80,24 @@
         };
 
         traverse(menuData, 0);
-        if (newAccordionValue) accordionValue = newAccordionValue;
-        if (autoExpand.size > 0) expandedGroups = autoExpand;
+        if (newAccordionValue && newAccordionValue !== accordionValue) {
+            accordionValue = newAccordionValue;
+        }
+        // #12645: autoExpand 로 덮어쓰면 사용자가 수동으로 펼친/접은 상태가 게시판을
+        // 선택할 때마다 리셋되고, 매 내비게이션마다 새 Set 할당으로 목록 전체가
+        // 접혔다 펼쳐지는 재렌더가 발생한다. 합집합으로 병합하고 실제 변화가 있을
+        // 때만 할당한다.
+        if (autoExpand.size > 0) {
+            const merged = new Set(expandedGroups);
+            let changed = false;
+            for (const id of autoExpand) {
+                if (!merged.has(id)) {
+                    merged.add(id);
+                    changed = true;
+                }
+            }
+            if (changed) expandedGroups = merged;
+        }
     });
 
     // 메뉴 필터링과 로딩은 menuStore에서 SSR로 처리됨


### PR DESCRIPTION
## 요약
왼쪽 게시판 목록을 선택할 때마다 **목록이 접혔다 다시 펼쳐지는** 문제를 수정합니다. (버그게시판 #12645)

## 원인
`sidebar.svelte` 의 $effect 가 라우트 변경마다:
1. `expandedGroups = autoExpand` 로 **수동 펼침 상태를 무조건 덮어씀** (3/10 `2c11e903` 회귀)
2. 매번 새 Set 을 할당해 목록 전체가 재렌더 → 접힘/펼침 깜빡임 (Windows 에서 렌더 타이밍상 더 잘 보일 뿐 전 플랫폼 공통)

## 수정
- autoExpand 를 기존 상태와 **합집합 병합** — 활성 경로 자동 펼침은 유지하면서 사용자가 만진 상태 보존
- **실제 변화가 있을 때만 할당** — 동일 상태 재할당으로 인한 재렌더 제거
- accordionValue 동일 값 재할당 방지

## 검증
- svelte-check 0 errors
- canary: 커뮤 펼침 → 자유게시판 선택 → 목록이 그대로 유지(재접힘 없음), 다른 그룹 수동 펼침 후 게시판 이동해도 유지