### PR TITLE
feat(home): 홈 main 위젯 카드 그리드 통일 (gallery·group → card 뷰)

### DIFF
--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -35,7 +35,7 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
         enabled: true,
         settings: {
             boardId: 'gallery',
-            layout: 'gallery',
+            layout: 'card',
             sortBy: 'date',
             count: 12,
             showTitle: true
@@ -53,7 +53,7 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
         type: 'post-list',
         position: 7,
         enabled: true,
-        settings: { boardId: 'group', layout: 'grid', sortBy: 'date', count: 10, showTitle: true }
+        settings: { boardId: 'group', layout: 'card', sortBy: 'date', count: 10, showTitle: true }
     },
     {
         id: 'celebration',


### PR DESCRIPTION
## 목적
홈 하단을 일관된 '작은 카드 여러 개' 그리드로. 현재 홈은 이미 결합 row(공감글/톺아보기, 새소식/알뜰구매=각 2카드) + celebration 카드인데, gallery(갤러리뷰)·group(그리드뷰)만 톤이 달라 통일.

## 변경
- `default-widgets.ts`: gallery·group post-list 위젯 `layout` → `card` (celebration·post-list 카드뷰와 동일한 Card+헤더 패턴, 썸네일 없으면 텍스트 카드 폴백).
- **기본 레이아웃만** 변경 → 신규·리셋 사용자에 적용. 기존 사용자 일괄 반영은 마이그레이션(별도, 승인 후).

## 확인
- canary 시크릿창(기본 레이아웃)에서 홈 하단이 카드 그리드로 통일됐는지 육안 확인.
- 광고 밀집(#715 트레이드오프) 점검.

## 후속
- 좋으면 기존 사용자 마이그레이션 추가. 더 많은 보드를 카드로 넣는 구성 조정 가능.