### PR TITLE
ux(board): 활성 페이지·탭 재클릭 dead click 제거 (Clarity UX-001)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1110,7 +1110,9 @@
                         href={buildMessagePeriodHref('today')}
                         variant={selectedMessagePeriod === 'today' ? 'default' : 'outline'}
                         size="sm"
-                        class="h-8 rounded-full px-4"
+                        class="h-8 rounded-full px-4 {selectedMessagePeriod === 'today'
+                            ? 'pointer-events-none'
+                            : ''}"
                         aria-current={selectedMessagePeriod === 'today' ? 'page' : undefined}
                     >
                         오늘 마음메시지
@@ -1119,7 +1121,9 @@
                         href={buildMessagePeriodHref('month')}
                         variant={selectedMessagePeriod === 'month' ? 'default' : 'outline'}
                         size="sm"
-                        class="h-8 rounded-full px-4"
+                        class="h-8 rounded-full px-4 {selectedMessagePeriod === 'month'
+                            ? 'pointer-events-none'
+                            : ''}"
                         aria-current={selectedMessagePeriod === 'month' ? 'page' : undefined}
                     >
                         이번달 마음메시지
@@ -1128,7 +1132,9 @@
                         href={buildMessagePeriodHref('upcoming')}
                         variant={selectedMessagePeriod === 'upcoming' ? 'default' : 'outline'}
                         size="sm"
-                        class="h-8 rounded-full px-4"
+                        class="h-8 rounded-full px-4 {selectedMessagePeriod === 'upcoming'
+                            ? 'pointer-events-none'
+                            : ''}"
                         aria-current={selectedMessagePeriod === 'upcoming' ? 'page' : undefined}
                     >
                         다가올 마음메시지
@@ -1137,7 +1143,9 @@
                         href={buildMessagePeriodHref('past')}
                         variant={selectedMessagePeriod === 'past' ? 'default' : 'outline'}
                         size="sm"
-                        class="h-8 rounded-full px-4"
+                        class="h-8 rounded-full px-4 {selectedMessagePeriod === 'past'
+                            ? 'pointer-events-none'
+                            : ''}"
                         aria-current={selectedMessagePeriod === 'past' ? 'page' : undefined}
                     >
                         추억의 마음메시지
@@ -1476,9 +1484,13 @@
                         onclick={() => goToPage(pagination.page - 1)}>이전</Button
                     >
                     {#each visiblePageNumbers as pageNum (pageNum)}
+                        <!-- Clarity UX-001: 현재 페이지 재클릭은 같은 URL goto() = 화면 무변화 dead click.
+                             pointer-events-none 으로 클릭 자체를 차단(시각 변화 없음), 스크린리더엔 aria-current. -->
                         <Button
                             variant={pageNum === pagination.page ? 'default' : 'outline'}
                             size="sm"
+                            aria-current={pageNum === pagination.page ? 'page' : undefined}
+                            class={pageNum === pagination.page ? 'pointer-events-none' : undefined}
                             onclick={() => goToPage(pageNum)}>{pageNum}</Button
                         >
                     {/each}


### PR DESCRIPTION
## 배경 — Clarity UX 브리프 (30일, 세션 63,661)
`/free` 목록 dead click 상위 요소가 `A/BUTTON.cursor-pointer.aria-invalid:border-destructive` 로 식별됨(280클릭). 코드 정밀 추적 결과:

- `aria-invalid:border-destructive` 는 shadcn **Button base 클래스의 Tailwind variant 문자열**일 뿐, `aria-invalid="true"` 를 실제 세팅하는 코드는 0건 → "폼 오류 상태" 아님
- 목록 행(classic)엔 Button/공감/북마크 없음 → 브리프의 비로그인 공감 가설 기각
- **진짜 원인 = 이미 활성인 컨트롤 재클릭**:
  - 페이지네이션 **현재 페이지 번호**: `goToPage()` 동일페이지 가드 없음 → 같은 URL `goto()` = 화면 무변화
  - 마음메시지 **활성 기간 탭**: 활성 탭에도 href → 같은 URL 재이동

## 변경 (표시 변화 없음)
- 현재 페이지 번호 버튼·활성 기간 탭에 `pointer-events-none` → 무의미한 클릭 자체 차단
- `aria-current="page"` 로 접근성 보강 (페이지네이션에 신규, 기간 탭은 기존 유지)
- disabled 경계 버튼(«/이전/다음/»)은 base `disabled:pointer-events-none` 으로 이미 차단 → 무변경

## 같은 분석에서 코드 무결 확인 (수정 불요 판정)
- **UX-003(썸네일)**: 리스트 6개 표면 전부 `<a href>` 래핑/onclick 수신 — 핸들러 누락 없음, 기각
- **UX-002(독일 rage click)**: 대상 글 본문에 클릭 요소 0개 + 오리진 로그 252요청 정상 분포 → 클라이언트 한정 현상(텍스트 드래그·번역 추정), 서버 부하 없음, WAF 불요·모니터링만

## 검증
- 시각 변화 0 (활성 상태 스타일 그대로), 활성 요소만 클릭 불가
- 빠른필터(내가 쓴 글/댓글)는 활성 재클릭=토글 해제라 제외(정상 동작)
- CI: svelte-check/build로 문법 검증