### PR TITLE
feat(disciplinelog): 상세에 기타 사유(회원 공개) 카드 추가

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -87,6 +87,7 @@ export interface DisciplineLogDetail {
     violation_types: ViolationType[];
     reported_items?: ReportedItem[];
     memo?: string;
+    member_reason?: string; // 회원 공개 사유 (운영자 입력 시에만 노출)
     created_by: string;
     created_at: string;
     status: 'pending' | 'approved' | 'rejected';

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -235,7 +235,7 @@
                     </Card.Title>
                 </Card.Header>
                 <Card.Content>
-                    <p class="text-sm whitespace-pre-line">{log.member_reason}</p>
+                    <p class="whitespace-pre-line text-sm">{log.member_reason}</p>
                 </Card.Content>
             </Card.Root>
         {/if}

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -12,6 +12,7 @@
     import Calendar from '@lucide/svelte/icons/calendar';
     import User from '@lucide/svelte/icons/user';
     import FileText from '@lucide/svelte/icons/file-text';
+    import Info from '@lucide/svelte/icons/info';
     import ExternalLink from '@lucide/svelte/icons/external-link';
     import History from '@lucide/svelte/icons/history';
     import {
@@ -223,6 +224,21 @@
                 </div>
             </Card.Content>
         </Card.Root>
+
+        <!-- 기타 사유: 회원 공개용 (운영자가 입력한 경우에만 표시) -->
+        {#if log.member_reason && log.member_reason.trim()}
+            <Card.Root class="mb-4">
+                <Card.Header>
+                    <Card.Title class="flex items-center gap-2">
+                        <Info class="text-muted-foreground h-5 w-5" />
+                        기타 사유
+                    </Card.Title>
+                </Card.Header>
+                <Card.Content>
+                    <p class="text-sm whitespace-pre-line">{log.member_reason}</p>
+                </Card.Content>
+            </Card.Root>
+        {/if}
 
         <!-- Memo: 비공개 (관리자 내부용) -->
 


### PR DESCRIPTION
## 개요
이용제한 기록 상세에서 운영자가 입력한 `member_reason`(회원 공개 사유)을 **기타 사유** 카드로 표시합니다.

## 변경
- `DisciplineLogDetail` 타입에 `member_reason?` 추가
- `disciplinelog/[id]`에 '기타 사유' 카드 추가 (값이 있을 때만 렌더)
- 기존 내부 메모(비공개)는 변경 없음

## 연관
- 읽기 API: angple-backend#520
- 쓰기: damoang-backend#108
- 입력 UI: damoang-ops(singo) 별도 PR