### PR TITLE
fix(sidebar): 홈에서 url='/' 그룹 메뉴(더보기 등) 오활성 방지

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -41,7 +41,10 @@
     const currentPath = $derived($page.url.pathname);
 
     function isActive(url: string): boolean {
-        if (!url) return false;
+        // url='/' 는 그룹/부모 메뉴(더보기·안내 등)의 placeholder 라 실제 목적지가 아니다.
+        // 홈(currentPath='/')에서 url='/' 메뉴가 전부 active 로 잡혀 "더보기"가 활성으로
+        // 보이던 문제 방지 — 홈에서는 어떤 메뉴도 활성으로 표시하지 않는다.
+        if (!url || url === '/') return false;
         return currentPath === url || currentPath.startsWith(url + '/');
     }
 


### PR DESCRIPTION
## 증상
첫 화면(홈)에서 사이드바 **'더보기'** 메뉴가 활성으로 표시됨(있지도 않은 섹션에 있는 듯한 오해).

## 원인
DB `menus` 의 그룹/부모 메뉴(더보기 id 10027, 안내, 게임 등) 다수가 실제 목적지가 없어 **placeholder 로 `url='/'`** 를 가짐. 사이드바 `isActive` 가 `currentPath === url` 라 홈(`/`)에서 `isActive('/')=true` → 해당 그룹들이 전부 active(특히 '더보기'는 자식도 url='/' 라 auto-open 까지 겹침).

## 변경
`isActive` 에서 `url='/'` 를 비활성 처리. 홈에선 어떤 메뉴도 활성 표시 안 함(로고=홈, 업계 일반 관행). 실제 게시판 메뉴(`/free` 등) 활성은 그대로.

## 검증
- svelte-check 0
- canary: 홈에서 더보기/안내 등 비활성, /free 등 진입 시 정상 활성