### PR TITLE
feat(empathy): 날짜별 공감글 추천수 필터/정렬 설정 유지 (#12897)

### DIFF
--- a/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
+++ b/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
+    import { browser } from '$app/environment';
     import { onMount } from 'svelte';
     import type {
         DailyCalendarEntry,
@@ -208,7 +209,29 @@
     // 오늘 데이터 폴링 (5분 간격)
     let pollingTimer: ReturnType<typeof setInterval> | undefined;
 
+    // 사용자가 설정한 추천수 필터/정렬을 세션 간 유지 (#12897).
+    // 하이드레이션 후(onMount) 복원 — SSR/클라 초기 마크업 일치를 유지해 미스매치 방지.
+    const LS_THRESHOLD = 'angple_daily_recommend_threshold';
+    const LS_SORT = 'angple_daily_recommend_sort';
+    // 복원 완료 전에는 지속 $effect가 기본값을 저장해 덮어쓰지 않도록 게이트.
+    let settingsRestored = $state(false);
+
     onMount(() => {
+        try {
+            const t = localStorage.getItem(LS_THRESHOLD);
+            if (t !== null) {
+                const n = parseInt(t, 10);
+                if (!Number.isNaN(n) && n >= 0) threshold = n;
+            }
+            const s = localStorage.getItem(LS_SORT);
+            if (s === 'recommend' || s === 'views' || s === 'comments' || s === 'latest') {
+                sortBy = s;
+            }
+        } catch {
+            // localStorage 접근 실패 무시
+        }
+        settingsRestored = true;
+
         if (isToday) {
             pollingTimer = setInterval(
                 async () => {
@@ -227,6 +250,17 @@
         return () => {
             if (pollingTimer) clearInterval(pollingTimer);
         };
+    });
+
+    // 설정 변경 시 즉시 저장 → 글 읽고 돌아와도 유지(#12897). 클라 전용, 복원 완료 후에만.
+    $effect(() => {
+        if (!browser || !settingsRestored) return;
+        try {
+            localStorage.setItem(LS_THRESHOLD, String(threshold));
+            localStorage.setItem(LS_SORT, sortBy);
+        } catch {
+            // 저장 실패 무시
+        }
     });
 
     function handleDateChange(newDate: string) {


### PR DESCRIPTION
## 요청 (#12897)
날짜별 공감글 보기에서 최소 추천수 필터와 정렬(최신순 등)을 설정해도, 아무 글이나 읽고 돌아오면 설정이 풀려 다시 지정해야 합니다.

## 원인
`daily-recommended-page.svelte` 의 `threshold`·`sortBy` 가 순수 `$state` 라 SPA 네비게이션으로 컴포넌트가 재마운트되면 기본값(0 / 'recommend')으로 초기화됩니다.

## 수정
- 두 설정을 `localStorage` 에 저장해 페이지 재진입·세션 간 유지합니다.
- 복원은 하이드레이션 후(`onMount`)에 수행 → SSR/클라 초기 마크업 일치를 보존(하이드레이션 미스매치 없음).
- `settingsRestored` 게이트로 복원 완료 전 지속 effect 가 기본값을 덮어쓰는 레이스를 차단.
- 전부 클라이언트 전용(`browser` 가드), 서버 부하 0.

## 검증
- `svelte-check`: 변경 파일 오류 0
- `prettier --check`: 통과