### PR TITLE
fix(author): '전체 게시물'을 프로필 글 목록으로 — 작성자 조회 복원 (#12657)

### DIFF
--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -181,7 +181,7 @@
                 </DropdownMenu.Item>
                 <DropdownMenu.Item
                     class="cursor-pointer gap-2"
-                    onclick={() => goto(`/search?sfl=author&q=${encodeURIComponent(authorId)}`)}
+                    onclick={() => goto(`/member/${encodeURIComponent(authorId)}?tab=posts`)}
                 >
                     <FileText class="h-3.5 w-3.5" />
                     전체 게시물

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -10,6 +10,7 @@
     import { apiClient } from '$lib/api/index.js';
     import { blockedUsersStore } from '$lib/stores/blocked-users.svelte';
     import { goto } from '$app/navigation';
+    import { page } from '$app/stores';
     import { onMount } from 'svelte';
     import User from '@lucide/svelte/icons/user';
     import Calendar from '@lucide/svelte/icons/calendar';
@@ -167,6 +168,15 @@
     let loadingComments = $state(false);
     let loadingLiked = $state(false);
     let postsLoaded = $state(false);
+
+    // #12657: ?tab= 딥링크. 작성자 dropdown "전체 게시물"이 깨진 풀텍스트 검색 대신
+    // 프로필의 정확한(mb_id 기준) 글 목록으로 들어오도록 posts 탭을 직접 열 수 있게 한다.
+    const VALID_TABS = ['info', 'posts', 'comments', 'liked'];
+    let activeTab = $state(
+        VALID_TABS.includes($page.url.searchParams.get('tab') ?? '')
+            ? ($page.url.searchParams.get('tab') as string)
+            : 'info'
+    );
     let commentsLoaded = $state(false);
     let likedLoaded = $state(false);
 
@@ -182,6 +192,9 @@
 
     onMount(async () => {
         if (!p?.mb_id) return;
+
+        // 딥링크로 info 외 탭 진입 시 해당 탭 데이터 즉시 로드
+        if (activeTab !== 'info') handleTabChange(activeTab);
 
         // 팔로우 상태 조회
         if (authStore.isAuthenticated && !isOwnProfile) {
@@ -521,7 +534,7 @@
         <Card class="bg-background">
             <!-- 플러그인 슬롯: 탭 직전 (탭 위 배너/공지 등) — Slot Catalog Sprint 2c -->
             <PluginSlot name="member-profile-tabs-before" mbId={p.mb_id} />
-            <Tabs.Root value="info" onValueChange={handleTabChange}>
+            <Tabs.Root bind:value={activeTab} onValueChange={handleTabChange}>
                 <Tabs.List class="border-border w-full justify-start border-b">
                     <Tabs.Trigger value="info">정보</Tabs.Trigger>
                     <Tabs.Trigger value="posts">최근 글</Tabs.Trigger>


### PR DESCRIPTION
## 요약
닉네임 클릭 → '전체 게시물' 선택 시 **게시물이 안 보이는** 문제를 수정합니다. (버그게시판 #12657)

## 원인 (Manticore 실측 확정)
'전체 게시물'은 `/search?sfl=author&q={mb_id}` 로 이동하는데, 검색의 `author` 필드는 mb_id 를 **풀텍스트로 토큰화**합니다. mb_id(예: `naver_7cba07d2`)로는 특정 1명을 정확히 좁힐 수 없음 — 직접 질의 결과 어떤 쿼리 형태(`*..*` / phrase / exact / escape)로도 정답 690건 대신 **1746건(naver_* 전체)** 매칭, 앱의 exact 필터 후 **0건(게시물 없음)**. 풀텍스트 검색은 '특정 사용자 전체글' 조회에 부적합한 도구.

## 모범사례 수정
정확한 출처인 **프로필 글 목록**(백엔드 `/members/{mb_id}/activity`, mb_id 정확조회)으로 리라우트:
- `author-link`: '전체 게시물' → `/member/{mb_id}?tab=posts`
- `member/[id]`: `?tab=` 딥링크 지원 (`Tabs bind:value` + onMount 초기 탭 로드)

## 검증
- svelte-check 0 errors
- canary: 닉네임 → '전체 게시물' → 프로필 글 탭에 본인 글 정상 노출 (이전: 0건)

## 참고
크로스보드 '전체글 검색'을 풀텍스트로 살리려면 Manticore mb_id 인덱싱(charset/attribute) 개편 + 재인덱싱이 필요(별도 인프라 작업). 본 PR 은 사용자 가시 버그를 정확한 데이터로 즉시 해결.