### PR TITLE
fix(comment): 댓글 하트 토글 stale 해소 — 좋아요 상태 글 단위 조회 + 정렬 결정화

### DIFF
--- a/apps/web/src/lib/server/comment-likes.ts
+++ b/apps/web/src/lib/server/comment-likes.ts
@@ -21,24 +21,27 @@ export interface CommentLikeStatuses {
 const COMMENT_LIKE_STATUSES_CACHE_TTL_SEC = 30;
 
 /**
- * 댓글 좋아요/비추천 상태 배치 조회
+ * 댓글 좋아요/비추천 상태 배치 조회 — 글 단위
+ *
+ * 과거에는 SSR 1페이지 댓글 ID 목록만 조회해서, 11번째 이후(backfill) 댓글은
+ * 새로고침/재방문 시 하트 토글 상태가 영원히 비어 있었다(economy/77128 제보).
+ * 글 전체 댓글을 조인으로 한 번에 조회해 페이지네이션·정렬 순서와 절연한다.
  * @param boardId 게시판 ID
- * @param commentIds 댓글 ID 배열
+ * @param postId 글 ID (wr_parent)
  * @param userId 현재 사용자 mb_id
  */
 export async function fetchCommentLikeStatuses(
     boardId: string,
-    commentIds: number[],
+    postId: number,
     userId: string
 ): Promise<CommentLikeStatuses> {
-    if (!commentIds.length || !userId) {
+    if (!postId || !userId) {
         return { likedIds: [], dislikedIds: [] };
     }
 
     const safeBoardId = boardId.replace(/[^a-zA-Z0-9_-]/g, '');
-    const sortedIds = [...commentIds].sort((a, b) => a - b);
     const version = await getCommentReactionVersion(safeBoardId);
-    const cacheKey = `comment_like_statuses:${userId}:${safeBoardId}:${sortedIds.join(',')}:v${version}`;
+    const cacheKey = `comment_like_statuses:${userId}:${safeBoardId}:${postId}:v${version}`;
 
     try {
         const cached = await getRedis().get(cacheKey);
@@ -49,12 +52,14 @@ export async function fetchCommentLikeStatuses(
         // Redis 장애 시 DB fallback
     }
 
-    const placeholders = commentIds.map(() => '?').join(',');
-
+    // fkey1(bo_table, wr_id, mb_id) 인덱스 + 보드 테이블 PK 조인 — 글당 수십 행 수준
     const [rows] = await pool.query<GoodRow[]>(
-        `SELECT wr_id, bg_flag FROM g5_board_good
-         WHERE bo_table = ? AND wr_id IN (${placeholders}) AND mb_id = ?`,
-        [safeBoardId, ...commentIds, userId]
+        `SELECT g.wr_id, g.bg_flag
+         FROM g5_board_good g
+         JOIN ?? w ON w.wr_id = g.wr_id
+         WHERE g.bo_table = ? AND g.mb_id = ?
+           AND w.wr_parent = ? AND w.wr_is_comment = 1`,
+        [`g5_write_${safeBoardId}`, safeBoardId, userId, postId]
     );
 
     const likedIds: number[] = [];

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -522,16 +522,13 @@ export const load: PageServerLoad = async ({
                         : null
                 ),
                 (() => {
-                    if (!locals.user?.id || !commentsData.comments.items?.length) {
+                    if (!locals.user?.id) {
                         return Promise.resolve({ likedIds: [], dislikedIds: [] });
                     }
-                    const commentIds = commentsData.comments.items
-                        .map((c: { id: number | string }) => Number(c.id))
-                        .filter((id: number) => !isNaN(id));
-                    if (commentIds.length === 0) {
-                        return Promise.resolve({ likedIds: [], dislikedIds: [] });
-                    }
-                    return fetchCommentLikeStatuses(boardId, commentIds, locals.user.id).catch(
+                    // 글 단위 조회 — SSR 1페이지(10개) 밖 backfill 댓글의 하트 토글 상태
+                    // 누락 방지 (economy/77128 제보: 정렬 동률로 1페이지에서 밀린 댓글의
+                    // 좋아요가 새로고침 후 미표시되던 문제)
+                    return fetchCommentLikeStatuses(boardId, Number(postId), locals.user.id).catch(
                         () => ({
                             likedIds: [],
                             dislikedIds: []

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -183,7 +183,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
 			        wr_deleted_at, wr_deleted_by, wr_7
 			 FROM ??
 			 WHERE wr_parent = ? AND wr_is_comment = 1
-			 ORDER BY wr_comment, wr_comment_reply
+			 ORDER BY wr_comment, wr_comment_reply, wr_id
 			 LIMIT ? OFFSET ?`,
             [tableName, safePostId, limit, (effectivePage - 1) * limit]
         );


### PR DESCRIPTION
## 문제 (economy/77128 실사용 제보)
댓글 좋아요가 **서버(g5_board_good)에는 정상 기록**되는데, 새로고침/재방문 시 **하트 토글이 표시되지 않음**.

## 원인 (2중)
1. **커버리지**: `fetchCommentLikeStatuses`가 SSR 1페이지 댓글 **10개 ID만** 조회 — backfill(11번째~)로 로드된 댓글은 좋아요 상태를 가져오는 경로가 없어 영원히 빈 하트.
2. **정렬 비결정성**: 댓글 목록 `ORDER BY wr_comment, wr_comment_reply`에 `wr_id` 타이브레이커 부재 → 계층 문자열 동률(`AAAAA` 8중 — be#546의 varchar(5) truncate 산물)에서 대상 댓글(77148)이 1페이지 밖으로 밀려 조회 대상 탈락. 페이지 경계 중복/누락도 가능.

## 수정
| 파일 | 내용 |
|---|---|
| `lib/server/comment-likes.ts` | ID 목록 → **글 단위(JOIN wr_parent)** 조회. 전 댓글 커버, 정렬과 절연. 운영 EXPLAIN: `ref`(17행)+`eq_ref(fkey1)` |
| `[postId]/+page.server.ts` | 호출부 postId 기반 교체 |
| `api/.../comments/+server.ts` | `ORDER BY ..., wr_id` 타이브레이커 (결정화) |

## 연관
- be#546(댓글 계층 varchar(5)→10)과 형제 수정 — 같은 근본(truncate 동률)에서 파생된 두 증상.

## 검증
- [ ] canary: 댓글 11개+ 글에서 뒤쪽 댓글 좋아요 → 새로고침 후 하트 유지
- [ ] 댓글 페이지네이션 순서 결정성(중복/누락 없음)
- [ ] CI (svelte-check 등)