### PR TITLE
fix(seo): 글 공유 시 og:title/description 중복 제거 (#12699)

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -655,15 +655,14 @@
     {:else}
         <link rel="icon" href={favicon} />
     {/if}
-    {#if data.site?.title}
-        <meta property="og:title" content={data.site.title} />
-    {/if}
+    <!--
+        og:title / og:description / og:image 는 페이지별 <SeoHead> (lib/seo) 가 단독 emit 한다.
+        과거 여기서 data.site 기본 OG 를 함께 내보내 글 페이지에 og:title·og:description 가
+        2개씩 렌더 → 카톡/페북 크롤러(first-wins)가 글 제목 대신 사이트명을 가져가던 회귀(#12699).
+        site 기본 description 은 SeoHead 미사용 유틸 페이지용으로만 남긴다.
+    -->
     {#if data.site?.description}
         <meta name="description" content={data.site.description} />
-        <meta property="og:description" content={data.site.description} />
-    {/if}
-    {#if data.site?.logo_url}
-        <meta property="og:image" content={data.site.logo_url} />
     {/if}
     {#if data.site?.keywords?.length}
         <meta name="keywords" content={data.site.keywords.join(', ')} />


### PR DESCRIPTION
## 문제
버그 #12699 — 다모앙 링크를 카톡에 공유하면 글 제목·썸네일이 제대로 안 뜸("예전엔 제목+썸네일 떴는데 이젠 안 뜸").

## 원인 (실측)
이미지 글의 라이브 OG 메타:
```
og:title       → ["다모앙 종합 커뮤니티 damoang", "주말 아침엔 역시 곤냥이죠 ㅋ"]   ← 2개
og:description → ["다 같이 모여, 더욱 자유로운…", "간만에 토.일 쉬는 휴무가…"]       ← 2개
og:image       → ["https://r2.damoang.net/.../400x225.webp"]                       ← 1개(정상)
```
- `+layout.svelte` 가 `data.site` 기본 OG(og:title/description/image)를, 페이지별 `SeoHead`(lib/seo) 가 글별 OG 를 **각각** emit → og:title·og:description 가 **2개씩**.
- 레이아웃 것이 **먼저** 렌더 → 카톡/페북 크롤러(first-wins)가 **글 제목 대신 사이트명**, 글 설명 대신 사이트 설명을 가져감.
- 레이아웃 OG 는 멀티사이트(Path D′) 추가분인데 SeoHead 가 이미 site_name 포함 완전한 OG 를 내므로 **중복·불필요**.
- og:image(썸네일) 자체는 정상(글 이미지). 이미지 없는 글만 아이콘 fallback.

## 변경
- `+layout.svelte` 에서 중복인 `og:title` / `og:description` / `og:image` 3개 제거.
- OG 는 `SeoHead` 단일 출처로 일원화 — 공유 대상 라우트(글/게시판/홈/explore/games/groups…)는 전부 SeoHead 사용.
- site 기본 `name="description"` 은 SeoHead 미사용 유틸 페이지용으로 유지(크롤러는 og 미존재 시 `<title>` 폴백).

## 검증
- prettier 통과, svelte-check 신규 에러 0(기존 baseline 동일).
- 배포 후: 카톡 공유/디버거에서 글 제목·설명·썸네일이 글 기준으로 단일 노출 확인 + 카톡 캐시 갱신(공유 디버거 재스크랩) 안내.