### PR TITLE
fix(member): 프로필 조회 시 mb_id 정확 일치 우선

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -120,6 +120,9 @@ export const GET: RequestHandler = async ({ params, locals }) => {
     }
 
     try {
+        // mb_id / mb_nick 둘 다 허용하되, 슬러그가 한 계정의 mb_id이자 다른 계정의 닉네임일 때
+        // (소셜로그인 닉 충돌 등) mb_id 정확 일치를 우선시킨다. 우선순위가 없으면 rows[0]이
+        // 비결정적으로 닉 매칭 계정을 반환해 엉뚱한 프로필이 노출됨.
         const [rows] = await pool.query<MemberRow[]>(
             `SELECT mb_id, mb_name, mb_nick, mb_level, mb_point,
                     mb_signature, mb_homepage, mb_profile,
@@ -127,8 +130,10 @@ export const GET: RequestHandler = async ({ params, locals }) => {
                     mb_image_url, mb_image_updated_at, mb_certify, mb_leave_date, mb_leave_reason,
                     as_level, as_exp
              FROM g5_member
-             WHERE mb_id = ? OR mb_nick = ?`,
-            [memberId, memberId]
+             WHERE mb_id = ? OR mb_nick = ?
+             ORDER BY (mb_id = ?) DESC
+             LIMIT 1`,
+            [memberId, memberId, memberId]
         );
 
         if (rows.length === 0) {


### PR DESCRIPTION
## 배경
회원 프로필 API(`/api/members/[id]/profile`)가 슬러그를 `WHERE mb_id = ? OR mb_nick = ?`로 조회하면서 **우선순위가 없어**, 슬러그가 한 계정의 `mb_id`이면서 동시에 다른 계정의 `mb_nick`(소셜로그인 닉 충돌 등)일 때 `rows[0]`이 비결정적으로 **닉 매칭 계정**을 반환했다. 그 결과 기대한 URL에 **엉뚱한 회원의 프로필**(이용제한 내역·포인트·활동·팔로워 등)이 노출됨.

## 현황 (실측)
- 모호 슬러그(한 계정 mb_id == 다른 계정 닉) **23건**
- 그중 **19건이 현재 오해석** 상태(정확 mb_id 매칭이 닉 매칭에 짐)
- 소셜로그인(google_/naver_/kakao_)이 기존 mb_id와 같은 닉을 계속 생성 → 향후 증가

## 변경
- 쿼리에 `ORDER BY (mb_id = ?) DESC LIMIT 1` 추가 → **mb_id 정확 일치 우선**
- 한글 닉네임/멘션(@닉) 등 mb_id에 없는 슬러그는 기존대로 mb_nick 폴백
- followers/memos/interactions 등 다른 `[id]` 라우트는 `[id]`를 mb_id로 직접 사용 → 프로필만 어긋났던 정합성도 해소

## 영향/리스크
- 단일 파일·단일 쿼리, 스키마/데이터 변경 없음, 가역적
- 동작 변화: 모호 슬러그에서 항상 mb_id 정확 일치 계정을 반환(정식 의미와 일치)

## 검증
- 배포 후 23개 모호 슬러그 재측정 → 23 정상 / 0 오해석 기대