### PR TITLE
fix(notification): 알림 드롭다운 재오픈 시 체감 지연 제거

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -345,7 +345,8 @@
         </div>
 
         <div class="max-h-80 overflow-y-auto">
-            {#if isLoading}
+            {#if isLoading && notifications.length === 0}
+                <!-- 캐시된 알림이 있으면 스피너로 가리지 않고 즉시 노출 → 재오픈 시 백그라운드 갱신(체감 지연 제거) -->
                 <div class="flex items-center justify-center py-8">
                     <Loader2 class="text-muted-foreground h-6 w-6 animate-spin" />
                 </div>


### PR DESCRIPTION
## 문제
알림 버튼을 누르면 너무 느림(매번 스피너).

## 원인
`handleOpenChange(open)` → `loadNotifications()`가 매 오픈마다 `isLoading=true`. 렌더가 `{#if isLoading}`로 **캐시된 알림 목록까지 스피너로 가려서**, 열 때마다 스피너 → 느린 체감. (백엔드 grouped notifications API는 ~104ms로 빠름)

## 수정
`{#if isLoading && notifications.length === 0}` — 스피너는 캐시가 비었을 때(첫 로드)만. 기존 항목이 있으면 즉시 노출 후 백그라운드 갱신.

## 검증
- canary: 알림 두 번째 오픈부터 스피너 없이 즉시 목록 표시 확인