### PR TITLE
fix(comments): 삭제된 게시글의 댓글 노출 차단 (#12711)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -156,6 +156,9 @@ export const load: PageServerLoad = async ({
             post.videos = [];
             post.downloads = [];
             post.files = [];
+            // 삭제글은 댓글도 노출하지 않는다(#12711). 댓글 API(부모 삭제 시 빈 배열 반환)와
+            // 정합을 맞추기 위해 권위 카운트도 0으로 — 헤더 카운트 라벨/SSR total/클라 backfill 게이트 일치.
+            post.comments_count = 0;
             setHeaders({ 'X-Robots-Tag': 'noindex, noarchive' });
         }
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -128,6 +128,32 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
     const tableName = `g5_write_${safeBoardId}`;
 
     try {
+        // 부모 글 삭제 여부 확인 — 삭제된 글은 본문이 "[삭제된 게시물]"로 가려지므로
+        // 그 아래 댓글도 노출하지 않는다(#12711: 삭제글 자리에 이전 댓글이 남아 보이는 문제).
+        // 관리자는 조정 목적상 계속 열람 가능.
+        if (!isAdmin) {
+            const [parentRows] = await pool.query<RowDataPacket[]>(
+                `SELECT wr_deleted_at FROM ?? WHERE wr_id = ? AND wr_is_comment = 0 LIMIT 1`,
+                [tableName, safePostId]
+            );
+            const parent = parentRows[0];
+            if (!parent || parent.wr_deleted_at) {
+                return json(
+                    {
+                        success: true,
+                        data: {
+                            comments: [],
+                            total: 0,
+                            page: effectivePage,
+                            limit,
+                            total_pages: 0
+                        }
+                    },
+                    { headers: { 'Cache-Control': 'private, no-cache, no-store, must-revalidate' } }
+                );
+            }
+        }
+
         // 전체 댓글 수
         const [countRows] = await pool.query<CountRow[]>(
             `SELECT COUNT(*) AS total FROM ?? WHERE wr_parent = ? AND wr_is_comment = 1`,


### PR DESCRIPTION
## 문제 (#12711)
삭제된 게시글은 본문이 `[삭제된 게시물]`로 가려지지만, 그 아래에 삭제 전 달렸던 댓글이 그대로 남아 보입니다. 사용자에게는 "삭제된 자리에 다른 내용이 보이는" 것으로 인지됩니다.

## 원인
- 글 soft-delete 시 댓글은 보존되는데, 댓글 조회 API(`/api/boards/[boardId]/posts/[postId]/comments`)가 **부모 글의 삭제 여부를 확인하지 않아** 삭제글에도 기존 댓글을 계속 반환했습니다.
- 글 상세 SSR 은 삭제글 본문을 비우면서도 `comments_count` 는 그대로 두어, 헤더 카운트/backfill 게이트가 댓글이 있는 것처럼 동작했습니다.

## 수정
1. **댓글 API**: 부모 글이 삭제(`wr_deleted_at`)됐거나 존재하지 않으면 빈 댓글(`total: 0`)을 반환합니다. 관리자(level ≥ 10)는 조정 목적상 계속 열람 가능합니다.
2. **글 상세 SSR**: 삭제글 분기에서 `comments_count = 0` 으로 맞춰 헤더 카운트·SSR total·클라이언트 backfill 게이트 정합을 확보합니다.

SSR 초기 로드와 '더보기' 페이지네이션이 동일 라우트를 경유하므로 한 곳의 가드로 양쪽 모두 해결됩니다.

## 검증
- `svelte-check`: 변경 파일 오류 0
- `prettier --check`: 통과