### PR TITLE
fix(comments): 댓글 수>0인데 목록 빈 화면 '댓글 없음' 거짓표시 수정 (#12663 #12668)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -107,6 +107,9 @@
         initialDislikedCommentIds?: number[]; // SSR에서 전달된 비추천한 댓글 ID 목록
         truthroomCommentMap?: Record<number, number>; // 잠긴 댓글 → 진실의방 글 ID 매핑
         isRestricted?: boolean; // 제한된 유저 (영구정지 등)
+        // 기대 댓글 수 (SSR 메타의 comments_count). comments 가 아직 비어도 이 값이 0보다 크면
+        // "댓글 없음" 대신 "불러오는 중"을 표시 — SPA 네비/하이드레이션 갭의 거짓 empty 방지 (#12663·#12668)
+        expectedTotal?: number;
         // 댓글 수정 정책 (단일 진실 근원: 백엔드 env). 미전달 시 default 사용 (코드 하드코딩 금지 — 부모가 API 메타에서 받아 전달).
         editPolicy?: { cost: number; grace_seconds: number };
     }
@@ -130,6 +133,7 @@
         initialDislikedCommentIds = [],
         truthroomCommentMap = {},
         isRestricted = false,
+        expectedTotal = 0,
         // 댓글 수정 정책 (사용자 확정 2026-05-22):
         // - 대댓글 없는 댓글: 항상 무료 수정 (grace 무관)
         // - 대댓글 달린 댓글: cost 포인트 차감 + 수정 이력 카운트 표시
@@ -1896,9 +1900,16 @@
             </li>
         {/if}
     {:else}
-        <li class="text-muted-foreground py-8 text-center">
-            아직 댓글이 없습니다. 첫 댓글을 작성해보세요!
-        </li>
+        {#if expectedTotal > 0}
+            <!-- 댓글 수는 있는데 목록이 아직 비어있음 (SPA 네비/하이드레이션 갭) — 거짓 "댓글 없음" 대신 로딩 표시 (#12663·#12668) -->
+            <li class="text-muted-foreground py-8 text-center text-sm">
+                댓글을 불러오는 중입니다…
+            </li>
+        {:else}
+            <li class="text-muted-foreground py-8 text-center">
+                아직 댓글이 없습니다. 첫 댓글을 작성해보세요!
+            </li>
+        {/if}
     {/each}
 </ul>
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2010,6 +2010,7 @@
                             {initialDislikedCommentIds}
                             {truthroomCommentMap}
                             isRestricted={data.isRestricted}
+                            expectedTotal={commentsTotal}
                             editPolicy={commentEditPolicy}
                         />
                     {/if}


### PR DESCRIPTION
## 증상 (제보 2건)
- #12663(Phil2030): 댓글 70개여도 '현재 댓글이 없습니다' 표시
- #12668(추목, PC 파이어폭스): '댓글(2)' 배지인데 목록은 비어있음, **스크롤/새로고침하면 나타남**, 빈도 높음

## 원인
`comment-list.svelte` 의 `{#each}{:else}` empty-state 가 `commentTree.length===0` 만 보고 '아직 댓글이 없습니다'를 렌더. SPA 네비게이션(`+page.server.ts` `isDataRequest` → `comments.items:[]`) 또는 하이드레이션 갭에서 **comments=[] 이지만 commentsTotal>0** 인 구간에, '댓글(N)' 배지와 모순되는 거짓 빈 화면이 노출됨. backfill `$effect`(+page.svelte:1255)가 곧 채우지만 그 전까지 잘못된 메시지가 보이고, 스크롤/새로고침이 렌더·SSR을 재트리거해 나타남.

## 변경
- `comment-list.svelte`: `expectedTotal?: number` prop 추가. empty-state 분기 → `expectedTotal>0` 이면 **'댓글을 불러오는 중입니다…'**, 아니면 기존 '아직 댓글이 없습니다' 유지.
- `[postId]/+page.svelte`: `<CommentList expectedTotal={commentsTotal} />` 전달.

## 영향
- 댓글 수>0 + 목록 미도착 구간 → 거짓 '댓글 없음' 제거(로딩 표시). backfill 완료 시 정상 목록.
- 진짜 0개 글 → expectedTotal=0 → 기존 empty-state 그대로(회귀 0).
- backfill fetch 로직 무변경.

## 검증
- svelte-check 0
- canary: 목록→글 클릭(SPA nav) 진입 시 '댓글 없음' 깜빡임 없이 로딩→목록. 0개 글은 empty-state 정상.