### PR TITLE
fix(ci): three vendor 버전 감지 fs read (exports 제한 회피)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,7 +208,7 @@ jobs:
         run: |
           set -uo pipefail
           cd apps/web
-          THREE_VER=$(node -p "require('three/package.json').version")
+          THREE_VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('node_modules/three/package.json','utf8')).version)")
           KEY="vendor/three/three-vendor.${THREE_VER}.js"
           ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           if aws s3 ls "s3://${R2_BUCKET}/${KEY}" --endpoint-url "$ENDPOINT" >/dev/null 2>&1; then

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -34,3 +34,7 @@ vite.config.ts.timestamp-*
 
 # Multisite Site-Resolver (premium install.sh 가 site-overrides.json 배치)
 /.angple/
+
+# three vendor 빌드 산출물 (CI 에서 생성·업로드, 커밋 안 함)
+build-vendor/
+.three-vendor-entry.tmp.js

--- a/apps/web/scripts/build-three-vendor.mjs
+++ b/apps/web/scripts/build-three-vendor.mjs
@@ -13,14 +13,16 @@
  * premium plugins/brickang/lib/three-scene.ts 의 THREE_VENDOR_URL 도 함께 갱신해야 한다.
  */
 import { build } from 'vite';
-import { createRequire } from 'node:module';
-import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
-const require = createRequire(import.meta.url);
 const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..'); // apps/web
-const version = require('three/package.json').version;
+// three 의 package.json 은 exports 맵에 없어 require('three/package.json') 가
+// ERR_PACKAGE_PATH_NOT_EXPORTED 로 실패한다(Node 22). 파일을 직접 읽어 버전 추출.
+const version = JSON.parse(
+    readFileSync(resolve(webRoot, 'node_modules/three/package.json'), 'utf8')
+).version;
 const outDir = resolve(webRoot, 'build-vendor');
 // 진입 파일은 apps/web 내부에 둬야 'three' 가 정상 해석된다.
 const entry = resolve(webRoot, '.three-vendor-entry.tmp.js');


### PR DESCRIPTION
## 문제
PR #1692 의 vendor 자동 업로드 스텝이 `require('three/package.json')` 로 버전을 감지하는데, three 의 `package.json` 이 exports 맵에 없어 Node22 에서 `ERR_PACKAGE_PATH_NOT_EXPORTED` 로 실패 → 스텝이 버전 감지 단계에서 죽어 **vendor 자동 업로드가 no-op**이었음(continue-on-error 라 배포는 무영향, 1 error 주석만). 현재 vendor 파일은 수동 업로드분으로 존재해 three 외부화는 작동 중.

## 수정
- `deploy.yml` THREE_VER + `scripts/build-three-vendor.mjs`: 버전 감지를 `JSON.parse(fs.readFileSync('node_modules/three/package.json'))` 로 변경(exports 우회).
- 빌드 산출물(build-vendor/, .three-vendor-entry.tmp.js) gitignore.

## 검증
- 로컬에서 `node scripts/build-three-vendor.mjs` 실제 실행 → `three-vendor.0.171.0.js` 생성, export(THREE.Scene/OrbitControls/REVISION 171) 확인.
- 머지 후 다음 web 배포의 vendor 스텝이 실제로 동작(이미 있으면 skip, three 업그레이드 시 자동 업로드).