### PR TITLE
fix(post): 댓글 앵커 스크롤 재시도 연장 — '내 댓글 클릭 시 글로만 이동' (#12688)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -812,13 +812,16 @@
         const targetId = getAnchorTargetId(hash);
         if (!targetId) return;
 
-        let attempts = 0;
+        // 댓글이 비동기로 로드/렌더되므로(특히 모바일·긴 스레드, 초기 limit 초과 댓글은
+        // backfill 후 렌더) 짧은 재시도(20프레임 ≈0.3s)로는 대상 댓글이 아직 DOM 에 없어
+        // 글 상단에만 머무는 사례(#12688: '내 댓글 클릭 시 글로만 이동')가 있었다.
+        // 대상이 나타날 때까지 최대 ~5초간 rAF 재시도(발견 즉시 중단, 비용 저렴).
+        const deadline = Date.now() + 5000;
         const tryScroll = () => {
             const el = document.getElementById(targetId);
             if (el) {
                 scrollToAndHighlight(el);
-            } else if (attempts < 20) {
-                attempts++;
+            } else if (Date.now() < deadline) {
                 requestAnimationFrame(tryScroll);
             }
         };


### PR DESCRIPTION
## 배경 (#12688)
프로필 '내가 쓴 댓글'을 누르면 댓글 위치가 아니라 글 상단으로만 이동(모바일/알로하).

## 분석 (origin/main fresh)
- 댓글 href 는 백엔드(mypage_handler.go:250)에서 `/board/parent#c_댓글ID` 로 **앵커 포함 정상**.
- 글 상세도 `#c_` 해시를 처리(getAnchorTargetId).
- 원인: 댓글이 **비동기 로드/렌더**(특히 모바일, 초기 limit 초과 댓글은 backfill 후 렌더)되는데 `scheduleAnchorScroll` 재시도가 **20프레임(~0.3s)** 뿐 → 대상 댓글이 아직 DOM 에 없어 스크롤 실패 → 글 상단 유지.

## 변경
재시도를 `attempts<20` → **deadline 기반 최대 ~5초 rAF 재시도**(대상 발견 즉시 중단, 비용 저렴). 댓글이 렌더된 뒤 정확히 해당 댓글로 스크롤+하이라이트.

## 검증
- svelte-check 오류 0, prettier 통과.
- canary: 프로필 '내가 쓴 댓글' 클릭 → 해당 댓글로 스크롤(긴 스레드/모바일 포함).