### PR TITLE
feat(discipline): 이용제한 근거 글·댓글 공개 시 워터마크 표시 (#12920)

### DIFF
--- a/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
+++ b/apps/web/src/lib/components/ui/discipline-related/disciplined-content.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+    import { onDestroy } from 'svelte';
     import Scale from '@lucide/svelte/icons/scale';
     import Eye from '@lucide/svelte/icons/eye';
     import Lock from '@lucide/svelte/icons/lock';
+    import { disciplineRevealStore } from '$lib/stores/discipline-reveal.svelte.js';
+    import { authStore } from '$lib/stores/auth.svelte.js';
 
     interface Props {
         children: import('svelte').Snippet;
@@ -26,6 +29,32 @@
     }: Props = $props();
 
     const label = $derived(`이용제한 근거 ${isComment ? '댓글' : '글'}`);
+
+    // #12920: 공개 인스턴스 등록 → 페이지가 revealCount > 0 이면 전체화면 워터마크 렌더.
+    // 클릭 핸들러가 아닌 상태 관찰 기반: 제목·본문이 bind:revealed 로 상태를 공유해도
+    // 인스턴스별 Symbol + 멱등 add/remove 라 이중 증감이 없다.
+    const instanceId = Symbol();
+    $effect(() => {
+        if (revealed) {
+            disciplineRevealStore.add(instanceId);
+        } else {
+            disciplineRevealStore.remove(instanceId);
+        }
+    });
+    onDestroy(() => {
+        disciplineRevealStore.remove(instanceId);
+    });
+
+    // #12920: 좁은 영역(한 줄 댓글 등) 캡처 시 전체화면 워터마크가 프레임 밖일 수 있어,
+    // 공개된 블록 자체에 고밀도 보강 워터마크를 겹친다. viewer(SSR) 우선, authStore 폴백.
+    const overlayText = $derived.by(() => {
+        const v = disciplineRevealStore.viewer;
+        const nickname = v?.nickname || authStore.user?.mb_name || '';
+        const userId = v?.userId || authStore.user?.mb_id || '';
+        const clientIp = v?.clientIp || '';
+        if (!nickname && !userId) return '';
+        return `@${nickname}(${userId}) ${clientIp} `.repeat(120);
+    });
 </script>
 
 {#if inline}
@@ -70,6 +99,17 @@
             >
                 {@render children()}
             </div>
+            {#if revealed && overlayText}
+                <!-- #12920: 좁은 영역 보강 워터마크. leading-4(1rem)가 댓글 한 줄
+                     line-height 보다 작아 어떤 한 줄 캡처에도 식별 텍스트가 교차한다.
+                     무회전(모서리 공백 방지), inline(제목) 변형에는 미적용. -->
+                <div
+                    class="pointer-events-none absolute inset-0 select-none overflow-hidden break-all text-[10px] leading-4 text-red-500/10"
+                    aria-hidden="true"
+                >
+                    {overlayText}
+                </div>
+            {/if}
             {#if !revealed}
                 <div
                     class="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-amber-500/5 p-4 backdrop-blur-sm"

--- a/apps/web/src/lib/stores/discipline-reveal.svelte.ts
+++ b/apps/web/src/lib/stores/discipline-reveal.svelte.ts
@@ -1,0 +1,56 @@
+/**
+ * 이용제한 근거 콘텐츠 공개 상태 스토어 (Svelte 5 Runes)
+ *
+ * #12920: 이용제한 근거 글·댓글을 [보기]로 공개하면 전체화면 워터마크를
+ * 띄우기 위한 트리거. DisciplinedContent 인스턴스가 공개 시 자신의
+ * Symbol 을 등록하고, 페이지는 revealCount > 0 이면 Watermark 를 렌더한다.
+ * viewer 는 SSR(+page.server.ts)에서 내려준 열람자 정보(닉네임/ID/IP).
+ */
+
+let revealedIds = $state<Set<symbol>>(new Set());
+let viewer = $state<{ nickname: string; userId: string; clientIp: string } | null>(null);
+
+/**
+ * 공개된 인스턴스 등록 (멱등 — 이미 있으면 무시)
+ */
+function add(id: symbol): void {
+    if (revealedIds.has(id)) return;
+    revealedIds = new Set([...revealedIds, id]);
+}
+
+/**
+ * 인스턴스 등록 해제 (멱등 — 없으면 무시)
+ */
+function remove(id: symbol): void {
+    if (!revealedIds.has(id)) return;
+    const next = new Set(revealedIds);
+    next.delete(id);
+    revealedIds = next;
+}
+
+/**
+ * 열람자 정보 설정 (게시글 상세 페이지 진입 시)
+ */
+function setViewer(v: { nickname: string; userId: string; clientIp: string } | null): void {
+    viewer = v;
+}
+
+/**
+ * 열람자 정보 초기화 (페이지 이탈 시 — 모듈 싱글톤 잔존 방지)
+ */
+function clearViewer(): void {
+    viewer = null;
+}
+
+export const disciplineRevealStore = {
+    get revealCount() {
+        return revealedIds.size;
+    },
+    get viewer() {
+        return viewer;
+    },
+    add,
+    remove,
+    setViewer,
+    clearViewer
+};

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -626,19 +626,30 @@ export const load: PageServerLoad = async ({
         })();
 
         // 워터마크 대상 게시판: 열람자 정보 전달
+        // 로그인 사용자에게만 발급 — 익명 SSR/데이터 캐시 응답에 최초 방문자 IP 가
+        // 잔존하는 것을 방지 (#12920 부수 수정. 기존에도 워터마크 식별 대상은 로그인 사용자).
         let watermark: { nickname: string; userId: string; clientIp: string } | null = null;
-        if (boardId === 'truthroom') {
+
+        // #12920: 이용제한 근거 글·댓글 [보기] 공개 시 전체화면 워터마크용 열람자 정보.
+        // 동일하게 로그인 사용자에게만 발급, 비로그인은 null.
+        let disciplineViewer: { nickname: string; userId: string; clientIp: string } | null = null;
+
+        if (locals.user) {
             let clientIp = '';
             try {
                 clientIp = getClientAddress();
             } catch {
                 clientIp = '';
             }
-            watermark = {
-                nickname: locals.user?.nickname || '',
-                userId: locals.user?.id || '',
+            const viewerInfo = {
+                nickname: locals.user.nickname || '',
+                userId: locals.user.id || '',
                 clientIp
             };
+            disciplineViewer = viewerInfo;
+            if (boardId === 'truthroom') {
+                watermark = viewerInfo;
+            }
         }
 
         // 잠긴 게시글 → 진실의방 글 ID 조회
@@ -710,6 +721,7 @@ export const load: PageServerLoad = async ({
             isRestricted: isRestrictedUser(locals.user as AuthUser | null),
             promotionExpired,
             watermark,
+            disciplineViewer,
             truthroomPostId,
             originalPostLink,
             recentPosts,

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -626,14 +626,24 @@ export const load: PageServerLoad = async ({
         })();
 
         // 워터마크 대상 게시판: 열람자 정보 전달
-        // 로그인 사용자에게만 발급 — 익명 SSR/데이터 캐시 응답에 최초 방문자 IP 가
-        // 잔존하는 것을 방지 (#12920 부수 수정. 기존에도 워터마크 식별 대상은 로그인 사용자).
         let watermark: { nickname: string; userId: string; clientIp: string } | null = null;
+        if (boardId === 'truthroom') {
+            let clientIp = '';
+            try {
+                clientIp = getClientAddress();
+            } catch {
+                clientIp = '';
+            }
+            watermark = {
+                nickname: locals.user?.nickname || '',
+                userId: locals.user?.id || '',
+                clientIp
+            };
+        }
 
         // #12920: 이용제한 근거 글·댓글 [보기] 공개 시 전체화면 워터마크용 열람자 정보.
-        // 동일하게 로그인 사용자에게만 발급, 비로그인은 null.
+        // 로그인 사용자에게만 발급 — 익명 SSR/데이터 캐시 응답에 IP 가 잔존하지 않게 한다.
         let disciplineViewer: { nickname: string; userId: string; clientIp: string } | null = null;
-
         if (locals.user) {
             let clientIp = '';
             try {
@@ -641,15 +651,11 @@ export const load: PageServerLoad = async ({
             } catch {
                 clientIp = '';
             }
-            const viewerInfo = {
+            disciplineViewer = {
                 nickname: locals.user.nickname || '',
                 userId: locals.user.id || '',
                 clientIp
             };
-            disciplineViewer = viewerInfo;
-            if (boardId === 'truthroom') {
-                watermark = viewerInfo;
-            }
         }
 
         // 잠긴 게시글 → 진실의방 글 ID 조회

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -128,6 +128,7 @@
     import { createScrollDepthObserver, trackEvent, trackPostView } from '$lib/services/ga4.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { commentTracker } from '$lib/stores/comment-tracker.svelte.js';
+    import { disciplineRevealStore } from '$lib/stores/discipline-reveal.svelte.js';
     import { onDestroy } from 'svelte';
     import { TouchGestureService } from '$lib/services/touch-gestures.svelte.js';
 
@@ -275,6 +276,15 @@
     // 게시판 정보
     const boardId = $derived(data.boardId);
     const boardTitle = $derived(data.board?.subject || data.board?.name || boardId);
+
+    // #12920: 이용제한 근거 콘텐츠 공개 워터마크용 열람자 정보를 스토어에 동기화.
+    // 스토어가 모듈 싱글톤이라 teardown 에서 반드시 정리해 페이지 이탈 후 잔존을 방지.
+    $effect(() => {
+        disciplineRevealStore.setViewer(data.disciplineViewer ?? null);
+        return () => {
+            disciplineRevealStore.clearViewer();
+        };
+    });
 
     // 특수 게시판 타입 감지
     const boardType = $derived(
@@ -1736,6 +1746,18 @@
         userId={data.watermark.userId}
         clientIp={data.watermark.clientIp}
         pageTitle={boardTitle}
+    />
+{/if}
+
+<!-- #12920: 이용제한 근거 글·댓글 [보기] 공개 시 전체화면 워터마크.
+     truthroom 워터마크와의 이중 렌더 방지를 위해 !data.watermark 가드. -->
+{#if !data.watermark && disciplineRevealStore.revealCount > 0 && data.disciplineViewer}
+    <Watermark
+        nickname={data.disciplineViewer.nickname}
+        userId={data.disciplineViewer.userId}
+        clientIp={data.disciplineViewer.clientIp}
+        pageTitle={boardTitle}
+        redirectUrl={`/${boardId}`}
     />
 {/if}
 


### PR DESCRIPTION
## 배경 (#12920)

이용제한 근거 글·댓글은 현재 blur 처리 후 [보기] 버튼으로 로그인 회원만 열람할 수 있습니다. 다만 공개 후 캡처·유포에 대한 억지력이 없어, 열람자 식별 워터마크를 2중으로 추가합니다.

1. **전체화면 워터마크**: 근거 콘텐츠를 하나라도 [보기]로 공개하면 진실의방과 동일한 전체화면 워터마크(닉네임/ID/IP/시각)를 표시합니다.
2. **좁은 영역 보강 워터마크**: 한 줄 댓글처럼 좁은 영역만 잘라 캡처하면 전체화면 워터마크가 프레임 밖일 수 있어, 공개된 블록 자체에 고밀도(줄간격 1rem) 식별 텍스트 레이어를 겹칩니다. 어떤 한 줄 캡처에도 식별 텍스트가 교차합니다.

## 변경 사항

| 파일 | 변경 |
|------|------|
| `lib/stores/discipline-reveal.svelte.ts` (신규) | 공개 인스턴스 Symbol 등록(멱등 add/remove) + SSR 열람자 정보(viewer) 보관 스토어 |
| `routes/[boardId]/[postId]/+page.server.ts` | 로그인 사용자에 한해 `disciplineViewer`(닉네임/ID/IP) 전달. truthroom 워터마크 동작은 무변경. 익명 SSR 캐시의 truthroom IP 잔존 문제는 별도 후속 PR로 처리 예정 |
| `routes/[boardId]/[postId]/+page.svelte` | 공개 인스턴스가 1개 이상이면 전체화면 `Watermark` 렌더. 페이지 이탈 시 스토어 viewer 정리 |
| `lib/components/ui/discipline-related/disciplined-content.svelte` | 상태 관찰(`$effect`) 기반 인스턴스 등록 + 블록 변형(본문·댓글)에 보강 워터마크 레이어. **props 시그니처 무변경** (사용처 3곳 무수정) |
| `lib/components/ui/watermark/watermark.svelte` | **무변경** (truthroom 회귀 없음) |

## 하위 호환

- 비로그인 사용자: `disciplineViewer = null`, [보기] 자체가 없어 동작 무영향. 익명 캐시 응답에 `disciplineViewer` 로 인한 개인정보(IP) 추가 없음.
- truthroom: 기존 워터마크 동작 유지. 새 워터마크는 `!data.watermark` 가드로 이중 렌더 방지.
- 인스턴스 등록이 클릭 핸들러가 아닌 상태 관찰 기반이라, 제목·본문이 `bind:revealed`로 상태를 공유해도 이중 증감 없음(Symbol별 멱등 add/remove).

## 검증 체크리스트

- [ ] 이용제한 근거 글에서 [보기] 클릭 → 전체화면 워터마크 표출
- [ ] 새로고침 시 blur 상태로 복귀(워터마크 미표출)
- [ ] 한 줄 댓글 공개 시 블록 내 보강 워터마크 텍스트 교차 확인
- [ ] truthroom 글에서 워터마크 1개만 렌더(이중 렌더 없음)
- [ ] 워터마크 DOM 변조 시 목록으로 이탈(기존 Watermark 변조 감지 동작)
- [ ] 비로그인 응답(`__data.json` 포함)에 `disciplineViewer = null`
- [ ] truthroom 익명 열람 시 기존 워터마크 그대로 표출(base 대비 diff 0)

`pnpm check`/`pnpm lint`는 로컬 worktree에 node_modules가 없어 CI에 위임합니다(prettier 포맷은 로컬 검증 완료).

## 알려진 한계

- 클라이언트 렌더 워터마크 특성상 완전한 유출 차단이 아닌 **억지력** 목적입니다(개발자 도구로 제거 가능하나, 변조 감지 시 이탈).
- 번역 확장 프로그램 등 DOM을 변경하는 확장 사용 시 변조 감지 오탐으로 목록 이탈이 발생할 수 있습니다(기존 truthroom 워터마크와 동일한 특성).
