### PR TITLE
fix(editor): 이미지 변환 중 제출 시 alert 차단 대신 자동 대기

### DIFF
--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -330,6 +330,26 @@
     // 중복 제출 방지
     let isSubmitting = $state(false);
 
+    // bug/12839 후속: 에디터의 백그라운드 이미지 변환 진행 개수.
+    // 제출 시 0 이 될 때까지 자동 대기 → "이미지가 떴는데 완료가 막힌다"는 마찰 제거.
+    let uploadingCount = $state(0);
+
+    // 진행 중인 이미지 변환이 모두 끝날 때까지(또는 타임아웃) 대기한다.
+    function waitForUploads(timeoutMs = 21000): Promise<void> {
+        if (uploadingCount === 0) return Promise.resolve();
+        return new Promise((resolve) => {
+            const start = Date.now();
+            const tick = () => {
+                if (uploadingCount === 0 || Date.now() - start >= timeoutMs) {
+                    resolve();
+                    return;
+                }
+                setTimeout(tick, 150);
+            };
+            tick();
+        });
+    }
+
     // 폼 제출
     async function handleSubmit(e: Event): Promise<void> {
         e.preventDefault();
@@ -337,11 +357,19 @@
         if (isSubmitting || isLoading) return;
         if (!validate()) return;
 
-        // bug/12839: 본문에 로컬 미리보기(blob:) 이미지가 남아있으면 변환본 교체 완료까지 제출 차단.
-        // blob: 은 세션 한정 URL이라 그대로 저장하면 이미지가 깨진다. 보통 수초 내 자동 교체됨.
+        // bug/12839: 본문에 로컬 미리보기(blob:) 이미지가 남아있으면 변환본 교체 완료까지 대기.
+        // blob: 은 세션 한정 URL이라 그대로 저장하면 이미지가 깨진다.
+        // 이전엔 alert 후 사용자가 직접 다시 제출해야 했으나(불만 #12839 후속),
+        // 이제 제출 버튼을 누르면 변환 완료까지 자동 대기 후 그대로 전송한다.
         if (content.includes('blob:')) {
-            alert('이미지를 처리하는 중입니다. 잠시 후(몇 초) 다시 시도해 주세요.');
-            return;
+            isSubmitting = true;
+            await waitForUploads();
+            isSubmitting = false;
+            // 대기 후에도 blob 이 남으면(변환 지연/실패) 저장 시 깨지므로 안내하고 중단.
+            if (content.includes('blob:')) {
+                alert('이미지 변환이 지연되고 있습니다. 잠시 후 다시 시도해 주세요.');
+                return;
+            }
         }
 
         isSubmitting = true;
@@ -624,6 +652,7 @@
                     disabled={isLoading}
                     onUpdate={(value) => (content = value)}
                     onImageUpload={handleEditorImageUpload}
+                    onUploadingChange={(n) => (uploadingCount = n)}
                     class={errors.content ? 'border-destructive' : ''}
                 />
                 {#if errors.content}
@@ -716,6 +745,9 @@
                 <Button type="submit" disabled={isLoading || isSubmitting}>
                     {#if isLoading || isSubmitting}
                         <span class="mr-2">처리 중...</span>
+                    {:else if uploadingCount > 0}
+                        <!-- 이미지 변환 진행 중에도 클릭 가능 — 누르면 완료까지 자동 대기 후 전송 -->
+                        <span class="mr-2">이미지 처리 중...</span>
                     {:else}
                         {submitText}
                     {/if}

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -89,6 +89,8 @@
         contentFormat?: 'html' | 'markdown';
         onUpdate?: (value: string) => void;
         onImageUpload?: (file: File) => Promise<string | null>;
+        /** 백그라운드 이미지 변환(blob→변환본 스왑) 진행 개수 변화 알림. 0 이면 모두 완료. */
+        onUploadingChange?: (count: number) => void;
         class?: string;
     }
 
@@ -99,8 +101,15 @@
         contentFormat = 'html',
         onUpdate,
         onImageUpload,
+        onUploadingChange,
         class: className = ''
     }: Props = $props();
+
+    // 진행 중인 백그라운드 이미지 변환 개수. 제출 측(post-form)이 0 이 될 때까지 자동 대기한다.
+    let pendingUploads = $state(0);
+    $effect(() => {
+        onUploadingChange?.(pendingUploads);
+    });
 
     let isUploading = $state(false);
 
@@ -467,6 +476,7 @@
         if (!onImageUpload || !editor) return;
         const blobUrl = URL.createObjectURL(file);
         insertBlob(blobUrl);
+        pendingUploads++;
         void (async () => {
             try {
                 const dataUrl = await onImageUpload!(file);
@@ -486,6 +496,8 @@
                 console.error('Image upload failed:', err);
                 removeImageBySrc(blobUrl);
                 URL.revokeObjectURL(blobUrl);
+            } finally {
+                pendingUploads--;
             }
         })();
     }


### PR DESCRIPTION
## 문제
이미지를 올리면 즉시 미리보기(`blob:`)가 뜨지만, 저장 가능한 변환본으로 교체되는 데 평균 4.5초·최대 15초가 걸립니다. 그 사이 글 작성 완료를 누르면 "잠시 후 다시 시도해 주세요" alert로 막혀, 사용자가 직접 다시 눌러야 했습니다. → 사용자 피드백: "이미지는 바로 떴는데 백그라운드 업로드 때문에 바로 글작성완료가 안 된다"

## 수정
- 에디터가 백그라운드 변환 진행 개수(`pendingUploads`)를 부모에 통지 (`onUploadingChange`)
- 제출 시 본문에 `blob:`이 남아 있으면 alert 대신 **변환 완료까지 자동 대기 후 그대로 전송**. 21초 대기 후에도 남아 있으면(드문 지연/실패) 그때만 안내 후 중단
- 제출 버튼에 `이미지 처리 중...` 표시 — 진행 중에도 클릭 가능(누르면 완료까지 자동 대기)

`blob:` 저장 차단(깨진 이미지 방지, #12839) 정책은 그대로 유지합니다.

## 변경 파일
- `apps/web/src/lib/components/features/editor/tiptap-editor.svelte`
- `apps/web/src/lib/components/features/board/post-form.svelte`

## 검증
- 타입: 변경 라인 svelte-check 에러 0건
- canary: ① 큰 이미지 올린 직후 작성하기 클릭 → alert 없이 "이미지 처리 중..." 후 자동 등록 ② 이미지 없는 글 정상 등록 ③ 변환 실패 케이스에서 깨진 이미지 저장 안 됨