### PR TITLE
fix(comments): backfill 전송 실패 시 재시도 — '불러오는 중' 고착 방지 (#12668)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1280,6 +1280,28 @@
         }
     }
 
+    // 댓글 수>0 인데 목록이 0개일 때, 단발 fetch 가 전송 실패(네트워크 순단/모바일 webview)하면
+    // 재시도가 없어 "불러오는 중"에 고착되는 사례(#12668: 간헐 발생, 새로고침하면 보임)가 있어
+    // 짧은 백오프로 몇 번 재시도한다. 실제 0개이거나 채워지면 종료.
+    let backfillInProgress = false;
+    async function backfillWithRetry(): Promise<void> {
+        if (backfillInProgress) return;
+        backfillInProgress = true;
+        try {
+            for (let attempt = 0; attempt < 3; attempt++) {
+                try {
+                    await refetchComments();
+                } catch {
+                    // 전송 실패 — 재시도
+                }
+                if (comments.length > 0 || commentsTotal === 0) return;
+                await new Promise((resolve) => setTimeout(resolve, 800 * (attempt + 1)));
+            }
+        } finally {
+            backfillInProgress = false;
+        }
+    }
+
     // 댓글 backfill: SSR에서 일부만 로드된 경우 전체 댓글 가져오기
     // onMount 대신 $effect로 SPA 네비게이션에서도 동작하도록
     $effect(() => {
@@ -1289,7 +1311,7 @@
         if (total <= loaded) return;
 
         if (loaded === 0) {
-            void refetchComments();
+            void backfillWithRetry();
             return;
         }
 


### PR DESCRIPTION
## 배경
"댓글(N)로 표시되는데 목록은 비어있고, 새로고침/스크롤하면 보임"(#12668, 간헐·빈도 높음).

## 분석
- 거짓 '댓글 없음' → '불러오는 중' 표시는 **이미 #1607 에서 해결·배포**됨(expectedTotal).
- 남은 갭: 목록 0개 + 댓글 수>0 일 때 backfill `refetchComments()` 가 **단발**이라, 전송 실패(네트워크 순단/모바일 webview/SW 가로채기)하면 재시도 없이 **'불러오는 중'에 고착** → 새로고침해야만 보임.

## 변경
backfill 을 `backfillWithRetry()` 로 — 짧은 백오프(0.8s·1.6s·2.4s)로 최대 3회 재시도. 댓글이 채워지거나 실제 0개면 종료. 중복 실행 가드(`backfillInProgress`).

## 범위 밖 (후속)
- **#12663**("수동 새로고침해도 70개 안 보임"): refetch 가 성공해도 빈 응답 → **백엔드 댓글 API가 특정 글에 빈 결과 반환** 의심. 별도 백엔드 조사 필요.

## 검증
- svelte-check 오류 0, prettier 통과.
- canary: 댓글 있는 글 SPA 진입 시 일시적 네트워크 실패 후에도 자동 재시도로 댓글 표시되는지.