### PR TITLE
feat(post): 게시물 상세페이지에 tag-nav(빠른 이동) 추가

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -183,6 +183,8 @@
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
     let reactionPluginActive = $derived(pluginStore.isPluginActive('da-reaction'));
 
+    import TagNav from '$lib/components/ui/tag-nav/tag-nav.svelte';
+
     // 동적 import: member-memo 플러그인 컴포넌트
     import type { Component } from 'svelte';
     let MemoBadge = $state<Component | null>(null);
@@ -1590,6 +1592,11 @@
             >{data.post.title}</span
         >
     </nav>
+
+    <!-- 빠른 이동(tag-nav) — 목록 페이지와 동일. 메뉴는 admin 설정/DEFAULT_MENUS 공유 -->
+    <div class="mb-3">
+        <TagNav />
+    </div>
 
     <!-- 상단 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
     <div


### PR DESCRIPTION
## 요약
게시물 상세페이지(`[boardId]/[postId]`) breadcrumb 아래에 상단 빠른 이동 바(tag-nav)를 추가합니다.

## 변경
- `[boardId]/[postId]/+page.svelte`: `TagNav` import + breadcrumb 직후 `<div class="mb-3"><TagNav /></div>`
- props 없이 사용 → 메뉴는 목록 페이지와 동일하게 `widgetLayoutStore.tagNavMenus → DEFAULT_MENUS` 폴백 공유 (admin 편집 시 상세페이지에도 자동 반영)

## 검증
- svelte-check 0 errors
- canary `/free/<postId>`: breadcrumb 아래 tag-nav 노출, 활성 게시판 하이라이트