### PR TITLE
fix(editor): 이미지 업로드 race 해소 — 로컬 즉시표시 후 변환본 스왑 (#12839)

### DIFF
--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -337,6 +337,13 @@
         if (isSubmitting || isLoading) return;
         if (!validate()) return;
 
+        // bug/12839: 본문에 로컬 미리보기(blob:) 이미지가 남아있으면 변환본 교체 완료까지 제출 차단.
+        // blob: 은 세션 한정 URL이라 그대로 저장하면 이미지가 깨진다. 보통 수초 내 자동 교체됨.
+        if (content.includes('blob:')) {
+            alert('이미지를 처리하는 중입니다. 잠시 후(몇 초) 다시 시도해 주세요.');
+            return;
+        }
+
         isSubmitting = true;
 
         // 첨부 이미지를 content 끝에 <img> 태그로 삽입 (Go 백엔드 호환)

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -396,49 +396,123 @@
         lastLoadedContent = c;
     });
 
+    // === 이미지 업로드 race 해소 (bug/12839): 로컬 blob 즉시표시 → 변환본 준비 시 src 스왑 ===
+    // 변환(raw→data) Lambda 가 평균 4.5초·최대 15초라, 업로드 응답 URL 을 곧바로 박으면
+    // 아직 안 만들어진 data/ 이미지를 가리켜 깨짐/부분표시가 비결정적으로 발생한다.
+    // → 올리는 즉시 blob 미리보기(0초, 안 깨짐) 삽입 후, data URL 이 실제 로드 가능해질 때까지
+    //   백그라운드 preload(재시도) → 준비되면 해당 노드 src 만 교체. 제출 가드(post-form)가 blob 잔존 차단.
+    const IMAGE_SWAP_MAX_MS = 20000;
+
+    // data URL 이 실제 200 으로 로드될 때까지 preload 재시도(지수백오프). 성공 시 true.
+    // CDN 이 변환 전 404 를 max-age=300 으로 캐시할 수 있어 프로브엔 캐시버스터를 붙인다.
+    function preloadImage(url: string, maxMs = IMAGE_SWAP_MAX_MS): Promise<boolean> {
+        return new Promise((resolve) => {
+            const start = Date.now();
+            let delay = 400;
+            const tryLoad = () => {
+                const img = new Image();
+                img.onload = () => resolve(true);
+                img.onerror = () => {
+                    if (Date.now() - start >= maxMs) {
+                        resolve(false);
+                        return;
+                    }
+                    window.setTimeout(tryLoad, delay);
+                    delay = Math.min(Math.round(delay * 1.8), 3000);
+                };
+                img.src = url + (url.includes('?') ? '&' : '?') + '_p=' + Date.now();
+            };
+            tryLoad();
+        });
+    }
+
+    // 문서에서 src 가 oldSrc 인 image 노드를 찾아 newSrc 로 교체 (위치는 교체 시점 기준 재탐색).
+    function swapImageSrc(oldSrc: string, newSrc: string): boolean {
+        if (!editor) return false;
+        const { state, view } = editor;
+        let found: { pos: number; attrs: Record<string, unknown> } | null = null;
+        state.doc.descendants((node, pos) => {
+            if (!found && node.type.name === 'image' && node.attrs.src === oldSrc) {
+                found = { pos, attrs: node.attrs };
+                return false;
+            }
+            return undefined;
+        });
+        if (!found) return false;
+        view.dispatch(
+            state.tr.setNodeMarkup(found.pos, undefined, { ...found.attrs, src: newSrc })
+        );
+        return true;
+    }
+
+    // 업로드 실패 시 임시 blob 이미지 노드 제거 (깨진 채 남기지 않음).
+    function removeImageBySrc(src: string): void {
+        if (!editor) return;
+        const { state, view } = editor;
+        let target: { pos: number; size: number } | null = null;
+        state.doc.descendants((node, pos) => {
+            if (!target && node.type.name === 'image' && node.attrs.src === src) {
+                target = { pos, size: node.nodeSize };
+                return false;
+            }
+            return undefined;
+        });
+        if (target) view.dispatch(state.tr.delete(target.pos, target.pos + target.size));
+    }
+
+    // blob 즉시삽입 + 백그라운드 업로드/스왑. insertBlob 으로 삽입 위치를 주입한다.
+    function uploadAndSwap(file: File, insertBlob: (blobUrl: string) => void): void {
+        if (!onImageUpload || !editor) return;
+        const blobUrl = URL.createObjectURL(file);
+        insertBlob(blobUrl);
+        void (async () => {
+            try {
+                const dataUrl = await onImageUpload!(file);
+                if (!dataUrl) {
+                    removeImageBySrc(blobUrl);
+                    URL.revokeObjectURL(blobUrl);
+                    return;
+                }
+                const ready = await preloadImage(dataUrl);
+                if (ready && swapImageSrc(blobUrl, dataUrl)) {
+                    URL.revokeObjectURL(blobUrl);
+                } else {
+                    // 변환 지연(>20s, 드묾): 로컬 미리보기 유지. 제출 가드가 blob 차단 → 데이터 유실 방지.
+                    console.warn('[image] 변환본 준비 지연 — 로컬 미리보기 유지:', dataUrl);
+                }
+            } catch (err) {
+                console.error('Image upload failed:', err);
+                removeImageBySrc(blobUrl);
+                URL.revokeObjectURL(blobUrl);
+            }
+        })();
+    }
+
     // 이미지 파일 업로드 처리 (커서 위치에 삽입)
     async function handleImageFile(file: File): Promise<void> {
         if (!onImageUpload || !editor) return;
         if (!isImageFile(file)) return;
-
-        isUploading = true;
-        try {
-            const imageUrl = await onImageUpload(file);
-            if (imageUrl) {
-                // #9328: 이미지 삽입 후 빈 paragraph 추가 — 사용자가 이미지 다음 줄에 바로 입력 가능하도록
-                editor.chain().focus().setImage({ src: imageUrl }).createParagraphNear().run();
-            }
-        } catch (err) {
-            console.error('Image upload failed:', err);
-        } finally {
-            isUploading = false;
-        }
+        uploadAndSwap(file, (blobUrl) => {
+            // #9328: 이미지 삽입 후 빈 paragraph 추가 — 사용자가 이미지 다음 줄에 바로 입력 가능하도록
+            editor!.chain().focus().setImage({ src: blobUrl }).createParagraphNear().run();
+        });
     }
 
     // 특정 위치에 이미지 삽입 (드래그 앤 드롭용)
     async function handleImageFileAtPosition(file: File, pos: number): Promise<void> {
         if (!onImageUpload || !editor) return;
         if (!isImageFile(file)) return;
-
-        isUploading = true;
-        try {
-            const imageUrl = await onImageUpload(file);
-            if (imageUrl) {
-                // 특정 위치에 이미지 삽입 (기존 내용 유지)
-                // #9328: 이미지 다음에 빈 paragraph 함께 삽입 — 사용자가 이미지 아래 줄에 바로 입력 가능하도록
-                editor
-                    .chain()
-                    .insertContentAt(pos, [
-                        { type: 'image', attrs: { src: imageUrl } },
-                        { type: 'paragraph' }
-                    ])
-                    .run();
-            }
-        } catch (err) {
-            console.error('Image upload failed:', err);
-        } finally {
-            isUploading = false;
-        }
+        uploadAndSwap(file, (blobUrl) => {
+            // 특정 위치에 이미지 삽입 (기존 내용 유지)
+            // #9328: 이미지 다음에 빈 paragraph 함께 삽입 — 사용자가 이미지 아래 줄에 바로 입력 가능하도록
+            editor!
+                .chain()
+                .insertContentAt(pos, [
+                    { type: 'image', attrs: { src: blobUrl } },
+                    { type: 'paragraph' }
+                ])
+                .run();
+        });
     }
 
     // 드래그 앤 드롭 핸들러 (드롭 위치에 이미지/동영상 삽입)

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -430,34 +430,36 @@
     function swapImageSrc(oldSrc: string, newSrc: string): boolean {
         if (!editor) return false;
         const { state, view } = editor;
-        let found: { pos: number; attrs: Record<string, unknown> } | null = null;
+        let done = false;
+        // 노드를 찾으면 콜백 내부에서 바로 교체 (외부 변수 캡처 시 TS 가 never 로 좁히는 문제 회피)
         state.doc.descendants((node, pos) => {
-            if (!found && node.type.name === 'image' && node.attrs.src === oldSrc) {
-                found = { pos, attrs: node.attrs };
+            if (done) return false;
+            if (node.type.name === 'image' && node.attrs.src === oldSrc) {
+                view.dispatch(
+                    state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, src: newSrc })
+                );
+                done = true;
                 return false;
             }
             return undefined;
         });
-        if (!found) return false;
-        view.dispatch(
-            state.tr.setNodeMarkup(found.pos, undefined, { ...found.attrs, src: newSrc })
-        );
-        return true;
+        return done;
     }
 
     // 업로드 실패 시 임시 blob 이미지 노드 제거 (깨진 채 남기지 않음).
     function removeImageBySrc(src: string): void {
         if (!editor) return;
         const { state, view } = editor;
-        let target: { pos: number; size: number } | null = null;
+        let done = false;
         state.doc.descendants((node, pos) => {
-            if (!target && node.type.name === 'image' && node.attrs.src === src) {
-                target = { pos, size: node.nodeSize };
+            if (done) return false;
+            if (node.type.name === 'image' && node.attrs.src === src) {
+                view.dispatch(state.tr.delete(pos, pos + node.nodeSize));
+                done = true;
                 return false;
             }
             return undefined;
         });
-        if (target) view.dispatch(state.tr.delete(target.pos, target.pos + target.size));
     }
 
     // blob 즉시삽입 + 백그라운드 업로드/스왑. insertBlob 으로 삽입 위치를 주입한다.


### PR DESCRIPTION
## 문제
에디터에 이미지를 올리면 변환 Lambda(raw→data, 평균 4.5s·p99 10s·최대 15s)보다 서버 폴링(8s)이 짧아, 아직 안 만들어진 `data/` URL 을 그대로 본문에 박음 → 깨짐·상단만 표시·비결정적. 자동 재로드도 없어 새로고침 전까지 그대로. (#12839, 설계: /home/damoang/docs/bug-12839-image-upload-race/index.html)

## 수정 (채택안: 로컬 즉시표시 → data 스왑)
- 업로드 즉시 `URL.createObjectURL(file)` blob 미리보기 삽입 — 0초, 안 깨짐.
- 백그라운드로 `onImageUpload` 응답 data URL 을 `preloadImage`(지수백오프 재시도 + 캐시버스터로 변환전 404 캐시 우회)로 실제 로드 확인 → 준비되면 해당 image 노드 src 만 `swapImageSrc` 로 교체 + `revokeObjectURL`.
- 업로드 실패 시 임시 blob 노드 제거(`removeImageBySrc`), 변환 지연(>20s 드묾) 시 로컬 미리보기 유지.
- **제출 가드**(post-form): 본문에 `blob:` 가 남아있으면 교체 완료까지 제출 차단(세션한정 blob 저장=깨짐 방지).
- 드롭·붙여넣기·다이얼로그 모두 공통 핸들러(`handleImageFile`/`handleImageFileAtPosition`) 경유 → 일괄 적용.

## 범위/안전
- 에디터 클라이언트 경로만 변경(라우트 분할/SSR/하이드레이션 무관). 비디오·외부 URL 붙여넣기는 범위 외(별개).
- `pnpm check` 변경 2파일 클린. **에디터 핵심 경로라 canary first.**

## 검증 (canary)
1. 큰 이미지 업로드 → 즉시 blob 미리보기 → 수초 후 data/ 로 자동 교체(DevTools Elements/Network)
2. 동일 이미지 10회 → 전부 정상(비결정성 해소)
3. 제출 → 저장 본문에 blob: 없음, data/editor URL 만
4. 회귀: 드롭/붙여넣기/다이얼로그/제출차단 안내

## 일정
완료 안내 댓글(금요일 정기배포+canary)과 맞춰 진행.