### PR TITLE
fix(comments): 차단한 사용자 댓글 서버측 판정으로 깜박임 제거 (#12825)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -107,6 +107,8 @@ export interface FreeComment {
     is_restricted?: boolean;
     /** 이용제한 근거 댓글 (g5_na_singo.discipline_log_id IS NOT NULL). PR #484. */
     is_discipline_related?: boolean;
+    /** 요청자가 이 댓글 작성자를 차단했는지(서버 판정). 클라 스토어 로드 전 깜박임 방지(#12825). */
+    is_blocked?: boolean;
     link1?: string;
     link2?: string;
     link1_display?: string;

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -397,7 +397,10 @@
     let expandedBlockedComments = new SvelteSet<string>();
 
     function isBlockedComment(comment: FreeComment): boolean {
-        return blockedUsersStore.isBlocked(comment.author_id);
+        // 서버 판정(is_blocked) 우선 — 클라 차단 스토어가 로드되기 전에도 첫 렌더부터
+        // 접힘 상태로 표시되어 "보였다 숨었다" 깜박임을 방지(#12825).
+        // 스토어는 차단 직후 즉시 반영(fallback)용으로 OR 결합.
+        return comment.is_blocked === true || blockedUsersStore.isBlocked(comment.author_id);
     }
 
     function toggleBlockedComment(commentId: string): void {

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -74,6 +74,8 @@ interface CommentResponseItem {
     link2_affiliate?: boolean;
     report_count?: string | number;
     is_discipline_related?: boolean;
+    /** 요청자가 이 댓글 작성자를 차단했는지(서버 판정). 클라 스토어 로드 전 깜박임 방지용(#12825). */
+    is_blocked?: boolean;
 }
 
 interface DisciplineRow extends RowDataPacket {
@@ -226,6 +228,25 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             }
         }
 
+        // 요청자가 차단한 작성자 집합 (#12825). 서버에서 is_blocked 를 판정해 내려주면
+        // 클라이언트 차단 스토어가 비동기 로드되기 전에도 첫 렌더부터 접힘 상태로 표시되어
+        // "보였다 숨었다" 깜박임이 사라진다. 실패는 무시(클라 스토어가 fallback).
+        const blockedSet = new Set<string>();
+        const viewerId = locals.user?.id;
+        if (viewerId) {
+            try {
+                const [bRows] = await pool.query<RowDataPacket[]>(
+                    `SELECT blocked_mb_id FROM g5_member_block WHERE mb_id = ?`,
+                    [viewerId]
+                );
+                for (const b of bRows) {
+                    if (b.blocked_mb_id) blockedSet.add(String(b.blocked_mb_id));
+                }
+            } catch (e) {
+                console.warn('[block] enrich(comments) failed:', e);
+            }
+        }
+
         const comments: CommentResponseItem[] = rows.map((row) => ({
             id: row.wr_id,
             content: row.wr_deleted_at ? (isAdmin ? row.wr_content : '') : row.wr_content,
@@ -263,6 +284,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             deleted_at: row.wr_deleted_at || null,
             deleted_by: row.wr_deleted_by || null,
             edit_count: editCountMap.get(row.wr_id) || 0,
+            ...(row.mb_id && blockedSet.has(String(row.mb_id)) ? { is_blocked: true } : {}),
             ...(disciplineSet.has(row.wr_id) ? { is_discipline_related: true } : {}),
             ...(isAdmin && row.wr_7
                 ? {


### PR DESCRIPTION
## 문제 (#12825)
차단한 계정의 댓글이 "보였다가 숨겨졌다가" 반복됩니다.

## 원인
댓글 프록시 라우트가 차단 필터를 전혀 적용하지 않아 SSR/초기 응답에 차단 사용자의 댓글이 그대로 포함되고, 클라이언트 차단 스토어(`blockedUsersStore`)가 로그인 후 **비동기로 1회 로드**된 뒤에야 뒤늦게 접힙니다. 글을 이동/재조회할 때마다 새 SSR이 다시 보였다가 숨겨져 깜박임이 반복됩니다.

## 수정
- 댓글 조회 API(`comments/+server.ts`)가 요청자(`locals.user.id`)의 차단 목록(`g5_member_block`)을 1회 조회해 각 댓글에 서버 판정 `is_blocked` 플래그를 부여합니다(방어적 try/catch, 실패 시 클라 스토어 fallback).
- `comment-list.svelte` 의 `isBlockedComment` 가 서버 플래그를 우선 신뢰(스토어와 OR)하여 **첫 렌더부터 접힘 상태**로 표시됩니다.
- 기존 "차단된 사용자의 댓글입니다 [펼치기]" 토글 UX·스레딩은 그대로 유지(전면 제외가 아닌 플래그 방식).

SSR·'더보기' 모두 동일 라우트를 경유하므로 한 곳의 서버 판정으로 양쪽 해결됩니다.

## 검증
- `svelte-check`: 변경 파일 오류 0
- `prettier --check`: 통과
- 쪽지 차단(백엔드)은 angple-backend PR #537 로 분리 처리