### PR TITLE
fix: 버그 배치 — 댓글 즉시표시(#12548) + 게시판 메뉴 재클릭 갱신(#12778)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar-board-groups.svelte
+++ b/apps/web/src/lib/components/layout/sidebar-board-groups.svelte
@@ -4,6 +4,8 @@
      * 게시판을 그룹별로 묶어 표시
      */
     import type { BoardGroup } from '$lib/api/types.js';
+    import { page } from '$app/stores';
+    import { handleBoardLinkClick } from '$lib/utils/board-nav.js';
     import { SvelteSet } from 'svelte/reactivity';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
@@ -54,6 +56,8 @@
                         {@const isActive = currentBoardId === board.board_id}
                         <a
                             href="/{board.board_id}"
+                            onclick={(e) =>
+                                handleBoardLinkClick(e, board.board_id, $page.url.pathname)}
                             class="block rounded-md px-3 py-1.5 text-base transition-colors"
                             class:bg-primary={isActive}
                             class:text-primary-foreground={isActive}

--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -9,6 +9,7 @@
     } from '$lib/components/ui/accordion';
     import { Button } from '$lib/components/ui/button';
     import { cn } from '$lib/utils';
+    import { handleBoardLinkClick } from '$lib/utils/board-nav.js';
     import { menuStore } from '$lib/stores/menu.svelte';
 
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
@@ -150,6 +151,7 @@
                     {@const active = isActive(`/${entry.boardId}`)}
                     <a
                         href="/{entry.boardId}"
+                        onclick={(e) => handleBoardLinkClick(e, entry.boardId, $page.url.pathname)}
                         class={cn(
                             'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors',
                             active
@@ -188,6 +190,8 @@
                             {@const active = isActive(`/${entry.boardId}`)}
                             <a
                                 href="/{entry.boardId}"
+                                onclick={(e) =>
+                                    handleBoardLinkClick(e, entry.boardId, $page.url.pathname)}
                                 class={cn(
                                     'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
                                     active

--- a/apps/web/src/lib/utils/board-nav.ts
+++ b/apps/web/src/lib/utils/board-nav.ts
@@ -1,0 +1,35 @@
+import { invalidateAll } from '$app/navigation';
+
+/**
+ * 사이드바 게시판 링크 클릭 처리 (#12778).
+ *
+ * #1635 에서 사이드바 보드 링크의 `rel="external"`(전체 리로드 → 깜빡임)을 제거해
+ * SPA 네비게이션으로 바꾼 뒤, 이미 보고 있는 게시판 목록(같은 URL)을 다시 클릭하면
+ * 라우터가 같은 경로로의 네비게이션을 무시해 목록이 전혀 갱신되지 않는 문제가 생겼다
+ * ("자유게시판을 눌러도 새 글이 안 올라온다, F5 하거나 다른 곳에 갔다 와야 한다").
+ *
+ * 같은 경로일 때만 `invalidateAll()` 로 load 를 재실행해 새 글을 불러온다. 전체 페이지
+ * 리로드가 아니므로 #1635 의 깜빡임은 재발하지 않는다. 다른 경로(게시글 등)에서의 클릭은
+ * 평소대로 SPA 네비게이션이 일어나 load 가 자연히 재실행되므로 손대지 않는다.
+ */
+export function handleBoardLinkClick(
+    event: MouseEvent,
+    boardId: string,
+    currentPathname: string
+): void {
+    // 새 탭/창 등 보조 클릭이나 수정키 동반 클릭은 브라우저 기본 동작을 보존한다.
+    if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+    ) {
+        return;
+    }
+    if (currentPathname === `/${boardId}`) {
+        event.preventDefault();
+        void invalidateAll();
+    }
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1427,21 +1427,31 @@
             });
 
             // Optimistic update: 서버 응답 즉시 목록에 추가 (#11946)
+            let optimisticComment: FreeComment | null = null;
             if (newComment && newComment.id) {
-                const optimistic = {
+                optimisticComment = {
                     ...newComment,
                     author_id: authStore.user.mb_id || '',
                     author_image_url: authStore.user.mb_image || '',
                     author_level: authStore.user.mb_level ?? 0
                 } as unknown as FreeComment;
-                if (!comments.some((c) => c.id === optimistic.id)) {
-                    comments = [...comments, optimistic];
+                if (!comments.some((c) => c.id === optimisticComment!.id)) {
+                    comments = [...comments, optimisticComment];
                     commentsTotal = commentsTotal + 1;
                 }
             }
 
             // 서버에서 정렬된 댓글 목록 다시 가져오기 (중복 제거 포함)
             await refetchComments();
+
+            // #12548: 쓰기 직후 refetch 가 백엔드 쓰기→읽기 가시성 지연으로 새 댓글을 아직
+            // 돌려주지 않으면, refetchComments 의 `comments = all` 이 위 optimistic 댓글을
+            // 덮어써 "댓글 작성 후 새로고침해야 보임" 이 재현된다. refetch 후에도 새 댓글이
+            // 목록에 없으면 다시 끼워넣어 항상 즉시 보이게 한다(다음 자연스러운 refetch 가 정렬·정정).
+            if (optimisticComment && !comments.some((c) => c.id === optimisticComment!.id)) {
+                comments = [...comments, optimisticComment];
+                commentsTotal = commentsTotal + 1;
+            }
 
             // @멘션 알림 전송 (fire-and-forget)
             sendMentionNotifications({


### PR DESCRIPTION
오리지널 버그 배치 수정. canary 검증 후 prod 일괄 promote 예정.

## #12548 — 댓글 작성 직후 새로고침해야 보임
`handleCreateComment` 작성 직후 `refetchComments()` 의 목록 전체 교체가, 백엔드 쓰기→읽기 가시성 지연으로 새 댓글이 아직 안 잡힐 때 optimistic 추가분을 덮어써 새로고침 전까지 사라지는 문제. refetch 후에도 새 댓글이 없으면 다시 보존(중복 시 .some 으로 비추가).

## #12778 — 보고 있는 게시판 메뉴 재클릭 시 목록 미갱신
#1635(사이드바 rel=external 제거 → SPA)로 같은 게시판을 다시 클릭하면 같은 URL 이라 네비게이션이 무시돼 갱신 안 됨. 같은 경로 재클릭 시에만 `invalidateAll()` 로 load 재실행(전체 리로드 없이 = #1635 깜빡임 회피). 공용 헬퍼 `board-nav.ts` + 사이드바 3개 링크 위치 배선. 수정키/보조클릭은 기본 동작 보존.

## 검증
- 로컬 svelte-check: 변경 파일 에러 0 (잔존 2건은 무관한 기존 zod 모듈 건)
- canary 배포 후 실동작 확인 예정