### PR TITLE
feat(report): 운영 현황 보고서에 전주 대비 변화율·4주 평균 겹치기 렌더

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/report-charts.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report-charts.svelte
@@ -22,13 +22,22 @@
 
     interface Props {
         dailyStats?: Record<string, DailyStatEntry>;
+        // 직전 4주 요일별 평균(일별 트렌드에 신고 평균선 겹치기용). key=요일명.
+        dailyAvg4w?: Record<string, { reports: number; posts: number; comments: number }>;
         weeklyStats?: Record<string, WeeklyStatEntry>;
         reportTypes?: Record<string, number>;
         boardStats?: BoardStatEntry[];
         periodDays?: number;
     }
 
-    let { dailyStats, weeklyStats, reportTypes, boardStats, periodDays = 1 }: Props = $props();
+    let {
+        dailyStats,
+        dailyAvg4w,
+        weeklyStats,
+        reportTypes,
+        boardStats,
+        periodDays = 1
+    }: Props = $props();
 
     let dailyCanvas: HTMLCanvasElement | undefined = $state();
     let weeklyCanvas: HTMLCanvasElement | undefined = $state();
@@ -48,6 +57,10 @@
                 const reports: number[] = [];
                 const posts: number[] = [];
                 const comments: number[] = [];
+                // 직전 4주 요일별 평균(신고). 요일명 배열은 getDay() 0=일..6=토 순.
+                const dowNames = ['일', '월', '화', '수', '목', '금', '토'];
+                const hasAvg = !!dailyAvg4w && Object.keys(dailyAvg4w).length > 0;
+                const avgReports: number[] = [];
 
                 for (const [date, data] of Object.entries(dailyStats)) {
                     const d = new Date(date + 'T00:00:00');
@@ -55,6 +68,10 @@
                     reports.push(data.reports || 0);
                     posts.push(data.posts || 0);
                     comments.push(data.comments || 0);
+                    if (hasAvg) {
+                        const av = dailyAvg4w?.[dowNames[d.getDay()]];
+                        avgReports.push(av ? Math.round(av.reports) : 0);
+                    }
                 }
 
                 charts.push(
@@ -83,7 +100,21 @@
                                     borderColor: '#10b981',
                                     backgroundColor: '#10b981',
                                     pointRadius: 4
-                                }
+                                },
+                                // 신고 4주 평균(점선) — 이번 주 신고가 평소보다 많/적은지 비교용.
+                                ...(hasAvg
+                                    ? [
+                                          {
+                                              label: '신고 4주 평균',
+                                              data: avgReports,
+                                              borderColor: '#ef4444',
+                                              backgroundColor: 'transparent',
+                                              borderDash: [5, 5],
+                                              borderWidth: 1.5,
+                                              pointRadius: 0
+                                          }
+                                      ]
+                                    : [])
                             ]
                         },
                         options: {

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -149,6 +149,17 @@
         daily_stats?: Record<string, DailyStatEntry>;
         weekly_stats?: Record<string, WeeklyStatEntry>;
         board_stats?: BoardStatEntry[];
+        // 전주 대비 변화율용(직전 주 동일 지표). 구 보고서엔 없을 수 있음.
+        prev_week?: {
+            total_reports?: number;
+            report_count?: number;
+            report_month?: number;
+            completed_reports?: number;
+            claim_reports?: number;
+            reporter_count?: number;
+        };
+        // 직전 4주 요일별 평균(일별 트렌드 겹치기용). key=요일명.
+        daily_avg_4w?: Record<string, { reports: number; posts: number; comments: number }>;
     }
 
     const stats = $derived.by((): ReportStats => {
@@ -193,11 +204,18 @@
         }
     ]);
 
-    // 보조 지표 카드 정의
+    // 전주 대비 변화율(%). 직전 주 값이 없거나 0이면 null(뱃지 미표시).
+    function deltaPct(cur: number, prev: number | undefined): number | null {
+        if (prev == null || prev === 0) return null;
+        return Math.round(((cur - prev) / prev) * 100);
+    }
+
+    // 보조 지표 카드 정의 (value=이번 주, prev=직전 주)
     const secondaryMetrics = $derived([
         {
             label: '총 신고 처리',
             value: stats.total_reports ?? 0,
+            prev: stats.prev_week?.total_reports,
             icon: Shield,
             color: 'text-purple-600 dark:text-purple-400',
             bg: 'bg-purple-50 dark:bg-purple-950/30'
@@ -205,6 +223,7 @@
         {
             label: '이용제한',
             value: stats.completed_reports ?? 0,
+            prev: stats.prev_week?.completed_reports,
             icon: Gavel,
             color: 'text-red-600 dark:text-red-400',
             bg: 'bg-red-50 dark:bg-red-950/30'
@@ -212,6 +231,7 @@
         {
             label: '신고된 게시글',
             value: stats.report_count ?? 0,
+            prev: stats.prev_week?.report_count,
             icon: AlertTriangle,
             color: 'text-orange-600 dark:text-orange-400',
             bg: 'bg-orange-50 dark:bg-orange-950/30'
@@ -219,6 +239,7 @@
         {
             label: '소명건수',
             value: stats.claim_reports ?? 0,
+            prev: stats.prev_week?.claim_reports,
             icon: Scale,
             color: 'text-teal-600 dark:text-teal-400',
             bg: 'bg-teal-50 dark:bg-teal-950/30'
@@ -226,6 +247,7 @@
         {
             label: '신고된 댓글',
             value: stats.report_month ?? 0,
+            prev: stats.prev_week?.report_month,
             icon: MessageCircle,
             color: 'text-amber-600 dark:text-amber-400',
             bg: 'bg-amber-50 dark:bg-amber-950/30'
@@ -233,6 +255,7 @@
         {
             label: '신고자 수',
             value: stats.reporter_count ?? 0,
+            prev: stats.prev_week?.reporter_count,
             icon: Users,
             color: 'text-indigo-600 dark:text-indigo-400',
             bg: 'bg-indigo-50 dark:bg-indigo-950/30'
@@ -398,12 +421,25 @@
             <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
                 {#each secondaryMetrics as metric (metric.label)}
                     {@const Icon = metric.icon}
+                    {@const d = deltaPct(metric.value, metric.prev)}
                     <div class="rounded-lg border p-3 text-center {metric.bg}">
                         <Icon class="mx-auto mb-1.5 h-5 w-5 {metric.color}" />
                         <p class="text-foreground text-lg font-bold">
                             {metric.value.toLocaleString()}
                         </p>
                         <p class="text-muted-foreground text-xs">{metric.label}</p>
+                        {#if d != null}
+                            <p
+                                class="mt-0.5 text-[11px] font-medium {d > 0
+                                    ? 'text-red-500'
+                                    : d < 0
+                                      ? 'text-blue-500'
+                                      : 'text-muted-foreground'}"
+                                title="직전 주 대비"
+                            >
+                                {d > 0 ? '▲' : d < 0 ? '▼' : '—'}{Math.abs(d)}%
+                            </p>
+                        {/if}
                     </div>
                 {/each}
             </div>
@@ -412,6 +448,7 @@
             {#if hasChartData}
                 <ReportCharts
                     dailyStats={stats.daily_stats}
+                    dailyAvg4w={stats.daily_avg_4w}
                     weeklyStats={stats.weekly_stats}
                     reportTypes={stats.report_types}
                     boardStats={stats.board_stats}


### PR DESCRIPTION
## 배경
주간 신고 통계 보고서(report 게시판) 차트가 해당 주 7일만 보여줘 "943건이 많은지 적은지, 전주 대비 늘었는지" 판단이 어렵다는 피드백(report/296#c_299, 드라마중독님).

## 변경 (frontend 렌더)
backend PR(angple-backend #538)이 보고서에 넣어주는 `prev_week`/`daily_avg_4w`(via `extra_9`)를 렌더:
- **(a) 전주 대비 변화율**: 주간 지표 카드(총 신고 처리·이용제한·신고된 글/댓글·소명건수·신고자 수)에 ▲/▼ % 뱃지 추가. 증가=빨강/감소=파랑. 누적 지표(전체 게시글/댓글)엔 미적용.
- **(b) 4주 평균 겹치기**: 일별 활동 트렌드(line 차트)에 '신고 4주 평균' 점선 dataset 추가(요일별 평균). 이번 주 신고선과 비교.

## 호환성
- `prev_week`/`daily_avg_4w` 부재 시(구 보고서) → 뱃지·평균선 미표시, 기존 렌더 그대로(옵셔널 fallback).
- backend 배포 후 다음 보고서(일요일 자정 생성)부터 데이터가 채워짐.

## 검증
- `svelte-check`: 변경 파일 신규 오류 0 / `prettier --check`: 통과
- 짝 PR: angple-backend #538 (데이터 생성)