### PR TITLE
fix(editor): 깨진 youtube 임베드로 인한 글 수정 본문 사라짐 방지 (#12686)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -339,6 +339,16 @@
     let lastLoadedContent = '';
     let isSettingContent = false;
 
+    // #12686: src 가 누락된 깨진 youtube 임베드(<div data-youtube-video><iframe ...no src...></div>)는
+    // 수정 진입 시 setContent 파싱을 깨 본문이 통째로 비워지는 원인이 된다. 에디터에 주입하기 전
+    // 그 깨진 래퍼만 제거해 나머지 본문은 보존한다. (백엔드 sanitize 도 저장 시 동일 처리)
+    function stripBrokenYoutube(html: string): string {
+        return html.replace(
+            /<div[^>]*\bdata-youtube-video\b[^>]*>\s*<iframe(?![^>]*\ssrc\s*=\s*["'][^"']+["'])[^>]*>\s*<\/iframe>\s*<\/div>/gi,
+            ''
+        );
+    }
+
     $effect(() => {
         const c = content ?? '';
 
@@ -367,9 +377,9 @@
             return;
         }
 
-        // 비동기 로드된 content를 에디터에 반영
+        // 비동기 로드된 content를 에디터에 반영 (깨진 youtube 임베드는 사전 제거)
         isSettingContent = true;
-        editor.commands.setContent(c);
+        editor.commands.setContent(stripBrokenYoutube(c));
         isSettingContent = false;
         lastLoadedContent = c;
     });


### PR DESCRIPTION
## 배경 (#12686)
모바일에서 유튜브 임베드가 있는 글을 수정 진입하면 본문이 안 보이는 버그. src 가 누락된 youtube 임베드(`<div data-youtube-video><iframe class=tiptap-youtube ...no src...></iframe></div>`)가 저장돼 있을 때, 수정 화면에서 tiptap `setContent` 파싱이 본문을 통째로 비우는 것이 직접 원인.

## 변경 (프론트)
- content 를 에디터에 주입하기 전 `stripBrokenYoutube` 로 **src 없는 깨진 youtube 래퍼만 제거**(negative lookahead 로 정상 src 임베드는 보존). 나머지 본문 텍스트는 그대로 유지 → 수정 가능.
- 기존에 **이미 저장된 깨진 글**의 수정 복구용. 신규 저장 차단은 백엔드 PR(angple-backend#507)에서 처리.

## 짝 PR
- damoang/angple-backend#507 (sanitize: src 없는 iframe 저장 차단)

## 검증
- prettier 통과, 변경 구간 타입오류 0
- ⚠️ canary+모바일 확인 권장: 깨진 임베드 글 수정 진입 시 본문 정상 표시 / 정상 youtube 글은 임베드 유지.