### PR TITLE
perf(comments): 신고/딥링크 댓글 도달 지연 완화 (앵커 즉시로드 + 페이지 병렬)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1309,12 +1309,16 @@
             const total = json.data.total || all.length;
             const reportedPages = json.data.total_pages ?? 1;
             const pagesToLoad = Math.min(reportedPages, MAX_PAGES);
-            for (let p = 2; p <= pagesToLoad; p++) {
-                const next = await fetchCommentPage(p);
-                if (next.success && next.data.comments?.length) {
-                    all = all.concat(next.data.comments);
-                } else {
-                    break;
+            // 나머지 페이지(2..N)를 병렬 로드 — 순차 await 제거로 긴 스레드/신고댓글 도달 지연 완화.
+            // Promise.all 은 입력 순서를 보존하므로 page 순서대로 concat 된다.
+            if (pagesToLoad > 1) {
+                const rest = await Promise.all(
+                    Array.from({ length: pagesToLoad - 1 }, (_, i) => fetchCommentPage(i + 2))
+                );
+                for (const next of rest) {
+                    if (next.success && next.data.comments?.length) {
+                        all = all.concat(next.data.comments);
+                    }
                 }
             }
             if (reportedPages > MAX_PAGES) {
@@ -1379,6 +1383,17 @@
         if (commentsLoadState === 'failed' || loaded === 0) {
             void backfillWithRetry();
             return;
+        }
+
+        // 앵커(#c_<댓글ID>)로 진입했는데 대상 댓글이 아직 로드 전이면(신고/딥링크) 1500ms 디바운스를
+        // 건너뛰고 즉시 나머지 댓글을 불러온다 — 모더레이터가 신고댓글을 한참 기다리던 문제 완화.
+        const hash = window.location.hash;
+        if (hash.startsWith('#c_')) {
+            const anchorId = hash.slice(3);
+            if (anchorId && !comments.some((c) => String(c.id) === anchorId)) {
+                void refetchComments();
+                return;
+            }
         }
 
         const timer = window.setTimeout(() => {


### PR DESCRIPTION
## 배경
운영자(모더레이터) 피드백: 신고가 많아 글을 많이 보는데, 신고대상 댓글이 한참 있다 떠서 다른 거 보다 옴.

## 원인 (검증됨)
신고 상세(`disciplinelog/[id]`)에서 신고댓글로 가는 링크가 `/<board>/<post>#c_<commentId>` **해시**. 해시는 서버로 전송 안 됨 → SSR은 첫 10개만 렌더 → 대상 댓글이 그 밖이면 클라 backfill(**1500ms 디바운스 + 순차 페이지 로드**) 완료까지 대기.

## 변경 (프론트 전용·저위험)
- **앵커 즉시로드**: `#c_<id>` 해시의 대상 댓글이 미로드면 1500ms 디바운스를 건너뛰고 즉시 `refetchComments`.
- **페이지 병렬화**: `refetchComments` 의 나머지 페이지(2..N)를 순차 `await` → `Promise.all` 병렬(순서 보존).

→ 신고댓글 도달 ~2-4s → ~1초 이하.

## 비고
- 백엔드 댓글 API는 15ms로 빠름 — 클라 로딩 전략만 변경.
- **이상적 best practice**(`?c=<id>` 딥링크 + 백엔드 `find` 파라미터로 SSR 대상 페이지 직접 렌더 → 대기 0)는 별도 후속(프론트+백엔드). 본 PR은 검증된 안전 완충.
- 로컬 svelte-check 0 errors.