### PR TITLE
chore(plugins): payment + brickang 활성화

### DIFF
--- a/apps/web/data/plugin-settings.json
+++ b/apps/web/data/plugin-settings.json
@@ -7,7 +7,9 @@
         "interaction-analysis",
         "da-reaction",
         "affiliate-link-private",
-        "archive"
+        "archive",
+        "payment",
+        "brickang"
     ],
     "plugins": {
         "ad-widget": {
@@ -53,6 +55,14 @@
         "archive": {
             "settings": {},
             "activatedAt": "2026-05-24T00:00:00.000Z"
+        },
+        "payment": {
+            "settings": {},
+            "activatedAt": "2026-06-09T00:00:00.000Z"
+        },
+        "brickang": {
+            "settings": {},
+            "activatedAt": "2026-06-09T00:00:00.000Z"
         }
     },
     "version": "1.0.0"


### PR DESCRIPTION
## 배경
캐너리에서 `/brickang` 접근 시 `/api/plugins/brickang/villages/1` 이 `404 Plugin not active: brickang` 을 반환합니다. brickang 코드·페이지는 premium 경유로 배포되어 있으나, `data/plugin-settings.json` 의 `activePlugins` 에 등록되지 않아 plugin route dispatcher(`route-dispatcher.ts:92`)가 차단합니다.

## 변경
- `activePlugins` 에 `payment`, `brickang` 추가 (기존 premium 플러그인 `archive` 와 동일 패턴)
- `plugins{}` 에 해당 항목 추가

## 영향
- `brickang`: `/brickang` 페이지 조회(villages/buildings/bricks) 정상화
- `payment`: brickang 결제 위임 대상 활성화. **가맹점 키(`payment_provider_configs`) 설정 전까지 checkout 은 `provider not configured`(400) 로 응답** — 조회/뷰에는 영향 없음
- 운영에도 동일 적용됨 (canary/prod 공통 빌드). brickang 광화문 seed 건축물 뷰가 노출됨
