### PR TITLE
feat(disciplinelog): 이용제한 상세 SSR 전환 — 진입 지연 제거

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -163,7 +163,11 @@ export async function getDisciplineLogs(
     if (memberId) {
         url += `&member_id=${encodeURIComponent(memberId)}`;
     }
-    const response = await fetch(url, { credentials: 'include' });
+    // 무한 스피너 방지: 15초 내 응답 없으면 중단하고 상위에서 에러 처리
+    const response = await fetch(url, {
+        credentials: 'include',
+        signal: AbortSignal.timeout(15000)
+    });
 
     if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
@@ -177,7 +181,11 @@ export async function getDisciplineLogs(
  */
 export async function getDisciplineLog(id: number): Promise<DisciplineLogDetailResponse> {
     const url = `${API_BASE}/discipline-logs/${id}`;
-    const response = await fetch(url, { credentials: 'include' });
+    // 무한 스피너 방지: 15초 내 응답 없으면 중단하고 상위에서 에러 처리
+    const response = await fetch(url, {
+        credentials: 'include',
+        signal: AbortSignal.timeout(15000)
+    });
 
     if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);

--- a/apps/web/src/routes/disciplinelog/[id]/+page.server.ts
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.server.ts
@@ -1,0 +1,58 @@
+/**
+ * 이용제한 기록 상세 - SSR 데이터 로드
+ *
+ * 기존엔 클라이언트에서만 fetch(loading 스피너 → 왕복)해서 진입 시 지연이 체감됐다.
+ * 상세 + 회원 이력을 서버에서 미리 로드해 즉시 렌더한다(스피너·클라 왕복 제거).
+ * SvelteKit 이 라우트 파라미터 변경 시 load 를 재실행하므로 목록/이력에서 다른 row
+ * 클릭(SPA 네비게이션)에도 그대로 반영된다.
+ */
+import type { PageServerLoad } from './$types';
+import { backendFetch } from '$lib/server/backend-fetch.js';
+import { safeJson } from '$lib/api/safe-json.js';
+import type { DisciplineLogDetail, DisciplineLogListItem } from '$lib/api/discipline-log.js';
+
+const SSR_HEADERS = { Accept: 'application/json', 'User-Agent': 'Angple-Web-SSR/1.0' };
+
+export const load: PageServerLoad = async ({ params }) => {
+    const id = Number(params.id);
+    if (!Number.isFinite(id) || id <= 0) {
+        return {
+            log: null as DisciplineLogDetail | null,
+            memberHistory: [] as DisciplineLogListItem[],
+            loadError: true
+        };
+    }
+
+    try {
+        const res = await backendFetch(`/api/v1/discipline-logs/${id}`, { headers: SSR_HEADERS });
+        if (!res.ok) {
+            return { log: null, memberHistory: [] as DisciplineLogListItem[], loadError: true };
+        }
+        const result = await safeJson(res);
+        const log: DisciplineLogDetail | null = result.data ?? null;
+        if (!log) {
+            return { log: null, memberHistory: [] as DisciplineLogListItem[], loadError: true };
+        }
+
+        // 이 회원의 전체 이용제한 이력(최대 100) — 함께 서버 로드. 실패해도 상세는 표시.
+        let memberHistory: DisciplineLogListItem[] = [];
+        if (log.member_id) {
+            try {
+                const hres = await backendFetch(
+                    `/api/v1/discipline-logs?page=1&limit=100&member_id=${encodeURIComponent(log.member_id)}`,
+                    { headers: SSR_HEADERS }
+                );
+                if (hres.ok) {
+                    const hjson = await safeJson(hres);
+                    memberHistory = hjson.data ?? [];
+                }
+            } catch {
+                memberHistory = [];
+            }
+        }
+
+        return { log, memberHistory, loadError: false };
+    } catch {
+        return { log: null, memberHistory: [] as DisciplineLogListItem[], loadError: true };
+    }
+};

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -2,12 +2,10 @@
     /**
      * 이용제한 기록 상세 페이지
      */
-    import { page } from '$app/state';
     import * as Card from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import ArrowLeft from '@lucide/svelte/icons/arrow-left';
-    import Loader2 from '@lucide/svelte/icons/loader-2';
     import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
     import Calendar from '@lucide/svelte/icons/calendar';
     import User from '@lucide/svelte/icons/user';
@@ -16,54 +14,21 @@
     import ExternalLink from '@lucide/svelte/icons/external-link';
     import History from '@lucide/svelte/icons/history';
     import {
-        getDisciplineLog,
-        getDisciplineLogs,
         getPenaltyDisplay,
         type DisciplineLogDetail,
         type DisciplineLogListItem
     } from '$lib/api/discipline-log.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { getReportReasonLabel } from '$lib/utils/report-reasons.js';
+    import type { PageData } from './$types';
 
-    let log = $state<DisciplineLogDetail | null>(null);
-    let loading = $state(true);
-    let error = $state<string | null>(null);
-    let memberHistory = $state<DisciplineLogListItem[]>([]);
+    let { data }: { data: PageData } = $props();
 
-    const id = $derived(Number(page.params.id));
-
-    async function fetchMemberHistory(memberId: string, currentId: number) {
-        try {
-            const result = await getDisciplineLogs(1, 100, memberId);
-            // race-condition 방지: 이미 다른 id 로 이동했으면 폐기
-            if (currentId !== id) return;
-            memberHistory = result.data;
-        } catch {
-            if (currentId !== id) return;
-            memberHistory = [];
-        }
-    }
-
-    async function fetchLog(targetId: number) {
-        loading = true;
-        error = null;
-        memberHistory = [];
-        try {
-            const result = await getDisciplineLog(targetId);
-            // 비동기 응답 도착 시점에 id 가 바뀌었으면 폐기 (race-condition 방지)
-            if (targetId !== id) return;
-            log = result.data;
-            if (log.member_id) {
-                fetchMemberHistory(log.member_id, targetId);
-            }
-        } catch {
-            if (targetId !== id) return;
-            error = '이용제한 기록을 불러오는데 실패했습니다.';
-            log = null;
-        } finally {
-            if (targetId === id) loading = false;
-        }
-    }
+    // SSR 로드(+page.server.ts)에서 상세·회원이력을 미리 받아 즉시 렌더(스피너·클라 왕복 제거).
+    // 라우트 파라미터 변경 시 load 가 재실행되므로 목록/이력에서 다른 row 클릭에도 반영된다.
+    const log = $derived<DisciplineLogDetail | null>(data.log);
+    const memberHistory = $derived<DisciplineLogListItem[]>(data.memberHistory ?? []);
+    const error = $derived(data.loadError ? '이용제한 기록을 불러오는데 실패했습니다.' : null);
 
     function getPenaltyBadgeVariant(
         period: number,
@@ -126,13 +91,6 @@
     function isOwnPenalty(log: DisciplineLogDetail): boolean {
         return !!authStore.user && log.member_id === authStore.user.mb_id;
     }
-
-    // id 가 바뀔 때마다 재조회 (목록/회원 이력에서 다른 row 클릭 시에도 반영)
-    $effect(() => {
-        if (Number.isFinite(id) && id > 0) {
-            fetchLog(id);
-        }
-    });
 </script>
 
 <svelte:head>
@@ -148,20 +106,14 @@
         </Button>
     </div>
 
-    {#if loading}
-        <div class="flex items-center justify-center py-12">
-            <Loader2 class="text-muted-foreground h-8 w-8 animate-spin" />
-        </div>
-    {:else if error || !log}
+    {#if error || !log}
         <Card.Root>
             <Card.Content
                 class="text-muted-foreground flex flex-col items-center justify-center py-12"
             >
                 <AlertTriangle class="mb-4 h-12 w-12" />
                 <p>{error || '이용제한 기록을 찾을 수 없습니다.'}</p>
-                <Button variant="outline" class="mt-4" onclick={() => fetchLog(id)}
-                    >다시 시도</Button
-                >
+                <Button variant="outline" class="mt-4" href="/disciplinelog">목록으로</Button>
             </Card.Content>
         </Card.Root>
     {:else}
@@ -350,7 +302,7 @@
                             <a
                                 href="/disciplinelog/{item.id}"
                                 class="hover:bg-muted/50 flex items-center justify-between rounded p-2 text-sm transition-all duration-200 ease-out {item.id ===
-                                id
+                                log.id
                                     ? 'bg-primary/10 border-primary/30 border font-semibold'
                                     : ''}"
                             >


### PR DESCRIPTION
## 배경
이용제한 상세보기(`/disciplinelog/[id]`) 진입 시 스피너가 오래 돌고 서버 왕복이 끝나야 내용이 표시돼 체감 로딩이 길다는 제보가 있었습니다.

백엔드 응답 자체는 빠릅니다(공개 CDN 경유 50~78ms). 원인은 이 라우트에 `+page.server.ts`가 없어 **상세를 클라이언트에서만 fetch** → 하이드레이션 후 스피너 + 서버 왕복이 끝나야 표시되는 구조였습니다.

## 변경
- **`+page.server.ts` 신규**: 상세 + 해당 회원의 이용제한 이력을 서버에서 미리 로드해 즉시 렌더(스피너·클라 왕복 제거). SvelteKit 이 라우트 파라미터 변경 시 `load` 를 재실행하므로, 목록/이력에서 다른 row 클릭(SPA 네비게이션)에도 그대로 반영됩니다. 이력 로드는 실패해도 상세는 표시되도록 격리했습니다.
- **`+page.svelte`**: 클라 `fetch`/`loading` 상태와 `$effect` 재조회 로직 제거 → SSR `data` 기반 `$derived` 로 단순화. (`loading` 스피너 분기 삭제, 에러 시 "목록으로" 링크)
- **`discipline-log.ts`**: 클라 GET(`getDisciplineLog`/`getDisciplineLogs`)에 15초 `AbortSignal.timeout` 추가 — 무한 스피너 방지(다른 클라 호출처 방어).

## 검증
- `svelte-check`: 0 errors (변경 파일 경고 0)
- `prettier`: clean
- 백엔드 계약(`/api/v1/discipline-logs/{id}`, `?member_id=`) 변경 없음 — 표현 계층만 수정

## 배포
- canary 확인 후 **매주 토요일 새벽 4시 정기 배포** 윈도우에 반영 예정.