### PR TITLE
feat(sidebar): 후원하기 아래 '마음메시지 신청하기' 카드 + 신청 버튼 라벨 통일

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -448,6 +448,14 @@
                 <span>♡ 다모앙 후원하기</span>
                 <span aria-hidden="true" class="leading-none">→</span>
             </a>
+            <!-- 후원하기 바로 아래: 마음메시지 신청하기 1줄 카드 (동일 스타일). 내부 페이지라 같은 탭 이동. -->
+            <a
+                href="/message/144"
+                class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 mt-2 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
+            >
+                <span>♡ 마음메시지 신청하기</span>
+                <span aria-hidden="true" class="leading-none">→</span>
+            </a>
         {/if}
         <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
             {#if compact}{:else}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1156,7 +1156,7 @@
                         size="sm"
                         class="h-8 rounded-full px-4"
                     >
-                        마음메시지 신청
+                        ♡ 마음메시지 신청하기 →
                     </Button>
                 </div>
             {/if}


### PR DESCRIPTION
## 요청
- 사이드바 데스크톱 좌측 메뉴의 **♡ 다모앙 후원하기** 카드 바로 아래에 **♡ 마음메시지 신청하기 →** 1줄 카드 추가(후원하기와 동일 디자인).
- 마음메시지 게시판의 **마음메시지 신청** 버튼 라벨을 **♡ 마음메시지 신청하기 →** 로 통일.

## 변경
| 파일 | 내용 |
|---|---|
| `layout/sidebar.svelte` | 후원하기 카드(데스크톱 메뉴) 아래에 동일 스타일 `<a href="/message/144">♡ 마음메시지 신청하기 →</a>` 추가 (`mt-2` 간격). **내부 페이지라 같은 탭**(target 없음) |
| `[boardId]/+page.svelte` | 마음메시지 기간탭의 `마음메시지 신청` 버튼 라벨 → `♡ 마음메시지 신청하기 →` (버튼 모양 유지) |

## 결정(컨펌 반영)
- 사이드바: **데스크톱 좌측 메뉴(1곳)만** (마음메시지 아래 후원하기 블록은 미변경)
- 신청 버튼: **텍스트만 변경, 버튼 유지**
- 링크: **같은 탭** (`/message/144` 내부 페이지)

## 검증
- 후원하기와 동일 클래스 → 시각 일관
- CI: svelte-check/build