### PR TITLE
fix(message): 익명 마음메시지 신청자 프로필 유출 차단 (하단목록·댓글)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -245,6 +245,18 @@
                 summary: useSummaryListResponse
             });
             posts = response.items;
+            // 마음메시지(message) 익명 글: 클라 fetch 경로는 SSR 마스킹을 우회하므로
+            // 여기서 동일하게 신청자 프로필(아바타/mb_id)을 가린다. 익명 글은 author 가 빈 문자열.
+            if (boardId === 'message') {
+                for (const p of posts) {
+                    if (!p.author) {
+                        p.author_image = undefined;
+                        p.author_image_updated_at = undefined;
+                        p.author_id = '';
+                        p.author = '익명';
+                    }
+                }
+            }
             currentPage = response.page;
             totalPages = response.total_pages;
             totalItems = response.total;

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -128,6 +128,21 @@
     });
     let posts = $state<FreePost[]>(initialPosts);
 
+    // 마음메시지(message) 익명 글: 클라 fetch 경로(apiClient→Go 백엔드)는 SSR 마스킹을
+    // 우회하므로, SSR(`[boardId]/+page.server.ts`)과 동일하게 신청자 프로필(아바타/mb_id)을
+    // 가린다. 익명 글은 wr_name='' → author 가 빈 문자열로 내려온다.
+    function maskAnonymousMessagePosts() {
+        if (boardId !== 'message') return;
+        for (const p of posts) {
+            if (!p.author) {
+                p.author_image = undefined;
+                p.author_image_updated_at = undefined;
+                p.author_id = '';
+                p.author = '익명';
+            }
+        }
+    }
+
     // 차단 키워드 적용: 차단된 글은 목록에서 완전 제외 (#12215)
     // 게시판 목록(`[boardId]/+page.svelte`)과 동일한 필터 (#11935)
     const filteredPosts = $derived(posts.filter((p) => !uiSettingsStore.isMuted(p.title)));
@@ -197,6 +212,7 @@
                 summary: useSummaryListResponse
             });
             posts = response.items;
+            maskAnonymousMessagePosts();
             currentPage = response.page;
             totalPages = response.total_pages;
             totalItems = response.total;
@@ -245,18 +261,7 @@
                 summary: useSummaryListResponse
             });
             posts = response.items;
-            // 마음메시지(message) 익명 글: 클라 fetch 경로는 SSR 마스킹을 우회하므로
-            // 여기서 동일하게 신청자 프로필(아바타/mb_id)을 가린다. 익명 글은 author 가 빈 문자열.
-            if (boardId === 'message') {
-                for (const p of posts) {
-                    if (!p.author) {
-                        p.author_image = undefined;
-                        p.author_image_updated_at = undefined;
-                        p.author_id = '';
-                        p.author = '익명';
-                    }
-                }
-            }
+            maskAnonymousMessagePosts();
             currentPage = response.page;
             totalPages = response.total_pages;
             totalItems = response.total;

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -130,15 +130,26 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
     const tableName = `g5_write_${safeBoardId}`;
 
     try {
+        // 부모 글 조회 — 삭제 여부(#12711) + 마음메시지 익명 판정에 사용.
+        // 익명 마음메시지는 PublishToGnuboard() 에서 wr_name="" 로 저장된다.
+        const [parentRows] = await pool.query<RowDataPacket[]>(
+            `SELECT wr_deleted_at, mb_id, wr_name FROM ?? WHERE wr_id = ? AND wr_is_comment = 0 LIMIT 1`,
+            [tableName, safePostId]
+        );
+        const parent = parentRows[0];
+
+        // 마음메시지(message) 익명 글: 신청자(원글 작성자)의 신원이 댓글에서 노출되지
+        // 않도록, 원글 작성자 본인이 단 댓글은 아바타/프로필/닉을 '익명'으로 가린다.
+        // (표시 마스킹만 수행 — 댓글 알림은 write 시점 백엔드에서 실제 mb_id 로 발송되므로 영향 없음)
+        const postIsAnonymousMessage =
+            safeBoardId === 'message' &&
+            !!parent &&
+            (parent.wr_name ?? '').toString().trim() === '';
+        const anonymousAuthorId = postIsAnonymousMessage ? String(parent.mb_id ?? '') : '';
+
         // 부모 글 삭제 여부 확인 — 삭제된 글은 본문이 "[삭제된 게시물]"로 가려지므로
-        // 그 아래 댓글도 노출하지 않는다(#12711: 삭제글 자리에 이전 댓글이 남아 보이는 문제).
-        // 관리자는 조정 목적상 계속 열람 가능.
+        // 그 아래 댓글도 노출하지 않는다. 관리자는 조정 목적상 계속 열람 가능.
         if (!isAdmin) {
-            const [parentRows] = await pool.query<RowDataPacket[]>(
-                `SELECT wr_deleted_at FROM ?? WHERE wr_id = ? AND wr_is_comment = 0 LIMIT 1`,
-                [tableName, safePostId]
-            );
-            const parent = parentRows[0];
             if (!parent || parent.wr_deleted_at) {
                 return json(
                     {
@@ -293,6 +304,19 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
                   }
                 : {})
         }));
+
+        // 마음메시지 익명: 원글 작성자(신청자) 본인의 댓글은 신원을 가린다.
+        // author/author_id/author_image 를 비워 프로필·팔로우·쪽지 링크로 신원이 드러나지 않게 한다.
+        if (postIsAnonymousMessage && anonymousAuthorId) {
+            for (const c of comments) {
+                if (c.author_id === anonymousAuthorId) {
+                    c.author = '익명';
+                    c.author_id = '';
+                    c.author_image = '';
+                    c.author_image_updated_at = undefined;
+                }
+            }
+        }
 
         // Bluesky handle → DID prefetch (#12050).
         // 댓글 본문 내 `bsky.app/profile/<handle>/post/<id>` URL 의 handle 을 DID 로


### PR DESCRIPTION
## 제보
익명으로 신청한 마음메시지가 **목록에선 익명**이지만, **상세 페이지로 들어가면 하단 목록·댓글에 신청자 프로필 이미지(및 mb_id)가 노출**되어 익명성이 깨짐.

## 근본 원인
익명 마스킹이 **SvelteKit SSR 3곳**(게시판목록·상세본문·배너API)에만 구현돼 있고, 이를 **우회하는 두 경로가 Go 백엔드 원본을 그대로** 렌더. 익명 글은 별도 플래그 없이 `wr_name=''`(작성자명 빈값)로만 구분됨.

## 수정 (2곳, 프론트)
| 유출 | 수정 |
|---|---|
| **상세 하단 최근글 목록** | `recent-posts.svelte` — `apiClient.getBoardPosts`(→Go 백엔드) 결과에 SSR과 **동일한 message 익명 마스킹**(author 빈값 → `author_image/author_id` 제거, `author='익명'`) 적용 |
| **댓글** | `comments/+server.ts` — 원글 익명 여부(`wr_name=''`)+원글 작성자 mb_id 조회 후, **신청자 본인이 단 댓글**의 아바타/프로필/닉을 '익명'으로 마스킹 |

## 알림 보존 (요구사항)
표시(read) 마스킹만 수행 — **댓글 알림은 그대로 발송**됩니다. 알림은 댓글 *작성(write)* 시점에 백엔드가 원글 작성자 **실제 mb_id**로 보내므로, 표시 마스킹과 독립적입니다.

## 후속(권장)
근본 해결은 익명 마스킹을 SSR 보정이 아니라 **데이터소스(Go 백엔드 글목록·댓글)로 단일화** — 미적용 시 새 클라이언트 경로마다 재발.

## 검증
- 익명 마음메시지 상세: 하단목록·본인 댓글에서 아바타/프로필 링크 미노출, 닉 '익명'
- 일반(기명) 메시지·타 게시판 회귀 0
- 댓글 알림 신청자 수신 정상(write 경로 무변경)