### PR TITLE
fix(header): 전체 검색 돋보기를 로그인 시에만 노출 (#12666)

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -407,15 +407,17 @@
                 {/if}
             </button>
 
-            <!-- 검색 아이콘 -->
-            <button
-                onclick={() => goto('/search')}
-                class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out"
-                aria-label="검색"
-            >
-                <span class="pointer-events-none absolute inset-0 md:-inset-1"></span>
-                <Search class="text-muted-foreground h-5 w-5" />
-            </button>
+            <!-- 검색 아이콘 — 전체 검색은 로그인 필수(/api/search 401)라 로그인 시에만 노출 (#12666) -->
+            {#if isEffectivelyLoggedIn}
+                <button
+                    onclick={() => goto('/search')}
+                    class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out"
+                    aria-label="검색"
+                >
+                    <span class="pointer-events-none absolute inset-0 md:-inset-1"></span>
+                    <Search class="text-muted-foreground h-5 w-5" />
+                </button>
+            {/if}
 
             <!-- 사용자 아이콘 (로그인/프로필) -->
             <!-- #12642: SSR_STRIP_USER 환경에서는 SSR 시점에 로그인 여부를 알 수 없어,


### PR DESCRIPTION
## 배경
전체 검색(`/api/search`)은 `locals.user` 없으면 **401 '로그인이 필요합니다'**(`+server.ts:38`). 비로그인 유저는 돋보기를 눌러 `/search` 에 가도 '로그인 후 검색할 수 있습니다' 만 보게 되어 헛걸음 + '검색이 안 된다'는 혼란(#12666).

## 변경
헤더 검색 돋보기 버튼을 사용자 아바타 아이콘과 동일하게 `{#if isEffectivelyLoggedIn}` 로 게이트. 비로그인 시 미노출, 로그인 시 정상.

## 참고
- 검색 백엔드(Manticore)·라우트·핸들러는 정상(결과 다수 반환) — 본 PR은 비로그인 UX 정리.
- `isEffectivelyLoggedIn` 은 SSR-strip/복원 + user_basic 쿠키 fast-path 를 반영하므로 로그인 유저는 즉시 노출(#12661 적용 후).

## 검증
- svelte-check 0
- canary: 로그아웃 상태 헤더에 돋보기 미표시 / 로그인 시 표시·동작