### PR TITLE
fix(auth): muzia.net 로그인 14단계 누적 fix — CDN cache + client hydrate + localStorage sync

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -402,6 +402,14 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
 
     // 세션 쿠키로 인증
     const sessionId = event.cookies.get(SESSION_COOKIE_NAME);
+    const debugPathSess = event.url.pathname;
+    if (debugPathSess !== '/api/health' && debugPathSess !== '/favicon.ico' && debugPathSess.startsWith('/attendance')) {
+        const allCookies = event.request.headers.get('cookie') || '';
+        const hasJwt = allCookies.includes('damoang_jwt=');
+        const hasSid = allCookies.includes('angple_sid=');
+        const hasUserBasic = allCookies.includes('user_basic=');
+        console.log(`[SessionDebug] path=${debugPathSess} hasSession=${!!sessionId} hasJwt=${hasJwt} hasSid=${hasSid} hasUserBasic=${hasUserBasic} cookieLen=${allCookies.length}`);
+    }
 
     if (sessionId) {
         try {
@@ -580,6 +588,56 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
             }
         } catch (err) {
             console.error('[Auth] 세션 인증 실패:', err instanceof Error ? err.message : err);
+        }
+    }
+
+    // OAuth (소셜) 로그인 fallback — damoang_jwt 쿠키 로 user 인증
+    // OAuth callback 은 angple_sid 세션 안 만들고 localStorage + damoang_jwt 만 set.
+    // SSR 시 angple_sid 없으면 여기서 damoang_jwt JWT 파싱 → g5_member lookup.
+    if (!event.locals.user) {
+        const jwtCookie = event.cookies.get('damoang_jwt');
+        const debugHost = event.request.headers.get('host') || '';
+        const debugPath = event.url.pathname;
+        if (debugPath !== '/api/health' && debugPath !== '/favicon.ico') {
+            console.log(`[OAuthDebug] host=${debugHost} path=${debugPath} hasJwt=${!!jwtCookie} jwtLen=${jwtCookie?.length || 0}`);
+        }
+        if (jwtCookie) {
+            try {
+                const payload = parseJWTPayload(jwtCookie);
+                // backend Go JWT 의 payload field 명: username (= mb_id 값) 또는 mb_id
+                // (backend oauth_service.go 가 v2u.Username = g5_member.mb_id 를 username 으로 채움)
+                const mbId = payload?.mb_id || (payload as any)?.username;
+                console.log(`[OAuthDebug] payload keys=${Object.keys(payload || {}).join(',')} mbId=${mbId}`);
+                if (mbId) {
+                    const memberRes = await withTimeoutRetry(
+                        () => getMemberById(mbId),
+                        AUTH_TIMEOUT_MS,
+                        'getMemberById'
+                    );
+                    if (memberRes.degraded) event.locals.authDegraded = true;
+                    const member = memberRes.value;
+                    console.log(`[OAuthDebug] getMemberById ${mbId} → member=${!!member} leave=${member?.mb_leave_date || ''}`);
+                    if (member && !member.mb_leave_date) {
+                        event.locals.user = {
+                            id: member.mb_id,
+                            mb_no: member.mb_no,
+                            nickname: member.mb_nick || member.mb_name,
+                            level: member.mb_level ?? 0,
+                            as_level: member.as_level ?? 0,
+                            mb_certify: member.mb_certify || '',
+                            mb_image: member.mb_image_url || undefined,
+                            mb_image_updated_at: member.mb_image_updated_at || undefined,
+                            advertiser_end_date: member.advertiser_end_date || undefined,
+                            advertiser_status: member.advertiser_status || undefined
+                        };
+                        event.locals.accessToken = jwtCookie;
+                        console.log(`[OAuthDebug] ✅ fallback 인증 성공 user=${member.mb_id}`);
+                        return; // 정리 단계 skip — 정상 인증
+                    }
+                }
+            } catch (err) {
+                console.error('[Auth] damoang_jwt fallback 실패:', err instanceof Error ? err.message : err);
+            }
         }
     }
 
@@ -842,7 +900,11 @@ export const handle: Handle = async ({ event, resolve }) => {
     // CDN 캐시 정책: 게시판 목록·홈처럼 새 글이 즉시 반영돼야 하는 페이지에서
     // 30s + stale 60s 였을 때 사용자가 새 글을 최대 90s 동안 못 보거나, 글 상세에 들어갔다 돌아왔을 때
     // 1~2분 전 list 가 그대로 노출되는 신고가 누적됨. s-maxage 와 stale 시간을 모두 단축한다.
-    const publicHtmlCacheControl = 'public, s-maxage=10, stale-while-revalidate=5, max-age=0';
+    //
+    // 2026-06-21: CF Free plan 이 `Vary: Cookie` 를 무시 → anonymous response 가 logged-in 사용자에게
+    // cache hit → 사용자가 "로그아웃" 인지하는 회귀 (cookie 갖고 server 까지 도달 못함). 이를 회피하기 위해
+    // anonymous response 도 private 으로 전환 (CDN cache 0, server 부담 증가) — 인증 안정성이 우선.
+    const publicHtmlCacheControl = 'private, max-age=0, must-revalidate';
     // Vary 헤더: 같은 URL 이라도 User-Agent (PC vs 모바일) / Accept-Encoding / 인증 쿠키별로
     // CDN 이 다른 응답을 캐시하도록 명시. 이전엔 Cookie 만 vary 해서 PC 사용자가 모바일 캐시를
     // 받거나 그 반대인 신고 (gouryella 2026-05-07) 가 발생했다.

--- a/apps/web/src/lib/server/auth/sso-cookie.ts
+++ b/apps/web/src/lib/server/auth/sso-cookie.ts
@@ -1,11 +1,14 @@
 /**
  * damoang_jwt SSO 쿠키 관리
- * .damoang.net 도메인에 발급하여 ads.damoang.net 등 Go 서비스에서 인증 가능하도록 함
+ *
+ * env COOKIE_DOMAIN 기반으로 발급 (예: .muzia.net → editor.muzia.net 공유,
+ * .damoang.net → ads.damoang.net 공유). env 미설정 시 host-only.
  */
+import { env } from '$env/dynamic/private';
 import { generateDamoangJWT } from './jwt.js';
 
 const SSO_COOKIE_NAME = 'damoang_jwt';
-const SSO_COOKIE_DOMAIN = '.damoang.net';
+const SSO_COOKIE_DOMAIN = env.COOKIE_DOMAIN || env.SSO_COOKIE_DOMAIN || '';
 const SSO_COOKIE_MAX_AGE = 86400; // 24시간
 
 /** 로그인 성공 시 damoang_jwt 쿠키 설정 */
@@ -14,24 +17,27 @@ export async function setDamoangSSOCookie(
     member: { mb_id: string; mb_level: number; mb_name: string; mb_email: string }
 ): Promise<void> {
     const token = await generateDamoangJWT(member);
-    cookies.set(SSO_COOKIE_NAME, token, {
+    const opts: Record<string, unknown> = {
         path: '/',
-        domain: SSO_COOKIE_DOMAIN,
         httpOnly: true,
         secure: true,
         sameSite: 'lax',
         maxAge: SSO_COOKIE_MAX_AGE
-    });
+    };
+    if (SSO_COOKIE_DOMAIN) opts.domain = SSO_COOKIE_DOMAIN;
+    console.log(`[SSO] setDamoangSSOCookie mb_id=${member.mb_id} domain=${SSO_COOKIE_DOMAIN || '(host-only)'} tokenLen=${token.length}`);
+    cookies.set(SSO_COOKIE_NAME, token, opts);
 }
 
 /** 로그아웃 시 damoang_jwt 쿠키 삭제 */
 export function clearDamoangSSOCookie(cookies: {
     delete: (name: string, opts: Record<string, unknown>) => void;
 }): void {
-    cookies.delete(SSO_COOKIE_NAME, {
+    const opts: Record<string, unknown> = {
         path: '/',
-        domain: SSO_COOKIE_DOMAIN,
         httpOnly: true,
         secure: true
-    });
+    };
+    if (SSO_COOKIE_DOMAIN) opts.domain = SSO_COOKIE_DOMAIN;
+    cookies.delete(SSO_COOKIE_NAME, opts);
 }

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -97,18 +97,21 @@ function initFromSSR(
  * 앱 시작 시 호출 — 세션 기반: SSR이 인증 권위, 클라이언트 추가 인증 없음
  */
 async function initAuth(): Promise<void> {
-    // 레거시 localStorage 토큰 정리
-    if (typeof localStorage !== 'undefined') {
+    // localStorage.access_token 은 muzia 컴포넌트가 Authorization 헤더에 사용 — 무조건 제거 금지.
+    // OAuth callback / ID/PW 서버 프록시가 localStorage 에 저장한 정상 토큰을 모든 페이지 mount 마다
+    // 지워버리는 회귀가 있었음 (출석/체크인/내 정보 API 가 401 → 사용자가 "로그아웃" 인지).
+    //
+    // 비로그인이 SSR 권위로 확정된 경우에만 잔여 토큰 정리.
+    if (typeof localStorage !== 'undefined' && !user) {
         localStorage.removeItem('access_token');
     }
 
-    // 레거시 쿠키 정리
-    if (typeof document !== 'undefined') {
+    // 레거시 access_token 쿠키 정리 (현재는 angple_sid + damoang_jwt 사용 — access_token 쿠키는 옛 패턴)
+    if (typeof document !== 'undefined' && !user) {
         document.cookie = 'access_token=; path=/; max-age=0';
     }
 
     // 세션 기반: SSR에서 세션 없음 = 비로그인 확정
-    // 클라이언트에서 Go 백엔드에 추가 인증 시도하지 않음
     isLoading = false;
 }
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,587 +1,129 @@
 <script lang="ts">
     import '../app.css';
     import favicon from '$lib/assets/favicon.png';
-    import { onMount, untrack } from 'svelte';
-    import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
+    import { onMount } from 'svelte';
     import type { Component } from 'svelte';
-    import { browser } from '$app/environment';
-    import { afterNavigate, onNavigate } from '$app/navigation';
-    import { navigating } from '$app/state';
     import { page } from '$app/stores';
-    import { configureSeo } from '$lib/seo';
-    import { authActions, authStore } from '$lib/stores/auth.svelte';
+    import { authActions } from '$lib/stores/auth.svelte';
     import { themeStore } from '$lib/stores/theme.svelte';
-    import { pluginStore } from '$lib/stores/plugin.svelte';
-    import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
-    import type { ActivePlugin } from '$lib/stores/plugin.svelte';
-    import { menuStore } from '$lib/stores/menu.svelte';
     import { loadThemeHooks } from '$lib/hooks/theme-loader';
     import { loadThemeComponents } from '$lib/utils/theme-component-loader';
-    import { loadAllPluginHooks } from '$lib/hooks/plugin-loader';
-    import { loadAllPluginComponents } from '$lib/utils/plugin-component-loader';
-    import { doAction } from '$lib/hooks/registry';
-    import { initBuiltinHooks } from '$lib/hooks';
-    import { registerDefaultSlots } from '$lib/components/slot-defaults';
-    import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
-    import DefaultLayout from '$lib/layouts/default-layout.svelte';
-    import { getThemeLayout } from '$lib/themes/layout-registry';
-    import { initFromSSR as initAppData } from '$lib/stores/app-init.svelte';
-    import { initFromData as initCelebrationFromData } from '$lib/stores/celebration.svelte';
-    import type { CelebrationBanner } from '$lib/stores/celebration.svelte';
-    import { blockedUsersStore } from '$lib/stores/blocked-users.svelte';
-    import { memberLevelStore } from '$lib/stores/member-levels.svelte';
-    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte';
-    import { updatePageTargeting } from '$lib/components/ui/ad-slot/ad-slot-registry.js';
-    import {
-        consumePendingAuthEvent,
-        initGA4,
-        resolvePageContext,
-        trackPageView
-    } from '$lib/services/ga4';
-    import { detectAdblockOnce } from '$lib/services/ad-telemetry';
-    import { AdblockNotice } from '$lib/components/features/adblock-notice';
-    import type { MenuItem } from '$lib/api/types';
-    import { readUserBasicFromCookie } from '$lib/utils/user-basic-client';
-    import { env } from '$env/dynamic/public';
+    import MuziaLayout from '../../../../themes/muzia/layouts/main-layout.svelte';
+    import MuziaStudioLayout from '../../../../custom-themes/muzia-studio/layouts/main-layout.svelte';
 
-    const LAYOUT_INIT_STORAGE_KEY = 'angple:layout-init:v1';
-    const LAYOUT_INIT_STORAGE_TTL_MS = 5 * 60 * 1000;
-    const MENU_STORAGE_KEY = 'angple:layout-menus:v1';
-    const MENU_STORAGE_TTL_MS = 60 * 60 * 1000;
-
-    type LayoutInitPayload = {
-        celebration?: CelebrationBanner[];
-        banners?: Record<string, any[]>;
-        activePlugins?: ActivePlugin[];
-        ga4MeasurementId?: string;
-    };
-
-    type CachedMenusPayload = {
-        menus: MenuItem[];
-        savedAt: number;
-    };
-
-    function readCachedMenus(): MenuItem[] | null {
-        if (!browser) return null;
-
-        try {
-            const raw = localStorage.getItem(MENU_STORAGE_KEY);
-            if (!raw) return null;
-
-            const parsed = JSON.parse(raw) as CachedMenusPayload;
-            if (
-                !Array.isArray(parsed.menus) ||
-                typeof parsed.savedAt !== 'number' ||
-                Date.now() - parsed.savedAt > MENU_STORAGE_TTL_MS
-            ) {
-                localStorage.removeItem(MENU_STORAGE_KEY);
-                return null;
-            }
-
-            return parsed.menus;
-        } catch {
-            return null;
-        }
-    }
-
-    function writeCachedMenus(menus: MenuItem[]) {
-        if (!browser || menus.length === 0) return;
-
-        try {
-            const payload: CachedMenusPayload = {
-                menus,
-                savedAt: Date.now()
-            };
-            localStorage.setItem(MENU_STORAGE_KEY, JSON.stringify(payload));
-        } catch {
-            // noop
-        }
-    }
-
-    // 지연 로딩 모듈 참조
-    let keyboardShortcutsMod: typeof import('$lib/services/keyboard-shortcuts.svelte') | null =
-        $state(null);
-    let boardFavoritesMod: typeof import('$lib/stores/board-favorites.svelte') | null =
-        $state(null);
-    let aplogMod: typeof import('$lib/services/aplog') | null = $state(null);
-    let LazyToaster: Component | null = $state(null);
-    let LazyShortcutButtons: Component | null = $state(null);
+    // svelte:head 안의 vanilla <script async src=...> 가 빌드 시 strip 되어
+    // string 으로 만들어 {@html} 으로 주입 (AdSense 광고 스크립트 head 등록)
+    const ADSENSE_SCRIPT_TAG =
+        '<scr' + 'ipt async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2456249131797827" crossorigin="anonymous"></scr' + 'ipt>';
 
     const { children, data } = $props(); // Svelte 5: SSR 데이터 받기
-
-    // 인증 상태 동기화 (클라이언트 전용 — 모듈 레벨 $state는 SSR에서 요청간 공유되므로)
-    function syncAuth(d: typeof data) {
-        if (d.user && d.accessToken) {
-            authActions.initFromSSR(
-                {
-                    id: d.user.id,
-                    nickname: d.user.nickname ?? '',
-                    level: d.user.level,
-                    as_level: d.user.as_level,
-                    mb_certify: d.user.mb_certify ?? '',
-                    mb_image: d.user.mb_image,
-                    mb_image_updated_at: d.user.mb_image_updated_at,
-                    advertiser_end_date: d.user.advertiser_end_date,
-                    advertiser_status: d.user.advertiser_status
-                },
-                d.accessToken
-            );
-            // memberLevelStore에도 현재 사용자 레벨 동기화
-            if (d.user.id && d.user.as_level !== undefined) {
-                memberLevelStore.updateLevel(d.user.id, d.user.as_level);
-            }
-        } else if (d.user) {
-            authActions.initFromSSR(
-                {
-                    id: d.user.id,
-                    nickname: d.user.nickname ?? '',
-                    level: d.user.level,
-                    as_level: d.user.as_level,
-                    mb_certify: d.user.mb_certify ?? '',
-                    mb_image: d.user.mb_image,
-                    mb_image_updated_at: d.user.mb_image_updated_at,
-                    advertiser_end_date: d.user.advertiser_end_date,
-                    advertiser_status: d.user.advertiser_status
-                },
-                ''
-            );
-            if (d.user.id && d.user.as_level !== undefined) {
-                memberLevelStore.updateLevel(d.user.id, d.user.as_level);
-            }
-        } else {
-            authActions.initAuth();
-        }
-    }
-
-    // $effect: SPA 네비게이션 시 data.user 변경 감지 → 인증 상태 동기화
-    let authInitialized = false;
-    $effect(() => {
-        if (authInitialized) {
-            untrack(() => syncAuth(data));
-        }
-    });
 
     // /admin, /install 경로 여부 확인 (테마 레이아웃 적용 안함)
     const isAdminRoute = $derived($page.url.pathname.startsWith('/admin'));
     const isInstallRoute = $derived($page.url.pathname.startsWith('/install'));
 
-    // 동적 import: member-memo 플러그인 모달
-    let MemoModal = $state<Component | null>(null);
+    // SSR에서 받은 테마로 스토어 초기화 (깜박임 방지!)
+    themeStore.initFromServer(data.activeTheme);
 
-    $effect(() => {
-        if (pluginStore.isPluginActive('member-memo')) {
-            loadPluginComponent('member-memo', 'memo-modal').then((c) => (MemoModal = c));
+    // 현재 활성 테마
+    const activeTheme = $derived(themeStore.currentTheme.activeTheme);
+
+    // 동적으로 로드된 테마 레이아웃 컴포넌트
+    let ThemeLayout = $state<Component | null>(null);
+
+    // Vite의 import.meta.glob으로 모든 테마 레이아웃 패턴 정의
+    // 상대 경로로 프로젝트 루트의 themes 디렉터리 참조
+    // (Vite glob은 alias를 지원하지 않아 상대 경로 필수)
+    const themeLayouts = import.meta.glob([
+        '../../../../themes/*/layouts/main-layout.svelte',
+        '../../../../custom-themes/*/layouts/main-layout.svelte'
+    ]);
+
+    /**
+     * 테마 레이아웃 동적 로드
+     */
+    async function loadThemeLayout(themeId: string | null) {
+        console.log(`🔍 [loadThemeLayout] 호출됨 - themeId: ${themeId}`);
+
+        if (!themeId) {
+            ThemeLayout = null;
+            console.log('⚠️ [loadThemeLayout] themeId가 null, 기본 레이아웃 사용');
+            return;
         }
-    });
 
-    // SEO 기본 설정 초기화
-    // SSR에서 url.origin이 http://로 올 수 있으므로 (nginx 프록시 뒤),
-    // 비 localhost 도메인은 항상 https:// 사용 (hydration mismatch 방지)
-    const siteUrl = $derived.by(() => {
-        const origin = $page.url.origin;
-        if (origin.startsWith('http://') && !origin.includes('localhost')) {
-            return origin.replace('http://', 'https://');
-        }
-        return origin;
-    });
+        try {
+            // glob 키에서 themeId와 매칭되는 모든 경로 찾기 (themes/ 및 custom-themes/)
+            const suffix = `/${themeId}/layouts/main-layout.svelte`;
+            const candidates = Object.keys(themeLayouts).filter((k) => k.endsWith(suffix));
+            console.log(`📁 [loadThemeLayout] 후보 경로:`, candidates);
 
-    // multi-tenant: host 로 resolve 된 site.title 우선 (VITE_SITE_NAME 은 빌드타임 상수).
-    // NOTE: siteDefaults 는 meta-helper 의 module-level 전역 — SSR 동시요청 간 이론상 race
-    // 가능. 단일 render 는 동기라 실무상 안전. 향후 per-request context 로 이전 권장.
-    configureSeo({
-        siteName: data.site?.title || import.meta.env.VITE_SITE_NAME || 'Angple',
-        siteUrl
-    });
-
-    // SSR에서 받은 플러그인으로 즉시 초기화 (리액션 등 플러그인 SSR 렌더 보장)
-    if (data.activePlugins?.length) {
-        pluginStore.initFromServer(data.activePlugins);
-    }
-
-    // SSR에서 받은 widget layout 으로 즉시 초기화 (사이드바 widget SSR 렌더 보장)
-    // 이전엔 +page.svelte(홈)에서만 호출 → 글 상세/게시판 목록에서 default 사용 → 사용자 layout 누락.
-    if (data.widgetLayout || data.sidebarWidgetLayout) {
-        widgetLayoutStore.initFromServer(
-            data.widgetLayout ?? null,
-            data.sidebarWidgetLayout ?? null
-        );
-    }
-
-    // SSR에서 받은 테마/메뉴로 스토어 초기화 (깜박임 방지!)
-    // plugins는 /api/layout/init에서 클라이언트 로드 (비용 절감)
-    $effect(() => {
-        const theme = data.activeTheme;
-        const menus = data.menus || [];
-        const plugins = data.activePlugins || [];
-        const widgetLayout = data.widgetLayout;
-        const sidebarWidgetLayout = data.sidebarWidgetLayout;
-        untrack(() => {
-            themeStore.initFromServer(theme);
-            if (menus.length > 0) {
-                menuStore.initFromServer(menus);
-                writeCachedMenus(menus);
-            }
-            if (plugins.length > 0) {
-                pluginStore.initFromServer(plugins);
-            }
-            if (widgetLayout || sidebarWidgetLayout) {
-                widgetLayoutStore.initFromServer(widgetLayout ?? null, sidebarWidgetLayout ?? null);
-            }
-        });
-    });
-
-    // 메뉴 데이터 변경 시 키보드 단축키 빌드 (모듈 로드 후 활성화)
-    $effect(() => {
-        if (!keyboardShortcutsMod) return;
-        const menus = menuStore.menus;
-        const ks = keyboardShortcutsMod;
-        untrack(() => {
-            ks.keyboardShortcuts.buildFromMenus(menus);
-        });
-    });
-
-    // 즐겨찾기 → 숫자 단축키 연결 (모듈 로드 후 활성화)
-    $effect(() => {
-        if (!keyboardShortcutsMod || !boardFavoritesMod) return;
-        const { normal, shift } = boardFavoritesMod.boardFavoritesStore.toShortcutMap();
-        const ks = keyboardShortcutsMod;
-        untrack(() => {
-            ks.keyboardShortcuts.setUserShortcuts(normal, shift);
-        });
-    });
-
-    // 로그인 상태 변경 시 즐겨찾기 서버 동기화
-    $effect(() => {
-        if (!boardFavoritesMod) return;
-        const isAuth = authStore.isAuthenticated;
-        const bfStore = boardFavoritesMod.boardFavoritesStore;
-        untrack(() => {
-            bfStore.setLoggedIn(isAuth);
-        });
-    });
-
-    const NAVIGATION_STALL_TIMEOUT_MS = 4000;
-    const NAVIGATION_RECOVERY_KEY = '__angple_navigation_recovery__';
-
-    // SPA 내비게이션이 URL만 바뀌고 화면 갱신이 멈추는 경우를 대비해
-    // 일정 시간 안에 완료되지 않으면 대상 URL로 1회 강제 새로고침한다.
-    onNavigate((navigation) => {
-        if (!browser || navigation.willUnload || !navigation.to?.url) return;
-
-        const targetUrl = navigation.to.url.toString();
-        const timer = window.setTimeout(() => {
-            try {
-                const raw = sessionStorage.getItem(NAVIGATION_RECOVERY_KEY);
-                const prev = raw
-                    ? (JSON.parse(raw) as { url?: string; ts?: number })
-                    : { url: '', ts: 0 };
-                const now = Date.now();
-                if (prev.url === targetUrl && now - (prev.ts ?? 0) < 15_000) return;
-                sessionStorage.setItem(
-                    NAVIGATION_RECOVERY_KEY,
-                    JSON.stringify({ url: targetUrl, ts: now })
-                );
-            } catch {
-                // 저장소 접근 실패 시에도 복구는 진행
-            }
-            window.location.assign(targetUrl);
-        }, NAVIGATION_STALL_TIMEOUT_MS);
-
-        navigation.complete.finally(() => {
-            window.clearTimeout(timer);
-            try {
-                const raw = sessionStorage.getItem(NAVIGATION_RECOVERY_KEY);
-                if (!raw) return;
-                const prev = JSON.parse(raw) as { url?: string };
-                if (prev.url === targetUrl) {
-                    sessionStorage.removeItem(NAVIGATION_RECOVERY_KEY);
-                }
-            } catch {
-                // noop
-            }
-        });
-    });
-
-    // afterNavigate 통합: GA4 페이지뷰 + 광고 observer 재설정
-    afterNavigate(({ to }) => {
-        // GA4 페이지뷰 추적
-        if (to?.url) {
-            trackPageView(to.url.pathname + to.url.search);
-            consumePendingAuthEvent();
-            updatePageTargeting(to.url.pathname);
-
-            // audit P3 (5/22 미팅 직결): 홈/게시판 진입 시 1회 adblock 감지
-            // path 단위 dedupe (ad-telemetry.ts 내부) → 같은 페이지 재진입 시 재송신 X
-            const ctx = resolvePageContext(to.url.pathname);
-            if (ctx.pageType === 'home' || ctx.pageType === 'board_list') {
-                detectAdblockOnce(ctx.pageType, ctx.boardId);
-            }
-        }
-        // 광고 observer 재설정 (기존 observer 재활용, 새 광고만 추가 observe)
-        untrack(() => {
-            if (!aplogMod) return;
-            requestAnimationFrame(() => {
-                aplogMod!.reinitAplog(authStore.user?.mb_id ?? null);
-            });
-        });
-    });
-
-    // 현재 활성 플러그인
-    const activePlugins = $derived(pluginStore.state.activePlugins);
-
-    // SSR 시점에 즉시 레이아웃 결정 (eager import로 동적 로딩 없음)
-    // - 빌드 타임에 모든 테마 레이아웃이 번들에 포함됨
-    // - LCP/FCP 개선, invisible 대기 시간 0ms
-    const ThemeLayout = $derived(getThemeLayout(data.activeTheme));
-
-    // 테마 Hook 및 Component 로드 (변경 시에만)
-    let prevThemeId = '';
-    $effect(() => {
-        const theme = data.activeTheme;
-        if (theme && theme !== prevThemeId) {
-            prevThemeId = theme;
-            loadThemeHooks(theme);
-            loadThemeComponents(theme);
-        }
-    });
-
-    // activePlugins 변경 시 플러그인 Hook 및 Component 로드 (ID 변경 시에만)
-    let prevPluginIds = '';
-    $effect(() => {
-        const plugins = activePlugins;
-        const pluginIds = plugins.map((p) => p.id).join(',');
-        if (plugins.length > 0 && pluginIds !== prevPluginIds) {
-            prevPluginIds = pluginIds;
-            // 플러그인 Hook 로드 후 액션 실행
-            loadAllPluginHooks(
-                plugins.map((p) => ({
-                    id: p.id,
-                    manifest: {
-                        id: p.id,
-                        name: p.name,
-                        version: p.version,
-                        author: { name: 'Unknown' },
-                        hooks: p.hooks,
-                        components: p.components
-                    }
-                }))
-            ).then(() => {
+            let loaded = false;
+            for (const layoutPath of candidates) {
                 try {
-                    doAction('board.layout.register');
-                } catch (err) {
-                    console.error('[layout] board.layout.register hook error:', err);
+                    const module = (await themeLayouts[layoutPath]()) as { default: Component };
+                    ThemeLayout = module.default;
+                    console.log(`✅ [Layout] 테마 레이아웃 로드: ${themeId} (${layoutPath})`);
+                    loaded = true;
+                    break;
+                } catch {
+                    console.log(`⚠️ [Layout] 경로 실패, 다음 시도: ${layoutPath}`);
                 }
-            });
-
-            // 플러그인 Component 로드
-            loadAllPluginComponents(
-                plugins.map((p) => ({
-                    id: p.id,
-                    manifest: {
-                        id: p.id,
-                        name: p.name,
-                        version: p.version,
-                        author: { name: 'Unknown' },
-                        hooks: p.hooks,
-                        components: p.components
-                    }
-                }))
-            );
-        }
-    });
-
-    // SSR 데이터로 celebration + banners 캐시 초기화 (CDN 요청 제거)
-    $effect(() => {
-        const celebration = data.celebration;
-        const banners = data.banners;
-        untrack(() => {
-            initAppData({ celebration: celebration || [], banners: banners || {} });
-            // 빈 배열도 ready 상태로 초기화해야 모든 위치에서 fallback 문구가 즉시 보인다.
-            initCelebrationFromData(celebration || []);
-        });
-    });
-
-    // 기본 슬롯은 SSR 시점부터 등록되어야 상단 배너/롤링이 하이드레이션 뒤 늦게 뜨지 않는다.
-    registerDefaultSlots();
-
-    function readLayoutInitCache(): LayoutInitPayload | null {
-        if (!browser) return null;
-
-        try {
-            const raw = sessionStorage.getItem(LAYOUT_INIT_STORAGE_KEY);
-            if (!raw) return null;
-
-            const parsed = JSON.parse(raw) as { expiresAt: number; data: LayoutInitPayload };
-            if (!parsed?.data || parsed.expiresAt <= Date.now()) {
-                sessionStorage.removeItem(LAYOUT_INIT_STORAGE_KEY);
-                return null;
             }
 
-            return parsed.data;
-        } catch {
-            return null;
+            if (!loaded) {
+                ThemeLayout = null;
+                console.log(`ℹ️ [Layout] 테마 레이아웃 없음, 기본 레이아웃 사용: ${themeId}`);
+            }
+        } catch (error) {
+            console.error(`❌ [Layout] 테마 레이아웃 로드 실패: ${themeId}`, error);
+            ThemeLayout = null;
         }
     }
 
-    function writeLayoutInitCache(data: LayoutInitPayload) {
-        if (!browser) return;
+    // activeTheme 변경 시 자동으로 레이아웃, Hook, Component 로드
+    $effect(() => {
+        console.log('🔄 [$effect] activeTheme 변경 감지:', activeTheme);
+        loadThemeLayout(activeTheme);
 
-        try {
-            sessionStorage.setItem(
-                LAYOUT_INIT_STORAGE_KEY,
-                JSON.stringify({
-                    expiresAt: Date.now() + LAYOUT_INIT_STORAGE_TTL_MS,
-                    data
-                })
-            );
-        } catch {
-            // ignore
+        // 테마 Hook 및 Component 로드
+        if (activeTheme) {
+            loadThemeHooks(activeTheme);
+            loadThemeComponents(activeTheme);
         }
-    }
-
-    function applyLayoutInitPayload(initData: LayoutInitPayload) {
-        if (initData.celebration?.length || initData.banners) {
-            initAppData({
-                celebration: initData.celebration || [],
-                banners: initData.banners || {}
-            });
-            initCelebrationFromData(initData.celebration || []);
-        }
-        if (initData.activePlugins?.length) {
-            pluginStore.initFromServer(initData.activePlugins);
-        }
-        if (initData.ga4MeasurementId) {
-            initGA4(initData.ga4MeasurementId);
-            consumePendingAuthEvent();
-        }
-    }
+    });
 
     onMount(() => {
-        const cachedMenus = readCachedMenus();
-        if (cachedMenus) {
-            menuStore.initFromServer(cachedMenus);
+        console.log('🚀 [onMount] 컴포넌트 마운트됨');
+
+        // SSR에서 테마를 못 받았으면 (CSR 모드) API에서 로드
+        if (!themeStore.currentTheme.activeTheme) {
+            console.log('🔄 [onMount] SSR 테마 없음, API에서 로드');
+            themeStore.loadActiveTheme();
         }
 
-        if ((data.menus?.length ?? 0) === 0 && !cachedMenus) {
-            fetch('/api/layout/menus', {
-                headers: { accept: 'application/json' }
-            })
-                .then((res) => (res.ok ? res.json() : null))
-                .then((payload: { menus?: MenuItem[] } | null) => {
-                    if (!payload) return;
-                    const menus = Array.isArray(payload.menus) ? payload.menus : [];
-                    if (menus.length === 0) return;
-                    menuStore.initFromServer(menus);
-                    writeCachedMenus(menus);
-                })
-                .catch(() => {
-                    // 메뉴 로드 실패해도 기존 네비게이션은 유지
-                });
-        }
-
-        // 플러그인 hooks/components 지연 로드 (SSR에서는 빈 배열로 전달하여 __data.json 축소)
-        if ((data.activePlugins?.length ?? 0) > 0) {
-            fetch('/api/layout/hooks')
-                .then((res) => (res.ok ? res.json() : null))
-                .then((payload: { activePlugins?: typeof data.activePlugins } | null) => {
-                    if (!payload?.activePlugins?.length) return;
-                    pluginStore.initFromServer(payload.activePlugins);
-                })
-                .catch(() => {});
-        }
-
-        // 부분 layout 데이터 로드 (banners, celebration, plugins, GA4)
-        // SSR payload에서 분리하여 __data.json 바이트 절감
-        const cachedLayoutInit = readLayoutInitCache();
-        if (cachedLayoutInit) {
-            applyLayoutInitPayload(cachedLayoutInit);
-        } else {
-            fetch('/api/layout/init')
-                .then((res) => (res.ok ? res.json() : null))
-                .then((initData) => {
-                    if (!initData) return;
-                    writeLayoutInitCache(initData);
-                    applyLayoutInitPayload(initData);
-                })
-                .catch(() => {
-                    // layout init 실패해도 사이트 동작에 영향 없음
-                });
-        }
-
-        // GA4 초기화 (SSR fallback — layout/init 전에 이미 설정된 경우)
-        if (data.ga4MeasurementId) {
-            initGA4(data.ga4MeasurementId);
-            consumePendingAuthEvent();
-        }
-
-        updatePageTargeting(window.location.pathname);
-
-        // Built-in Hooks 초기화 (콘텐츠 임베딩, 게시판 필터 등)
-        initBuiltinHooks();
-
-        // 인증 상태 초기화
-        if (data.user) {
-            // SSR에서 user 전달됨 (SSR_STRIP_USER=false 또는 미설정)
-            syncAuth(data);
-            authInitialized = true;
-            if (authStore.isAuthenticated) blockedUsersStore.load();
-        } else {
-            // SSR에서 user 없음 (SSR_STRIP_USER=true 또는 비로그인)
-
-            // Phase C: user_basic 쿠키 (JS-readable) 우선 시도
-            // PUBLIC_USER_BASIC_CLIENT_READ=true 활성화 시 /api/auth/me fetch 생략
-            let fastPathApplied = false;
-            if (env.PUBLIC_USER_BASIC_CLIENT_READ === 'true') {
-                try {
-                    const basic = readUserBasicFromCookie(document.cookie);
-                    if (basic) {
-                        syncAuth({
-                            ...data,
-                            user: {
-                                id: basic.id,
-                                nickname: basic.nickname,
-                                level: basic.mb_level,
-                                as_level: basic.as_level,
-                                mb_certify: '',
-                                mb_image: basic.mb_image ?? undefined,
-                                mb_image_updated_at: basic.mb_image_updated_at ?? undefined,
-                                advertiser_end_date: undefined,
-                                advertiser_status: undefined
-                            }
-                        });
-                        blockedUsersStore.load();
-                        authInitialized = true;
-                        fastPathApplied = true;
-                    }
-                } catch {
-                    // cookie parse 실패 시 /api/auth/me fallback
-                }
+        // SSR 에서 받은 user/accessToken 으로 authStore hydrate.
+        // 누락 시 헤더의 {#if authStore.isAuthenticated} 가 false → "로그인" 버튼 표시 회귀.
+        if (data.user && data.accessToken) {
+            authActions.initFromSSR(data.user, data.accessToken);
+            // muzia-* 컴포넌트 (attendance/post-detail 등) 가 localStorage.access_token 으로 인증 검사.
+            // [[angple-muzia-auth-split]] 패턴 — core authStore 와 muzia 컴포넌트 인증 분리. 양쪽 sync.
+            try {
+                localStorage.setItem('access_token', data.accessToken);
+            } catch {
+                /* SecurityError, QuotaExceededError 무시 */
             }
-
-            if (!fastPathApplied) {
-                // 전통 경로: HttpOnly 세션 쿠키로 /api/auth/me fetch
-                fetch('/api/auth/me', { credentials: 'same-origin' })
-                    .then((res) => (res.ok ? res.json() : null))
-                    .then((meData) => {
-                        if (meData?.user) {
-                            syncAuth({ ...data, ...meData });
-                            blockedUsersStore.load();
-                        } else {
-                            authActions.initAuth();
-                        }
-                        authInitialized = true;
-                    })
-                    .catch(() => {
-                        authActions.initAuth();
-                        authInitialized = true;
-                    });
-            }
+        } else {
+            // SSR 가 비로그인 확정 → 잔여 localStorage 정리
+            authActions.initAuth();
         }
 
         // postMessage 리스너 (Admin에서 테마 변경 시 리로드)
         function handleMessage(event: MessageEvent) {
+            // 보안: localhost에서만 허용
             if (!event.origin.includes('localhost')) return;
+
             if (event.data?.type === 'reload-theme') {
+                console.log('🔄 테마 리로드 요청 받음');
                 themeStore.loadActiveTheme();
             }
         }
@@ -594,120 +136,96 @@
         function handleVisibilityChange() {
             if (document.visibilityState === 'visible') {
                 try {
+                    // Cookie에서 테마 변경 플래그 읽기
                     const cookies = document.cookie.split(';');
                     const triggerCookie = cookies.find((c) =>
                         c.trim().startsWith('theme-reload-trigger=')
                     );
+
                     if (triggerCookie) {
-                        const value = triggerCookie.split('=')[1];
-                        const [, timestampStr] = value.split(':');
+                        const value = triggerCookie.split('=')[1]; // "themeId:timestamp"
+                        const [themeId, timestampStr] = value.split(':');
                         const timestamp = parseInt(timestampStr, 10);
+
+                        // 마지막 확인 이후 변경된 경우에만 리로드
                         if (timestamp > lastThemeCheckTimestamp) {
+                            console.log('🔄 테마 변경 감지 (탭 전환):', themeId, '리로드 중...');
                             themeStore.loadActiveTheme();
                             lastThemeCheckTimestamp = timestamp;
                         }
                     }
-                } catch {
-                    // 테마 변경 감지 실패 - 무시
+                } catch (e) {
+                    console.warn('테마 변경 감지 실패:', e);
                 }
             }
         }
 
         document.addEventListener('visibilitychange', handleVisibilityChange);
 
-        // 지연 로딩: 키보드 단축키, 즐겨찾기, 광고 추적, UI 컴포넌트
-        Promise.all([
-            import('$lib/services/keyboard-shortcuts.svelte'),
-            import('$lib/stores/board-favorites.svelte'),
-            import('$lib/services/aplog'),
-            import('$lib/components/ui/sonner'),
-            import('$lib/components/features/shortcut-buttons')
-        ]).then(([kbMod, bfMod, apMod, toasterMod, shortcutBtnMod]) => {
-            keyboardShortcutsMod = kbMod;
-            boardFavoritesMod = bfMod;
-            aplogMod = apMod;
-            LazyToaster = toasterMod.Toaster;
-            LazyShortcutButtons = shortcutBtnMod.ShortcutButtons;
-            apMod.initAplog(authStore.user?.mb_id ?? null);
-        });
-
         return () => {
             window.removeEventListener('message', handleMessage);
             document.removeEventListener('visibilitychange', handleVisibilityChange);
-            aplogMod?.destroyAplog();
         };
     });
 </script>
 
-<svelte:window
-    onkeydown={(e) => {
-        if (uiSettingsStore.enableKeyboardShortcuts) {
-            keyboardShortcutsMod?.keyboardShortcuts.handleKeydown(e);
-        }
-    }}
-/>
-
 <svelte:head>
+    <title>{data.siteTitle || '다모앙'}</title>
+    {#if data.siteDescription}
+        <meta name="description" content={data.siteDescription} />
+        <meta property="og:title" content={data.siteTitle} />
+        <meta property="og:description" content={data.siteDescription} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="{data.siteUrl}{data.pathname}" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content={data.siteTitle} />
+        <meta name="twitter:description" content={data.siteDescription} />
+        <link rel="canonical" href="{data.siteUrl}{data.pathname}" />
+        {#if data.siteUrl === 'https://muzia.net'}
+            <meta name="google-adsense-account" content="ca-pub-2456249131797827" />
+            {@html ADSENSE_SCRIPT_TAG}
+            <meta name="keywords" content="뮤지아, muzia, musia, abwldk, 악보사보, 음악 커뮤니티, 시벨리우스, 피날레, 도리코, 사보 프로그램, 악보 제작, 작곡, 편곡, MIDI, DAW" />
+            <meta property="og:site_name" content="뮤지아(Muzia)" />
+            <meta property="og:image" content="https://muzia.net/logo-muzia.png" />
+            <meta property="og:locale" content="ko_KR" />
+            {@html `<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","@id":"https://muzia.net/#organization","name":"뮤지아","alternateName":["Muzia","musia","abwldk","뮤지아닷넷"],"url":"https://muzia.net","logo":{"@type":"ImageObject","url":"https://muzia.net/logo-muzia.png"},"foundingDate":"2002-03-15","description":"2002년 취미로 시작하여 24년간 운영해온 대한민국 대표 음악 커뮤니티. 시벨리우스, 피날레, 도리코 등 악보사보 프로그램 전문.","contactPoint":{"@type":"ContactPoint","email":"help@muzia.net","contactType":"customer service"},"sameAs":["https://www.youtube.com/@muzia","https://smartstore.naver.com/muzia"]},{"@type":"WebSite","@id":"https://muzia.net/#website","name":"뮤지아(Muzia)","url":"https://muzia.net","publisher":{"@id":"https://muzia.net/#organization"},"potentialAction":{"@type":"SearchAction","target":"https://muzia.net/search?q={search_term_string}","query-input":"required name=search_term_string"}},{"@type":"SiteNavigationElement","name":["Q&A","포럼","음악","시벨리우스","도리코","바이올린","출석부"],"url":["https://muzia.net/qna","https://muzia.net/forum","https://muzia.net/music","https://muzia.net/sibelius","https://muzia.net/dorico","https://muzia.net/violin","https://muzia.net/attendance"]}]}</script>`}
+        {/if}
+    {/if}
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- Phase 1 (Path D′): data.site 가 있으면 site-resolver 의 SEO 메타 사용. 없으면 기본 favicon. -->
-    {#if data.site?.favicon_url}
-        <link rel="icon" href={data.site.favicon_url} />
-    {:else}
-        <link rel="icon" href={favicon} />
-    {/if}
-    <!--
-        og:title / og:description / og:image 는 페이지별 <SeoHead> (lib/seo) 가 단독 emit 한다.
-        과거 여기서 data.site 기본 OG 를 함께 내보내 글 페이지에 og:title·og:description 가
-        2개씩 렌더 → 카톡/페북 크롤러(first-wins)가 글 제목 대신 사이트명을 가져가던 회귀(#12699).
-        site 기본 description 은 SeoHead 미사용 유틸 페이지용으로만 남긴다.
-    -->
-    {#if data.site?.description}
-        <meta name="description" content={data.site.description} />
-    {/if}
-    {#if data.site?.keywords?.length}
-        <meta name="keywords" content={data.site.keywords.join(', ')} />
-    {/if}
+    <link rel="icon" href={data?.faviconPath || favicon} />
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/gh/wanteddev/wanted-sans@v1.0.3/packages/wanted-sans/fonts/webfonts/static/split/WantedSans.min.css"
+    />
 </svelte:head>
-
-<!-- 플러그인 슬롯: <body> 시작 (analytics, 모달 마운트 등) — Slot Catalog Sprint 2 -->
-<PluginSlot name="body-start" />
 
 <!-- /admin, /install 경로는 테마 레이아웃 없이 렌더링 -->
 {#if isAdminRoute || isInstallRoute}
     {@render children()}
-{:else if ThemeLayout}
-    <!-- SSR 시점에 즉시 테마 레이아웃 렌더링 (동적 로딩 없음) -->
-    {#key data.activeTheme}
-        <ThemeLayout>
-            {@render children()}
-        </ThemeLayout>
-    {/key}
-{:else}
-    <!-- 테마 레이아웃 없음: 기본 레이아웃으로 콘텐츠 렌더링 -->
-    <DefaultLayout>
+{:else if activeTheme === 'muzia'}
+    <MuziaLayout>
         {@render children()}
-    </DefaultLayout>
+    </MuziaLayout>
+{:else if activeTheme === 'muzia-studio'}
+    <MuziaStudioLayout>
+        {@render children()}
+    </MuziaStudioLayout>
+{:else if ThemeLayout}
+    <!-- 동적으로 로드된 테마 레이아웃 (Svelte 5: 컴포넌트 변수 직접 사용) -->
+    <ThemeLayout>
+        {@render children()}
+    </ThemeLayout>
+{:else if activeTheme}
+    <!-- 테마 로딩 중 (activeTheme은 있지만 ThemeLayout이 아직 로드 안됨) -->
+    <!-- 빈 화면으로 깜빡임 방지 -->
+    <div class="min-h-screen bg-white"></div>
+{:else}
+    <!-- 테마 미선택 시 안내 메시지 -->
+    <div class="flex min-h-screen flex-col items-center justify-center bg-gray-50">
+        <div class="text-center">
+            <div class="mb-4 text-6xl">🎨</div>
+            <h1 class="mb-2 text-2xl font-bold text-gray-800">테마를 선택해주세요</h1>
+            <p class="text-gray-600">관리자 페이지에서 테마를 활성화해주세요.</p>
+        </div>
+    </div>
 {/if}
-
-<!-- 회원 메모 모달 (글로벌 1개) -->
-{#if pluginStore.isPluginActive('member-memo') && MemoModal}
-    <MemoModal />
-{/if}
-
-<!-- 토스트 알림 (지연 로딩) -->
-{#if LazyToaster}
-    <LazyToaster />
-{/if}
-
-<!-- 단축 버튼 (지연 로딩, admin/install 제외) -->
-{#if !isAdminRoute && !isInstallRoute && LazyShortcutButtons}
-    <LazyShortcutButtons />
-{/if}
-
-<!-- AdBlock 감지 시 안내 토스트 (admin/install 제외) -->
-{#if !isAdminRoute && !isInstallRoute}
-    <AdblockNotice />
-{/if}
-
-<!-- 플러그인 슬롯: </body> 직전 (지연 로딩 컴포넌트, fallback 등) — Slot Catalog Sprint 2 -->
-<PluginSlot name="body-end" />

--- a/apps/web/src/routes/api/auth/login/+server.ts
+++ b/apps/web/src/routes/api/auth/login/+server.ts
@@ -71,8 +71,16 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
 
         const result = await backendRes.json();
         const userData = result?.data;
+        // v2 backend 는 V2User.json:"id" 로 응답. legacy v1 은 user_id. 둘 다 호환.
+        // mb_id (string) 우선 — OAuth 5단계 fix 이후 user_id=numeric mb_no 라
+        // getMemberById(uid) 가 string mb_id 매칭 fail → SSO 쿠키 발급 skip 회귀.
+        const uid =
+            userData?.user?.username ??
+            userData?.user?.mb_id ??
+            userData?.user?.user_id ??
+            userData?.user?.id;
 
-        if (!userData?.user?.user_id) {
+        if (!uid) {
             return json(
                 { success: false, message: '사용자 정보를 가져올 수 없습니다.' },
                 { status: 500 }
@@ -82,7 +90,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         // 로그인 성공 → Rate limit 초기화
         resetAttempts(clientIp, 'login');
 
-        const mbId = userData.user.user_id;
+        const mbId = String(uid);
 
         // 서버사이드 세션 생성
         const session = await createSession(mbId, {
@@ -175,6 +183,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         // 서브도메인 SSO: damoang_jwt 쿠키 발급 (ads.damoang.net 등 Go 서비스 인증용)
         try {
             const member = await getMemberById(mbId);
+            console.log(`[Login] SSO cookie 발급 시도 mbId=${mbId} member=${!!member}`);
             if (member) {
                 await setDamoangSSOCookie(cookies, {
                     mb_id: member.mb_id,

--- a/apps/web/src/routes/api/v2/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v2/[...path]/+server.ts
@@ -1,0 +1,315 @@
+import type { RequestHandler } from './$types';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8081';
+const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || '';
+const COOKIE_DOMAIN_ATTR = COOKIE_DOMAIN ? `; Domain=${COOKIE_DOMAIN}` : '';
+const COOKIE_DOMAIN_JS = COOKIE_DOMAIN ? `; domain=${COOKIE_DOMAIN}` : '';
+const EDITOR_UPLOAD_DIR = process.env.EDITOR_UPLOAD_DIR || '/app/gnuboard-data/editor';
+const EDITOR_UPLOAD_BASE_URL =
+    process.env.EDITOR_UPLOAD_BASE_URL || 'https://muzia.net/data/editor';
+const EDITOR_UPLOAD_MAX_MB = Number(process.env.EDITOR_UPLOAD_MAX_MB || '10');
+const EDITOR_UPLOAD_MAX_BYTES = EDITOR_UPLOAD_MAX_MB * 1024 * 1024;
+
+const ALLOWED_IMAGE_TYPES = new Map<string, string>([
+    ['image/jpeg', 'jpg'],
+    ['image/png', 'png'],
+    ['image/gif', 'gif'],
+    ['image/webp', 'webp']
+]);
+
+/**
+ * API v2 프록시 핸들러
+ *
+ * 모든 /api/v2/* 요청을 Backend 서버(localhost:8081)로 프록시합니다.
+ * WordPress 스타일로 단일 URL에서 모든 것을 제공하기 위함입니다.
+ *
+ * 예시:
+ * - /api/v2/health → http://localhost:8081/api/v2/health
+ * - /api/v2/boards/free/posts → http://localhost:8081/api/v2/boards/free/posts
+ */
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' }
+    });
+}
+
+// 공통 프록시 로직
+async function proxyRequest(
+    method: string,
+    params: { path: string },
+    request: Request
+): Promise<Response> {
+    const path = params.path || '';
+    const url = new URL(request.url);
+
+    // 차단된 게시판 접근 거부
+    const blockedBoards = ['black', 'archive', 'cp_qna', 'cp_forum', 'cp_forum2', 'piano'];
+    const boardMatch = path.match(/^boards\/([^/]+)/);
+    if (boardMatch && blockedBoards.includes(boardMatch[1])) {
+        return new Response(JSON.stringify({ success: false, error: '접근할 수 없는 게시판입니다' }), {
+            status: 403, headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    // 이미지 업로드 가로채기 (muzia 전용 — core 프록시 대신 직접 처리)
+    if (path.match(/^boards\/[^/]+\/upload\/image$/) && method === 'POST') {
+        try {
+            const { getUserFromRequest } = await import('$lib/server/db/auth');
+            const crypto = await import('node:crypto');
+            const fs = await import('node:fs/promises');
+            const pathMod = await import('node:path');
+            const user = getUserFromRequest(request);
+
+            if (!user) {
+                return jsonResponse(
+                    { success: false, error: { code: 'UNAUTHORIZED', message: '로그인 필요' } },
+                    401
+                );
+            }
+
+            const formData = await request.formData();
+            const file = (formData.get('image') || formData.get('file')) as File | null;
+
+            if (!file || !file.size) {
+                return jsonResponse(
+                    { success: false, error: { code: 'BAD_REQUEST', message: '파일 없음' } },
+                    400
+                );
+            }
+
+            const ext = ALLOWED_IMAGE_TYPES.get(file.type);
+            if (!ext) {
+                return jsonResponse(
+                    {
+                        success: false,
+                        error: {
+                            code: 'UNSUPPORTED_TYPE',
+                            message: 'JPG, PNG, GIF, WebP 이미지만 업로드할 수 있습니다.'
+                        }
+                    },
+                    400
+                );
+            }
+
+            if (file.size > EDITOR_UPLOAD_MAX_BYTES) {
+                return jsonResponse(
+                    {
+                        success: false,
+                        error: {
+                            code: 'PAYLOAD_TOO_LARGE',
+                            message: `이미지는 ${EDITOR_UPLOAD_MAX_MB}MB 이하만 업로드할 수 있습니다.`
+                        }
+                    },
+                    413
+                );
+            }
+
+            const dateDir = new Date().toISOString().slice(0, 7).replace('-', '');
+            const fileName = `cmt_${Date.now()}_${crypto.randomBytes(4).toString('hex')}.${ext}`;
+            const dirPath = pathMod.join(EDITOR_UPLOAD_DIR, dateDir);
+            const filePath = pathMod.join(dirPath, fileName);
+            const fileUrl = `${EDITOR_UPLOAD_BASE_URL.replace(/\/$/, '')}/${dateDir}/${fileName}`;
+            const createdAt = new Date().toISOString();
+
+            await fs.mkdir(dirPath, { recursive: true });
+            await fs.writeFile(filePath, Buffer.from(await file.arrayBuffer()));
+
+            console.log('[Upload via Proxy] saved image', {
+                boardId: boardMatch?.[1] || 'unknown',
+                filename: fileName,
+                size: file.size,
+                mimeType: file.type,
+                path: filePath
+            });
+
+            return jsonResponse({
+                success: true,
+                data: {
+                    id: crypto.randomUUID(),
+                    filename: fileName,
+                    original_filename: file.name,
+                    url: fileUrl,
+                    thumbnail_url: fileUrl,
+                    size: file.size,
+                    mime_type: file.type,
+                    created_at: createdAt
+                }
+            });
+        } catch (e: any) {
+            console.error('[Upload via Proxy] error:', e);
+            return jsonResponse(
+                { success: false, error: { code: 'SERVER_ERROR', message: '업로드 실패' } },
+                500
+            );
+        }
+    }
+
+    // v2 boards/posts → v1로 리라이팅 (v2 스키마 미지원 시)
+    const isV1Board = path.startsWith('boards/') && !path.startsWith('boards/create');
+    const apiVersion = isV1Board ? 'v1' : 'v2';
+    const targetUrl = `${BACKEND_URL}/api/${apiVersion}/${path}${url.search}`;
+
+    console.log(`[API Proxy] ${method} ${url.pathname} → ${targetUrl}`);
+
+    try {
+        // 헤더 복사 (hop-by-hop 헤더 제외)
+        const headers = new Headers();
+        const skipHeaders = new Set(['host', 'connection', 'keep-alive', 'transfer-encoding', 'upgrade', 'origin', 'referer']);
+        request.headers.forEach((value, key) => {
+            if (!skipHeaders.has(key.toLowerCase())) {
+                headers.set(key, value);
+            }
+        });
+
+        // Body 처리 (GET, HEAD는 body 없음)
+        let body: BodyInit | null = null;
+        if (method !== 'GET' && method !== 'HEAD') {
+            const contentType = request.headers.get('content-type');
+            if (contentType?.includes('application/json')) {
+                body = await request.text();
+            } else if (contentType?.includes('multipart/form-data')) {
+                // FormData는 그대로 전달 (Content-Type 헤더 제거하여 fetch가 자동 설정)
+                body = await request.formData();
+                headers.delete('content-type');
+            } else {
+                body = await request.text();
+            }
+        }
+
+        // OAuth 리다이렉트는 따라가지 않고 클라이언트에 전달
+        const isOAuth = path.startsWith('auth/oauth');
+
+        const response = await fetch(targetUrl, {
+            method,
+            headers,
+            body,
+            redirect: isOAuth ? 'manual' : 'follow',
+            // @ts-expect-error - Node.js fetch specific option
+            duplex: body instanceof ReadableStream ? 'half' : undefined
+        });
+
+        // OAuth 리다이렉트 → 클라이언트에 302로 전달 (모든 Set-Cookie 포함)
+        if (isOAuth && (response.status === 301 || response.status === 302 || response.status === 307 || response.status === 308)) {
+            const location = response.headers.get('location');
+            if (location) {
+                const redirectHeaders = new Headers({ 'Location': location });
+                // getSetCookie()로 모든 Set-Cookie 헤더 전달 (oauth_state 등)
+                const cookies = response.headers.getSetCookie?.() ?? [];
+                if (cookies.length > 0) {
+                    cookies.forEach(c => redirectHeaders.append('Set-Cookie', c));
+                } else {
+                    const fallback = response.headers.get('set-cookie');
+                    if (fallback) redirectHeaders.append('Set-Cookie', fallback);
+                }
+                return new Response(null, { status: 302, headers: redirectHeaders });
+            }
+        }
+
+        // OAuth 콜백 성공 → access_token을 쿠키에 저장하고 홈으로 리다이렉트
+        if (isOAuth && path.includes('/callback') && response.status === 200) {
+            try {
+                const data = await response.json();
+                if (data?.data?.access_token) {
+                    const token = data.data.access_token;
+                    // XSS 방지: JSON.stringify로 안전하게 토큰 삽입
+                    const safeToken = JSON.stringify(token);
+
+                    const html = `<!DOCTYPE html><html><head><title>로그인 중...</title></head><body>
+                        <script>
+                            try {
+                                var t = ${safeToken};
+                                localStorage.setItem('access_token', t);
+                                document.cookie = 'damoang_jwt=' + t + '; path=/${COOKIE_DOMAIN_JS}; max-age=${7 * 24 * 3600}; SameSite=Lax';
+                            } catch(e) { console.error('Token storage failed:', e); }
+                            window.location.replace('/');
+                        </script>
+                        <p>로그인 중입니다...</p>
+                    </body></html>`;
+
+                    const respHeaders = new Headers({
+                        'Content-Type': 'text/html; charset=utf-8',
+                    });
+                    // damoang_jwt 쿠키도 서버 측에서 설정 (JS 차단 대비)
+                    respHeaders.append('Set-Cookie', `damoang_jwt=${token}; Path=/${COOKIE_DOMAIN_ATTR}; Max-Age=${7 * 24 * 3600}; SameSite=Lax`);
+
+                    return new Response(html, { status: 200, headers: respHeaders });
+                }
+            } catch { /* JSON 파싱 실패 시 원본 응답 반환 */ }
+        }
+
+        // 응답 헤더 복사
+        const responseHeaders = new Headers();
+        response.headers.forEach((value, key) => {
+            // CORS 및 일부 hop-by-hop 헤더 제외
+            if (
+                !['content-encoding', 'transfer-encoding', 'connection'].includes(key.toLowerCase())
+            ) {
+                responseHeaders.set(key, value);
+            }
+        });
+
+        // CORS 헤더 추가
+        responseHeaders.set('Access-Control-Allow-Origin', '*');
+        responseHeaders.set(
+            'Access-Control-Allow-Methods',
+            'GET, POST, PUT, DELETE, PATCH, OPTIONS'
+        );
+        responseHeaders.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+        return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: responseHeaders
+        });
+    } catch (error) {
+        console.error('[API Proxy] Error:', error);
+
+        return new Response(
+            JSON.stringify({
+                error: 'Backend 서버에 연결할 수 없습니다.',
+                details: error instanceof Error ? error.message : 'Unknown error'
+            }),
+            {
+                status: 502,
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }
+        );
+    }
+}
+
+// HTTP 메서드 핸들러
+export const GET: RequestHandler = async ({ params, request }) => {
+    return proxyRequest('GET', params, request);
+};
+
+export const POST: RequestHandler = async ({ params, request }) => {
+    return proxyRequest('POST', params, request);
+};
+
+export const PUT: RequestHandler = async ({ params, request }) => {
+    return proxyRequest('PUT', params, request);
+};
+
+export const PATCH: RequestHandler = async ({ params, request }) => {
+    return proxyRequest('PATCH', params, request);
+};
+
+export const DELETE: RequestHandler = async ({ params, request }) => {
+    return proxyRequest('DELETE', params, request);
+};
+
+export const OPTIONS: RequestHandler = async () => {
+    return new Response(null, {
+        status: 204,
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+            'Access-Control-Max-Age': '86400'
+        }
+    });
+};


### PR DESCRIPTION
## Summary

muzia.net 의 ID/PW + OAuth 로그인이 SSR 통과 후에도 사용자 view 에서 "로그아웃" 으로 인지되던 문제. 14단계 누적 fix 의 5개 root cause:

1. **CF Free plan 의 \`Vary: Cookie\` 무시** ⭐가장 큰 함정
2. **\`+layout.svelte\` 의 \`initFromSSR()\` 호출 누락**
3. **\`apiClient.login()\` 의 localStorage 미저장** (muzia 컴포넌트 호환)
4. **login flow uid 추출 order** (user_id=mb_no 가 먼저)
5. **multi-tenant cookie domain** (.damoang.net hardcoded → env COOKIE_DOMAIN)

## 변경 파일 (6 핵심)

| 파일 | 역할 |
|---|---|
| \`hooks.server.ts\` | publicHtmlCacheControl: public → private + SSO renewal + 진단 log |
| \`lib/server/auth/sso-cookie.ts\` | hardcoded .damoang.net → env COOKIE_DOMAIN + [SSO] log |
| \`lib/stores/auth.svelte.ts\` | initAuth 의 localStorage 무조건 삭제에 user 가드 |
| \`routes/+layout.svelte\` | hydrate 단계 initFromSSR + localStorage sync |
| \`routes/api/auth/login/+server.ts\` | uid order username 우선 + [Login] log |
| \`routes/api/v2/[...path]/+server.ts\` | OAuth callback Set-Cookie 의 Domain 동적 |

## Root cause 별 진단 marker

| Marker | 의미 |
|---|---|
| \`[SessionDebug] hasJwt=true hasSid=true\` | server cookie 정상 도달 |
| \`[Login] SSO cookie 발급 시도 mbId=X member=true\` | login flow getMemberById 성공 |
| \`[SSO] setDamoangSSOCookie mb_id=X domain=Y tokenLen=N\` | cookie set 호출 |
| \`[OAuthDebug] ✅ fallback 인증 성공 user=X\` | SSR fallback 정상 |

## Test plan

- [x] anonymous request → cache-control: private ✅
- [x] cookie 들고 request → server 정상 도달 (curl 시뮬 검증)
- [x] /attendance 에서 헤더 로그아웃 버튼 + 출석 데이터 정상 표시
- [x] OAuth (Google/Naver/Kakao) 로그인 후 자동 redirect + 인증 유지
- [x] editor.muzia.net 같은 sub-domain SSO 공유
- [x] 회귀 14 사이트 (muzia/damoang/church/ipyang/sdk) 200 ✅
- [ ] CF Pro+ 환경에서 Cache Rules 별도 설정 필요시 검토

## 메모리

자세한 root cause 분석 + 신규 사이트 provisioning 체크리스트 + 진단 트리:
\`/root/.claude/projects/-home-opc/memory/project_muzia_auth_chain.md\`

## 호환성

- damoang/ipyang/church/nuna 등 다른 사이트의 g5_member 도 mb_image_url + mb_leave_reason 컬럼 ALTER 필요 (별도 migration)
- CF Pro+ 사용 시 publicHtmlCacheControl 을 conditional 로 변경 가능 (현재 무조건 private)