### PR TITLE
feat(sidebar): 마음메시지 아래 후원하기 1줄 카드 추가

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -458,6 +458,16 @@
             </div>
             <!-- 드로워: 마음메시지 -->
             <CelebrationRolling />
+            <!-- 마음메시지 아래: 후원하기 1줄 카드 (benecent). 강조색으로 눈에 띄게, 1줄로 작게. -->
+            <a
+                href="https://damoang.benecent.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
+            >
+                <span>💛 다모앙 후원하기</span>
+                <span aria-hidden="true" class="leading-none">→</span>
+            </a>
             <!-- 마음메시지 바로 아래: 벽돌한장 · 광고 제거 inline -->
             <div class="text-muted-foreground flex items-center justify-center gap-3 px-2 text-xs">
                 <a href="/brickang" class="hover:text-primary underline-offset-2 hover:underline">


### PR DESCRIPTION
## 변경
사이드바 마음메시지(CelebrationRolling) 아래에 **후원하기 1줄 강조 카드** 추가.

- 위치: 마음메시지 ↔ `벽돌한장·광고 제거` 지원 링크 묶음 사이 (같은 '다모앙 지원' 맥락)
- 모양: 1줄 카드(~36px), primary 틴트 강조색으로 눈에 띄되 작게. `💛 다모앙 후원하기 →`
- 동작: 클릭 시 후원 채널(https://damoang.benecent.org) 새 탭

## 의도
'잘 보이는 위치' 요청 반영 — 마음메시지(공동체 감성) 직후라 전환 동선이 자연스럽고, 기존 지원 링크와 한 묶음. 광고처럼 보이지 않게 1줄 accent.

## 검증
- 로컬 svelte-check: sidebar.svelte 에러 0
- canary에서 실제 모양(크기/색/위치) 확인 후 prod 반영 예정