### PR TITLE
fix(noti): 알림설정 fallback 에 noti_board_subscribe 보정

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1946,6 +1946,7 @@ class ApiClient {
                 noti_mention: true,
                 noti_like: true,
                 noti_follow: true,
+                noti_board_subscribe: true,
                 like_threshold: 1
             }
         );


### PR DESCRIPTION
## 문제
알림설정의 `getNotificationPreferences()` API 실패 fallback 객체에 `noti_board_subscribe` 필드가 누락되어, API 오류 시 게시판 구독 알림 토글이 undefined→켜짐으로 표시됩니다.

## 변경
- fallback 객체에 `noti_board_subscribe: true` 추가(다른 항목과 동일 기본값).

## 비고
- 운영 핵심 버그(#12760: 설정 저장 불가·구독 폭주)는 별도로 DB 마이그(009/010/011 잔여 적용: noti_board_subscribe 컬럼 + cron 테이블 + free→level2)로 **이미 라이브 복구**됨. 본 PR 은 API 실패 시 표시 정합 보강(부차).