### PR TITLE
fix(layout): fullWidth 시 좌측 메뉴 유지(오른쪽만 숨김)

### DIFF
--- a/apps/web/src/lib/layouts/default-layout.svelte
+++ b/apps/web/src/lib/layouts/default-layout.svelte
@@ -48,7 +48,7 @@
         <Header />
 
         <div class="mx-auto flex w-full flex-1">
-            {#if snbPosition === 'right' && !fullWidth}
+            {#if snbPosition === 'right'}
                 <aside
                     class="bg-subtle border-border my-5 hidden w-[320px] flex-shrink-0 rounded-md border lg:flex lg:flex-col"
                 >
@@ -56,7 +56,7 @@
                     <Panel />
                 </aside>
             {/if}
-            {#if snbPosition === 'left' && !fullWidth}
+            {#if snbPosition === 'left'}
                 <aside class="bg-background hidden 2xl:block 2xl:!w-[230px]">
                     <Sidebar />
                 </aside>


### PR DESCRIPTION
풀폭은 본문+오른쪽 사이드바(공지/미니메뉴)만 합치고 왼쪽 메뉴는 유지. main 앞쪽(좌측) aside 게이트 해제, 뒤쪽(우측)만 !fullWidth.