### PR TITLE
feat(content): 세로 이미지를 본문 너비에 맞춰 표시

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -304,6 +304,31 @@
             });
         });
     });
+
+    // 세로(portrait) 본문 이미지를 본문 너비에 맞춰 채움.
+    // max-w-full(=max-width:100%)은 상한만 지정하므로 자연 너비가 좁은 세로 이미지가
+    // 작게 표시되어 가독성이 떨어진다. 로드 후 naturalHeight>naturalWidth면 width:100%를 적용한다.
+    // (가로/정사각 이미지는 영향 없음. 자연 너비가 본문보다 큰 세로 이미지는 어차피 100%라 동일.)
+    $effect(() => {
+        void renderedHtml;
+        if (!browser || !proseEl) return;
+        tick().then(() => {
+            const imgs = proseEl.querySelectorAll<HTMLImageElement>(
+                'img:not(.emoticon-inline):not([src*="/emoticons/"])'
+            );
+            imgs.forEach((img) => {
+                const applyOrientation = () => {
+                    if (img.naturalWidth === 0) return;
+                    img.classList.toggle('dm-portrait-fill', img.naturalHeight > img.naturalWidth);
+                };
+                if (img.complete && img.naturalWidth > 0) {
+                    applyOrientation();
+                } else {
+                    img.addEventListener('load', applyOrientation, { once: true });
+                }
+            });
+        });
+    });
 </script>
 
 <div
@@ -316,6 +341,12 @@
 </div>
 
 <style>
+    /* 세로 이미지: 본문 너비 100%로 채움 (좁은 세로 스크린샷이 작게 보이는 문제 해결) */
+    .prose :global(img.dm-portrait-fill) {
+        width: 100%;
+        height: auto;
+    }
+
     /* Tailwind Typography 플러그인이 없을 경우를 위한 기본 스타일 */
     .prose :global(h1) {
         font-size: 1.75em;


### PR DESCRIPTION
## 배경
좁은 세로(portrait) 이미지가 본문에서 작게 표시되어 가독성이 떨어지는 문제가 있습니다. 본문 이미지에는 `max-w-full`(=`max-width:100%`)만 적용되어 **상한만 제한**하므로, 자연 너비가 본문 컬럼보다 좁은 세로 이미지는 작은 크기 그대로 표시됩니다. (예: 254×1024 모바일 스크린샷이 254px로만 노출)

## 변경
- `apps/web/src/lib/components/ui/markdown/markdown.svelte`
  - 본문 렌더 후 이미지 로드 시 `naturalHeight > naturalWidth`(세로)면 `dm-portrait-fill` 클래스 부여 (이미 로드된 이미지는 즉시 적용)
  - CSS: `.prose img.dm-portrait-fill { width: 100%; height: auto; }`

## 영향 범위
- 본문 뷰(`Markdown` 컴포넌트 — 게시글 상세에서만 사용, 댓글 영향 없음)
- **가로/정사각 이미지는 영향 없음.** 자연 너비가 본문보다 큰 세로 이미지도 기존과 동일(이미 100%).
- 이모티콘/인라인 이미지는 제외.

## 참고
- 자연 너비가 매우 좁은 세로 이미지는 100%로 확대 시 다소 흐려질 수 있습니다(가독성 우선). 필요 시 확대 상한 캡을 후속으로 추가할 수 있습니다.

## 배포
- 새벽 4시 배포 게이트, canary 검증(세로 이미지 100% / 가로 무영향) 후 full.