### PR TITLE
fix(seo): 게시판별 고유 meta description (layout 중복 해소, CTR 개선)

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -173,6 +173,16 @@
     const isAdminRoute = $derived($page.url.pathname.startsWith('/admin'));
     const isInstallRoute = $derived($page.url.pathname.startsWith('/install'));
 
+    // <SeoHead> 로 자체 meta description 을 렌더하는 라우트 목록.
+    // 이 라우트들에서 layout 이 기본 description 을 함께 내보내면 태그가 2개가 되어
+    // 검색엔진(first-wins)이 사이트 슬로건을 채택 → 전 페이지 동일 description 중복.
+    // SeoHead 를 새 라우트에 추가하면 여기에도 route id 를 추가할 것.
+    const SEO_HEAD_ROUTES = ['/', '/[boardId]', '/[boardId]/[postId]', '/groups', '/explore'];
+    const routeHasSeoHead = $derived(
+        SEO_HEAD_ROUTES.includes($page.route.id ?? '') ||
+            ($page.route.id ?? '').startsWith('/games')
+    );
+
     // 동적 import: member-memo 플러그인 모달
     let MemoModal = $state<Component | null>(null);
 
@@ -764,8 +774,11 @@
         과거 여기서 data.site 기본 OG 를 함께 내보내 글 페이지에 og:title·og:description 가
         2개씩 렌더 → 카톡/페북 크롤러(first-wins)가 글 제목 대신 사이트명을 가져가던 회귀(#12699).
         site 기본 description 은 SeoHead 미사용 유틸 페이지용으로만 남긴다.
+        일반 description 도 같은 first-wins 문제: SeoHead 라우트에서 함께 내보내면 태그가
+        2개가 되어 Google 이 이 기본값(사이트 슬로건)을 채택 → 전 게시판/글이 동일 description
+        으로 집계(중복 메타, CTR 손실). SeoHead 를 렌더하는 라우트에서는 여기서 내보내지 않는다.
     -->
-    {#if data.site?.description}
+    {#if data.site?.description && !routeHasSeoHead}
         <meta name="description" content={data.site.description} />
     {/if}
     {#if data.site?.keywords?.length}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -690,7 +690,10 @@
                     : currentPage > 1
                       ? `${boardTitle} - ${currentPage}페이지`
                       : boardTitle,
-                description: `${boardTitle} 게시판 - ${import.meta.env.VITE_SITE_NAME || 'Angple'}`,
+                // 게시판별 고유 description — multi-tenant: site.title(런타임 resolve) 우선.
+                // layout 의 기본 description 과 함께 2개 렌더되어 전 게시판이 사이트 슬로건으로
+                // 중복 집계되던 문제의 페이지측 짝 (+layout.svelte routeHasSeoHead 참조)
+                description: `${data.site?.title || import.meta.env.VITE_SITE_NAME || 'Angple'} ${boardTitle} 게시판 — 최신 글과 인기 글, 회원들의 실시간 이야기를 만나보세요.`,
                 canonicalUrl: pageSeo.canonical,
                 noIndex: pageSeo.noIndex,
                 noFollow: pageSeo.noFollow


### PR DESCRIPTION
## 배경 (성장 엔진 축A · SEO P1)
GSC 관측 파이프라인 구축 중 발견: **모든 게시판·글 페이지의 meta description 이 사이트 슬로건으로 동일**하게 집계되고 있었습니다.

## 원인
- `+layout.svelte` 가 모든 페이지에 기본 description(사이트 슬로건)을 **먼저** 렌더
- 페이지별 SeoHead 가 두 번째 description 을 렌더 → 태그 2개
- 검색엔진은 first-wins → 전 페이지가 슬로건으로 통일 (수백 게시판 중복 메타 = CTR 손실)
- #12699 에서 og 중복은 해결했으나 일반 description 은 남아 있었습니다
- 부수: 게시판 목록 문구가 `"자유게시판 게시판 - Angple"` (어색한 중복 + 빌드타임 사이트명 오류)

## 수정
1. **layout**: SeoHead 렌더 라우트(`SEO_HEAD_ROUTES` 목록)에서는 기본 description 미출력 — 유틸 페이지에서만 유지 (og 때와 동일한 원칙)
2. **게시판 목록**: `site.title`(멀티테넌트 런타임) 기반 고유 문구로 개선
   - before: `자유게시판 게시판 - Angple` (그마저 슬로건에 가려짐)
   - after: `다모앙 자유게시판 게시판 — 최신 글과 인기 글, 회원들의 실시간 이야기를 만나보세요.`

## 검증
- svelte-check 0 errors
- 배포 후: 게시판 10곳 description 유니크 curl 확인
- 효과 측정: `seo.gsc_page_daily` 로 목록 페이지 CTR 2주 추적 (성장 파이프라인)