### PR TITLE
fix(widget): 홈 상단 배너 마음메시지 중복 제거

### DIFF
--- a/widgets/ad-slot/index.svelte
+++ b/widgets/ad-slot/index.svelte
@@ -19,7 +19,10 @@
 
     const isSidebar = $derived(slot === 'sidebar');
     const isHomeTopBanner = $derived(position === 'index-head' || position === 'index-top');
-    const showCelebration = $derived(position === 'index-head');
+    // 마음메시지(celebration)는 전용 celebration 위젯이 카드 형태로 단독 표시한다.
+    // index-head 배너에서도 표시하면 좁은 폭(모바일·사이드바 접힘)에서 같은 마음메시지가
+    // 위젯 카드 + 이 배너로 두 번 노출되는 중복이 발생 → 배너에서는 표시하지 않는다.
+    const showCelebration = false;
 </script>
 
 {#if isSidebar}


### PR DESCRIPTION
## 문제
홈에서 마음메시지(celebration)가 **두 번** 노출. 전용 celebration 위젯이 카드(헤더·더보기·롤링 이미지)로 표시하는데, `widgets/ad-slot` 의 index-head 배너도 `showCelebration` 으로 같은 마음메시지 이미지를 렌더 → 좁은 폭(모바일·사이드바 접힘)에서 카드 + bare 이미지 중복.

## 수정
- `widgets/ad-slot/index.svelte`: `showCelebration` 을 false 로(전용 celebration 위젯이 마음메시지 표시 전담). index-head 배너는 자체광고 → GAM 폴백만 담당.

## 영향
- 마음메시지 표시는 celebration 위젯 1곳으로 단일화(중복 제거). 배너의 광고/GAM 동작은 불변.
- 1줄 변경, 되돌리기 쉬움. canary 확인 후 운영.