### PR TITLE
fix(post): 모바일 글상세 액션 버튼 줄바꿈 (삭제 화면밖 밀림 해결)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1630,7 +1630,7 @@
 
     <!-- 상단 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
     <div
-        class="-mx-2 mb-2 flex items-center gap-3 px-2 py-2 md:mx-0 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+        class="-mx-2 mb-2 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-3 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
     >
         <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
@@ -1658,7 +1658,8 @@
             </Button>
         {/if}
 
-        <div class="flex-1"></div>
+        <!-- 데스크톱: 우측 그룹을 오른쪽으로 미는 스페이서. 모바일은 줄바꿈되므로 숨김(좌측 정렬) -->
+        <div class="hidden flex-1 md:block"></div>
 
         <div class="flex shrink-0 gap-2">
             {#if authStore.isAuthenticated}
@@ -2105,13 +2106,14 @@
 
         <!-- 댓글 아래 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
         <div
-            class="-mx-2 mt-4 flex items-center gap-3 px-2 py-2 md:mx-0 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+            class="-mx-2 mt-4 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-3 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
         >
             <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0"
                 >←</Button
             >
             <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
-            <div class="flex-1"></div>
+            <!-- 데스크톱: 우측 그룹을 오른쪽으로 미는 스페이서. 모바일은 줄바꿈되므로 숨김(좌측 정렬) -->
+            <div class="hidden flex-1 md:block"></div>
             {#if authStore.isAuthenticated && checkPermission(data.board, 'can_write', authStore.user ?? null)}
                 <Button
                     variant="default"


### PR DESCRIPTION
## 증상 (모바일 글 상세)
액션 버튼 행(목록/글쓰기/수정/삭제 등)의 높이가 크고 **삭제 버튼이 화면 밖으로 밀림**.

## 원인
상·하단 액션 행 컨테이너가 `flex items-center`(**flex-wrap 없음**) + 중간 `<div class="flex-1">` 스페이서가 우측 그룹(수정/삭제/스크랩 등)을 오른쪽 끝으로 밀고, 모든 요소가 `shrink-0` → 모바일 폭 초과 시 줄바꿈·축소 둘 다 안 돼 마지막 **삭제가 오른쪽으로 넘쳐 화면 밖**. (데스크톱 전제 레이아웃의 모바일 미대응)

## 수정
- 컨테이너 2곳: `flex-wrap md:flex-nowrap` + `gap-2 md:gap-3` → 모바일 줄바꿈, 데스크톱 단일행 유지
- `flex-1` 스페이서 2곳: `hidden md:block` → 모바일은 좌측 정렬로 자연 줄바꿈, 데스크톱은 기존 우측 정렬 유지
- `min-h-11`(44px) 터치타깃은 a11y 위해 유지

## 검증
- 모바일 폭(≤768px) 글 상세 상·하단 액션행: 버튼이 줄바꿈되어 **삭제까지 모두 보임**, 가로 오버플로 없음.
- 데스크톱(md+): 기존과 동일(단일행, 우측 정렬).

⚠️ draft — CI 통과·검토 후 머지.