### PR TITLE
fix(sidebar): 게시판 메뉴 rel=external 제거 — 선택 시 전체 새로고침/깜빡임 (#12690)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -316,7 +316,6 @@
                                                                     )}
                                                                     <a
                                                                         href={grandchild.url}
-                                                                        rel="external"
                                                                         class={cn(
                                                                             'bg-background flex items-center justify-center px-1 py-2 text-center text-[11px] leading-tight transition-all duration-200 ease-out active:scale-[0.98]',
                                                                             gcActive
@@ -354,7 +353,6 @@
                                                                                 : 'hover:bg-accent'
                                                                         )}
                                                                         href={grandchild.url}
-                                                                        rel="external"
                                                                     >
                                                                         <GcIcon class="size-3.5" />
                                                                         {grandchild.title}
@@ -381,7 +379,6 @@
                                                             : 'hover:bg-accent'
                                                     )}
                                                     href={child.url}
-                                                    rel="external"
                                                 >
                                                     <ChildIcon class="size-4" />
                                                     {child.title}
@@ -405,7 +402,7 @@
                         <a
                             href={menu.url}
                             target={external ? '_blank' : undefined}
-                            rel={external ? 'noopener noreferrer' : 'external'}
+                            rel={external ? 'noopener noreferrer' : undefined}
                             class={cn(
                                 'flex w-full items-center gap-2 rounded-md py-4 text-sm font-semibold transition-colors',
                                 active


### PR DESCRIPTION
## 증상 (#12690, #12645)
왼쪽 사이드바에서 게시판을 선택할 때마다 메뉴 목록 전체가 새로고침되어 아코디언이 접혔다 펴지는 깜빡임. #12645 로 한 번 '수정' 처리했으나 재현(c_12680/12681, #12690). 제보자 추가정보: 모든 게시판/주소창 리로드 아님/**macOS Safari 도 재현**/**단축키 이동은 재현 안 됨**.

## 근본 원인 (Playwright 로 prod 재현 확인)
사이드바 게시판 링크에 `rel="external"` 이 붙어 있었습니다(아코디언 2/3depth `child.url`·`grandchild.url`, 1depth 단독 메뉴의 `rel={external ? 'noopener noreferrer' : 'external'}` 삼항 else). SvelteKit 에서 `rel="external"` 은 **클라이언트 라우팅을 끄고 풀 페이지 리로드**를 강제합니다 → 게시판 클릭마다 앱 전체(사이드바 포함) 재로드 = 깜빡임.

- 단축키는 `keyboard-shortcuts` 의 `goto()`(SPA) → 리로드 없음 → **깜빡임 없음** (제보와 일치)
- 본문 목록의 동일 게시판 링크는 rel 없이 이미 SPA 정상 동작 → **제거 안전(회귀 위험 없음)**
- 이전 #12645/#1589 수정은 펼침상태 리셋만 다뤄 근본(풀 리로드)을 놓쳤습니다.

## 수정
내부 게시판/메뉴 링크 4곳에서 `rel="external"` 제거(외부 _blank 링크의 noopener 는 유지).

⚠️ draft — CI 통과·사람 검토 후 머지, 배포는 4시 게이트. 배포 후 #12690 재현 종료 확인.