### PR TITLE
feat(tag-nav): 빠른 이동에 나눔/앙지도/앙티티 추가

### DIFF
--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -26,7 +26,10 @@
         { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
         { key: 'lecture', text: '강좌팁', url: '/lecture', show: true },
         { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
-        { key: 'message', text: '마음메시지', url: '/message', show: true }
+        { key: 'message', text: '마음메시지', url: '/message', show: true },
+        { key: 'giving', text: '나눔', url: '/giving', show: true },
+        { key: 'angmap', text: '앙지도', url: '/angmap', show: true },
+        { key: 'angtt', text: '앙티티', url: '/angtt', show: true }
     ];
 
     let { menus: menusProp, class: className = '' }: Props = $props();


### PR DESCRIPTION
## 요약
메인 상단 **빠른 이동(tag-nav)** 에 나눔·앙지도·앙티티 3개 게시판을 추가합니다.

| 라벨 | URL | 게시판 |
|---|---|---|
| 나눔 | /giving | giving |
| 앙지도 | /angmap | angmap |
| 앙티티 | /angtt | angtt |

## 참고
- 컴포넌트: `tag-nav.svelte` (aria-label '빠른 이동')
- prod 는 settings.json 의 tag-nav 위젯 설정이 없어 `DEFAULT_MENUS` 를 사용함(실측 확인) → **코드 추가만으로 반영**, DB/설정 작업 불필요
- 슬러그는 g5_board 에서 확인 (giving=나눔, angmap=앙지도, angtt=앙티티)

## 검증
- CI TypeScript/Build (기존 TagNavMenu 타입과 동일 구조 3줄 추가)