### PR TITLE
fix(my): 마이페이지에 경험치 레벨 배지 표시 (#12812 후속)

### DIFF
--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -6,6 +6,7 @@
     import type { PageData } from './$types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { getGradeName } from '$lib/utils/grade.js';
+    import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import MySkeleton from '$lib/components/features/my/my-skeleton.svelte';
     import FileText from '@lucide/svelte/icons/file-text';
@@ -128,7 +129,14 @@
                 </div>
                 <div>
                     <h1 class="text-foreground text-2xl font-bold">{authStore.user.mb_name}</h1>
-                    <p class="text-secondary-foreground">{getGradeName(authStore.user.mb_level)}</p>
+                    <div class="flex items-center gap-1.5">
+                        {#if authStore.user.as_level}
+                            <LevelBadge level={authStore.user.as_level} />
+                        {/if}
+                        <p class="text-secondary-foreground">
+                            {getGradeName(authStore.user.mb_level)}
+                        </p>
+                    </div>
                     {#if authStore.user.mb_id}
                         <p class="text-muted-foreground mt-0.5 text-sm">
                             아이디 {authStore.user.mb_id}


### PR DESCRIPTION
## 배경 (#12812)
'댓글에서 보이는 레벨과 내 계정 프로필 레벨이 다르다'는 제보. 원인은 화면별 표시 필드 불일치:
- 댓글: `as_level`(경험치 레벨) → LevelBadge 배지
- 타인 프로필(`/member/[id]`): `as_level` 배지 + `mb_level` 등급명 둘 다
- **내 계정(`/my`): `mb_level` 등급명만** — as_level 배지 누락

## 수정
`/my` 헤더에 `LevelBadge level={as_level}` 를 등급명과 함께 표시(타인 프로필과 동일 패턴). `as_level` 있을 때만 렌더.

## 검증
- canary: 마이페이지 헤더에 댓글과 동일한 경험치 레벨 배지가 등급명과 함께 표시되는지