### PR TITLE
fix(memos): /my/memos 삭제 확인을 인라인 2단계로 변경 (#12862)

### DIFF
--- a/apps/web/src/routes/my/memos/+page.svelte
+++ b/apps/web/src/routes/my/memos/+page.svelte
@@ -34,6 +34,8 @@
     let { data }: { data: PageData } = $props();
 
     let deletingId = $state<string | null>(null);
+    // 인라인 2단계 삭제 확인 (iOS Safari 의 window.confirm 미동작 케이스 회피 — #12862)
+    let confirmingId = $state<string | null>(null);
 
     // 검색 상태
     let searchColor = $state(data.search?.color ?? '');
@@ -126,7 +128,12 @@
     }
 
     async function handleDelete(targetMemberId: string) {
-        if (!confirm('이 회원의 메모를 삭제하시겠습니까?')) return;
+        // 1차 클릭: 해당 행을 확인 단계로(네이티브 confirm 미사용 — iOS 호환)
+        if (confirmingId !== targetMemberId) {
+            confirmingId = targetMemberId;
+            return;
+        }
+        confirmingId = null;
 
         deletingId = targetMemberId;
         try {
@@ -422,6 +429,7 @@
                 <ul class="divide-border divide-y">
                     {#each data.memos as memo (memo.id)}
                         {@const isDeleting = deletingId === memo.target_member_id}
+                        {@const isConfirming = confirmingId === memo.target_member_id}
                         {@const colorStyle = getColorStyle(memo.color)}
                         <li
                             class="py-3 transition-opacity first:pt-0 last:pb-0"
@@ -501,12 +509,17 @@
                                         <Pencil class="h-4 w-4" />
                                     </Button>
                                     <Button
-                                        variant="ghost"
+                                        variant={isConfirming ? 'destructive' : 'ghost'}
                                         size="icon"
-                                        class="text-muted-foreground hover:text-destructive h-8 w-8"
+                                        class="text-muted-foreground hover:text-destructive h-8 w-8 {isConfirming
+                                            ? 'text-destructive-foreground'
+                                            : ''}"
                                         onclick={() => handleDelete(memo.target_member_id)}
                                         disabled={isDeleting}
-                                        aria-label="메모 삭제"
+                                        aria-label={isConfirming
+                                            ? '한 번 더 눌러 삭제'
+                                            : '메모 삭제'}
+                                        title={isConfirming ? '한 번 더 눌러 삭제' : '메모 삭제'}
                                     >
                                         <Trash2 class="h-4 w-4" />
                                     </Button>


### PR DESCRIPTION
## 문제 (#12862)
메모 삭제가 동작하지 않는 현상(iOS Safari). 메모 모달은 premium 측에서 별도 수정(angple-premium #126), 본 PR은 `/my/memos` 목록 페이지의 동일 `confirm()` 패턴을 정리.

## 수정
삭제 핸들러의 `confirm()` → 인라인 2단계: 1차 클릭 시 해당 행 삭제 버튼이 destructive 상태("한 번 더 눌러 삭제")로 바뀌고 2차 클릭 시 삭제. (네이티브 confirm 미동작 케이스 회피)

## 검증
- canary: /my/memos 에서 삭제 2단계 동작 + 백엔드 DELETE 도달 확인