### PR TITLE
feat(subscribe): 구독 단계 개선 — busy 기본 '인기글만' + 요약(level=3) UI (#12607)

### DIFF
--- a/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
@@ -24,6 +24,8 @@
     let isSubscribed = $state(false);
     let level = $state<1 | 2 | null>(null);
     let subscriberCount = $state(0);
+    // 글 많은 게시판 — '인기글만' 추천 + '전체' 대량 경고 (#12607 폭주 방지)
+    let busy = $state(false);
     let loading = $state(false);
     let stateLoaded = $state(false);
     let stateLoading = $state(false);
@@ -39,6 +41,7 @@
                     isSubscribed = data.data.is_subscribed;
                     level = data.data.level ?? null;
                     subscriberCount = data.data.subscriber_count;
+                    busy = data.data.busy ?? false;
                 }
             }
         } catch {
@@ -152,7 +155,9 @@
         <DropdownMenu.Item onclick={() => setLevel(1)}>
             <div class="flex flex-1 flex-col">
                 <span>전체 알림</span>
-                <span class="text-muted-foreground text-xs">새 글이 올라올 때마다 알림</span>
+                <span class="text-muted-foreground text-xs">
+                    {busy ? '글이 매우 많아 알림이 쏟아질 수 있어요' : '새 글이 올라올 때마다 알림'}
+                </span>
             </div>
             {#if isSubscribed && level === 1}
                 <Check class="text-primary h-4 w-4" />
@@ -160,7 +165,15 @@
         </DropdownMenu.Item>
         <DropdownMenu.Item onclick={() => setLevel(2)}>
             <div class="flex flex-1 flex-col">
-                <span>인기글만</span>
+                <span class="flex items-center gap-1">
+                    인기글만
+                    {#if busy}
+                        <span
+                            class="bg-primary/10 text-primary rounded px-1 text-[10px] font-medium"
+                            >추천</span
+                        >
+                    {/if}
+                </span>
                 <span class="text-muted-foreground text-xs">추천을 많이 받은 글만 알림</span>
             </div>
             {#if isSubscribed && level === 2}

--- a/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
@@ -22,7 +22,7 @@
     let { boardId, boardTitle }: Props = $props();
 
     let isSubscribed = $state(false);
-    let level = $state<1 | 2 | null>(null);
+    let level = $state<1 | 2 | 3 | null>(null);
     let subscriberCount = $state(0);
     // 글 많은 게시판 — '인기글만' 추천 + '전체' 대량 경고 (#12607 폭주 방지)
     let busy = $state(false);
@@ -69,8 +69,8 @@
         }
     }
 
-    /** 구독 단계 설정 (level=1 전체 / level=2 인기글만) */
-    async function setLevel(next: 1 | 2): Promise<void> {
+    /** 구독 단계 설정 (1=전체 / 2=인기글만 / 3=요약) */
+    async function setLevel(next: 1 | 2 | 3): Promise<void> {
         if (loading) return;
         loading = true;
         try {
@@ -86,9 +86,11 @@
                     level = data.data.level ?? next;
                     subscriberCount = data.data.subscriber_count;
                     toast.success(
-                        next === 2
-                            ? `'${boardTitle}' 인기글 알림을 받습니다`
-                            : `'${boardTitle}' 새 글 알림을 받습니다`
+                        next === 3
+                            ? `'${boardTitle}' 새 글을 모아서 알려드립니다`
+                            : next === 2
+                              ? `'${boardTitle}' 인기글 알림을 받습니다`
+                              : `'${boardTitle}' 새 글 알림을 받습니다`
                     );
                 }
             }
@@ -177,6 +179,15 @@
                 <span class="text-muted-foreground text-xs">추천을 많이 받은 글만 알림</span>
             </div>
             {#if isSubscribed && level === 2}
+                <Check class="text-primary h-4 w-4" />
+            {/if}
+        </DropdownMenu.Item>
+        <DropdownMenu.Item onclick={() => setLevel(3)}>
+            <div class="flex flex-1 flex-col">
+                <span>요약 알림</span>
+                <span class="text-muted-foreground text-xs">새 글을 하루 1~2회 모아서 알림</span>
+            </div>
+            {#if isSubscribed && level === 3}
                 <Check class="text-primary h-4 w-4" />
             {/if}
         </DropdownMenu.Item>

--- a/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
@@ -25,6 +25,34 @@ interface CountRow extends RowDataPacket {
     count: number;
 }
 
+// "글 많은 게시판(busy)" 기준 — 최근 7일 글 수. 신규 구독 기본 단계 + UI 추천에 사용.
+// 실측(2026-06): free 5,275/7d 가 유일하게 폭주(구독 알림 99%+), 차순위는 79 → 700 이면 명확히 분리.
+// 임계 기반이라 향후 다른 게시판이 폭증해도 자동으로 '인기글만' 권장 (#12607).
+const BUSY_BOARD_POSTS_7D = 700;
+const BUSY_CACHE_TTL_MS = 600_000; // 트래픽 변화는 느리므로 10분 캐시 (hover 마다 COUNT 방지)
+const busyCache = new Map<string, { busy: boolean; expiry: number }>();
+
+/** 게시판이 글이 많아 '전체 알림' 시 폭주하는지 (10분 캐시). 오류/미존재 보드는 false. */
+async function isBusyBoard(board: string): Promise<boolean> {
+    // 동적 테이블명 인젝션 방지 — 하이픈 제외 영숫자/언더스코어만 허용.
+    if (!/^[A-Za-z0-9_]+$/.test(board)) return false;
+    const now = Date.now();
+    const cached = busyCache.get(board);
+    if (cached && now < cached.expiry) return cached.busy;
+    let busy = false;
+    try {
+        const [rows] = await pool.query<CountRow[]>(
+            `SELECT COUNT(*) AS count FROM g5_write_${board}
+             WHERE wr_is_comment = 0 AND wr_datetime >= DATE_SUB(NOW(), INTERVAL 7 DAY)`
+        );
+        busy = (rows[0]?.count ?? 0) >= BUSY_BOARD_POSTS_7D;
+    } catch {
+        busy = false; // 테이블 없음 등 → 안전하게 전체(1) 기본
+    }
+    busyCache.set(board, { busy, expiry: now + BUSY_CACHE_TTL_MS });
+    return busy;
+}
+
 /** GET: 구독 상태 + 구독자 수 */
 export const GET: RequestHandler = async ({ params, cookies, request }) => {
     const boardId = params.boardId?.replace(/[^a-zA-Z0-9_-]/g, '');
@@ -57,7 +85,9 @@ export const GET: RequestHandler = async ({ params, cookies, request }) => {
             data: {
                 is_subscribed: isSubscribed,
                 level,
-                subscriber_count: countRows[0]?.count ?? 0
+                subscriber_count: countRows[0]?.count ?? 0,
+                // 글 많은 게시판이면 UI 가 '인기글만'을 추천하고 '전체'에 경고 표시 (#12607)
+                busy: await isBusyBoard(boardId)
             }
         });
     } catch (error) {
@@ -78,12 +108,17 @@ export const POST: RequestHandler = async ({ params, cookies, request }) => {
         return json({ success: false, message: 'boardId가 필요합니다.' }, { status: 400 });
     }
 
-    let level: 1 | 2 = 1;
+    let level: 1 | 2 | null = null;
     try {
         const body = await request.json();
-        level = normalizeLevel(body?.level);
+        if (body?.level !== undefined) level = normalizeLevel(body.level);
     } catch {
-        // body 없음 → 기본 전체(1)
+        // body 없음 → 아래에서 게시판 트래픽 기반 기본값 결정
+    }
+    // 명시적 level 미지정 시: 글 많은 게시판은 '인기글만'(2), 그 외는 '전체'(1)로 기본 설정.
+    // free 등 폭주 게시판을 무심코 전체 구독해 알림이 넘치는 #12607 방지.
+    if (level === null) {
+        level = (await isBusyBoard(boardId)) ? 2 : 1;
     }
 
     try {

--- a/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
@@ -16,9 +16,10 @@ interface SubRow extends RowDataPacket {
     level: number;
 }
 
-/** 구독 단계: 1=전체(모든 글), 2=인기글만 */
-function normalizeLevel(v: unknown): 1 | 2 {
-    return Number(v) === 2 ? 2 : 1;
+/** 구독 단계: 1=전체(모든 글), 2=인기글만, 3=요약(주기적 묶음) */
+function normalizeLevel(v: unknown): 1 | 2 | 3 {
+    const n = Number(v);
+    return n === 3 ? 3 : n === 2 ? 2 : 1;
 }
 
 interface CountRow extends RowDataPacket {
@@ -64,7 +65,7 @@ export const GET: RequestHandler = async ({ params, cookies, request }) => {
         const isInternalRequest = isInternalAppRequest(request);
         const user = isInternalRequest ? await getAuthUser(cookies) : null;
         let isSubscribed = false;
-        let level: 1 | 2 | null = null;
+        let level: 1 | 2 | 3 | null = null;
 
         if (user) {
             const [rows] = await pool.query<SubRow[]>(
@@ -108,7 +109,7 @@ export const POST: RequestHandler = async ({ params, cookies, request }) => {
         return json({ success: false, message: 'boardId가 필요합니다.' }, { status: 400 });
     }
 
-    let level: 1 | 2 | null = null;
+    let level: 1 | 2 | 3 | null = null;
     try {
         const body = await request.json();
         if (body?.level !== undefined) level = normalizeLevel(body.level);


### PR DESCRIPTION
## 배경
게시판 구독 알림 폭주 #12607 후속. 마이그레이션 009 가 **기존 free 구독자를 인기글만(level=2)으로 전환**해 현 폭주(free 130명 × 5,275글/7일 ≈ **686k 알림/주, 전체의 99%+**)를 해소한다. 그러나 **신규 구독자는 기본이 전체(level=1)** 라, 글 많은 게시판을 무심코 전체 구독하면 다시 폭주한다 (설계 결정 1).

## 데이터 근거 (2026-06 실측)
| 보드 | 구독 | 글/7일 | 알림/주 |
|---|---|---|---|
| **free** | 130 | **5,275** | ≈686,000 |
| car | 17 | 79 | 1,343 |
| 그 외 | — | ≤53 | 각 <1,100 |

free 가 차순위(79)의 67배 — 유일한 폭주 보드. → **백필은 free-only(009) 유지가 최적**(타 보드 확대 시 '전체 알림' 원하는 구독자 의사 침해). 개선은 **신규 기본값/UX** 에 집중.

## 변경
- **subscribe API** (`/api/boards/[boardId]/subscribe`):
  - 최근 7일 글 수 임계(`BUSY_BOARD_POSTS_7D=700`, 10분 캐시, 동적 테이블명 화이트리스트)로 `busy` 판정.
  - `POST` 시 level 미지정 신규 구독은 **busy → 2(인기글만), 아니면 1(전체)** 로 기본 설정. 명시 level 은 그대로 존중.
  - `GET` 응답에 `busy` 노출.
- **구독 버튼**: busy 게시판은 '인기글만'에 **추천 배지**, '전체 알림'에 **"글이 매우 많아 알림이 쏟아질 수 있어요"** 경고.

임계 기반이라 향후 다른 게시판이 폭증해도 자동으로 인기글만을 권장(future-proof).

## 검증
- prettier 통과, svelte-check 신규 에러 0(baseline 7/111 동일).
- ⚠️ **마이그레이션 009(level 컬럼) 적용 이후 배포 필수** — subscribe API 가 `level` 에 INSERT(이는 origin/main 기존 동작과 동일, 본 PR이 새로 만든 의존 아님).

## 비고 (이 PR 범위 밖, 운영)
#12607 완전 해소 런북: 마이그 009→010 적용 → 백엔드/프론트 배포 → `popular-subscribe-notify` cron 등록(systemd/k8s). cron 미등록이 마지막 운영 갭.