### PR TITLE
feat(noti): 게시판 구독 단계 선택 UI (전체/인기글만) — 알림 폭주 해소 프론트 (#12607)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1005,6 +1005,7 @@ export interface NotificationPreferences {
     noti_mention: boolean;
     noti_like: boolean;
     noti_follow: boolean;
+    noti_board_subscribe: boolean;
     like_threshold: number;
 }
 

--- a/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
     /**
      * 게시판 구독 버튼
-     * 게시판 헤더에 벨 아이콘으로 표시
-     * 구독 시 새 글 알림을 받을 수 있음
+     * 게시판 헤더에 벨 아이콘으로 표시. 클릭 시 구독 단계를 선택한다.
+     *  - 전체 알림(level=1): 새 글마다 알림
+     *  - 인기글만(level=2): 추천을 많이 받은 인기글만 알림 (글 많은 게시판 권장)
+     *  - 구독 안 함: 구독 해제
      */
     import { Button } from '$lib/components/ui/button/index.js';
+    import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
     import Bell from '@lucide/svelte/icons/bell';
     import BellOff from '@lucide/svelte/icons/bell-off';
+    import Check from '@lucide/svelte/icons/check';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { toast } from 'svelte-sonner';
 
@@ -18,6 +22,7 @@
     let { boardId, boardTitle }: Props = $props();
 
     let isSubscribed = $state(false);
+    let level = $state<1 | 2 | null>(null);
     let subscriberCount = $state(0);
     let loading = $state(false);
     let stateLoaded = $state(false);
@@ -32,6 +37,7 @@
                 const data = await res.json();
                 if (data.success) {
                     isSubscribed = data.data.is_subscribed;
+                    level = data.data.level ?? null;
                     subscriberCount = data.data.subscriber_count;
                 }
             }
@@ -50,30 +56,59 @@
         void loadSubscribeState();
     }
 
-    async function toggle(): Promise<void> {
-        if (!authStore.isAuthenticated) {
-            authStore.redirectToLogin();
-            return;
+    function onOpenChange(open: boolean): void {
+        if (open) {
+            if (!authStore.isAuthenticated) {
+                authStore.redirectToLogin();
+                return;
+            }
+            void loadSubscribeState();
         }
+    }
 
-        if (!stateLoaded) {
-            await loadSubscribeState();
-        }
-
+    /** 구독 단계 설정 (level=1 전체 / level=2 인기글만) */
+    async function setLevel(next: 1 | 2): Promise<void> {
+        if (loading) return;
         loading = true;
         try {
-            const method = isSubscribed ? 'DELETE' : 'POST';
-            const res = await fetch(`/api/boards/${boardId}/subscribe`, { method });
+            const res = await fetch(`/api/boards/${boardId}/subscribe`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ level: next })
+            });
             if (res.ok) {
                 const data = await res.json();
                 if (data.success) {
                     isSubscribed = data.data.is_subscribed;
+                    level = data.data.level ?? next;
                     subscriberCount = data.data.subscriber_count;
                     toast.success(
-                        isSubscribed
-                            ? `'${boardTitle}' 구독 완료 — 새 글 알림을 받습니다`
-                            : `'${boardTitle}' 구독 해제`
+                        next === 2
+                            ? `'${boardTitle}' 인기글 알림을 받습니다`
+                            : `'${boardTitle}' 새 글 알림을 받습니다`
                     );
+                }
+            }
+        } catch {
+            toast.error('구독 처리에 실패했습니다.');
+        } finally {
+            loading = false;
+        }
+    }
+
+    /** 구독 해제 */
+    async function unsubscribe(): Promise<void> {
+        if (loading || !isSubscribed) return;
+        loading = true;
+        try {
+            const res = await fetch(`/api/boards/${boardId}/subscribe`, { method: 'DELETE' });
+            if (res.ok) {
+                const data = await res.json();
+                if (data.success) {
+                    isSubscribed = data.data.is_subscribed;
+                    level = null;
+                    subscriberCount = data.data.subscriber_count;
+                    toast.success(`'${boardTitle}' 구독 해제`);
                 }
             }
         } catch {
@@ -84,26 +119,62 @@
     }
 </script>
 
-<Button
-    variant="ghost"
-    size="icon"
-    onclick={toggle}
-    onmouseenter={primeSubscribeState}
-    onfocus={primeSubscribeState}
-    disabled={loading}
-    aria-label={isSubscribed ? '구독 해제' : '새 글 알림 구독'}
-    aria-pressed={isSubscribed}
-    title={isSubscribed
-        ? `'${boardTitle}' 구독 중 (${subscriberCount}명) — 클릭하여 해제`
-        : `'${boardTitle}' 구독하기 — 새 글 알림 받기${subscriberCount > 0 ? ` (${subscriberCount}명 구독 중)` : ''}`}
-    class="relative h-8 w-8 {isSubscribed
-        ? 'text-primary hover:text-primary/80'
-        : 'text-muted-foreground hover:text-primary'}"
->
-    <span class="absolute -inset-2"></span>
-    {#if isSubscribed}
-        <Bell class="h-4 w-4" fill="currentColor" />
-    {:else}
-        <BellOff class="h-4 w-4" />
-    {/if}
-</Button>
+<DropdownMenu.Root {onOpenChange}>
+    <DropdownMenu.Trigger>
+        {#snippet child({ props })}
+            <Button
+                {...props}
+                variant="ghost"
+                size="icon"
+                onmouseenter={primeSubscribeState}
+                onfocus={primeSubscribeState}
+                disabled={loading}
+                aria-label={isSubscribed ? '구독 설정' : '새 글 알림 구독'}
+                title={isSubscribed
+                    ? `'${boardTitle}' 구독 중 (${subscriberCount}명) — 클릭하여 설정`
+                    : `'${boardTitle}' 구독하기 — 새 글 알림 받기${subscriberCount > 0 ? ` (${subscriberCount}명 구독 중)` : ''}`}
+                class="relative h-8 w-8 {isSubscribed
+                    ? 'text-primary hover:text-primary/80'
+                    : 'text-muted-foreground hover:text-primary'}"
+            >
+                <span class="absolute -inset-2"></span>
+                {#if isSubscribed}
+                    <Bell class="h-4 w-4" fill="currentColor" />
+                {:else}
+                    <BellOff class="h-4 w-4" />
+                {/if}
+            </Button>
+        {/snippet}
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content align="end" class="w-56">
+        <DropdownMenu.Label>{boardTitle} 알림</DropdownMenu.Label>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item onclick={() => setLevel(1)}>
+            <div class="flex flex-1 flex-col">
+                <span>전체 알림</span>
+                <span class="text-muted-foreground text-xs">새 글이 올라올 때마다 알림</span>
+            </div>
+            {#if isSubscribed && level === 1}
+                <Check class="text-primary h-4 w-4" />
+            {/if}
+        </DropdownMenu.Item>
+        <DropdownMenu.Item onclick={() => setLevel(2)}>
+            <div class="flex flex-1 flex-col">
+                <span>인기글만</span>
+                <span class="text-muted-foreground text-xs">추천을 많이 받은 글만 알림</span>
+            </div>
+            {#if isSubscribed && level === 2}
+                <Check class="text-primary h-4 w-4" />
+            {/if}
+        </DropdownMenu.Item>
+        {#if isSubscribed}
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item
+                onclick={unsubscribe}
+                class="text-destructive focus:text-destructive"
+            >
+                구독 안 함
+            </DropdownMenu.Item>
+        {/if}
+    </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
@@ -13,6 +13,12 @@ import { isInternalAppRequest } from '$lib/server/internal-api.js';
 
 interface SubRow extends RowDataPacket {
     id: number;
+    level: number;
+}
+
+/** 구독 단계: 1=전체(모든 글), 2=인기글만 */
+function normalizeLevel(v: unknown): 1 | 2 {
+    return Number(v) === 2 ? 2 : 1;
 }
 
 interface CountRow extends RowDataPacket {
@@ -30,13 +36,15 @@ export const GET: RequestHandler = async ({ params, cookies, request }) => {
         const isInternalRequest = isInternalAppRequest(request);
         const user = isInternalRequest ? await getAuthUser(cookies) : null;
         let isSubscribed = false;
+        let level: 1 | 2 | null = null;
 
         if (user) {
             const [rows] = await pool.query<SubRow[]>(
-                'SELECT id FROM g5_board_subscribe WHERE mb_id = ? AND bo_table = ?',
+                'SELECT id, level FROM g5_board_subscribe WHERE mb_id = ? AND bo_table = ?',
                 [user.mb_id, boardId]
             );
             isSubscribed = rows.length > 0;
+            if (isSubscribed) level = normalizeLevel(rows[0].level);
         }
 
         const [countRows] = await pool.query<CountRow[]>(
@@ -48,6 +56,7 @@ export const GET: RequestHandler = async ({ params, cookies, request }) => {
             success: true,
             data: {
                 is_subscribed: isSubscribed,
+                level,
                 subscriber_count: countRows[0]?.count ?? 0
             }
         });
@@ -57,8 +66,8 @@ export const GET: RequestHandler = async ({ params, cookies, request }) => {
     }
 };
 
-/** POST: 구독 */
-export const POST: RequestHandler = async ({ params, cookies }) => {
+/** POST: 구독 / 구독 단계 변경 (body: { level?: 1 | 2 }) */
+export const POST: RequestHandler = async ({ params, cookies, request }) => {
     const boardId = params.boardId?.replace(/[^a-zA-Z0-9_-]/g, '');
     const user = await getAuthUser(cookies);
     if (!user) {
@@ -69,10 +78,24 @@ export const POST: RequestHandler = async ({ params, cookies }) => {
         return json({ success: false, message: 'boardId가 필요합니다.' }, { status: 400 });
     }
 
+    let level: 1 | 2 = 1;
     try {
+        const body = await request.json();
+        level = normalizeLevel(body?.level);
+    } catch {
+        // body 없음 → 기본 전체(1)
+    }
+
+    try {
+        // 신규 구독(insert) + 단계 변경(update) 모두 처리. INSERT IGNORE 후 UPDATE 로
+        // (mb_id, bo_table) unique 유무와 무관하게 안전하게 동작.
         await pool.query<ResultSetHeader>(
-            'INSERT IGNORE INTO g5_board_subscribe (mb_id, bo_table) VALUES (?, ?)',
-            [user.mb_id, boardId]
+            'INSERT IGNORE INTO g5_board_subscribe (mb_id, bo_table, level) VALUES (?, ?, ?)',
+            [user.mb_id, boardId, level]
+        );
+        await pool.query<ResultSetHeader>(
+            'UPDATE g5_board_subscribe SET level = ? WHERE mb_id = ? AND bo_table = ?',
+            [level, user.mb_id, boardId]
         );
 
         const [countRows] = await pool.query<CountRow[]>(
@@ -84,6 +107,7 @@ export const POST: RequestHandler = async ({ params, cookies }) => {
             success: true,
             data: {
                 is_subscribed: true,
+                level,
                 subscriber_count: countRows[0]?.count ?? 0
             }
         });
@@ -120,6 +144,7 @@ export const DELETE: RequestHandler = async ({ params, cookies }) => {
             success: true,
             data: {
                 is_subscribed: false,
+                level: null,
                 subscriber_count: countRows[0]?.count ?? 0
             }
         });

--- a/apps/web/src/routes/api/my/subscriptions/+server.ts
+++ b/apps/web/src/routes/api/my/subscriptions/+server.ts
@@ -12,6 +12,7 @@ import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/int
 interface SubBoardRow extends RowDataPacket {
     board_id: string;
     board_name: string;
+    level: number;
 }
 
 export const GET: RequestHandler = async ({ cookies, request }) => {
@@ -26,7 +27,7 @@ export const GET: RequestHandler = async ({ cookies, request }) => {
 
     try {
         const [rows] = await readPool.query<SubBoardRow[]>(
-            `SELECT s.bo_table AS board_id, b.bo_subject AS board_name
+            `SELECT s.bo_table AS board_id, b.bo_subject AS board_name, s.level AS level
 			 FROM g5_board_subscribe s
 			 JOIN g5_board b
 			   ON s.bo_table COLLATE utf8mb4_unicode_ci = b.bo_table COLLATE utf8mb4_unicode_ci
@@ -39,7 +40,8 @@ export const GET: RequestHandler = async ({ cookies, request }) => {
             success: true,
             data: rows.map((r) => ({
                 board_id: r.board_id,
-                board_name: r.board_name
+                board_name: r.board_name,
+                level: Number(r.level) === 2 ? 2 : 1
             }))
         });
     } catch (error) {

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -211,6 +211,7 @@
     interface SubBoard {
         board_id: string;
         board_name: string;
+        level?: 1 | 2;
     }
     interface FollowMember {
         mb_id: string;
@@ -258,6 +259,24 @@
         }
     }
 
+    // 구독 단계 변경 (1=전체, 2=인기글만)
+    async function setSubLevel(boardId: string, next: 1 | 2) {
+        try {
+            const res = await fetch(`/api/boards/${boardId}/subscribe`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ level: next })
+            });
+            if (res.ok) {
+                subscriptions = subscriptions.map((s) =>
+                    s.board_id === boardId ? { ...s, level: next } : s
+                );
+            }
+        } catch {
+            // ignore
+        }
+    }
+
     async function unfollow(mbId: string) {
         try {
             await fetch(`/api/members/${mbId}/follow`, { method: 'DELETE' });
@@ -274,6 +293,7 @@
         noti_mention: true,
         noti_like: true,
         noti_follow: true,
+        noti_board_subscribe: true,
         like_threshold: 1
     });
     let notiLoading = $state(false);
@@ -1185,14 +1205,27 @@
                         <Separator />
                         <div class="flex items-center justify-between">
                             <div>
-                                <Label>팔로우/구독 알림</Label>
+                                <Label>팔로우 알림</Label>
                                 <p class="text-muted-foreground text-xs">
-                                    팔로우 회원이나 구독 게시판에 새 글이 올라오면 알림을 받습니다
+                                    팔로우한 회원이 새 글을 올리면 알림을 받습니다
                                 </p>
                             </div>
                             <Switch
                                 checked={notiPrefs.noti_follow}
                                 onCheckedChange={(v) => saveNotiPrefs({ noti_follow: v })}
+                            />
+                        </div>
+                        <Separator />
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <Label>게시판 구독 알림</Label>
+                                <p class="text-muted-foreground text-xs">
+                                    구독한 게시판에 새 글(또는 인기글)이 올라오면 알림을 받습니다
+                                </p>
+                            </div>
+                            <Switch
+                                checked={notiPrefs.noti_board_subscribe}
+                                onCheckedChange={(v) => saveNotiPrefs({ noti_board_subscribe: v })}
                             />
                         </div>
                         {#if notiSaving}
@@ -1221,19 +1254,42 @@
                         <div class="space-y-1">
                             {#each subscriptions as sub (sub.board_id)}
                                 <div
-                                    class="border-border flex items-center justify-between rounded-md border px-3 py-2"
+                                    class="border-border flex items-center justify-between gap-2 rounded-md border px-3 py-2"
                                 >
                                     <a
                                         href="/{sub.board_id}"
-                                        class="text-foreground text-sm hover:underline"
+                                        class="text-foreground min-w-0 flex-1 truncate text-sm hover:underline"
                                         >{sub.board_name}</a
                                     >
-                                    <button
-                                        onclick={() => unsubscribe(sub.board_id)}
-                                        class="text-muted-foreground hover:text-destructive p-1 transition-colors"
-                                    >
-                                        <XIcon class="h-3.5 w-3.5" />
-                                    </button>
+                                    <div class="flex shrink-0 items-center gap-1">
+                                        <div class="bg-muted flex rounded-md p-0.5 text-xs">
+                                            <button
+                                                onclick={() => setSubLevel(sub.board_id, 1)}
+                                                class="rounded px-2 py-0.5 transition-colors {(sub.level ??
+                                                    1) === 1
+                                                    ? 'bg-background text-foreground shadow-sm'
+                                                    : 'text-muted-foreground'}"
+                                            >
+                                                전체
+                                            </button>
+                                            <button
+                                                onclick={() => setSubLevel(sub.board_id, 2)}
+                                                class="rounded px-2 py-0.5 transition-colors {sub.level ===
+                                                2
+                                                    ? 'bg-background text-foreground shadow-sm'
+                                                    : 'text-muted-foreground'}"
+                                            >
+                                                인기글만
+                                            </button>
+                                        </div>
+                                        <button
+                                            onclick={() => unsubscribe(sub.board_id)}
+                                            class="text-muted-foreground hover:text-destructive p-1 transition-colors"
+                                            aria-label="구독 해제"
+                                        >
+                                            <XIcon class="h-3.5 w-3.5" />
+                                        </button>
+                                    </div>
                                 </div>
                             {/each}
                         </div>


### PR DESCRIPTION
## 배경
게시판 구독이 새 글마다 1:1 알림 → 자유게시판 폭주(#12607). 백엔드에서 구독을 단계화(level 1=전체 / 2=인기글만)하고, 본 PR은 사용자가 그 단계를 직접 고를 수 있는 프론트.

## 변경
- **구독 버튼**(`board-subscribe-button.svelte`): 단순 토글 → **드롭다운(전체 알림 / 인기글만 / 구독 안 함)**. 현재 구독 단계 체크 표시.
- **구독 API**(`/api/boards/[boardId]/subscribe`): GET 응답에 `level` 추가, POST body `{ level }` 로 구독 단계 지정/변경(INSERT IGNORE + UPDATE 로 신규 구독·단계 변경 모두 처리).
- **`/api/my/subscriptions`**: 목록 응답에 `level` 포함.
- **알림 설정**(`member/settings/ui`): 기존 '팔로우/구독 알림' 한 토글 → **'팔로우 알림' + '게시판 구독 알림'(noti_board_subscribe)** 분리. 구독 게시판 목록 각 행에 전체/인기글만 단계 토글.
- `NotificationPreferences` 타입에 `noti_board_subscribe`.

## 짝 PR (백엔드)
- damoang/angple-backend#504 (구독 단계화 + 인기글 트리거 cron + migration 009)
- damoang/angple-backend#503 (na_noti 정리 cron)

⚠️ 배포 순서: 백엔드 migration 009(`level`/`noti_board_subscribe` 컬럼) → 백엔드 → 본 프론트.

## 검증
- svelte-check: 변경 파일 오류/경고 0 (기존 무관 에러만)
- canary: 드롭다운으로 전체/인기글만/해제 동작, GET level 반영, 설정 토글 저장.