### PR TITLE
fix(seo): BreadcrumbList 빈 name 항목 미출력 (GSC 리치 결과 오류 해소)

### DIFF
--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -106,10 +106,49 @@ describe('SEO meta-helper', () => {
     describe('createBreadcrumbJsonLd', () => {
         it('올바른 position', () => {
             const ld = createBreadcrumbJsonLd([{ name: '홈', url: '/' }, { name: '게시판' }]);
-            expect(ld.itemListElement).toHaveLength(2);
-            expect(ld.itemListElement[0].position).toBe(1);
-            expect(ld.itemListElement[1].position).toBe(2);
-            expect(ld.itemListElement[1].item).toBeUndefined();
+            expect(ld).not.toBeNull();
+            expect(ld!.itemListElement).toHaveLength(2);
+            expect(ld!.itemListElement[0].position).toBe(1);
+            expect(ld!.itemListElement[1].position).toBe(2);
+            expect(ld!.itemListElement[1].item).toBeUndefined();
+        });
+
+        // GSC "'name' 또는 'item.name' 지정 필요" 에러 방지 (빈 제목 글 등)
+        it('name 이 빈 항목은 제외하고 position 재부여', () => {
+            const ld = createBreadcrumbJsonLd([
+                { name: '홈', url: '/' },
+                { name: '', url: '/free' },
+                { name: '   ' },
+                { name: undefined },
+                { name: '글제목' }
+            ]);
+            expect(ld).not.toBeNull();
+            expect(ld!.itemListElement).toHaveLength(2);
+            expect(ld!.itemListElement[0].name).toBe('홈');
+            expect(ld!.itemListElement[1].name).toBe('글제목');
+            expect(ld!.itemListElement[1].position).toBe(2);
+        });
+
+        it('유효 항목이 없으면 null (빈 BreadcrumbList 미출력)', () => {
+            expect(createBreadcrumbJsonLd([])).toBeNull();
+            expect(createBreadcrumbJsonLd([{ name: '' }, { name: undefined }])).toBeNull();
+        });
+
+        it('name 앞뒤 공백 trim', () => {
+            const ld = createBreadcrumbJsonLd([{ name: '  홈  ', url: '/' }]);
+            expect(ld!.itemListElement[0].name).toBe('홈');
+        });
+    });
+
+    describe('buildJsonLd null 필터', () => {
+        it('null 항목 제외 후 직렬화', () => {
+            const result = buildJsonLd([createWebSiteJsonLd(), null, undefined]);
+            const parsed = JSON.parse(result);
+            expect(parsed['@type']).toBe('WebSite');
+        });
+
+        it('전부 null 이면 빈 문자열 (script 태그 생략)', () => {
+            expect(buildJsonLd([null, undefined])).toBe('');
         });
     });
 });

--- a/apps/web/src/lib/seo/meta-helper.ts
+++ b/apps/web/src/lib/seo/meta-helper.ts
@@ -90,12 +90,17 @@ export function buildTwitterTags(meta: SeoMeta, twitter?: TwitterMeta): Record<s
     return tags;
 }
 
-/** JSON-LD 스크립트 문자열 생성 */
-export function buildJsonLd(data: JsonLdData[]): string {
-    const wrapped = data.map((item) => ({
-        '@context': 'https://schema.org',
-        ...item
-    }));
+/** JSON-LD 스크립트 문자열 생성
+ * null/undefined 항목은 제외한다 (생성 헬퍼가 유효하지 않은 데이터에 null 을 반환하는 경우).
+ * 유효 항목이 없으면 빈 문자열 → SeoHead 의 {#if jsonLdScript} 가 스크립트 자체를 생략. */
+export function buildJsonLd(data: Array<JsonLdData | null | undefined>): string {
+    const wrapped = data
+        .filter((item): item is JsonLdData => item != null)
+        .map((item) => ({
+            '@context': 'https://schema.org',
+            ...item
+        }));
+    if (wrapped.length === 0) return '';
 
     const json = wrapped.length === 1 ? JSON.stringify(wrapped[0]) : JSON.stringify(wrapped);
     // </script> 주입 방지
@@ -140,16 +145,22 @@ export function createArticleJsonLd(options: {
     return data;
 }
 
-/** Breadcrumb JSON-LD 생성 헬퍼 */
+/** Breadcrumb JSON-LD 생성 헬퍼
+ * GSC "'name' 또는 'item.name' 지정 필요" 에러 방지:
+ * - name 이 빈 항목(빈 제목 글 등)은 제외하고 position 을 재부여한다.
+ * - 유효 항목이 없으면 null 을 반환해 BreadcrumbList 블록 자체를 생략한다.
+ *   (breadcrumb 이 없는 것은 정상, 빈/name 누락 breadcrumb 은 리치 결과 오류) */
 export function createBreadcrumbJsonLd(
-    items: Array<{ name: string; url?: string }>
-): JsonLdBreadcrumb {
+    items: Array<{ name: string | null | undefined; url?: string }>
+): JsonLdBreadcrumb | null {
+    const valid = items.filter((item) => item.name != null && String(item.name).trim() !== '');
+    if (valid.length === 0) return null;
     return {
         '@type': 'BreadcrumbList',
-        itemListElement: items.map((item, i) => ({
+        itemListElement: valid.map((item, i) => ({
             '@type': 'ListItem' as const,
             position: i + 1,
-            name: item.name,
+            name: String(item.name).trim(),
             ...(item.url ? { item: item.url } : {})
         }))
     };

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -147,6 +147,7 @@ export interface SeoConfig {
     meta: SeoMeta;
     og?: OgMeta;
     twitter?: TwitterMeta;
-    jsonLd?: JsonLdData[];
+    /** null/undefined 항목 허용 — 생성 헬퍼가 유효하지 않은 데이터에 null 을 반환 (buildJsonLd 가 필터) */
+    jsonLd?: Array<JsonLdData | null | undefined>;
     pagination?: PaginationSeo;
 }


### PR DESCRIPTION
## 배경
Google Search Console 에서 **"'name' 또는 'item.name'이(가) 지정되어야 합니다 (경로: itemListElement)"** 탐색경로 구조화 데이터 오류가 **+400% 급증**했다는 경고를 받았습니다.

## 원인
- 글 상세 breadcrumb 의 마지막 항목이 `{ name: data.post.title }` 인데(폴백 없음), **제목이 빈 글(엣지 케이스)** 에서는 `"name":""` ListItem 이 출력되어 GSC 가 정확히 위 오류를 냅니다. '홈'(리터럴)과 boardTitle(slug 폴백 보유)은 항상 유효해, 유일한 취약점입니다.
- breadcrumb JSON-LD 는 2026-02-09 SvelteKit 전환(#125)부터 동일 로직으로, 최근 회귀가 아니라 **Google 이 84만 글을 누적 크롤하며 엣지 케이스 집계가 함께 증가**한 것입니다.
- 정상 글은 전부 유효함을 실측 확인했습니다 (Googlebot UA 로 게시판 8종 · 글 228건 샘플링, name 누락 0건).

## 수정 (직렬화 지점 방어 — 모든 caller 일괄 하드닝)
- `createBreadcrumbJsonLd`: name 이 빈 항목은 제외하고 position 재부여, 유효 항목이 없으면 `null` 반환 → **어떤 데이터 상태에서도 nameless ListItem / 빈 BreadcrumbList 가 출력되지 않습니다.** 빈 제목 글은 `홈 > 게시판` 2단계로 유효하게 출력됩니다 (breadcrumb 축소는 정상, name 누락은 오류)
- `buildJsonLd`: null/undefined 항목 필터, 전부 비면 빈 문자열 → SeoHead 의 `{#if}` 가 script 태그 자체를 생략
- `SeoConfig.jsonLd` 타입에 null 허용 반영, 단위 테스트 6종 추가

## 검증
- 단위 테스트 18/18 통과 (신규 6종 포함)
- svelte-check 0 errors
- 배포 후: Googlebot UA 로 글 상세 breadcrumb 재확인 → GSC "수정 확인 요청" 시작 예정