### PR TITLE
fix(read-state): 읽음 표시 effect 자기참조 무한루프로 읽음 유실 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -50,7 +50,7 @@
     import { insertReplyAfterParent, type CommentLike } from '$lib/utils/comment-insert.js';
     import type { ReactionItem } from '$lib/types/reaction.js';
     import { generateParentId, generateDocumentTargetId } from '$lib/types/reaction.js';
-    import { onMount } from 'svelte';
+    import { onMount, untrack } from 'svelte';
     import { doAction } from '$lib/hooks/registry';
     import { page } from '$app/stores';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
@@ -727,13 +727,20 @@
         };
     });
 
-    // 읽음 표시 + GA4 이벤트 — SPA 네비게이션(하단 리스트 클릭)에서도 반응
+    // 읽음 표시 + GA4 이벤트 — SPA 네비게이션(하단 리스트 클릭)에서도 반응.
+    // markAsRead 는 내부에서 read-store 의 posts 를 읽고(스프레드) 다시 쓴다. 그 읽기가
+    // 이 $effect 의 반응 의존성으로 잡히면 자기참조가 되어(쓰기→재실행) Svelte 가 effect 를
+    // 반복 실행하다 effect_update_depth_exceeded 로 상태를 롤백 → 방금 읽은 글이 유실된다.
+    // 부수효과(읽음 저장/GA4)는 반응 의존성을 만들 필요가 없으므로 untrack 으로 격리한다.
+    // effect 는 boardId/postId(untrack 밖)에만 의존해 네비게이션마다 1회만 실행된다.
     $effect(() => {
         const postViewKey = `${boardId}:${data.post.id}`;
         if (trackedPostViewKey === postViewKey) return;
         trackedPostViewKey = postViewKey;
-        readPostsStore.markAsRead(boardId, data.post.id);
-        trackPostView(boardId, data.post.id);
+        untrack(() => {
+            readPostsStore.markAsRead(boardId, data.post.id);
+            trackPostView(boardId, data.post.id);
+        });
     });
 
     // 조회수: SSR에서 처리 (CDN 요청 제거)


### PR DESCRIPTION
## 증상
게시글을 열어도 잠시 뒤 '다시 안 본 글'처럼 읽음 표시가 초기화됩니다. 운영(sha-fc2c2fb) 프로덕션에서 게시글 1회 조회에 `markAsRead`→localStorage write 가 **4,430회** 발생 후 상태가 롤백되며 방금 읽은 글이 유실되는 것을 확인했습니다.

## 원인 (번들+소스맵 역추적으로 확정)
- 스택: `markAsRead` ← `+page.svelte` 읽음 `$effect` ← Svelte `update_reaction`(내부 effect 재실행기).
- 읽음 `$effect` 가 `readPostsStore.markAsRead()` 를 호출하고, markAsRead 내부는 `data.posts = { ...data.posts, [key]: now }` 로 **posts 를 읽고(스프레드) 다시 씁니다**.
- 그 **읽기가 effect 의 반응 의존성으로 등록** → 같은 effect 가 posts 를 쓰므로 **자기참조**(쓰기→재실행) → Svelte 가 반복 실행 → `effect_update_depth_exceeded` → 상태를 effect 진입 전(예: 1227개)으로 **롤백** → 방금 추가한 항목 유실.

## 수정
읽음 저장·GA4 는 부수효과라 반응 의존성이 필요 없으므로 `untrack()` 으로 격리:
```ts
$effect(() => {
  const postViewKey = `${boardId}:${data.post.id}`;
  if (trackedPostViewKey === postViewKey) return;
  trackedPostViewKey = postViewKey;
  untrack(() => {
    readPostsStore.markAsRead(boardId, data.post.id);
    trackPostView(boardId, data.post.id);
  });
});
```
- effect 의 의존성은 `boardId`/`data.post.id`(untrack 밖)뿐 → 네비게이션마다 **1회** 실행.
- markAsRead 의 posts 읽기가 더 이상 의존성으로 잡히지 않아 자기참조·롤백 소멸 → 읽음 상태 정상 저장.

## 검증
- `svelte-check`: 변경 구간 신규 오류 0 / `prettier --check`: 통과
- **canary 런타임 실측 필수**: 게시글 조회 시 markAsRead 1회만 실행되고 읽음 상태가 유지되는지 확인 예정