### PR TITLE
fix(sidebar): 후원하기 카드 데스크톱에도 노출 (#1672 후속)

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -479,6 +479,16 @@
                 </a>
             </div>
         {:else}
+            <!-- 데스크톱 사이드바: 후원하기 1줄 카드 (benecent). 드로워(compact)와 동일 — 데스크톱에도 노출(#1672 후속). -->
+            <a
+                href="https://damoang.benecent.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
+            >
+                <span>💛 다모앙 후원하기</span>
+                <span aria-hidden="true" class="leading-none">→</span>
+            </a>
             <!-- Slot: sidebar-left-bottom -->
             {#each getComponentsForSlot('sidebar-left-bottom') as slotComp (slotComp.id)}
                 {@const Component = slotComp.component}


### PR DESCRIPTION
#1672 는 사이드바 드로워(compact) 분기에만 후원 카드를 넣어 **데스크톱(compact=false, {:else} 분기)에선 안 보였습니다**. 데스크톱 분기에도 동일 1줄 카드를 추가해 드로워+데스크톱 양쪽 노출. svelte-check 통과.