### PR TITLE
feat(sidebar): 즐겨찾기 아래 고정 바로가기 2개 추가 (마음메시지·상생홍보)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -12,6 +12,8 @@
     import { menuStore } from '$lib/stores/menu.svelte';
 
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
+    import Heart from '@lucide/svelte/icons/heart';
+    import Megaphone from '@lucide/svelte/icons/megaphone';
     import { getIcon } from '$lib/utils/icon-map';
 
     import UserWidget from './user-widget.svelte';
@@ -200,6 +202,36 @@
             {/if}
         </div>
     {/if}
+
+    <!-- 고정 바로가기: 마음메시지 · 상생홍보 (즐겨찾기 아래 1행 2열) -->
+    <div class={compact ? 'px-1' : 'px-2'}>
+        <div class="grid grid-cols-2 gap-0.5">
+            <a
+                href="/message"
+                class={cn(
+                    'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors',
+                    isActive('/message')
+                        ? 'bg-primary text-primary-foreground'
+                        : 'hover:bg-accent text-muted-foreground'
+                )}
+            >
+                <Heart class="h-3.5 w-3.5 shrink-0" />
+                <span class="truncate">마음메시지</span>
+            </a>
+            <a
+                href="/promotion"
+                class={cn(
+                    'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors',
+                    isActive('/promotion')
+                        ? 'bg-primary text-primary-foreground'
+                        : 'hover:bg-accent text-muted-foreground'
+                )}
+            >
+                <Megaphone class="h-3.5 w-3.5 shrink-0" />
+                <span class="truncate">상생홍보</span>
+            </a>
+        </div>
+    </div>
 
     <nav
         class={cn(


### PR DESCRIPTION
## 변경
사이드바 **즐겨찾기 그리드 바로 아래**에 고정 바로가기 1행 2열 추가:
- **마음메시지** → `/message`
- **상생홍보** → `/promotion`

즐겨찾기 항목과 동일한 스타일(2열 grid, active 하이라이트, compact 대응) + 아이콘(Heart/Megaphone). 즐겨찾기 유무와 무관하게 항상 노출.

## 검증
- prettier 통과, sidebar.svelte 타입오류 0
- 두 보드(message=마음메시지, promotion=직접홍보) 라우트 정상.