### PR TITLE
fix(markdown): 크롬 본문 video 로드 후 클릭 씹힘 — .prose contain layout 제거 (#12910)

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -373,10 +373,16 @@
     });
 </script>
 
+<!--
+    #12910: contain 에 `layout` 을 넣으면 크롬에서 본문 <video> 로드 완료 후에도
+    몇 초간 클릭·우클릭이 씹힌다(레이아웃 컨테인먼트가 비디오 합성 레이어의 히트테스트
+    타이밍과 충돌). 로고 이미지에서도 같은 이유로 contain 을 제거한 선례가 있다.
+    perf 격리 효과는 style 컨테인먼트만으로도 충분하므로 layout 을 제거한다.
+-->
 <div
     bind:this={proseEl}
     class="prose prose-neutral dark:prose-invert max-w-none {className}"
-    style="font-size: var(--content-font-size, 16px); overflow-wrap: break-word; word-wrap: break-word; overflow-x: hidden; contain: layout style;"
+    style="font-size: var(--content-font-size, 16px); overflow-wrap: break-word; word-wrap: break-word; overflow-x: hidden; contain: style;"
 >
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html renderedHtml}


### PR DESCRIPTION
## 제보 (#12910)
크롬에서 게시글 본문의 `<video>`(mp4)가 로드 완료된 뒤에도 **몇 초간 클릭·우클릭이 씹힘**. 동영상 URL 직접 접속은 정상. (예: /free/6626729)

## 원인
`markdown.svelte:379` — 본문을 감싸는 `.prose` div 인라인 스타일에 `contain: layout style` 이 있는데, **`layout` 컨테인먼트가 크롬 비디오 합성(compositing) 레이어의 히트테스트 타이밍과 충돌**해 로드 직후 몇 초간 포인터 이벤트가 씹힘.
- "직접 URL 접속은 정상"(=.prose 컨테이너 밖)과 정합.
- 로고 이미지에서도 같은 이유로 contain 을 제거한 **선례** 있음.
- 제보자가 재현 + 원인(.prose contain)까지 정확히 짚어주심.

## 수정
- `contain: layout style` → **`contain: style`** (문제의 `layout` 제거).
- perf 격리 목적은 style 컨테인먼트로도 충분, layout 제거로 히트테스트 정상화.

## 검증
- GPU 합성 타이밍 버그라 헤드리스 CI로 재현이 불확실 → 제보자 실측 진단 + CSS 메커니즘(layout containment ↔ 히트테스트) + 인레포 선례로 확정. **최종 확인은 배포 후 실제 크롬.**
- CI: svelte-check/build (문법·타입)