### PR TITLE
fix(editor): 에디터 트랜잭션 state_unsafe_mutation 제거 (/free 다수)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-editor.svelte
+++ b/apps/web/src/lib/components/features/board/comment-editor.svelte
@@ -116,8 +116,15 @@
                 onUpdate?.(e.getHTML());
             },
             onTransaction: ({ editor: e }) => {
-                isBold = e.isActive('bold');
-                isItalic = e.isActive('italic');
+                // ProseMirror 트랜잭션은 Svelte 렌더/effect 중 동기 호출될 수 있어, 여기서
+                // $state 를 직접 변이하면 state_unsafe_mutation 발생(/free·홈 다수). microtask 로
+                // 반응 컨텍스트 밖에서 갱신한다(툴바 표시는 사실상 즉시).
+                const b = e.isActive('bold');
+                const i = e.isActive('italic');
+                queueMicrotask(() => {
+                    isBold = b;
+                    isItalic = i;
+                });
             }
         });
     });

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -166,24 +166,33 @@
 
     function updateActiveState(): void {
         if (!editor) return;
+        const e = editor;
 
-        isActive = {
-            bold: editor.isActive('bold'),
-            italic: editor.isActive('italic'),
-            underline: editor.isActive('underline'),
-            strike: editor.isActive('strike'),
-            h1: editor.isActive('heading', { level: 1 }),
-            h2: editor.isActive('heading', { level: 2 }),
-            h3: editor.isActive('heading', { level: 3 }),
-            bulletList: editor.isActive('bulletList'),
-            orderedList: editor.isActive('orderedList'),
-            blockquote: editor.isActive('blockquote'),
-            codeBlock: editor.isActive('codeBlock'),
-            link: editor.isActive('link')
+        // ProseMirror 트랜잭션 콜백은 Svelte 렌더/effect 중 동기 호출될 수 있어, 여기서
+        // $state 를 직접 변이하면 state_unsafe_mutation 발생. 값은 지금 계산하고
+        // microtask 로 반응 컨텍스트 밖에서 할당한다(툴바 표시는 사실상 즉시).
+        const next = {
+            bold: e.isActive('bold'),
+            italic: e.isActive('italic'),
+            underline: e.isActive('underline'),
+            strike: e.isActive('strike'),
+            h1: e.isActive('heading', { level: 1 }),
+            h2: e.isActive('heading', { level: 2 }),
+            h3: e.isActive('heading', { level: 3 }),
+            bulletList: e.isActive('bulletList'),
+            orderedList: e.isActive('orderedList'),
+            blockquote: e.isActive('blockquote'),
+            codeBlock: e.isActive('codeBlock'),
+            link: e.isActive('link')
         };
+        const undo = e.can().undo();
+        const redo = e.can().redo();
 
-        canUndo = editor.can().undo();
-        canRedo = editor.can().redo();
+        queueMicrotask(() => {
+            isActive = next;
+            canUndo = undo;
+            canRedo = redo;
+        });
     }
 
     onMount(() => {


### PR DESCRIPTION
## 증상 (Dantry JS 에러 로그)
`Uncaught Error: https://svelte.dev/e/state_unsafe_mutation` 가 하루 **~543 고유 유저**(/free 395 + 홈 166 등)에게 발생. 스택: ProseMirror `dispatchTransaction → onTransaction` (에디터 blur/입력 시).

## 원인
- `comment-editor.svelte` `onTransaction`: `isBold/isItalic` $state 직접 변이
- `tiptap-editor.svelte` `updateActiveState()`: `isActive/canUndo/canRedo` $state 직접 변이

ProseMirror 트랜잭션 콜백이 Svelte 렌더/effect 도중 **동기 호출**되면, 그 안의 $state 쓰기를 Svelte5 가 `state_unsafe_mutation` 으로 throw.

## 수정
콜백에서 값은 즉시 계산하되, $state 할당만 `queueMicrotask` 로 **반응 컨텍스트 밖**에서 수행. 툴바 활성표시(굵게/기울임 등)는 microtask 후 갱신이라 체감 차이 없음.

## 검증
- 댓글/글 에디터에서 입력·blur·서식토글 시 콘솔에 state_unsafe_mutation 미발생.
- 굵게/기울임/실행취소 버튼 활성표시 정상.
- 배포 후 Dantry `state_unsafe_mutation` 카운트 급감 확인.

⚠️ draft — CI 통과 후 머지.