### PR TITLE
fix(celebration): 마음메시지 배너 링크 값 우선 이동

### DIFF
--- a/apps/web/src/lib/server/celebration.ts
+++ b/apps/web/src/lib/server/celebration.ts
@@ -91,7 +91,8 @@ export async function fetchCelebrations(isRecent: boolean = false): Promise<Cele
         for (const row of rows as RowDataPacket[]) {
             const linkUrl =
                 row.external_url ||
-                (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
+                row.link_url ||
+                (row.source_wr_id ? `/message/${row.source_wr_id}` : '');
             const sourceWrName = (row.source_wr_name ?? '').toString().trim();
             const anonymous = !!row.is_anonymous || (!!row.source_wr_id && sourceWrName === '');
 


### PR DESCRIPTION
## 변경 내용
마음메시지(celebration) 배너 클릭 시, 메시지에 연결된 링크 값이 있으면 해당 링크로 이동하도록 수정합니다.

## 배경
- 일부 마음메시지는 외부 링크 값(`link_url`, source 글의 `wr_link2` 동기화)을 가지고 있습니다.
- 기존 로직은 `source_wr_id` 가 있으면 항상 `/message/{id}` 로 이동해, 연결된 링크가 무시되었습니다.

## 수정
`apps/web/src/lib/server/celebration.ts` 의 링크 우선순위를 조정합니다.
- 기존: `external_url → /message/{source_wr_id} → link_url`
- 변경: `external_url → link_url → /message/{source_wr_id}`

링크 값이 있으면 그 링크로, 없으면 기존처럼 메시지 글로 이동합니다. 링크가 없는 배너는 동작 변화가 없습니다.

## 검증
- 타입 체크 통과 (celebration.ts 무관 오류 없음).
- 배포 후: 링크 있는 마음메시지 배너 → 연결 글로 이동 / 링크 없는 배너 → 기존대로 메시지 글.