### PR TITLE
fix(auth): user_basic 쿠키에 실명인증 여부(certified) 포함 — fast-path 실명인증 오판 근본 해소 (#12789)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -497,11 +497,16 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                     const memberImageTs: number | null = member.mb_image_updated_at
                         ? Math.floor(new Date(member.mb_image_updated_at).getTime() / 1000) || null
                         : null;
+                    // 실명인증 여부 — fast-path 가 공감/글쓰기 게이트를 정확히 판단하려면
+                    // 쿠키에 반드시 담아야 한다(#12789 incident: certified 누락 → 미인증 오판 →
+                    // 전원 실명인증 유도). PII 없이 boolean 만.
+                    const memberCertified = !!member.mb_certify;
                     const existingBasic = parseUserBasicCookie(event.cookies.get('user_basic'));
                     if (
                         !existingBasic ||
                         existingBasic.id !== member.mb_id ||
-                        existingBasic.mb_image_updated_at !== memberImageTs
+                        existingBasic.mb_image_updated_at !== memberImageTs ||
+                        existingBasic.certified !== memberCertified
                     ) {
                         issueUserBasicCookie(event.cookies, {
                             id: member.mb_id,
@@ -510,7 +515,8 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                             mb_level: member.mb_level ?? 0,
                             as_level: member.as_level ?? 0,
                             mb_image: member.mb_image_url || null,
-                            mb_image_updated_at: memberImageTs
+                            mb_image_updated_at: memberImageTs,
+                            certified: memberCertified
                         });
                     }
 

--- a/apps/web/src/lib/server/auth/user-basic.ts
+++ b/apps/web/src/lib/server/auth/user-basic.ts
@@ -23,6 +23,13 @@ export interface UserBasic {
     as_level: number;
     mb_image: string | null;
     mb_image_updated_at: number | null;
+    /**
+     * 실명인증 여부(불리언). 클라 fast-path 가 실명인증 게이트(공감·글쓰기)를 정확히
+     * 판단하려면 필요(#12789 incident). PII(실명/인증값)는 싣지 않고 여부만 담는다.
+     * 구쿠키 호환을 위해 optional — undefined(레거시)면 클라는 fast-path 대신
+     * /api/auth/me 로 폴백해 진실을 조회한다(미인증 단정 금지).
+     */
+    certified?: boolean;
 }
 
 /**
@@ -51,7 +58,9 @@ export function parseUserBasicCookie(encoded: string | null | undefined): UserBa
             as_level: d.as_level,
             mb_image: typeof d.mb_image === 'string' ? d.mb_image : null,
             mb_image_updated_at:
-                typeof d.mb_image_updated_at === 'number' ? d.mb_image_updated_at : null
+                typeof d.mb_image_updated_at === 'number' ? d.mb_image_updated_at : null,
+            // 레거시 쿠키는 certified 가 없다 → undefined 유지(클라가 폴백 판단에 사용).
+            certified: typeof d.certified === 'boolean' ? d.certified : undefined
         };
     } catch {
         return null;
@@ -77,7 +86,9 @@ export function issueUserBasicCookie(cookies: Cookies, basic: UserBasic): void {
         mb_level: basic.mb_level,
         as_level: basic.as_level,
         mb_image: basic.mb_image,
-        mb_image_updated_at: basic.mb_image_updated_at
+        mb_image_updated_at: basic.mb_image_updated_at,
+        // 실명인증 여부(boolean). undefined(미지정)면 키를 생략해 레거시와 동일 취급.
+        ...(typeof basic.certified === 'boolean' ? { certified: basic.certified } : {})
     };
     const encoded = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
     const domainOpt = env.COOKIE_DOMAIN ? { domain: env.COOKIE_DOMAIN } : {};

--- a/apps/web/src/lib/utils/user-basic-client.ts
+++ b/apps/web/src/lib/utils/user-basic-client.ts
@@ -14,6 +14,8 @@ export interface UserBasic {
     as_level: number;
     mb_image: string | null;
     mb_image_updated_at: number | null;
+    /** 실명인증 여부. 레거시 쿠키엔 없음(undefined) → 호출측이 /api/auth/me 폴백 판단. */
+    certified?: boolean;
 }
 
 function validateUserBasic(data: unknown): UserBasic | null {
@@ -30,7 +32,8 @@ function validateUserBasic(data: unknown): UserBasic | null {
         as_level: d.as_level,
         mb_image: typeof d.mb_image === 'string' ? d.mb_image : null,
         mb_image_updated_at:
-            typeof d.mb_image_updated_at === 'number' ? d.mb_image_updated_at : null
+            typeof d.mb_image_updated_at === 'number' ? d.mb_image_updated_at : null,
+        certified: typeof d.certified === 'boolean' ? d.certified : undefined
     };
 }
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -545,7 +545,11 @@
             if (env.PUBLIC_USER_BASIC_CLIENT_READ === 'true') {
                 try {
                     const basic = readUserBasicFromCookie(document.cookie);
-                    if (basic) {
+                    // #12789 incident: 쿠키에 실명인증 여부(certified)가 없으면 fast-path 가
+                    // mb_certify='' 로 렌더해 인증 유저를 미인증으로 오판 → 공감·글쓰기가
+                    // 실명인증으로 잘못 유도된다. certified 를 담은 쿠키만 fast-path 로 신뢰하고,
+                    // 레거시 쿠키(certified=undefined)는 /api/auth/me 로 폴백해 진실을 조회한다.
+                    if (basic && basic.certified !== undefined) {
                         syncAuth({
                             ...data,
                             user: {
@@ -553,7 +557,7 @@
                                 nickname: basic.nickname,
                                 level: basic.mb_level,
                                 as_level: basic.as_level,
-                                mb_certify: '',
+                                mb_certify: basic.certified ? 'Y' : '',
                                 mb_image: basic.mb_image ?? undefined,
                                 mb_image_updated_at: basic.mb_image_updated_at ?? undefined,
                                 advertiser_end_date: undefined,


### PR DESCRIPTION
## 장애 (2026-06-23 22시경, P0)
닉네임 깨짐 + 공감·글쓰기 시 실명인증 화면으로 잘못 유도. 전 로그인 유저(특히 모바일). #1667(user_basic sliding 재발행, #12513) 배포 직후 발생.

## 근본 원인
`SSR_STRIP_USER=true` 라 클라는 user_basic 쿠키 fast-path(`+layout.svelte`)로 인증을 렌더한다. 그런데 쿠키가 **실명인증 여부를 싣지 않아** fast-path 가 `mb_certify:''`(미인증)으로 렌더 → `isCertifiedUser` 게이트가 인증 유저를 미인증으로 오판 → 공감·글쓰기가 실명인증으로 차단. #1667 이 쿠키를 보편화하면서 전 유저로 확대.

## 수정 (장기·모범사례)
- `UserBasic` 쿠키에 `certified`(boolean, PII 아님) 추가 — 서버 파서/발급(user-basic.ts)·클라 파서(user-basic-client.ts).
- hooks sliding 재발행이 `certified` 를 담고, certified/이미지ts 불일치 시 재발행 → 활성 쿠키 자동 업그레이드.
- **fast-path 안전장치**: `certified` 가 담긴 쿠키만 신뢰. 레거시 쿠키(`certified===undefined`)는 fast-path 대신 `/api/auth/me` 폴백해 진실 조회(미인증 단정 금지). → flag 재활성 시 레거시 쿠키 유저도 안전.

## 현재 prod 상태 / 롤아웃
- 장애 완화로 prod 는 `PUBLIC_USER_BASIC_CLIENT_READ=false`(fast-path OFF) + 이미지 `cfbbbc9` 롤백 상태.
- 이 PR 머지 → canary 빌드. canary 에서 flag ON 으로 두고 검증(쿠키 삭제→fast-path→공감/글쓰기/닉네임/실명인증 정확).
- 충분히 검증 후 prod 에 이 이미지 배포 + flag ON 재개 → #12513 속도개선 안전 재도입.

## 검증
- 로컬 svelte-check: 변경 4파일 에러 0(잔존 2건 무관 zod).
- 시나리오: ①신규 certified 쿠키 → 공감/글쓰기 정상 ②레거시 쿠키 → /api/auth/me 폴백(정상) ③미인증 유저 → 실명인증 정상 유도.