### PR TITLE
chore(ads): AdSense 로더 스크립트 추가

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -254,6 +254,12 @@
             })();
         </script>
         %sveltekit.head%
+        <!-- AdSense 로더 (광고 단위 미포함 — 표시/레이아웃 변화 없음) -->
+        <script
+            async
+            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6922133409882969"
+            crossorigin="anonymous"
+        ></script>
     </head>
     <body>
         <div style="display: contents">%sveltekit.body%</div>


### PR DESCRIPTION
## 변경
- `apps/web/src/app.html` `<head>`에 AdSense 로더 스크립트 1개 추가.
- 광고 단위(`<ins>`)는 포함하지 않아 **화면 표시/레이아웃 변화가 없습니다.** 기존 광고 동작도 그대로 유지됩니다.

## 배포
- 새벽 4시 배포 게이트 준수, canary 검증(전 페이지 head에 로더 1개 존재 / 광고 신규 노출 없음) 후 full.