### PR TITLE
ci(web): three vendor 번들 자동 빌드+R2 업로드 (idempotent)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,6 +194,37 @@ jobs:
             --cache-control "public, max-age=31536000, immutable" \
             --no-progress
 
+      # three(+OrbitControls)는 bundleStrategy:'single' 에서 앱 번들에 인라인되지 않도록
+      # 자체호스팅 vendor 번들(static.damoang.net/vendor/three/...)로 분리해 brickang 만 로드.
+      # 버전 파일명 고정(immutable) → 이미 있으면 스킵(idempotent). 실패해도 배포는 비차단.
+      - name: Build & upload three vendor bundle to R2 (idempotent)
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
+        run: |
+          set -uo pipefail
+          cd apps/web
+          THREE_VER=$(node -p "require('three/package.json').version")
+          KEY="vendor/three/three-vendor.${THREE_VER}.js"
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          if aws s3 ls "s3://${R2_BUCKET}/${KEY}" --endpoint-url "$ENDPOINT" >/dev/null 2>&1; then
+            echo "three vendor already present: ${KEY} — skip"
+            exit 0
+          fi
+          echo "building three vendor (three@${THREE_VER})..."
+          node scripts/build-three-vendor.mjs
+          aws s3 cp "build-vendor/three-vendor.${THREE_VER}.js" \
+            "s3://${R2_BUCKET}/${KEY}" \
+            --endpoint-url "$ENDPOINT" \
+            --content-type application/javascript \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress
+          echo "uploaded ${KEY}"
+
       - name: Prepare deploy package
         run: |
           pnpm --filter web deploy --prod --legacy apps/web/deploy

--- a/apps/web/scripts/build-three-vendor.mjs
+++ b/apps/web/scripts/build-three-vendor.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * three core + OrbitControls 를 자체완결 ESM 1파일로 번들한다.
+ * 출력: apps/web/build-vendor/three-vendor.<three-version>.js
+ *
+ * 배경: 앱이 bundleStrategy:'single' 이라 npm 'three' 를 import 하면 ~1.3MB 가
+ * 단일 앱 번들에 전 페이지 인라인된다(brickang 전용인데도). 이 vendor 파일을
+ * static.damoang.net 에 올려 brickang(three-scene.ts)이 절대 URL 로 로드하면
+ * three 가 앱 번들에서 빠지고 brickang 진입 시에만 fetch 된다.
+ *
+ * deploy.yml 의 "Build & upload three vendor bundle to R2" 스텝에서 호출.
+ * 버전 파일명 고정(immutable). three 업그레이드 시 파일명이 바뀌므로
+ * premium plugins/brickang/lib/three-scene.ts 의 THREE_VENDOR_URL 도 함께 갱신해야 한다.
+ */
+import { build } from 'vite';
+import { createRequire } from 'node:module';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..'); // apps/web
+const version = require('three/package.json').version;
+const outDir = resolve(webRoot, 'build-vendor');
+// 진입 파일은 apps/web 내부에 둬야 'three' 가 정상 해석된다.
+const entry = resolve(webRoot, '.three-vendor-entry.tmp.js');
+
+mkdirSync(outDir, { recursive: true });
+writeFileSync(
+    entry,
+    "export * as THREE from 'three';\n" +
+        "export { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';\n"
+);
+
+try {
+    await build({
+        root: webRoot,
+        configFile: false,
+        logLevel: 'warn',
+        build: {
+            outDir,
+            emptyOutDir: false,
+            minify: 'esbuild',
+            target: 'es2020',
+            lib: {
+                entry,
+                formats: ['es'],
+                fileName: () => `three-vendor.${version}.js`
+            },
+            // external 없음: three 전부 번들 내부에 포함 (자체완결)
+            rollupOptions: { external: [] }
+        }
+    });
+    console.log(`[three-vendor] built three-vendor.${version}.js`);
+} finally {
+    rmSync(entry, { force: true });
+}


### PR DESCRIPTION
## 목적
brickang 전용 three.js(~1.3MB)가 bundleStrategy:'single' 단일 앱 번들에 전 페이지 인라인되는 것을 막기 위해, three 를 자체호스팅 vendor 번들로 분리(premium #110 짝). 그 vendor 파일의 빌드+업로드를 배포에 자동 편입.

## 변경
- `apps/web/scripts/build-three-vendor.mjs`: three core+OrbitControls 를 자체완결 ESM 1파일로 vite lib 빌드 (`build-vendor/three-vendor.<ver>.js`).
- `deploy.yml` build job: 'Upload immutable assets to R2' 직후에 **idempotent vendor 업로드 스텝** 추가 — three 버전 감지 → R2에 해당 파일 없을 때만 빌드+`aws s3 cp` (CI의 CLOUDFLARE_R2_* 시크릿, `--region auto`).

## 안전성
- `continue-on-error: true` — vendor 스텝 실패해도 배포 비차단.
- 이미 있으면 스킵(immutable, 재업로드 안 함). 기존 release 자산 업로드 흐름 불변.
- 버전 파일명 고정 → 캐시 영구 재사용.

## 짝 PR / 후속
- premium #110: three-scene.ts 가 `static.damoang.net/vendor/three/three-vendor.0.171.0.js` 로딩.
- three 업그레이드 시 premium THREE_VENDOR_URL 버전도 함께 갱신 필요(주석 명시).

## 검증 (canary)
- 배포 로그에 'uploaded vendor/three/...' / vendor URL 200·immutable / 메인 번들에서 three 제거 / brickang 3D 정상 / 게시글·하이드레이션 클린.