### PR TITLE
fix(author-link): 댓글 짧은/특수 닉네임 모바일 클릭 복원 (#12652)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1153,7 +1153,11 @@
                         <p
                             class="text-foreground mb-1 ml-1 flex items-center gap-1 text-xs font-semibold"
                         >
-                            <AuthorLink authorId={comment.author_id} authorName={comment.author} />
+                            <AuthorLink
+                                authorId={comment.author_id}
+                                authorName={comment.author}
+                                expandTouchArea
+                            />
                             <LevelBadge level={memberLevelStore.getLevel(comment.author_id)} />
                             {#if !postDeleted && postAuthorId && comment.author_id === postAuthorId}
                                 <span
@@ -1246,6 +1250,7 @@
                                         <AuthorLink
                                             authorId={comment.author_id}
                                             authorName={comment.author}
+                                            expandTouchArea
                                         />
                                         <LevelBadge
                                             level={memberLevelStore.getLevel(comment.author_id)}

--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -20,6 +20,12 @@
         authorName: string;
         isWithdrawn?: boolean;
         class?: string;
+        /**
+         * 모바일에서도 클릭 영역을 확장할지 (#12652).
+         * 목록뷰는 제목과 인접해 모바일 확장 시 제목 오터치가 발생(#12480)하므로 false(기본).
+         * 댓글/상세처럼 인접 제목이 없는 곳은 true 로 짧은 닉네임 클릭을 보장.
+         */
+        expandTouchArea?: boolean;
         children?: Snippet;
     }
 
@@ -28,10 +34,16 @@
         authorName,
         isWithdrawn = false,
         class: className = '',
+        expandTouchArea = false,
         children
     }: Props = $props();
 
     const isOwnProfile = $derived(authStore.user?.mb_id === authorId);
+
+    // 클릭 영역 확장 클래스: 댓글/상세(expandTouchArea)는 전 viewport, 목록은 PC(md:)만.
+    const touchAreaClass = $derived(
+        expandTouchArea ? '-mx-0.5 min-w-[2ch] px-0.5' : 'md:-mx-0.5 md:min-w-[2ch] md:px-0.5'
+    );
 
     // 팔로우 상태 (드롭다운 열릴 때 조회)
     let isFollowing = $state(false);
@@ -149,7 +161,7 @@
               모바일은 기본 텍스트 너비만큼만 클릭 영역 — 제목 의도 터치 보호.
             -->
             <DropdownMenu.Trigger
-                class="inline-block cursor-pointer text-left hover:underline focus:outline-none md:-mx-0.5 md:min-w-[2ch] md:px-0.5 {className} {isWithdrawn
+                class="inline-block cursor-pointer text-left hover:underline focus:outline-none {touchAreaClass} {className} {isWithdrawn
                     ? 'line-through opacity-60'
                     : ''}"
             >


### PR DESCRIPTION
## 요약
**특정 아이디(닉네임) 선택 안 됨** 재발을 수정합니다. (버그게시판 #12652 — #12444 회귀)

## 원인 (회귀 확정)
- #12444(PR #1463, 5/22): 짧은 닉네임 클릭영역 `min-w-[2ch] -mx-0.5 px-0.5` 추가 → PC·모바일 클릭 가능
- **바로 다음날 #12480(PR #1474, 5/23)** 이 모바일 목록 제목 오터치를 막으려 이 확장을 **`md:`(PC) 한정**으로 변경 → 모바일 클릭영역 원복 → 짧은닉/특수닉(예: `PWL⠀` — 끝에 U+2800 점자공백) **모바일 클릭 불가 재발**

## 수정 (viewport 분기 → 컨텍스트 분기)
- `AuthorLink` 에 `expandTouchArea` prop 추가. 기본 false = 기존 `md:` 한정 유지(목록뷰 제목 오터치 보호 #12480 그대로)
- **댓글(comment-list)** 은 인접 제목이 없어 안전 → `expandTouchArea` 로 모바일에서도 짧은닉 클릭 보장

## 검증
- svelte-check 0 errors
- canary 모바일: 댓글의 짧은닉/`PWL⠀` 클릭 → dropdown 정상 / 목록뷰 제목 터치 시 작성자 dropdown 안 뜸(#12480 유지)