### PR TITLE
feat(sidebar): 즐겨찾기 아래 빠른 바로가기 2열 그리드 (DB 메뉴 그룹 구동)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -34,6 +34,17 @@
 
     // 메뉴 데이터는 SSR에서 초기화된 스토어에서 가져옴
     const menuData = $derived(menuStore.menus.filter((m) => m.show_in_sidebar !== false));
+
+    // 빠른 바로가기: DB 메뉴 그룹(센티넬 URL)의 자식을 즐겨찾기 아래 2열 그리드로 렌더한다.
+    // 라벨/URL/아이콘은 전부 DB(menus 테이블)에서 오며(하드코딩 없음), 관리자가 그룹의
+    // 자식 메뉴를 추가/수정/정렬해 구성한다. 그룹이 없으면 아무것도 렌더하지 않는다.
+    const SIDEBAR_QUICKLINKS_URL = '#sidebar-quicklinks';
+    const quickLinksGroup = $derived(menuData.find((m) => m.url === SIDEBAR_QUICKLINKS_URL));
+    const quickLinks = $derived(
+        (quickLinksGroup?.children ?? []).filter((c) => c.show_in_sidebar !== false)
+    );
+    // 그룹 자체는 일반 nav 에서 제외(자식만 2열로 별도 렌더)
+    const mainMenus = $derived(menuData.filter((m) => m.url !== SIDEBAR_QUICKLINKS_URL));
     const loading = $derived(menuStore.loading);
     const error = $derived(menuStore.error);
 
@@ -201,6 +212,31 @@
         </div>
     {/if}
 
+    <!-- 빠른 바로가기 (DB 메뉴 그룹): 즐겨찾기 아래 2열 그리드 -->
+    {#if quickLinks.length > 0}
+        <div class={compact ? 'px-1' : 'px-2'}>
+            <div class="grid grid-cols-2 gap-0.5">
+                {#each quickLinks as link (link.id)}
+                    {@const LinkIcon = getIcon(link.icon)}
+                    {@const active = isActive(link.url)}
+                    <a
+                        href={link.url}
+                        target={link.target || undefined}
+                        class={cn(
+                            'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors',
+                            active
+                                ? 'bg-primary text-primary-foreground'
+                                : 'hover:bg-accent text-muted-foreground'
+                        )}
+                    >
+                        <LinkIcon class="h-3.5 w-3.5 shrink-0" />
+                        <span class="truncate">{link.title}</span>
+                    </a>
+                {/each}
+            </div>
+        </div>
+    {/if}
+
     <nav
         class={cn(
             'grid group-[[data-collapsed=true]]:justify-center group-[[data-collapsed=true]]:px-2',
@@ -213,7 +249,7 @@
             <div class="text-destructive text-center text-sm">{error}</div>
         {:else}
             <Accordion type="single" class="w-full" bind:value={accordionValue}>
-                {#each menuData as menu (menu.id)}
+                {#each mainMenus as menu (menu.id)}
                     {@const IconComponent = getIcon(menu.icon)}
                     {#if menu.children && menu.children.length > 0}
                         <!-- 하위 메뉴가 있는 경우 -->


### PR DESCRIPTION
## 목적
사이드바 **즐겨찾기 블록 바로 아래**에, 즐겨찾기와 **동일한 2열 그리드**로 빠른 바로가기(예: 마음메시지·상생홍보)를 노출. 하드코딩 없이 **DB 메뉴로 관리**.

## 설계 (모범사례)
- 센티넬 URL `#sidebar-quicklinks` 를 가진 **부모 메뉴 그룹**의 **자식들**을 2열 그리드로 렌더. 라벨/URL/아이콘/순서 전부 DB(`menus`)에서 옴 → 관리자가 메뉴 관리에서 자식 추가/수정/정렬.
- 그룹이 없으면 **아무것도 렌더 안 함**(배포 후 그룹 구성 전까지 무영향 — 점진 적용 안전).
- 해당 그룹은 일반 nav 목록에서 **제외**(자식만 2열로 별도 표시, 중복 없음).
- 아이콘=메뉴 `icon` 필드(getIcon), active=isActive, compact 대응. 즐겨찾기 항목과 동일 스타일.

## 배포 후 데이터 구성 (별도, 코드 아님)
`menus` 에 그룹 + 자식 구성 후 관리자 **메뉴 캐시 무효화**:
```sql
-- 그룹 부모 (url 센티넬)
INSERT INTO menus (title, url, depth, order_num, is_active, view_level, show_in_header, show_in_sidebar, created_at, updated_at)
VALUES ('바로가기', '#sidebar-quicklinks', 0, 0, 1, 0, 0, 1, NOW(3), NOW(3));
SET @g := LAST_INSERT_ID();
-- 자식: 마음메시지 · 상생홍보 (기존 더보기/정보 하위 메뉴는 그대로 둠)
INSERT INTO menus (parent_id, title, url, icon, depth, order_num, is_active, view_level, show_in_header, show_in_sidebar, created_at, updated_at)
VALUES (@g, '마음메시지', '/message', 'Heart', 1, 0, 1, 0, 0, 1, NOW(3), NOW(3)),
       (@g, '상생홍보', '/promotion', 'Megaphone', 1, 1, 1, 0, 0, 1, NOW(3), NOW(3));
```

## 검증
- svelte-check: sidebar.svelte 오류 0, prettier 통과
- 그룹 미존재 시 렌더 0 확인(가드). canary: 그룹 구성+캐시 무효화 후 즐겨찾기 아래 2열 노출 확인.