### PR TITLE
fix(payment): route 핸들러 @sveltejs/kit 값 import 제거 (raw Response)

### DIFF
--- a/plugins/payment/routes/checkout/complete.ts
+++ b/plugins/payment/routes/checkout/complete.ts
@@ -1,5 +1,5 @@
-import { json, error } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
+import { json, error } from '../../server/http.js';
 import { resolveSiteId } from '../../hooks/site-context.js';
 import { getProviderConfig } from '../../server/config-store.js';
 import { getOrderByUid, updateOrderStatus, recordEvent } from '../../server/orders-store.js';

--- a/plugins/payment/routes/checkout/start.ts
+++ b/plugins/payment/routes/checkout/start.ts
@@ -1,5 +1,5 @@
-import { json, error } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
+import { json, error } from '../../server/http.js';
 import { resolveSiteId } from '../../hooks/site-context.js';
 import { getProviderConfig } from '../../server/config-store.js';
 import { createOrder } from '../../server/orders-store.js';

--- a/plugins/payment/routes/refund/index.ts
+++ b/plugins/payment/routes/refund/index.ts
@@ -1,5 +1,5 @@
-import { json, error } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
+import { json, error } from '../../server/http.js';
 import { resolveSiteId } from '../../hooks/site-context.js';
 import { getProviderConfig } from '../../server/config-store.js';
 import { getOrderByUid, updateOrderStatus, recordEvent } from '../../server/orders-store.js';

--- a/plugins/payment/routes/webhook/_handler.ts
+++ b/plugins/payment/routes/webhook/_handler.ts
@@ -1,5 +1,5 @@
-import { json } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
+import { json } from '../../server/http.js';
 import { resolveSiteId } from '../../hooks/site-context.js';
 import { getProviderConfig } from '../../server/config-store.js';
 import { recordEvent } from '../../server/orders-store.js';

--- a/plugins/payment/server/http.ts
+++ b/plugins/payment/server/http.ts
@@ -1,0 +1,23 @@
+/**
+ * payment HTTP 응답 헬퍼 (no @sveltejs/kit).
+ *
+ * plugin route 핸들러는 plugins/ 트리에 있어 `@sveltejs/kit` 값 import(json/error)가
+ * 빌드(Rollup)에서 resolve 되지 않는다 — @sveltejs/kit 는 apps/web 의존성이라
+ * plugins/ 에서 node 해석으로 도달 불가. (archive·brickang 과 동일하게 raw Response 사용.)
+ * RequestEvent 는 타입이므로 `import type` 로만 쓰면 esbuild 가 제거하여 무해하다.
+ */
+
+/** @sveltejs/kit 의 json() 대체. */
+export function json(data: unknown, init?: ResponseInit): Response {
+    const headers = new Headers(init?.headers);
+    if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+    return new Response(JSON.stringify(data), { ...init, headers });
+}
+
+/** @sveltejs/kit 의 error() 대체 — JSON 본문 Response 를 throw. (`throw error(400, ...)`) */
+export function error(status: number, message: string): never {
+    throw new Response(JSON.stringify({ message }), {
+        status,
+        headers: { 'content-type': 'application/json' }
+    });
+}


### PR DESCRIPTION
## 배경
payment REST 라우트를 shim(+server.ts)으로 노출하면 빌드 실패: route 핸들러가 `plugins/` 트리에서 `@sveltejs/kit`(json/error) **값 import** → Rollup 이 `@sveltejs/kit`(apps/web 의존성)를 plugins/ 에서 resolve 못 함. (brickang #79 와 동일)

## 변경
- `plugins/payment/server/http.ts` 신설 (no @sveltejs/kit json/error helper)
- `checkout/start`, `checkout/complete`, `refund/index`, `webhook/_handler` 의 값 import 를 `../../server/http.js` 로 교체. `RequestEvent` 는 `import type` 유지.

로직 변경 없음. shim(+server.ts)은 premium api-routes 에서 별도 PR.
