### PR TITLE
feat(content): 본문 폭에 근접한 가로 이미지 채움 (임계값 60%)

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -348,7 +348,20 @@
             imgs.forEach((img) => {
                 const applyOrientation = () => {
                     if (img.naturalWidth === 0) return;
-                    img.classList.toggle('dm-portrait-fill', img.naturalHeight > img.naturalWidth);
+                    const isPortrait = img.naturalHeight > img.naturalWidth;
+                    img.classList.toggle('dm-portrait-fill', isPortrait);
+                    // 가로 이미지가 본문 폭에 근접(자연폭 ≥ 컨테이너 60%)하면 본문 폭에 맞춰 채운다.
+                    // "거의 꽉 찼는데 안 채워지는" 애매한 이미지를 잡되, 명확히 작은 이미지
+                    // (이모지·로고·썸네일, 대개 50% 미만)는 그대로 자연 크기 유지(#12895).
+                    // 컨테이너보다 크거나 같은 이미지는 상위 max-width:100% 가 처리하므로 제외.
+                    const parentW = img.parentElement?.offsetWidth ?? 0;
+                    img.classList.toggle(
+                        'dm-landscape-fill',
+                        !isPortrait &&
+                            parentW > 0 &&
+                            img.naturalWidth >= parentW * 0.6 &&
+                            img.naturalWidth < parentW
+                    );
                 };
                 if (img.complete && img.naturalWidth > 0) {
                     applyOrientation();
@@ -372,6 +385,12 @@
 <style>
     /* 세로 이미지: 본문 너비 100%로 채움 (좁은 세로 스크린샷이 작게 보이는 문제 해결) */
     .prose :global(img.dm-portrait-fill) {
+        width: 100%;
+        height: auto;
+    }
+
+    /* 가로 이미지 중 본문 폭에 근접한 것(자연폭 ≥ 컨테이너 60%)만 채움. 로드 후 JS 판정. */
+    .prose :global(img.dm-landscape-fill) {
         width: 100%;
         height: auto;
     }


### PR DESCRIPTION
## 배경
본문 가로 이미지가 컨테이너보다 작으면(`max-width:100%`만 적용, `width` 없음) 자연 크기로 표시되어 "거의 꽉 찼는데 왜 안 채워지지" 하는 경우가 있습니다. (예: /free/6633742 — 480px 이미지 / 786px 컨테이너 = 61%)

반대로 #12895 에서는 작은 이미지가 강제로 전폭 확대되는 문제를 없앴기에, 단순히 전체 `width:100%` 로 되돌릴 수 없습니다(작은 이미지 업스케일·흐림 재발).

## 수정 (임계값 60% 절충)
로드 후 orientation 판정과 같은 시점에:
- **가로** 이미지의 `naturalWidth ≥ parentElement.offsetWidth × 0.6` 이고 `naturalWidth < parentW` 이면 `.dm-landscape-fill`(`width:100%; height:auto`) 적용 → 본문 폭에 맞춤.
- 그 미만(이모지·로고·썸네일, 대개 <50%)은 자연 크기 유지 → #12895 정책 보존.
- 세로 이미지는 기존 `.dm-portrait-fill` 담당(가로 판별 `!isPortrait` 로 중복 방지), 컨테이너 이상 크기는 `max-width:100%` 가 처리.

## 임계값 근거 (60%)
- 대상 예시 61% → 채워짐(목적 달성). 70% 로 하면 61% 가 미달돼 정작 이 케이스가 안 채워짐.
- 명확히 작은 이미지는 대개 50% 미만이라 60% 에서도 안전하게 제외.

## 검증
- `svelte-check`: 변경 파일 신규 오류 0
- `prettier --check`: 통과
- canary 런타임에서 60% 경계(채움/미채움)·세로·이모지 회귀 확인 예정