### PR TITLE
fix(home): 공감글 위젯 SSR 스켈레톤 장기 노출 — prefetch 키 누락 복구

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -87,6 +87,15 @@
                 ? { data: data.recommendedData, period: data.recommendedPeriod }
                 : undefined,
             explore: data.exploreData ? { data: data.exploreData } : undefined,
+            // 결합 위젯(공감글+모아보기 2단)이 실제 홈 레이아웃에 쓰이므로 이 키로도 SSR 데이터를
+            // 매핑해야 함. 누락 시 empathy-explore-row 의 prefetchData 가 undefined → RecommendedPosts
+            // 가 SSR 에서 스켈레톤(loading=true)으로 렌더되어 CDN 캐시 → 전 방문자가 스켈레톤+재fetch.
+            'empathy-explore-row': {
+                recommended: data.recommendedData
+                    ? { data: data.recommendedData, period: data.recommendedPeriod }
+                    : undefined,
+                explore: data.exploreData ? { data: data.exploreData } : undefined
+            },
             // 홈 공감글 터치 오인식(#11998) — SSR 데이터가 빈 배열일 때 undefined 를 넘기면
             // 클라이언트 $effect 가 재요청을 보내 마음메시지 Card 가 hydration 직후 삽입되며
             // 그 아래 위젯이 밀리는 레이아웃 shift 를 유발. 빈 배열이라도 항상 prefetchData 로


### PR DESCRIPTION
## 증상
홈 **공감 글** 위젯이 1시간 기본 탭에서 **스켈레톤이 오래 떠 있음** (사용자 제보).

## 원인 (라이브 SSR 실측으로 확정)
홈 메인은 결합 위젯 `empathy-explore-row`(공감글+모아보기 2단)를 렌더하는데, `+page.svelte` 의 `prefetchDataMap` 키가 `recommended`/`explore`/`celebration` 뿐이고 **`empathy-explore-row` 키가 없습니다**.

결합 위젯(`widgets/empathy-explore-row/index.svelte`)은 `prefetchData.recommended` 를 읽어 `RecommendedPosts` 로 넘기는데, 맵에 그 키가 없어 `prefetchData=undefined` → `hasSSRData=false` → `loading=true` → **SSR 이 스켈레톤을 렌더 → CDN 캐시 → 전 방문자가 스켈레톤 후 클라이언트 재fetch**.

### 실측 근거
- 라이브 홈 SSR HTML 에 `recommendedData`(period:1hour, community 15건 등) **정상 임베드** + 1h 캐시 파일 신선 + API 11~118ms
- 그럼에도 공감글 영역은 `animate-pulse` 스켈레톤 + 게시물 링크 0개
- 캐시 우회(`?nocache`) 신선 origin 렌더에서도 동일 → transient 아님, **구조적 prefetch 키 불일치**
- 위젯 컨테이너 `grid-cols-2` 확인 → 라이브 위젯 = 결합 `empathy-explore-row`

## 변경
`prefetchDataMap` 에 결합 위젯이 기대하는 중첩 구조로 키 추가:
```svelte
'empathy-explore-row': {
    recommended: data.recommendedData ? { data: data.recommendedData, period: data.recommendedPeriod } : undefined,
    explore: data.exploreData ? { data: data.exploreData } : undefined
}
```

## 영향
- 공감글 위젯 SSR 즉시 렌더 복구 → 스켈레톤/CLS 제거
- 불필요한 클라이언트 `/api/widgets/recommended/data` 재fetch 제거 → **CDN 비용 소폭 절감**
- 회귀 0: explore 반쪽은 `exploreData` 가 SSR 미적재라 기존대로 client fetch 유지. 단독 `recommended`/`explore` 키는 보존.

## 검증
- svelte-check 0 errors
- canary 배포 후 `?nocache` 신선 렌더에서 공감글 위젯이 스켈레톤이 아닌 **실제 목록**(animate-pulse 0, 게시물 링크 존재)으로 SSR 되는지 확인