### PR TITLE
fix(disciplinelog): 삭제된 신고글도 링크 유지 (#12817)

### DIFF
--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -257,28 +257,24 @@
                             <div
                                 class="hover:bg-muted/50 rounded p-2 transition-all duration-200 ease-out"
                             >
-                                {#if item.deleted}
-                                    <!-- 신고 접수 후 삭제된 글: 링크 비활성 + 삭제됨 배지 -->
-                                    <div
-                                        class="text-muted-foreground flex items-center gap-2 text-sm"
+                                <!-- 삭제 여부와 무관하게 링크 유지 (삭제글도 글 페이지로 이동 가능).
+                                     삭제된 경우 취소선 + 삭제됨 배지로 상태만 표시. -->
+                                <a
+                                    href={getReportedItemUrl(item)}
+                                    class="flex items-center gap-2 text-sm"
+                                >
+                                    <ExternalLink class="text-muted-foreground h-4 w-4" />
+                                    <span
+                                        class="hover:underline {item.deleted
+                                            ? 'text-muted-foreground line-through'
+                                            : 'text-primary'}"
                                     >
-                                        <ExternalLink class="h-4 w-4" />
-                                        <span class="line-through">
-                                            {getReportedItemLabel(item)}
-                                        </span>
+                                        {getReportedItemLabel(item)}
+                                    </span>
+                                    {#if item.deleted}
                                         <Badge variant="secondary" class="text-xs">삭제됨</Badge>
-                                    </div>
-                                {:else}
-                                    <a
-                                        href={getReportedItemUrl(item)}
-                                        class="flex items-center gap-2 text-sm"
-                                    >
-                                        <ExternalLink class="text-muted-foreground h-4 w-4" />
-                                        <span class="text-primary hover:underline">
-                                            {getReportedItemLabel(item)}
-                                        </span>
-                                    </a>
-                                {/if}
+                                    {/if}
+                                </a>
                                 {#if (item.sg_types && item.sg_types.length > 0) || item.penalty_days != null}
                                     <div class="ml-6 mt-1.5 flex flex-wrap items-center gap-1">
                                         {#if item.sg_types}


### PR DESCRIPTION
## 제보 (bug #12817)
이용제한 근거 페이지의 '신고 접수된 글' 목록에서, 신고 후 삭제된 글/댓글은 표식만 생기고 **링크가 제거**되어 이동할 수 없었습니다. 원글·댓글은 삭제 후에도 글 페이지로 접근 가능하므로 링크가 유지되어야 한다는 제보입니다.

## 원인
`routes/disciplinelog/[id]/+page.svelte` 에서 `item.deleted` 일 때 `<a>` 대신 비활성 `<div>`(취소선+배지)로 렌더 → 클릭 불가. 다른 목록 레이아웃(card/archive/classic)은 삭제글도 링크를 유지하는데 이 페이지만 불일치.

## 수정
- 삭제 여부와 무관하게 `<a href>` 링크 유지 → 삭제글도 글 페이지(삭제 안내 placeholder)로 이동 가능
- URL(라벨) 표시 유지, 삭제 상태는 취소선 + '삭제됨' 배지로 구분
- 코드베이스 링크 유지 정책으로 통일

## 검증
- canary: 이용제한 근거 페이지에서 삭제된 신고 항목 클릭 시 글 페이지로 이동 / '삭제됨' 배지 표시 확인