### PR TITLE
fix(auth): 쪽지함 새로고침 시 세션 끊김/무한 왕복 근본 차단 (#12642)

### DIFF
--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -35,6 +35,12 @@ declare global {
             sessionId: string | null;
             /** CSRF 토큰 (세션에 연결, double-submit cookie 검증용) */
             csrfToken: string | null;
+            /**
+             * 세션 쿠키는 있으나 SSR 세션/회원 조회가 일시 장애(타임아웃)로 실패한 상태.
+             * 보호 페이지는 이 경우 /login 하드 리다이렉트 대신 셸을 렌더하고 클라이언트가
+             * 최종 판정하도록 위임한다 (#12621/#12642 무한 새로고침 방지).
+             */
+            authDegraded: boolean;
             /** Phase 1: site-resolver 가 host 기반으로 주입한 site 컨텍스트. miss 시 null (기본 테마 사용). */
             site: SiteContext | null;
         }

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -359,11 +359,17 @@ const AUTH_TIMEOUT_MS = 1500;
  * sentinel 로 타임아웃을 구분하고, 타임아웃/예외 시 1회 재시도한다.
  */
 const AUTH_LOOKUP_TIMEOUT: unique symbol = Symbol('auth-lookup-timeout');
+/**
+ * 반환값으로 "조회 결과(value, null 포함)"와 "일시 장애로 판정 불가(degraded)"를 구분한다.
+ * - degraded=false: fn 이 정상 resolve (value 가 null 이면 진짜 "세션/회원 없음" = 로그아웃).
+ * - degraded=true : 2회 모두 타임아웃/예외로 결과를 못 얻음 (Redis/DB 일시 지연 등).
+ *   보호 페이지가 이 경우를 로그아웃으로 오인해 /login 으로 보내면 무한 왕복(#12621/#12642)이 된다.
+ */
 async function withTimeoutRetry<T>(
     fn: () => Promise<T>,
     ms: number,
     label: string
-): Promise<T | null> {
+): Promise<{ degraded: boolean; value: T | null }> {
     for (let attempt = 1; attempt <= 2; attempt++) {
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timeoutPromise = new Promise<typeof AUTH_LOOKUP_TIMEOUT>((resolve) => {
@@ -374,7 +380,7 @@ async function withTimeoutRetry<T>(
             const result = await Promise.race([fn(), timeoutPromise]).finally(() => {
                 if (timer) clearTimeout(timer);
             });
-            if (result !== AUTH_LOOKUP_TIMEOUT) return result;
+            if (result !== AUTH_LOOKUP_TIMEOUT) return { degraded: false, value: result };
             console.error(`[Auth] ${label} 타임아웃 (시도 ${attempt}/2)`);
         } catch (err) {
             console.error(
@@ -383,7 +389,7 @@ async function withTimeoutRetry<T>(
             );
         }
     }
-    return null;
+    return { degraded: true, value: null };
 }
 
 /** SSR 인증: 서버사이드 세션 only (JWT 미사용) */
@@ -392,17 +398,21 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
     event.locals.accessToken = null;
     event.locals.sessionId = null;
     event.locals.csrfToken = null;
+    event.locals.authDegraded = false;
 
     // 세션 쿠키로 인증
     const sessionId = event.cookies.get(SESSION_COOKIE_NAME);
 
     if (sessionId) {
         try {
-            const session = await withTimeoutRetry(
+            const sessionRes = await withTimeoutRetry(
                 () => getSession(sessionId),
                 AUTH_TIMEOUT_MS,
                 'getSession'
             );
+            // 세션 쿠키는 있는데 조회가 일시 장애로 실패 → degraded 표시(로그아웃과 구분).
+            if (sessionRes.degraded) event.locals.authDegraded = true;
+            const session = sessionRes.value;
             if (session) {
                 // FAST PATH: user_basic 쿠키 + JWT cache hit → DB 조회 0 (Phase B wire-up)
                 // feature flag USER_BASIC_FAST_PATH=true 시 활성화. default off.
@@ -441,11 +451,13 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                     }
                 }
 
-                const member = await withTimeoutRetry(
+                const memberRes = await withTimeoutRetry(
                     () => getMemberById(session.mbId),
                     AUTH_TIMEOUT_MS,
                     'getMemberById'
                 );
+                if (memberRes.degraded) event.locals.authDegraded = true;
+                const member = memberRes.value;
                 if (member) {
                     // 탈퇴 회원 세션 차단 (이용제한 회원은 글 열람 허용을 위해 세션 유지)
                     if (member.mb_leave_date) {

--- a/apps/web/src/routes/messages/+page.server.ts
+++ b/apps/web/src/routes/messages/+page.server.ts
@@ -2,7 +2,11 @@ import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = async ({ url, locals }) => {
-    if (!locals.user) {
+    // SSR 인증이 비었어도 "일시 장애(authDegraded)"면 /login 하드 리다이렉트하지 않는다.
+    // 세션 쿠키는 있는데 조회만 지연된 경우 리다이렉트하면 /messages ↔ /login 무한 왕복
+    // ("새로고침 시 세션 끊겼다 연결" #12621/#12642). 셸을 렌더하고 클라이언트(authStore +
+    // 쪽지 API 401)가 최종 판정한다 — 클라가 미인증이면 +page.svelte 가 1회만 로그인 유도.
+    if (!locals.user && !locals.authDegraded) {
         redirect(302, `/login?redirect=${encodeURIComponent(url.pathname + url.search)}`);
     }
     const kind = (url.searchParams.get('kind') as 'recv' | 'send') || 'recv';
@@ -14,6 +18,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
         kind,
         page,
         limit,
-        to
+        to,
+        authDegraded: !locals.user && locals.authDegraded
     };
 };


### PR DESCRIPTION
## 문제
버그 #12642 — 쪽지함에서 새로고침하면 "세션 끊겼다 연결" 되는 현상이 **PR #1580(재시도 + login bounce 가드) 이후에도 재발**(같은 제보자가 캐시 삭제 후에도 동일 증상 확인).

## 원인
보호 페이지(`messages/+page.server.ts`)는 `!locals.user` 면 무조건 `/login` 으로 302 리다이렉트한다. 그런데 SSR 인증(`authenticateSSR`)은 **세션 쿠키가 유효해도 Redis/DB 조회가 일시 지연(타임아웃)되면 `locals.user` 를 비운다**. 즉 "진짜 로그아웃"과 "일시 장애"가 구분되지 않아, 장애 한 번에 `/messages → /login → 복귀 → 또 장애 → ...` 무한 왕복(#12621/#12642)이 발생. PR #1580 의 재시도/bounce 가드는 완화일 뿐 근본 제거가 아니었다.

## 변경 (모범사례 — 일시 장애와 로그아웃 분리)
- **hooks.server.ts**: `withTimeoutRetry` 가 `{ degraded, value }` 를 반환해 "조회 결과 없음(로그아웃)"과 "타임아웃 소진(degraded)"을 구분. `authenticateSSR` 이 degraded 시 `locals.authDegraded = true` 설정. **성공/판정 로직·locals.user 세팅은 불변** (인증 자체 동작 변화 없음).
- **app.d.ts**: `Locals.authDegraded: boolean`.
- **messages/+page.server.ts**: `!user && !authDegraded` 일 때만 `/login` 리다이렉트. degraded 면 셸을 렌더하고 클라이언트(`authStore` + 쪽지 API 401)가 1회 최종 판정 → 무한 왕복 제거.

진짜 로그아웃(세션 쿠키 없음 / 세션 만료로 getSession=null)은 **종전대로 즉시 /login**. degraded 신호는 다른 보호 페이지(write/edit 등)도 채택 가능.

## 동작 매트릭스
| 상황 | 종전 | 변경 후 |
|---|---|---|
| 정상 로그인 | 렌더 | 렌더(불변) |
| 세션 없음/만료 | /login | /login(불변) |
| 세션 유효 + 조회 타임아웃 | /login → 무한 왕복 | 셸 렌더 → 클라 판정(루프 없음) |

## 검증
- prettier 통과, svelte-check 신규 에러 0(기존 baseline 7/111 동일).
- ⚠️ **auth 핵심 경로(hooks.server.ts) 변경 — 반드시 canary.damoang.net 에서 로그인/쪽지함 새로고침 정상 + 미로그인 /login 리다이렉트 정상 확인 후 prod 배포.**