### PR TITLE
fix(editor): 본문 이미지에 max-w-full rounded-lg 클래스 baked-in 제거 (#12858)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -235,10 +235,10 @@
                 }),
                 LinkedImage.configure({
                     inline: false,
-                    allowBase64: true,
-                    HTMLAttributes: {
-                        class: 'max-w-full rounded-lg'
-                    }
+                    allowBase64: true
+                    // #12858: 본문 HTML 에 max-w-full rounded-lg 유틸 클래스를 baked-in 하지 않는다.
+                    // 반응형 크기는 에디터 CSS(.tiptap-content .tiptap img)와 뷰 prose 가 보장하므로
+                    // 콘텐츠에는 스타일 클래스를 남기지 않는다(댓글 에디터와 동일한 CSS 기반 방식).
                 }),
                 Placeholder.configure({
                     placeholder


### PR DESCRIPTION
## 문제 (#12858)
본문에 이미지를 삽입하면 에디터가 저장 HTML에 `class="max-w-full rounded-lg"`를 강제로 박아, 모든 이미지가 해당 스타일로 고정됩니다.

## 원인
`tiptap-editor.svelte`의 `LinkedImage.configure({ HTMLAttributes: { class: 'max-w-full rounded-lg' } })` — 삽입되는 모든 이미지에 유틸 클래스를 baked-in.

## 수정 (best practice — CSS 기반)
콘텐츠에 프레젠테이션 유틸 클래스를 남기지 않습니다. 반응형 크기는 이미 보장됩니다:
- **에디터 미리보기**: 컴포넌트 CSS `:global(.tiptap-content .tiptap img) { max-width: 100%; height: auto; }`
- **본문 뷰**: `markdown.svelte`의 `prose` 컨테이너(Tailwind typography가 `img` max-width 자동 적용)

따라서 `HTMLAttributes(class)`만 제거하면 저장 본문이 깨끗해지고(`<img src=...>`), 댓글 에디터(이미 CSS 기반)와 동작이 통일됩니다.

## 영향
- 신규 삽입 이미지부터 적용. 기존 글에 baked된 클래스는 그대로(영향 없음).
- `rounded-lg`가 빠져 신규 이미지 모서리는 직각(에디터 plain-image CSS의 의도와 일치).

## 변경 파일
- `apps/web/src/lib/components/features/editor/tiptap-editor.svelte` (1줄 그룹)

## 검증
- 타입: tiptap-editor svelte-check 신규 에러 0건
- canary: 이미지 삽입 → 저장된 본문 `<img>`에 class 미부여 확인, 이미지가 컨테이너 폭 내로 정상 표시(overflow 없음)