### PR TITLE
fix(ads): infeed 광고 아래 게시물 클릭 가로채기 (#12632)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -367,7 +367,10 @@
                 />
             </div>
             {#if widgetLayoutStore.hasEnabledAds && i + 1 === 12}
-                <div class="py-2" style="min-height: 90px; contain: layout;">
+                <!-- #12632: infeed 90px 배너가 overflow-y-visible 로 아래 게시물 위까지 수직 침범해
+                     클릭을 가로채던 문제(사파리) — 이 슬롯(윙 불필요)만 overflow 클립으로 격리.
+                     min-height 유지로 AdSlot 의 반응형 예약 높이를 따라가며, 그 박스를 넘는 spill 만 잘라낸다. -->
+                <div class="py-2" style="min-height: 90px; overflow: hidden; contain: layout;">
                     <AdSlot
                         position="board-list-infeed"
                         height="90px"


### PR DESCRIPTION
## 문제 (#12632)
게시판 목록의 중간(12번째 뒤) infeed 광고 바로 아래 게시물을 클릭하면, 클릭이 그 게시물이 아니라 위 광고로 들어감(맥/사파리 반복 재현).

## 원인
ad-slot(`dm-display-frame`)은 윙 광고를 위해 `overflow-y: visible`. infeed 90px 배너에서 광고 iframe 이 예약 박스를 넘어 **아래 게시물 위로 수직 침범** → 보이지 않는 영역이 클릭을 가로챔.

## 변경
- infeed 광고 wrapper(`recent-posts.svelte`)에만 `overflow: hidden` 추가 — 윙이 필요 없는 90px 배너라 안전. `min-height` 유지로 AdSlot 반응형 예약 높이는 따라가고, 그 박스를 넘는 spill 만 잘라냄.
- AdSlot 컴포넌트(윙 쓰는 사이드 광고)는 미변경 → AdSense 정책 영향 없음.

## 검증
- 로컬 svelte-check 0 errors. 배포 후 **사파리에서 infeed 광고 아래 게시물 클릭 정상** 확인 필요(코드 추론 기반 — 사파리 실기기 검증 권장).