### PR TITLE
fix(celebration): 배너 API 링크 값 우선 이동

### DIFF
--- a/apps/web/src/routes/api/ads/celebration/today/+server.ts
+++ b/apps/web/src/routes/api/ads/celebration/today/+server.ts
@@ -98,7 +98,8 @@ export const GET: RequestHandler = async () => {
             for (const row of rows as RowDataPacket[]) {
                 const linkUrl =
                     row.external_url ||
-                    (row.source_wr_id ? `/message/${row.source_wr_id}` : row.link_url || '');
+                    row.link_url ||
+                    (row.source_wr_id ? `/message/${row.source_wr_id}` : '');
                 const sourceWrName = (row.source_wr_name ?? '').toString().trim();
                 const anonymous = !!row.is_anonymous || (!!row.source_wr_id && sourceWrName === '');
 


### PR DESCRIPTION
## 변경 내용
마음메시지 롤링 배너가 실제로 사용하는 `/api/celebration/today` (`/api/ads/celebration/today`) 엔드포인트의 링크 우선순위를 조정합니다.

이전 PR(#1676)에서 공유 모듈 `celebration.ts` 를 고쳤으나, 배너 표시에 실제 사용되는 데이터는 이 별도 엔드포인트에서 오며 동일한 로직이 복제되어 있었습니다.

## 수정
- 기존: `external_url → /message/{source_wr_id} → link_url`
- 변경: `external_url → link_url → /message/{source_wr_id}`

링크 값이 있으면 그 링크로, 없으면 기존처럼 메시지 글로 이동합니다.

## 검증
- 배포 후 `/api/celebration/today` 응답의 link_url 이 연결 글 주소로 나오는지 확인.