### PR TITLE
fix(auth): SSR 인증 타임아웃 3000→1500 — 로그인 지연 완화 (#12661)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -345,7 +345,11 @@ function getGlobalApiRateLimitKey(
     return clientIp ? `ip:${clientIp}` : null;
 }
 
-const AUTH_TIMEOUT_MS = 3000;
+// #12661: per-attempt 타임아웃. withTimeoutRetry 가 1회 재시도하므로 worst-case 는
+// 이 값의 2배다. 3000 이면 getSession 만으로도 6s 까지 늘어나 "로그인 지연" 으로
+// 체감됨(특히 SSR_STRIP_USER 환경에서 /api/auth/me 가 이 경로를 탐). 1500 으로 줄여
+// worst-case 6s→3s. 재시도가 있어 일시 지연은 여전히 흡수된다.
+const AUTH_TIMEOUT_MS = 1500;
 
 /**
  * withTimeout 은 타임아웃 시 null 을 반환해 "조회 결과 없음(로그아웃)"과


### PR DESCRIPTION
## 요약
새로고침/이동 시 **로그인 표시가 최대 7초 지연**되는 문제를 완화합니다. (버그게시판 #12661, #12513 재제보)

## 원인
`SSR_STRIP_USER=true` 라 클라이언트가 `/api/auth/me` 로 로그인 상태를 복원하는데, 그 경로의 `authenticateSSR` 가 `withTimeoutRetry`(#12621, 1회 재시도)를 씀. per-attempt 3000ms × 2 = getSession 만으로 worst-case **6s** → 체감 7초 지연.

## 변경
`AUTH_TIMEOUT_MS` 3000 → **1500**. 재시도 유지(#12621 무한루프 방지 정합성)하면서 worst-case **6s→3s**. 재시도가 있어 일시 Redis/DB 지연은 여전히 흡수.

## 참고 (근본 해소는 별도)
이건 **보조(②)** 입니다. 근본은 `PUBLIC_USER_BASIC_CLIENT_READ=true`(클라이언트가 user_basic 쿠키로 즉시 렌더 → /api/auth/me round-trip 자체 제거)이며 angple-k8s env 로 canary 먼저 적용 예정. (heap-safe — 4/30 OOM 의심 당사자는 서버측 USER_BASIC_FAST_PATH 로, 그건 false 유지)

## 검증
- svelte-check 0 errors
- canary: 로그인 상태 새로고침 시 지연 단축 + 일시 지연에도 false-logout 없음