### PR TITLE
fix(points): 포인트 내역 '사용' 항목 만료됨 오표기 수정 (#12829)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -911,7 +911,8 @@ export interface PointHistory {
     po_point: number; // 포인트 금액 (양수: 적립, 음수: 사용)
     po_use_point?: number; // 사용된 포인트 (적립 포인트 중 소진된 양)
     po_datetime: string; // 발생 시간
-    po_expired: boolean; // 만료 여부 (0=활성, 1=만료, 100=전부사용)
+    po_expired: boolean; // 만료/사용여부 (raw 1 또는 100 → true)
+    po_expired_raw?: number; // raw 값 (0=활성, 1=만료, 100=전부사용) — 음수행에도 1이 찍히므로 라벨 구분용
     po_expire_date: string; // 만료일
     po_mb_point?: number; // 거래 시점 보유 포인트 (잔액 스냅샷)
     po_rel_table?: string; // 관련 테이블 (예: 게시판)

--- a/apps/web/src/routes/my/points/+page.server.ts
+++ b/apps/web/src/routes/my/points/+page.server.ts
@@ -91,6 +91,8 @@ export const load: PageServerLoad = async ({ url, locals }) => {
                     : String(row.po_datetime || ''),
             // po_expired: 0=활성, 1=만료, 100=전부 사용됨
             po_expired: row.po_expired === 1 || row.po_expired === 100,
+            // raw 값 — 음수(사용) 행에도 1이 찍히므로 라벨 구분(기간만료 vs 사용)에 필요
+            po_expired_raw: row.po_expired,
             po_expire_date:
                 row.po_expire_date instanceof Date
                     ? row.po_expire_date.toISOString().split('T')[0]

--- a/apps/web/src/routes/my/points/+page.svelte
+++ b/apps/web/src/routes/my/points/+page.svelte
@@ -239,13 +239,27 @@
                                             class="text-muted-foreground mt-1 flex items-center gap-2 text-xs"
                                         >
                                             <span>{formatDate(item.po_datetime)}</span>
-                                            {#if item.po_expired}
+                                            {#if item.po_point > 0 && item.po_expired_raw === 1}
+                                                <!-- 적립 포인트가 유효기간 경과로 소멸된 경우만 '기간만료' -->
                                                 <Badge
                                                     variant="secondary"
                                                     class="text-muted-foreground text-[10px]"
-                                                    >만료됨</Badge
+                                                    >기간만료</Badge
                                                 >
-                                            {:else if isExpiringSoon(item.po_expire_date)}
+                                            {:else if item.po_point > 0 && item.po_expired_raw === 100}
+                                                <Badge
+                                                    variant="secondary"
+                                                    class="text-muted-foreground text-[10px]"
+                                                    >전부 사용</Badge
+                                                >
+                                            {:else if item.po_point < 0}
+                                                <!-- 음수=사용(쪽지/응모/댓글수정 등). 내용(po_content)이 곧 사유 -->
+                                                <Badge
+                                                    variant="outline"
+                                                    class="text-muted-foreground text-[10px]"
+                                                    >사용</Badge
+                                                >
+                                            {:else if !item.po_expired && isExpiringSoon(item.po_expire_date)}
                                                 <Badge
                                                     variant="outline"
                                                     class="border-orange-300 text-[10px] text-orange-600"
@@ -253,7 +267,7 @@
                                                     <Clock class="mr-0.5 h-2.5 w-2.5" />
                                                     만료 임박
                                                 </Badge>
-                                            {:else if item.po_expire_date && item.po_expire_date !== '9999-12-31'}
+                                            {:else if !item.po_expired && item.po_expire_date && item.po_expire_date !== '9999-12-31'}
                                                 <span class="text-muted-foreground"
                                                     >만료: {item.po_expire_date}</span
                                                 >


### PR DESCRIPTION
## 배경 (#12829 '마이너스 포인트')
포인트 내역에서 음수(사용) 항목 — 쪽지 발송·나눔 응모·댓글 수정 비용 등 — 이 **'만료됨' 으로 잘못 표시**되어 사용자 혼란. 원인: gnuboard 가 음수 차감행에도 po_expired=1 을 기록하는데, 화면이 po_expired=1/100 을 무조건 '만료됨' 으로 표기.

## 수정
po_point 부호 + raw 상태로 라벨 분기:
| 조건 | 라벨 |
|---|---|
| po_point < 0 | **사용** (po_content 이 사유) |
| po_point > 0 & raw=1 | **기간만료** |
| po_point > 0 & raw=100 | 전부 사용 |
| po_point > 0 & 활성 | 만료 임박 / 만료일 (기존) |

- server()가 `po_expired_raw`(원본 0/1/100) 추가 노출, 타입(`PointHistory`)에 필드 추가
- 적립 포인트가 유효기간 경과로 소멸된 경우에만 '기간만료' 표기

## 검증
- canary: 포인트 내역에서 쪽지/응모/댓글수정 = '사용', 실제 만료 적립건 = '기간만료' 로 구분 표시