### PR TITLE
fix(favorites): 즐겨찾기 삭제가 페이지 이탈 시 유실되는 문제 (#12912)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2163,11 +2163,13 @@ class ApiClient {
      * 🔒 인증 필요
      */
     async saveFavorites(
-        favorites: Record<string, { boardId: string; title: string }>
+        favorites: Record<string, { boardId: string; title: string }>,
+        keepalive = false
     ): Promise<void> {
         await this.request<void>('/my/favorites', {
             method: 'PUT',
-            body: JSON.stringify(favorites)
+            body: JSON.stringify(favorites),
+            keepalive
         });
     }
 

--- a/apps/web/src/lib/stores/board-favorites.svelte.ts
+++ b/apps/web/src/lib/stores/board-favorites.svelte.ts
@@ -82,10 +82,26 @@ class BoardFavoritesStore {
     private debouncedSync = debounce(() => {
         this.syncToServer();
     }, 500);
+    /** debounce 발화 대기 중인 변경이 있는지 (#12912 flush 판단용) */
+    private pendingSync = false;
 
     constructor() {
         if (browser) {
             this.loadFromStorage();
+            // #12912: 삭제 등 변경은 persist()에서 500ms debounce로 서버에 저장되는데,
+            // debounce 발화 전 탭 전환/종료/새로고침이 일어나면 서버에 삭제가 전달되지 않는다.
+            // 이후 재로그인 시 syncFromServer()가 (타임스탬프 비교 없이) 서버 데이터를 로컬에
+            // 무조건 덮어써 삭제한 항목이 부활한다. 페이지가 숨겨지거나 이탈할 때 대기 중인
+            // 동기화를 즉시 flush 하여(keepalive 로 unload 중에도 전송 보장) 유실을 막는다.
+            const flush = () => {
+                if (this.loggedIn && this.pendingSync) {
+                    void this.syncToServer(true);
+                }
+            };
+            document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'hidden') flush();
+            });
+            window.addEventListener('pagehide', flush);
         }
     }
 
@@ -151,11 +167,12 @@ class BoardFavoritesStore {
         }
     }
 
-    /** 현재 상태를 서버에 저장 */
-    private async syncToServer(): Promise<void> {
+    /** 현재 상태를 서버에 저장 (keepalive: 페이지 이탈 중에도 전송 보장) */
+    private async syncToServer(keepalive = false): Promise<void> {
         if (!browser || !this.loggedIn) return;
+        this.pendingSync = false;
         try {
-            await apiClient.saveFavorites(toRecord(this.favorites));
+            await apiClient.saveFavorites(toRecord(this.favorites), keepalive);
         } catch {
             // 서버 저장 실패 시 무시 (localStorage에는 이미 저장됨)
         }
@@ -165,6 +182,7 @@ class BoardFavoritesStore {
     private persist(): void {
         this.saveToStorage();
         if (this.loggedIn) {
+            this.pendingSync = true;
             this.debouncedSync();
         }
     }


### PR DESCRIPTION
## 제보 (#12912)
소모임(=게시판) 즐겨찾기를 등록 후 삭제 → 정상 삭제되지만, **재로그인/브라우저 재실행 시 삭제한 항목이 다시 살아난 상태**로 표시.

## 원인 (코드 확인)
`board-favorites.svelte.ts`:
1. 변경(삭제 포함)은 `persist()` → **500ms `debounce`** 로 서버 저장(`syncToServer`).
2. **debounce 발화 전 탭 전환/종료/새로고침** 시 서버에 삭제 미전달.
3. 재로그인 시 `syncFromServer()`가 서버에 데이터가 있으면 **타임스탬프 비교 없이 로컬을 무조건 덮어씀**(`hasServerData` → line 128-131, Last Write Wins=서버).
4. → 삭제 전 서버 스냅샷 복원 = 항목 부활. **한 번 유실되면 매 로그인 재현**되어 "항상"으로 체감.

## 수정
- `pendingSync` 플래그로 debounce 대기 여부 추적.
- **페이지 숨김/이탈 시 즉시 flush**: `visibilitychange`(hidden, 탭 전환) + `pagehide`(이탈) 리스너에서 대기 중 동기화를 즉시 `syncToServer(keepalive)` 로 전송.
- **`keepalive: true`** 로 unload 중에도 요청 완료 보장 → 삭제가 서버에 반영됨.
- `apiClient.saveFavorites`에 `keepalive` 옵션 추가(`request`가 fetch options로 전달).

## 영향/안전
- 정상 저장(디바운스) 경로 무변경, flush는 pendingSync 있을 때만.
- SSR 안전(`browser` 가드), 싱글턴 스토어라 리스너 1회 등록.
- favorites 페이로드는 작아 keepalive 64KB 제한 무관.

## 검증
- 삭제 → 즉시 새로고침/탭닫기 → 재로그인 시 삭제 유지(부활 안 함)
- CI: svelte-check/build