### PR TITLE
perf(web): 번들 전략 single → split (코드 분할 복원)

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -50,8 +50,12 @@ const config = {
             trustedOrigins: ['*']
         },
         output: {
-            // 청크 수를 줄이기 위해 단일 번들 전략 사용
-            bundleStrategy: 'single',
+            // 코드 분할 사용(SvelteKit 기본). 앱이 커지며 단일 번들의 단점이 큼:
+            //  - 매 배포마다 전체 번들 해시 변경 → 재방문자가 전체 재다운로드(캐시 재사용 0)
+            //  - Three.js 등 무거운 동적 import 가 모든 페이지에 인라인
+            // 분할 시 벤더/라우트 청크가 배포 간 캐시 유지되어 대역폭·로드 모두 개선.
+            // (Cloudflare h2/h3 멀티플렉싱이라 청크 다수의 요청 오버헤드는 미미)
+            bundleStrategy: 'split',
             // modulepreload: 브라우저 기본 동작에 위임하여 불필요한 prefetch 감소
             preloadStrategy: 'modulepreload'
         },


### PR DESCRIPTION
## 배경
bundleStrategy 'single' 은 앱이 작던 초기(#420 '용량이 적어서') 결정. 현재 ~6MB(압축 1.68MB)로 커져 단점이 큼: 매 배포마다 전체 해시 변경 → 재방문자 1.68MB 전체 재다운로드, Three.js(~1.3MB)가 전 페이지 인라인.

## 변경
bundleStrategy 'single' → 'split'(SvelteKit 기본). 라우트/벤더/동적 import 자동 분할.

## 효과
벤더·라우트 청크 배포 간 캐시 유지 → 대역폭·반복로드·origin egress 감소. 무거운 three 는 진입 페이지에서만 로드. Cloudflare h2/h3 라 청크 다수 오버헤드 미미.

## 검증(canary 전수)
/brickang 3D + 주요 페이지 에셋404·CSP·SSR 정상, 메인 엔트리 크기 감소 + three 별도 청크, 청크수 합리적. 과도분할 시 manualChunks 후속 튜닝.