### PR TITLE
feat(my): 마이페이지에 회원 아이디 표시

### DIFF
--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -129,6 +129,11 @@
                 <div>
                     <h1 class="text-foreground text-2xl font-bold">{authStore.user.mb_name}</h1>
                     <p class="text-secondary-foreground">{getGradeName(authStore.user.mb_level)}</p>
+                    {#if authStore.user.mb_id}
+                        <p class="text-muted-foreground mt-0.5 text-sm">
+                            아이디 {authStore.user.mb_id}
+                        </p>
+                    {/if}
                     {#if authStore.user.mb_level === 5}
                         <div class="mt-1 text-sm">
                             <span class="text-muted-foreground">광고 종료일</span>


### PR DESCRIPTION
마이페이지(/my) 프로필에서 닉네임·등급 아래에 **회원 아이디(mb_id)** 를 추가 표시.

- `my/+page.svelte`: 등급 줄 아래 `아이디 {authStore.user.mb_id}` (muted, sm). mb_id 없으면 미표시.
- svelte-check 신규 에러 0(baseline 동일), prettier 통과.
- 4시 frontend 배포 묶음 합류.