### PR TITLE
chore(ads): 본문 멀티플렉스 광고 단위 갱신

### DIFF
--- a/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
+++ b/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
@@ -18,8 +18,8 @@
 
     let { class: className = '' }: Props = $props();
 
-    const ADSENSE_CLIENT = 'ca-pub-5124617752473025';
-    const ADSENSE_SLOT = '3075504524';
+    const ADSENSE_CLIENT = 'ca-pub-6922133409882969';
+    const ADSENSE_SLOT = '3037103743';
 
     let ready = $state(false);
     let insEl: HTMLElement | null = null;


### PR DESCRIPTION
## 변경
- `apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte`의 멀티플렉스(autorelaxed) 광고 단위 client/slot 값을 갱신합니다.
- 광고 표시 위치·형식·개수는 동일합니다. 미충족 시 collapse(빈 공간 없음) 동작도 그대로입니다.

## 배포
- 새벽 4시 게이트, canary 검증 후 full.