### PR TITLE
feat(comment): 댓글 공감자 목록에 날짜+시각 표시

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
+++ b/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
@@ -6,7 +6,7 @@
     import type { Component } from 'svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
-    import { formatDate } from '$lib/utils/format-date.js';
+    import { formatDateTime } from '$lib/utils/format-date.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     // 동적 플러그인 임포트: member-memo
@@ -146,7 +146,7 @@
                                             <span>({liker.bg_ip})</span>
                                             <span class="mx-1">&middot;</span>
                                         {/if}
-                                        <span>{formatDate(liker.liked_at)}</span>
+                                        <span>{formatDateTime(liker.liked_at)}</span>
                                     </div>
                                 </div>
 

--- a/apps/web/src/lib/utils/format-date.ts
+++ b/apps/web/src/lib/utils/format-date.ts
@@ -60,6 +60,29 @@ export function formatDateCompact(dateString: DateInput): string {
         return `${dateStr.slice(2, 4)}.${dateStr.slice(5, 7)}.${dateStr.slice(8, 10)}`;
     }
 }
+
+/**
+ * 전체 날짜+시각 포맷 (YYYY.MM.DD HH:MM, 서울 시간).
+ * formatDate 는 상대형(오늘만 시각, 그 외 날짜만)이라 목록 공간을 아끼지만,
+ * 공감/추천 목록처럼 "언제 눌렀는지" 정확한 시각이 의미 있는 곳에서는 항상 시각까지 표시한다.
+ */
+export function formatDateTime(dateString: DateInput): string {
+    const normalized = normalizeDateInput(dateString);
+    if (!normalized) return '';
+    const date = new Date(normalized);
+    if (isNaN(date.getTime())) return '';
+    const datePart = date
+        .toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' }) // "2026-06-28"
+        .replace(/-/g, '.');
+    const timePart = date.toLocaleTimeString('ko-KR', {
+        timeZone: 'Asia/Seoul',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
+    return `${datePart} ${timePart}`; // "2026.06.28 19:48"
+}
+
 /**
  * 주어진 날짜가 오늘(서울 시간 기준)인지 확인
  */


### PR DESCRIPTION
## 요청
댓글 '공감한 사람들' 목록에서 공감을 누른 시각이 보이지 않는다는 피드백.

## 원인
다이얼로그가 공용 `formatDate` 를 사용 → 상대 포맷이라 **오늘** 공감만 시각(HH:MM)을 보이고 어제·올해·이전은 **날짜만**(MM.DD / YY.MM.DD) 표시. (데이터 `g5_board_good.bg_datetime` 는 모두 정상 존재)

## 변경
- `format-date.ts` 에 항상 `YYYY.MM.DD HH:MM` 으로 표기하는 `formatDateTime` 추가.
- 댓글 공감자 다이얼로그(`comment-likers-dialog.svelte`)가 이를 사용 → 모든 공감에 정확한 시각 표시.

## 참고
- 게시글(포스트) 공감자 다이얼로그는 이미 날짜+시각을 표시(별도 로컬 포맷)하므로 변경 없음.
- `pnpm check` 변경 파일 클린.