### PR TITLE
feat(discipline): 이용제한 근거 글 제목 마스킹 — 검색·피드·소모임·스크랩·RSS (P2)

### DIFF
--- a/apps/web/src/lib/server/discipline-mask.ts
+++ b/apps/web/src/lib/server/discipline-mask.ts
@@ -1,0 +1,64 @@
+/**
+ * 이용제한 근거 글/댓글 마스킹 공용 헬퍼 (SSR 전용).
+ *
+ * 원천: `g5_na_singo.discipline_log_id IS NOT NULL` + sg_table(board) + sg_id(wr_id).
+ * 운영자가 이용제한 근거로 지목한 글/댓글이며, 제목에 욕설·분란 유도가 많아 목록·검색·
+ * 피드·RSS 등 서버 렌더 표면에서 제목을 치환한다(무조건 마스킹 → auth 무관 캐시 안전,
+ * 비로그인 소스에도 원문 미포함 = 봇/작업세력 추출 차단). 상세 페이지의 로그인 토글 열람은
+ * 백엔드(angple-backend)가 별도 처리하며, 이 헬퍼는 목록성 표면 전용이다.
+ */
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+
+/** 이용제한 근거 글 제목 placeholder (백엔드 표기와 일치). */
+export const DISCIPLINED_TITLE = '[이용제한 근거 글]';
+
+interface SingoRow extends RowDataPacket {
+    sg_id: number;
+}
+
+/**
+ * 한 게시판(boardId=bo_table)에서 주어진 wr_id 중 이용제한 근거로 지목된 id 집합 반환.
+ * 빈 입력이면 빈 Set. 실패해도 throw 하지 않고 빈 Set 반환(표면 렌더를 막지 않음).
+ */
+export async function findDisciplinedIds(boardId: string, wrIds: number[]): Promise<Set<number>> {
+    const set = new Set<number>();
+    if (!boardId || wrIds.length === 0) return set;
+    const ph = wrIds.map(() => '?').join(',');
+    try {
+        const [rows] = await readPool.query<SingoRow[]>(
+            `SELECT DISTINCT sg_id FROM g5_na_singo WHERE sg_table = ? AND sg_id IN (${ph}) AND discipline_log_id IS NOT NULL`,
+            [boardId, ...wrIds]
+        );
+        for (const r of rows) set.add(r.sg_id);
+    } catch {
+        // 조회 실패 시 마스킹만 생략(표면은 정상 렌더). 원문 노출은 되지만 가용성 우선.
+        return set;
+    }
+    return set;
+}
+
+/**
+ * 여러 게시판에 걸친 (board, wr_id) 쌍을 board별로 묶어 한 번에 조회.
+ * 반환: `${board}:${wr_id}` 키 Set (검색의 deletedSet 패턴과 동일).
+ */
+export async function findDisciplinedKeys(
+    pairs: Array<{ board: string; wrId: number }>
+): Promise<Set<string>> {
+    const keys = new Set<string>();
+    if (pairs.length === 0) return keys;
+    const byBoard = new Map<string, number[]>();
+    for (const { board, wrId } of pairs) {
+        if (!board || !wrId) continue;
+        const arr = byBoard.get(board);
+        if (arr) arr.push(wrId);
+        else byBoard.set(board, [wrId]);
+    }
+    await Promise.all(
+        [...byBoard.entries()].map(async ([board, ids]) => {
+            const set = await findDisciplinedIds(board, ids);
+            for (const id of set) keys.add(`${board}:${id}`);
+        })
+    );
+    return keys;
+}

--- a/apps/web/src/lib/server/discipline-mask.ts
+++ b/apps/web/src/lib/server/discipline-mask.ts
@@ -37,28 +37,3 @@ export async function findDisciplinedIds(boardId: string, wrIds: number[]): Prom
     }
     return set;
 }
-
-/**
- * 여러 게시판에 걸친 (board, wr_id) 쌍을 board별로 묶어 한 번에 조회.
- * 반환: `${board}:${wr_id}` 키 Set (검색의 deletedSet 패턴과 동일).
- */
-export async function findDisciplinedKeys(
-    pairs: Array<{ board: string; wrId: number }>
-): Promise<Set<string>> {
-    const keys = new Set<string>();
-    if (pairs.length === 0) return keys;
-    const byBoard = new Map<string, number[]>();
-    for (const { board, wrId } of pairs) {
-        if (!board || !wrId) continue;
-        const arr = byBoard.get(board);
-        if (arr) arr.push(wrId);
-        else byBoard.set(board, [wrId]);
-    }
-    await Promise.all(
-        [...byBoard.entries()].map(async ([board, ids]) => {
-            const set = await findDisciplinedIds(board, ids);
-            for (const id of set) keys.add(`${board}:${id}`);
-        })
-    );
-    return keys;
-}

--- a/apps/web/src/lib/server/new-posts.ts
+++ b/apps/web/src/lib/server/new-posts.ts
@@ -5,6 +5,7 @@
 import { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { TieredCache } from '$lib/server/cache.js';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
 
 export interface NewPostItem {
     bn_id: number;
@@ -189,6 +190,8 @@ export async function getNewPosts(
 
     // 테이블별 병렬 배치 쿼리 실행
     const writeDataMap = new Map<string, RowDataPacket>(); // key: "bo_table:wr_id"
+    // 이용제한 근거 글: 피드에서도 제목·본문 치환(#12908).
+    const disciplinedSet = new Set<string>(); // key: "bo_table:wr_id"
 
     const batchPromises = Array.from(grouped.entries()).map(async ([boTable, tableRows]) => {
         const wrIds = tableRows.map((r) => r.wr_id);
@@ -205,6 +208,8 @@ export async function getNewPosts(
         } catch {
             // 삭제된 게시판 등 오류 무시
         }
+        const disciplined = await findDisciplinedIds(boTable, wrIds);
+        for (const id of disciplined) disciplinedSet.add(`${boTable}:${id}`);
     });
 
     await Promise.all(batchPromises);
@@ -214,6 +219,7 @@ export async function getNewPosts(
     for (const row of rows) {
         const writeData = writeDataMap.get(`${row.bo_table}:${row.wr_id}`);
         if (writeData) {
+            const isDisciplined = disciplinedSet.has(`${row.bo_table}:${row.wr_id}`);
             items.push({
                 bn_id: row.bn_id,
                 bo_table: row.bo_table,
@@ -221,8 +227,8 @@ export async function getNewPosts(
                 wr_parent: row.wr_parent,
                 bn_datetime: row.bn_datetime,
                 bo_subject: row.bo_subject,
-                wr_subject: writeData.wr_subject,
-                wr_content: extractContentPreview(writeData.wr_content || ''),
+                wr_subject: isDisciplined ? DISCIPLINED_TITLE : writeData.wr_subject,
+                wr_content: isDisciplined ? '' : extractContentPreview(writeData.wr_content || ''),
                 mb_id: row.mb_id,
                 wr_name: writeData.wr_name,
                 wr_comment: writeData.wr_comment,

--- a/apps/web/src/lib/server/scrap.ts
+++ b/apps/web/src/lib/server/scrap.ts
@@ -11,6 +11,7 @@
 import { readPool, pool } from '$lib/server/db.js';
 import { TieredCache } from '$lib/server/cache.js';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
 
 interface ScrapRow extends RowDataPacket {
     ms_id: number;
@@ -82,6 +83,8 @@ async function enrichScraps(rows: ScrapRow[]): Promise<ScrapItem[]> {
     }
 
     const titleMap = new Map<string, WriteRow>();
+    // 이용제한 근거 글: 스크랩 목록 제목 치환(#12908). key: "bo_table:wr_id"
+    const disciplinedSet = new Set<string>();
     await Promise.all(
         Array.from(groups.entries()).map(([boTable, wrIds]) =>
             readPool
@@ -89,10 +92,15 @@ async function enrichScraps(rows: ScrapRow[]): Promise<ScrapItem[]> {
                     `SELECT wr_id, wr_subject, wr_name FROM g5_write_${boTable} WHERE wr_id IN (?)`,
                     [wrIds]
                 )
-                .then(([writeRows]) => {
+                .then(async ([writeRows]) => {
                     for (const wr of writeRows) {
                         titleMap.set(`${boTable}:${wr.wr_id}`, wr);
                     }
+                    const disciplined = await findDisciplinedIds(
+                        boTable,
+                        wrIds.map((id) => Number(id))
+                    );
+                    for (const id of disciplined) disciplinedSet.add(`${boTable}:${id}`);
                 })
                 .catch(() => {})
         )
@@ -100,13 +108,14 @@ async function enrichScraps(rows: ScrapRow[]): Promise<ScrapItem[]> {
 
     return rows.map((row) => {
         const wr = titleMap.get(`${row.bo_table}:${row.wr_id}`);
+        const isDisciplined = disciplinedSet.has(`${row.bo_table}:${row.wr_id}`);
         return {
             ms_id: row.ms_id,
             mb_id: row.mb_id,
             bo_table: row.bo_table,
             wr_id: row.wr_id,
             ms_datetime: row.ms_datetime,
-            wr_subject: wr?.wr_subject,
+            wr_subject: isDisciplined ? DISCIPLINED_TITLE : wr?.wr_subject,
             wr_name: wr?.wr_name
         };
     });

--- a/apps/web/src/routes/api/search/+server.ts
+++ b/apps/web/src/routes/api/search/+server.ts
@@ -16,6 +16,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { readPool } from '$lib/server/db.js';
 import { searchAllBoards, buildMatchExpr } from '$lib/server/sphinx-search.js';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
 import type { RowDataPacket } from 'mysql2';
 
 interface BoardRow extends RowDataPacket {
@@ -98,6 +99,8 @@ export const GET: RequestHandler = async ({ url, locals }) => {
         // Sphinx 인덱스가 소프트 삭제된 글을 즉시 반영하지 못해 검색 결과에 노출되는 문제(#12173)
         // 방지를 위해 MySQL 에서 wr_deleted_at 가 설정되었거나 행이 사라진 글을 추적해 제외한다.
         const deletedSet = new Set<string>();
+        // 이용제한 근거 글: 검색 결과에서도 제목·본문을 원문 노출 없이 치환(#12908).
+        const disciplinedSet = new Set<string>();
 
         const perBoardPromises = boardIds.map(async (boardId) => {
             const rows = boardMap.get(boardId)!;
@@ -105,6 +108,10 @@ export const GET: RequestHandler = async ({ url, locals }) => {
             if (!wrIds.length) return;
 
             const ph = wrIds.map(() => '?').join(',');
+
+            // 이용제한 근거 글 집합 조회
+            const disciplined = await findDisciplinedIds(boardId, wrIds);
+            for (const id of disciplined) disciplinedSet.add(`${boardId}:${id}`);
 
             // 작성자 정보 + 삭제 상태 조회
             try {
@@ -174,10 +181,15 @@ export const GET: RequestHandler = async ({ url, locals }) => {
                     is_comment: isCommentSearch,
                     posts: liveRows.map((row) => {
                         const author = authorMap.get(`${boardId}:${row.wr_id}`);
+                        const isDisciplined = disciplinedSet.has(`${boardId}:${row.wr_id}`);
                         return {
                             id: row.wr_id,
-                            title: isCommentSearch ? '' : row.wr_subject,
-                            content: stripHtml(row.wr_content).slice(0, 200),
+                            title: isCommentSearch
+                                ? ''
+                                : isDisciplined
+                                  ? DISCIPLINED_TITLE
+                                  : row.wr_subject,
+                            content: isDisciplined ? '' : stripHtml(row.wr_content).slice(0, 200),
                             author: author?.wr_name || '',
                             author_id: author?.mb_id || '',
                             board_id: boardId,

--- a/apps/web/src/routes/groups/groups-data.ts
+++ b/apps/web/src/routes/groups/groups-data.ts
@@ -5,6 +5,7 @@
 import { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { TieredCache } from '$lib/server/cache.js';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
 
 export interface GroupLatestPost {
     bo_table: string;
@@ -81,11 +82,13 @@ export async function fetchPostDetails(
                      WHERE wr_id IN (?) AND wr_is_comment = 0`,
                     [wrIds]
                 )
-                .then(([rows]) => {
+                .then(async ([rows]) => {
                     const postMap = new Map<number, RowDataPacket>();
                     for (const row of rows) {
                         postMap.set(row.wr_id as number, row);
                     }
+                    // 이용제한 근거 글: 소모임 최근글 제목 치환(#12908).
+                    const disciplined = await findDisciplinedIds(safeTable, wrIds);
 
                     for (const item of items) {
                         const post = postMap.get(item.wr_id);
@@ -94,7 +97,9 @@ export async function fetchPostDetails(
                                 bo_table: item.bo_table,
                                 bo_subject: item.bo_subject,
                                 wr_id: item.wr_id,
-                                wr_subject: post.wr_subject as string,
+                                wr_subject: disciplined.has(item.wr_id)
+                                    ? DISCIPLINED_TITLE
+                                    : (post.wr_subject as string),
                                 mb_id: item.mb_id,
                                 mb_nick: item.mb_id,
                                 wr_datetime: item.bn_datetime,

--- a/apps/web/src/routes/rss/+server.ts
+++ b/apps/web/src/routes/rss/+server.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from './$types';
 import pool from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
 
 /**
  * 전체 RSS 피드 (최근 게시글)
@@ -40,21 +41,30 @@ export const GET: RequestHandler = async ({ url }) => {
 					 ORDER BY wr_datetime DESC LIMIT 5`
                 );
 
-                for (const post of posts as Array<{
+                const typedPosts = posts as Array<{
                     wr_id: number;
                     wr_subject: string;
                     wr_content: string;
                     wr_name: string;
                     wr_datetime: string;
-                }>) {
+                }>;
+                // 이용제한 근거 글: 전면 공개 피드라 제목·본문을 원문 노출 없이 치환.
+                const disciplined = await findDisciplinedIds(
+                    board.bo_table,
+                    typedPosts.map((p) => p.wr_id)
+                );
+                for (const post of typedPosts) {
+                    const masked = disciplined.has(post.wr_id);
                     allPosts.push({
-                        title: escapeXml(post.wr_subject),
+                        title: escapeXml(masked ? DISCIPLINED_TITLE : post.wr_subject),
                         link: `${siteUrl}/${board.bo_table}/${post.wr_id}`,
-                        description: escapeXml(stripHtmlTags(post.wr_content).slice(0, 200)),
+                        description: masked
+                            ? ''
+                            : escapeXml(stripHtmlTags(post.wr_content).slice(0, 200)),
                         author: escapeXml(post.wr_name),
                         pubDate: new Date(post.wr_datetime).toUTCString(),
                         boardSubject: escapeXml(board.bo_subject),
-                        imageUrl: extractFirstImage(post.wr_content) || ''
+                        imageUrl: masked ? '' : extractFirstImage(post.wr_content) || ''
                     });
                 }
             } catch {


### PR DESCRIPTION
## 배경
#12908 P2. P1(#1725 상세 토글 + #542 백엔드 목록/프로필)에 이어, **백엔드 글목록 API를 우회하고 SvelteKit 서버에서 직접 MySQL을 조회하는 표면들**도 이용제한 근거 글 제목을 마스킹합니다. 제목에 욕설·분란 유도가 많아 목록 노출을 차단하고, 서버에서 원문을 치환하므로 **비로그인 소스에도 원문이 남지 않습니다**.

## 변경 (프론트 P2, 단일 PR)
- **`$lib/server/discipline-mask.ts` (신규)**: `findDisciplinedIds(board, wrIds)` / `findDisciplinedKeys(pairs)` 공용 헬퍼 — `g5_na_singo.discipline_log_id IS NOT NULL` 조인(글/댓글 공용), `DISCIPLINED_TITLE` 상수. 실패 시 빈 Set(가용성 우선).
- **`routes/rss/+server.ts`**: 게시판별 루프에서 근거 글 제목→placeholder, 본문/이미지 blank.
- **`routes/api/search/+server.ts`**: 기존 `deletedSet` 패턴과 동일하게 `disciplinedSet` 추가 → 제목·본문 치환.
- **`lib/server/new-posts.ts` (피드)**: 배치 조회 루프에 근거 글 집합 추가 → 조립부 제목·본문 치환.
- **`routes/groups/groups-data.ts` (소모임)**: 게시판별 `.then`에서 제목 치환.
- **`lib/server/scrap.ts`**: `enrichScraps`에 근거 글 집합 추가 → 제목 치환(일반/검색 경로 모두 경유).

## 아키텍처
5개 표면 모두 `$lib/server/db.js`(readPool/pool)로 직접 SQL을 쓰므로, 백엔드 신규 엔드포인트 없이 **공용 TS 헬퍼**로 처리(무조건 마스킹 → auth 무관 캐시 안전, 비로그인 소스 유출 0).

## 검증
- `svelte-check` 0 errors(변경 파일 경고 0), `prettier` 클린
- 목록 7 레이아웃·프로필은 백엔드 PR #542가 커버(중복 없음)

## 배포
P1(#542+#1725)과 함께 canary 확인 후 정기 배포 윈도우. 세트 배포 권장.