### PR TITLE
fix(editor): 깨진 YouTube 임베드로 글 수정 시 본문 비워지는 문제 (#12727)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -292,7 +292,10 @@
             ],
             // markdown 포맷이면 ProseMirror(WYSIWYG)는 비워두고 마크다운 원문은 rawContent(textarea)로 다룬다.
             // (마크다운 텍스트를 HTML로 오해해 ProseMirror에 주입하는 것을 방지)
-            content: contentFormat === 'markdown' ? '' : content,
+            // #12727: 초기 content 도 stripBrokenYoutube 적용 — src 없는 깨진 youtube 임베드가
+            // 에디터 생성 시점 파싱을 깨 본문이 통째로 비워지는 것을 막는다($effect 만으로는
+            // 생성 시 초기 주입 경로가 빠져 수정 진입 시 그대로 비워졌음).
+            content: contentFormat === 'markdown' ? '' : stripBrokenYoutube(content),
             editable: !disabled,
             // #9223: 편집 모드에서 링크(<a>) 클릭 시 외부 이동 방지.
             // Link extension 의 openOnClick:false 는 mark 만 처리하므로,
@@ -816,13 +819,22 @@
     }
 
     function insertYoutube(): void {
-        if (!youtubeUrl) {
+        const url = youtubeUrl?.trim() ?? '';
+        if (!url) {
             showYoutubeDialog = false;
             return;
         }
-        const timeMatch = youtubeUrl.match(/[?&]t=(\d+)/);
+        // #12727: 유효한 YouTube 주소만 삽입 — 잘못된 입력이 src 없는 빈 임베드로 저장되어
+        // 이후 수정 진입 시 본문이 비워지는 문제를 원천 차단(붙여넣기 핸들러와 동일 패턴 검증).
+        if (!YOUTUBE_PASTE_PATTERN.test(url)) {
+            alert(
+                '유효한 YouTube 주소를 입력해 주세요.\n예: https://www.youtube.com/watch?v=영상ID'
+            );
+            return;
+        }
+        const timeMatch = url.match(/[?&]t=(\d+)/);
         const start = timeMatch ? parseInt(timeMatch[1], 10) : 0;
-        editor?.chain().focus().setYoutubeVideo({ src: youtubeUrl, start }).run();
+        editor?.chain().focus().setYoutubeVideo({ src: url, start }).run();
         showYoutubeDialog = false;
         youtubeUrl = '';
     }


### PR DESCRIPTION
## 버그 #12727 — 글 수정 먹통 (깨진 YouTube 임베드)

특정 글(유튜브 임베드 포함)을 수정하려 하면 크롬·사파리 모두에서 ① 본문이 빈 상태로 나오고 ② 화면이 한 번 깜빡인 뒤 ③ 다시 빈 상태가 됩니다. 제보자는 유튜브 삽입 시 "빈 공간만 잡혔다"고 했고, 실제 저장된 본문을 확인하니 **`src` 속성이 없는 깨진 youtube 노드**였습니다:

```html
<div data-youtube-video=""><iframe class="tiptap-youtube" ... start="0"></iframe></div>
```
(정상이면 `src="https://www.youtube.com/embed/영상ID?rel=1"`)

이 깨진 노드가 든 글을 에디터로 다시 열면 TipTap 파싱이 깨지며 **본문 전체가 비워집니다.**

## 원인

기존 #12686 수정은 `stripBrokenYoutube()`로 깨진 임베드를 제거하지만, **`$effect`(비동기 content 변경)에만 적용**됩니다. 에디터 생성 시 초기 주입 경로(`new Editor({ content })`, tiptap-editor.svelte:295)는 strip 을 거치지 않아, **수정 진입 첫 파싱에서 그대로 본문이 비워졌습니다.**

## 변경

- **`content: ... stripBrokenYoutube(content)`** (line 295) — 에디터 생성 시 초기 content 에도 strip 적용. (`stripBrokenYoutube` 는 hoisted function declaration)
- **`insertYoutube()`** — 다이얼로그 입력도 `YOUTUBE_PASTE_PATTERN` 으로 검증. 잘못된 입력이 `src` 없는 빈 임베드로 저장되는 것을 원천 차단(붙여넣기 핸들러와 동일 기준).

## 검증
- 실제 저장 HTML(free/6490675)에 대해 `stripBrokenYoutube` 정규식이 정상 매치(제거)됨을 확인.
- 초기·비동기 두 경로 모두 strip 적용으로 일관.

## 배포
- canary 확인 → 새벽 4시 윈도우 prod 배포 권장.
