### PR TITLE
feat(member): 탈퇴 숙려기간(30일) 프론트 UX

### DIFF
--- a/apps/web/src/lib/server/auth/withdrawal.ts
+++ b/apps/web/src/lib/server/auth/withdrawal.ts
@@ -1,0 +1,191 @@
+/**
+ * 회원 탈퇴 숙려기간(30일) 관련 서버 유틸리티
+ *
+ * 백엔드(angple-backend)가 탈퇴 신청/취소의 원본 로직을 담당한다.
+ *  - POST   /api/v1/members/me/leave  : 탈퇴 신청(숙려 상태 진입)
+ *  - DELETE /api/v1/members/me/leave  : 숙려기간 내 탈퇴 취소
+ *
+ * 이 모듈은 프론트(SvelteKit)에서
+ *  1) g5_member.mb_leave_date / mb_leave_reason 로 "숙려 중(취소 가능)" 여부를 판정하고,
+ *  2) 백엔드 탈퇴/취소 API를 호출하며,
+ *  3) 재로그인 시 숙려 취소 화면으로 넘길 때 사용하는 단기 서명 토큰을 발급/검증한다.
+ */
+import { SignJWT, jwtVerify } from 'jose';
+import { env } from '$env/dynamic/private';
+import type { MemberRow } from './oauth/types.js';
+
+const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
+const JWT_SECRET = env.JWT_SECRET || '';
+const secret = new TextEncoder().encode(JWT_SECRET);
+
+/** 숙려기간(일) — 백엔드와 동일하게 30일 */
+export const WITHDRAWAL_GRACE_DAYS = 30;
+
+/** 재로그인 → 취소 화면 인계용 단기 쿠키 이름 */
+export const WITHDRAWAL_GRACE_COOKIE = 'withdrawal_grace';
+
+/** 관리자 처리 탈퇴 사유 — 재로그인으로 취소 불가(영구 차단) */
+const PROTECTED_LEAVE_REASONS = new Set([
+    'admin',
+    'terms_violation',
+    'contract_withdrawal',
+    'account_abuse'
+]);
+
+/** YYYYMMDD 문자열을 자정 기준 Date 로 파싱. 실패 시 null. */
+function parseLeaveDate(raw: string | null | undefined): Date | null {
+    if (!raw) return null;
+    const compact = String(raw).replace(/[^0-9]/g, '');
+    if (compact.length < 8) return null;
+    const year = Number(compact.slice(0, 4));
+    const month = Number(compact.slice(4, 6));
+    const day = Number(compact.slice(6, 8));
+    if (!year || !month || !day) return null;
+    const d = new Date(year, month - 1, day, 0, 0, 0, 0);
+    return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function toIsoDate(d: Date): string {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+export interface WithdrawalGraceStatus {
+    /** 숙려 중이며 재로그인으로 취소 가능한 상태 */
+    inGrace: boolean;
+    /** 신청일 (YYYY-MM-DD) */
+    leaveDate: string;
+    /** 확정 예정일 (YYYY-MM-DD, 신청일 + 30일) */
+    deadline: string;
+    /** 남은 일수 (0 이상) */
+    daysRemaining: number;
+}
+
+/**
+ * g5_member 행으로 탈퇴 숙려 상태를 계산한다.
+ *  - mb_leave_date 미설정 → null (정상 회원)
+ *  - 관리자 처리 탈퇴(PROTECTED_LEAVE_REASONS) → inGrace=false (영구 차단)
+ *  - 신청일 + 30일 경과 → inGrace=false (확정 대상, 취소 불가)
+ *  - 그 외 자발적 탈퇴 & 30일 이내 → inGrace=true (취소 가능)
+ */
+export function computeWithdrawalGrace(member: MemberRow): WithdrawalGraceStatus | null {
+    if (!member.mb_leave_date) return null;
+
+    const leaveDate = parseLeaveDate(member.mb_leave_date);
+    if (!leaveDate) {
+        // 날짜 파싱 불가 — 안전하게 취소 불가로 처리
+        return { inGrace: false, leaveDate: '', deadline: '', daysRemaining: 0 };
+    }
+
+    const deadline = new Date(leaveDate);
+    deadline.setDate(deadline.getDate() + WITHDRAWAL_GRACE_DAYS);
+
+    const now = new Date();
+    const msPerDay = 24 * 60 * 60 * 1000;
+    const daysRemaining = Math.max(0, Math.ceil((deadline.getTime() - now.getTime()) / msPerDay));
+
+    const reason = (member.mb_leave_reason || '').trim();
+    const isProtected = PROTECTED_LEAVE_REASONS.has(reason);
+    const inGrace = !isProtected && daysRemaining > 0;
+
+    return {
+        inGrace,
+        leaveDate: toIsoDate(leaveDate),
+        deadline: toIsoDate(deadline),
+        daysRemaining
+    };
+}
+
+/** 백엔드 탈퇴/취소 인증 헤더 구성 (Bearer + 내부 신뢰 헤더) */
+function buildAuthHeaders(accessToken: string, mbId: string, level: number): HeadersInit {
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`
+    };
+    // 프록시(/api/v1/[...path])와 동일한 내부 신뢰 헤더 — Bearer 검증 실패 대비.
+    headers['X-Internal-User-ID'] = mbId;
+    headers['X-Internal-User-Level'] = String(level || 0);
+    headers['X-Internal-Auth'] = 'sveltekit-session';
+    headers['X-Internal-Secret'] = env.INTERNAL_SECRET || '';
+    return headers;
+}
+
+export interface LeaveApiResult {
+    ok: boolean;
+    status: number;
+    message?: string;
+    deadline?: string;
+    daysRemaining?: number;
+    leaveStatus?: string;
+}
+
+/** 백엔드 탈퇴 신청 (POST /api/v1/members/me/leave) */
+export async function requestMemberLeave(
+    accessToken: string,
+    mbId: string,
+    level: number,
+    reason?: string
+): Promise<LeaveApiResult> {
+    const res = await fetch(`${BACKEND_URL}/api/v1/members/me/leave`, {
+        method: 'POST',
+        headers: buildAuthHeaders(accessToken, mbId, level),
+        body: JSON.stringify(reason ? { reason } : {})
+    });
+    const data = await res.json().catch(() => ({}) as Record<string, unknown>);
+    const withdrawal = (data?.data?.withdrawal ?? {}) as Record<string, unknown>;
+    return {
+        ok: res.ok && data?.success !== false,
+        status: res.status,
+        message: (data?.data?.message as string) || (data?.message as string) || undefined,
+        deadline: (withdrawal.deadline as string) || undefined,
+        daysRemaining: (withdrawal.days_remaining as number) ?? undefined,
+        leaveStatus: (withdrawal.status as string) || undefined
+    };
+}
+
+/** 백엔드 탈퇴 취소 (DELETE /api/v1/members/me/leave) */
+export async function cancelMemberLeave(
+    accessToken: string,
+    mbId: string,
+    level: number
+): Promise<LeaveApiResult> {
+    const res = await fetch(`${BACKEND_URL}/api/v1/members/me/leave`, {
+        method: 'DELETE',
+        headers: buildAuthHeaders(accessToken, mbId, level)
+    });
+    const data = await res.json().catch(() => ({}) as Record<string, unknown>);
+    return {
+        ok: res.ok && data?.success !== false,
+        status: res.status,
+        message: (data?.data?.message as string) || (data?.message as string) || undefined
+    };
+}
+
+const GRACE_TOKEN_ISSUER = 'angple';
+const GRACE_TOKEN_PURPOSE = 'withdrawal_grace';
+
+/**
+ * 재로그인 → 취소 화면 인계용 단기 서명 토큰 발급 (15분).
+ * mb_id 위조를 막기 위해 서명하며, httpOnly 쿠키로만 전달한다.
+ */
+export async function signWithdrawalGraceToken(mbId: string): Promise<string> {
+    return new SignJWT({ sub: mbId, purpose: GRACE_TOKEN_PURPOSE })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setIssuedAt()
+        .setExpirationTime('15m')
+        .setIssuer(GRACE_TOKEN_ISSUER)
+        .sign(secret);
+}
+
+/** 취소 화면 인계 토큰 검증 → mb_id 반환 (실패 시 null) */
+export async function verifyWithdrawalGraceToken(token: string): Promise<string | null> {
+    try {
+        const { payload } = await jwtVerify(token, secret, { issuer: GRACE_TOKEN_ISSUER });
+        if (payload.purpose !== GRACE_TOKEN_PURPOSE) return null;
+        return (payload.sub as string) || null;
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -41,6 +41,11 @@ import {
     createMember,
     findExistingTempAccount
 } from '$lib/server/auth/register.js';
+import {
+    WITHDRAWAL_GRACE_COOKIE,
+    computeWithdrawalGrace,
+    signWithdrawalGraceToken
+} from '$lib/server/auth/withdrawal.js';
 
 // 미설정 시 .damoang.net 으로 폴백 — host-only 쿠키가 되면 새 탭/PWA 에서 세션이 격리됨 (#12260, #12179).
 const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
@@ -294,6 +299,21 @@ async function handleCallback(
                     redirect(302, '/login?error=account_inactive');
                 }
             } else {
+                // 탈퇴 숙려기간(30일) 중 & 취소 가능 → 탈퇴 취소 화면으로 인계.
+                // 완전한 로그인 세션 대신 단기 서명 쿠키만 발급한다.
+                const grace = member ? computeWithdrawalGrace(member) : null;
+                if (member && grace?.inGrace) {
+                    const graceToken = await signWithdrawalGraceToken(member.mb_id);
+                    cookies.set(WITHDRAWAL_GRACE_COOKIE, graceToken, {
+                        path: '/',
+                        httpOnly: true,
+                        sameSite: 'lax',
+                        secure: !dev,
+                        maxAge: 60 * 15,
+                        ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {})
+                    });
+                    redirect(302, '/member/leave/cancel');
+                }
                 redirect(302, '/login?error=account_inactive');
             }
         }

--- a/apps/web/src/routes/member/leave/+page.server.ts
+++ b/apps/web/src/routes/member/leave/+page.server.ts
@@ -1,56 +1,99 @@
 /**
- * 회원 탈퇴 페이지 서버
+ * 회원 탈퇴 신청 페이지 서버
+ *
+ * 탈퇴 숙려기간(30일) 모델:
+ *  - 신청 시 백엔드(POST /api/v1/members/me/leave)가 계정을 비활성화하고 숙려 상태로 전환.
+ *  - 신청 후 즉시 로그아웃 처리하고, 확정 예정일을 안내 페이지로 전달한다.
  */
 import type { PageServerLoad, Actions } from './$types';
 import { redirect, fail } from '@sveltejs/kit';
-import { verifyToken } from '$lib/server/auth/jwt.js';
-import { processMemberLeave } from '$lib/server/auth/member-leave.js';
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import {
+    destroySession,
+    SESSION_COOKIE_NAME,
+    CSRF_COOKIE_NAME
+} from '$lib/server/auth/session-store.js';
+import { hashToken, revokeToken } from '$lib/server/auth/token-store.js';
+import { clearDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
+import { requestMemberLeave } from '$lib/server/auth/withdrawal.js';
 
-export const load: PageServerLoad = async ({ cookies }) => {
-    const refreshToken = cookies.get('refresh_token');
-    if (!refreshToken) {
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || '';
+
+export const load: PageServerLoad = async ({ locals }) => {
+    if (!locals.user?.id) {
         redirect(302, '/login?redirect=/member/leave');
     }
-
-    const payload = await verifyToken(refreshToken);
-    if (!payload?.sub) {
-        redirect(302, '/login?redirect=/member/leave');
-    }
-
-    return { mbId: payload.sub };
+    return { mbId: locals.user.id };
 };
 
+/** 로그인 세션/쿠키 일괄 정리 (로그아웃) */
+async function clearAuthCookies(
+    cookies: import('@sveltejs/kit').Cookies,
+    sessionId: string | undefined | null,
+    refreshToken: string | undefined
+): Promise<void> {
+    if (sessionId) {
+        await destroySession(sessionId).catch(() => {});
+    }
+    if (refreshToken) {
+        await revokeToken(hashToken(refreshToken)).catch(() => {});
+    }
+
+    const domainOpt = COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {};
+    const base = { path: '/', secure: !dev, httpOnly: true, ...domainOpt } as const;
+
+    cookies.delete(SESSION_COOKIE_NAME, base);
+    cookies.delete(CSRF_COOKIE_NAME, { ...base, httpOnly: false, sameSite: 'lax' as const });
+    cookies.delete('refresh_token', base);
+    cookies.delete('access_token', { ...base, httpOnly: false });
+    cookies.delete('damoang_jwt', { ...base, httpOnly: false });
+    cookies.delete('user_basic', { ...base, httpOnly: false });
+    clearDamoangSSOCookie(cookies);
+}
+
 export const actions: Actions = {
-    default: async ({ request, cookies }) => {
-        const refreshToken = cookies.get('refresh_token');
-        if (!refreshToken) return fail(401, { error: '로그인이 필요합니다.' });
-
-        const payload = await verifyToken(refreshToken);
-        if (!payload?.sub) return fail(401, { error: '로그인이 필요합니다.' });
-
-        const formData = await request.formData();
-        const confirmText = (formData.get('confirmText') as string)?.trim();
-
-        if (confirmText !== '탈퇴합니다') {
-            return fail(400, { error: '"탈퇴합니다"를 정확히 입력해주세요.' });
+    default: async ({ request, cookies, locals }) => {
+        const mbId = locals.user?.id;
+        const accessToken = locals.accessToken;
+        if (!mbId || !accessToken) {
+            return fail(401, { error: '로그인이 필요합니다.' });
         }
 
+        const formData = await request.formData();
+        const agreed = formData.get('agree') === 'on' || formData.get('agree') === 'true';
+        if (!agreed) {
+            return fail(400, { error: '탈퇴 안내에 동의해주세요.' });
+        }
+        const reason = ((formData.get('reason') as string) || '').trim() || undefined;
+
+        let deadline: string | undefined;
         try {
-            const result = await processMemberLeave(payload.sub);
-            if (!result.success) {
-                return fail(400, { error: result.error });
+            const result = await requestMemberLeave(
+                accessToken,
+                mbId,
+                locals.user?.level ?? 0,
+                reason
+            );
+            if (!result.ok) {
+                return fail(result.status >= 400 && result.status < 500 ? result.status : 400, {
+                    error: result.message || '탈퇴 처리에 실패했습니다.'
+                });
             }
+            deadline = result.deadline;
         } catch (err) {
-            console.error('회원탈퇴 처리 에러:', err);
+            console.error('[회원탈퇴] 처리 에러:', err);
             return fail(500, {
                 error: '탈퇴 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
             });
         }
 
-        // 쿠키 삭제
-        cookies.delete('refresh_token', { path: '/' });
-        cookies.delete('access_token', { path: '/' });
+        // 탈퇴 신청 성공 → 로그아웃 처리
+        await clearAuthCookies(cookies, locals.sessionId, cookies.get('refresh_token'));
 
-        redirect(302, '/?left=1');
+        const target = deadline
+            ? `/member/leave/complete?deadline=${encodeURIComponent(deadline)}`
+            : '/member/leave/complete';
+        redirect(302, target);
     }
 };

--- a/apps/web/src/routes/member/leave/+page.svelte
+++ b/apps/web/src/routes/member/leave/+page.svelte
@@ -8,21 +8,18 @@
         CardDescription
     } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
-    import { Input } from '$lib/components/ui/input/index.js';
+    import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import { Label } from '$lib/components/ui/label/index.js';
     import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
     import CircleAlert from '@lucide/svelte/icons/circle-alert';
-    import { enhance, applyAction } from '$app/forms';
-    import { goto } from '$app/navigation';
+    import { enhance } from '$app/forms';
     import type { PageData } from './$types.js';
 
     let { data }: { data: PageData } = $props();
 
-    let confirmText = $state('');
+    let agreed = $state(false);
     let errorMsg = $state<string | null>(null);
     let submitting = $state(false);
-
-    const isValid = $derived(confirmText.trim() === '탈퇴합니다');
 </script>
 
 <svelte:head>
@@ -34,35 +31,34 @@
         <CardHeader>
             <CardTitle class="flex items-center gap-2 text-red-600">
                 <TriangleAlert class="h-5 w-5" />
-                회원 탈퇴
+                회원 탈퇴 안내
             </CardTitle>
-            <CardDescription>탈퇴 시 아래 사항을 확인해주세요.</CardDescription>
+            <CardDescription>탈퇴를 신청하시기 전에 아래 내용을 확인해주세요.</CardDescription>
         </CardHeader>
         <CardContent>
-            <!-- 경고 사항 -->
+            <!-- 탈퇴 숙려기간(30일) 고지문 -->
             <div
                 class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200"
             >
                 <ul class="space-y-2">
-                    <li>- 탈퇴 후 동일 아이디로 재가입이 불가합니다.</li>
-                    <li>- 작성한 게시글과 댓글은 삭제되지 않습니다.</li>
-                    <li>- 연결된 소셜 계정이 모두 해제됩니다.</li>
-                    <li>- 보유 포인트가 소멸됩니다.</li>
+                    <li>
+                        - 탈퇴를 신청하시면 계정이 즉시 비활성화되어, 게시글·댓글이 더 이상 표시되지
+                        않습니다.
+                    </li>
+                    <li>
+                        - 신청일로부터 30일 이내에 다시 로그인하시면 언제든 탈퇴를 취소하고 원래대로
+                        복구하실 수 있습니다.
+                    </li>
+                    <li>
+                        - 30일이 지나면 탈퇴가 확정되며, 회원정보는 익명 처리됩니다. 단, 부정 이용
+                        및 중복가입 방지를 위한 최소한의 식별정보는 관련 법령·개인정보처리방침에
+                        따라 일정 기간 보관 후 파기됩니다.
+                    </li>
+                    <li>
+                        - 이용제한(제재)이 적용 중인 경우, 탈퇴하거나 취소하더라도 제재 이력은
+                        유지되며 탈퇴로 제재를 회피할 수 없습니다.
+                    </li>
                 </ul>
-                <div class="mt-3 border-t border-red-200 pt-3 dark:border-red-800">
-                    <p class="font-semibold">게시물 삭제 관련 안내</p>
-                    <ul class="mt-1 space-y-1">
-                        <li>- 탈퇴 전에 게시글과 댓글은 직접 삭제해 주세요.</li>
-                        <li>
-                            - 탈퇴 후에는 삭제 요청을 받지 않습니다. (<a
-                                href="https://damoang.net/notice/18204"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="underline underline-offset-2">공지사항</a
-                            >)
-                        </li>
-                    </ul>
-                </div>
             </div>
 
             <form
@@ -70,33 +66,26 @@
                 use:enhance={() => {
                     submitting = true;
                     errorMsg = null;
-                    return async ({ result }) => {
+                    return async ({ result, update }) => {
                         submitting = false;
-                        if (result.type === 'redirect') {
-                            goto(result.location, { replaceState: true, invalidateAll: true });
-                        } else if (result.type === 'failure') {
+                        if (result.type === 'failure') {
                             errorMsg =
                                 (result.data?.error as string) || '탈퇴 처리에 실패했습니다.';
                         } else {
-                            await applyAction(result);
+                            // 성공(리다이렉트) 등은 기본 처리에 위임
+                            await update();
                         }
                     };
                 }}
                 class="space-y-4"
             >
                 <input type="hidden" name="_csrf" value={page.data.csrfToken ?? ''} />
-                <div class="space-y-2">
-                    <Label for="confirmText">
-                        탈퇴를 원하시면 <strong class="text-red-600">"탈퇴합니다"</strong>를
-                        입력하세요
+
+                <div class="flex items-start gap-2">
+                    <Checkbox id="agree" name="agree" bind:checked={agreed} class="mt-0.5" />
+                    <Label for="agree" class="cursor-pointer text-sm leading-relaxed">
+                        위 내용을 확인하였으며 탈퇴에 동의합니다.
                     </Label>
-                    <Input
-                        id="confirmText"
-                        name="confirmText"
-                        bind:value={confirmText}
-                        placeholder="탈퇴합니다"
-                        autocomplete="off"
-                    />
                 </div>
 
                 {#if errorMsg}
@@ -111,9 +100,9 @@
                         type="submit"
                         variant="destructive"
                         class="flex-1"
-                        disabled={!isValid || submitting}
+                        disabled={!agreed || submitting}
                     >
-                        {submitting ? '처리 중...' : '회원 탈퇴'}
+                        {submitting ? '처리 중...' : '회원 탈퇴 신청'}
                     </Button>
                 </div>
             </form>

--- a/apps/web/src/routes/member/leave/cancel/+page.server.ts
+++ b/apps/web/src/routes/member/leave/cancel/+page.server.ts
@@ -1,0 +1,164 @@
+/**
+ * 탈퇴 숙려기간 중 재로그인 → 탈퇴 취소 화면 서버
+ *
+ * OAuth 콜백에서 숙려 상태(취소 가능)를 감지하면 단기 서명 쿠키
+ * (WITHDRAWAL_GRACE_COOKIE)를 심고 이 화면으로 보낸다. 이 화면은 완전한 로그인
+ * 세션 없이 동작하며, 사용자가 "탈퇴 취소"를 선택하면 백엔드
+ * DELETE /api/v1/members/me/leave 로 취소 후 정상 세션을 발급한다.
+ */
+import type { PageServerLoad, Actions } from './$types';
+import { redirect, fail } from '@sveltejs/kit';
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import { getMemberById, updateLoginTimestamp } from '$lib/server/auth/oauth/member.js';
+import {
+    createSession,
+    SESSION_COOKIE_NAME,
+    CSRF_COOKIE_NAME,
+    SESSION_COOKIE_MAX_AGE
+} from '$lib/server/auth/session-store.js';
+import { generateRefreshToken, generateAccessToken } from '$lib/server/auth/jwt.js';
+import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
+import {
+    WITHDRAWAL_GRACE_COOKIE,
+    verifyWithdrawalGraceToken,
+    computeWithdrawalGrace,
+    cancelMemberLeave
+} from '$lib/server/auth/withdrawal.js';
+
+const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
+
+function clearGraceCookie(cookies: import('@sveltejs/kit').Cookies): void {
+    cookies.delete(WITHDRAWAL_GRACE_COOKIE, {
+        path: '/',
+        ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {})
+    });
+}
+
+export const load: PageServerLoad = async ({ cookies }) => {
+    const token = cookies.get(WITHDRAWAL_GRACE_COOKIE);
+    const mbId = token ? await verifyWithdrawalGraceToken(token) : null;
+    if (!mbId) {
+        redirect(302, '/login');
+    }
+
+    const member = await getMemberById(mbId);
+    const grace = member ? computeWithdrawalGrace(member) : null;
+    if (!member || !grace?.inGrace) {
+        // 이미 확정됐거나 취소 불가(관리자 처리) → 일반 차단 화면으로
+        clearGraceCookie(cookies);
+        redirect(302, '/login?error=account_inactive');
+    }
+
+    return {
+        nickname: member.mb_nick || member.mb_name || member.mb_id,
+        leaveDate: grace.leaveDate,
+        deadline: grace.deadline,
+        daysRemaining: grace.daysRemaining
+    };
+};
+
+export const actions: Actions = {
+    // 탈퇴 취소 → 계정/데이터 복구 + 정상 로그인
+    cancel: async ({ cookies, request, getClientAddress }) => {
+        const token = cookies.get(WITHDRAWAL_GRACE_COOKIE);
+        const mbId = token ? await verifyWithdrawalGraceToken(token) : null;
+        if (!mbId) {
+            return fail(401, { error: '세션이 만료되었습니다. 다시 로그인해 주세요.' });
+        }
+
+        const member = await getMemberById(mbId);
+        const grace = member ? computeWithdrawalGrace(member) : null;
+        if (!member || !grace?.inGrace) {
+            clearGraceCookie(cookies);
+            return fail(403, { error: '이미 탈퇴가 확정되어 취소할 수 없습니다.' });
+        }
+
+        const clientIp = getClientAddress();
+
+        // 백엔드 탈퇴 취소 (DELETE /api/v1/members/me/leave)
+        try {
+            const accessToken = await generateAccessToken({
+                mb_id: member.mb_id,
+                mb_nick: member.mb_nick || member.mb_name,
+                mb_level: member.mb_level ?? 0,
+                mb_email: member.mb_email || ''
+            });
+            const result = await cancelMemberLeave(accessToken, member.mb_id, member.mb_level ?? 0);
+            if (!result.ok) {
+                if (result.status === 403) {
+                    clearGraceCookie(cookies);
+                    return fail(403, { error: '이미 탈퇴가 확정되어 취소할 수 없습니다.' });
+                }
+                return fail(502, {
+                    error:
+                        result.message ||
+                        '탈퇴 취소 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'
+                });
+            }
+        } catch (err) {
+            console.error('[탈퇴취소] 백엔드 호출 실패:', err);
+            return fail(502, { error: '탈퇴 취소 처리 중 오류가 발생했습니다.' });
+        }
+
+        // 프론트 DB 동기화: mb_leave_date 클리어 + 로그인 시각 갱신 (자발적 탈퇴 자동 복귀)
+        await updateLoginTimestamp(member.mb_id, clientIp, member.mb_leave_reason);
+
+        // 정상 로그인 세션 발급 (OAuth 콜백과 동일 패턴)
+        const session = await createSession(member.mb_id, {
+            ip: clientIp,
+            userAgent: request.headers.get('user-agent') || ''
+        });
+        const domainOpt = COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {};
+
+        cookies.set(SESSION_COOKIE_NAME, session.sessionId, {
+            path: '/',
+            httpOnly: true,
+            sameSite: 'lax',
+            secure: !dev,
+            maxAge: SESSION_COOKIE_MAX_AGE,
+            ...domainOpt
+        });
+        cookies.set(CSRF_COOKIE_NAME, session.csrfToken, {
+            path: '/',
+            httpOnly: false,
+            sameSite: 'lax',
+            secure: !dev,
+            maxAge: SESSION_COOKIE_MAX_AGE,
+            ...domainOpt
+        });
+
+        const { token: refreshToken } = await generateRefreshToken(member.mb_id, {
+            ip: clientIp,
+            userAgent: request.headers.get('user-agent') || ''
+        });
+        cookies.set('refresh_token', refreshToken, {
+            path: '/',
+            httpOnly: true,
+            sameSite: 'lax',
+            secure: !dev,
+            maxAge: 60 * 60 * 24 * 7,
+            ...domainOpt
+        });
+
+        try {
+            await setDamoangSSOCookie(cookies, {
+                mb_id: member.mb_id,
+                mb_level: member.mb_level ?? 0,
+                mb_name: member.mb_name || member.mb_nick,
+                mb_email: member.mb_email
+            });
+        } catch (e) {
+            console.error('[탈퇴취소] SSO cookie 발급 실패:', e);
+        }
+
+        clearGraceCookie(cookies);
+        redirect(302, '/');
+    },
+
+    // 유지 → 탈퇴 상태 그대로 두고 로그아웃 (세션 없음, 쿠키만 정리)
+    keep: async ({ cookies }) => {
+        clearGraceCookie(cookies);
+        redirect(302, '/');
+    }
+};

--- a/apps/web/src/routes/member/leave/cancel/+page.svelte
+++ b/apps/web/src/routes/member/leave/cancel/+page.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    import {
+        Card,
+        CardContent,
+        CardHeader,
+        CardTitle,
+        CardDescription
+    } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import CircleAlert from '@lucide/svelte/icons/circle-alert';
+    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+    import { enhance } from '$app/forms';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    let errorMsg = $state<string | null>(null);
+    let submitting = $state<'cancel' | 'keep' | null>(null);
+</script>
+
+<svelte:head>
+    <title>탈퇴 취소 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<div class="mx-auto max-w-lg px-4 py-8">
+    <Card class="border-amber-300/50">
+        <CardHeader>
+            <CardTitle class="flex items-center gap-2 text-amber-600">
+                <RotateCcw class="h-5 w-5" />
+                현재 탈퇴 신청 상태입니다
+            </CardTitle>
+            <CardDescription>
+                {data.nickname}님, 지금 취소하시면 계정과 모든 데이터가 그대로 복구됩니다.
+            </CardDescription>
+        </CardHeader>
+        <CardContent class="space-y-6">
+            <div
+                class="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
+            >
+                <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
+                    <dt class="text-muted-foreground">신청일</dt>
+                    <dd class="font-medium">{data.leaveDate}</dd>
+                    <dt class="text-muted-foreground">확정 예정일</dt>
+                    <dd class="font-medium">{data.deadline}</dd>
+                    <dt class="text-muted-foreground">남은 기간</dt>
+                    <dd class="font-medium">{data.daysRemaining}일</dd>
+                </dl>
+            </div>
+
+            {#if errorMsg}
+                <p class="flex items-center gap-1 text-sm text-red-600">
+                    <CircleAlert class="h-4 w-4" />{errorMsg}
+                </p>
+            {/if}
+
+            <div class="flex flex-col gap-3 sm:flex-row">
+                <form
+                    method="POST"
+                    action="?/cancel"
+                    class="flex-1"
+                    use:enhance={() => {
+                        submitting = 'cancel';
+                        errorMsg = null;
+                        return async ({ result, update }) => {
+                            if (result.type === 'failure') {
+                                submitting = null;
+                                errorMsg =
+                                    (result.data?.error as string) || '탈퇴 취소에 실패했습니다.';
+                            } else {
+                                await update();
+                            }
+                        };
+                    }}
+                >
+                    <Button type="submit" class="w-full" disabled={submitting !== null}>
+                        {submitting === 'cancel' ? '처리 중...' : '탈퇴 취소하고 계속 이용하기'}
+                    </Button>
+                </form>
+
+                <form
+                    method="POST"
+                    action="?/keep"
+                    class="flex-1"
+                    use:enhance={() => {
+                        submitting = 'keep';
+                        return async ({ update }) => {
+                            await update();
+                        };
+                    }}
+                >
+                    <Button
+                        type="submit"
+                        variant="outline"
+                        class="w-full"
+                        disabled={submitting !== null}
+                    >
+                        {submitting === 'keep' ? '처리 중...' : '유지(로그아웃)'}
+                    </Button>
+                </form>
+            </div>
+        </CardContent>
+    </Card>
+</div>

--- a/apps/web/src/routes/member/leave/complete/+page.svelte
+++ b/apps/web/src/routes/member/leave/complete/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import { page } from '$app/state';
+    import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import CircleCheck from '@lucide/svelte/icons/circle-check';
+
+    const deadline = $derived(page.url.searchParams.get('deadline') || '');
+</script>
+
+<svelte:head>
+    <title>탈퇴 신청 완료 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<div class="mx-auto max-w-lg px-4 py-8">
+    <Card>
+        <CardHeader>
+            <CardTitle class="flex items-center gap-2">
+                <CircleCheck class="h-5 w-5 text-emerald-600" />
+                탈퇴가 신청되었습니다
+            </CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-6">
+            <p class="text-muted-foreground text-sm leading-relaxed">
+                {#if deadline}
+                    <strong class="text-foreground">{deadline}</strong>까지 다시 로그인하시면 탈퇴를
+                    취소할 수 있습니다.
+                {:else}
+                    신청일로부터 30일 이내에 다시 로그인하시면 탈퇴를 취소할 수 있습니다.
+                {/if}
+            </p>
+            <p class="text-muted-foreground text-xs leading-relaxed">
+                30일이 지나면 탈퇴가 확정되며 회원정보는 익명 처리됩니다. 그동안 이용해 주셔서
+                감사합니다.
+            </p>
+            <div class="flex justify-end">
+                <Button href="/">홈으로</Button>
+            </div>
+        </CardContent>
+    </Card>
+</div>


### PR DESCRIPTION
## 개요
회원 "탈퇴 숙려기간(30일)" 기능의 프론트엔드(UX)를 구현합니다. 백엔드(angple-backend#536)가 확정한 API 계약을 그대로 사용합니다.

- `POST /api/v1/members/me/leave` — 탈퇴 신청(숙려 상태 진입)
- `DELETE /api/v1/members/me/leave` — 숙려기간 내 탈퇴 취소

## 변경 사항

### 1. 탈퇴 신청 화면 (`/member/leave`)
- 기존 "탈퇴합니다" 텍스트 입력 방식을 숙려기간(30일) 안내문 + 동의 체크박스 방식으로 개편했습니다.
- 신청 시 서버 액션이 백엔드 `POST /api/v1/members/me/leave` 를 호출하고, 성공하면 세션·인증 쿠키를 정리(로그아웃)한 뒤 완료 안내 페이지로 이동합니다.

### 2. 탈퇴 신청 완료 안내 (`/member/leave/complete`)
- 확정 예정일을 표시하고, "해당 일자까지 다시 로그인하면 취소할 수 있다"는 안내를 제공합니다. (비로그인 접근 가능)

### 3. 숙려기간 중 재로그인 분기 → 탈퇴 취소 화면 (`/member/leave/cancel`)
- 실제 라이브 로그인 경로인 OAuth 콜백(`/auth/callback/[provider]`)에서, 탈퇴 상태이면서 30일 이내·취소 가능한 계정으로 재로그인하면 일반 차단(account_inactive) 대신 탈퇴 취소 화면으로 인계합니다.
- 신청일·확정 예정일·남은 기간을 표시하고, "탈퇴 취소하고 계속 이용하기" 선택 시 백엔드 `DELETE /api/v1/members/me/leave` 로 취소 후 정상 세션을 발급해 복구합니다. "유지(로그아웃)" 선택 시 그대로 로그아웃합니다.
- 관리자 처리 탈퇴(admin/terms_violation/contract_withdrawal/account_abuse)와 30일 경과 계정은 기존과 동일하게 차단됩니다.

## 설계 메모 (최소 침습)
- 취소 화면 인계는 완전한 로그인 세션 대신 **단기(15분) 서명 쿠키**를 사용합니다. hooks.server.ts가 탈퇴 회원 세션을 즉시 파기하므로 세션 기반 인계가 불가능하기 때문입니다.
- 백엔드 호출 인증은 프록시(`/api/v1/[...path]`)와 동일한 방식(Bearer 토큰 + 내부 신뢰 헤더)을 사용합니다.
- 숙려 판정(신청일·확정 예정일·남은 기간)은 `$lib/server/auth/withdrawal.ts` 에 집약했습니다.

## 검증
- `pnpm check`: 본 변경 파일에서 신규 오류/경고 없음. (기존 환경 이슈인 `zod`, `@tiptap/extension-text-align` 미설치 오류 7건은 본 변경과 무관)
