### PR TITLE
fix(widget): 마음메시지는 최상단(index-head) 배너에서만 노출

### DIFF
--- a/widgets/ad-slot/index.svelte
+++ b/widgets/ad-slot/index.svelte
@@ -19,9 +19,9 @@
 
     const isSidebar = $derived(slot === 'sidebar');
     const isHomeTopBanner = $derived(position === 'index-head' || position === 'index-top');
-    // 홈 최상단 배너에는 마음메시지(celebration)를 노출한다(최상단 1개).
-    // 하단은 마음메시지 카드가 아니라 작은 게시물 카드 그리드로 구성하므로 중복되지 않는다.
-    const showCelebration = $derived(isHomeTopBanner);
+    // 마음메시지(celebration)는 홈 '최상단' 배너(index-head)에서만 노출한다.
+    // index-top(공감글·모아보기 아래)은 구글 애드센스 자리이므로 마음메시지를 띄우지 않는다.
+    const showCelebration = $derived(position === 'index-head');
 </script>
 
 {#if isSidebar}


### PR DESCRIPTION
## 문제
#1700에서 `showCelebration`을 `isHomeTopBanner`(index-head + index-top)로 넓혀, **공감글·모아보기 아래 구글 애드센스 자리(index-top)까지 마음메시지**가 표시됨.

## 수정
`showCelebration = $derived(position === 'index-head')` — 최상단(index-head) 배너에서만 마음메시지. index-top은 애드센스 유지. (원래 #757 동작)

## 결과 (홈)
- 최상단: 마음메시지 1개
- 공감글·모아보기 아래: 구글 애드센스
- 하단: 작은 게시물 카드 그리드(#1696)