### PR TITLE
perf(menu): 사이드바 메뉴 캐시 TTL 단축 (24h/7일 → 60초/5분)

### DIFF
--- a/apps/web/src/lib/server/menu-loader.ts
+++ b/apps/web/src/lib/server/menu-loader.ts
@@ -14,9 +14,12 @@ import { TieredCache } from '$lib/server/cache';
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
 
-// 메뉴는 거의 안 바뀜 → L1 24시간, L2(Redis) 7일. 변경 시 invalidateMenuCache() 호출
+// 메뉴 캐시: L1 60초 / L2(Redis) 5분. 짧게 둬서 메뉴 변경(관리자 편집/외부 INSERT)이
+// invalidateMenuCache() 수동 호출 없이도 수 분 내 자동 반영되게 한다. menu 쿼리는 가벼워
+// 5분마다 재조회해도 부하 무시 가능(L1 60초가 대부분 흡수). 이전엔 24h/7일이라 stale 메뉴가
+// 오래 남아 "관리자에서 바꿔도 안 보임"이 반복됐다.
 // 2026-04-26: maxL1=100 명시 (이전엔 무제한). 사이트별 1키만 사용해 충분.
-const menuCache = new TieredCache<MenuItem[]>('menus:sidebar', 86_400_000, 604_800, 100);
+const menuCache = new TieredCache<MenuItem[]>('menus:sidebar', 60_000, 300, 100);
 
 /**
  * 백엔드 연결 불가 시 최소한의 기본 메뉴


### PR DESCRIPTION
## 배경
메뉴 캐시(`menu-loader.ts`)가 **L1 24시간 / L2(Redis) 7일**로 너무 길어, 관리자에서 메뉴를 바꾸거나 외부에서 메뉴를 INSERT/수정해도 `invalidateMenuCache()`를 **super_admin이 수동 호출**하기 전까지 stale 메뉴가 오래 남았습니다. → '관리자에서 바꿔도 안 보임', '한 번 보였다 다시 안 보임'이 반복(특히 즐겨찾기 아래 빠른 바로가기 그룹 #sidebar-quicklinks).

## 변경
- `menus:sidebar` 캐시 TTL: **L1 60초 / L2 5분**으로 단축 (`60_000, 300`).
- 효과: 메뉴 변경이 **수 분 내 자동 반영**(수동 무효화 불필요) → 재발 차단.
- 부하: menu 쿼리는 인덱스 가벼운 단발, L1 60초가 대부분 흡수 → 무시 가능.

## 주의 (배포 후 1회)
기존 stale L2 엔트리(옛 7일 TTL)는 이 변경의 영향을 안 받으므로, **배포 후 1회 무효화**(super_admin 콘솔 `POST /api/admin/invalidate-menu-cache`)가 필요합니다. 이후부터는 5분 TTL로 자가복구.

## 검증
- prettier 통과. 배포+1회 무효화 후 관리자 메뉴 변경 → 수 분 내 사이드바 자동 반영 확인.