### PR TITLE
UI 설정(뮤트 키워드) 서버 저장으로 리셋 방지 (#12891)

### DIFF
--- a/apps/web/src/lib/server/ui-settings-store.ts
+++ b/apps/web/src/lib/server/ui-settings-store.ts
@@ -1,0 +1,123 @@
+/**
+ * 회원 UI 설정 서버 저장 (L2) — MySQL(진실 원본) + Redis(읽기 캐시)
+ *
+ * UI 개인화 설정(뮤트 키워드 등)은 그동안 localStorage(L1)에만 저장돼
+ * Safari ITP(7일 미상호작용 삭제)·캐시삭제·기기 간 미동기로 "리셋"되는
+ * 구조적 문제가 있었다(#12891). 이를 보완하기 위해 로그인 회원의 설정
+ * 전체 JSON을 계정 단위로 MySQL에 영구 저장하고 Redis로 읽기 캐시한다.
+ *
+ * - 키: `uis:{mbId}` → settings JSON 문자열, TTL 300s. read-through.
+ * - 진실 원본: g5_da_member_ui_settings(회원당 1행, ON DUPLICATE KEY upsert).
+ * - 장애/미적용 시 graceful degrade: 모든 DB/Redis 접근을 try/catch로 감싸
+ *   읽기는 null, 쓰기는 false 를 반환한다. 예외를 요청 핸들러로 전파하지 않아
+ *   테이블 미생성·Redis 장애에도 앱은 L1(localStorage)로 계속 동작한다.
+ */
+
+import type { RowDataPacket } from 'mysql2';
+import pool, { readPool } from '$lib/server/db';
+import { getRedis } from '$lib/server/redis';
+
+/** Redis 캐시 키 접두사 */
+const CACHE_PREFIX = 'uis:';
+/** Redis 캐시 TTL (초) */
+const CACHE_TTL_SEC = 300;
+
+interface UiSettingsRow extends RowDataPacket {
+    settings: unknown;
+}
+
+function keyFor(mbId: string): string {
+    return `${CACHE_PREFIX}${mbId}`;
+}
+
+/**
+ * mysql2 JSON 컬럼은 드라이버 설정에 따라 객체 또는 문자열로 올 수 있어
+ * 둘 다 안전하게 파싱한다. 파싱 불가/비객체면 null.
+ */
+function toObject(value: unknown): Record<string, unknown> | null {
+    if (value == null) return null;
+    if (typeof value === 'string') {
+        try {
+            const parsed = JSON.parse(value);
+            return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                ? (parsed as Record<string, unknown>)
+                : null;
+        } catch {
+            return null;
+        }
+    }
+    if (typeof value === 'object' && !Array.isArray(value)) {
+        return value as Record<string, unknown>;
+    }
+    return null;
+}
+
+/**
+ * 회원 UI 설정 조회 (read-through: Redis → MySQL → Redis 캐시).
+ * 서버에 저장된 값이 없으면 null. 장애 시에도 절대 throw 하지 않고 null 반환.
+ */
+export async function getMemberUiSettings(mbId: string): Promise<Record<string, unknown> | null> {
+    if (!mbId) return null;
+    try {
+        const redis = getRedis();
+        const cached = await redis.get(keyFor(mbId));
+        if (cached) {
+            const obj = toObject(cached);
+            if (obj) return obj;
+        }
+    } catch {
+        // Redis 장애 → DB로 폴백
+    }
+
+    try {
+        const [rows] = await readPool.query<UiSettingsRow[]>(
+            'SELECT settings FROM g5_da_member_ui_settings WHERE mb_id = ?',
+            [mbId]
+        );
+        if (!rows || rows.length === 0) return null;
+        const obj = toObject(rows[0].settings);
+        if (!obj) return null;
+
+        // best-effort 캐시 채우기 (실패해도 결과에는 영향 없음)
+        try {
+            await getRedis().setex(keyFor(mbId), CACHE_TTL_SEC, JSON.stringify(obj));
+        } catch {
+            // 캐시 실패 무시
+        }
+        return obj;
+    } catch {
+        // 테이블 미생성/DB 장애 → localStorage(L1) 폴백
+        return null;
+    }
+}
+
+/**
+ * 회원 UI 설정 저장 (MySQL upsert + Redis 캐시 갱신).
+ * 성공 시 true, 장애/실패 시 false. 절대 throw 하지 않음.
+ */
+export async function putMemberUiSettings(
+    mbId: string,
+    settings: Record<string, unknown>
+): Promise<boolean> {
+    if (!mbId) return false;
+    const payload = JSON.stringify(settings);
+    try {
+        await pool.query(
+            `INSERT INTO g5_da_member_ui_settings (mb_id, settings, updated_at)
+             VALUES (?, ?, NOW())
+             ON DUPLICATE KEY UPDATE settings = VALUES(settings), updated_at = NOW()`,
+            [mbId, payload]
+        );
+    } catch {
+        // 테이블 미생성/DB 장애 → 저장 실패(localStorage는 그대로 유지)
+        return false;
+    }
+
+    // best-effort 캐시 갱신 (실패해도 저장 자체는 성공)
+    try {
+        await getRedis().setex(keyFor(mbId), CACHE_TTL_SEC, payload);
+    } catch {
+        // 캐시 실패 무시 — 다음 읽기에서 DB로 채워짐
+    }
+    return true;
+}

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -16,7 +16,7 @@ export type ListViewMode = 'classic' | 'modern';
 export type ContentFontSize = 'small' | 'base' | 'large' | 'xlarge' | '2xlarge' | '3xlarge';
 export type ListFontSize = 'xsmall' | 'small' | 'base' | 'large' | 'xlarge';
 
-interface UiSettings {
+export interface UiSettings {
     // 레이아웃
     titleBold: boolean;
     listView: ListViewMode;
@@ -136,8 +136,42 @@ function loadSettings(): UiSettings {
     return { ...DEFAULTS };
 }
 
+/** 서버 write-through 디바운스 지연(ms) — 잦은 설정 변경을 1회 PUT으로 병합 */
+const SERVER_SYNC_DEBOUNCE_MS = 1500;
+
 function createUiSettingsStore() {
     let settings = $state<UiSettings>(loadSettings());
+
+    // 서버 저장(L2) 디바운스 타이머. 로그인 여부는 엔드포인트가 판단하며,
+    // 비로그인은 401 을 받아 조용히 무시된다(여기서 authStore 를 import 하지 않음 — 순환 회피).
+    let syncTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /** 현재 설정을 서버에 즉시 PUT(fire-and-forget). 비로그인 401 은 무시. */
+    function syncToServer() {
+        if (!browser) return;
+        try {
+            fetch('/api/my/ui-settings', {
+                method: 'PUT',
+                credentials: 'include',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ settings })
+            }).catch(() => {
+                // 네트워크/비로그인 실패는 무시 — L1(localStorage)이 원본 유지
+            });
+        } catch {
+            // ignore
+        }
+    }
+
+    /** save() 마다 호출되는 디바운스 서버 동기화(1.5s 병합). */
+    function scheduleServerSync() {
+        if (!browser) return;
+        if (syncTimer) clearTimeout(syncTimer);
+        syncTimer = setTimeout(() => {
+            syncTimer = null;
+            syncToServer();
+        }, SERVER_SYNC_DEBOUNCE_MS);
+    }
 
     function save() {
         if (!browser) return;
@@ -146,6 +180,8 @@ function createUiSettingsStore() {
         } catch {
             // ignore
         }
+        // 로그인 회원은 서버(L2)로 디바운스 write-through — save() 를 블록하지 않음
+        scheduleServerSync();
     }
 
     function applyCSS() {
@@ -416,6 +452,22 @@ function createUiSettingsStore() {
             settings.blurMemo = v;
             save();
         },
+
+        /**
+         * 서버(L2) 설정을 로컬에 병합. 로그인 회원은 서버가 진실 원본이므로
+         * 서버 값이 우선한다(server wins). 병합 후 localStorage 에도 반영.
+         * null/비객체면 no-op(서버에 저장값 없음 = 첫 도입).
+         */
+        mergeServerSettings(server: Partial<UiSettings> | null): void {
+            if (!browser) return;
+            if (!server || typeof server !== 'object') return;
+            settings = { ...settings, ...server };
+            save();
+            applyCSS();
+        },
+
+        /** 현재 로컬 설정을 서버에 즉시 올림(첫 로그인 마이그레이션용). */
+        syncToServer,
 
         /** 제목이 뮤트 키워드에 매칭되는지 확인 */
         isMuted(title: string): boolean {

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -484,6 +484,29 @@
                 });
         }
 
+        // 로그인 회원 UI 설정(L2, MySQL+Redis) 병합 — 크로스기기·ITP 대비(#12891).
+        // 서버 값 있음 → 서버가 진실 원본으로 로컬에 반영. 서버 비어있음(첫 도입)
+        // → 현재 로컬 설정을 서버로 올려 마이그레이션(기존 사용자 설정 무손실).
+        if (browser && authStore.isAuthenticated) {
+            fetch('/api/my/ui-settings', { headers: { accept: 'application/json' } })
+                .then((res) => (res.ok ? res.json() : null))
+                .then((payload: { settings?: Record<string, unknown> | null } | null) => {
+                    if (payload?.settings) {
+                        uiSettingsStore.mergeServerSettings(
+                            payload.settings as Partial<
+                                import('$lib/stores/ui-settings.svelte').UiSettings
+                            >
+                        );
+                    } else {
+                        // 서버에 저장값 없음 → 로컬 설정을 서버로 마이그레이션
+                        uiSettingsStore.syncToServer();
+                    }
+                })
+                .catch(() => {
+                    // 실패해도 로컬(L1) 설정은 그대로 유지
+                });
+        }
+
         const cachedMenus = readCachedMenus();
         if (cachedMenus) {
             menuStore.initFromServer(cachedMenus);

--- a/apps/web/src/routes/api/my/ui-settings/+server.ts
+++ b/apps/web/src/routes/api/my/ui-settings/+server.ts
@@ -1,0 +1,140 @@
+/**
+ * 회원 UI 개인화 설정 API (#12891)
+ *
+ * localStorage(L1) 전용 저장의 취약성을 보완하기 위한 서버 저장(L2) 엔드포인트.
+ * - GET: 로그인 회원의 서버 저장 설정을 반환(없으면 settings=null).
+ * - PUT: 클라이언트의 UiSettings 전체 blob 을 검증·상한 후 upsert(디바운스 write-through).
+ *
+ * per-user 응답이므로 `private, no-store`(공유 캐시 누출 방지). 내부 앱 전용.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getAuthUser } from '$lib/server/auth';
+import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/internal-api.js';
+import { getMemberUiSettings, putMemberUiSettings } from '$lib/server/ui-settings-store';
+
+/**
+ * 허용된 UiSettings 최상위 키 화이트리스트.
+ * stores/ui-settings.svelte.ts 의 UiSettings 인터페이스와 동일하게 유지한다.
+ * 알 수 없는 키는 오류 대신 드롭(forward-compatible).
+ */
+const ALLOWED_KEYS = new Set<string>([
+    'titleBold',
+    'listView',
+    'lineHeight',
+    'fontFamily',
+    'contentFontSize',
+    'commentFontSize',
+    'hideMyProfile',
+    'contentBlur',
+    'hidePostList',
+    'hideReadNotices',
+    'muteKeywords',
+    'showNewComments',
+    'enableKeyboardShortcuts',
+    'showShortcutBadge',
+    'showShortcutButtons',
+    'shortcutButtonSize',
+    'enableTouchGestures',
+    'swipeThreshold',
+    'doubleTapInterval',
+    'listFontSize',
+    'recommendFontSize',
+    'pinSearch',
+    'pinMemoSearch',
+    'hideMemo',
+    'hideMemoInList',
+    'blurMemo'
+]);
+
+/** 남용 방어 상한 */
+const MAX_JSON_BYTES = 16384;
+const MAX_MUTE_KEYWORDS = 200;
+const MAX_MUTE_KEYWORD_LEN = 50;
+
+export const GET: RequestHandler = async ({ cookies, request, setHeaders }) => {
+    if (!isInternalAppRequest(request)) {
+        return internalOnlyErrorResponse();
+    }
+
+    const user = await getAuthUser(cookies);
+    if (!user) {
+        return json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    // 장애 시 getMemberUiSettings 는 null 반환(throw 안 함) → 클라는 L1 유지
+    const settings = await getMemberUiSettings(user.mb_id);
+    return json({ success: true, settings });
+};
+
+export const PUT: RequestHandler = async ({ cookies, request, setHeaders }) => {
+    if (!isInternalAppRequest(request)) {
+        return internalOnlyErrorResponse();
+    }
+
+    const user = await getAuthUser(cookies);
+    if (!user) {
+        return json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return json({ success: false, message: '잘못된 요청 본문입니다.' }, { status: 400 });
+    }
+
+    const settings = (body as { settings?: unknown } | null)?.settings;
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+        return json({ success: false, message: 'settings 객체가 필요합니다.' }, { status: 400 });
+    }
+
+    const raw = settings as Record<string, unknown>;
+
+    // 전체 크기 상한
+    if (JSON.stringify(raw).length > MAX_JSON_BYTES) {
+        return json({ success: false, message: '설정 크기가 너무 큽니다.' }, { status: 400 });
+    }
+
+    // muteKeywords 상한/형식 검증
+    if ('muteKeywords' in raw && raw.muteKeywords !== undefined) {
+        const mk = raw.muteKeywords;
+        if (!Array.isArray(mk)) {
+            return json(
+                { success: false, message: 'muteKeywords 형식이 올바르지 않습니다.' },
+                { status: 400 }
+            );
+        }
+        if (mk.length > MAX_MUTE_KEYWORDS) {
+            return json(
+                { success: false, message: '뮤트 키워드가 너무 많습니다.' },
+                { status: 400 }
+            );
+        }
+        for (const item of mk) {
+            if (typeof item !== 'string' || item.length > MAX_MUTE_KEYWORD_LEN) {
+                return json(
+                    { success: false, message: '뮤트 키워드 형식/길이가 올바르지 않습니다.' },
+                    { status: 400 }
+                );
+            }
+        }
+    }
+
+    // 화이트리스트: 알려진 키만 통과, 알 수 없는 키는 드롭(forward-compatible)
+    const cleaned: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(raw)) {
+        if (ALLOWED_KEYS.has(k)) cleaned[k] = v;
+    }
+
+    const ok = await putMemberUiSettings(user.mb_id, cleaned);
+    if (!ok) {
+        // 저장 실패해도 예외는 아님 — 클라는 L1(localStorage)로 계속 동작
+        return json({ success: false, message: '저장에 실패했습니다.' }, { status: 500 });
+    }
+    return json({ success: true });
+};

--- a/migrations/005_ui_settings.sql
+++ b/migrations/005_ui_settings.sql
@@ -1,0 +1,13 @@
+-- UI 개인화 설정 서버 저장 (#12891)
+-- localStorage 전용 저장의 취약성(Safari ITP 7일 삭제 / 캐시삭제 / 기기 간 미동기)을
+-- 보완하기 위해 로그인 회원의 UiSettings 전체 JSON을 회원당 1행으로 영구 저장한다.
+-- MySQL = 진실 원본(durable), Redis(uis:{mb_id}) = 읽기 캐시.
+-- 코드는 이 테이블이 없어도 graceful degrade(localStorage로 폴백)하므로,
+-- 배포 후 아무 때나 적용해도 무방하다(적용 전에는 서버 저장이 비활성).
+
+CREATE TABLE IF NOT EXISTS g5_da_member_ui_settings (
+    mb_id      VARCHAR(20) NOT NULL,
+    settings   JSON        NOT NULL COMMENT 'UiSettings 전체 blob(뮤트 키워드 포함)',
+    updated_at DATETIME    NOT NULL,
+    PRIMARY KEY (mb_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## 문제
UI 개인화 설정(뮤트 키워드 등)이 `localStorage`(`angple_ui_settings`) **전용**으로만 저장돼 아래 경로로 소실됩니다.
- Safari ITP: 7일 미상호작용 시 localStorage 자동 삭제 → "설정이 자꾸 리셋"
- 브라우저 캐시/사이트데이터 삭제 시 소실
- 기기·브라우저 간 동기화 없음

## 설계
L1(localStorage)은 즉시성·오프라인·비로그인용으로 유지하고, 로그인 회원에 한해 서버 저장(L2)을 추가합니다.
- **MySQL `g5_da_member_ui_settings` = 진실 원본(durable)**, 회원당 1행에 UiSettings 전체 JSON blob 저장 → 뮤트뿐 아니라 폰트/밀도 등 모든 설정 리셋 문제를 한 번에 해결
- **Redis `uis:{mb_id}` = 읽기 캐시(TTL 300s)**, read-through(미스 시 MySQL→캐시)
- 전부 SvelteKit 서버에서 처리 — **백엔드(Go) 변경 없음**
- 병합 정책: 로그인 시 서버 우선(server wins), 첫 로그인 시 기존 localStorage 설정을 서버로 올려 무손실 마이그레이션

## 엔드포인트 (내부 앱 전용, `private, no-store`)
- `GET /api/my/ui-settings` → `{ success, settings }` (없으면 `settings: null`)
- `PUT /api/my/ui-settings` (body `{ settings }`) → `{ success }` — 클라에서 debounce(1.5s) write-through

## 남용 상한(시스템 경계 검증)
- 전체 JSON ≤ 16KB
- muteKeywords ≤ 200개, 항목당 ≤ 50자, 문자열만 → 위반 시 400
- 알려진 최상위 키만 화이트리스트 통과(알 수 없는 키는 드롭, forward-compatible)

## graceful degrade
- 서버 모듈의 모든 DB/Redis 접근을 try/catch로 감싸 읽기는 `null`, 쓰기는 `false` 반환 — 예외를 요청 핸들러로 전파하지 않음
- 따라서 **테이블 미생성/Redis 장애에도 앱은 localStorage로 계속 동작**
- 비로그인 PUT은 401을 받고 클라에서 조용히 무시(fire-and-forget)

## 적용 순서
- `migrations/005_ui_settings.sql` 을 운영 DB에 적용해야 서버 저장이 활성화됩니다.
- 적용 전에는 코드가 graceful degrade로 기존 localStorage 동작을 그대로 유지하므로 배포는 안전합니다.

## 변경 파일
- `migrations/005_ui_settings.sql` (신규 테이블, 적용 전까지 미활성)
- `apps/web/src/lib/server/ui-settings-store.ts` (MySQL+Redis, 신규)
- `apps/web/src/routes/api/my/ui-settings/+server.ts` (GET/PUT, 신규)
- `apps/web/src/lib/stores/ui-settings.svelte.ts` (`mergeServerSettings`/`syncToServer`/debounce write-through)
- `apps/web/src/routes/+layout.svelte` (로그인 시 서버 설정 병합 + 첫 로그인 마이그레이션)