### PR TITLE
fix(author-link): 모바일 스크롤 중 닉네임 프로필 메뉴 오터치 차단 (#6477893)

### DIFF
--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -126,6 +126,30 @@
         e.preventDefault();
         e.stopPropagation();
     }
+
+    // 모바일 스크롤 오터치 차단 (#6477893): bits-ui 메뉴 트리거는 터치에서 'pointerup' 에 열린다
+    // (pointerdown 은 무시). 따라서 닉네임 위에서 시작한 스크롤도 pointerup 에서 메뉴를 열어버린다.
+    // pointerdown~up 사이 이동이 임계(10px)를 넘으면 스크롤로 보고, capture 단계에서 pointerup 의
+    // 전파를 끊어 bits-ui 의 open 을 차단한다. 의도된 탭(이동 없음)은 그대로 열림 → #12652 유지.
+    const SCROLL_TAP_THRESHOLD = 10;
+    let touchStartY = 0;
+    let touchMoved = false;
+    function onTriggerPointerDown(e: PointerEvent): void {
+        if (e.pointerType !== 'touch') return;
+        touchStartY = e.clientY;
+        touchMoved = false;
+    }
+    function onTriggerPointerMove(e: PointerEvent): void {
+        if (e.pointerType !== 'touch') return;
+        if (Math.abs(e.clientY - touchStartY) > SCROLL_TAP_THRESHOLD) touchMoved = true;
+    }
+    function onTriggerPointerUp(e: PointerEvent): void {
+        if (e.pointerType === 'touch' && touchMoved) {
+            // 스크롤로 판정 → bits-ui 트리거의 pointerup-open 미도달
+            e.stopPropagation();
+            e.preventDefault();
+        }
+    }
 </script>
 
 {#if !authorId || !authStore.isAuthenticated}
@@ -144,7 +168,15 @@
     </span>
 {:else}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <span onclick={stopPropagation} onkeydown={stopPropagation} class="inline-flex items-center">
+    <!-- capture 단계 포인터 핸들러: 스크롤(이동) 중 pointerup 을 가로채 bits-ui 트리거의 open 차단 (#6477893) -->
+    <span
+        onclick={stopPropagation}
+        onkeydown={stopPropagation}
+        onpointerdowncapture={onTriggerPointerDown}
+        onpointermovecapture={onTriggerPointerMove}
+        onpointerupcapture={onTriggerPointerUp}
+        class="inline-flex items-center"
+    >
         <DropdownMenu.Root
             onOpenChange={(open) => {
                 if (open) checkFollowStatus();


### PR DESCRIPTION
## 증상 (free #6477893)
아이폰에서 스크롤 시 닉네임이 눌려 프로필 팝업이 뜸. '전에는 안 그랬는데' (댓글 동조 다수).

## 원인
닉네임 = bits-ui `DropdownMenu.Trigger`. bits-ui v2 는 **터치에서 `pointerdown` 은 무시, `pointerup` 에서 open** (마우스는 pointerdown). 즉 닉네임 위에서 시작한 **스크롤도 pointerup 에서 메뉴를 염**(이동 여부 미체크). #1596(06-09)이 짧은닉네임 클릭불가(#12652)를 고치며 `expandTouchArea` 로 모바일 탭영역을 넓힌 뒤 이 오터치가 재발.

## 수정 (안전·타깃)
래퍼 span 에 **capture 단계** 포인터 핸들러: pointerdown~up 사이 이동이 10px 초과면 스크롤로 판정 → pointerup 의 전파를 `stopPropagation` 으로 끊어 bits-ui 의 open 차단.
- 의도된 탭(이동 없음): 그대로 열림 → **#12652 짧은닉네임 클릭 유지**
- 마우스/데스크톱: `pointerType==='touch'` 한정이라 무영향
- 핑퐁(#12444↔#12480↔#12652)의 '클릭영역 조절' 대신 **탭 vs 스크롤 판별**로 근본 해결

## 검증
- iOS/안드로이드 모바일: 닉네임 위에서 스크롤 → 메뉴 안 뜸. 닉네임 의도 탭 → 메뉴 정상. 짧은닉네임(ㅇㅇ, M.M.)도 탭 동작.
- 데스크톱 마우스 클릭: 기존과 동일.

⚠️ draft — CI 통과·모바일 실기기 확인 후 머지.