### PR TITLE
fix(reaction): SPA 네비게이션 레이스 시 reactions data.post 가드

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -598,6 +598,10 @@
 
     async function fetchBatchReactions(): Promise<void> {
         if (!reactionPluginActive) return;
+        // SPA 내비게이션 레이스 가드: 상세→목록 전환 중 이 effect 가 재실행되면
+        // data.post 가 일시적으로 undefined 라 data.post.id 접근 시 throw → unhandledrejection
+        // (/free·/ 위치로 보고되던 "Cannot read properties of undefined (reading 'id')")
+        if (!data.post?.id) return;
         const parentId = generateParentId(boardId, data.post.id);
         // 동일 parentId 중복 호출 방지 (SPA 네비게이션 시 이중 fetch 제거)
         if (lastFetchedReactionsKey === parentId && reactionsMap) return;


### PR DESCRIPTION
## 문제
`TypeError: Cannot read properties of undefined (reading 'id')` 가 `unhandledrejection` 으로 만성 발생 — Dantry 로그상 안드로이드 전용(iOS 0건), 하루 약 700~960 고유 유저, 위치는 `/`·`/free` (목록·홈).

## 근본 원인
소스맵으로 추적: minified `tt()` = `[boardId]/[postId]/+page.svelte` 의 `fetchBatchReactions()`. 상세→목록 SPA 네비게이션 중 post-reset `$effect`(line ~397)가 재실행될 때 `data.post` 가 일시적으로 undefined 가 되는데, `generateParentId(boardId, data.post.id)` 가 가드 없이 `.id` 를 읽어 throw. async 함수라 호출자에 전파되지 않고 전역 unhandledrejection 으로 보고(그래서 location 이 목록/홈으로 기록됨).

## 수정
`fetchBatchReactions` 상단에 `if (!data.post?.id) return;` 가드 추가. 정상 상세 페이지에서는 `data.post` 가 항상 존재 → 동작 무변경. 목록/홈 전환 레이스에서만 조용히 스킵.

## 영향
- 만성 unhandledrejection 제거(안드로이드 ~700-960 유저/일 + other ~260/일)
- 안드로이드 크롬 이용곤란 제보(free #6468180) 유저의 로그 에러 경로 해소
- 동작 변경 없음(가드만)

⚠️ draft — CI 통과·사람 검토 후 머지, 배포는 4시 게이트.