### PR TITLE
fix(post): 로그인 유저 SPA 이동 시 댓글 SSR 즉시 제공 (스켈레톤 제거)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -299,8 +299,11 @@ export const load: PageServerLoad = async ({
 
         // --- 2단계: 핵심/보조 데이터를 분리해 스트리밍 ---
         const commentsData = await (async () => {
-            if (isDataRequest) {
-                // SPA 네비(__data.json): 댓글은 클라가 backfill 로 로드. total 은 권위값 보존.
+            if (isDataRequest && !locals.user?.id) {
+                // 비로그인 SPA 네비(__data.json): 댓글은 클라가 backfill 로 로드. total 은 권위값 보존.
+                // 비로그인 __data.json 은 nginx/SSR 캐시 대상이라 댓글을 비워 stale 캐시를 방지.
+                // 로그인 유저는 응답이 private(캐시 우회)이므로 아래에서 댓글을 SSR 에 포함 →
+                // SPA 이동 시 클라 재요청(스켈레톤) 없이 즉시 노출 (캐시 정합성 영향 없음).
                 return {
                     comments: {
                         items: [],


### PR DESCRIPTION
## 문제
목록 → 글 상세 **SPA 네비게이션** 시 댓글 스켈레톤 지연이 보임. 원인: `+page.server.ts` 가 `isDataRequest`(__data.json)에서 댓글을 빈 배열로 반환 → 클라이언트가 `refetchComments` 로 별도 왕복 후 렌더.

## 변경
- strip 분기를 `isDataRequest && !locals.user?.id` 로 한정.
- 로그인 유저: 댓글을 SSR 데이터에 포함 → SPA 이동 시 재요청 없이 즉시 노출.
- 비로그인: 현행 유지(빈 배열 → 클라 backfill).

## 안전성
- 비로그인 공개 HTML/__data.json 만 SSR 캐시 대상(`hooks.server.ts:897 isAnonymousPublicHtml = !hasSessionCookie ...`). 로그인 응답은 `private`(`:1129`) → 공유 캐시 미적재라 stale 위험 0.
- 클라 backfill effect 는 `total<=loaded` 면 재요청 안 함 → SSR 로 채워지면 자동으로 추가 요청 없음.
- >10 댓글 글은 기존 직접로드와 동일하게 첫 10개 SSR + 나머지 backfill.

## 검증
- canary: 로그인 세션 `__data.json` 에 댓글 내용 포함 / 비로그인은 여전히 strip 확인.
- `pnpm check` 해당 파일 클린.