### PR TITLE
fix(message): 마음메시지 신청 링크를 구글폼(새 탭)으로 연결

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -448,9 +448,11 @@
                 <span>♡ 다모앙 후원하기</span>
                 <span aria-hidden="true" class="leading-none">→</span>
             </a>
-            <!-- 후원하기 바로 아래: 마음메시지 신청하기 1줄 카드 (동일 스타일). 내부 페이지라 같은 탭 이동. -->
+            <!-- 후원하기 바로 아래: 마음메시지 신청하기 1줄 카드 (동일 스타일). 구글폼 신청서라 새 탭으로 이동. -->
             <a
-                href="/message/144"
+                href="https://forms.gle/Yj3D28THBxVNMWn2A"
+                target="_blank"
+                rel="noopener noreferrer"
                 class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 mt-2 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
             >
                 <span>♡ 마음메시지 신청하기</span>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1151,7 +1151,9 @@
                         추억의 마음메시지
                     </Button>
                     <Button
-                        href="/message/144"
+                        href="https://forms.gle/Yj3D28THBxVNMWn2A"
+                        target="_blank"
+                        rel="noopener noreferrer"
                         variant="outline"
                         size="sm"
                         class="h-8 rounded-full px-4"


### PR DESCRIPTION
## 요약
사이드바 카드와 `/message` 페이지 상단 버튼의 '♡ 마음메시지 신청하기'가 안내글(`/message/144`)로만 가던 것을, 실제 **신청 구글폼**으로 바로(새 탭) 이동하도록 변경합니다.

- 구글폼: `https://forms.gle/Yj3D28THBxVNMWn2A` (message/144 안내글 본문에 있던 링크)
- 외부 폼이라 `target="_blank"` + `rel="noopener noreferrer"` 로 새 탭 열림

## 변경
| 파일 | 내용 |
|---|---|
| `apps/web/src/lib/components/layout/sidebar.svelte` | 후원하기 아래 '♡ 마음메시지 신청하기' 카드 href → 폼 URL, 새 탭 |
| `apps/web/src/routes/[boardId]/+page.svelte` | `/message` 상단 '♡ 마음메시지 신청하기 →' 버튼 href → 폼 URL, 새 탭 (Button 이 restProps 로 target/rel 전달) |

## 검증
- [ ] canary 에서 두 링크 클릭 → 새 탭으로 구글폼 열림
- [ ] 사이드바 카드 스타일(후원하기와 동일) 유지