### PR TITLE
fix(site-resolver): angple_sites JSON 컬럼 객체/문자열 모두 처리

### DIFF
--- a/apps/web/src/lib/server/site-resolver/db.ts
+++ b/apps/web/src/lib/server/site-resolver/db.ts
@@ -37,28 +37,32 @@ function isMissingTableError(err: unknown): boolean {
     return dbErr?.code === 'ER_NO_SUCH_TABLE' || dbErr?.errno === 1146;
 }
 
-function rowToContext(row: SiteRow): SiteContext {
-    let keywords: string[] | undefined;
-    if (row.keywords) {
+// JSON 컬럼(keywords/business)은 드라이버/설정에 따라 직렬화된 문자열로 오거나
+// 이미 파싱된 객체/배열로 올 수 있다(mysql2 는 JSON 타입을 자동 파싱). 문자열이면
+// JSON.parse, 이미 객체면 그대로 반환해 두 경우 모두 안전하게 처리한다.
+function parseJsonColumn(val: unknown): unknown {
+    if (val == null) return undefined;
+    if (typeof val === 'string') {
         try {
-            const parsed = JSON.parse(row.keywords) as unknown;
-            if (Array.isArray(parsed) && parsed.every((k) => typeof k === 'string')) {
-                keywords = parsed;
-            }
+            return JSON.parse(val) as unknown;
         } catch {
-            // ignore malformed JSON
+            return undefined;
         }
     }
+    if (typeof val === 'object') return val;
+    return undefined;
+}
+
+function rowToContext(row: SiteRow): SiteContext {
+    let keywords: string[] | undefined;
+    const parsedKeywords = parseJsonColumn(row.keywords);
+    if (Array.isArray(parsedKeywords) && parsedKeywords.every((k) => typeof k === 'string')) {
+        keywords = parsedKeywords;
+    }
     let business: SiteContext['business'];
-    if (row.business) {
-        try {
-            const parsed = JSON.parse(row.business) as unknown;
-            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-                business = parsed as SiteContext['business'];
-            }
-        } catch {
-            // ignore malformed JSON
-        }
+    const parsedBusiness = parseJsonColumn(row.business);
+    if (parsedBusiness && typeof parsedBusiness === 'object' && !Array.isArray(parsedBusiness)) {
+        business = parsedBusiness as SiteContext['business'];
     }
     return {
         id: `db:${row.id}`,


### PR DESCRIPTION
## 문제
`angple_sites.business`(사이트별 사업자/저작권 정보, #1599)가 채워져 있어도 푸터에 표시되지 않습니다.

## 원인
`keywords`/`business` 는 **JSON 타입 컬럼**이라 드라이버(mysql2)가 조회 시 **이미 객체로 자동 파싱**합니다. 그런데 `rowToContext` 는 값을 **문자열로 가정**하고 `JSON.parse` 해서 객체에 대해 예외가 나고, catch 에서 조용히 드롭됩니다. 그 결과 `site.business` 가 항상 undefined → 푸터의 사업자정보 블록이 렌더되지 않습니다(기본 사이트도 site 레코드가 생기면서 동일 증상).

## 변경
- `parseJsonColumn(val)` 헬퍼 추가: 문자열이면 `JSON.parse`, 이미 객체/배열이면 그대로 사용. keywords·business 양쪽에 적용.
- DB/스키마 변경 없음. 표시 외 다른 동작 변경 없음.

## 검증
- 배포 후 damoang.net 푸터에 사업자/저작권 정보 표시 확인.