### PR TITLE
feat(admin): tag-nav 메뉴 admin 편집기 (menu-list 필드 타입)

### DIFF
--- a/apps/web/src/lib/components/admin/widgets/widget-settings-form.svelte
+++ b/apps/web/src/lib/components/admin/widgets/widget-settings-form.svelte
@@ -8,7 +8,12 @@
     import { Input } from '$lib/components/ui/input';
     import { Label } from '$lib/components/ui/label';
     import { Switch } from '$lib/components/ui/switch';
+    import { Button } from '$lib/components/ui/button';
     import { onMount } from 'svelte';
+    import {
+        DEFAULT_TAG_NAV_MENUS,
+        type TagNavMenu
+    } from '$lib/components/ui/tag-nav/default-menus';
 
     interface SettingOption {
         label: string;
@@ -17,7 +22,7 @@
 
     interface SettingField {
         label: string;
-        type: 'text' | 'color' | 'boolean' | 'number' | 'select';
+        type: 'text' | 'color' | 'boolean' | 'number' | 'select' | 'menu-list';
         default: unknown;
         description?: string;
         placeholder?: string;
@@ -78,6 +83,74 @@
         return values[key] ?? field.default;
     }
 
+    // === menu-list (tag-nav 등 메뉴 배열) 편집 헬퍼 ===
+    function getMenuList(key: string, field: SettingField): TagNavMenu[] {
+        const v = (values[key] ?? field.default) as TagNavMenu[] | undefined;
+        return Array.isArray(v) ? v.map((m) => ({ ...m })) : [];
+    }
+
+    /** url 에서 slug(key) 파생: '/giving' → 'giving', 빈 값이면 인덱스 기반 */
+    function slugFromUrl(url: string, index: number): string {
+        const s = (url || '').replace(/^\/+/, '').split(/[/?#]/)[0];
+        return s || `item-${index}`;
+    }
+
+    function commitMenuList(key: string, list: TagNavMenu[]) {
+        // 저장 전 정리: text 비어있는 항목 제거, key 비면 url 에서 파생, key 중복은 suffix
+        const seen = new Set<string>();
+        const cleaned: TagNavMenu[] = [];
+        list.forEach((m, i) => {
+            const text = (m.text || '').trim();
+            if (!text) return; // 라벨 없는 항목은 저장하지 않음
+            const url = (m.url || '').trim();
+            let k = (m.key || '').trim() || slugFromUrl(url, i);
+            while (seen.has(k)) k = `${k}-${i}`;
+            seen.add(k);
+            cleaned.push({ key: k, text, url, show: m.show !== false });
+        });
+        onchange(key, cleaned);
+    }
+
+    function updateMenuField(
+        key: string,
+        field: SettingField,
+        index: number,
+        prop: keyof TagNavMenu,
+        value: string | boolean
+    ) {
+        const list = getMenuList(key, field);
+        if (!list[index]) return;
+        (list[index][prop] as string | boolean) = value;
+        commitMenuList(key, list);
+    }
+
+    function addMenuItem(key: string, field: SettingField) {
+        const list = getMenuList(key, field);
+        list.push({ key: '', text: '', url: '/', show: true });
+        commitMenuList(key, list);
+    }
+
+    function removeMenuItem(key: string, field: SettingField, index: number) {
+        const list = getMenuList(key, field);
+        list.splice(index, 1);
+        commitMenuList(key, list);
+    }
+
+    function moveMenuItem(key: string, field: SettingField, index: number, dir: -1 | 1) {
+        const list = getMenuList(key, field);
+        const next = index + dir;
+        if (next < 0 || next >= list.length) return;
+        [list[index], list[next]] = [list[next], list[index]];
+        commitMenuList(key, list);
+    }
+
+    function resetMenuToDefault(key: string) {
+        commitMenuList(
+            key,
+            DEFAULT_TAG_NAV_MENUS.map((m) => ({ ...m }))
+        );
+    }
+
     const selectClass =
         'border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
 </script>
@@ -88,7 +161,89 @@
 
         {#each Object.entries(settings) as [key, field]}
             <div class="space-y-2">
-                {#if field.type === 'boolean'}
+                {#if field.type === 'menu-list'}
+                    <div class="flex items-center justify-between">
+                        <Label>{field.label}</Label>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onclick={() => resetMenuToDefault(key)}>기본값 불러오기</Button
+                        >
+                    </div>
+                    {#if field.description}
+                        <p class="text-muted-foreground text-xs">{field.description}</p>
+                    {/if}
+                    <div class="space-y-2">
+                        {#each getMenuList(key, field) as item, index (index)}
+                            <div
+                                class="border-border flex items-center gap-2 rounded-md border p-2"
+                            >
+                                <div class="flex flex-col gap-0.5">
+                                    <button
+                                        type="button"
+                                        class="text-muted-foreground hover:text-foreground text-xs leading-none disabled:opacity-30"
+                                        disabled={index === 0}
+                                        aria-label="위로"
+                                        onclick={() => moveMenuItem(key, field, index, -1)}
+                                        >▲</button
+                                    >
+                                    <button
+                                        type="button"
+                                        class="text-muted-foreground hover:text-foreground text-xs leading-none disabled:opacity-30"
+                                        disabled={index === getMenuList(key, field).length - 1}
+                                        aria-label="아래로"
+                                        onclick={() => moveMenuItem(key, field, index, 1)}>▼</button
+                                    >
+                                </div>
+                                <Input
+                                    class="flex-1"
+                                    placeholder="라벨"
+                                    value={item.text}
+                                    oninput={(e) =>
+                                        updateMenuField(
+                                            key,
+                                            field,
+                                            index,
+                                            'text',
+                                            e.currentTarget.value
+                                        )}
+                                />
+                                <Input
+                                    class="flex-1"
+                                    placeholder="/주소"
+                                    value={item.url}
+                                    oninput={(e) =>
+                                        updateMenuField(
+                                            key,
+                                            field,
+                                            index,
+                                            'url',
+                                            e.currentTarget.value
+                                        )}
+                                />
+                                <Switch
+                                    checked={item.show !== false}
+                                    onCheckedChange={(checked) =>
+                                        updateMenuField(key, field, index, 'show', checked)}
+                                />
+                                <button
+                                    type="button"
+                                    class="text-destructive hover:text-destructive/80 px-1 text-sm"
+                                    aria-label="삭제"
+                                    onclick={() => removeMenuItem(key, field, index)}>✕</button
+                                >
+                            </div>
+                        {/each}
+                    </div>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        class="w-full"
+                        onclick={() => addMenuItem(key, field)}>+ 항목 추가</Button
+                    >
+                {:else if field.type === 'boolean'}
                     <div class="flex items-center justify-between">
                         <div>
                             <Label for="setting-{key}">{field.label}</Label>

--- a/apps/web/src/lib/components/ui/tag-nav/default-menus.ts
+++ b/apps/web/src/lib/components/ui/tag-nav/default-menus.ts
@@ -1,0 +1,30 @@
+/**
+ * tag-nav(상단 빠른 이동) 메뉴 타입 + 기본값.
+ *
+ * 단일 출처(single source of truth): tag-nav.svelte 의 런타임 폴백과 admin
+ * 편집기의 "기본값 불러오기" 가 동일 목록을 공유하도록 여기로 분리한다.
+ * widget.json 의 settings.menus.default 도 이 목록과 동일하게 유지한다.
+ */
+export interface TagNavMenu {
+    key: string;
+    text: string;
+    url: string;
+    show: boolean;
+}
+
+export const DEFAULT_TAG_NAV_MENUS: TagNavMenu[] = [
+    { key: 'explore', text: '모아보기', url: '/explore', show: true },
+    { key: 'empathy', text: '공감글', url: '/empathy', show: true },
+    { key: 'group', text: '소모임', url: '/groups', show: true },
+    { key: 'free', text: '자유게시판', url: '/free', show: true },
+    { key: 'qa', text: '질문답변', url: '/qa', show: true },
+    { key: 'new', text: '새소식', url: '/new', show: true },
+    { key: 'economy', text: '알뜰구매', url: '/economy', show: true },
+    { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
+    { key: 'lecture', text: '강좌팁', url: '/lecture', show: true },
+    { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
+    { key: 'message', text: '마음메시지', url: '/message', show: true },
+    { key: 'giving', text: '나눔', url: '/giving', show: true },
+    { key: 'angmap', text: '앙지도', url: '/angmap', show: true },
+    { key: 'angtt', text: '앙티티', url: '/angtt', show: true }
+];

--- a/apps/web/src/lib/components/ui/tag-nav/index.ts
+++ b/apps/web/src/lib/components/ui/tag-nav/index.ts
@@ -1,2 +1,3 @@
 export { default as TagNav } from './tag-nav.svelte';
-export type { TagNavMenu } from './tag-nav.svelte';
+export type { TagNavMenu } from './default-menus';
+export { DEFAULT_TAG_NAV_MENUS } from './default-menus';

--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -2,40 +2,17 @@
     import { page } from '$app/stores';
     import { invalidateAll } from '$app/navigation';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
-
-    export interface TagNavMenu {
-        key: string;
-        text: string;
-        url: string;
-        show: boolean;
-    }
+    import { DEFAULT_TAG_NAV_MENUS, type TagNavMenu } from './default-menus';
 
     interface Props {
         menus?: TagNavMenu[];
         class?: string;
     }
 
-    const DEFAULT_MENUS: TagNavMenu[] = [
-        { key: 'explore', text: '모아보기', url: '/explore', show: true },
-        { key: 'empathy', text: '공감글', url: '/empathy', show: true },
-        { key: 'group', text: '소모임', url: '/groups', show: true },
-        { key: 'free', text: '자유게시판', url: '/free', show: true },
-        { key: 'qa', text: '질문답변', url: '/qa', show: true },
-        { key: 'new', text: '새소식', url: '/new', show: true },
-        { key: 'economy', text: '알뜰구매', url: '/economy', show: true },
-        { key: 'promotion', text: '직접홍보', url: '/promotion', show: true },
-        { key: 'lecture', text: '강좌팁', url: '/lecture', show: true },
-        { key: 'tutorial', text: '사용기', url: '/tutorial', show: true },
-        { key: 'message', text: '마음메시지', url: '/message', show: true },
-        { key: 'giving', text: '나눔', url: '/giving', show: true },
-        { key: 'angmap', text: '앙지도', url: '/angmap', show: true },
-        { key: 'angtt', text: '앙티티', url: '/angtt', show: true }
-    ];
-
     let { menus: menusProp, class: className = '' }: Props = $props();
 
-    // 우선순위: props > 위젯 레이아웃 스토어(DB) > DEFAULT_MENUS
-    const menus = $derived(menusProp ?? widgetLayoutStore.tagNavMenus ?? DEFAULT_MENUS);
+    // 우선순위: props > 위젯 레이아웃 스토어(DB) > 기본값
+    const menus = $derived(menusProp ?? widgetLayoutStore.tagNavMenus ?? DEFAULT_TAG_NAV_MENUS);
 
     const visibleMenus = $derived(menus.filter((m) => m.show));
     const currentPath = $derived($page.url.pathname);

--- a/widgets/tag-nav/widget.json
+++ b/widgets/tag-nav/widget.json
@@ -8,5 +8,28 @@
     "slots": ["main"],
     "icon": "Tag",
     "allowMultiple": false,
-    "main": "index.svelte"
+    "main": "index.svelte",
+    "settings": {
+        "menus": {
+            "label": "메뉴 항목",
+            "type": "menu-list",
+            "description": "상단 빠른 이동 바에 표시할 메뉴 (라벨 / 주소 / 표시여부 / 순서)",
+            "default": [
+                { "key": "explore", "text": "모아보기", "url": "/explore", "show": true },
+                { "key": "empathy", "text": "공감글", "url": "/empathy", "show": true },
+                { "key": "group", "text": "소모임", "url": "/groups", "show": true },
+                { "key": "free", "text": "자유게시판", "url": "/free", "show": true },
+                { "key": "qa", "text": "질문답변", "url": "/qa", "show": true },
+                { "key": "new", "text": "새소식", "url": "/new", "show": true },
+                { "key": "economy", "text": "알뜰구매", "url": "/economy", "show": true },
+                { "key": "promotion", "text": "직접홍보", "url": "/promotion", "show": true },
+                { "key": "lecture", "text": "강좌팁", "url": "/lecture", "show": true },
+                { "key": "tutorial", "text": "사용기", "url": "/tutorial", "show": true },
+                { "key": "message", "text": "마음메시지", "url": "/message", "show": true },
+                { "key": "giving", "text": "나눔", "url": "/giving", "show": true },
+                { "key": "angmap", "text": "앙지도", "url": "/angmap", "show": true },
+                { "key": "angtt", "text": "앙티티", "url": "/angtt", "show": true }
+            ]
+        }
+    }
 }


### PR DESCRIPTION
## 요약
상단 빠른 이동 바(tag-nav) 메뉴를 **admin 위젯 설정에서 편집** 가능하게 합니다. 기존엔 `DEFAULT_MENUS` 코드 고정이었습니다(widget.json 에 settings 없음 + 폼에 배열 편집 필드 타입 부재).

## 변경
- **`default-menus.ts` 신규**: `TagNavMenu` 타입 + `DEFAULT_TAG_NAV_MENUS` 단일 출처 (런타임 폴백 + admin 기본값 공유)
- **`widget-settings-form.svelte`**: `menu-list` 필드 타입 추가 — 행별 라벨/주소 입력 + 표시 토글 + 순서(▲▼) + 삭제 + '+ 항목 추가' + '기본값 불러오기'. 저장 전 라벨없음 제거·key 파생/중복 가드. **기존 저장 파이프라인 재사용**(handleSettingChange → /api/layout → settings.json)
- **`widgets/tag-nav/widget.json`**: `settings.menus`(menu-list) 스키마 + default
- **`tag-nav.svelte`**: DEFAULT_MENUS → default-menus.ts import 전환

## 동작
admin 위젯 관리 → tag-nav 추가/선택 → 메뉴 편집기 노출 → 저장 → `settings.json` → 전역 `widgetLayoutStore.tagNavMenus` → 목록/explore/**상세** 모두 반영. settings 없을 땐 DEFAULT 폴백(회귀 없음).

## 검증
- svelte-check 0 errors
- canary: admin 편집 → 항목 추가/삭제/순서/표시토글/URL 변경 → 저장 후 tag-nav 반영 / 기존 위젯 설정폼(boolean/select/number/color) 회귀 없음