### PR TITLE
fix(widget): 홈 최상단 배너에 마음메시지 복원

### DIFF
--- a/widgets/ad-slot/index.svelte
+++ b/widgets/ad-slot/index.svelte
@@ -19,10 +19,9 @@
 
     const isSidebar = $derived(slot === 'sidebar');
     const isHomeTopBanner = $derived(position === 'index-head' || position === 'index-top');
-    // 마음메시지(celebration)는 전용 celebration 위젯이 카드 형태로 단독 표시한다.
-    // index-head 배너에서도 표시하면 좁은 폭(모바일·사이드바 접힘)에서 같은 마음메시지가
-    // 위젯 카드 + 이 배너로 두 번 노출되는 중복이 발생 → 배너에서는 표시하지 않는다.
-    const showCelebration = false;
+    // 홈 최상단 배너에는 마음메시지(celebration)를 노출한다(최상단 1개).
+    // 하단은 마음메시지 카드가 아니라 작은 게시물 카드 그리드로 구성하므로 중복되지 않는다.
+    const showCelebration = $derived(isHomeTopBanner);
 </script>
 
 {#if isSidebar}


### PR DESCRIPTION
## 문제
홈 최상단(구글 애드센스 자리) 배너에서 마음메시지가 사라짐.

## 원인
#1695에서 `ad-slot`의 `showCelebration`을 `false`로 고정 → 상단 배너 마음메시지 미표시. (해당 변경이 6/30 prod 승격분 sha-7acc47d에 포함되어 운영 반영됨)

## 수정
`showCelebration = $derived(isHomeTopBanner)` — 홈 최상단 배너에 마음메시지를 다시 노출. 하단은 작은 게시물 카드 그리드(#1696)라 중복되지 않음.

## 검증
- canary 홈 최상단 배너에 마음메시지 표시 확인
- 하단 중복 없음 확인