### PR TITLE
fix(comments): 댓글 수만 있고 목록 비어 보이는 버그 근본 수정 (#12663 #12668)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -326,15 +326,6 @@ export const load: PageServerLoad = async ({
             //   total<=loaded 산술(0/0 함정) 대신 이 신호에 기반.
             // - 실패는 무성으로 삼키지 않고 구조적 로그로 노출(재발 조기탐지).
             const expectedTotal = post.comments_count ?? 0;
-            const failedMeta = {
-                items: [],
-                total: expectedTotal,
-                page: 1,
-                limit: initialCommentsLimit,
-                total_pages:
-                    expectedTotal > 0 ? Math.ceil(expectedTotal / initialCommentsLimit) : 0,
-                loadState: 'failed' as 'complete' | 'partial' | 'failed'
-            };
             const ssrStart = Date.now();
             const warnFail = (reason: string, status?: number) =>
                 console.warn('[comments-ssr] fetch failed', {
@@ -345,50 +336,56 @@ export const load: PageServerLoad = async ({
                     expectedTotal,
                     durationMs: Date.now() - ssrStart
                 });
-
-            let commentsResult: typeof failedMeta & {
-                edit_policy?: { cost: number; grace_seconds: number };
-            };
-            try {
-                // svelteKitFetch 는 표준 platform fetch(timeout 옵션 미지원)이므로 AbortSignal.timeout
-                // 으로 2.5s 상한을 건다 — 무제한 대기로 SSR 본문이 블로킹되는 것 방지(초과 시
-                // AbortError → 아래 catch → failedMeta 로 일관 처리).
-                const res = await svelteKitFetch(
-                    `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=${initialCommentsLimit}`,
-                    { signal: AbortSignal.timeout(2_500) }
-                );
-                if (!res.ok) {
-                    warnFail('http_error', res.status);
-                    commentsResult = failedMeta;
-                } else {
+            // 실패/타임아웃 시에도 total 은 권위값(expectedTotal=post.comments_count) 보존 +
+            // loadState='failed'. total:0 으로 덮으면 클라 backfill 게이트가 0/0 으로 막혀
+            // 자가복구 불가(#12663·#12668). items 는 union 추론으로 any 소비 유지(다운스트림 호환).
+            const failedMeta = () => ({
+                items: [] as never[],
+                total: expectedTotal,
+                page: 1,
+                limit: initialCommentsLimit,
+                total_pages:
+                    expectedTotal > 0 ? Math.ceil(expectedTotal / initialCommentsLimit) : 0,
+                loadState: 'failed' as 'complete' | 'partial' | 'failed'
+            });
+            // svelteKitFetch 는 표준 platform fetch(timeout 옵션 미지원) → AbortSignal.timeout 으로
+            // 2.5s 상한. 초과/네트워크 오류는 .catch → failedMeta 로 일관 처리(무제한 대기 차단).
+            const commentsResult = await svelteKitFetch(
+                `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=${initialCommentsLimit}`,
+                { signal: AbortSignal.timeout(2_500) }
+            )
+                .then(async (res) => {
+                    if (!res.ok) {
+                        warnFail('http_error', res.status);
+                        return failedMeta();
+                    }
                     const json = await res.json();
                     if (!json.success) {
                         warnFail('not_success');
-                        commentsResult = failedMeta;
-                    } else {
-                        const data = json.data;
-                        const items = data.comments || [];
-                        const total = data.total || items.length;
-                        commentsResult = {
-                            items,
-                            total,
-                            page: data.page || 1,
-                            limit: data.limit || initialCommentsLimit,
-                            total_pages: data.total_pages || 1,
-                            loadState: (items.length >= total ? 'complete' : 'partial') as
-                                | 'complete'
-                                | 'partial'
-                                | 'failed',
-                            edit_policy: json.meta?.comment_edit_policy as
-                                | { cost: number; grace_seconds: number }
-                                | undefined
-                        };
+                        return failedMeta();
                     }
-                }
-            } catch {
-                warnFail('timeout_or_network');
-                commentsResult = failedMeta;
-            }
+                    const data = json.data;
+                    const items = data.comments || [];
+                    const total = data.total || items.length;
+                    return {
+                        items,
+                        total,
+                        page: data.page || 1,
+                        limit: data.limit || initialCommentsLimit,
+                        total_pages: data.total_pages || 1,
+                        loadState: (items.length >= total ? 'complete' : 'partial') as
+                            | 'complete'
+                            | 'partial'
+                            | 'failed',
+                        edit_policy: json.meta?.comment_edit_policy as
+                            | { cost: number; grace_seconds: number }
+                            | undefined
+                    };
+                })
+                .catch(() => {
+                    warnFail('timeout_or_network');
+                    return failedMeta();
+                });
 
             const comments = commentsResult;
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -314,7 +314,10 @@ export const load: PageServerLoad = async ({
                         loadState: ((post.comments_count ?? 0) > 0 ? 'partial' : 'complete') as
                             | 'complete'
                             | 'partial'
-                            | 'failed'
+                            | 'failed',
+                        edit_policy: undefined as
+                            | { cost: number; grace_seconds: number }
+                            | undefined
                     }
                 };
             }
@@ -346,7 +349,8 @@ export const load: PageServerLoad = async ({
                 limit: initialCommentsLimit,
                 total_pages:
                     expectedTotal > 0 ? Math.ceil(expectedTotal / initialCommentsLimit) : 0,
-                loadState: 'failed' as 'complete' | 'partial' | 'failed'
+                loadState: 'failed' as 'complete' | 'partial' | 'failed',
+                edit_policy: undefined as { cost: number; grace_seconds: number } | undefined
             });
             // svelteKitFetch 는 표준 platform fetch(timeout 옵션 미지원) → AbortSignal.timeout 으로
             // 2.5s 상한. 초과/네트워크 오류는 .catch → failedMeta 로 일관 처리(무제한 대기 차단).

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -300,6 +300,7 @@ export const load: PageServerLoad = async ({
         // --- 2단계: 핵심/보조 데이터를 분리해 스트리밍 ---
         const commentsData = await (async () => {
             if (isDataRequest) {
+                // SPA 네비(__data.json): 댓글은 클라가 backfill 로 로드. total 은 권위값 보존.
                 return {
                     comments: {
                         items: [],
@@ -309,43 +310,83 @@ export const load: PageServerLoad = async ({
                         total_pages:
                             (post.comments_count ?? 0) > 0
                                 ? Math.ceil((post.comments_count ?? 0) / initialCommentsLimit)
-                                : 0
+                                : 0,
+                        loadState: ((post.comments_count ?? 0) > 0 ? 'partial' : 'complete') as
+                            | 'complete'
+                            | 'partial'
+                            | 'failed'
                     }
                 };
             }
 
-            const commentsResult = await svelteKitFetch(
-                `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=${initialCommentsLimit}`
-            ).then(async (res) => {
-                if (!res.ok)
-                    return {
-                        items: [],
-                        total: 0,
-                        page: 1,
-                        limit: initialCommentsLimit,
-                        total_pages: 0
-                    };
-                const json = await res.json();
-                if (!json.success)
-                    return {
-                        items: [],
-                        total: 0,
-                        page: 1,
-                        limit: initialCommentsLimit,
-                        total_pages: 0
-                    };
-                const data = json.data;
-                return {
-                    items: data.comments || [],
-                    total: data.total || 0,
-                    page: data.page || 1,
-                    limit: data.limit || initialCommentsLimit,
-                    total_pages: data.total_pages || 1,
-                    edit_policy: json.meta?.comment_edit_policy as
-                        | { cost: number; grace_seconds: number }
-                        | undefined
-                };
-            });
+            // 댓글 SSR 로드. 핵심 계약(#12663·#12668):
+            // - total 은 항상 "글의 권위 있는 댓글 수"(post.comments_count). SSR fetch 가
+            //   실패/타임아웃해도 0 으로 덮지 않는다 → 클라 backfill 이 확실히 발화.
+            // - loadState 로 complete/partial/failed 를 명시 → 클라 backfill 게이트가
+            //   total<=loaded 산술(0/0 함정) 대신 이 신호에 기반.
+            // - 실패는 무성으로 삼키지 않고 구조적 로그로 노출(재발 조기탐지).
+            const expectedTotal = post.comments_count ?? 0;
+            const failedMeta = {
+                items: [],
+                total: expectedTotal,
+                page: 1,
+                limit: initialCommentsLimit,
+                total_pages:
+                    expectedTotal > 0 ? Math.ceil(expectedTotal / initialCommentsLimit) : 0,
+                loadState: 'failed' as 'complete' | 'partial' | 'failed'
+            };
+            const ssrStart = Date.now();
+            const warnFail = (reason: string, status?: number) =>
+                console.warn('[comments-ssr] fetch failed', {
+                    boardId,
+                    postId,
+                    reason,
+                    status,
+                    expectedTotal,
+                    durationMs: Date.now() - ssrStart
+                });
+
+            let commentsResult: typeof failedMeta & {
+                edit_policy?: { cost: number; grace_seconds: number };
+            };
+            try {
+                // post fetch 와 동일하게 timeout 부여 — 무제한 대기로 SSR 본문이 블로킹되는 것 방지.
+                const res = await svelteKitFetch(
+                    `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=${initialCommentsLimit}`,
+                    { timeout: 2_500 }
+                );
+                if (!res.ok) {
+                    warnFail('http_error', res.status);
+                    commentsResult = failedMeta;
+                } else {
+                    const json = await res.json();
+                    if (!json.success) {
+                        warnFail('not_success');
+                        commentsResult = failedMeta;
+                    } else {
+                        const data = json.data;
+                        const items = data.comments || [];
+                        const total = data.total || items.length;
+                        commentsResult = {
+                            items,
+                            total,
+                            page: data.page || 1,
+                            limit: data.limit || initialCommentsLimit,
+                            total_pages: data.total_pages || 1,
+                            loadState: (items.length >= total ? 'complete' : 'partial') as
+                                | 'complete'
+                                | 'partial'
+                                | 'failed',
+                            edit_policy: json.meta?.comment_edit_policy as
+                                | { cost: number; grace_seconds: number }
+                                | undefined
+                        };
+                    }
+                }
+            } catch {
+                warnFail('timeout_or_network');
+                commentsResult = failedMeta;
+            }
 
             const comments = commentsResult;
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -350,10 +350,12 @@ export const load: PageServerLoad = async ({
                 edit_policy?: { cost: number; grace_seconds: number };
             };
             try {
-                // post fetch 와 동일하게 timeout 부여 — 무제한 대기로 SSR 본문이 블로킹되는 것 방지.
+                // svelteKitFetch 는 표준 platform fetch(timeout 옵션 미지원)이므로 AbortSignal.timeout
+                // 으로 2.5s 상한을 건다 — 무제한 대기로 SSR 본문이 블로킹되는 것 방지(초과 시
+                // AbortError → 아래 catch → failedMeta 로 일관 처리).
                 const res = await svelteKitFetch(
                     `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=${initialCommentsLimit}`,
-                    { timeout: 2_500 }
+                    { signal: AbortSignal.timeout(2_500) }
                 );
                 if (!res.ok) {
                     warnFail('http_error', res.status);

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -337,7 +337,16 @@
 
     // 댓글/프로모션/리비전 — Streaming SSR (2단계 데이터)
     let comments = $state<FreeComment[]>(data.commentsData?.comments.items || []);
-    let commentsTotal = $state<number>(data.commentsData?.comments.total || comments.length);
+    // total 은 SSR 가 권위값(post.comments_count)을 보존하므로 그대로 신뢰. 구버전/누락 방어로 post.comments_count 폴백.
+    let commentsTotal = $state<number>(
+        data.commentsData?.comments.total ?? data.post.comments_count ?? comments.length
+    );
+    // SSR 댓글 로드 상태: complete(전량/정상 0개) | partial(일부) | failed(SSR fetch 실패).
+    // backfill 게이트가 total<=loaded 산술(0/0 함정) 대신 이 신호에 기반 (#12663·#12668).
+    let commentsLoadState = $state<'complete' | 'partial' | 'failed'>(
+        data.commentsData?.comments.loadState ??
+            (commentsTotal > comments.length ? 'partial' : 'complete')
+    );
     // 댓글 수정 정책 — backend 단일 출처. proxy 응답의 meta.comment_edit_policy 에서 전달.
     let commentEditPolicy = $state<{ cost: number; grace_seconds: number } | undefined>(
         data.commentsData?.comments.edit_policy
@@ -371,7 +380,10 @@
         syncedCommentsPostId = postId;
 
         comments = result?.comments.items || [];
-        commentsTotal = result?.comments.total || comments.length;
+        commentsTotal = result?.comments.total ?? data.post.comments_count ?? comments.length;
+        commentsLoadState =
+            result?.comments.loadState ??
+            (commentsTotal > comments.length ? 'partial' : 'complete');
         initialLikedCommentIds = [];
         initialDislikedCommentIds = [];
         truthroomCommentMap = {};
@@ -1312,6 +1324,9 @@
             }
             comments = all;
             commentsTotal = total || all.length;
+            // 클라가 전량 로드 완료 — backfill 게이트가 재발화하지 않도록 complete 로 확정.
+            commentsLoadState = 'complete';
+            commentsError = false;
             // backfill 완료 후 앵커 스크롤 재시도 (#c_댓글ID로 접근 시)
             requestAnimationFrame(() => scheduleAnchorScroll());
         }
@@ -1341,6 +1356,10 @@
                 if (comments.length > 0 || commentsTotal === 0) return;
                 await new Promise((resolve) => setTimeout(resolve, 800 * (attempt + 1)));
             }
+            // 3회 모두 실패 + 여전히 빈 목록 → 에러/복구 UI 노출(무한 "불러오는 중" 고착 방지).
+            if (comments.length === 0 && commentsTotal > 0) {
+                commentsError = true;
+            }
         } finally {
             backfillInProgress = false;
         }
@@ -1350,11 +1369,14 @@
     // onMount 대신 $effect로 SPA 네비게이션에서도 동작하도록
     $effect(() => {
         if (!browser || !canViewSecret) return;
-        const total = commentsTotal;
+        // loadState 신호 기반(총<=로드 산술의 0/0 함정 제거, #12663·#12668):
+        // - complete: SSR 전량 로드(정상 0개 포함) → backfill 불필요.
+        // - failed 또는 목록 0개: 즉시 재시도(backfillWithRetry, 백오프 3회).
+        // - partial: 1500ms 후 나머지 페이지 채움(refetchComments 다중페이지).
+        if (commentsLoadState === 'complete') return;
         const loaded = comments.length;
-        if (total <= loaded) return;
 
-        if (loaded === 0) {
+        if (commentsLoadState === 'failed' || loaded === 0) {
             void backfillWithRetry();
             return;
         }


### PR DESCRIPTION
## 문제
게시글 상세에서 헤더는 `댓글(N)`인데 목록은 "아직 댓글이 없습니다"로 비어 보임. #12668(간헐·스크롤/새로고침하면 보임), #12663(70개 영구 미표시).

## 근본 원인
SSR 댓글 로드(`+page.server.ts`)가 내부 API fetch 실패(`!res.ok`/`!json.success`/timeout) 시 **`total: 0`을 하드코딩**해 글의 권위 있는 댓글 수(`post.comments_count`)를 파괴. 그 결과 클라(`+page.svelte`) backfill `$effect`의 게이트 `if (total <= loaded) return`이 `0 <= 0`으로 막혀 **자가복구(재페치)가 발화하지 않음** → 영구/간헐 빈 목록. `total` 필드가 "SSR이 실제 가져온 수"와 "글의 권위 댓글 수" 두 의미를 오버로딩한 게 뿌리.

## 수정 (모범사례 재설계)
- **메타 의미 분리**: `total`은 항상 권위값(post.comments_count) 보존 + 신규 `loadState`(`complete`|`partial`|`failed`) 명시.
- **backfill 게이트를 loadState 신호 기반으로** → `total<=loaded` 산술(0/0 함정) 구조적 제거. failed/0개 → 즉시 재시도, partial → 나머지 페이지 채움, complete(정상 0개 포함) → 미발화.
- **SSR 댓글 fetch에 timeout 2.5s**(`AbortSignal.timeout`) — 무제한 대기 블로킹 방지, 초과 시 일관된 failed 메타.
- **무성 실패 제거**: SSR fetch 실패를 구조적 로그(`[comments-ssr] fetch failed`)로 노출.
- backfill 3회 소진 시 에러/복구 UI 노출(무한 "불러오는 중" 방지). 정상 0개 글과 로드 실패를 구분.

## 검증
- 독립 Evaluator 에이전트 검증: 계약 일관성·total 보존·게이트 무한루프 차단·회귀(0개/비밀글/낙관적추가/200개초과)·TS 건전성 전부 PASS. (초안의 timeout 오용 1건 지적 → AbortSignal.timeout으로 교정 완료.)
- 배포 후 #12663 글(70개)/#12668 재현 글에서 목록 정상 표시 확인 필요. SSR 실패 주입 시 `[comments-ssr] fetch failed` 로그 + 클라 자가복구 확인.