### PR TITLE
feat(discipline): 글 상세 제목·본문 이용제한 근거 마스킹 토글

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -29,6 +29,7 @@
     import Flag from '@lucide/svelte/icons/flag';
     import ScrapButton from '$lib/components/post/scrap-button.svelte';
     import { authStore } from '$lib/stores/auth.svelte.js';
+    import { DisciplinedContent } from '$lib/components/ui/discipline-related';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
     import ContentBlur from '$lib/components/features/board/content-blur.svelte';
     import { uiSettingsStore, type ContentFontSize } from '$lib/stores/ui-settings.svelte.js';
@@ -108,6 +109,10 @@
     }: ViewLayoutProps = $props();
 
     let hasAffiliateLinks = $derived(postContent?.includes('data-affiliate') ?? false);
+
+    // 이용제한 근거 글: 제목·본문 인스턴스가 이 상태를 공유해 어느 "보기"를 눌러도 함께 공개.
+    // 비로그인은 백엔드가 이미 원문을 strip 했고 컴포넌트가 placeholder 만 렌더(소스 유출 0).
+    let discReveal = $state(false);
 
     const isLockedPost = $derived(postReportCount === 'lock' || post.extra_7 === 'lock');
 
@@ -192,7 +197,17 @@
                 {#if post.is_secret}
                     <Lock class="text-muted-foreground h-6 w-6 shrink-0" />
                 {/if}
-                {post.title}
+                {#if post.is_discipline_related}
+                    <DisciplinedContent
+                        inline
+                        isLoggedIn={authStore.isAuthenticated}
+                        bind:revealed={discReveal}
+                    >
+                        {post.title}
+                    </DisciplinedContent>
+                {:else}
+                    {post.title}
+                {/if}
                 {#if isLockedPost}
                     <span
                         class="bg-destructive/10 text-destructive inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium"
@@ -392,7 +407,16 @@
                         : undefined}
                 >
                     <div id="economy-post-content" style="font-size: {FONT_SIZES[currentFontSize]}">
-                        <Markdown content={postContent} />
+                        {#if post.is_discipline_related}
+                            <DisciplinedContent
+                                isLoggedIn={authStore.isAuthenticated}
+                                bind:revealed={discReveal}
+                            >
+                                <Markdown content={postContent} />
+                            </DisciplinedContent>
+                        {:else}
+                            <Markdown content={postContent} />
+                        {/if}
                     </div>
 
                     {#if hasAffiliateLinks}

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -43,6 +43,7 @@
     import Scale from '@lucide/svelte/icons/scale';
     import CalendarDays from '@lucide/svelte/icons/calendar-days';
     import { authStore } from '$lib/stores/auth.svelte.js';
+    import { DisciplinedContent } from '$lib/components/ui/discipline-related';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
     import ContentBlur from '$lib/components/features/board/content-blur.svelte';
     import { uiSettingsStore, type ContentFontSize } from '$lib/stores/ui-settings.svelte.js';
@@ -106,6 +107,9 @@
     }: ViewLayoutProps = $props();
 
     let hasAffiliateLinks = $derived(postContent?.includes('data-affiliate') ?? false);
+
+    // 이용제한 근거 글: 제목·본문이 공유하는 보기 토글 상태 (basic.svelte 와 동일 패턴).
+    let discReveal = $state(false);
     function getAttachmentPreview(url: string): string {
         return isTransformableMediaImage(url) ? toThumbnailUrl(url, '835x626') : url;
     }
@@ -287,7 +291,17 @@
             <CardTitle
                 class="text-foreground flex items-center gap-2 text-xl font-bold sm:text-2xl"
             >
-                {post.title}
+                {#if post.is_discipline_related}
+                    <DisciplinedContent
+                        inline
+                        isLoggedIn={authStore.isAuthenticated}
+                        bind:revealed={discReveal}
+                    >
+                        {post.title}
+                    </DisciplinedContent>
+                {:else}
+                    {post.title}
+                {/if}
             </CardTitle>
 
             <!-- 리포트 기간 배지 -->
@@ -494,7 +508,16 @@
             <AdultBlur isAdult={post.is_adult ?? false}>
                 <ContentBlur shouldBlur={uiSettingsStore.shouldBlurContent(post.title)}>
                     <div id="economy-post-content" style="font-size: {FONT_SIZES[currentFontSize]}">
-                        <Markdown content={postContent} />
+                        {#if post.is_discipline_related}
+                            <DisciplinedContent
+                                isLoggedIn={authStore.isAuthenticated}
+                                bind:revealed={discReveal}
+                            >
+                                <Markdown content={postContent} />
+                            </DisciplinedContent>
+                        {:else}
+                            <Markdown content={postContent} />
+                        {/if}
                     </div>
 
                     {#if hasAffiliateLinks}

--- a/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
+++ b/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
@@ -9,63 +9,103 @@
         // 비로그인 사용자는 children 자체를 렌더하지 않아 봇 추출 차단.
         // 로그인 사용자만 blur + 보기 토글 동작.
         isLoggedIn?: boolean;
+        // inline=true: 제목처럼 한 줄 인라인 텍스트용(작은 blur + 보기 칩). 기본은 블록 박스.
+        inline?: boolean;
+        // revealed 를 bindable 로 승격 → 제목·본문 인스턴스가 상태를 공유해
+        // 어느 "보기"를 눌러도 함께 공개된다. 기본값 false 라 기존 단독 사용처는 무변경.
+        revealed?: boolean;
         class?: string;
     }
     let {
         children,
         isComment = false,
         isLoggedIn = false,
+        inline = false,
+        revealed = $bindable(false),
         class: className = ''
     }: Props = $props();
 
-    let revealed = $state(false);
+    const label = $derived(`이용제한 근거 ${isComment ? '댓글' : '글'}`);
 </script>
 
-<div class="relative {className}">
+{#if inline}
+    <!-- 인라인(제목) 변형 -->
     {#if isLoggedIn}
-        <div
-            class={revealed
-                ? ''
-                : 'pointer-events-none select-none blur-md transition-[filter] duration-200'}
-            aria-hidden={!revealed}
+        <span class="inline-flex items-center gap-1 {className}">
+            <span
+                class={revealed ? '' : 'pointer-events-none select-none blur-sm'}
+                aria-hidden={!revealed}
+            >
+                {@render children()}
+            </span>
+            {#if !revealed}
+                <button
+                    type="button"
+                    onclick={() => (revealed = true)}
+                    class="bg-background inline-flex shrink-0 items-center gap-1 rounded border border-amber-500/40 px-2 py-0.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
+                >
+                    <Eye class="h-3 w-3" />
+                    보기
+                </button>
+            {/if}
+        </span>
+    {:else}
+        <!-- 비로그인: children 미렌더 → 소스 유출 0 -->
+        <span
+            class="inline-flex items-center gap-1 rounded border border-amber-500/30 bg-amber-500/5 px-2 py-0.5 text-sm font-medium text-amber-700 dark:text-amber-400 {className}"
         >
-            {@render children()}
-        </div>
-        {#if !revealed}
+            <Scale class="h-3.5 w-3.5" />
+            {label}
+        </span>
+    {/if}
+{:else}
+    <!-- 블록(본문) 변형 -->
+    <div class="relative {className}">
+        {#if isLoggedIn}
             <div
-                class="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-amber-500/5 p-4 backdrop-blur-sm"
+                class={revealed
+                    ? ''
+                    : 'pointer-events-none select-none blur-md transition-[filter] duration-200'}
+                aria-hidden={!revealed}
+            >
+                {@render children()}
+            </div>
+            {#if !revealed}
+                <div
+                    class="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-amber-500/5 p-4 backdrop-blur-sm"
+                >
+                    <div
+                        class="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400"
+                    >
+                        <Scale class="h-3.5 w-3.5" />
+                        {label}
+                    </div>
+                    <button
+                        type="button"
+                        onclick={() => (revealed = true)}
+                        class="bg-background inline-flex items-center gap-1 rounded border border-amber-500/40 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
+                    >
+                        <Eye class="h-3.5 w-3.5" />
+                        보기
+                    </button>
+                </div>
+            {/if}
+        {:else}
+            <!-- 비로그인: children 자체 미렌더 → 페이지 소스에 본문 노출 0 (봇 추출 차단). -->
+            <div
+                class="flex flex-col items-center justify-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-4"
             >
                 <div
                     class="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400"
                 >
                     <Scale class="h-3.5 w-3.5" />
-                    이용제한 근거 {isComment ? '댓글' : '글'}
+                    {label}
                 </div>
-                <button
-                    type="button"
-                    onclick={() => (revealed = true)}
-                    class="bg-background inline-flex items-center gap-1 rounded border border-amber-500/40 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-400"
-                >
-                    <Eye class="h-3.5 w-3.5" />
-                    보기
-                </button>
+                <div class="text-muted-foreground inline-flex items-center gap-1 text-xs">
+                    <Lock class="h-3 w-3" />
+                    회원만 열람 가능
+                </div>
             </div>
         {/if}
-    {:else}
-        <!-- 비로그인: children 자체 미렌더 → 페이지 소스에 본문 노출 0 (봇 추출 차단). -->
-        <div
-            class="flex flex-col items-center justify-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 p-4"
-        >
-            <div
-                class="inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400"
-            >
-                <Scale class="h-3.5 w-3.5" />
-                이용제한 근거 {isComment ? '댓글' : '글'}
-            </div>
-            <div class="text-muted-foreground inline-flex items-center gap-1 text-xs">
-                <Lock class="h-3 w-3" />
-                회원만 열람 가능
-            </div>
-        </div>
-    {/if}
-</div>
+    </div>
+{/if}


### PR DESCRIPTION
## 배경
버그게시판 #12908 요청. 이용제한 근거가 된 글은 제목에 욕설·분란 유도가 많아 제목·본문 모두 가려야 하고, 비로그인 시 원문을 페이지 소스에 싣지 않아야 합니다. 기존 댓글 마스킹을 **글 상세**로 확장합니다.

## 변경 (프론트 P1)
- **`disciplined-content.svelte`**: `revealed`를 `$bindable(false)`로 승격 → 제목·본문 두 인스턴스가 상태를 공유해 **어느 "보기"를 눌러도 함께 공개**. `inline` variant 추가(제목용 인라인 blur+칩). 기본값 유지라 **기존 댓글 사용처 무변경**.
- **`basic.svelte`/`report.svelte`**: `post.is_discipline_related`일 때 제목(`inline`)·본문을 `DisciplinedContent isLoggedIn={authStore.isAuthenticated} bind:revealed={discReveal}`로 래핑.

## 동작
- **로그인**: 제목·본문 blur, "보기" 1클릭에 동시 공개.
- **비로그인**: 백엔드(PR damoang/angple-backend#542)가 이미 제목→`[이용제한 근거 글]`, 본문→`""`로 strip → 컴포넌트가 amber placeholder만 렌더(SvelteKit `data` 직렬화 포함 원문 유출 0).

## 검증
- `svelte-check` 0 errors(변경 파일 경고 0, 기존 경고만), `prettier` 클린
- 백엔드 PR #542와 함께 canary 검증(비로그인 view-source·로그인 토글·작성자/관리자)

## 배포
백엔드 #542와 세트. canary 확인 후 정기 배포 윈도우. 목록/프로필은 백엔드가 처리(프론트 무변경), 검색/피드/RSS는 P2 후속.