### PR TITLE
feat(disciplinelog): 신고 항목별 적용 일수 표시

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -56,6 +56,7 @@ export interface ReportedItem {
     id: number; // post_id
     parent?: number; // comment parent (legacy: "parent" field)
     sg_types?: number[]; // 개별 신고 사유 코드 (g5_na_singo.sg_type 21~40, omitempty)
+    penalty_days?: number; // 항목별 적용 일수 (-1=영구, 0=주의, >0=일수, omitempty)
 }
 
 export interface ViolationType {

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -250,13 +250,20 @@
                                         {getReportedItemLabel(item)}
                                     </span>
                                 </a>
-                                {#if item.sg_types && item.sg_types.length > 0}
-                                    <div class="ml-6 mt-1.5 flex flex-wrap gap-1">
-                                        {#each item.sg_types as code (code)}
-                                            <Badge variant="secondary" class="text-xs">
-                                                {getReportReasonLabel(code)}
+                                {#if (item.sg_types && item.sg_types.length > 0) || item.penalty_days != null}
+                                    <div class="ml-6 mt-1.5 flex flex-wrap items-center gap-1">
+                                        {#if item.sg_types}
+                                            {#each item.sg_types as code (code)}
+                                                <Badge variant="secondary" class="text-xs">
+                                                    {getReportReasonLabel(code)}
+                                                </Badge>
+                                            {/each}
+                                        {/if}
+                                        {#if item.penalty_days != null}
+                                            <Badge variant="outline" class="text-xs">
+                                                {getPenaltyDisplay(item.penalty_days).text}
                                             </Badge>
-                                        {/each}
+                                        {/if}
                                     </div>
                                 {/if}
                             </div>


### PR DESCRIPTION
## 배경

disciplinelog 정규화(angple-backend#514)로 한 disciplinelog 글이 **피신고자·날짜 단위**로 묶이며, 글 안의 신고 항목마다 다른 사유·일수가 적용될 수 있다. 상세 페이지는 이미 항목별 **사유** 배지를 표시하지만 **적용 일수**는 표시하지 않았다.

상세 API(angple-backend#514, v2 `GetDetail`)가 `reported_items[].penalty_days`를 반환하도록 확장됨에 따라 프론트에서 이를 표시한다.

## 변경

- `ReportedItem` 타입에 `penalty_days?: number`(-1=영구, 0=주의, >0=일수) 추가
- 상세 페이지 '신고 접수된 글'에서 항목별 사유 배지 옆에 일수 배지 표시
- 메모는 기존과 동일하게 비공개(관리자 내부용) 유지

## 의존성

- angple-backend#514 머지·배포 후 값이 채워짐. 미배포 상태에선 penalty_days 미표시(기존과 동일)

## 검증

- 배포 후 /disciplinelog/{id}에서 한 글 안 항목들이 각자 사유+일수로 표시되는지 확인