### PR TITLE
fix(my): 내가 쓴 댓글 클릭 시 해당 댓글 위치로 이동

### DIFF
--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -310,7 +310,7 @@
                                     <li class="py-3 first:pt-0 last:pb-0">
                                         <a
                                             href="/{comment.board_id || 'free'}/{comment.post_id ||
-                                                comment.parent_id}"
+                                                comment.parent_id}#c_{comment.id}"
                                             class="hover:bg-accent -m-2 block rounded-md p-2 no-underline transition-colors"
                                         >
                                             {#if comment.post_title}


### PR DESCRIPTION
## 문제 (버그게시판 #12688)
내 프로필 → '내가 쓴 댓글' 클릭 시 본인 댓글 위치가 아니라 글 최상단으로만 이동합니다.

## 원인
`apps/web/src/routes/my/+page.svelte`의 댓글 링크가 `/{board}/{post}` 까지만 가리키고 댓글 앵커(fragment)가 없었습니다.

## 수정
- 링크에 `#c_{comment.id}` 추가. 게시글 상세의 각 댓글은 `id="c_{wr_id}"` 앵커를 가지며(SSR 렌더), `MyComment.id`(=댓글 wr_id)와 일치합니다.

## 영향/한계
- 가로/다른 동작 변화 없음. 대상 댓글이 페이지네이션 등으로 초기 DOM에 없을 경우 기존처럼 글 상단으로 이동(회귀 없음).

## 배포
- 새벽 4시 게이트, canary 검증 후 full.