### PR TITLE
feat(disciplinelog): 신고 접수 후 삭제된 글 삭제됨 배지 표시

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -57,6 +57,7 @@ export interface ReportedItem {
     parent?: number; // comment parent (legacy: "parent" field)
     sg_types?: number[]; // 개별 신고 사유 코드 (g5_na_singo.sg_type 21~40, omitempty)
     penalty_days?: number; // 항목별 적용 일수 (-1=영구, 0=주의, >0=일수, omitempty)
+    deleted?: boolean; // 신고 접수 후 삭제된 글 여부 (삭제됨 배지 표시용)
 }
 
 export interface ViolationType {

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -257,15 +257,26 @@
                             <div
                                 class="hover:bg-muted/50 rounded p-2 transition-all duration-200 ease-out"
                             >
-                                <a
-                                    href={getReportedItemUrl(item)}
-                                    class="flex items-center gap-2 text-sm"
-                                >
-                                    <ExternalLink class="text-muted-foreground h-4 w-4" />
-                                    <span class="text-primary hover:underline">
-                                        {getReportedItemLabel(item)}
-                                    </span>
-                                </a>
+                                {#if item.deleted}
+                                    <!-- 신고 접수 후 삭제된 글: 링크 비활성 + 삭제됨 배지 -->
+                                    <div class="text-muted-foreground flex items-center gap-2 text-sm">
+                                        <ExternalLink class="h-4 w-4" />
+                                        <span class="line-through">
+                                            {getReportedItemLabel(item)}
+                                        </span>
+                                        <Badge variant="secondary" class="text-xs">삭제됨</Badge>
+                                    </div>
+                                {:else}
+                                    <a
+                                        href={getReportedItemUrl(item)}
+                                        class="flex items-center gap-2 text-sm"
+                                    >
+                                        <ExternalLink class="text-muted-foreground h-4 w-4" />
+                                        <span class="text-primary hover:underline">
+                                            {getReportedItemLabel(item)}
+                                        </span>
+                                    </a>
+                                {/if}
                                 {#if (item.sg_types && item.sg_types.length > 0) || item.penalty_days != null}
                                     <div class="ml-6 mt-1.5 flex flex-wrap items-center gap-1">
                                         {#if item.sg_types}

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -259,7 +259,9 @@
                             >
                                 {#if item.deleted}
                                     <!-- 신고 접수 후 삭제된 글: 링크 비활성 + 삭제됨 배지 -->
-                                    <div class="text-muted-foreground flex items-center gap-2 text-sm">
+                                    <div
+                                        class="text-muted-foreground flex items-center gap-2 text-sm"
+                                    >
                                         <ExternalLink class="h-4 w-4" />
                                         <span class="line-through">
                                             {getReportedItemLabel(item)}


### PR DESCRIPTION
## 배경
이용제한 기록(`disciplinelog/:id`)에서 신고 접수 후 삭제된 글이 정상 글과 구분 없이 링크로 노출되어, 이미 삭제된 글로 이동하거나 삭제 사실을 알 수 없는 문제가 있었습니다.

## 변경
- `ReportedItem` 타입에 `deleted?: boolean` 추가
- 상세 페이지 '신고 접수된 글' 렌더에서 `item.deleted`면 링크 대신 취소선 텍스트 + `삭제됨` 배지로 표시 (정상 글의 줄단위 사유/일수 배지는 그대로)

## 의존
- 백엔드에서 `deleted` 필드를 내려줘야 동작 (angple-backend#522)

## 검증
- 백엔드 PR 병합 후 dev에서 삭제된 글이 든 기존 이용제한 기록으로 배지 노출 확인 예정

> ⚠️ prod 배포는 운영자 수동 승인 게이트 (자동배포 아님)