### PR TITLE
게시판 이동 시 이전 알림 설정 표시 문제 (#12875)

### DIFF
--- a/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
@@ -30,6 +30,20 @@
     let stateLoaded = $state(false);
     let stateLoading = $state(false);
 
+    // #12875: SvelteKit 은 같은 [boardId] 라우트 내 이동(예: /nyangs → /free)에서 이 컴포넌트를
+    // 재마운트하지 않고 boardId prop 만 바꾼다. stateLoaded 가 남아 있으면 이전 게시판의 구독
+    // 상태가 새 게시판에 그대로 표시된다. boardId 변경 시 상태를 초기화해, 다음 hover/open 에서
+    // 새 게시판을 다시 로드하도록 한다.
+    $effect(() => {
+        boardId; // 의존성 추적
+        stateLoaded = false;
+        stateLoading = false;
+        isSubscribed = false;
+        level = null;
+        subscriberCount = 0;
+        busy = false;
+    });
+
     async function loadSubscribeState(): Promise<void> {
         if (stateLoaded || stateLoading) return;
         stateLoading = true;

--- a/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
@@ -35,7 +35,7 @@
     // 상태가 새 게시판에 그대로 표시된다. boardId 변경 시 상태를 초기화해, 다음 hover/open 에서
     // 새 게시판을 다시 로드하도록 한다.
     $effect(() => {
-        boardId; // 의존성 추적
+        void boardId; // 의존성 추적
         stateLoaded = false;
         stateLoading = false;
         isSubscribed = false;
@@ -46,11 +46,16 @@
 
     async function loadSubscribeState(): Promise<void> {
         if (stateLoaded || stateLoading) return;
+        // 요청 시작 시점의 boardId 를 캡처. 응답 도착 전에 게시판이 바뀌면(SPA 이동) 이 응답은
+        // 이전 게시판 것이므로 폐기한다 — stale 응답이 새 게시판에 커밋되어 고착되는 레이스 방지(#12875).
+        const reqBoard = boardId;
         stateLoading = true;
         try {
-            const res = await fetch(`/api/boards/${boardId}/subscribe`);
+            const res = await fetch(`/api/boards/${reqBoard}/subscribe`);
+            if (reqBoard !== boardId) return; // 그 사이 게시판 전환됨 → 폐기
             if (res.ok) {
                 const data = await res.json();
+                if (reqBoard !== boardId) return;
                 if (data.success) {
                     isSubscribed = data.data.is_subscribed;
                     level = data.data.level ?? null;
@@ -61,8 +66,11 @@
         } catch {
             // 조회 실패 시 무시
         } finally {
-            stateLoaded = true;
-            stateLoading = false;
+            // stale 응답이면 현재 게시판 상태(로드 가드)를 건드리지 않는다.
+            if (reqBoard === boardId) {
+                stateLoaded = true;
+                stateLoading = false;
+            }
         }
     }
 


### PR DESCRIPTION
## 배경
소모임 게시판에서 전체알림을 켜면 자유게시판에도 켜진 것처럼 보이고, 한쪽에서 끄면 다른 쪽도 꺼진 것처럼 보이는(게시판별 알림 설정이 서로 연동돼 보이는) 문제.

## 원인
SvelteKit은 같은 `[boardId]` 라우트 내 이동(예: `/nyangs` → `/free`)에서 이 버튼 컴포넌트를 **재마운트하지 않고 boardId prop만 교체**한다. `stateLoaded`(1회 로드 가드)가 남아 있어 새 게시판에서 재로드하지 않고 **이전 게시판의 구독 상태가 그대로 표시**됨. (저장 테이블 `g5_board_subscribe`는 `bo_table`별 독립 행이라 DB는 정상 — 순수 프론트 컴포넌트 캐시 버그)

## 수정
`board-subscribe-button.svelte`에 `boardId`를 추적하는 `$effect` 추가 → boardId 변경 시 구독 상태 초기화, 다음 hover/open에서 새 게시판을 다시 로드.

## 검증
svelte-check 통과. canary에서 게시판 간 이동 시 구독 버튼이 각 게시판의 실제 상태를 표시하는지 확인 예정.