### PR TITLE
fix(reaction): 똥 앙티콘(emo-001) 신규 선택 비활성화

### DIFF
--- a/apps/web/src/lib/config/reaction-config.ts
+++ b/apps/web/src/lib/config/reaction-config.ts
@@ -59,7 +59,7 @@ const EMOJIS: EmoticonDef[] = [
 // 앙티콘 세트 (다모앙 커스텀 GIF)
 const ANGTICON_IDS = [
     'emo-000',
-    'emo-001',
+    // 'emo-001' (똥 모양) 비활성화 — 신규 선택 차단. 기존 반응은 reaction.ts url 빌더로 계속 렌더.
     'emo-002',
     'emo-003',
     'emo-004',


### PR DESCRIPTION
## 요청
똥 모양 앙티콘 리액션(`nariya/damoang-emo-001.gif`)을 앞으로 입력 못하게(선택지에서 제외). 기존 반응은 그대로.

## 수정
`reaction-config.ts` ANGTICON_IDS 에서 `emo-001` 제외 → 리액션 피커에 노출 안 됨. 기존 반응(angticon:emo-001)은 `reaction.ts` url 빌더가 계속 렌더(콘텐츠/DB 미변경).

## 비고
- 코멘트 이모티콘 피커(/api/emoticons/list)는 `damoang-emo-001.gif` 가 이미 SKIP_FILES 에 있어 별도 조치 불필요.
- ⚠️ 서버의 `nariya/damoang-emo-001.gif` 파일이 이미 삭제돼 있어 기존 emo-001 반응은 현재 액박(404)으로 표시됨 — '기존 것 보이게'는 파일 복원이 필요(별도 논의). svelte-check 통과.