### PR TITLE
fix(auth): SSR 세션조회 일시장애 시 로그아웃 깜빡임 방지 (#12719 #12723)

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -57,6 +57,9 @@ export const load: LayoutServerLoad = async ({
             user: stripUser ? null : (locals.user ?? null),
             accessToken: stripUser ? null : (locals.accessToken ?? null),
             csrfToken: stripUser ? null : (locals.csrfToken ?? null),
+            // #12719/#12723: SSR 세션 조회 일시 장애 여부. 클라이언트가 "로그아웃 확정"과
+            // 구분해 재조회하도록 전달(로그아웃 깜빡임 방지).
+            authDegraded: locals.authDegraded ?? false,
 
             celebration: [],
             banners: {},
@@ -166,6 +169,9 @@ export const load: LayoutServerLoad = async ({
         user: stripUser ? null : (locals.user ?? null),
         accessToken: stripUser ? null : (locals.accessToken ?? null),
         csrfToken: stripUser ? null : (locals.csrfToken ?? null),
+        // #12719/#12723: SSR 세션 조회 일시 장애 여부. 클라이언트가 "로그아웃 확정"과
+        // 구분해 재조회하도록 전달(로그아웃 깜빡임 방지).
+        authDegraded: locals.authDegraded ?? false,
         // logoData: previews 제거 (SSR 불필요), schedules는 header 로고에서 사용
         logoData: {
             active: logoData.active,

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -149,6 +149,12 @@
             if (d.user.id && d.user.as_level !== undefined) {
                 memberLevelStore.updateLevel(d.user.id, d.user.as_level);
             }
+        } else if (d.authDegraded) {
+            // #12719/#12723: SSR 세션 조회가 일시 장애(타임아웃)로 비었을 뿐 로그아웃 확정이 아님.
+            // initAuth()로 "비로그인 확정" 처리하면 다음 네비게이션까지 로그아웃으로 깜빡인다.
+            // 이 경우에만 클라이언트에서 현재 사용자를 재조회(isLoading 유지 → 헤더는 로딩 표시,
+            // 로그아웃 표시 아님). 정상 경로는 변경 없음 = SSR 권위 + heap-safe 설계 유지.
+            authActions.fetchCurrentUser();
         } else {
             authActions.initAuth();
         }


### PR DESCRIPTION
## 버그 묶음: 로그인/댓글 로딩 지연 + 깜빡임

- **#12719** 쪽지함 새로고침 시 세션 끊김 깜빡임 — 이전 수정 안내에도 canary·본서버 모두 여전히 발생
- **#12723** 모바일(삼성 브라우저) 접속 후 한동안(글 3-4개 볼 시간) 로그아웃 상태로 보이고 댓글 미표시 + 간헐 깜빡임

## 원인

인증은 SSR 권위 모델입니다(#12661, heap-safe — 클라이언트 재조회 안 함). 그런데 **SSR 세션 조회가 타임아웃**되면(`hooks.server.ts`가 `locals.authDegraded=true`로 표시) `user=null`이 클라이언트로 전달됩니다. 클라이언트 `+layout.svelte`의 `syncAuth`는 이를 **"비로그인 확정"으로 처리**(`initAuth()`)해, 실제로는 로그인된 사용자가 **다음 네비게이션까지 로그아웃 상태로 표시**됩니다.

- `initAuth()`는 의도적으로 클라이언트 재조회를 하지 않으므로(세션 권위 설계), 한 번 degraded되면 그 페이지에선 로그아웃으로 머뭅니다 → #12723 "한동안 로그아웃".
- 쪽지함은 매 새로고침이 SSR 인증에 민감해 깜빡임이 두드러짐 → #12719.
- 이전 #12642/#12719 수정은 **서버 측 `/login` 리다이렉트 회피**만 다뤘고 **클라이언트 hydration은 그대로**여서 무효했습니다.

또한 root `+layout.server.ts`가 `authDegraded`를 클라이언트 `data`로 전달하지 않아, 클라이언트가 "일시 장애"와 "비로그인 확정"을 구분할 수 없었습니다.

## 변경

- **`+layout.server.ts`**: `data.authDegraded = locals.authDegraded` 전달(두 return 모두).
- **`+layout.svelte` `syncAuth`**: `user` 없고 `authDegraded`이면 `initAuth()`(비로그인 확정) 대신 **`fetchCurrentUser()`**(클라이언트 재조회). `isLoading`이 유지되어 헤더는 **로딩 표시**(로그아웃 아님 — `header.svelte`의 `authResolving` 모델과 일치), 재조회 성공 시 로그인 복구.
- **정상 경로(SSR이 user 또는 비로그인 확정)는 변경 없음** = SSR 권위 + heap-safe 설계 유지. 재조회는 degraded일 때만.

## 검증
- `header.svelte`: `authResolving = isLoading && !ssrUser` → degraded+로딩 시 로그아웃이 아닌 로딩 UI. `fetchCurrentUser`는 `authActions`에 이미 존재.
- 회귀 없음: 실패(진짜 로그아웃) 시 user=null 유지 = 기존과 동일.

## 후속 (별도)
**#12716** (PC 크롬 댓글 10초 지연): 댓글 SSR 스트리밍에 타임아웃이 없어 백엔드 지연 시 그대로 노출. 게시글 페이지에 이미 복잡한 클라이언트 댓글 recovery 머신이 있어, 그와의 상호작용을 검토한 뒤 별도 PR로 처리 예정.

## 배포
- canary에서 쪽지함 새로고침/모바일 로그인 깜빡임 확인 → 새벽 4시 윈도우 prod 배포 권장.
