### PR TITLE
fix(sidebar): sidebar-banner 슬롯 마음메시지 중복 제거

### DIFF
--- a/apps/web/src/lib/components/slot-defaults.ts
+++ b/apps/web/src/lib/components/slot-defaults.ts
@@ -53,11 +53,15 @@ export function registerDefaultSlots(): void {
     registerComponent('board-view-rolling', CelebrationRolling, 10, {}, 'core-damoang');
 
     // 사이드바 배너
+    // 마음메시지(celebration)는 사이드바의 전용 celebration 위젯 카드가 단독 표시한다.
+    // 이 배너까지 showCelebration 기본값(true)으로 두면 같은 마음메시지가 사이드바에
+    // 위젯 카드 + 이 배너로 두 번 노출되므로(board-list/board-view 배너와 동일하게)
+    // showCelebration: false 로 두어 광고 배너 용도로만 사용한다.
     registerComponent(
         'sidebar-banner',
         DamoangBanner,
         10,
-        { position: 'sidebar', height: 'auto' },
+        { position: 'sidebar', height: 'auto', showCelebration: false },
         'core-damoang'
     );
 


### PR DESCRIPTION
## 문제
사이드바에 마음메시지가 2줄로 중복(미니배너 위젯 바로 윗줄).

## 원인 (렌더 HTML로 확정)
사이드바 마음메시지가 두 곳에서 렌더됨:
1. 전용 `celebration` 위젯 카드 (PartyPopper + 더보기 + 캐러셀)
2. `sidebar-banner` 슬롯의 `DamoangBanner` (`data-dm-source=core-damoang`)

`slot-defaults.ts`에서 board-list(`showCelebration: false`)·board-view(`showCelebration: false`)와 달리 **sidebar-banner만 showCelebration 미지정** → 기본값 `true` → 마음메시지 중복.

## 수정
sidebar-banner 등록 props에 `showCelebration: false` 추가. 배너 슬롯은 광고 용도로만 쓰고, 마음메시지는 전용 위젯 카드 1개만 표시.

## 검증
- canary 사이드바: 마음메시지 1줄(위젯 카드)만, 미니배너 위쪽 중복 사라짐