### PR TITLE
읽은 글/공감 표시 크로스기기 일관성 개선

### DIFF
--- a/apps/web/src/lib/server/read-posts.ts
+++ b/apps/web/src/lib/server/read-posts.ts
@@ -1,0 +1,63 @@
+/**
+ * 회원 읽은 글 read-set (L2, Redis)
+ *
+ * localStorage(L1, stores/read-posts.svelte.ts)는 기기·브라우저 단위라
+ * 메일 인앱브라우저·타기기 간 읽음이 넘어가지 않습니다. 이를 보완하기 위해
+ * 로그인 회원의 읽은 글을 계정 단위 Redis 정렬셋에 기록하고, 목록 진입 시
+ * 병합해 크로스기기로 일관되게 "읽음"을 표시합니다.
+ *
+ * - 키: `rp:{mbId}` 정렬셋. member = `{boardId}:{postId}`, score = ms timestamp.
+ * - 쓰기: 글 조회 시(로그인) ZADD → 상한 초과분 오래된 것부터 제거 → TTL 갱신.
+ * - 읽기: 최신순 최대 N개 반환(`{boardId}:{postId}` 문자열).
+ * - Redis 장애 시 조용히 degrade(빈 배열 / no-op) — L1이 같은 기기는 커버.
+ */
+
+import { getRedis } from './redis';
+
+/** 회원별 read-set 키 접두사 */
+const READ_SET_PREFIX = 'rp:';
+/** 회원당 최대 보관 개수 (localStorage 1000 이상으로 두어 병합 시 굶기지 않음) */
+const MAX_READ_ENTRIES = 2000;
+/** 비활성 회원 read-set 자동 정리 (180일, 쓰기마다 갱신) */
+const READ_SET_TTL_SEC = 180 * 24 * 60 * 60;
+
+function keyFor(mbId: string): string {
+    return `${READ_SET_PREFIX}${mbId}`;
+}
+
+/**
+ * 읽은 글 기록 (로그인 회원). 상한 초과 시 오래된 것부터 제거.
+ * best-effort — 실패해도 예외를 전파하지 않음(조회 흐름 방해 금지).
+ */
+export async function addReadPost(mbId: string, boardId: string, postId: number): Promise<void> {
+    if (!mbId || !boardId || !Number.isFinite(postId)) return;
+    try {
+        const redis = getRedis();
+        const key = keyFor(mbId);
+        const member = `${boardId}:${postId}`;
+        const pipeline = redis.pipeline();
+        pipeline.zadd(key, Date.now(), member);
+        // 최신 MAX_READ_ENTRIES개만 유지: rank 0 ~ -(MAX+1) 범위(가장 오래된 것들) 제거
+        pipeline.zremrangebyrank(key, 0, -(MAX_READ_ENTRIES + 1));
+        pipeline.expire(key, READ_SET_TTL_SEC);
+        await pipeline.exec();
+    } catch {
+        // Redis 장애 시 무시 — L1(localStorage)이 같은 기기는 커버
+    }
+}
+
+/**
+ * 회원의 읽은 글 목록(최신순, 최대 limit개) 반환.
+ * @returns `{boardId}:{postId}` 형식 문자열 배열. 실패/미로그인 시 빈 배열.
+ */
+export async function getReadPosts(mbId: string, limit = MAX_READ_ENTRIES): Promise<string[]> {
+    if (!mbId) return [];
+    try {
+        const redis = getRedis();
+        const safeLimit = Math.max(1, Math.min(limit, MAX_READ_ENTRIES));
+        // 최신순(score 내림차순) 상위 limit개
+        return await redis.zrevrange(keyFor(mbId), 0, safeLimit - 1);
+    } catch {
+        return [];
+    }
+}

--- a/apps/web/src/lib/stores/post-like-store.svelte.ts
+++ b/apps/web/src/lib/stores/post-like-store.svelte.ts
@@ -1,0 +1,35 @@
+/**
+ * 공감/비공감 낙관적 상태 스토어 (세션 인메모리)
+ *
+ * 공감 상태는 트래픽 다이어트로 SSR에서 로드되는데, 사용자가 방금 누른
+ * 공감이 SSR/백엔드 조회에 아직 반영되기 전 SPA로 재진입하면 "공감 안 됨"으로
+ * 보이고 새로고침해야 반영되는 문제가 있었다.
+ *
+ * 이 스토어는 "이 세션에서 사용자가 직접 누른 마지막 공감/비공감"을 기억해,
+ * 글 재진입 시 아직 반영 안 된 SSR 값보다 우선 표시한다(낙관적 오버레이).
+ * - 인메모리(모듈 스코프)라 전체 새로고침 시 초기화 → 그때는 SSR이 권위 소스.
+ * - localStorage 미사용: "내 방금 액션"만 다루므로 세션 범위로 충분.
+ */
+
+interface LikeState {
+    liked: boolean;
+    disliked: boolean;
+}
+
+const map = new Map<string, LikeState>();
+
+function keyFor(boardId: string, postId: number): string {
+    return `${boardId}:${postId}`;
+}
+
+export const postLikeStore = {
+    /** 사용자가 직접 토글한 공감/비공감 상태 기록 */
+    set(boardId: string, postId: number, state: LikeState): void {
+        map.set(keyFor(boardId, postId), { liked: state.liked, disliked: state.disliked });
+    },
+
+    /** 이 세션에서 기록된 내 공감 상태 (없으면 undefined) */
+    get(boardId: string, postId: number): LikeState | undefined {
+        return map.get(keyFor(boardId, postId));
+    }
+};

--- a/apps/web/src/lib/stores/read-posts.svelte.ts
+++ b/apps/web/src/lib/stores/read-posts.svelte.ts
@@ -1,14 +1,19 @@
 /**
  * 읽은 글 표시 기능 스토어
  *
- * localStorage 기반으로 읽은 글 ID를 저장하고 관리합니다.
+ * localStorage(L1) 기반으로 읽은 글 ID를 저장하고 관리합니다.
  * 최대 1000개까지 유지하며, 오래된 것은 자동 삭제됩니다.
+ *
+ * 로그인 회원은 서버 read-set(L2, Redis)을 병합해 기기·브라우저 간 읽음이
+ * 일관되게 표시됩니다(메일 인앱브라우저·타기기 크로스기기). L1은 즉시 반응·
+ * 오프라인·비로그인 용도로 유지하고, L2는 mergeServerReadPosts()로 합칩니다.
  */
 
 import { browser } from '$app/environment';
 
 const STORAGE_KEY = 'angple_read_posts';
-const MAX_ENTRIES = 1000;
+// 서버 read-set(L2) 상한(2000)과 맞춰, 병합 시 로컬 읽음이 굶기지 않도록 함.
+const MAX_ENTRIES = 2000;
 
 interface ReadPostsData {
     // postId를 key로, timestamp를 value로 저장 (FIFO 삭제용)
@@ -93,6 +98,39 @@ function createReadPostsStore() {
             }
 
             return result;
+        },
+
+        /**
+         * 서버 read-set(L2)을 로컬(L1)에 병합
+         *
+         * 로그인 시 /api/read-posts 응답(`boardId:postId` 키 배열)을 받아
+         * 로컬에 없는 항목만 추가합니다. 기존 로컬 항목의 timestamp는 보존해
+         * "방금 읽음"이 서버 병합으로 밀려나지 않도록 합니다.
+         * @param keys `boardId:postId` 형식 키 배열 (서버 최신순)
+         */
+        mergeServerReadPosts(keys: string[]): void {
+            if (!Array.isArray(keys) || keys.length === 0) return;
+            const next = { ...data.posts };
+            // 병합 항목은 로컬 최소 timestamp보다 아래로 부여 → cleanup 시 로컬(실제
+            // 최근 읽음)을 우선 보존하고 서버 병합분이 먼저 밀려나게 한다.
+            // 서버는 최신순이므로 index 0이 가장 높고(=base) 이후 감소해 순서 보존.
+            let localMin = Number.POSITIVE_INFINITY;
+            for (const ts of Object.values(next)) {
+                if (ts < localMin) localMin = ts;
+            }
+            const base = (Number.isFinite(localMin) ? localMin : Date.now()) - 1;
+            let added = 0;
+            for (let i = 0; i < keys.length; i++) {
+                const key = keys[i];
+                if (typeof key !== 'string' || !key.includes(':')) continue;
+                if (key in next) continue; // 로컬에 있으면 로컬 timestamp 유지
+                next[key] = base - i;
+                added++;
+            }
+            if (added === 0) return;
+            data.posts = next;
+            cleanup();
+            save();
         },
 
         /**

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
     import { page } from '$app/stores';
     import { configureSeo } from '$lib/seo';
     import { authActions, authStore } from '$lib/stores/auth.svelte';
+    import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { collectAndReportFingerprint } from '$lib/fingerprint/device-fingerprint';
     import { themeStore } from '$lib/stores/theme.svelte';
     import { pluginStore } from '$lib/stores/plugin.svelte';
@@ -467,6 +468,21 @@
         // 디바이스 핑거프린트 수집 (로그인 사용자 한정, 1일 1회 throttle).
         // 기본 비활성 — PUBLIC_FINGERPRINT_ENABLED=true + 처리방침 공시·법률검토 후에만 동작.
         if (browser && authStore.isAuthenticated) void collectAndReportFingerprint();
+
+        // 로그인 회원 서버 read-set(L2, Redis) 병합 — 크로스기기 읽음 표시.
+        // localStorage(L1)에 없는 항목만 추가(기존 로컬 timestamp 보존).
+        if (browser && authStore.isAuthenticated) {
+            fetch('/api/read-posts', { headers: { accept: 'application/json' } })
+                .then((res) => (res.ok ? res.json() : null))
+                .then((payload: { posts?: string[] } | null) => {
+                    if (payload?.posts?.length) {
+                        readPostsStore.mergeServerReadPosts(payload.posts);
+                    }
+                })
+                .catch(() => {
+                    // 병합 실패해도 로컬(L1) 읽음 표시는 유지
+                });
+        }
 
         const cachedMenus = readCachedMenus();
         if (cachedMenus) {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -18,6 +18,7 @@ import {
     hasRecentlyViewed,
     markViewed
 } from '$lib/server/viewcount.js';
+import { addReadPost } from '$lib/server/read-posts.js';
 import { fetchReactionsByParentId } from '$lib/server/reactions.js';
 import { fetchMemberImagesWithTimestamp } from '$lib/server/member-images.js';
 import { fetchCommentLikeStatuses } from '$lib/server/comment-likes.js';
@@ -294,6 +295,13 @@ export const load: PageServerLoad = async ({
                         maxAge: 60 * 60 * 24
                     });
                 }
+            }
+
+            // 로그인 회원 read-set(L2, Redis) 기록 — 크로스기기 읽음 표시용.
+            // fire-and-forget: 응답에 쓰이지 않으므로 로드 지연을 피하려 await 하지 않음.
+            // best-effort(내부 try/catch), ZADD 멱등이라 재진입 시 재기록해도 무해.
+            if (locals.user?.id) {
+                void addReadPost(locals.user.id, boardId, Number(postId));
             }
         }
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -123,6 +123,7 @@
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { checkPermission, getPermissionMessage } from '$lib/utils/board-permissions.js';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { postLikeStore } from '$lib/stores/post-like-store.svelte.js';
     import { createScrollDepthObserver, trackEvent, trackPostView } from '$lib/services/ga4.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { commentTracker } from '$lib/stores/comment-tracker.svelte.js';
@@ -473,6 +474,14 @@
                     isDisliked = result.postLikeStatus.userDisliked;
                 }
 
+                // 낙관적 오버레이: 이 세션에서 직접 누른 공감/비공감이 있으면
+                // (SPA 재진입 시) 아직 반영 안 된 SSR 값보다 우선.
+                const myLike = postLikeStore.get(boardId, data.post.id);
+                if (myLike) {
+                    isLiked = myLike.liked;
+                    isDisliked = myLike.disliked;
+                }
+
                 if (result.commentLikeStatuses) {
                     initialLikedCommentIds = result.commentLikeStatuses.likedIds || [];
                     initialDislikedCommentIds = result.commentLikeStatuses.dislikedIds || [];
@@ -769,6 +778,13 @@
                     isDisliked = status.user_disliked ?? false;
                     likeCount = status.likes;
                     dislikeCount = status.dislikes ?? 0;
+
+                    // 낙관적 오버레이 (fallback 경로에서도 내 방금 액션 우선)
+                    const myLike = postLikeStore.get(boardId, data.post.id);
+                    if (myLike) {
+                        isLiked = myLike.liked;
+                        isDisliked = myLike.disliked;
+                    }
                 } catch (err) {
                     console.error('Failed to load like status:', err);
                 }
@@ -1105,6 +1121,7 @@
             isDisliked = response.user_disliked ?? false;
             likeCount = response.likes;
             dislikeCount = response.dislikes ?? 0;
+            postLikeStore.set(boardId, data.post.id, { liked: isLiked, disliked: isDisliked });
 
             // 추천 성공 시 애니메이션 (취소가 아닌 경우만)
             if (!wasLiked && isLiked) {
@@ -1139,6 +1156,10 @@
                     isDisliked = status.user_disliked ?? false;
                     likeCount = status.likes;
                     dislikeCount = status.dislikes ?? 0;
+                    postLikeStore.set(boardId, data.post.id, {
+                        liked: isLiked,
+                        disliked: isDisliked
+                    });
                     if (!prevLiked && isLiked) {
                         trackEvent('like', { board_id: boardId, post_id: data.post.id });
                     }
@@ -1181,6 +1202,7 @@
             isDisliked = response.user_disliked ?? false;
             likeCount = response.likes;
             dislikeCount = response.dislikes ?? 0;
+            postLikeStore.set(boardId, data.post.id, { liked: isLiked, disliked: isDisliked });
 
             trackEvent('dislike', { board_id: boardId, post_id: data.post.id });
 
@@ -1201,6 +1223,10 @@
                     isDisliked = status.user_disliked ?? false;
                     likeCount = status.likes;
                     dislikeCount = status.dislikes ?? 0;
+                    postLikeStore.set(boardId, data.post.id, {
+                        liked: isLiked,
+                        disliked: isDisliked
+                    });
                     return;
                 }
             } catch {

--- a/apps/web/src/routes/api/read-posts/+server.ts
+++ b/apps/web/src/routes/api/read-posts/+server.ts
@@ -1,0 +1,22 @@
+/**
+ * GET /api/read-posts
+ *
+ * 로그인 회원의 서버 read-set(L2, Redis)을 반환합니다.
+ * 클라이언트가 hydration 후 1회 호출해 localStorage(L1)에 병합 → 크로스기기 읽음 표시.
+ * per-user 개인 데이터이므로 캐시 금지(private, no-store).
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getReadPosts } from '$lib/server/read-posts';
+
+export const GET: RequestHandler = async ({ locals, setHeaders }) => {
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    const mbId = locals.user?.id;
+    if (!mbId) {
+        return json({ posts: [] });
+    }
+
+    const posts = await getReadPosts(mbId);
+    return json({ posts });
+};


### PR DESCRIPTION
## 배경

- **읽은 글 표시**가 브라우저 localStorage 에만 저장되어, 메일 인앱브라우저나 다른 기기에서 읽은 글이 목록에서 계속 "안읽음"으로 표시되었습니다.
- **공감 상태**가 SSR 로딩으로 옮겨진 뒤, 방금 누른 공감이 반영되기 전 페이지를 다시 열면 "공감 안 됨"으로 보이고 새로고침해야 표시되는 문제가 있었습니다.

## 변경

### 1. 크로스기기 읽은 글 (서버 read-set, L2)
- 기존 localStorage(L1) 는 즉시 반응·오프라인·비로그인 용도로 유지합니다.
- 로그인 회원의 읽은 글을 계정 단위 Redis 정렬셋(`rp:{mbId}`)에 기록하고, 목록 진입 시 병합하여 기기·브라우저 간 일관되게 표시합니다.
- `lib/server/read-posts.ts` — read-set 기록/조회 (상한 2000, TTL 180일, 장애 시 graceful degrade)
- `api/read-posts` — 회원 read-set 반환 (`private, no-store`, 비로그인 시 빈 배열)
- `[postId]/+page.server.ts` — 로그인 조회 시 기록 (fire-and-forget)
- `stores/read-posts.svelte.ts` — `mergeServerReadPosts` (로컬 timestamp 보존, 병합분은 로컬 최소값 아래로 부여해 실제 최근 읽음을 우선 보존)
- `+layout.svelte` — 로그인 시 1회 병합

### 2. 공감 상태 낙관적 오버레이
- 세션 인메모리 스토어로 "내 마지막 공감/비공감"을 기억해, 글 재진입 시 아직 반영 안 된 SSR 값보다 우선 표시합니다.
- 전체 새로고침 시 초기화되어 그때는 SSR 이 권위 소스입니다.

## 검증
- 타입 체크(svelte-check) 통과 — 변경 파일 에러 없음.
- 독립 검증: write→read→display 키 포맷 정합, cap/GC(newest 2000 유지) 정확, Redis 장애 degrade, per-user 응답 no-store 확인.

## 배포
- canary 확인 후 승인 시 full promote 예정.