### PR TITLE
fix(content): 본문 이미지 가로 강제 확대 제거 (#12895)

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -493,10 +493,12 @@
         margin: 1rem 0;
     }
 
-    /* 백엔드 썸네일 변환된 이미지: 컨테이너 전폭 */
+    /* 백엔드 썸네일 변환된 이미지: 블록 레이아웃만 지정.
+       가로 폭 강제(width:100%)는 제거 — 작은/가로 이미지가 컨테이너 폭까지 확대되던 문제(#12895).
+       세로 이미지 채움은 로드 후 orientation 판정으로 .dm-portrait-fill 이 담당(#1645).
+       가로 상한은 상위 .prose img 규칙의 max-width:100% 로 유지. */
     .prose :global(img[data-original]) {
         display: block;
-        width: 100%;
     }
 
     .prose :global(table) {


### PR DESCRIPTION
## 문제 (#12895)
본문에 이미지를 삽입하면 가로·작은 이미지까지 자동으로 컨테이너 폭으로 꽉 채워져(가로 full) 확대됩니다. 이전 #12858 수정 후에도 동일하게 재현되어 재제보되었습니다.

## 원인
- 본문 뷰(`markdown.svelte`)에 썸네일 변환 이미지용 규칙 `.prose img[data-original] { width: 100% }` 가 남아 있어 **모든** 변환 이미지를 컨테이너 전폭으로 강제했습니다.
- 최근 #1645 가 "세로 이미지만 본문 폭에 맞춤"(`.dm-portrait-fill`, 로드 후 orientation 판정)으로 방식을 바꿨으나, **옛 일괄 `width:100%` 규칙을 제거하지 않아** 가로 이미지가 계속 확대되었습니다.
- #12858 은 에디터의 저장 클래스(`max-w-full`)만 정리해 표시 CSS에는 영향이 없었습니다(오진).

## 수정
- `img[data-original]` 규칙에서 `width: 100%` 제거(블록 레이아웃 `display:block`만 유지).
- 결과: 가로/작은 이미지 = 자연 크기(상한 `max-width:100%`), 세로 이미지 = 기존대로 `.dm-portrait-fill` 로 본문 폭 채움.

## 검증
- `svelte-check`: 변경 구간 오류 0 (기존 무관 경고/tiptap 에러 제외)
- `prettier --check`: 통과
- 추가: canary 런타임에서 가로/세로 이미지 표시 확인 예정