### PR TITLE
빈 광고 예약영역 클릭 차단 (#12877)

### DIFF
--- a/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
+++ b/apps/web/src/lib/components/ui/ad-slot/ad-slot.svelte
@@ -427,6 +427,11 @@
     .ad-slot-empty {
         border: 0;
         background: transparent;
+        /* #12877: 빈(미채움) 광고 예약영역은 투명하지만 opacity:0 만으로는 클릭이 살아 있어,
+           이미지 없는 "보이지 않는 클릭 가능 광고"가 된다(AdSense 무효클릭 리스크).
+           빈 상태에서는 포인터 이벤트를 차단한다. 광고가 채워지면(isEmpty=false) 이 클래스가
+           제거되어 pointer-events 가 기본값(auto)으로 복원되므로 정상 광고 클릭에 영향 없음. */
+        pointer-events: none;
     }
 
     .ad-slot-empty-collapsed {


### PR DESCRIPTION
## 배경
사이드바 '진행 중 나눔' 하단 회색 영역에 이미지 없는 클릭 가능 광고가 상주하여 의도치 않은 클릭이 발생(재발 제보). AdSense 무효클릭 정책 리스크.

## 원인
미채움 광고 슬롯이 CLS 방지를 위해 예약 공간(min-height)을 유지하는데, `.ad-slot-empty-collapsed`가 `opacity:0`만 걸어 시각적으로만 투명할 뿐 **클릭은 살아 있어** 보이지 않는 클릭 가능 영역이 됨.

## 수정
`.ad-slot-empty`(isEmpty일 때 프레임 div에 적용)에 `pointer-events: none` 추가. 광고가 채워지면 `isEmpty=false`로 클래스가 제거되어 `pointer-events`가 기본값(auto)으로 복원 → 정상 광고 클릭에는 영향 없음. CLS 예약(min-height)은 그대로 유지.

## 검증
svelte-check 통과. canary에서 사이드바 빈 광고 영역 마우스오버/클릭 시 광고로 안 넘어가는지, 광고 채워졌을 때 정상 클릭되는지 확인 예정.