### PR TITLE
fix(report): 신고 사유에서 뉴스펌글누락·뉴스전문전재 숨김

### DIFF
--- a/apps/web/src/lib/components/features/report/report-dialog.svelte
+++ b/apps/web/src/lib/components/features/report/report-dialog.svelte
@@ -58,9 +58,9 @@
         { value: 35, label: '광고/홍보' },
         { value: 36, label: '운영정책부정' },
         { value: 37, label: '다중이' },
-        { value: 38, label: '기타사유' },
-        { value: 39, label: '뉴스펌글누락' },
-        { value: 40, label: '뉴스전문전재' }
+        { value: 38, label: '기타사유' }
+        // 뉴스펌글누락(39)·뉴스전문전재(40)는 일반 신고 사유 선택에서 숨김(운영 전용).
+        // 기존 신고 내역의 라벨 표시는 report-reasons.ts 매핑으로 유지됨.
     ];
 
     // 상태


### PR DESCRIPTION
## 요청
게시글 상세보기 및 댓글 신고 팝업의 신고 사유 선택에서 **뉴스펌글누락·뉴스전문전재** 항목을 숨깁니다.

## 변경
- `apps/web/src/lib/components/features/report/report-dialog.svelte`의 REPORT_REASONS에서 39(뉴스펌글누락)·40(뉴스전문전재) 제거.
- 게시글 상세(`[postId]/+page.svelte`)와 댓글(`comment-list.svelte`)이 **동일 ReportDialog를 공유**하므로 한 곳 수정으로 둘 다 적용됩니다.
- 표시용 매핑(`report-reasons.ts`)은 미변경 → 기존 신고 내역의 라벨은 그대로 표시됩니다.

## 배포
- 새벽 4시 게이트, canary 검증 후 full.