### PR TITLE
feat(seo): 사이트맵 게시글 전량 커버 (40k 하드캡 해소)

### DIFF
--- a/apps/web/src/lib/server/sitemap.ts
+++ b/apps/web/src/lib/server/sitemap.ts
@@ -1,0 +1,107 @@
+/**
+ * 사이트맵 공용 로직 (SSR 전용).
+ *
+ * 게시글 sitemap 을 전 게시판(bo_use_search=1) 실제 글 수 기준으로 40,000개씩
+ * 페이지 분할한다. index(sitemap.xml)와 각 페이지(sitemap-posts-N.xml)가 이
+ * 매니페스트를 공유해 페이지 수·경계가 항상 일치한다.
+ *
+ * 이전 구조의 문제: index 가 보드 30개만 카운트(LIMIT 30)해 posts-1 하나만 등재했고,
+ * 페이지 핸들러는 보드당 2000개(POSTS_PER_BOARD)로 캡을 걸어 대형 게시판(자유게시판
+ * 71만 글) 대부분이 어떤 sitemap 에도 포함되지 않았다. → 실제 글 수 기반 일관 페이징.
+ */
+import pool from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+import { TieredCache } from '$lib/server/cache.js';
+
+export const SITEMAP_POSTS_PER_PAGE = 40000; // Google 권장 최대 50,000 이하
+const SAFE_TABLE = /^[a-zA-Z0-9_]+$/;
+
+export interface BoardPostCount {
+    board: string;
+    count: number;
+}
+
+// 게시판별 글 수(COUNT)는 무거우므로 길게 캐시(L1 6h, L2 6h). sitemap 은 크롤러용이라
+// 몇 시간 지연은 무방하고, 대형 테이블 COUNT 반복을 피한다.
+const boardCountCache = new TieredCache<BoardPostCount[]>(
+    'sitemap-board-counts',
+    6 * 60 * 60 * 1000,
+    6 * 60 * 60,
+    1
+);
+
+/** bo_use_search=1 전 게시판의 실제 글 수(wr_is_comment=0). 캐시. */
+export async function getSitemapBoardCounts(): Promise<BoardPostCount[]> {
+    return boardCountCache.getOrFetch('all', async () => {
+        const [boards] = await pool.query<RowDataPacket[]>(
+            'SELECT bo_table FROM g5_board WHERE bo_use_search = 1 ORDER BY bo_order'
+        );
+        const result: BoardPostCount[] = [];
+        for (const b of boards as Array<{ bo_table: string }>) {
+            const board = b.bo_table;
+            if (!SAFE_TABLE.test(board)) continue;
+            try {
+                const [rows] = await pool.query<RowDataPacket[]>(
+                    `SELECT COUNT(*) AS cnt FROM g5_write_${board} WHERE wr_is_comment = 0`
+                );
+                const count = Number((rows[0] as { cnt: number }).cnt) || 0;
+                if (count > 0) result.push({ board, count });
+            } catch {
+                // 없는 테이블 등은 건너뛴다.
+            }
+        }
+        return result;
+    });
+}
+
+export interface SitemapSegment {
+    board: string;
+    offset: number;
+    limit: number;
+}
+
+/**
+ * 게시판 카운트를 PAGE_SIZE 단위로 이어붙여 페이지별 세그먼트 매니페스트를 만든다.
+ * pages[p-1] = 페이지 p(1-based)가 담을 (board, offset, limit) 목록.
+ * 한 보드가 PAGE_SIZE 를 넘으면 여러 세그먼트/페이지로 나뉜다.
+ */
+export function buildSitemapManifest(
+    counts: BoardPostCount[],
+    pageSize: number = SITEMAP_POSTS_PER_PAGE
+): SitemapSegment[][] {
+    const pages: SitemapSegment[][] = [];
+    let current: SitemapSegment[] = [];
+    let fill = 0;
+    for (const { board, count } of counts) {
+        let boardOffset = 0;
+        let remaining = count;
+        while (remaining > 0) {
+            const take = Math.min(pageSize - fill, remaining);
+            current.push({ board, offset: boardOffset, limit: take });
+            fill += take;
+            boardOffset += take;
+            remaining -= take;
+            if (fill >= pageSize) {
+                pages.push(current);
+                current = [];
+                fill = 0;
+            }
+        }
+    }
+    if (current.length > 0) pages.push(current);
+    return pages.length > 0 ? pages : [[]];
+}
+
+/** 게시글 sitemap 총 페이지 수(최소 1). */
+export async function getSitemapPageCount(): Promise<number> {
+    const counts = await getSitemapBoardCounts();
+    const total = counts.reduce((sum, c) => sum + c.count, 0);
+    return Math.max(1, Math.ceil(total / SITEMAP_POSTS_PER_PAGE));
+}
+
+/** 특정 페이지(1-based)의 세그먼트 목록. 범위 밖이면 빈 배열. */
+export async function getSitemapPageSegments(pageNum: number): Promise<SitemapSegment[]> {
+    const counts = await getSitemapBoardCounts();
+    const pages = buildSitemapManifest(counts);
+    return pages[pageNum - 1] ?? [];
+}

--- a/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
+++ b/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
@@ -1,16 +1,15 @@
 import type { RequestHandler } from './$types';
 import pool from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
+import { getSitemapPageSegments } from '$lib/server/sitemap.js';
 
 /**
  * 게시글 Sitemap (분할)
  *
  * /sitemap-posts-1.xml, /sitemap-posts-2.xml, ...
- * 각 파일당 최대 40,000개 URL
+ * 각 파일당 최대 40,000개 URL. 페이지 경계는 $lib/server/sitemap 매니페스트가 결정하며
+ * index(sitemap.xml)와 공유해 항상 일치한다. 게시판당 캡 없이 전 글을 커버한다.
  */
-
-const POSTS_PER_PAGE = 40000;
-const POSTS_PER_BOARD = 2000; // 각 게시판당 최대 게시글 수
 
 export const GET: RequestHandler = async ({ params, url }) => {
     const siteUrl = url.origin.replace('http://', 'https://');
@@ -20,43 +19,22 @@ export const GET: RequestHandler = async ({ params, url }) => {
         return new Response('Invalid page number', { status: 400 });
     }
 
-    const globalOffset = (pageNum - 1) * POSTS_PER_PAGE;
     const postUrls: string[] = [];
 
     try {
-        // 주요 게시판 목록 조회
-        const [boards] = await pool.query<RowDataPacket[]>(
-            'SELECT bo_table FROM g5_board WHERE bo_use_search = 1 ORDER BY bo_order'
-        );
+        const segments = await getSitemapPageSegments(pageNum);
 
-        let totalCollected = 0;
-        let skipped = 0;
-
-        for (const board of boards as Array<{ bo_table: string }>) {
-            if (totalCollected >= POSTS_PER_PAGE) break;
-
-            const boTable = board.bo_table;
-            // SQL injection 방지
-            if (!/^[a-zA-Z0-9_]+$/.test(boTable)) continue;
-
+        for (const seg of segments) {
+            // 세그먼트 board 는 매니페스트에서 왔지만 방어적으로 재검증.
+            if (!/^[a-zA-Z0-9_]+$/.test(seg.board)) continue;
             try {
-                // 이 게시판에서 가져올 게시글 수 계산
-                const toSkipInThisBoard = Math.max(0, globalOffset - skipped);
-                const toCollect = Math.min(POSTS_PER_BOARD, POSTS_PER_PAGE - totalCollected);
-
-                // 아직 건너뛸 게시글이 남아있으면 이 게시판 카운트만 확인
-                if (toSkipInThisBoard >= POSTS_PER_BOARD) {
-                    skipped += POSTS_PER_BOARD;
-                    continue;
-                }
-
                 const [posts] = await pool.query<RowDataPacket[]>(
                     `SELECT wr_id, wr_datetime, wr_last, LEFT(wr_content, 1000) AS content_head
-                     FROM g5_write_${boTable}
+                     FROM g5_write_${seg.board}
 					 WHERE wr_is_comment = 0
 					 ORDER BY wr_id DESC
 					 LIMIT ? OFFSET ?`,
-                    [toCollect, toSkipInThisBoard]
+                    [seg.limit, seg.offset]
                 );
 
                 for (const post of posts as Array<{
@@ -73,18 +51,15 @@ export const GET: RequestHandler = async ({ params, url }) => {
                         : '';
 
                     postUrls.push(`  <url>
-    <loc>${siteUrl}/${boTable}/${post.wr_id}</loc>
+    <loc>${siteUrl}/${seg.board}/${post.wr_id}</loc>
     <lastmod>${lastmodDate}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>${imageTag}
   </url>`);
-                    totalCollected++;
                 }
-
-                skipped += POSTS_PER_BOARD;
             } catch (err) {
                 // 테이블이 없거나 쿼리 에러 - 로그만 남기고 계속
-                console.error('[Sitemap Posts]', boTable, '조회 실패:', err);
+                console.error('[Sitemap Posts]', seg.board, '조회 실패:', err);
             }
         }
     } catch (err) {

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -1,6 +1,5 @@
 import type { RequestHandler } from './$types';
-import pool from '$lib/server/db.js';
-import type { RowDataPacket } from 'mysql2';
+import { getSitemapPageCount } from '$lib/server/sitemap.js';
 
 /**
  * Sitemap Index 생성 엔드포인트
@@ -10,45 +9,22 @@ import type { RowDataPacket } from 'mysql2';
  * - /sitemap.xml (index) - 분할된 sitemap 목록
  * - /sitemap-static.xml - 정적 페이지
  * - /sitemap-boards.xml - 게시판 목록
- * - /sitemap-posts-{page}.xml - 게시글 (50,000개씩 분할)
+ * - /sitemap-posts-{page}.xml - 게시글 (40,000개씩 분할, 전 게시판 실제 글 수 기준)
+ *
+ * 페이지 수는 $lib/server/sitemap 의 매니페스트와 공유해 각 posts 페이지와 항상 일치.
  */
-
-const POSTS_PER_SITEMAP = 40000; // Google 권장 최대 50,000개
 
 export const GET: RequestHandler = async ({ url }) => {
     const siteUrl = url.origin.replace('http://', 'https://');
-
-    // 전체 게시글 수 조회 (sitemap 분할 계산용)
-    let totalPosts = 0;
-    try {
-        // 주요 게시판 목록 조회
-        const [boards] = await pool.query<RowDataPacket[]>(
-            'SELECT bo_table FROM g5_board WHERE bo_use_search = 1 ORDER BY bo_order LIMIT 30'
-        );
-
-        for (const board of boards as Array<{ bo_table: string }>) {
-            const boTable = board.bo_table;
-            // SQL injection 방지
-            if (!/^[a-zA-Z0-9_]+$/.test(boTable)) continue;
-
-            try {
-                const [countResult] = await pool.query<RowDataPacket[]>(
-                    `SELECT COUNT(*) as cnt FROM g5_write_${boTable} WHERE wr_is_comment = 0`
-                );
-                totalPosts += (countResult[0] as { cnt: number }).cnt || 0;
-            } catch {
-                // 테이블이 없을 수 있음
-            }
-        }
-    } catch (err) {
-        console.error('[Sitemap Index] 게시글 수 조회 실패:', err);
-    }
-
-    // 게시글 sitemap 페이지 수 계산
-    const postSitemapCount = Math.max(1, Math.ceil(totalPosts / POSTS_PER_SITEMAP));
     const now = new Date().toISOString().split('T')[0];
 
-    // Sitemap Index 생성
+    let postSitemapCount = 1;
+    try {
+        postSitemapCount = await getSitemapPageCount();
+    } catch (err) {
+        console.error('[Sitemap Index] 페이지 수 계산 실패:', err);
+    }
+
     const sitemaps: string[] = [
         // 정적 페이지
         `  <sitemap>
@@ -62,7 +38,7 @@ export const GET: RequestHandler = async ({ url }) => {
   </sitemap>`
     ];
 
-    // 게시글 sitemap (분할)
+    // 게시글 sitemap (분할) — 전 게시판 실제 글 수 기준 전체 페이지 등재
     for (let i = 1; i <= postSitemapCount; i++) {
         sitemaps.push(`  <sitemap>
     <loc>${siteUrl}/sitemap-posts-${i}.xml</loc>


### PR DESCRIPTION
## 배경 (사이트 SEO 감사 P1 — 최대 유입 레버)
기존 사이트맵은 게시글 **4만 개(posts-1 한 페이지)만** 색인됐습니다. 자유게시판 하나만 **71만 글**인데 전체 4만만 노출 → **오래된 본문 99%+가 구글·네이버에 미색인 = 신규 검색 유입 상시 손실**.

## 원인 (2중 버그)
1. **index(`sitemap.xml`)의 `LIMIT 30`**: 120개 게시판 중 30개만 카운트 → 그 합이 23,545글(대형 게시판은 `bo_order` 30위 밖이라 제외)이라 `postSitemapCount=1` → `sitemap-posts-1`만 등재.
2. **posts 핸들러의 `POSTS_PER_BOARD=2000`**: 게시판당 2000글 캡 → 자유게시판 71만 중 2000개만 포함. index 카운트(무제한)와도 불일치.

## 변경
- **`$lib/server/sitemap.ts` (신규)**: `bo_use_search=1` 전 게시판 실제 글 수(`COUNT`, 6h 캐시) 기반 **페이지 매니페스트**. index 와 각 posts 페이지가 공유 → 페이지 수·경계 항상 일치, 게시판당 캡 제거로 전 글 커버.
- **`sitemap.xml`**: `getSitemapPageCount()` 로 전체 페이지 등재.
- **`sitemap-posts-[page].xml`**: 매니페스트 세그먼트 `(board, offset, limit)` 로 조회.

## 실측
- **총 843,851글 → 22페이지** (기존 40k/1페이지 → **21배, 사실상 전량**)
- 최악 깊은 OFFSET(자유게시판 `OFFSET 673444 LIMIT 40000`) = **0.43s** + 1h 캐시 → 성능 리스크 없음
- `svelte-check` 0 errors, `prettier` 클린
- sitemap image 확장·`lastmod`·`changefreq`·`priority` 기존 동작 유지

## 배포 후
Google Search Console·네이버 서치어드바이저에서 sitemap 재제출 시 색인 대상이 4만→84만으로 확대.