### PR TITLE
fix(content): 본문/댓글 이미지 URL 더블슬래시 정규화 (#12697)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -30,6 +30,7 @@
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { dompurify as DOMPurify } from '$lib/utils/dompurify.js';
+    import { normalizeHtmlMediaUrls } from '$lib/utils/media-url';
     import { applyFilter } from '$lib/hooks/registry';
     import { getHookVersion } from '$lib/hooks/hook-state.svelte';
     import { onMount, tick } from 'svelte';
@@ -759,37 +760,39 @@
             const withBr = comment.content.replace(/\n/g, '<br>');
             map.set(
                 comment.id,
-                DOMPurify.sanitize(withBr, {
-                    ALLOWED_TAGS: [
-                        'p',
-                        'img',
-                        'br',
-                        'div',
-                        'blockquote',
-                        'a',
-                        'span',
-                        'pre',
-                        'code',
-                        'strong',
-                        'em',
-                        'del',
-                        'details',
-                        'summary'
-                    ],
-                    ALLOWED_ATTR: [
-                        'src',
-                        'width',
-                        'alt',
-                        'loading',
-                        'class',
-                        'height',
-                        'href',
-                        'target',
-                        'rel',
-                        'data-affiliate',
-                        'data-original'
-                    ]
-                })
+                normalizeHtmlMediaUrls(
+                    DOMPurify.sanitize(withBr, {
+                        ALLOWED_TAGS: [
+                            'p',
+                            'img',
+                            'br',
+                            'div',
+                            'blockquote',
+                            'a',
+                            'span',
+                            'pre',
+                            'code',
+                            'strong',
+                            'em',
+                            'del',
+                            'details',
+                            'summary'
+                        ],
+                        ALLOWED_ATTR: [
+                            'src',
+                            'width',
+                            'alt',
+                            'loading',
+                            'class',
+                            'height',
+                            'href',
+                            'target',
+                            'rel',
+                            'data-affiliate',
+                            'data-original'
+                        ]
+                    })
+                )
             );
         }
         return map;
@@ -815,56 +818,58 @@
                 const withLinks = autoLinkUrls(withMentions);
                 processedComments.set(
                     comment.id,
-                    DOMPurify.sanitize(withLinks, {
-                        ALLOWED_TAGS: [
-                            'p',
-                            'img',
-                            'br',
-                            'div',
-                            'iframe',
-                            'video',
-                            'audio',
-                            'source',
-                            'blockquote',
-                            'a',
-                            'span',
-                            'pre',
-                            'code',
-                            'strong',
-                            'em',
-                            'del',
-                            'details',
-                            'summary'
-                        ],
-                        ALLOWED_ATTR: [
-                            'src',
-                            'width',
-                            'alt',
-                            'loading',
-                            'class',
-                            'height',
-                            'style',
-                            'data-platform',
-                            'data-bluesky-uri',
-                            'data-bluesky-cid',
-                            'data-embed-height',
-                            'frameborder',
-                            'allow',
-                            'allowfullscreen',
-                            'allowtransparency',
-                            'scrolling',
-                            'referrerpolicy',
-                            'type',
-                            'controls',
-                            'title',
-                            'href',
-                            'target',
-                            'rel',
-                            'data-mention',
-                            'data-affiliate',
-                            'data-original'
-                        ]
-                    })
+                    normalizeHtmlMediaUrls(
+                        DOMPurify.sanitize(withLinks, {
+                            ALLOWED_TAGS: [
+                                'p',
+                                'img',
+                                'br',
+                                'div',
+                                'iframe',
+                                'video',
+                                'audio',
+                                'source',
+                                'blockquote',
+                                'a',
+                                'span',
+                                'pre',
+                                'code',
+                                'strong',
+                                'em',
+                                'del',
+                                'details',
+                                'summary'
+                            ],
+                            ALLOWED_ATTR: [
+                                'src',
+                                'width',
+                                'alt',
+                                'loading',
+                                'class',
+                                'height',
+                                'style',
+                                'data-platform',
+                                'data-bluesky-uri',
+                                'data-bluesky-cid',
+                                'data-embed-height',
+                                'frameborder',
+                                'allow',
+                                'allowfullscreen',
+                                'allowtransparency',
+                                'scrolling',
+                                'referrerpolicy',
+                                'type',
+                                'controls',
+                                'title',
+                                'href',
+                                'target',
+                                'rel',
+                                'data-mention',
+                                'data-affiliate',
+                                'data-original'
+                            ]
+                        })
+                    )
                 );
             })();
         }

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -7,6 +7,7 @@
     import { browser } from '$app/environment';
     import { highlightAllCodeBlocks } from '$lib/utils/code-highlight';
     import { transformEscapedMedia } from '$lib/utils/content-transform';
+    import { normalizeHtmlMediaUrls } from '$lib/utils/media-url';
     import { processContent as processEmbeds } from '$lib/plugins/auto-embed/embedder.js';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
     import {
@@ -238,7 +239,8 @@
         let rawHtml = marked.parse(content) as string;
         rawHtml = transformEscapedMedia(rawHtml);
         // processEmbeds는 클라이언트 $effect에서만 실행 (SSR 부하 방지)
-        return DOMPurify.sanitize(rawHtml, PURIFY_CONFIG);
+        // 본문 이미지 src 더블슬래시 collapse + CDN 호스트 정규화 (#12697)
+        return normalizeHtmlMediaUrls(DOMPurify.sanitize(rawHtml, PURIFY_CONFIG));
     }
 
     // 초기 렌더링 (SSR + 클라이언트 초기값)
@@ -265,6 +267,7 @@
 
             applyFilter<string>('post_content', rawHtml).then((filtered) => {
                 let sanitized = DOMPurify.sanitize(filtered, PURIFY_CONFIG);
+                sanitized = normalizeHtmlMediaUrls(sanitized);
                 sanitized = addLinkMismatchWarnings(sanitized);
                 renderedHtml = sanitized;
             });

--- a/apps/web/src/lib/utils/media-url.test.ts
+++ b/apps/web/src/lib/utils/media-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeMediaUrl } from './media-url';
+import { normalizeMediaUrl, normalizeHtmlMediaUrls } from './media-url';
 
 describe('normalizeMediaUrl — R2 prefix routing (Phase B1)', () => {
     it('routes data/content/* to r2.damoang.net (R2 prefix)', () => {
@@ -41,5 +41,71 @@ describe('normalizeMediaUrl — R2 prefix routing (Phase B1)', () => {
         expect(normalizeMediaUrl(null)).toBe(null);
         expect(normalizeMediaUrl(undefined)).toBe(null);
         expect(normalizeMediaUrl('')).toBe(null);
+    });
+});
+
+describe('normalizeMediaUrl — 더블슬래시 collapse + CDN 정규화 (#12697)', () => {
+    it('메인 도메인 + leading 더블슬래시 → s3 단일슬래시', () => {
+        expect(normalizeMediaUrl('https://damoang.net//data/editor/2506/x.jpeg')).toBe(
+            'https://s3.damoang.net/data/editor/2506/x.jpeg'
+        );
+    });
+
+    it('s3 호스트 + 경로 중간 더블슬래시 → 단일슬래시', () => {
+        expect(normalizeMediaUrl('https://s3.damoang.net/data/editor/2404//y.jpg')).toBe(
+            'https://s3.damoang.net/data/editor/2404/y.jpg'
+        );
+    });
+
+    it('상대 경로(/data/...) → s3 절대 URL', () => {
+        expect(normalizeMediaUrl('/data/editor/x.jpg')).toBe(
+            'https://s3.damoang.net/data/editor/x.jpg'
+        );
+    });
+
+    it('상대 경로 더블슬래시도 collapse', () => {
+        expect(normalizeMediaUrl('data/editor/2404//y.jpg')).toBe(
+            'https://s3.damoang.net/data/editor/2404/y.jpg'
+        );
+    });
+
+    it('멱등: 이미 정규화된 s3 단일슬래시 URL 은 그대로', () => {
+        const url = 'https://s3.damoang.net/data/editor/x.jpg';
+        expect(normalizeMediaUrl(url)).toBe(url);
+    });
+
+    it('더블슬래시 + data/content/ 는 r2 라우팅 유지', () => {
+        expect(normalizeMediaUrl('https://damoang.net//data/content/z.webp')).toBe(
+            'https://r2.damoang.net/data/content/z.webp'
+        );
+    });
+
+    it('damoang 미디어가 아닌 외부 이미지는 변형하지 않음', () => {
+        expect(normalizeMediaUrl('https://example.com/a.png')).toBe('https://example.com/a.png');
+    });
+});
+
+describe('normalizeHtmlMediaUrls — 본문 HTML img src 정규화', () => {
+    it('더블슬래시 img src 를 collapse + 재호스팅', () => {
+        const html = '<p>x</p><img class="w" src="https://damoang.net//data/editor/2506/x.jpeg">';
+        expect(normalizeHtmlMediaUrls(html)).toContain(
+            'src="https://s3.damoang.net/data/editor/2506/x.jpeg"'
+        );
+    });
+
+    it('여러 img 처리, 외부 이미지는 보존', () => {
+        const html = '<img src="data/editor/a.jpg"><img src="https://example.com/b.png">';
+        const out = normalizeHtmlMediaUrls(html);
+        expect(out).toContain('src="https://s3.damoang.net/data/editor/a.jpg"');
+        expect(out).toContain('src="https://example.com/b.png"');
+    });
+
+    it('정상 URL 만 있으면 변화 없음(멱등)', () => {
+        const html = '<img src="https://s3.damoang.net/data/editor/x.jpg">';
+        expect(normalizeHtmlMediaUrls(html)).toBe(html);
+    });
+
+    it('빈 문자열은 그대로', () => {
+        expect(normalizeHtmlMediaUrls('')).toBe('');
     });
 });

--- a/apps/web/src/lib/utils/media-url.ts
+++ b/apps/web/src/lib/utils/media-url.ts
@@ -1,7 +1,17 @@
 import { normalizeWebUrl } from '$lib/utils/url-normalizer';
 
+// 호스트 직후 path. `\/{1,}` 로 leading 다중슬래시(`//data/...`)까지 매치 — 레거시
+// 네이버에디터 마이그레이션 글에 `damoang.net//data/...` 더블슬래시가 박혀 있다(#12697).
 const ABSOLUTE_MEDIA_HOST_REGEX =
-    /^https?:\/\/(?:www\.)?(?:damoang\.net|s3\.damoang\.net|cdn\.damoang\.net|r2\.damoang\.net)(\/data\/.+)$/i;
+    /^https?:\/\/(?:www\.)?(?:damoang\.net|s3\.damoang\.net|cdn\.damoang\.net|r2\.damoang\.net)(\/{1,}data\/.+)$/i;
+
+// 본문/댓글 HTML 에서 <img src> 추출용 (markdown.svelte 의 이미지 정규식과 동일 패턴).
+const IMG_SRC_REGEX = /<img\b([^>]*?)\bsrc=(["'])([^"']+)\2([^>]*)>/gi;
+
+/** path 의 연속 슬래시(`//`+)를 하나로 축소. 프로토콜(`://`)을 포함하지 않는 path 조각에만 적용. */
+function collapseSlashes(path: string): string {
+    return path.replace(/\/{2,}/g, '/');
+}
 
 // R2 origin (Cloudflare 자체 storage, egress 무료, Sippy 가 S3 fallback)
 const R2_BASE = 'https://r2.damoang.net';
@@ -36,17 +46,33 @@ export function normalizeMediaUrl(
     ) {
         const sameMediaPath = normalizedRawUrl.match(ABSOLUTE_MEDIA_HOST_REGEX);
         if (sameMediaPath) {
-            const cdnBase = normalizeCdnBase(cdnBaseUrl, sameMediaPath[1]);
-            return `${cdnBase}${sameMediaPath[1]}`;
+            // 더블슬래시 collapse 후 CDN 호스트로 정규화 (#12697 깨진 레거시 URL 복구).
+            const path = collapseSlashes(sameMediaPath[1]);
+            const cdnBase = normalizeCdnBase(cdnBaseUrl, path);
+            return `${cdnBase}${path}`;
         }
         return normalizeWebUrl(normalizedRawUrl);
     }
 
-    const trimmedPath = normalizedRawUrl.replace(/^\/+/, '');
+    const trimmedPath = collapseSlashes(normalizedRawUrl.replace(/^\/+/, ''));
     if (trimmedPath.startsWith('data/')) {
         const cdnBase = normalizeCdnBase(cdnBaseUrl, trimmedPath);
         return `${cdnBase}/${trimmedPath}`;
     }
 
     return normalizedRawUrl;
+}
+
+/**
+ * HTML 문자열 안의 모든 `<img src>` 를 normalizeMediaUrl 로 정규화.
+ * 더블슬래시 collapse + damoang 미디어/상대경로 → CDN 호스트 재호스팅(#12697).
+ * 멱등 — 이미 정규화된 URL·외부 이미지는 그대로 통과.
+ */
+export function normalizeHtmlMediaUrls(html: string, cdnBaseUrl?: string | null): string {
+    if (!html) return html;
+    return html.replace(IMG_SRC_REGEX, (match, before, quote, src, after) => {
+        const normalized = normalizeMediaUrl(src, cdnBaseUrl);
+        if (!normalized || normalized === src) return match;
+        return `<img${before}src=${quote}${normalized}${quote}${after}>`;
+    });
 }


### PR DESCRIPTION
## 문제
버그 게시판 #12697 "오래전에 올린 글에서 사진이 사라졌습니다" — 옛 글 본문 이미지가 안 보임.

**근본 원인**: 2024-04 네이버에디터 마이그레이션 잔재로 일부 글의 `<img src>` 경로에 **더블슬래시**가 박혀 있음.
- `https://damoang.net//data/editor/2506/x.jpeg` → 301 → HTML (이미지 아님)
- `https://s3.damoang.net/data/editor/2404//y.jpg` → 403 (S3 키 불일치)

파일 자체는 단일슬래시 경로에 모든 호스트(s3/cdn/r2)에 정상 존재(HEAD 200). 즉 **데이터 손실 아님, URL 형식 문제**. tutorial 보드만 136/1891글(~7%), 전 보드 합치면 수천 건 → 개별 DB 수정이 아닌 **렌더 시 정규화**로 해결.

기존에 본문 이미지는 host/slash 정규화를 거치지 않았음(`optimizeMediaHtml` 은 死코드라 호출 안 됨).

## 변경
- **`media-url.ts`**
  - `normalizeMediaUrl`: 호스트 직후 leading 다중슬래시(`//data/...`) 매치 + 경로 연속슬래시 `collapse` 후 CDN 호스트로 정규화. 멱등, `data/content/` 는 r2 유지.
  - 신규 export **`normalizeHtmlMediaUrls(html)`** — HTML 문자열의 모든 `<img src>` 를 `normalizeMediaUrl` 로 치환(외부 이미지·정상 URL 은 무변경).
- **`markdown.svelte`**(본문): SSR `getInitialHtml` + 클라이언트 `$effect` 의 `DOMPurify.sanitize` 직후 적용.
- **`comment-list.svelte`**(댓글): SSR/비동기 두 sanitize 직후 적용.
- **`media-url.test.ts`**: 더블슬래시 collapse·재호스팅·멱등·외부보존 케이스 추가.

## 검증
- 단위테스트 `media-url.test.ts` 19개 전부 pass.
- prettier 통과, svelte-check 신규 에러 0(기존 baseline 동일).
- **end-to-end 실측**: #12697 실제 깨진 src 2종 → 정규화 출력이 둘 다 HEAD 200(image/jpeg, image/webp) 확인.
- 멱등: 이미 s3/cdn 단일슬래시인 정상 글 본문은 무변경.

부수효과(의도): 본문/상대경로 이미지가 CDN(s3/cdn/r2) 경유로 정규화 → CDN 비용절감 방향과 일치.