### PR TITLE
feat(footer): 외부 링크 줄에 배내센트 텍스트 추가

### DIFF
--- a/apps/web/src/lib/components/layout/footer.svelte
+++ b/apps/web/src/lib/components/layout/footer.svelte
@@ -137,6 +137,8 @@
                     <ExternalLink class="h-3 w-3" />
                 </a>
             {/each}
+            <!-- 배내센트: 링크 오픈 전까지 텍스트만 노출 -->
+            <span class="text-muted-foreground flex items-center text-xs"> 배내센트 </span>
         </div>
     </div>
 


### PR DESCRIPTION
## 변경
- 푸터 외부 링크 한 줄(스마트스토어·마플샵·유튜브·X) 우측에 `배내센트` **텍스트**를 추가합니다.
- 링크 오픈 전까지 앵커가 아닌 일반 텍스트(span)로만 노출합니다. 링크 연결은 추후 적용 예정입니다.

## 영향
- footer.svelte 한 곳. 표시만 추가, 기존 링크/동작 변경 없음.