### PR TITLE
fix(comments): 댓글 200개 초과 글에서 댓글 다수 누락 수정

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -381,6 +381,15 @@
             flatTree.push(...buildTree(root, 0));
         });
 
+        // #12735 방어: 부모(상위 댓글)가 로드되지 않아 어느 트리에도 포함되지 못한
+        // 고아 댓글을 루트로 승격해 항상 렌더한다(조용히 누락 방지).
+        const includedIds = new SvelteSet<string>(flatTree.map((c) => String(c.id)));
+        comments.forEach((comment) => {
+            if (!includedIds.has(String(comment.id))) {
+                flatTree.push({ ...comment, depth: 0 });
+            }
+        });
+
         return flatTree;
     });
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1274,20 +1274,44 @@
         // 무시하는 사례가 있어 URL cache buster (`_t=${Date.now()}`) 로 강제 우회.
         // SW (service worker) 가 가로채는 케이스도 동일하게 URL 변화로 회피.
         const cacheBuster = Date.now();
-        const res = await fetch(
-            `/api/boards/${boardId}/posts/${data.post.id}/comments?page=1&limit=200&_t=${cacheBuster}`,
-            {
-                cache: 'no-store',
-                headers: {
-                    'Cache-Control': 'no-cache, no-store, must-revalidate',
-                    Pragma: 'no-cache'
+        // #12735: 댓글 API 는 페이지당 최대 200개라, 댓글이 200개를 넘는 글은
+        // page=1 한 번만 받으면 나머지가 누락된다("대댓글 많은데 안 보임").
+        // total_pages 만큼 순차로 모두 받아 합친다. (안전 상한 MAX_PAGES)
+        const PAGE_SIZE = 200;
+        const MAX_PAGES = 15;
+        const fetchCommentPage = (p: number) =>
+            fetch(
+                `/api/boards/${boardId}/posts/${data.post.id}/comments?page=${p}&limit=${PAGE_SIZE}&_t=${cacheBuster}`,
+                {
+                    cache: 'no-store',
+                    headers: {
+                        'Cache-Control': 'no-cache, no-store, must-revalidate',
+                        Pragma: 'no-cache'
+                    }
+                }
+            ).then((r) => r.json());
+
+        const json = await fetchCommentPage(1);
+        if (json.success) {
+            let all = json.data.comments ?? [];
+            const total = json.data.total || all.length;
+            const reportedPages = json.data.total_pages ?? 1;
+            const pagesToLoad = Math.min(reportedPages, MAX_PAGES);
+            for (let p = 2; p <= pagesToLoad; p++) {
+                const next = await fetchCommentPage(p);
+                if (next.success && next.data.comments?.length) {
+                    all = all.concat(next.data.comments);
+                } else {
+                    break;
                 }
             }
-        );
-        const json = await res.json();
-        if (json.success) {
-            comments = json.data.comments;
-            commentsTotal = json.data.total || json.data.comments?.length || comments.length;
+            if (reportedPages > MAX_PAGES) {
+                console.warn(
+                    `[comments] total_pages ${reportedPages} exceeds cap ${MAX_PAGES} — 일부 댓글 미로드`
+                );
+            }
+            comments = all;
+            commentsTotal = total || all.length;
             // backfill 완료 후 앵커 스크롤 재시도 (#c_댓글ID로 접근 시)
             requestAnimationFrame(() => scheduleAnchorScroll());
         }


### PR DESCRIPTION
## 문제 (버그게시판 #12735)
댓글이 많은 글(예: free/6504416, 댓글 469개)에서 대댓글을 많이 달면 상당수 댓글이 보이지 않습니다. DB에는 댓글이 모두 정상 존재하며, **불러오기 단계에서 누락**됩니다.

## 원인
- 게시글 상세 `refetchComments()`가 `page=1&limit=200` **1회만 요청** → 댓글 API는 페이지당 최대 200개이므로, 200개를 넘는 글은 나머지 페이지가 로드되지 않음.
- 부차: 부모(상위 댓글)가 미로드 페이지에 있는 대댓글이 트리 빌드에서 도달 불가 → 조용히 누락.

## 수정 (프론트 전용)
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` `refetchComments()`: 첫 응답의 `total_pages`만큼 **남은 페이지를 순차 로드해 합침**(안전 상한 15페이지 = ~3000개, 초과 시 경고 로그).
- `apps/web/src/lib/components/features/board/comment-list.svelte`: 트리에 포함되지 못한 **고아 댓글을 루트로 승격**해 항상 렌더(회귀 안전망).

## 비변경(회귀 방지)
- 댓글 API(internal 200/external 20/페이지네이션), SSR 초기 10개 로드, 외부 요청 제한 모두 그대로.

## 기대 효과
- #12735 해소. 관련 "댓글 있는데 안 보임"(#12668·#12663)도 동반 개선 가능성.

## 배포
- 새벽 4시 게이트, canary 검증(free/6504416 댓글 전체 표시) 후 full.