### PR TITLE
fix(header): 인증 확정 전 스켈레톤 — '세션 끊김' 깜빡임 제거 (#12642)

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -92,6 +92,9 @@
     );
     const effectiveUser = $derived(browser && !authStore.isLoading ? authStore.user : ssrUser);
     const isEffectivelyLoggedIn = $derived(effectiveUser !== null && effectiveUser !== undefined);
+    // #12642: SSR_STRIP_USER 환경에서 SSR user 가 없고 클라이언트 인증도 미해결인 동안.
+    // SSR/hydration 양쪽에서 동일하게 스켈레톤을 렌더해 비로그인 UI 깜빡임을 막는다.
+    const authResolving = $derived(authStore.isLoading && !ssrUser);
 
     let headerAvatarUrl = $derived(
         effectiveUser
@@ -415,7 +418,20 @@
             </button>
 
             <!-- 사용자 아이콘 (로그인/프로필) -->
-            {#if isEffectivelyLoggedIn && effectiveUser}
+            <!-- #12642: SSR_STRIP_USER 환경에서는 SSR 시점에 로그인 여부를 알 수 없어,
+                 비로그인 UI 를 먼저 그리면 새로고침마다 "로그아웃됐다 로그인되는" 깜빡임으로
+                 보인다. 인증이 확정될 때까지 중립 스켈레톤을 표시한다. -->
+            {#if authResolving}
+                <div class="flex items-center gap-1.5 px-2 py-1.5" aria-hidden="true">
+                    <div class="bg-muted h-6 w-6 shrink-0 animate-pulse rounded-full"></div>
+                </div>
+                <div class="p-2" aria-hidden="true">
+                    <div class="bg-muted h-5 w-5 animate-pulse rounded-full"></div>
+                </div>
+                <div class="p-2" aria-hidden="true">
+                    <div class="bg-muted h-5 w-5 animate-pulse rounded-full"></div>
+                </div>
+            {:else if isEffectivelyLoggedIn && effectiveUser}
                 <a
                     href="/my"
                     class="hover:bg-accent flex items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all duration-200 ease-out"
@@ -466,7 +482,7 @@
                 </button>
             {/if}
 
-            {#if isEffectivelyLoggedIn}
+            {#if !authResolving && isEffectivelyLoggedIn}
                 <!-- 쪽지 아이콘 + 미읽음 배지 -->
                 <MessageIcon />
 
@@ -474,7 +490,7 @@
                 <NotificationDropdown />
                 <LevelupCelebration />
                 <XpLevelupToast />
-            {:else}
+            {:else if !authResolving}
                 <!-- 알림 아이콘 (비로그인 시 단순 버튼) -->
                 <button
                     class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out"


### PR DESCRIPTION
## 요약
쪽지함 등에서 새로고침 시 **'세션이 끊겼다 연결됐다'처럼 보이는** 현상을 수정합니다. (버그게시판 #12642 — #12621 재제보)

## 원인 (실증)
- 전체 6 pod 12h 로그에서 `[Auth]` 세션 실패 **0건** → #1580 이 잡은 서버측 루프는 실제로 종결
- 남은 건 `SSR_STRIP_USER=true` 의 시각 현상: SSR 이 user 를 비워 보내 **새로고침마다 헤더가 비로그인 UI → 로그인 UI 로 전환** — 사용자에겐 세션 단절로 보임 (캐시 삭제와 무관하게 100% 재현되는 것과 정합)

## 수정
SSR user 가 없고 클라이언트 인증 미해결인 동안(`authResolving`) 헤더 프로필/쪽지/알림 영역을 **중립 스켈레톤**으로 렌더. SSR HTML 자체도 스켈레톤이라 hydration 전 깜빡임까지 제거. needsCsrf 경로(/member 등, SSR user 존재)는 기존대로 즉시 렌더.

## 검증
- svelte-check 0 errors
- canary: 로그인 상태로 /messages F5 연타 → 로그인 버튼 깜빡임 없이 스켈레톤→프로필 전환 확인 예정