### PR TITLE
시스템 테마 선택 시 다크 고정 문제 수정 (#12886)

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -36,10 +36,19 @@
             (function () {
                 var c = document.cookie.match(/angple_theme_mode=(\w+)/);
                 var m = c ? c[1] : null;
+                // fromStore: m 이 '명시적으로 저장된 선택'(쿠키/localStorage)에서 왔는지 여부.
+                // prefers-color-scheme 로 파생된 dark 는 fromStore=false → 쿠키에 박제하지 않는다.
+                var fromStore = !!m;
                 if (!m) {
                     try {
-                        m = localStorage.getItem('themeMode');
-                        if (!m && localStorage.getItem('darkMode') === 'true') m = 'dark';
+                        var lm = localStorage.getItem('themeMode');
+                        if (lm) {
+                            m = lm;
+                            fromStore = true;
+                        } else if (localStorage.getItem('darkMode') === 'true') {
+                            m = 'dark';
+                            fromStore = true;
+                        }
                     } catch (e) {}
                 }
                 if (!m && window.matchMedia('(prefers-color-scheme: dark)').matches) {
@@ -47,8 +56,9 @@
                 }
                 if (m === 'dark') document.documentElement.classList.add('dark');
                 else if (m === 'amoled') document.documentElement.classList.add('amoled');
-                // 쿠키에 기록 (SSR 동기화용, 1년 만료)
-                if (m === 'dark' || m === 'amoled') {
+                // SSR 동기화용 쿠키는 '명시적으로 저장된' dark/amoled 만 기록한다(1년 만료).
+                // prefers 파생 dark 를 기록하면 시스템 모드가 dark 로 영구 고정된다(#12886).
+                if (fromStore && (m === 'dark' || m === 'amoled')) {
                     document.cookie =
                         'angple_theme_mode=' + m + ';path=/;max-age=31536000;SameSite=Lax';
                 }

--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -213,11 +213,15 @@
                 if (!savedMode && legacyDark === 'true') savedMode = 'dark';
             } catch {}
         }
-        if (!savedMode && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            savedMode = 'dark';
-        }
+        // 저장값(쿠키/localStorage)이 없으면 '시스템 모드'로 본다. prefers-color-scheme 로
+        // savedMode 를 'dark' 로 덮어쓰면 시스템 사용자가 dark 로 오인되어 OS 변경 추종이
+        // 끊긴다(#12886). 다크 OS 의 실제 dark 클래스는 app.html 인라인 스크립트가 이미 적용.
         if (savedMode === 'dark' || savedMode === 'amoled') {
             themeMode = savedMode;
+        } else if (savedMode === 'light') {
+            themeMode = 'light';
+        } else {
+            themeMode = 'system';
         }
 
         // cross-tab 테마 동기화 (다른 탭에서 테마 변경 시)
@@ -246,10 +250,9 @@
             el.classList.remove('dark', 'amoled');
             if (e.matches) {
                 el.classList.add('dark');
-                themeMode = 'dark';
-            } else {
-                themeMode = 'light';
             }
+            // 시스템 모드 유지 — OS 변경을 계속 추종하고 라벨도 '시스템'으로 일관.
+            themeMode = 'system';
         }
         darkMq.addEventListener('change', handleSystemThemeChange);
         function handleReducedMotionChange(e: MediaQueryListEvent) {


### PR DESCRIPTION
## 배경
'시스템 테마 따라가기'를 선택해도 다크모드로 영구 고정되는 문제(주로 macOS + Safari, 다크 OS). 이전 #9381 조치(시스템 모드 순환 추가) 후에도 재발.

## 근본 원인
시스템 모드는 "저장값 없음(쿠키·localStorage 삭제)"으로 표현되는데, 초기화 코드가 이를 다크로 오인·박제:
1. `app.html` 인라인 스크립트가 `prefers-color-scheme`로 파생한 다크를 `angple_theme_mode=dark` 쿠키에 1년간 기록 → 시스템 사용자가 dark로 영구 고정. 이 쿠키 때문에 OS 변경 추종 리스너(`handleSystemThemeChange`, 쿠키 있으면 무시)까지 무력화.
2. `header.svelte` onMount가 저장값 없음 + 다크 OS를 `themeMode='dark'`로 오인.

## 수정
- **app.html**: 명시적으로 저장된(`fromStore`) dark/amoled만 SSR 동기화용 쿠키에 기록. prefers 파생 다크는 클래스만 적용하고 쿠키에 박제하지 않음.
- **header.svelte onMount**: 저장값 없음 → `themeMode='system'`(light는 localStorage로 구분). prefers로 'dark' 덮어쓰던 라인 제거.
- **handleSystemThemeChange**: OS 변경 후에도 `themeMode='system'` 유지(추종 지속 + 라벨 일관).

## 동작
| 상황 | 결과 |
|---|---|
| 명시적 dark/light 선택 | 회귀 없음(쿠키/localStorage로 유지) |
| 시스템 + 다크 OS | 다크 표시, 쿠키 박제 없음, 스토어='system' |
| 시스템 중 OS→라이트 | 리스너가 즉시 라이트로 추종(기존: 고정) |
| 새로고침 | 쿠키 없음 → 매번 OS 재평가 |

백엔드·SSR(hooks.server.ts는 쿠키만 read) 변경 없음. svelte-check 통과.

## 검증
canary에서 macOS Safari 다크 OS: 시스템 선택 → 다크 → macOS 라이트 전환 → 사이트 즉시 라이트 추종 → 새로고침 후에도 OS 따라감. 명시 dark/light 사용자 회귀 없음.