### PR TITLE
fix(seo): GSC 구조화 데이터 4종 해소 (잘린 유니코드·headline·image·comment)

### DIFF
--- a/apps/web/src/lib/seo/index.ts
+++ b/apps/web/src/lib/seo/index.ts
@@ -6,6 +6,7 @@ export {
     buildOgTags,
     buildTwitterTags,
     buildJsonLd,
+    truncateText,
     createWebSiteJsonLd,
     createArticleJsonLd,
     createBreadcrumbJsonLd

--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -64,13 +64,16 @@ export function createDiscussionForumPostingJsonLd(options: {
     commentCount?: number;
     upvoteCount?: number;
     image?: string;
+    /** 상위 댓글 (Google 포럼 리치 결과의 comment 노드, 최대 3개 출력) */
+    comments?: Array<{ text: string; author: string; datePublished?: string }>;
 }): JsonLdDiscussionForumPosting {
     const data: JsonLdDiscussionForumPosting = {
         '@type': 'DiscussionForumPosting',
         headline: options.headline,
         author: {
             '@type': 'Person',
-            name: options.author
+            // 삭제글 등에서 author 가 빈 값이면 name 누락 오류가 되므로 폴백
+            name: options.author?.trim() || '익명'
         },
         datePublished: options.datePublished,
         url: options.url
@@ -80,6 +83,20 @@ export function createDiscussionForumPostingJsonLd(options: {
     if (options.authorUrl) data.author.url = options.authorUrl;
     if (options.dateModified) data.dateModified = options.dateModified;
     if (options.image) data.image = options.image;
+
+    // GSC "comment 입력란 누락" 개선 — 유효한(내용·작성자 있는) 댓글만 최대 3개
+    if (options.comments?.length) {
+        const validComments = options.comments
+            .filter((c) => c.text?.trim() && c.author?.trim())
+            .slice(0, 3)
+            .map((c) => ({
+                '@type': 'Comment' as const,
+                text: c.text.trim(),
+                author: { '@type': 'Person' as const, name: c.author.trim() },
+                ...(c.datePublished ? { datePublished: c.datePublished } : {})
+            }));
+        if (validComments.length) data.comment = validComments;
+    }
 
     // 상호작용 통계 (댓글 수, 추천 수)
     if (options.commentCount !== undefined || options.upvoteCount !== undefined) {

--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -6,10 +6,12 @@ import {
     buildOgTags,
     buildTwitterTags,
     buildJsonLd,
+    truncateText,
     createArticleJsonLd,
     createBreadcrumbJsonLd,
     createWebSiteJsonLd
 } from './meta-helper';
+import { createDiscussionForumPostingJsonLd } from './json-ld';
 
 describe('SEO meta-helper', () => {
     beforeEach(() => {
@@ -149,6 +151,75 @@ describe('SEO meta-helper', () => {
 
         it('전부 null 이면 빈 문자열 (script 태그 생략)', () => {
             expect(buildJsonLd([null, undefined])).toBe('');
+        });
+    });
+
+    // GSC "잘린 유니코드 문자"(파싱 불가) 방지
+    describe('truncateText', () => {
+        it('이모지(서로게이트 쌍)가 경계에 걸려도 깨지지 않음', () => {
+            const text = 'a'.repeat(159) + '😀불닭';
+            const cut = truncateText(text, 160);
+            // .slice(0,160) 이었다면 😀 의 상위 서로게이트 반쪽이 남아 lone surrogate 발생
+            expect(/[\uD800-\uDBFF]$/.test(cut)).toBe(false);
+            expect(cut.endsWith('😀')).toBe(true);
+            expect([...cut]).toHaveLength(160);
+        });
+
+        it('길이 이내면 그대로', () => {
+            expect(truncateText('짧은 글 😀', 160)).toBe('짧은 글 😀');
+        });
+
+        it('잘린 결과의 JSON 직렬화에 lone surrogate 없음', () => {
+            const cut = truncateText('가'.repeat(158) + '🎉🎉🎉', 160);
+            const json = JSON.stringify({ text: cut });
+            expect(
+                /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+                    json
+                )
+            ).toBe(false);
+        });
+    });
+
+    // GSC "comment/headline 누락" 개선
+    describe('createDiscussionForumPostingJsonLd', () => {
+        const base = {
+            headline: '제목',
+            author: '앙님',
+            datePublished: '2026-07-08T00:00:00+09:00',
+            url: 'https://test.com/free/1'
+        };
+
+        it('comments 상위 3개만 Comment 노드로 출력', () => {
+            const ld = createDiscussionForumPostingJsonLd({
+                ...base,
+                comments: [1, 2, 3, 4, 5].map((i) => ({
+                    text: `댓글${i}`,
+                    author: `유저${i}`,
+                    datePublished: '2026-07-08T00:00:00+09:00'
+                }))
+            });
+            expect(ld.comment).toHaveLength(3);
+            expect(ld.comment![0]).toMatchObject({
+                '@type': 'Comment',
+                text: '댓글1',
+                author: { '@type': 'Person', name: '유저1' }
+            });
+        });
+
+        it('내용/작성자 빈 댓글은 제외, 전부 무효면 comment 필드 생략', () => {
+            const ld = createDiscussionForumPostingJsonLd({
+                ...base,
+                comments: [
+                    { text: '', author: '유저' },
+                    { text: '내용', author: '  ' }
+                ]
+            });
+            expect(ld.comment).toBeUndefined();
+        });
+
+        it('author 빈 값이면 익명 폴백 (name 누락 방지)', () => {
+            const ld = createDiscussionForumPostingJsonLd({ ...base, author: '' });
+            expect(ld.author.name).toBe('익명');
         });
     });
 });

--- a/apps/web/src/lib/seo/meta-helper.ts
+++ b/apps/web/src/lib/seo/meta-helper.ts
@@ -90,6 +90,16 @@ export function buildTwitterTags(meta: SeoMeta, twitter?: TwitterMeta): Record<s
     return tags;
 }
 
+/** 유니코드 안전 문자열 자르기 (SEO description/text 용)
+ * String.prototype.slice 는 UTF-16 코드유닛 단위라 이모지(서로게이트 쌍)가 경계에 걸리면
+ * 반쪽(lone surrogate)만 남아 GSC "잘린 유니코드 문자"(파싱 불가, 심각) 오류가 된다.
+ * 코드포인트 단위로 잘라 서로게이트가 절대 깨지지 않게 한다. */
+export function truncateText(text: string, maxLength: number): string {
+    const points = [...text];
+    if (points.length <= maxLength) return text;
+    return points.slice(0, maxLength).join('');
+}
+
 /** JSON-LD 스크립트 문자열 생성
  * null/undefined 항목은 제외한다 (생성 헬퍼가 유효하지 않은 데이터에 null 을 반환하는 경우).
  * 유효 항목이 없으면 빈 문자열 → SeoHead 의 {#if jsonLdScript} 가 스크립트 자체를 생략. */

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -107,6 +107,12 @@ export interface JsonLdDiscussionForumPosting {
         interactionType: string;
         userInteractionCount: number;
     }>;
+    comment?: Array<{
+        '@type': 'Comment';
+        text: string;
+        author: { '@type': 'Person'; name: string };
+        datePublished?: string;
+    }>;
 }
 
 /** JSON-LD 구조화 데이터 - FAQPage */

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -67,7 +67,8 @@
         createArticleJsonLd,
         createBreadcrumbJsonLd,
         createDiscussionForumPostingJsonLd,
-        getSiteUrl
+        getSiteUrl,
+        truncateText
     } from '$lib/seo/index.js';
     import type { SeoConfig } from '$lib/seo/types.js';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
@@ -1611,8 +1612,9 @@
     }
 
     // SEO 설정
+    // truncateText: .slice() 는 이모지(서로게이트 쌍)를 반쪽 내 GSC "잘린 유니코드"(파싱 불가) 오류가 됨
     const postDescription = $derived(
-        data.post.deleted_at ? '' : renderedPostContent.replace(/<[^>]+>/g, '').slice(0, 160)
+        data.post.deleted_at ? '' : truncateText(renderedPostContent.replace(/<[^>]+>/g, ''), 160)
     );
 
     const seoConfig: SeoConfig = $derived.by(() => {
@@ -1627,8 +1629,20 @@
         // (작성자 프로필, 댓글자 아바타 등) 를 썸네일로 잡아가는 문제 (#12417) 발생.
         const rawOgImage = data.post.thumbnail || data.post.images?.[0];
         const fallbackOgImage = publicEnv.PUBLIC_OG_FALLBACK_IMAGE || undefined;
-        const ogImageUrl = rawOgImage
-            ? `${rawOgImage}${rawOgImage.includes('?') ? '&' : '?'}v=${new Date(data.post.updated_at || data.post.created_at).getTime()}`
+        // GSC "image URL 잘못됨" 방지: 상대경로는 siteUrl 기준 절대화, http(s) 외 스킴은 fallback 으로
+        let safeOgImage: string | undefined;
+        if (rawOgImage) {
+            try {
+                const parsed = new URL(rawOgImage, siteUrl);
+                if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+                    safeOgImage = parsed.href;
+                }
+            } catch {
+                safeOgImage = undefined;
+            }
+        }
+        const ogImageUrl = safeOgImage
+            ? `${safeOgImage}${safeOgImage.includes('?') ? '&' : '?'}v=${new Date(data.post.updated_at || data.post.created_at).getTime()}`
             : fallbackOgImage;
 
         return {
@@ -1646,7 +1660,7 @@
                 image: ogImageUrl
             },
             twitter: {
-                card: rawOgImage ? 'summary_large_image' : 'summary',
+                card: safeOgImage ? 'summary_large_image' : 'summary',
                 title: data.post.title,
                 description: postDescription,
                 image: ogImageUrl
@@ -1654,7 +1668,8 @@
             jsonLd: [
                 // DiscussionForumPosting - 커뮤니티 게시글에 최적화된 구조화 데이터
                 createDiscussionForumPostingJsonLd({
-                    headline: data.post.title,
+                    // 빈 제목 글에서 headline 누락(GSC) 방지 — 게시판명 폴백
+                    headline: data.post.title?.trim() || boardTitle,
                     text: postDescription,
                     author: data.post.deleted_at ? '' : data.post.author,
                     authorUrl: data.post.deleted_at ? undefined : authorUrl,
@@ -1663,11 +1678,28 @@
                     url: postUrl,
                     commentCount: comments.length,
                     upvoteCount: data.post.likes || 0,
-                    image: ogImageUrl
+                    image: ogImageUrl,
+                    // 상위 원댓글 3개 (비밀·삭제·잠금·제재·차단 댓글 제외 — 마스킹 정책 준수)
+                    comments: comments
+                        .filter(
+                            (c) =>
+                                (c.depth ?? 0) === 0 &&
+                                !c.is_secret &&
+                                !c.deleted_at &&
+                                !c.is_restricted &&
+                                !c.is_discipline_related &&
+                                !c.is_blocked
+                        )
+                        .slice(0, 3)
+                        .map((c) => ({
+                            text: truncateText(c.content.replace(/<[^>]+>/g, '').trim(), 200),
+                            author: c.author,
+                            datePublished: c.created_at
+                        }))
                 }),
                 // Article - 일반 검색 결과용 (폴백)
                 createArticleJsonLd({
-                    headline: data.post.title,
+                    headline: data.post.title?.trim() || boardTitle,
                     author: data.post.deleted_at ? '' : data.post.author,
                     datePublished: data.post.created_at,
                     dateModified: data.post.updated_at || data.post.created_at,


### PR DESCRIPTION
## 배경
Search Console 알림 3통 대응:
- **파싱할 수 없는 구조화 데이터: 잘린 유니코드 문자** (심각)
- 토론 포럼: **comment 누락** / **headline 누락** / **image URL 잘못됨** (비심각 3건)

## 원인 → 수정
| 문제 | 원인 | 수정 |
|---|---|---|
| 🔴 잘린 유니코드 | 본문 요약 `.slice(0,160)` 이 UTF-16 코드유닛 단위라 이모지(서로게이트 쌍)가 경계에 걸리면 반쪽만 남음 | `truncateText()` 유틸 신설 — 코드포인트 단위 자르기로 원천 차단 |
| headline 누락 | `data.post.title` 폴백 없음 (빈 제목 글) | 게시판명 폴백 (Discussion/Article 공통) + author 빈 값 '익명' 폴백 |
| image URL 잘못 | `thumbnail` 을 검증 없이 사용 (상대경로·이상값) | `new URL(raw, siteUrl)` 절대화 + http(s) 검증, 아니면 fallback 이미지 |
| comment 누락 | DiscussionForumPosting 에 comment 배열 미구현 (전 글 해당) | 상위 원댓글 3개를 Comment 노드로 출력. **비밀·삭제·잠금(신고)·제재근거·차단 댓글 제외** (마스킹 정책 준수) |

## 검증
- 단위 테스트 24/24 통과 (신규 6종: 이모지 경계 lone-surrogate 부재, comment 필터/3개 제한, author 폴백)
- svelte-check 0 errors
- 라이브 실측 14건 병행 (comment 누락 = 14/14 구조적 확인, 나머지는 엣지)

## 배포 후
- Googlebot UA 로 글 상세 JSON-LD 재검증 (lone surrogate 0 · comment 노드 출력 · image 전부 https)
- GSC 보고서는 재크롤에 따라 자연 감소 (비심각 3건은 별도 Validate 불필요)