### PR TITLE
feat(onboarding): 신규 회원 웰컴 카드 — 가입인사 첫 기여 유도 (성장 실험 A)

### DIFF
--- a/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
+++ b/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
@@ -82,16 +82,24 @@
                 <div class="min-w-0 flex-1">
                     <p class="text-foreground text-base font-bold">앙님, 어서오세요! 💛</p>
                     <p class="text-muted-foreground mt-0.5 text-sm leading-relaxed">
-                        가입인사를 남기면 앙님들이 우르르 반겨줘요. 일부 게시판 글쓰기는 조금 활동한
-                        뒤에 열리니, 첫걸음은 인사가 딱이에요!
+                        가입인사를 남기면 앙님들이 우르르 반겨줘요. 게시판 글쓰기는 닉네임 옆에
+                        <span class="font-semibold text-amber-600 dark:text-amber-400">앙님💛</span
+                        >이 생기면 열리니, 첫걸음은 인사가 딱이에요!
                     </p>
                 </div>
-                <div class="flex shrink-0 items-center gap-2">
+                <div class="flex shrink-0 flex-wrap items-center gap-2">
                     <a
                         href="/hello"
                         class="inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-4 py-2 text-sm font-bold text-white shadow-sm transition-all hover:-translate-y-0.5 hover:bg-amber-600 hover:shadow-md"
                     >
                         💌 가입인사 남기기
+                    </a>
+                    <!-- 운영 안내글: 환영 안내(20754) — 새내기 필독 -->
+                    <a
+                        href="/hello/20754"
+                        class="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 rounded-full border border-amber-200 px-3 py-2 text-xs font-semibold transition-colors hover:border-amber-400 dark:border-amber-800/50"
+                    >
+                        📖 새내기 안내
                     </a>
                 </div>
             </div>

--- a/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
+++ b/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    /**
+     * 신규 회원 웰컴 온보딩 카드 (성장 엔진 축B — 실험 A)
+     *
+     * 목표: 가입→첫 기여 전환율 개선 (12주 실측 14.2%).
+     * 노출 조건 (전부 만족 시에만):
+     *  1) 로그인 && as_level ≤ 1 (XP 거의 없음 = 활동 전 — 프로필 조회 게이트)
+     *  2) 내 프로필: 가입 14일 이내 && 글/댓글 0 (정확한 "신규 미기여" 판별)
+     *  3) 닫기 안 누름 (localStorage)
+     * 첫 기여를 하면 post_count/comment_count > 0 이 되어 자연히 사라진다.
+     *
+     * 첫 기여 유도는 가입인사(/hello) 게시판으로 — 자유게시판 등은 신규에게
+     * 글쓰기가 제한될 수 있어, 항상 열려 있는 인사 게시판이 첫걸음으로 적합.
+     */
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { apiClient } from '$lib/api/index.js';
+
+    const DISMISS_KEY = 'angple_welcome_onboarding_dismissed';
+    const NEW_MEMBER_DAYS = 14;
+
+    let show = $state(false);
+    let checked = $state(false);
+
+    $effect(() => {
+        const user = authStore.user;
+        if (checked || !user) return;
+        if ((user.as_level ?? 1) > 1) {
+            checked = true;
+            return;
+        }
+        try {
+            if (localStorage.getItem(DISMISS_KEY)) {
+                checked = true;
+                return;
+            }
+        } catch {
+            checked = true;
+            return;
+        }
+        checked = true;
+        void (async () => {
+            try {
+                const profile = await apiClient.getMemberProfile(user.mb_id);
+                const signedAt = new Date(profile.mb_datetime).getTime();
+                const daysSince = (Date.now() - signedAt) / 86400000;
+                const contributed = (profile.post_count ?? 0) + (profile.comment_count ?? 0) > 0;
+                if (!Number.isNaN(signedAt) && daysSince <= NEW_MEMBER_DAYS && !contributed) {
+                    show = true;
+                }
+            } catch {
+                // 프로필 조회 실패 시 조용히 미노출 (온보딩은 있으면 좋은 기능)
+            }
+        })();
+    });
+
+    function dismiss() {
+        show = false;
+        try {
+            localStorage.setItem(DISMISS_KEY, String(Date.now()));
+        } catch {
+            /* localStorage 불가 환경 — 세션 내 숨김만 */
+        }
+    }
+</script>
+
+{#if show}
+    <div class="mx-auto mb-4 max-w-5xl px-4 pt-4">
+        <div
+            class="relative overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 px-5 py-4 shadow-sm dark:border-amber-800/40 dark:from-amber-950/40 dark:via-orange-950/30 dark:to-yellow-950/30"
+        >
+            <button
+                type="button"
+                onclick={dismiss}
+                class="text-muted-foreground hover:text-foreground absolute right-3 top-3 rounded-full p-1 text-lg leading-none transition-colors"
+                aria-label="환영 안내 닫기"
+            >
+                ✕
+            </button>
+
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                <div class="shrink-0 text-4xl" aria-hidden="true">🐣</div>
+                <div class="min-w-0 flex-1">
+                    <p class="text-foreground text-base font-bold">앙님, 어서오세요! 💛</p>
+                    <p class="text-muted-foreground mt-0.5 text-sm leading-relaxed">
+                        가입인사를 남기면 앙님들이 우르르 반겨줘요. 일부 게시판 글쓰기는 조금 활동한
+                        뒤에 열리니, 첫걸음은 인사가 딱이에요!
+                    </p>
+                </div>
+                <div class="flex shrink-0 items-center gap-2">
+                    <a
+                        href="/hello"
+                        class="inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-4 py-2 text-sm font-bold text-white shadow-sm transition-all hover:-translate-y-0.5 hover:bg-amber-600 hover:shadow-md"
+                    >
+                        💌 가입인사 남기기
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -7,6 +7,7 @@
     import { SeoHead, createWebSiteJsonLd, getSiteUrl } from '$lib/seo/index.js';
     import type { SeoConfig } from '$lib/seo/types.js';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
+    import WelcomeOnboarding from '$lib/components/features/onboarding/welcome-onboarding.svelte';
     import { getThemePageTemplate } from '$lib/themes/page-registry';
     import { browser } from '$app/environment';
     import { initFromData as initCelebrationFromData } from '$lib/stores/celebration.svelte';
@@ -80,6 +81,9 @@
         </div>
     </div>
 {/if}
+
+<!-- 신규 회원 웰컴 온보딩 (가입 14일 이내 + 미기여 회원에게만, 성장 실험 A) -->
+<WelcomeOnboarding />
 
 <!-- 플러그인 슬롯: 홈 콘텐츠 직전 (위젯 영역 위) — Slot Catalog Sprint 2c -->
 <PluginSlot name="home-content-before" />

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -690,10 +690,11 @@
                     : currentPage > 1
                       ? `${boardTitle} - ${currentPage}페이지`
                       : boardTitle,
-                // 게시판별 고유 description — multi-tenant: site.title(런타임 resolve) 우선.
-                // layout 의 기본 description 과 함께 2개 렌더되어 전 게시판이 사이트 슬로건으로
-                // 중복 집계되던 문제의 페이지측 짝 (+layout.svelte routeHasSeoHead 참조)
-                description: `${data.site?.title || import.meta.env.VITE_SITE_NAME || 'Angple'} ${boardTitle} 게시판 — 최신 글과 인기 글, 회원들의 실시간 이야기를 만나보세요.`,
+                // 게시판별 고유 description — layout 기본 description 과 2개 렌더되어 전 게시판이
+                // 사이트 슬로건으로 중복 집계되던 문제의 페이지측 짝 (+layout.svelte routeHasSeoHead 참조).
+                // 사이트명은 title 태그가 담당하므로 중복 표기하지 않고, '자유게시판 게시판' 같은
+                // 접미 중복은 boardTitle 로 흡수한다.
+                description: `${boardTitle.endsWith('게시판') ? boardTitle : `${boardTitle} 게시판`} — 최신 글과 인기 글, 회원들의 실시간 이야기를 만나보세요.`,
                 canonicalUrl: pageSeo.canonical,
                 noIndex: pageSeo.noIndex,
                 noFollow: pageSeo.noFollow


### PR DESCRIPTION
## 배경 (성장 엔진 축B · 실험 A)
growth 파이프라인 실측: 최근 12주 가입 1,259명 중 첫 기여(글/댓글) 전환 **179명(14.2%)**. 가입 직후 골든타임에 방향을 안내해 전환율을 개선합니다. 설계 문서: `docs/onboarding-first-contribution-design.html`

## 내용
홈 상단 웰컴 카드 (🐣 파스텔 그라데이션, 다크모드 대응):
> 🐣 **앙님, 어서오세요! 💛**
> 가입인사를 남기면 앙님들이 우르르 반겨줘요. 일부 게시판 글쓰기는 조금 활동한 뒤에 열리니, 첫걸음은 인사가 딱이에요!
> [💌 가입인사 남기기] → /hello

## 노출 조건 (전부 만족 시)
1. 로그인 && `as_level ≤ 1` (프로필 API 호출 게이트 — 기존 회원에겐 호출 자체가 없음)
2. 내 프로필: **가입 14일 이내 && post_count+comment_count = 0**
3. 닫기(X) 안 누름 (localStorage)
- 첫 기여를 하면 조건 2 가 깨져 자동 소멸

## 왜 /hello 인가
자유게시판 등 일부 게시판은 신규 회원에게 글쓰기가 제한됨 — 항상 열려 있는 가입인사 게시판이 첫걸음으로 적합 (문구에도 반영)

## 검증
- svelte-check 0 errors
- 효과 측정: `growth.*` 코호트 — 배포 전후 주차별 2주 기여 전환율 (기준선 14.2%, 매주 월 성장 리포트 자동 포함)