### PR TITLE
perf(home): 모아보기 SSR 프리페치로 스켈레톤 제거

### DIFF
--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -4,6 +4,7 @@ import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default
 import { buildIndexWidgets } from '$lib/server/index-widgets-builder';
 import { getDefaultPeriod, loadRecommendedData } from '$lib/server/recommended-loader';
 import { getCachedCelebrations } from '$lib/server/celebration';
+import { loadExploreData, buildExplorePreviewData } from '$lib/server/explore-loader';
 import { env } from '$env/dynamic/private';
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
@@ -15,7 +16,7 @@ interface HomePageData {
     sidebarWidgetLayout: typeof DEFAULT_SIDEBAR_WIDGETS;
     recommendedData: Awaited<ReturnType<typeof loadRecommendedData>> | null;
     recommendedPeriod: ReturnType<typeof getDefaultPeriod>;
-    exploreData: null;
+    exploreData: ReturnType<typeof buildExplorePreviewData> | null;
     celebrationRecent: Awaited<ReturnType<typeof getCachedCelebrations>> | null;
 }
 
@@ -26,8 +27,7 @@ const pendingByHost = new Map<string, Promise<HomePageData>>();
 
 async function buildHomePageData(): Promise<HomePageData> {
     const recommendedPeriod = getDefaultPeriod();
-    // 메인 SSR 페이로드를 줄이기 위해 explore는 클라이언트 fallback에 맡긴다.
-    const [indexWidgetsResult, layoutResult, celebrationResult, recommendedResult] =
+    const [indexWidgetsResult, layoutResult, celebrationResult, recommendedResult, exploreResult] =
         await Promise.allSettled([
             buildIndexWidgets(BACKEND_URL),
             (async () => {
@@ -43,7 +43,9 @@ async function buildHomePageData(): Promise<HomePageData> {
             // 인덱스 전용: 최근 마음메시지 (오늘뿐 아니라 최근 8건)
             getCachedCelebrations(true),
             // 공감글 SSR 프리페치 (스켈레톤 제거)
-            loadRecommendedData(recommendedPeriod)
+            loadRecommendedData(recommendedPeriod),
+            // 모아보기 SSR 프리페치 (스켈레톤 제거). 파일 캐시(60초 인메모리)라 SSR 부담 적음.
+            loadExploreData()
         ]);
 
     const indexWidgets =
@@ -54,6 +56,8 @@ async function buildHomePageData(): Promise<HomePageData> {
             : { widgetLayout: DEFAULT_WIDGETS, sidebarWidgetLayout: DEFAULT_SIDEBAR_WIDGETS };
     const celebrationRecent =
         celebrationResult.status === 'fulfilled' ? celebrationResult.value : null;
+    const exploreRaw = exploreResult.status === 'fulfilled' ? exploreResult.value : null;
+    const exploreData = exploreRaw ? buildExplorePreviewData(exploreRaw) : null;
 
     if (indexWidgetsResult.status === 'rejected') {
         console.error('[SSR] Failed to load index widgets:', indexWidgetsResult.reason);
@@ -65,7 +69,7 @@ async function buildHomePageData(): Promise<HomePageData> {
         sidebarWidgetLayout: layoutData.sidebarWidgetLayout,
         recommendedData: recommendedResult.status === 'fulfilled' ? recommendedResult.value : null,
         recommendedPeriod,
-        exploreData: null,
+        exploreData,
         celebrationRecent
     };
 }


### PR DESCRIPTION
## 변경 내용
홈 화면의 모아보기(explore) 위젯을 추천글과 동일하게 SSR 프리페치하여, 페이지와 함께 즉시 렌더되도록 합니다.

## 배경
- 모아보기만 SSR 프리로드에서 제외(`exploreData: null` 하드코딩)되어 있어, 항상 스켈레톤을 보인 뒤 클라이언트에서 lazy(IntersectionObserver / requestIdleCallback, 최대 1.5초) 후에야 데이터를 받아왔습니다.
- 데이터 API 자체는 빠릅니다(파일 캐시, 약 40~50ms). 지연의 대부분은 lazy 트리거 대기 시간입니다.

## 수정
- `+page.server.ts` 의 `Promise.allSettled` 에 `loadExploreData()` 추가, `buildExplorePreviewData()` 로 가공해 `exploreData` 로 반환.
- 프론트 prefetch 배선(`+page.svelte` 의 `explore` / `empathy-explore-row`)은 이미 존재하여 그대로 동작.
- 데이터는 파일 캐시(60초 인메모리)라 SSR 부담이 적고, 페이로드 증가는 약 6KB(gzip) 수준.

## 검증
- 배포 후 홈 SSR HTML 에 모아보기 데이터가 포함되어 스켈레톤 없이 즉시 표시되는지 확인.