### PR TITLE
fix(content): 본문 유튜브 시작시간 미적용 수정

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -233,6 +233,32 @@
         breaks: true
     });
 
+    // #12741: 유튜브 embed iframe은 src에 `start=초`가 있어야 시작시간이 적용된다.
+    // tiptap은 시작시간을 src의 `t=초`(및 start 속성)로 저장하지만 /embed/ 는 `t=` 를
+    // 무시하므로 항상 0초부터 재생됐다. DOMPurify가 start 속성을 제거하므로 src의 `t=`
+    // (sanitize 후에도 src 쿼리는 보존)에서 초를 구해 src에 `start=` 를 주입한다.
+    // (댓글 경로 youtube.ts 는 이미 start= 로 생성 → 동작 통일.)
+    function injectYoutubeStart(html: string): string {
+        if (!html || html.indexOf('youtube') === -1) return html;
+        return html.replace(/<iframe\b[^>]*>/gi, (tag) => {
+            const srcMatch = tag.match(/\bsrc=(["'])([^"']*)\1/i);
+            if (!srcMatch) return tag;
+            const src = srcMatch[2];
+            if (!/youtube(?:-nocookie)?\.com\/embed\//i.test(src)) return tag;
+            if (/[?&](?:amp;)?start=\d+/i.test(src)) return tag; // 이미 적용됨
+            const startAttr = tag.match(/\bstart=(["'])(\d+)\1/i);
+            let seconds = startAttr ? parseInt(startAttr[2], 10) : 0;
+            if (!seconds) {
+                const tMatch = src.match(/(?:[?&]|&amp;)t=(\d+)/i);
+                if (tMatch) seconds = parseInt(tMatch[1], 10);
+            }
+            if (!seconds) return tag;
+            const sep = src.includes('?') ? (src.includes('&amp;') ? '&amp;' : '&') : '?';
+            const newSrc = `${src}${sep}start=${seconds}`;
+            return tag.replace(/\bsrc=(["'])[^"']*\1/i, `src=$1${newSrc}$1`);
+        });
+    }
+
     // SSR용 기본 HTML (이스케이프된 미디어 태그 복원 + URL 자동 임베딩)
     function getInitialHtml(content: string): string {
         if (!content) return '';
@@ -240,7 +266,9 @@
         rawHtml = transformEscapedMedia(rawHtml);
         // processEmbeds는 클라이언트 $effect에서만 실행 (SSR 부하 방지)
         // 본문 이미지 src 더블슬래시 collapse + CDN 호스트 정규화 (#12697)
-        return normalizeHtmlMediaUrls(DOMPurify.sanitize(rawHtml, PURIFY_CONFIG));
+        return injectYoutubeStart(
+            normalizeHtmlMediaUrls(DOMPurify.sanitize(rawHtml, PURIFY_CONFIG))
+        );
     }
 
     // 초기 렌더링 (SSR + 클라이언트 초기값)
@@ -268,6 +296,7 @@
             applyFilter<string>('post_content', rawHtml).then((filtered) => {
                 let sanitized = DOMPurify.sanitize(filtered, PURIFY_CONFIG);
                 sanitized = normalizeHtmlMediaUrls(sanitized);
+                sanitized = injectYoutubeStart(sanitized);
                 sanitized = addLinkMismatchWarnings(sanitized);
                 renderedHtml = sanitized;
             });


### PR DESCRIPTION
## 문제 (버그게시판 #12741)
게시글 본문에 시작시간(예 t=573) 지정한 유튜브 링크를 넣어도 항상 처음부터 재생됩니다. (댓글은 정상)

## 원인 (DB 실측 + dompurify 실측 검증)
저장된 embed src가 `...embed/ID?si=...&t=573` 형태인데 YouTube `/embed/` 는 `t=` 를 무시하고 `start=` 만 인식합니다. 댓글은 `youtube.ts` 가 `start=` 로 생성해 정상.

## 수정 (프론트 1파일, 렌더 시점)
- `apps/web/src/lib/components/ui/markdown/markdown.svelte`: 독립 함수 `injectYoutubeStart(html)` 추가 → 실제 렌더 체인 두 곳(SSR `getInitialHtml` + 클라 `$effect`, `normalizeHtmlMediaUrls` 직후)에 연결. embed src의 `t=초` 에서 `start=초` 를 주입. DOMPurify가 src 쿼리(`t=`)는 보존하므로 sanitize 이후 동작.
- 이미 `start=` 있으면 멱등 no-op, 비-youtube iframe 무영향. **기존 저장 글도 재저장 없이 즉시 적용**.

## 검증 (하네스)
- 별도 Evaluator 에이전트가 isomorphic-dompurify 실측으로 `t=573` 생존 + `start=573` 주입 + 회귀 없음 확인(PASS).

## 배포
- 새벽 4시 게이트, canary 검증(qa/80873 본문 embed src에 start=573 포함) 후 full.