### PR TITLE
style(banner): 메인 가로 배너(마음메시지/B2B) 테두리·여백 제거 — 공간 활용 개선

### DIFF
--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -188,25 +188,38 @@
     }
 </script>
 
-<div class="dm-card {className}" data-position={position} style:min-height={height}>
+<div
+    class="dm-card {className}"
+    data-position={position}
+    style:min-height={position === 'sidebar' ? height : undefined}
+>
     {#if loading}
         <div
             aria-hidden="true"
-            class="pointer-events-none invisible"
-            style:min-height={height}
+            class="pointer-events-none invisible {position === 'sidebar'
+                ? ''
+                : 'aspect-[77/9] w-full'}"
+            style:min-height={position === 'sidebar' ? height : undefined}
         ></div>
     {:else if celebrationBanner}
         <!-- 마음메시지 배너 -->
+        <!-- index(가로형): 테두리 없이 비율(770×90=77/9)로 슬롯을 꽉 채워 레터박스 제거.
+             sidebar: 기존 테두리 + 고정 높이 유지. -->
         <a
             href={getCelebrationHref(celebrationBanner)}
-            class="border-border dm-media-card block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
-            style:min-height={height}
-            style:height
+            class="dm-media-card block overflow-hidden rounded-xl transition-opacity hover:opacity-90 {position ===
+            'sidebar'
+                ? 'border-border border'
+                : 'aspect-[77/9]'}"
+            style:min-height={position === 'sidebar' ? height : undefined}
+            style:height={position === 'sidebar' ? height : undefined}
         >
             <img
                 src={celebrationBanner.image_url}
                 alt={celebrationBanner.alt_text || '마음메시지'}
-                class="dm-media-card__image w-full object-contain"
+                class="dm-media-card__image w-full {position === 'sidebar'
+                    ? 'object-contain'
+                    : 'h-full object-cover'}"
                 loading="lazy"
             />
         </a>
@@ -227,9 +240,12 @@
                 slotKey: `damoang-banner:${position}`,
                 adUserId: adsBanner.advertiserId ?? undefined
             }}
-            class="border-border dm-media-card block overflow-hidden rounded-xl border transition-opacity hover:opacity-90"
-            style:min-height={height}
-            style:height
+            class="dm-media-card block overflow-hidden rounded-xl transition-opacity hover:opacity-90 {position ===
+            'sidebar'
+                ? 'border-border border'
+                : 'aspect-[77/9]'}"
+            style:min-height={position === 'sidebar' ? height : undefined}
+            style:height={position === 'sidebar' ? height : undefined}
         >
             {#if adsBanner.mobileImageUrl}
                 <picture>
@@ -237,7 +253,9 @@
                     <img
                         src={adsBanner.imageUrl}
                         alt={adsBanner.altText || '광고'}
-                        class="dm-media-card__image w-full object-contain"
+                        class="dm-media-card__image w-full {position === 'sidebar'
+                            ? 'object-contain'
+                            : 'h-full object-cover'}"
                         loading="lazy"
                     />
                 </picture>
@@ -245,7 +263,9 @@
                 <img
                     src={adsBanner.imageUrl}
                     alt={adsBanner.altText || '광고'}
-                    class="dm-media-card__image w-full object-contain"
+                    class="dm-media-card__image w-full {position === 'sidebar'
+                        ? 'object-contain'
+                        : 'h-full object-cover'}"
                     loading="lazy"
                 />
             {/if}


### PR DESCRIPTION
## 배경
홈 상단 가로 배너(마음메시지/B2B, `DamoangBanner position=index`)에 **테두리 + 위아래 빈 공간**이 있어 공간 활용도가 낮았음.

## 원인
`<a>` 슬롯이 `min-height:90px` 고정 + `.dm-media-card`의 `flex items-center`(세로 중앙) + 이미지 `object-contain`. 폭 기준으로 줄어든 770×90 이미지가 90px보다 짧아져 **위아래 레터박스 여백** 발생 + `rounded-xl border` 테두리.

## 변경 (index 가로형만)
- 고정 `min-height` → **`aspect-[77/9]`(770×90)** 로 슬롯 높이가 폭을 따라가게 → 이미지가 `object-cover` 로 **꽉 채움, 레터박스 0**.
- 테두리(`border border-border`) 제거 (엣지투엣지). `rounded-xl` 모서리는 유지.
- `min-height` 대신 aspect-ratio 로 자리 예약 → **CLS 없음**. 로딩 placeholder 도 동일 비율.
- **사이드바(200×200/드로워 320×100) 경로는 테두리·고정높이 그대로** 유지(조건 분기).
- 마음메시지·자체광고 두 렌더 경로 모두 적용. GAM 폴백 경로는 미변경.

전제: 광고 소재를 가로형 규격(770×90 비율)으로 업로드.

## 검증
- svelte-check: damoang-banner 오류 0, prettier 통과
- canary 확인 권장: 마음메시지/자체광고 배너 꽉 채움·여백0, 폭 축소 시 비율 유지, 사이드바 배너 영향 없음, 레이아웃 시프트 없음.