### PR TITLE
fix(board): 비밀글을 관리자도 열람 가능하게 — canViewSecret에 isAdmin 추가

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1012,8 +1012,12 @@
     // 직접홍보 게시판 만료 여부
     const promotionExpired = $derived(data.promotionExpired === true && !isAuthor);
 
-    // 비밀글 접근 권한 (작성자만 열람 가능, 홍보 만료 글도 차단)
-    const canViewSecret = $derived((!data.post.is_secret || isAuthor) && !promotionExpired);
+    // 비밀글 접근 권한 (작성자 또는 관리자 열람 가능, 홍보 만료 글도 차단)
+    // 백엔드 비밀글 strip 은 작성자+관리자에게 내용을 내려주는데 프론트 판정에
+    // isAdmin 이 빠져 관리자가 "비밀글입니다"만 보던 불일치 수정.
+    const canViewSecret = $derived(
+        (!data.post.is_secret || isAuthor || isAdmin) && !promotionExpired
+    );
 
     // 댓글 레이아웃 (관리자 변경 시 즉시 반영용)
     // eslint-disable-next-line svelte/prefer-writable-derived -- layout must refresh from route data while remaining locally writable


### PR DESCRIPTION
## 문제
관리자가 타인(예: ai) 작성 비밀글 상세에 들어가면 "비밀글입니다"만 표시됩니다.

- 백엔드(`cmd/api/main.go` 비밀글 접근 제어): 작성자 **또는 관리자(level>=10)** 에게 내용 전송 ✅
- 글쓰기 폼 안내: "비밀글은 작성자와 관리자만 볼 수 있습니다" ✅
- 프론트 글 상세 판정: `canViewSecret = (!is_secret || isAuthor) && !promotionExpired` — **isAdmin 누락** ❌

즉 데이터는 내려오는데 화면에서만 가려지는 불일치입니다. (운영 중 실사례: 관리자 계정으로 test 보드 비밀글 열람 불가)

## 수정
`[boardId]/[postId]/+page.svelte` 1줄 — 기존 파생값 `isAdmin`(mb_level>=10)을 `canViewSecret`에 추가.

## 검증
- [ ] 관리자 계정: 타인 비밀글 상세 → 본문·댓글 정상 표시
- [ ] 일반 계정: 타인 비밀글 → "비밀글입니다" 유지 (회귀 없음)
- [ ] 작성자 본인 열람 유지