### PR TITLE
feat(post): 작성자 최근 활동 SSR 직접 로딩 (클릭 없이 표시)

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -33,9 +33,11 @@
 
     interface Props {
         post: FreePost;
+        /** SSR 스트리밍으로 미리 받은 작성자 활동 (있으면 클릭 없이 즉시 표시, 클라 API fetch 생략) */
+        initialActivity?: { recentPosts: RecentPost[]; recentComments: RecentComment[] } | null;
     }
 
-    let { post }: Props = $props();
+    let { post, initialActivity = null }: Props = $props();
 
     let loading = $state(true);
     let recentPosts = $state<RecentPost[]>([]);
@@ -46,6 +48,24 @@
     let mobileExpanded = $state(false);
     let shouldLoad = $state(false);
     let desktopExpanded = $state(false);
+    // SSR(initialActivity)로 이미 채워졌는지 — 클릭 시 클라 API 재fetch 방지 + 펼침 표시
+    let ssrLoaded = $state(false);
+
+    // SSR 스트리밍으로 작성자 활동이 도착하면 클릭 없이 즉시 반영 + 패널 펼침.
+    // (SPA 네비게이션 등으로 initialActivity 가 없으면 기존 클릭-fetch 폴백 유지)
+    $effect(() => {
+        if (
+            initialActivity &&
+            (initialActivity.recentPosts.length > 0 || initialActivity.recentComments.length > 0)
+        ) {
+            recentPosts = initialActivity.recentPosts;
+            recentComments = initialActivity.recentComments;
+            loading = false;
+            ssrLoaded = true;
+            desktopExpanded = true;
+            mobileExpanded = true;
+        }
+    });
     const MOBILE_AD_MAX_HEIGHT = 88;
     const DESKTOP_AD_MAX_HEIGHT = 190;
     const ADSENSE_ACTIVITY_CLIENT =
@@ -110,6 +130,11 @@
     $effect(() => {
         const authorId = post.author_id;
         if (!browser || !authorId) {
+            loading = false;
+            return;
+        }
+        // SSR(initialActivity)로 이미 채워졌으면 클라 API 재호출 불필요
+        if (ssrLoaded) {
             loading = false;
             return;
         }

--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -51,8 +51,9 @@
     // SSR(initialActivity)로 이미 채워졌는지 — 클릭 시 클라 API 재fetch 방지 + 펼침 표시
     let ssrLoaded = $state(false);
 
-    // SSR 스트리밍으로 작성자 활동이 도착하면 클릭 없이 즉시 반영 + 패널 펼침.
-    // (SPA 네비게이션 등으로 initialActivity 가 없으면 기존 클릭-fetch 폴백 유지)
+    // SSR 스트리밍으로 작성자 활동이 도착하면 클릭 없이 즉시 반영.
+    // 데스크톱은 자동 펼침. 모바일은 공간 절약 위해 접어둠 — 데이터는 preload 라
+    // 탭하면 추가 fetch 없이 즉시 표시(ssrLoaded 가드). (SSR 데이터 없으면 클릭-fetch 폴백)
     $effect(() => {
         if (
             initialActivity &&
@@ -63,7 +64,6 @@
             loading = false;
             ssrLoaded = true;
             desktopExpanded = true;
-            mobileExpanded = true;
         }
     });
     const MOBILE_AD_MAX_HEIGHT = 88;

--- a/apps/web/src/lib/server/member-activity.ts
+++ b/apps/web/src/lib/server/member-activity.ts
@@ -1,0 +1,56 @@
+/**
+ * 작성자 최근 활동 서버사이드 조회 (SSR용)
+ *
+ * routes/api/members/[id]/activity/+server.ts 의 백엔드 호출 로직을 공유 모듈로 추출.
+ * +page.server.ts 에서 SSR 스트리밍으로 직접 호출하여 클릭-API(CDN 요청)를 제거한다.
+ * 최고 트래픽 페이지(글 상세)이므로 per-author Redis 캐시(60s)로 origin/DB 부하를 억제한다.
+ */
+import { backendFetch } from '$lib/server/backend-fetch';
+import { getRedis } from '$lib/server/redis';
+
+export interface MemberActivity {
+    recentPosts: unknown[];
+    recentComments: unknown[];
+}
+
+const EMPTY: MemberActivity = { recentPosts: [], recentComments: [] };
+const CACHE_TTL_SEC = 60;
+
+/**
+ * 작성자(authorId)의 최근 글/댓글을 조회한다. 실패/유효하지 않은 입력 시 빈 결과 반환(크래시 방지).
+ */
+export async function fetchMemberActivity(authorId: string, limit = 5): Promise<MemberActivity> {
+    if (!authorId || !/^[a-zA-Z0-9_-]+$/.test(authorId)) {
+        return EMPTY;
+    }
+
+    const cacheKey = `member_activity:${authorId}:l${limit}`;
+
+    try {
+        const cached = await getRedis().get(cacheKey);
+        if (cached) {
+            return JSON.parse(cached) as MemberActivity;
+        }
+    } catch {
+        // Redis 장애 → 백엔드 직접 조회로 진행
+    }
+
+    try {
+        const res = await backendFetch(
+            `/api/v1/members/${encodeURIComponent(authorId)}/activity?limit=${limit}`
+        );
+        const data = (await res.json()) as Partial<MemberActivity>;
+        const result: MemberActivity = {
+            recentPosts: Array.isArray(data.recentPosts) ? data.recentPosts : [],
+            recentComments: Array.isArray(data.recentComments) ? data.recentComments : []
+        };
+        try {
+            await getRedis().setex(cacheKey, CACHE_TTL_SEC, JSON.stringify(result));
+        } catch {
+            // 캐시 저장 실패는 무시
+        }
+        return result;
+    } catch {
+        return EMPTY;
+    }
+}

--- a/apps/web/src/lib/server/member-activity.ts
+++ b/apps/web/src/lib/server/member-activity.ts
@@ -36,8 +36,10 @@ export async function fetchMemberActivity(authorId: string, limit = 5): Promise<
     }
 
     try {
+        // 스트리밍(auxiliaryData) 블로킹 방지를 위한 타임아웃 — 느린 활동 조회가 본문 렌더를 막지 않게.
         const res = await backendFetch(
-            `/api/v1/members/${encodeURIComponent(authorId)}/activity?limit=${limit}`
+            `/api/v1/members/${encodeURIComponent(authorId)}/activity?limit=${limit}`,
+            { timeout: 2000 }
         );
         const data = (await res.json()) as Partial<MemberActivity>;
         const result: MemberActivity = {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -23,6 +23,7 @@ import { fetchMemberImagesWithTimestamp } from '$lib/server/member-images.js';
 import { fetchCommentLikeStatuses } from '$lib/server/comment-likes.js';
 
 import { fetchPostLikeStatus } from '$lib/server/post-like-status.js';
+import { fetchMemberActivity } from '$lib/server/member-activity.js';
 import { fetchTruthroomPostId, fetchTruthroomCommentMap } from '$lib/server/truthroom.js';
 import { BackendUnavailableError } from '$lib/server/backend-fetch.js';
 import { applyFilter } from '$lib/hooks/registry.js';
@@ -422,7 +423,8 @@ export const load: PageServerLoad = async ({
                 postLikeStatusResult,
                 scheduledDeleteResult,
                 commentLikeStatusesResult,
-                truthroomCommentMapResult
+                truthroomCommentMapResult,
+                memberActivityResult
             ] = await Promise.allSettled([
                 // 직접홍보 사잇광고 (ads 서버 직접 호출 + 캐시)
                 fetchPromotionPosts(),
@@ -492,7 +494,14 @@ export const load: PageServerLoad = async ({
                     return fetchTruthroomCommentMap(boardId, postId, lockedCommentIds).catch(
                         () => ({})
                     );
-                })()
+                })(),
+                // 작성자 최근 활동 (SSR 직접 조회 — 클릭 없이 표시, 클라이언트 API 요청 제거)
+                post.author_id
+                    ? fetchMemberActivity(post.author_id, 5).catch(() => ({
+                          recentPosts: [],
+                          recentComments: []
+                      }))
+                    : Promise.resolve({ recentPosts: [], recentComments: [] })
             ]);
 
             // 프로모션 사잇광고: board_exception에 포함된 게시판은 제외
@@ -538,6 +547,11 @@ export const load: PageServerLoad = async ({
                     ? truthroomCommentMapResult.value
                     : {};
 
+            const memberActivity =
+                memberActivityResult.status === 'fulfilled'
+                    ? memberActivityResult.value
+                    : { recentPosts: [], recentComments: [] };
+
             return {
                 promotionPosts,
                 reactions,
@@ -548,7 +562,8 @@ export const load: PageServerLoad = async ({
                 scheduledDelete,
                 commentLikeStatuses,
                 truthroomCommentMap,
-                linkAffiliate
+                linkAffiliate,
+                memberActivity
             };
         })();
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -111,8 +111,12 @@
         id: 'core:author-activity-panel',
         component: AuthorActivityPanel,
         priority: 20,
-        propsMapper: (pageData: { post: FreePost }) => ({
-            post: pageData.post
+        propsMapper: (pageData: {
+            post: FreePost;
+            memberActivity?: { recentPosts: unknown[]; recentComments: unknown[] } | null;
+        }) => ({
+            post: pageData.post,
+            initialActivity: pageData.memberActivity ?? null
         })
     });
 
@@ -340,6 +344,8 @@
     );
     let truthroomCommentMap = $state<Record<number, number>>({});
     let promotionPosts = $state<PromotionPost[]>([]);
+    // 작성자 최근 활동 (auxiliaryData 스트리밍으로 SSR 직접 로딩 — 작성자활동 패널에 주입)
+    let memberActivity = $state<{ recentPosts: unknown[]; recentComments: unknown[] } | null>(null);
     let revisions = $state<PostRevision[]>([]);
     let initialLikedCommentIds = $state<number[]>([]);
     let initialDislikedCommentIds = $state<number[]>([]);
@@ -409,6 +415,7 @@
         initialDislikedCommentIds = [];
         truthroomCommentMap = {};
         scheduledDelete = null;
+        memberActivity = null;
         auxiliaryLoaded = false;
 
         promise
@@ -419,6 +426,12 @@
                 promotionPosts = Array.isArray(result.promotionPosts)
                     ? (result.promotionPosts as PromotionPost[])
                     : [];
+
+                memberActivity =
+                    (result.memberActivity as {
+                        recentPosts: unknown[];
+                        recentComments: unknown[];
+                    }) ?? null;
 
                 if (result.reactions && Object.keys(result.reactions).length > 0) {
                     reactionsMap = result.reactions as Record<string, ReactionItem[]>;
@@ -1910,7 +1923,9 @@
         {#each beforeCommentsSlots as slot (slot.component)}
             {@const SlotComponent = slot.component}
             <SlotComponent
-                {...slot.propsMapper ? slot.propsMapper({ post: data.post, boardId }) : {}}
+                {...slot.propsMapper
+                    ? slot.propsMapper({ post: data.post, boardId, memberActivity })
+                    : {}}
             />
         {/each}
         <!-- 본문 직후, 댓글 직전 광고 (삭제된 글에서는 비표시) -->


### PR DESCRIPTION
## 배경
게시글 상세의 '작성자 최근 활동' 패널이 **클릭해야만** 클라이언트 API `/api/members/{id}/activity` 를 호출. 상세 페이지 로드 시 함께 보이길 원함.

## 비용/방식
클라이언트 API를 그냥 eager 호출하면 클릭자(~일부)만 내던 CDN 요청을 **모든 방문자**가 내 비용↑. 대신 **SSR 직접 로딩**(상세 `+page.server.ts` 의 `auxiliaryData` 스트리밍에 통합 — reactions·like-status·member-images 와 동일 패턴, PR #307/308)으로 하면 이미 캐시되는 상세 HTML에 포함 → **별도 CDN 요청 0건**(클릭-API 제거로 소폭↓).

## 변경
- 신규 `$lib/server/member-activity.ts`: `backendFetch` + per-author Redis 캐시(60s). 실패 시 빈 결과.
- `+page.server.ts`: `auxiliaryData` 에 `memberActivity` 추가(allSettled + return).
- `+page.svelte`: 스트리밍 수신 → `memberActivity` state → 슬롯 propsMapper 로 `initialActivity` 주입.
- `author-activity-panel.svelte`: `initialActivity` 있으면 즉시 채움+펼침, `ssrLoaded` 가드로 클릭 시 재fetch 방지. SSR 데이터 없으면 기존 클릭-fetch 폴백 유지.

## 트레이드오프 / 확인
- **Origin/DB**: 전 방문자가 활동 쿼리 → 전용 member_activity 테이블(인덱스) + Redis 60s 캐시로 억제. (어제 502가 DB/CPU성이었던 점 감안 — 캐시 히트율 모니터)
- ⚠️ **AdSense**: 패널 내 광고가 클릭자→전 방문자 노출로 전환(노출 수↑). 의도/정책(viewability) 확인 필요.

## 검증
- canary 배포 → 상세 로드 시 클릭 없이 글5/댓글5 표시. Network에 초기 `/api/members/.../activity` 0건.
- SPA 네비게이션(목록→상세) 폴백 정상.
- `pnpm check` + 기존 테스트(CI).

⚠️ draft — CI 통과·검토 후 머지, 배포는 4시 게이트.