### PR TITLE
fix(tag-nav): 글 상세에서 게시판 탭 클릭 시 목록 이동 안 되는 무반응 수정

### DIFF
--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -29,10 +29,11 @@
             <a
                 href={menu.url}
                 onclick={(e) => {
-                    // 현재 페이지와 동일한 메뉴 클릭 시 SvelteKit 이 navigation 을 생략해
-                    // "클릭해도 아무 반응 없음" 처럼 보이는 문제(#12027) 방지.
-                    // 좌측 카테고리 링크와 동일하게 invalidateAll() 로 새로고침.
-                    if (isActive(menu.url)) {
+                    // 정확히 같은 목록 페이지일 때만 navigation 을 생략하고 invalidateAll()
+                    // 로 새로고침(#12027). 하위 경로(글 상세 /free/123 등)에서는 isActive 가
+                    // true(탭 하이라이트용)여도 정상적으로 목록으로 이동해야 한다 — 안 그러면
+                    // 글 상세에서 해당 탭 클릭 시 목록이 안 뜨고 무반응처럼 보임.
+                    if (currentPath === menu.url) {
                         e.preventDefault();
                         invalidateAll();
                         window.scrollTo(0, 0);


### PR DESCRIPTION
## 증상
글 상세(예: `/free/12345`)를 보다가 상단 빠른이동(tag-nav)의 **자유게시판**을 누르면 목록이 떠야 하는데 **무반응**.

## 원인
tag-nav 는 글 상세 페이지에도 렌더됨(`[boardId]/[postId]/+page.svelte`). `onclick` 이 `isActive(url)`(=`currentPath === url || startsWith(url+'/')`)가 true면 `e.preventDefault()` + `invalidateAll()` 만 수행. 글 상세 경로는 `/free/` 로 시작하므로 `isActive('/free')`=true → 클릭해도 목록으로 이동하지 않고 상세 데이터만 갱신 → 무반응.

## 수정
navigation 생략(+invalidateAll)을 **정확히 같은 목록 경로일 때만**(`currentPath === menu.url`) 적용. 하위 경로(글 상세 등)에서는 정상적으로 목록으로 이동. 탭 하이라이트 스타일은 `isActive` 그대로 유지(상세에서도 해당 탭 강조). 모든 메뉴 공통 적용.

## 검증
- svelte-check: tag-nav 오류 0, prettier 통과
- /free/{글} 에서 자유게시판 클릭 → /free 목록 이동 / /free 목록에서 클릭 → invalidateAll 새로고침(#12027 유지)