### PR TITLE
메인 최상단 마음메시지 배너 하이드레이션 즉시 표시

### DIFF
--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -87,8 +87,23 @@
     const gamPosition = $derived(gamPositionProp || GAM_POSITION_MAP[position] || 'board-head');
 
     $effect(() => {
-        if (!showCelebration || !adsResolved) return;
+        if (!showCelebration) return;
 
+        // 마음메시지가 이미 있으면(하이드레이션 시 SSR 시드) 자체광고 왕복을 기다리지 않고 즉시 표시.
+        // 자체광고 우선순위는 celebrationBanner derived(adsBanner 있으면 null) + 템플릿 폴백 순서가
+        // 유지 → 자체광고가 늦게 resolve 되면 자연 전환.
+        const hasCelebration = celebrationReady && storeCelebrations.length > 0;
+        if (hasCelebration) {
+            loading = false;
+            useFallback = false;
+            return;
+        }
+
+        // 마음메시지가 없을 땐 자체광고 유무를 알아야 폴백(GAM/문구)을 정할 수 있으므로 adsResolved 대기.
+        if (!adsResolved) {
+            loading = true;
+            return;
+        }
         loading = !adsBanner && !celebrationReady;
         useFallback = !adsBanner && celebrationReady && storeCelebrations.length === 0;
     });
@@ -111,14 +126,13 @@
         if (!browser) return;
 
         if (showCelebration) {
-            // 마음메시지는 공유 스토어에서 관리 → 광고만 fetch
+            // 마음메시지는 공유 스토어에서 관리 → 광고만 fetch.
+            // loading/useFallback 은 위 $effect 가 단일 소스로 계산(adsResolved 변화가 트리거).
             const ads = await fetchAdsBanners();
             if (ads.length > 0) {
                 adsBanner = ads[Math.floor(Math.random() * ads.length)];
             }
             adsResolved = true;
-            loading = !adsBanner && !celebrationReady;
-            useFallback = !adsBanner && celebrationReady && storeCelebrations.length === 0;
         } else {
             // 게시판 페이지: 프리미엄 + 일반 배너만 (마음메시지 없음)
             const ads = await fetchAdsBanners();

--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -190,16 +190,19 @@ export function getLink(banner: CelebrationBanner): string {
 
 /** 외부 데이터로 초기화 (app-init 스토어에서 주입 시 fetch 스킵) */
 export function initFromData(data: CelebrationBanner[]): void {
+    // 실 fetch(mount의 doFetch)가 완료된 뒤에는 시드가 데이터를 덮어쓰지 않는다.
     if (fetched) return;
 
     if (data.length > 0) {
+        // 오늘자 SSR 시드로 첫 페인트를 즉시 채운다.
         celebrations = [...data];
         reshuffleOrder();
+        loadedDateKST = getTodayKST();
+        // fetched 는 설정하지 않는다 — mount()가 /api/celebration/today 로 1회 재검증해
+        // (yearly_repeat·최신 이미지·cache-bust 보정) 정확성을 맞춘다. 무감지 스왑.
     }
-    // 자정 롤오버 비교 기준 날짜 설정 (SSR 시드도 KST today 기준 데이터).
-    loadedDateKST = getTodayKST();
-    // 빈 배열로 초기화되더라도 ready=true 여야 fallback 문구를 렌더할 수 있다.
-    fetched = true;
+    // 빈 시드여도 fallback 문구 렌더용으로 ready 만 올린다. celebrations·fetched·loadedDateKST 는
+    // 건드리지 않아, 이미 시드된 데이터나 이후 실 fetch 를 막지 않는다(+layout 의 매 호출 무해화).
     ready = true;
 }
 

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -18,6 +18,8 @@ interface HomePageData {
     recommendedPeriod: ReturnType<typeof getDefaultPeriod>;
     exploreData: ReturnType<typeof buildExplorePreviewData> | null;
     celebrationRecent: Awaited<ReturnType<typeof getCachedCelebrations>> | null;
+    // 인덱스 최상단 배너용 오늘자 마음메시지 (하이드레이션 즉시 스토어 시드 → 빈 공간 제거).
+    celebrationToday: Awaited<ReturnType<typeof getCachedCelebrations>> | null;
 }
 
 // Phase 14 — multi-tenant: cache 를 host 별로 격리 (module singleton 이 SSR 요청 간
@@ -27,26 +29,34 @@ const pendingByHost = new Map<string, Promise<HomePageData>>();
 
 async function buildHomePageData(): Promise<HomePageData> {
     const recommendedPeriod = getDefaultPeriod();
-    const [indexWidgetsResult, layoutResult, celebrationResult, recommendedResult, exploreResult] =
-        await Promise.allSettled([
-            buildIndexWidgets(BACKEND_URL),
-            (async () => {
-                const [widgetLayout, sidebarWidgetLayout] = await Promise.all([
-                    getWidgetLayout(),
-                    getSidebarWidgetLayout()
-                ]);
-                return {
-                    widgetLayout: widgetLayout ?? DEFAULT_WIDGETS,
-                    sidebarWidgetLayout: sidebarWidgetLayout ?? DEFAULT_SIDEBAR_WIDGETS
-                };
-            })(),
-            // 인덱스 전용: 최근 마음메시지 (오늘뿐 아니라 최근 8건)
-            getCachedCelebrations(true),
-            // 공감글 SSR 프리페치 (스켈레톤 제거)
-            loadRecommendedData(recommendedPeriod),
-            // 모아보기 SSR 프리페치 (스켈레톤 제거). 파일 캐시(60초 인메모리)라 SSR 부담 적음.
-            loadExploreData()
-        ]);
+    const [
+        indexWidgetsResult,
+        layoutResult,
+        celebrationResult,
+        recommendedResult,
+        exploreResult,
+        celebrationTodayResult
+    ] = await Promise.allSettled([
+        buildIndexWidgets(BACKEND_URL),
+        (async () => {
+            const [widgetLayout, sidebarWidgetLayout] = await Promise.all([
+                getWidgetLayout(),
+                getSidebarWidgetLayout()
+            ]);
+            return {
+                widgetLayout: widgetLayout ?? DEFAULT_WIDGETS,
+                sidebarWidgetLayout: sidebarWidgetLayout ?? DEFAULT_SIDEBAR_WIDGETS
+            };
+        })(),
+        // 인덱스 전용: 최근 마음메시지 (오늘뿐 아니라 최근 8건)
+        getCachedCelebrations(true),
+        // 공감글 SSR 프리페치 (스켈레톤 제거)
+        loadRecommendedData(recommendedPeriod),
+        // 모아보기 SSR 프리페치 (스켈레톤 제거). 파일 캐시(60초 인메모리)라 SSR 부담 적음.
+        loadExploreData(),
+        // 최상단 배너용 오늘자 마음메시지. today:${KST} 캐시(60초)를 /api/layout/init 과 공유 → 추가 부하 거의 없음.
+        getCachedCelebrations(false)
+    ]);
 
     const indexWidgets =
         indexWidgetsResult.status === 'fulfilled' ? indexWidgetsResult.value : null;
@@ -56,6 +66,8 @@ async function buildHomePageData(): Promise<HomePageData> {
             : { widgetLayout: DEFAULT_WIDGETS, sidebarWidgetLayout: DEFAULT_SIDEBAR_WIDGETS };
     const celebrationRecent =
         celebrationResult.status === 'fulfilled' ? celebrationResult.value : null;
+    const celebrationToday =
+        celebrationTodayResult.status === 'fulfilled' ? celebrationTodayResult.value : null;
     const exploreRaw = exploreResult.status === 'fulfilled' ? exploreResult.value : null;
     const exploreData = exploreRaw ? buildExplorePreviewData(exploreRaw) : null;
 
@@ -70,7 +82,8 @@ async function buildHomePageData(): Promise<HomePageData> {
         recommendedData: recommendedResult.status === 'fulfilled' ? recommendedResult.value : null,
         recommendedPeriod,
         exploreData,
-        celebrationRecent
+        celebrationRecent,
+        celebrationToday
     };
 }
 
@@ -92,7 +105,8 @@ function emptyHomePageData(): HomePageData {
         recommendedData: null,
         recommendedPeriod: getDefaultPeriod(),
         exploreData: null,
-        celebrationRecent: null
+        celebrationRecent: null,
+        celebrationToday: null
     };
 }
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -8,6 +8,8 @@
     import type { SeoConfig } from '$lib/seo/types.js';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import { getThemePageTemplate } from '$lib/themes/page-registry';
+    import { browser } from '$app/environment';
+    import { initFromData as initCelebrationFromData } from '$lib/stores/celebration.svelte';
 
     let { data } = $props();
 
@@ -18,6 +20,13 @@
     // SSR 데이터 즉시 스토어 초기화 (hydration 전에 실행)
     indexWidgetsStore.initFromServer(data.indexWidgets);
     widgetLayoutStore.initFromServer(data.widgetLayout, data.sidebarWidgetLayout);
+
+    // 오늘자 마음메시지를 하이드레이션 즉시(무네트워크) 스토어에 시드 → 최상단 배너 빈 공간 제거.
+    // ⚠️ celebration 스토어는 모듈 싱글턴이고 전 페이지 SSR에서 읽히므로, SSR 중 쓰면 멀티테넌트
+    // 누수 발생 → 반드시 browser(하이드레이션) 전용. 자식 DamoangBanner onMount 보다 먼저 실행됨.
+    if (browser) {
+        initCelebrationFromData(data.celebrationToday ?? []);
+    }
 
     // SSR 데이터 변경 시 스토어 동기화 (SPA 내비게이션 대응)
     $effect(() => {


### PR DESCRIPTION
## 배경
메인 `/` 최상단 "오늘의 마음메시지" 배너가 최초 진입 시 빈 공간이었다가, 클라이언트 fetch(`/api/celebration/today`) + 자체광고 왕복(`/api/sidebar/items`, 현재 0개)이 끝난 뒤에야 표시되어 체감 지연이 있었습니다. (광고 스크립트는 원인이 아님)

## 변경
- **`+page.server.ts`**: 오늘자 마음메시지(`getCachedCelebrations(false)`)를 SSR 데이터로 로드. `today:${KST}` 60초 캐시를 `/api/layout/init`과 공유해 추가 DB 부하 거의 없음.
- **`+page.svelte`**: `browser` 전용으로 스토어 시드 → 하이드레이션 즉시(무네트워크) 채움. ⚠️ celebration 스토어는 모듈 싱글턴이고 전 페이지 SSR에서 읽히므로 SSR 중 쓰기 금지(멀티테넌트 누수 방지) — `if (browser)` 가드.
- **`celebration.svelte.ts`**: `initFromData` — 비어있지 않은 시드는 즉시 표시하되 `fetched` 미설정(→ `mount()`가 `/api/celebration/today`로 1회 재검증해 yearly_repeat·최신 이미지 보정). 빈 시드는 `ready`만 → 기존에 빈 시드가 스토어를 굳혀 재검증/사이드바 로딩을 막던 버그도 해소.
- **`damoang-banner.svelte`**: 마음메시지가 이미 있으면 자체광고 왕복을 기다리지 않고 즉시 표시. 자체광고 우선순위는 `celebrationBanner` derived(adsBanner 있으면 null) + 템플릿 폴백 순서로 보존.

## 회귀 가드
자체광고 우선순위 유지 / 롤링 유지 / 자정 롤오버 유지 / 빈 날 GAM·문구 폴백 / 비홈·사이드바 회귀 없음(개선) / SSR HTML은 정확 크기 플레이스홀더(시프트 0) / 멀티테넌트 누수 없음.

## 검증
svelte-check 통과. canary에서: 최초 방문 시 두 API pending 중에도 배너 표시, 롤링·빈날·자체광고 우선·타호스트 누수 없음·자정 롤오버 확인 예정.