### PR TITLE
feat(footer): 후원(베네센트) 외부 링크 추가

### DIFF
--- a/apps/web/src/lib/components/layout/footer.svelte
+++ b/apps/web/src/lib/components/layout/footer.svelte
@@ -65,7 +65,8 @@
         { name: '스마트스토어', href: 'https://smartstore.naver.com/damoang-net/' },
         { name: '마플샵', href: 'https://marpple.shop/kr/dma' },
         { name: '유튜브', href: 'https://www.youtube.com/@damoangnet' },
-        { name: 'X', href: 'https://x.com/@damoang_net' }
+        { name: 'X', href: 'https://x.com/@damoang_net' },
+        { name: '후원', href: 'https://damoang.benecent.org' }
     ];
 
     let openSections = $state<Set<number>>(new Set());
@@ -137,8 +138,6 @@
                     <ExternalLink class="h-3 w-3" />
                 </a>
             {/each}
-            <!-- 배내센트: 링크 오픈 전까지 텍스트만 노출 -->
-            <span class="text-muted-foreground flex items-center text-xs"> 배내센트 </span>
         </div>
     </div>
 


### PR DESCRIPTION
## 변경 내용
후원 채널 오픈에 따라 푸터 외부 링크 영역에 **후원** 링크를 추가합니다.

- `externalLinks` 배열에 `{ name: '후원', href: 'https://damoang.benecent.org' }` 추가 (스마트스토어·마플샵·유튜브·X 와 동일하게 `target=_blank` + 외부링크 아이콘으로 렌더)
- 링크 오픈 전까지 텍스트만 노출하던 임시 자리표시자(`배내센트` span) 제거

## 표시
푸터 외부 링크 줄: 스마트스토어 · 마플샵 · 유튜브 · X · **후원**

## 참고
- 라벨은 후원 목적이 명확하도록 `후원` 으로 정리했습니다(기존 자리표시자 텍스트 `배내센트` 오타 정정 포함). `베네센트` 브랜드명 노출을 원하시면 한 줄로 변경 가능합니다.