### PR TITLE
feat(board): 글쓰기·댓글 작성 조건 호버 안내 (등급명 포함)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -10,6 +10,7 @@
         goToCertification
     } from '$lib/utils/certification-gate.js';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
+    import { getGradeName } from '$lib/utils/grade.js';
     import type { BoardPermissions } from '$lib/api/types.js';
     import { apiClient } from '$lib/api/index.js';
     import { stripAdminMentions } from '$lib/utils/sanitize-mentions.js';
@@ -72,11 +73,12 @@
         return userLevel >= requiredCommentLevel;
     });
 
-    const permissionMessage = $derived(
-        isRestricted
-            ? '이용제한 중에는 댓글을 작성할 수 없습니다.'
-            : `레벨 ${requiredCommentLevel} 이상 작성 가능`
-    );
+    const permissionMessage = $derived.by(() => {
+        if (isRestricted) return '이용제한 중에는 댓글을 작성할 수 없습니다.';
+        const need = `${getGradeName(requiredCommentLevel)}(Lv.${requiredCommentLevel}) 이상 작성 가능`;
+        const lv = authStore.user?.mb_level;
+        return lv != null ? `${need} · 현재 ${getGradeName(lv)}(Lv.${lv})` : need;
+    });
 
     let commentAvatarUrl = $derived(
         getAvatarUrl(authStore.user?.mb_image, authStore.user?.mb_image_updated_at) || null

--- a/apps/web/src/lib/components/ui/tooltip/index.ts
+++ b/apps/web/src/lib/components/ui/tooltip/index.ts
@@ -1,0 +1,16 @@
+import Root from './tooltip.svelte';
+import Trigger from './tooltip-trigger.svelte';
+import Content from './tooltip-content.svelte';
+import Provider from './tooltip-provider.svelte';
+
+export {
+    Root,
+    Trigger,
+    Content,
+    Provider,
+    //
+    Root as Tooltip,
+    Trigger as TooltipTrigger,
+    Content as TooltipContent,
+    Provider as TooltipProvider
+};

--- a/apps/web/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/apps/web/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import { Tooltip as TooltipPrimitive } from 'bits-ui';
+    import { cn } from '$lib/utils.js';
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        sideOffset = 6,
+        children,
+        ...restProps
+    }: TooltipPrimitive.ContentProps = $props();
+</script>
+
+<TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+        bind:ref
+        data-slot="tooltip-content"
+        {sideOffset}
+        class={cn(
+            'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 w-fit max-w-xs rounded-md border px-3 py-2 text-xs leading-relaxed shadow-md',
+            className
+        )}
+        {...restProps}
+    >
+        {@render children?.()}
+    </TooltipPrimitive.Content>
+</TooltipPrimitive.Portal>

--- a/apps/web/src/lib/components/ui/tooltip/tooltip-provider.svelte
+++ b/apps/web/src/lib/components/ui/tooltip/tooltip-provider.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+    let { delayDuration = 150, ...restProps }: TooltipPrimitive.ProviderProps = $props();
+</script>
+
+<TooltipPrimitive.Provider {delayDuration} {...restProps} />

--- a/apps/web/src/lib/components/ui/tooltip/tooltip-trigger.svelte
+++ b/apps/web/src/lib/components/ui/tooltip/tooltip-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+    let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps = $props();
+</script>
+
+<TooltipPrimitive.Trigger bind:ref {...restProps} />

--- a/apps/web/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/apps/web/src/lib/components/ui/tooltip/tooltip.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+    let { ...restProps }: TooltipPrimitive.RootProps = $props();
+</script>
+
+<TooltipPrimitive.Root {...restProps} />

--- a/apps/web/src/lib/utils/board-permissions.ts
+++ b/apps/web/src/lib/utils/board-permissions.ts
@@ -1,4 +1,5 @@
 import type { Board, BoardPermissions, DamoangUser } from '$lib/api/types.js';
+import { getGradeName } from './grade.js';
 
 export type PermissionAction =
     | 'can_list'
@@ -93,6 +94,37 @@ export function getRequiredLevel(
 ): number {
     const levelKey = ACTION_LEVEL_MAP[action];
     return (board?.[levelKey] as number) ?? 1;
+}
+
+/** 권한 안내 툴팁용 구조화 데이터 (등급명 포함) */
+export interface RequirementHint {
+    actionName: string;
+    loggedIn: boolean;
+    requiredLevel: number;
+    requiredGrade: string;
+    currentLevel: number | null;
+    currentGrade: string | null;
+}
+
+/**
+ * 글쓰기/댓글 비활성 시 호버 안내에 쓸 조건 데이터를 만든다.
+ * 필요 등급명·현재 등급명을 함께 담아 친절한 안내가 가능하게 한다.
+ */
+export function getRequirementHint(
+    board: BoardPermissionTarget | undefined | null,
+    action: PermissionAction,
+    user: DamoangUser | null
+): RequirementHint {
+    const requiredLevel = getRequiredLevel(board, action);
+    const currentLevel = user?.mb_level ?? null;
+    return {
+        actionName: ACTION_NAMES[action],
+        loggedIn: !!user,
+        requiredLevel,
+        requiredGrade: getGradeName(requiredLevel),
+        currentLevel,
+        currentGrade: currentLevel != null ? getGradeName(currentLevel) : null
+    };
 }
 
 /**

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -82,7 +82,12 @@
         getPageSeoConfig
     } from '$lib/seo/index.js';
     import type { SeoConfig } from '$lib/seo/types.js';
-    import { checkPermission, getPermissionMessage } from '$lib/utils/board-permissions.js';
+    import {
+        checkPermission,
+        getPermissionMessage,
+        getRequirementHint
+    } from '$lib/utils/board-permissions.js';
+    import * as Tooltip from '$lib/components/ui/tooltip/index.js';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { densityStore } from '$lib/stores/density.svelte.js';
     import { readPostStyleStore, type ReadPostStyle } from '$lib/stores/read-post-style.svelte.js';
@@ -176,6 +181,9 @@
     });
 
     // 권한 부족 시 표시할 메시지
+    // 글쓰기 비활성 호버 안내용 조건(등급명 포함)
+    const writeHint = $derived(getRequirementHint(data.board, 'can_write', authStore.user ?? null));
+
     const writePermissionMessage = $derived.by(() => {
         if (!authStore.isAuthenticated) return '로그인이 필요합니다';
         return getPermissionMessage(data.board, 'can_write', authStore.user ?? null);
@@ -1055,15 +1063,42 @@
                             {#if !canUseCertifiedAction(authStore.user, boardId)}실명인증{:else}글쓰기{/if}
                         </Button>
                     {:else if authStore.isAuthenticated}
-                        <Button
-                            disabled
-                            size="sm"
-                            class="h-8 cursor-not-allowed opacity-60"
-                            title={writePermissionMessage}
-                        >
-                            <Lock class="mr-1.5 h-3.5 w-3.5" />
-                            글쓰기
-                        </Button>
+                        <!-- 권한 부족: 비활성 대신 호버/탭 시 작성 조건 안내 (disabled 버튼은 호버가 안 먹어 trigger 로 처리) -->
+                        <Tooltip.Provider>
+                            <Tooltip.Root>
+                                <Tooltip.Trigger>
+                                    {#snippet child({ props })}
+                                        <Button
+                                            {...props}
+                                            size="sm"
+                                            variant="secondary"
+                                            class="h-8 cursor-help opacity-70"
+                                            aria-label="글쓰기 조건 안내"
+                                        >
+                                            <Lock class="mr-1.5 h-3.5 w-3.5" />
+                                            글쓰기
+                                        </Button>
+                                    {/snippet}
+                                </Tooltip.Trigger>
+                                <Tooltip.Content>
+                                    <p class="mb-1 flex items-center gap-1 font-semibold">
+                                        <Lock class="h-3 w-3" />
+                                        {writeHint.actionName} 조건
+                                    </p>
+                                    <p>
+                                        이 게시판은 <span class="font-semibold"
+                                            >{writeHint.requiredGrade} (Lv.{writeHint.requiredLevel})</span
+                                        > 이상 작성할 수 있어요.
+                                    </p>
+                                    {#if writeHint.currentGrade}
+                                        <p class="text-muted-foreground mt-0.5">
+                                            현재: {writeHint.currentGrade} (Lv.{writeHint.currentLevel})
+                                            · 활동하면 등급이 올라가요.
+                                        </p>
+                                    {/if}
+                                </Tooltip.Content>
+                            </Tooltip.Root>
+                        </Tooltip.Provider>
                     {/if}
                 </div>
             {/if}


### PR DESCRIPTION
## 목적
권한 부족으로 **글쓰기/댓글이 막혔을 때**, 사용자가 "왜 막혔는지 + 어떤 조건이 필요한지"를 호버/탭으로 알 수 있게 안내.

## 변경
- **ui/tooltip** 추가 (bits-ui 기반 shadcn 패턴). 호버·포커스·모바일 탭 대응.
- **글쓰기 버튼**: 기존 `disabled` 버튼(브라우저에 따라 호버 `title`이 안 떠 안내 누락)을 **Tooltip trigger**로 전환 → 호버/탭 시 안내:
  > 🔒 글쓰기 조건 — 이 게시판은 **앙님💛(Lv.3) 이상** 작성할 수 있어요. 현재: 앙님❤️(Lv.2) · 활동하면 등급이 올라가요.
- **board-permissions**: `getRequirementHint()`(필요/현재 등급명 포함 구조화 데이터) 추가.
- **댓글 비활성 메시지**: `레벨 N 이상` → `{등급명}(Lv.N) 이상 · 현재 {등급명}(Lv.M)` 로 보강.
- 라벨/레벨은 전부 `board.write_level`/`comment_level` + `getGradeName` 데이터 구동 — **하드코딩 없음**.

## 검증
- svelte-check 변경 파일 오류 0, prettier 통과
- canary 확인 권장: 권한 부족 게시판에서 글쓰기 버튼 호버/탭 시 등급 조건 안내, 댓글 영역 메시지 등급명 표시.