### PR TITLE
fix(reaction): Noto 하트 애니모지 게시글 상세 액박 수정

### DIFF
--- a/apps/web/src/lib/types/reaction.ts
+++ b/apps/web/src/lib/types/reaction.ts
@@ -108,12 +108,17 @@ export function getReactionDisplay(reaction: string): {
                 url: `/api/emoticons/nariya/damoang-${reactionId}.gif`,
                 label: `앙티콘 ${reactionId}`
             };
-        case 'noto-animoji':
+        case 'noto-animoji': {
+            // Noto 애니메이션 CDN 경로는 복합 코드포인트를 '_' 로 잇는다(예: 2764_fe0f).
+            // 저장 형식은 '-' 를 쓰므로(2764-fe0f) '_' 로 변환해야 한다. 단일 코드포인트
+            // (1f44d 등)는 하이픈이 없어 영향 없음. 미변환 시 하트가 404(액박)로 표시됨.
+            const notoPath = reactionId.replace(/-/g, '_');
             return {
                 renderType: 'image',
-                url: `https://fonts.gstatic.com/s/e/notoemoji/latest/${reactionId}/512.webp`,
+                url: `https://fonts.gstatic.com/s/e/notoemoji/latest/${notoPath}/512.webp`,
                 label: `Noto ${reactionId}`
             };
+        }
         case 'import-image':
             return {
                 renderType: 'image',


### PR DESCRIPTION
## 문제
움직이는 이모지(Noto) 하트로 공감하면, 게시글 상세의 공감 표시에서 **깨진 이미지(액박)** 로 나옵니다.

## 원인
`getReactionDisplay` 가 `noto-animoji` URL 을 `${reactionId}` 로 직접 만드는데, 하트의 저장 ID 는 변형 선택자가 붙은 복합 코드포인트 `2764-fe0f`(하이픈)입니다. 그런데 Noto 애니메이션 CDN 경로는 `2764_fe0f`(언더스코어)라 `.../2764-fe0f/512.webp` 가 404 가 됩니다. (공감 선택창은 config 의 명시 url 을 써서 정상, 상세 표시만 동적 생성이라 깨짐.)

## 변경
- noto-animoji URL 생성 시 `reactionId` 의 `-` → `_` 변환. 단일 코드포인트(1f44d 등)는 하이픈이 없어 영향 없음.

## 검증
- 배포 후 하트 공감이 게시글 상세에서 정상 표시되는지 확인.