### PR TITLE
fix(auth): user_basic 쿠키 sliding 재발행 — 인증정보 로딩 10초+ 지연 해소 (#12513)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -11,7 +11,7 @@ import { grantLoginPoint } from '$lib/server/auth/point-grant.js';
 import { checkAndPromoteMember } from '$lib/server/auth/auto-promotion.js';
 import { generateAccessToken } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
-import { parseUserBasicCookie } from '$lib/server/auth/user-basic.js';
+import { parseUserBasicCookie, issueUserBasicCookie } from '$lib/server/auth/user-basic.js';
 import { loadAllPluginServerHooks } from '$lib/server/plugin-server-loader.js';
 import { CompositeSiteResolver } from '$lib/server/site-resolver/composite.js';
 import { ConfigSiteResolver } from '$lib/server/site-resolver/config.js';
@@ -483,6 +483,36 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                     };
                     event.locals.sessionId = sessionId;
                     event.locals.csrfToken = session.csrfToken;
+
+                    // user_basic fast-path 쿠키 sliding 재발행 (free/6538010, #12513).
+                    // 이 쿠키는 그동안 "로그인 시점"에만 발행돼, 캐시/쿠키 삭제·30일 만료·
+                    // SSO 로 세션만 갱신된 경우에는 사라진 채로 남는다. 그러면 SSR_STRIP_USER=true
+                    // 환경에서 클라이언트가 매 로드마다 느린 /api/auth/me(Redis+DB) 폴백을 타
+                    // "인증정보가 10초+ 늦게 뜨는" 증상이 재로그인 전까지 영구화된다.
+                    // 인증 사용자를 해석한 김에, 쿠키가 없거나 현재 사용자/아바타와 어긋나면
+                    // 재발행해 다음 로드부터 클라이언트 fast-path(백엔드 호출 0) 즉시 렌더로 복귀시킨다.
+                    // (USER_BASIC_FAST_PATH 와 무관 — DB 조회를 건너뛰지 않는 단순 Set-Cookie)
+                    // member.mb_image_updated_at 는 ISO 문자열이고 user_basic 쿠키/클라
+                    // fast-path 는 Unix 초(number)를 기대하므로 변환한다(파싱 불가 시 null).
+                    const memberImageTs: number | null = member.mb_image_updated_at
+                        ? Math.floor(new Date(member.mb_image_updated_at).getTime() / 1000) || null
+                        : null;
+                    const existingBasic = parseUserBasicCookie(event.cookies.get('user_basic'));
+                    if (
+                        !existingBasic ||
+                        existingBasic.id !== member.mb_id ||
+                        existingBasic.mb_image_updated_at !== memberImageTs
+                    ) {
+                        issueUserBasicCookie(event.cookies, {
+                            id: member.mb_id,
+                            mb_no: member.mb_no,
+                            nickname: member.mb_nick || member.mb_name,
+                            mb_level: member.mb_level ?? 0,
+                            as_level: member.as_level ?? 0,
+                            mb_image: member.mb_image_url || null,
+                            mb_image_updated_at: memberImageTs
+                        });
+                    }
 
                     // Go 백엔드 통신용 내부 JWT (캐시 사용, 5분 TTL)
                     const now = Date.now();


### PR DESCRIPTION
## 증상 (free/6538010, #12513 클러스터)
로그인 상태(인증정보)가 10초+ 늦게 떠 댓글/공감이 즉시 안 됨. 다수 사용자·모바일에서 더 심함·한 달째. 제보자 "캐시를 지워봐도" 지속.

## 원인
`SSR_STRIP_USER=true` 라 SSR 은 user 를 안 싣고, 클라이언트는 `PUBLIC_USER_BASIC_CLIENT_READ=true` 로 `user_basic` 쿠키를 읽어 즉시 렌더한다. 쿠키가 없으면 `/api/auth/me`(hooks 의 Redis `getSession` + DB `getMemberById`, 각 1500ms×2 재시도) 폴백을 타는데, `user_basic` 쿠키는 **로그인 시점에만 발행**되고 hooks·SSO 갱신에서 재발행되지 않았다. 그래서 캐시/쿠키 삭제·30일 만료·SSO 세션 갱신 사용자는 쿠키가 사라진 채로 남아 **매 로드마다 느린 폴백**을 타고, 부하 시 10초+ 지연이 재로그인 전까지 지속됐다.

## 수정
`hooks.server.ts` 에서 인증 사용자 해석 성공 후, `user_basic` 쿠키가 없거나 현재 사용자 id/아바타 타임스탬프와 어긋나면 `issueUserBasicCookie()` 로 재발행(sliding refresh). 다음 로드부터 클라이언트 fast-path(백엔드 호출 0) 즉시 렌더로 복귀한다.

- `USER_BASIC_FAST_PATH`(jwtCache 메모리/OOM 우려)와 **무관** — DB 조회를 건너뛰지 않는 단순 Set-Cookie.
- 쿠키 없음/불일치 시에만 set → 매 응답 Set-Cookie 회피. 비로그인은 발행 안 함(로그아웃 정상).
- `member.mb_image_updated_at`(ISO) → 쿠키 규격(Unix 초) 변환.

## 검증
- 로컬 svelte-check: hooks.server.ts 에러 0 (잔존 2건은 무관한 기존 zod 모듈 건)
- canary: 로그인 → user_basic 쿠키 삭제 → 새로고침 시 쿠키 재설정 + 이후 즉시 로그인 표시 확인 / 로그아웃 정상 / 비로그인 캐시 영향 없음
- 분석 문서: docs/auth-hydration-latency-analysis-2026-06-23.html