### PR TITLE
fix(report): 신고 사유 자동복원 제거 — 항상 빈 사유로 시작 (#12605)

### DIFF
--- a/apps/web/src/lib/components/features/report/report-dialog.svelte
+++ b/apps/web/src/lib/components/features/report/report-dialog.svelte
@@ -71,49 +71,9 @@
     let showConfirm = $state(false);
     let error = $state<string | null>(null);
 
-    // 직전 신고 사유 기억 (#12486) — 도배/연쇄 신고 시 매번 동일 사유 다시 선택하는 불편 해소
-    // 의견 (detail) 은 글마다 다를 수 있어 사유만 복원. TTL 30분.
-    const LAST_REASONS_KEY = 'damoang_report_lastReasons';
-    const LAST_REASONS_TTL_MS = 30 * 60 * 1000;
-
-    function loadLastReasons(): Set<ReportReason> {
-        if (typeof localStorage === 'undefined') return new Set();
-        try {
-            const raw = localStorage.getItem(LAST_REASONS_KEY);
-            if (!raw) return new Set();
-            const parsed = JSON.parse(raw) as { reasons?: number[]; ts?: number };
-            if (
-                !Array.isArray(parsed.reasons) ||
-                typeof parsed.ts !== 'number' ||
-                Date.now() - parsed.ts > LAST_REASONS_TTL_MS
-            ) {
-                return new Set();
-            }
-            return new Set(parsed.reasons as ReportReason[]);
-        } catch {
-            return new Set();
-        }
-    }
-
-    function saveLastReasons(reasons: Set<ReportReason>): void {
-        if (typeof localStorage === 'undefined' || reasons.size === 0) return;
-        try {
-            localStorage.setItem(
-                LAST_REASONS_KEY,
-                JSON.stringify({ reasons: [...reasons], ts: Date.now() })
-            );
-        } catch {
-            // 저장 실패 무시 (private 모드 / quota 등)
-        }
-    }
-
-    // 다이얼로그 open 시 직전 사유 자동 복원 (사용자가 수정 가능)
-    $effect(() => {
-        if (open && selectedReasons.size === 0 && !isSubmitting && !isSuccess) {
-            const restored = loadLastReasons();
-            if (restored.size > 0) selectedReasons = restored;
-        }
-    });
+    // #12605: 직전 신고 사유 자동복원(#12486) 제거. 신고는 이용제한 근거가 되므로
+    // 새 신고는 항상 빈 사유로 시작한다 — 이전 사유가 미리 선택돼 의도치 않은
+    // 사유로 접수되는 문제(원치 않는 사유가 자꾸 선택됨)를 방지.
 
     // 제출 가능 여부
     const canSubmit = $derived(selectedReasons.size > 0);
@@ -150,8 +110,6 @@
             }
 
             isSuccess = true;
-            // 다음 신고 시 자동 복원 위해 직전 사유 저장 (#12486)
-            saveLastReasons(selectedReasons);
             onSuccess?.();
 
             // 2초 후 다이얼로그 닫기


### PR DESCRIPTION
## 요약
신고 시 **원하지 않는 사유가 자꾸 선택되는** 문제를 수정합니다. (버그게시판 #12605)

## 원인 (UI 버그 아님 — 자동복원 부작용)
신고 다이얼로그가 `localStorage` 의 **직전 신고 사유를 자동복원**(#12486, `loadLastReasons` + open 시 effect)했습니다. 새 신고를 열면 이전 사유가 미리 체크돼 있어 '자꾸 선택됨' 으로 체감되고, 모르고 제출하면 의도치 않은 사유로 접수됩니다("기존 신고에도 원치 않은 사유 포함됐을 것 같다"와 일치). 사유 토글 로직(`toggleReason`)·`{#each}` 키는 정상.

## 수정
- 자동복원 effect + `loadLastReasons`/`saveLastReasons` + `LAST_REASONS_*` 상수 + 제출 후 저장 호출 제거
- 신고는 이용제한 근거라 정확성이 중요 → **매번 빈 사유로 시작**

## 검증
- svelte-check 0 errors
- canary: 신고 다이얼로그 → 사유 미선택 상태로 열림 / 선택·토글 정상 / 제출 후 재오픈 시에도 빈 상태