### PR TITLE
per-user API 응답 no-store 유지 (/api/read-posts 후속)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1159,6 +1159,10 @@ export const handle: Handle = async ({ event, resolve }) => {
     const existingCacheControl = response.headers.get('Cache-Control');
     const hasExplicitPublicCache =
         existingCacheControl?.includes('public') && pathname.startsWith('/api/');
+    // API 핸들러가 명시적으로 no-store 를 설정한 경우 유지 (per-user 개인 데이터 —
+    // 예: /api/read-posts). 그렇지 않으면 아래 else 기본값(private, max-age=2)이 덮어씀.
+    const hasExplicitNoStore =
+        existingCacheControl?.includes('no-store') && pathname.startsWith('/api/');
 
     if (response.status === 301 || response.status === 308) {
         // 영구 redirect: CDN 24h + browser 1h, swr 7d
@@ -1171,6 +1175,8 @@ export const handle: Handle = async ({ event, resolve }) => {
         mergeVarySet(response, publicVaryHeader);
     } else if (hasExplicitPublicCache) {
         // API 핸들러가 설정한 Cache-Control 유지 (celebration, banners, levels, reactions, init 등)
+    } else if (hasExplicitNoStore) {
+        // API 핸들러가 설정한 no-store 유지 (per-user 개인 데이터)
     } else if (event.url.pathname.startsWith('/_app/immutable')) {
         // SvelteKit이 이미 설정 → 그대로 유지
     } else if (!event.locals.user && isPublicCacheablePath(pathname)) {


### PR DESCRIPTION
## 배경
#1710 후속. `/api/read-posts`(로그인 회원 read-set)가 `setHeaders`로 `private, no-store`를 설정하지만, 전역 후처리(`hooks.server.ts`)의 기본 else 분기가 `private, max-age=2, must-revalidate`로 덮어써 2초 브라우저 캐시가 남았습니다.

- `private`이 있어 CDN/공유 캐시는 저장 안 함(크로스유저 누출 없음) → LOW.
- 다만 per-user 개인 데이터에 2초 브라우저 캐시가 남는 건 의도(no-store)와 불일치.

## 변경
`hooks.server.ts` — API 핸들러가 `'public'`을 명시한 경우만 유지하던 조건에 **`'no-store'` 명시 유지**를 추가. 해당 응답은 엔드포인트가 설정한 `private, no-store`를 그대로 내보냅니다.

## 영향 범위
`/api/*` 중 핸들러가 명시적으로 `no-store`를 설정한 응답만. 그 외 동작 불변.

## 검증
- svelte-check: hooks.server.ts 에러 없음.
- 배포 후 `curl -D- https://.../api/read-posts` → `cache-control: private, no-store` 확인 예정.

## 배포
단독 배포하지 않고 다음 배포건에 묶어 진행(캐시 효율).