### PR TITLE
feat(gif): GIF 제공자 Tenor → KLIPY 이관

### DIFF
--- a/apps/web/src/routes/api/tenor/featured/+server.ts
+++ b/apps/web/src/routes/api/tenor/featured/+server.ts
@@ -1,14 +1,15 @@
 /**
- * Tenor trending/featured GIF API 프록시
- * TENOR_API_KEY를 서버 사이드에서만 사용하여 클라이언트 노출 방지
+ * trending/featured GIF API 프록시 (KLIPY — Tenor 호환 v2 엔드포인트)
+ * KLIPY_API_KEY를 서버 사이드에서만 사용하여 클라이언트 노출 방지.
+ * Tenor API 종료(2026-06-30)에 따라 KLIPY(api.klipy.com)로 이관.
  */
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 
-const TENOR_API_URL = 'https://tenor.googleapis.com/v2/featured';
+const GIF_API_URL = 'https://api.klipy.com/v2/featured';
 
 export const GET: RequestHandler = async ({ url }) => {
-    const apiKey = env.TENOR_API_KEY;
+    const apiKey = env.KLIPY_API_KEY;
     if (!apiKey) {
         return new Response(JSON.stringify({ results: [], next: '' }), {
             headers: { 'Content-Type': 'application/json' }
@@ -26,7 +27,7 @@ export const GET: RequestHandler = async ({ url }) => {
     if (pos) params.set('pos', pos);
 
     try {
-        const res = await fetch(`${TENOR_API_URL}?${params.toString()}`);
+        const res = await fetch(`${GIF_API_URL}?${params.toString()}`);
         if (!res.ok) {
             return new Response(JSON.stringify({ results: [], next: '' }), {
                 status: res.status,

--- a/apps/web/src/routes/api/tenor/featured/+server.ts
+++ b/apps/web/src/routes/api/tenor/featured/+server.ts
@@ -1,12 +1,46 @@
 /**
- * trending/featured GIF API 프록시 (KLIPY — Tenor 호환 v2 엔드포인트)
+ * trending/featured GIF API 프록시 (KLIPY)
  * KLIPY_API_KEY를 서버 사이드에서만 사용하여 클라이언트 노출 방지.
  * Tenor API 종료(2026-06-30)에 따라 KLIPY(api.klipy.com)로 이관.
+ *
+ * KLIPY 계약: GET https://api.klipy.com/api/v1/{KEY}/gifs/trending?per_page=&page=&customer_id=
+ * 키는 경로(path)에 포함, 응답은 data.data[] 에 항목, 각 항목은 file.{hd|md|sm|xs}.{gif|webp|mp4}.{url,width,height}.
+ * 클라이언트 응답 형태({ results:[{id,title,url,preview_url,width,height}], next })는 기존 그대로 유지.
  */
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 
-const GIF_API_URL = 'https://api.klipy.com/v2/featured';
+const KLIPY_BASE = 'https://api.klipy.com/api/v1';
+// KLIPY 분석/식별용 customer_id (개인정보 아님, 고정값). 추후 사용자별 식별이 필요하면 교체.
+const CUSTOMER_ID = 'damoang-web';
+const PER_PAGE = 20;
+
+interface KlipyGif {
+    url?: string;
+    width?: number;
+    height?: number;
+}
+interface KlipyFileSize {
+    gif?: KlipyGif;
+}
+interface KlipyItem {
+    id?: number | string;
+    title?: string;
+    file?: Record<string, KlipyFileSize>;
+}
+
+// 지정한 사이즈 우선순위로 gif 포맷을 고른다 (없으면 다음 사이즈로 폴백).
+function pickGif(
+    file: Record<string, KlipyFileSize> | undefined,
+    sizes: string[]
+): KlipyGif | null {
+    if (!file) return null;
+    for (const s of sizes) {
+        const g = file[s]?.gif;
+        if (g?.url) return g;
+    }
+    return null;
+}
 
 export const GET: RequestHandler = async ({ url }) => {
     const apiKey = env.KLIPY_API_KEY;
@@ -16,18 +50,19 @@ export const GET: RequestHandler = async ({ url }) => {
         });
     }
 
+    // 기존 클라이언트는 페이지 커서를 pos 로 전달 → KLIPY 의 page 번호로 매핑.
     const pos = url.searchParams.get('pos') || '';
+    const page = pos && /^\d+$/.test(pos) ? Number(pos) : 1;
 
     const params = new URLSearchParams({
-        key: apiKey,
-        limit: '20',
-        media_filter: 'gif,tinygif',
-        locale: 'ko_KR'
+        per_page: String(PER_PAGE),
+        page: String(page),
+        customer_id: CUSTOMER_ID
     });
-    if (pos) params.set('pos', pos);
+    const endpoint = `${KLIPY_BASE}/${apiKey}/gifs/trending?${params.toString()}`;
 
     try {
-        const res = await fetch(`${GIF_API_URL}?${params.toString()}`);
+        const res = await fetch(endpoint);
         if (!res.ok) {
             return new Response(JSON.stringify({ results: [], next: '' }), {
                 status: res.status,
@@ -35,22 +70,37 @@ export const GET: RequestHandler = async ({ url }) => {
             });
         }
 
-        const data = await res.json();
-        const results = (data.results ?? []).map((item: Record<string, unknown>) => {
-            const media = item.media_formats as Record<string, { url: string; dims?: number[] }>;
-            const gif = media?.gif;
-            const tinygif = media?.tinygif;
-            return {
-                id: item.id,
-                title: item.title || '',
-                url: gif?.url || '',
-                preview_url: tinygif?.url || gif?.url || '',
-                width: gif?.dims?.[0] || 0,
-                height: gif?.dims?.[1] || 0
-            };
-        });
+        const json = await res.json();
+        if (!json?.result) {
+            return new Response(JSON.stringify({ results: [], next: '' }), {
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
 
-        return new Response(JSON.stringify({ results, next: data.next || '' }), {
+        const payload = json.data ?? {};
+        const items: KlipyItem[] = Array.isArray(payload.data) ? payload.data : [];
+
+        const results = items
+            .map((item) => {
+                const main = pickGif(item.file, ['md', 'hd', 'sm', 'xs']);
+                const preview = pickGif(item.file, ['sm', 'xs', 'md', 'hd']);
+                return {
+                    id: item.id,
+                    title: item.title || '',
+                    url: main?.url || '',
+                    preview_url: preview?.url || main?.url || '',
+                    width: main?.width || 0,
+                    height: main?.height || 0
+                };
+            })
+            .filter((r) => r.url);
+
+        const currentPage = Number(payload.current_page) || page;
+        const hasNext =
+            typeof payload.has_next === 'boolean' ? payload.has_next : items.length >= PER_PAGE;
+        const next = hasNext ? String(currentPage + 1) : '';
+
+        return new Response(JSON.stringify({ results, next }), {
             headers: {
                 'Content-Type': 'application/json',
                 'Cache-Control': 'public, max-age=300'

--- a/apps/web/src/routes/api/tenor/search/+server.ts
+++ b/apps/web/src/routes/api/tenor/search/+server.ts
@@ -1,14 +1,15 @@
 /**
- * Tenor GIF 검색 API 프록시
- * TENOR_API_KEY를 서버 사이드에서만 사용하여 클라이언트 노출 방지
+ * GIF 검색 API 프록시 (KLIPY — Tenor 호환 v2 엔드포인트)
+ * KLIPY_API_KEY를 서버 사이드에서만 사용하여 클라이언트 노출 방지.
+ * Tenor API 종료(2026-06-30)에 따라 KLIPY(api.klipy.com)로 이관.
  */
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 
-const TENOR_API_URL = 'https://tenor.googleapis.com/v2/search';
+const GIF_API_URL = 'https://api.klipy.com/v2/search';
 
 export const GET: RequestHandler = async ({ url }) => {
-    const apiKey = env.TENOR_API_KEY;
+    const apiKey = env.KLIPY_API_KEY;
     if (!apiKey) {
         return new Response(JSON.stringify({ results: [], next: '' }), {
             headers: { 'Content-Type': 'application/json' }
@@ -34,7 +35,7 @@ export const GET: RequestHandler = async ({ url }) => {
     if (pos) params.set('pos', pos);
 
     try {
-        const res = await fetch(`${TENOR_API_URL}?${params.toString()}`);
+        const res = await fetch(`${GIF_API_URL}?${params.toString()}`);
         if (!res.ok) {
             return new Response(JSON.stringify({ results: [], next: '' }), {
                 status: res.status,

--- a/apps/web/src/routes/api/tenor/search/+server.ts
+++ b/apps/web/src/routes/api/tenor/search/+server.ts
@@ -1,12 +1,46 @@
 /**
- * GIF 검색 API 프록시 (KLIPY — Tenor 호환 v2 엔드포인트)
+ * GIF 검색 API 프록시 (KLIPY)
  * KLIPY_API_KEY를 서버 사이드에서만 사용하여 클라이언트 노출 방지.
  * Tenor API 종료(2026-06-30)에 따라 KLIPY(api.klipy.com)로 이관.
+ *
+ * KLIPY 계약: GET https://api.klipy.com/api/v1/{KEY}/gifs/search?q=&per_page=&page=&customer_id=
+ * 키는 경로(path)에 포함, 응답은 data.data[] 에 항목, 각 항목은 file.{hd|md|sm|xs}.{gif|webp|mp4}.{url,width,height}.
+ * 클라이언트 응답 형태({ results:[{id,title,url,preview_url,width,height}], next })는 기존 그대로 유지.
  */
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 
-const GIF_API_URL = 'https://api.klipy.com/v2/search';
+const KLIPY_BASE = 'https://api.klipy.com/api/v1';
+// KLIPY 분석/식별용 customer_id (개인정보 아님, 고정값). 추후 사용자별 식별이 필요하면 교체.
+const CUSTOMER_ID = 'damoang-web';
+const PER_PAGE = 20;
+
+interface KlipyGif {
+    url?: string;
+    width?: number;
+    height?: number;
+}
+interface KlipyFileSize {
+    gif?: KlipyGif;
+}
+interface KlipyItem {
+    id?: number | string;
+    title?: string;
+    file?: Record<string, KlipyFileSize>;
+}
+
+// 지정한 사이즈 우선순위로 gif 포맷을 고른다 (없으면 다음 사이즈로 폴백).
+function pickGif(
+    file: Record<string, KlipyFileSize> | undefined,
+    sizes: string[]
+): KlipyGif | null {
+    if (!file) return null;
+    for (const s of sizes) {
+        const g = file[s]?.gif;
+        if (g?.url) return g;
+    }
+    return null;
+}
 
 export const GET: RequestHandler = async ({ url }) => {
     const apiKey = env.KLIPY_API_KEY;
@@ -17,7 +51,9 @@ export const GET: RequestHandler = async ({ url }) => {
     }
 
     const query = url.searchParams.get('q') || '';
+    // 기존 클라이언트는 페이지 커서를 pos 로 전달 → KLIPY 의 page 번호로 매핑.
     const pos = url.searchParams.get('pos') || '';
+    const page = pos && /^\d+$/.test(pos) ? Number(pos) : 1;
 
     if (!query.trim()) {
         return new Response(JSON.stringify({ results: [], next: '' }), {
@@ -26,16 +62,15 @@ export const GET: RequestHandler = async ({ url }) => {
     }
 
     const params = new URLSearchParams({
-        key: apiKey,
         q: query,
-        limit: '20',
-        media_filter: 'gif,tinygif',
-        locale: 'ko_KR'
+        per_page: String(PER_PAGE),
+        page: String(page),
+        customer_id: CUSTOMER_ID
     });
-    if (pos) params.set('pos', pos);
+    const endpoint = `${KLIPY_BASE}/${apiKey}/gifs/search?${params.toString()}`;
 
     try {
-        const res = await fetch(`${GIF_API_URL}?${params.toString()}`);
+        const res = await fetch(endpoint);
         if (!res.ok) {
             return new Response(JSON.stringify({ results: [], next: '' }), {
                 status: res.status,
@@ -43,22 +78,37 @@ export const GET: RequestHandler = async ({ url }) => {
             });
         }
 
-        const data = await res.json();
-        const results = (data.results ?? []).map((item: Record<string, unknown>) => {
-            const media = item.media_formats as Record<string, { url: string; dims?: number[] }>;
-            const gif = media?.gif;
-            const tinygif = media?.tinygif;
-            return {
-                id: item.id,
-                title: item.title || '',
-                url: gif?.url || '',
-                preview_url: tinygif?.url || gif?.url || '',
-                width: gif?.dims?.[0] || 0,
-                height: gif?.dims?.[1] || 0
-            };
-        });
+        const json = await res.json();
+        if (!json?.result) {
+            return new Response(JSON.stringify({ results: [], next: '' }), {
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
 
-        return new Response(JSON.stringify({ results, next: data.next || '' }), {
+        const payload = json.data ?? {};
+        const items: KlipyItem[] = Array.isArray(payload.data) ? payload.data : [];
+
+        const results = items
+            .map((item) => {
+                const main = pickGif(item.file, ['md', 'hd', 'sm', 'xs']);
+                const preview = pickGif(item.file, ['sm', 'xs', 'md', 'hd']);
+                return {
+                    id: item.id,
+                    title: item.title || '',
+                    url: main?.url || '',
+                    preview_url: preview?.url || main?.url || '',
+                    width: main?.width || 0,
+                    height: main?.height || 0
+                };
+            })
+            .filter((r) => r.url);
+
+        const currentPage = Number(payload.current_page) || page;
+        const hasNext =
+            typeof payload.has_next === 'boolean' ? payload.has_next : items.length >= PER_PAGE;
+        const next = hasNext ? String(currentPage + 1) : '';
+
+        return new Response(JSON.stringify({ results, next }), {
             headers: {
                 'Content-Type': 'application/json',
                 'Cache-Control': 'public, max-age=300'


### PR DESCRIPTION
## 배경
Tenor API 가 **2026-06-30 종료**(신규 키 발급은 1월부터 중단)됩니다. 댓글 GIF 검색/트렌딩이 키 만료로 이미 동작하지 않아, GIF 제공자를 KLIPY 로 이관합니다.

## 변경
- 서버 프록시 `/api/tenor/{search,featured}` 의 업스트림을 KLIPY 의 Tenor 호환 v2 엔드포인트(`api.klipy.com/v2/...`)로 교체
- 인증 env `TENOR_API_KEY` → `KLIPY_API_KEY`
- 응답 정규화 형태(`{id,title,url,preview_url,width,height}`)는 그대로 유지 → 클라이언트/타입/GIF 피커 **변경 없음**
- 라우트 경로(`/api/tenor/*`)는 프론트 호출 호환 위해 유지

## 남은 작업 (머지 전)
- [ ] `KLIPY_API_KEY` 를 Secret(angple-secrets)에 추가 (k8s 레포 PR)
- [ ] canary 에서 `/api/tenor/search?q=test` 실응답 검증 — KLIPY v2 가 `media_formats`(Tenor 형식)로 응답하는지 확인 후 필요 시 매핑 보정
- [ ] 댓글 GIF 피커 검색/트렌딩 동작 확인

draft 로 두고 키 확보 + canary 실응답 검증 후 ready 전환합니다.