### PR TITLE
perf(member-memo): 뱃지 청크 이거 프리로드로 지연 로딩 제거

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -24,7 +24,7 @@
     import { doAction } from '$lib/hooks/registry';
     import { initBuiltinHooks } from '$lib/hooks';
     import { registerDefaultSlots } from '$lib/components/slot-defaults';
-    import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
+    import { loadPluginComponent, loadPluginLib } from '$lib/utils/plugin-optional-loader';
     import DefaultLayout from '$lib/layouts/default-layout.svelte';
     import { getThemeLayout } from '$lib/themes/layout-registry';
     import { initFromSSR as initAppData } from '$lib/stores/app-init.svelte';
@@ -236,6 +236,20 @@
                 widgetLayoutStore.initFromServer(widgetLayout ?? null, sidebarWidgetLayout ?? null);
             }
         });
+    });
+
+    // 회원 메모 뱃지 지연 로딩 제거: member-memo 는 뱃지 컴포넌트(memo-badge)와 memo-store 가
+    // 코드 스플릿된 별도 청크라, 목록/상세의 per-page $effect 가 하이드레이션 후에야 동적
+    // import() 를 시작해 뱃지가 뒤늦게 떴다. 로그인 + 플러그인 활성 시 앱 마운트에서 해당
+    // 청크를 미리 로드해 import() 캐시를 데워두면, 각 페이지는 이미 로드된 청크를 즉시 사용한다.
+    // (activePlugins 는 위에서 SSR 로 동기 초기화되므로 onMount 시 활성 여부를 신뢰할 수 있다.)
+    // fire-and-forget — 실패해도 기존 per-page 지연 로딩으로 폴백되어 회귀 없음.
+    onMount(() => {
+        if (!authStore.isAuthenticated) return;
+        if (!pluginStore.isPluginActive('member-memo')) return;
+        loadPluginComponent('member-memo', 'memo-badge').catch(() => {});
+        loadPluginComponent('member-memo', 'memo-inline-editor').catch(() => {});
+        loadPluginLib('member-memo', 'memo-store').catch(() => {});
     });
 
     // 메뉴 데이터 변경 시 키보드 단축키 빌드 (모듈 로드 후 활성화)

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -240,13 +240,18 @@
 
     // 회원 메모 뱃지 지연 로딩 제거: member-memo 는 뱃지 컴포넌트(memo-badge)와 memo-store 가
     // 코드 스플릿된 별도 청크라, 목록/상세의 per-page $effect 가 하이드레이션 후에야 동적
-    // import() 를 시작해 뱃지가 뒤늦게 떴다. 로그인 + 플러그인 활성 시 앱 마운트에서 해당
-    // 청크를 미리 로드해 import() 캐시를 데워두면, 각 페이지는 이미 로드된 청크를 즉시 사용한다.
-    // (activePlugins 는 위에서 SSR 로 동기 초기화되므로 onMount 시 활성 여부를 신뢰할 수 있다.)
+    // import() 를 시작해 뱃지가 뒤늦게 떴다. 로그인 + 플러그인 활성 시 해당 청크를 미리 로드해
+    // import() 캐시를 데워두면, 각 페이지는 이미 로드된 청크를 즉시 사용한다.
+    // ⚠️ auth 는 별도 onMount 의 syncAuth/fast-path 로 하이드레이션 후 늦게 확립되므로
+    // onMount 로는 프리로드 시점에 isAuthenticated 가 아직 false → 스킵된다. $effect 로
+    // authStore.isAuthenticated 변화를 추적해, 로그인 확정 즉시 1회 발화한다.
     // fire-and-forget — 실패해도 기존 per-page 지연 로딩으로 폴백되어 회귀 없음.
-    onMount(() => {
+    let memoChunksPrefetched = false;
+    $effect(() => {
+        if (memoChunksPrefetched) return;
         if (!authStore.isAuthenticated) return;
         if (!pluginStore.isPluginActive('member-memo')) return;
+        memoChunksPrefetched = true;
         loadPluginComponent('member-memo', 'memo-badge').catch(() => {});
         loadPluginComponent('member-memo', 'memo-inline-editor').catch(() => {});
         loadPluginLib('member-memo', 'memo-store').catch(() => {});


### PR DESCRIPTION
## 제보
회원 메모 뱃지가 목록/상세에서 **바로 뜨지 않고 뒤늦게** 표시됨(딜레이 로딩).

## 원인 (데이터 아님, 코드 청크 지연)
데이터는 이미 최적화돼 있음 — `activePlugins`는 SSR, `author_memo`는 백엔드 인라인 임베드(PR #438)로 `preloadMemos` 캐시 채움 → **fetch 0**.

병목은 **플러그인 컴포넌트가 코드 스플릿된 별도 청크**라는 점:
1. 페이지 SSR/하이드레이션 (뱃지 없음)
2. 하이드레이션 후 per-page `$effect` 발화 → `loadPluginComponent('member-memo','memo-badge')` + `loadPluginLib(...,'memo-store')` = 동적 `import()` 로 청크 다운로드
3. 청크 도착·파싱 후 MemoBadge 마운트 → **뒤늦게 뜨는 지연** (콜드 캐시 첫 방문에서 큼)

## 수정 (A안 — 이거 프리로드)
`+layout.svelte`에서 **로그인 + `member-memo` 활성 시 앱 마운트에서 memo-badge·memo-inline-editor·memo-store 청크를 미리 로드**해 `import()` 캐시를 데워둠. 각 페이지의 per-page `$effect`는 이미 로드된 청크를 즉시 사용 → 뱃지 지연 없이 표시.

- 컴포넌트/lib 이름은 보드 컴포넌트가 쓰는 것과 동일 → `import()` 메모이즈 캐시 재사용
- 비로그인(메모 미노출)·플러그인 비활성 시 프리로드 안 함 → 익명 방문자 불필요 청크 없음
- fire-and-forget(`.catch`) → 실패 시 기존 per-page 지연 로딩 폴백, **회귀 없음**

## 검증
- 로그인 상태 목록/상세에서 memo-badge 지연 없이 표시
- 비로그인·member-memo 비활성 무영향, 콘솔 에러 0, 빌드 pass