### PR TITLE
fix(auth): user_basic 클라 파서 UTF-8 디코딩 — 한글 닉네임 깨짐 수정 (#12789)

### DIFF
--- a/apps/web/src/lib/utils/user-basic-client.ts
+++ b/apps/web/src/lib/utils/user-basic-client.ts
@@ -43,7 +43,11 @@ function validateUserBasic(data: unknown): UserBasic | null {
 export function parseUserBasicBase64(encoded: string | null | undefined): UserBasic | null {
     if (!encoded) return null;
     try {
-        const json = atob(encoded);
+        // atob 는 Latin-1 바이트 문자열을 돌려줘, 서버가 UTF-8 로 인코딩한 한글 닉네임을
+        // 그대로 JSON.parse 하면 깨진다(#12789 닉네임 깨짐). 바이트로 되돌려 UTF-8 로 디코딩.
+        const binary = atob(encoded);
+        const bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+        const json = new TextDecoder('utf-8').decode(bytes);
         const data = JSON.parse(json) as unknown;
         return validateUserBasic(data);
     } catch {


### PR DESCRIPTION
## 증상
fast-path 렌더 시 한글 닉네임이 깨져 표시(#12789 닉네임 깨짐 장애). 서버는 정상, 클라만 깨짐.

## 원인
클라 파서 `user-basic-client.ts` 가 `atob(encoded)`(Latin-1 바이트 문자열)를 UTF-8 복원 없이 `JSON.parse` → 서버가 UTF-8 base64 로 인코딩한 한글 닉네임이 깨진다. (서버 파서는 `Buffer.from(...,'base64').toString('utf-8')` 로 정상.)

## 수정
`atob` 결과를 바이트 배열로 되돌려 `TextDecoder('utf-8')` 로 디코딩. 서버 파서와 동일 결과.

## 영향
- #1669(certified)·#1667(sliding) 와 함께 fast-path 를 안전하게 재활성하기 위한 마지막 조각.
- 로컬 svelte-check: 변경 파일 에러 0(잔존 2건 무관 zod).

## 비고
prod 는 현재 완화로 PUBLIC_USER_BASIC_CLIENT_READ=false. 본 fix 배포 후 flag 재활성 시 닉네임/실명인증 모두 정상.