### PR TITLE
fix(board): 글 위치 페이지 계산을 목록과 동일 BOARD_LIST_PAGE_SIZE 로 통일 (#12571)

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/page-index/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/page-index/+server.ts
@@ -9,12 +9,16 @@
  *   - prior = COUNT(wr_id > targetId, wr_is_comment=0, wr_deleted_at IS NULL)
  *   - page  = floor(prior / page_rows) + 1
  *
- * page_rows 는 g5_board.bo_page_rows (게시판 설정), 미설정 시 25 default.
+ * page_rows 는 게시판 목록과 동일한 BOARD_LIST_PAGE_SIZE 를 사용한다(#12571).
+ * 목록 페이지/하단 RecentPosts 가 bo_page_rows 가 아니라 이 상수로 페이지네이션하므로,
+ * 여기서 bo_page_rows(미설정 시 25)를 쓰면 글 위치가 목록과 어긋나 페이지가 넘어갈수록
+ * 차이가 누적돼 놓치는 글이 생긴다. 세 곳을 같은 상수로 통일한다.
  */
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import pool from '$lib/server/db';
 import type { RowDataPacket } from 'mysql2';
+import { BOARD_LIST_PAGE_SIZE } from '$lib/constants/board.js';
 
 const BOARD_ID_RE = /^[a-zA-Z0-9_]{1,40}$/;
 
@@ -23,16 +27,11 @@ export const GET: RequestHandler = async ({ params, setHeaders }) => {
     const postId = parseInt(params.postId ?? '0', 10);
 
     if (!BOARD_ID_RE.test(boardId) || !Number.isFinite(postId) || postId <= 0) {
-        return json({ page: 1, page_rows: 25 }, { status: 400 });
+        return json({ page: 1, page_rows: BOARD_LIST_PAGE_SIZE }, { status: 400 });
     }
 
     try {
-        // 게시판 page_rows 조회
-        const [boardRows] = await pool.query<RowDataPacket[]>(
-            'SELECT bo_page_rows FROM g5_board WHERE bo_table = ? LIMIT 1',
-            [boardId]
-        );
-        const pageRows = Math.max(1, (boardRows[0]?.bo_page_rows as number | null) ?? 25);
+        const pageRows = BOARD_LIST_PAGE_SIZE;
 
         // 해당 글보다 최신인 정상 글 개수 (1페이지에 최신 글이 옴)
         const tableName = `g5_write_${boardId}`;
@@ -51,6 +50,6 @@ export const GET: RequestHandler = async ({ params, setHeaders }) => {
     } catch (err) {
         // DB 오류 시 1페이지 fallback (사용자 흐름 방해 X)
         console.error('[page-index] DB error:', err);
-        return json({ page: 1, page_rows: 25 });
+        return json({ page: 1, page_rows: BOARD_LIST_PAGE_SIZE });
     }
 };


### PR DESCRIPTION
## 배경 (#12571)
게시판 목록과 글 상세 하단(RecentPosts)에서 같은 글의 위치(페이지)가 달라, 페이지가 넘어갈수록 차이가 누적돼 놓치는 글이 생김.

## 원인
페이지 크기가 불일치:
- 게시판 목록(`[boardId]/+page.server.ts`): `BOARD_LIST_PAGE_SIZE`(24)
- 글 하단 RecentPosts: `limit={BOARD_LIST_PAGE_SIZE}`(24) ✅ (이미 통일됨)
- **page-index API**: `bo_page_rows ?? 25` ❌ ← 유일한 불일치

목록은 `bo_page_rows` 가 아니라 상수로 페이지네이션하는데, page-index 만 `bo_page_rows`(미설정 25)로 페이지를 계산해 위치가 어긋남.

## 변경
`page-index/+server.ts`: `pageRows` 를 `BOARD_LIST_PAGE_SIZE` 로 통일(단일 출처). 불필요한 `bo_page_rows` 조회 제거(DB 1회 절약).

## 검증
- svelte-check 타입오류 0.
- 배포 후: 글 상세에서 '목록으로' 진입 시 페이지/위치가 게시판 목록과 일치하는지 확인. (예: 목록 2페이지 첫 글 = 글 하단 목록 2페이지 첫 글)