### PR TITLE
feat(block): 회원별 차단 범위 UI — 쪽지만 차단 (#12916) [PR-2 프론트]

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -25,6 +25,7 @@ import type {
     MyActivity,
     MyComment,
     BlockedMember,
+    BlockScope,
     UploadedFile,
     PresignedUrlResponse,
     PostAttachment,
@@ -1515,8 +1516,11 @@ class ApiClient {
      * 회원 차단
      * 🔒 인증 필요
      */
-    async blockMember(memberId: string): Promise<void> {
-        await this.request<void>(`/members/${memberId}/block`, { method: 'POST' });
+    async blockMember(memberId: string, scope: BlockScope = 'all'): Promise<void> {
+        await this.request<void>(`/members/${memberId}/block`, {
+            method: 'POST',
+            body: JSON.stringify({ scope })
+        });
     }
 
     /**

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -567,10 +567,14 @@ export interface BoardStat {
 }
 
 // 차단 회원 정보
+// 차단 범위 (#12916): all=글+댓글+쪽지, message=쪽지만, content=글/댓글만
+export type BlockScope = 'all' | 'message' | 'content';
+
 export interface BlockedMember {
     mb_id: string;
     mb_name: string;
     blocked_at: string;
+    scope?: BlockScope;
 }
 
 // 게시글 작성 요청

--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -90,18 +90,26 @@
 
     let blockLoading = $state(false);
 
-    async function handleBlock(): Promise<void> {
+    async function handleBlock(scope: 'all' | 'message' = 'all'): Promise<void> {
         if (!authStore.isAuthenticated) {
             authStore.redirectToLogin();
             return;
         }
         if (blockLoading) return;
-        if (!confirm(`${authorName}님을 차단하시겠습니까?`)) return;
+        const confirmMsg =
+            scope === 'message'
+                ? `${authorName}님의 쪽지만 차단하시겠습니까? (게시글·댓글은 그대로 표시됩니다)`
+                : `${authorName}님을 차단하시겠습니까?`;
+        if (!confirm(confirmMsg)) return;
         blockLoading = true;
         try {
-            await apiClient.blockMember(authorId);
-            blockedUsersStore.add(authorId);
-            alert(`${authorName}님을 차단했습니다.`);
+            await apiClient.blockMember(authorId, scope);
+            blockedUsersStore.add(authorId, scope);
+            alert(
+                scope === 'message'
+                    ? `${authorName}님의 쪽지를 차단했습니다.`
+                    : `${authorName}님을 차단했습니다.`
+            );
         } catch (err) {
             console.error('[Block] Failed:', authorId, err);
             alert('차단 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
@@ -257,8 +265,16 @@
                         쪽지 보내기
                     </DropdownMenu.Item>
                     <DropdownMenu.Item
+                        class="cursor-pointer gap-2"
+                        onclick={() => handleBlock('message')}
+                        disabled={blockLoading}
+                    >
+                        <Ban class="h-3.5 w-3.5" />
+                        {blockLoading ? '처리 중...' : '쪽지만 차단'}
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
                         class="text-destructive cursor-pointer gap-2"
-                        onclick={handleBlock}
+                        onclick={() => handleBlock('all')}
                         disabled={blockLoading}
                     >
                         <Ban class="h-3.5 w-3.5" />

--- a/apps/web/src/lib/stores/blocked-users.svelte.ts
+++ b/apps/web/src/lib/stores/blocked-users.svelte.ts
@@ -17,7 +17,9 @@ async function load(): Promise<void> {
     if (loaded) return;
     try {
         const members = await apiClient.getBlockedMembers();
-        blockedIds = new Set(members.map((m) => m.mb_id));
+        // #12916: 이 Set 은 글/댓글 숨김에 쓰이므로 "쪽지만 차단"(message)은 제외한다.
+        // scope 미지정(구버전)은 전체 차단으로 간주해 포함.
+        blockedIds = new Set(members.filter((m) => m.scope !== 'message').map((m) => m.mb_id));
         loaded = true;
     } catch {
         // 비로그인 또는 API 실패 시 무시
@@ -32,9 +34,15 @@ function isBlocked(memberId: string): boolean {
 }
 
 /**
- * 차단 추가 (프로필에서 차단 시 로컬 동기화)
+ * 차단 추가 (프로필에서 차단 시 로컬 동기화).
+ * scope='message'(쪽지만 차단)는 글/댓글 숨김 대상이 아니므로 Set 에서 제외한다 (#12916).
  */
-function add(memberId: string): void {
+function add(memberId: string, scope: 'all' | 'message' | 'content' = 'all'): void {
+    if (scope === 'message') {
+        // 쪽지만 차단 → 콘텐츠 숨김 Set 에는 넣지 않되, 기존에 있었다면 제거(범위 축소 반영).
+        remove(memberId);
+        return;
+    }
     blockedIds = new Set([...blockedIds, memberId]);
 }
 

--- a/apps/web/src/routes/my/blocked/+page.svelte
+++ b/apps/web/src/routes/my/blocked/+page.svelte
@@ -44,6 +44,25 @@
         }
     }
 
+    // 차단 범위 변경 (#12916): 전체 ↔ 쪽지만. blockMember 는 이미 차단된 경우 범위만 갱신.
+    let scopeChangingId = $state<string | null>(null);
+    async function handleScopeChange(member: BlockedMember): Promise<void> {
+        const current = member.scope ?? 'all';
+        const next = current === 'message' ? 'all' : 'message';
+        scopeChangingId = member.mb_id;
+        try {
+            await apiClient.blockMember(member.mb_id, next);
+            blockedMembers = blockedMembers.map((m) =>
+                m.mb_id === member.mb_id ? { ...m, scope: next } : m
+            );
+        } catch (err) {
+            console.error('차단 범위 변경 실패:', err);
+            alert('차단 범위 변경에 실패했습니다.');
+        } finally {
+            scopeChangingId = null;
+        }
+    }
+
     // 회원 프로필로 이동
     function goToProfile(memberId: string): void {
         goto(`/member/${memberId}`);
@@ -61,7 +80,10 @@
             <Ban class="h-6 w-6" />
             차단 목록
         </h1>
-        <p class="text-secondary-foreground mt-1">차단한 회원의 글과 댓글이 숨겨집니다.</p>
+        <p class="text-secondary-foreground mt-1">
+            전체 차단은 글·댓글이 숨겨지고 쪽지도 차단됩니다. 쪽지만 차단은 글·댓글은 그대로 보이고
+            쪽지만 차단됩니다.
+        </p>
     </div>
 
     <!-- 에러 메시지 -->
@@ -102,18 +124,42 @@
                                             {member.mb_name}
                                         </button>
                                         <p class="text-muted-foreground text-xs">
-                                            {formatDate(member.blocked_at)} 차단
+                                            {formatDate(member.blocked_at)} 차단 ·
+                                            <span class="font-medium">
+                                                {(member.scope ?? 'all') === 'message'
+                                                    ? '쪽지만 차단'
+                                                    : '전체 차단'}
+                                            </span>
                                         </p>
                                     </div>
                                 </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onclick={() => handleUnblock(member.mb_id)}
-                                    disabled={unblockingId === member.mb_id}
-                                >
-                                    {unblockingId === member.mb_id ? '해제 중...' : '차단 해제'}
-                                </Button>
+                                <div class="flex items-center gap-2">
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onclick={() => handleScopeChange(member)}
+                                        disabled={scopeChangingId === member.mb_id}
+                                        title={(member.scope ?? 'all') === 'message'
+                                            ? '전체 차단으로 변경'
+                                            : '쪽지만 차단으로 변경'}
+                                    >
+                                        {#if scopeChangingId === member.mb_id}
+                                            변경 중...
+                                        {:else if (member.scope ?? 'all') === 'message'}
+                                            전체 차단으로
+                                        {:else}
+                                            쪽지만 차단으로
+                                        {/if}
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onclick={() => handleUnblock(member.mb_id)}
+                                        disabled={unblockingId === member.mb_id}
+                                    >
+                                        {unblockingId === member.mb_id ? '해제 중...' : '차단 해제'}
+                                    </Button>
+                                </div>
                             </li>
                         {/each}
                     </ul>


### PR DESCRIPTION
## 제안 #12916 (프론트)
백엔드 **PR damoang/angple-backend#545**(`block_scope` 컬럼) 위에 "쪽지만 차단" UI를 추가한다. **백엔드 선배포 필요.**

## 변경
- `types.ts`: `BlockScope`('all'|'message'|'content') + `BlockedMember.scope`
- `client.ts`: `blockMember(memberId, scope='all')` — body 로 scope 전달
- `stores/blocked-users.svelte.ts`: **글/댓글 숨김 Set 에서 "쪽지만 차단"(message) 제외** (`load` 필터 + `add(scope)` 조건) — 쪽지만 차단이 글을 숨기지 않도록 보장 (핵심 회귀 방지)
- `author-link.svelte`: 작성자 메뉴에 **"쪽지만 차단"** 항목 추가(기존 "차단하기"=전체 유지)
- `routes/my/blocked/+page.svelte`: 차단 범위 라벨(전체/쪽지만) + **전체↔쪽지만 토글** 버튼 + 안내 문구

## 하위호환
scope 미지정 → 전체 차단. 기존 차단·구 동작 불변.

## 검증
- [ ] CI: svelte-check / eslint (로컬 worktree node_modules 부재로 CI 위임)
- [ ] canary: "쪽지만 차단" 시 그 회원 글/댓글 **정상 노출** + 쪽지 전송 **거부**
- [ ] "전체 차단"은 글 숨김 + 쪽지 거부 유지
- [ ] my/blocked 에서 범위 토글 동작