### PR TITLE
fix(messages): 쪽지함 새로고침 세션 깜빡임 수정 (#12642)

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -37,7 +37,11 @@ export const load: LayoutServerLoad = async ({
     const needsCsrf =
         url.pathname.startsWith('/member/') ||
         url.pathname.startsWith('/admin/') ||
-        url.pathname.startsWith('/my/');
+        url.pathname.startsWith('/my/') ||
+        // 쪽지함: 로그인 전용·비공개 페이지라 SSR 캐시 대상이 아니다. user strip 시
+        // 새로고침마다 로그아웃→로그인 깜빡임(세션 끊김처럼 보임) 발생 (#12642).
+        url.pathname === '/messages' ||
+        url.pathname.startsWith('/messages/');
     const stripUser = env.SSR_STRIP_USER === 'true' && !needsCsrf;
 
     // Install wizard must not depend on runtime infra such as Redis, menus, banners, or MySQL.


### PR DESCRIPTION
## 증상
쪽지함(`/messages`)에서 새로고침 시 세션이 끊겼다 다시 연결되는 것처럼 로그아웃→로그인 **깜빡임** (#12642, #12621 후속).

## 원인
`/messages` 가 `+layout.server.ts` 의 `needsCsrf` 예외 목록(`/member`·`/admin`·`/my`)에 **없어서**, `SSR_STRIP_USER=true` 로 SSR payload 의 `user` 가 `null` 로 stripped 됨. 쪽지함은 로그인 전용 페이지라 SSR 은 인증 상태로 렌더되지만 클라이언트는 `data.user=null` 를 받아, 인증복원(쿠키/`api/auth/me`) 갭 동안 비로그인 UI → 복원 후 로그인 UI 로 깜빡임.

## 변경
`/messages`(정확/하위경로)를 `needsCsrf` 에 추가 → user strip 제외. 쪽지함은 본래 비공개·캐시 불가 페이지라 strip 대상이 아님(부작용 없음). SSR 에서 user 가 즉시 전달돼 깜빡임 제거.

## 검증
- svelte-check 0
- canary: 로그인 상태로 `/messages` 새로고침 반복 시 로그아웃 깜빡임 없음