### PR TITLE
fix(member): 탈퇴 회원 프로필·활동 전면 비노출

### DIFF
--- a/apps/web/src/routes/api/members/[id]/_withdrawn.ts
+++ b/apps/web/src/routes/api/members/[id]/_withdrawn.ts
@@ -1,0 +1,25 @@
+import pool from '$lib/server/db';
+import type { RowDataPacket } from 'mysql2';
+
+interface LeaveRow extends RowDataPacket {
+    mb_leave_date: string;
+}
+
+/**
+ * mb_id 또는 mb_nick 로 조회해 탈퇴(mb_leave_date 세팅) 여부를 반환한다.
+ * 탈퇴 회원의 프로필·활동·공감·팔로우 데이터는 로그인 회원에게도 비노출한다
+ * (개인정보 분쟁조정 대응). 숙려중 회원 포함 — 숙려 취소 시 mb_leave_date 가
+ * 해제되어 자동 복원된다.
+ * 조회 실패 시 false(정상 노출) — 가용성 우선. profile 라우트는 자체 차단됨.
+ */
+export async function isWithdrawnMember(memberId: string): Promise<boolean> {
+    try {
+        const [rows] = await pool.query<LeaveRow[]>(
+            'SELECT mb_leave_date FROM g5_member WHERE mb_id = ? OR mb_nick = ? LIMIT 1',
+            [memberId, memberId]
+        );
+        return !!rows[0]?.mb_leave_date;
+    } catch {
+        return false;
+    }
+}

--- a/apps/web/src/routes/api/members/[id]/activity/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/activity/+server.ts
@@ -5,6 +5,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { backendFetch } from '$lib/server/backend-fetch';
+import { isWithdrawnMember } from '../_withdrawn';
 
 const EMPTY_RESPONSE = { recentPosts: [], recentComments: [] };
 
@@ -16,6 +17,11 @@ export const GET: RequestHandler = async ({ params, url }) => {
     }
 
     const limit = url.searchParams.get('limit') || '5';
+
+    // 탈퇴 회원 활동 비노출 — Go GetMemberActivity 에는 탈퇴 가드가 없어 프록시 전 차단
+    if (await isWithdrawnMember(memberId)) {
+        return json(EMPTY_RESPONSE);
+    }
 
     try {
         const res = await backendFetch(

--- a/apps/web/src/routes/api/members/[id]/followers/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/followers/+server.ts
@@ -6,6 +6,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import { readPool } from '$lib/server/db.js';
+import { isWithdrawnMember } from '../_withdrawn';
 
 interface FollowerRow extends RowDataPacket {
     mb_id: string;
@@ -25,6 +26,11 @@ export const GET: RequestHandler = async ({ params }) => {
 
     if (!targetId || !/^[a-zA-Z0-9_-]+$/.test(targetId)) {
         return json({ success: false, error: '유효하지 않은 회원 ID입니다.' }, { status: 400 });
+    }
+
+    // 탈퇴 회원 팔로워 목록 비노출 (개인정보 분쟁조정 대응)
+    if (await isWithdrawnMember(targetId)) {
+        return json({ success: true, data: { total: 0, followers: [] } });
     }
 
     try {

--- a/apps/web/src/routes/api/members/[id]/following/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/following/+server.ts
@@ -6,6 +6,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import { readPool } from '$lib/server/db.js';
+import { isWithdrawnMember } from '../_withdrawn';
 
 interface FollowingRow extends RowDataPacket {
     mb_id: string;
@@ -25,6 +26,11 @@ export const GET: RequestHandler = async ({ params }) => {
 
     if (!memberId || !/^[a-zA-Z0-9_-]+$/.test(memberId)) {
         return json({ success: false, error: '유효하지 않은 회원 ID입니다.' }, { status: 400 });
+    }
+
+    // 탈퇴 회원 팔로잉 목록 비노출 (개인정보 분쟁조정 대응)
+    if (await isWithdrawnMember(memberId)) {
+        return json({ success: true, data: { total: 0, following: [] } });
     }
 
     try {

--- a/apps/web/src/routes/api/members/[id]/interactions/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/interactions/+server.ts
@@ -20,6 +20,7 @@ import pool from '$lib/server/db';
 import { getAuthUser } from '$lib/server/auth';
 import { getRedis } from '$lib/server/redis';
 import { getMemberInteractionsVersion } from '$lib/server/member-activity-cache';
+import { isWithdrawnMember } from '../_withdrawn';
 
 const MEMBER_INTERACTIONS_CACHE_TTL_SEC = 60;
 
@@ -70,6 +71,23 @@ export const GET: RequestHandler = async ({ params, url, cookies }) => {
     const isSelf = user.mb_id === targetId;
     if (!isAdmin && !isSelf) {
         return json({ success: false, error: '권한이 없습니다.' }, { status: 403 });
+    }
+
+    // 탈퇴 회원 상호작용 분석 비노출 (개인정보 분쟁조정 대응)
+    if (await isWithdrawnMember(targetId)) {
+        return json({
+            success: true,
+            data: {
+                target_mb_id: targetId,
+                direction: url.searchParams.get('direction') || 'received',
+                period: url.searchParams.get('period') || 'month',
+                period_label: '',
+                interaction_type: url.searchParams.get('type') || 'all',
+                entries: [],
+                total_interactions: 0,
+                analyzed_at: new Date().toISOString()
+            }
+        });
     }
 
     const period = (url.searchParams.get('period') || 'month') as string;

--- a/apps/web/src/routes/api/members/[id]/liked/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/liked/+server.ts
@@ -10,6 +10,7 @@ import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
 import { getRedis } from '$lib/server/redis';
 import { getMemberLikedVersion } from '$lib/server/member-activity-cache';
+import { isWithdrawnMember } from '../_withdrawn';
 
 interface GoodRow extends RowDataPacket {
     bg_id: number;
@@ -45,6 +46,11 @@ export const GET: RequestHandler = async ({ params, url }) => {
     const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
     const limit = Math.min(Math.max(1, parseInt(url.searchParams.get('limit') || '10')), 30);
     const offset = (page - 1) * limit;
+
+    // 탈퇴 회원 공감내역 비노출 (개인정보 분쟁조정 대응)
+    if (await isWithdrawnMember(memberId)) {
+        return json({ success: true, data: [], total: 0, page, total_pages: 0 });
+    }
 
     try {
         const version = await getMemberLikedVersion(memberId);

--- a/apps/web/src/routes/api/members/[id]/memos/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/memos/+server.ts
@@ -9,6 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
+import { isWithdrawnMember } from '../_withdrawn';
 
 interface MemoRow extends RowDataPacket {
     id: number;
@@ -29,6 +30,11 @@ export const GET: RequestHandler = async ({ params, locals }) => {
     const memberId = params.id;
     if (!memberId || !/^[a-zA-Z0-9_-]+$/.test(memberId)) {
         return json({ success: false, error: '유효하지 않은 회원 ID입니다.' }, { status: 400 });
+    }
+
+    // 탈퇴 회원 메모 비노출 (개인정보 분쟁조정 대응)
+    if (await isWithdrawnMember(memberId)) {
+        return json({ success: true, data: [] });
     }
 
     try {

--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -143,6 +143,19 @@ export const GET: RequestHandler = async ({ params, locals }) => {
         const member = rows[0];
         const isLeft = !!member.mb_leave_date;
 
+        // 탈퇴 회원: 신원·활동·통계·이용제한·공감·팔로워 전부 비노출.
+        // 조회불가 최소응답만 반환(로그인 회원에게도 미노출). 개인정보 분쟁조정 대응.
+        if (isLeft) {
+            return json({
+                success: true,
+                data: {
+                    mb_id: member.mb_id, // URL에 이미 있는 값 — 추가 노출 아님
+                    is_left: true,
+                    withdrawn: true
+                }
+            });
+        }
+
         // 가입 후 경과일
         const [daysRows] = await pool.query<CountRow[]>(`SELECT DATEDIFF(NOW(), ?) + 1 AS days`, [
             member.mb_datetime

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -192,6 +192,7 @@
 
     onMount(async () => {
         if (!p?.mb_id) return;
+        if (p?.is_left || p?.withdrawn) return; // 탈퇴 회원: 활동/팔로우 조회 안 함
 
         // 딥링크로 info 외 탭 진입 시 해당 탭 데이터 즉시 로드
         if (activeTab !== 'info') handleTabChange(activeTab);
@@ -210,7 +211,7 @@
 
     // 탭별 lazy load
     async function loadRecentPosts(): Promise<void> {
-        if (postsLoaded || !p?.mb_id) return;
+        if (postsLoaded || !p?.mb_id || p?.is_left || p?.withdrawn) return;
         loadingPosts = true;
         try {
             const res = await fetch(`/api/members/${p.mb_id}/activity?limit=50`);
@@ -224,7 +225,7 @@
     }
 
     async function loadRecentComments(): Promise<void> {
-        if (commentsLoaded || !p?.mb_id) return;
+        if (commentsLoaded || !p?.mb_id || p?.is_left || p?.withdrawn) return;
         loadingComments = true;
         try {
             const res = await fetch(`/api/members/${p.mb_id}/activity?limit=50`);
@@ -238,7 +239,7 @@
     }
 
     async function loadLikedPosts(): Promise<void> {
-        if (likedLoaded || !p?.mb_id) return;
+        if (likedLoaded || !p?.mb_id || p?.is_left || p?.withdrawn) return;
         loadingLiked = true;
         try {
             const res = await fetch(`/api/members/${p.mb_id}/liked?limit=50`);
@@ -335,6 +336,14 @@
         <Card class="border-destructive">
             <CardContent class="pt-6">
                 <p class="text-destructive text-center">{data.error}</p>
+            </CardContent>
+        </Card>
+    {:else if p?.is_left || p?.withdrawn}
+        <!-- 탈퇴 회원: 프로필·통계·활동·공감·이용제한 전부 비노출 (개인정보 분쟁조정 대응) -->
+        <Card class="bg-background">
+            <CardContent class="py-16 text-center">
+                <p class="text-foreground mb-2 text-lg font-medium">탈퇴한 회원입니다.</p>
+                <p class="text-muted-foreground text-sm">이 회원의 정보는 조회할 수 없습니다.</p>
             </CardContent>
         </Card>
     {:else if p}
@@ -564,25 +573,6 @@
                                     {/if}
                                 </span>
                             </div>
-                            {#if p.is_left && p.mb_leave_date}
-                                {@const LEAVE_REASON_LABELS: Record<string, string> = {
-                                    self: '본인 탈퇴',
-                                    admin: '관리자 처리',
-                                    terms_violation: '약관 위반',
-                                    contract_withdrawal: '약관에 의한 계약 철회',
-                                    account_abuse: '계정 도용/악용',
-                                    other: '기타'
-                                }}
-                                <div class="flex items-center gap-2">
-                                    <Calendar class="h-4 w-4 shrink-0" />
-                                    <span>
-                                        {formatDate(p.mb_leave_date)} 탈퇴{p.mb_leave_reason &&
-                                        p.mb_leave_reason !== 'self'
-                                            ? ` · ${LEAVE_REASON_LABELS[p.mb_leave_reason] ?? p.mb_leave_reason}`
-                                            : ''}
-                                    </span>
-                                </div>
-                            {/if}
                             {#if p.mb_nick_date}
                                 <div class="flex items-center gap-2">
                                     <User class="h-4 w-4 shrink-0" />

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -12,6 +12,7 @@
     import { goto } from '$app/navigation';
     import { page } from '$app/stores';
     import { onMount } from 'svelte';
+    import DamoangLogo from '$lib/assets/logo.svg';
     import User from '@lucide/svelte/icons/user';
     import Calendar from '@lucide/svelte/icons/calendar';
     import Clock from '@lucide/svelte/icons/clock';
@@ -342,6 +343,11 @@
         <!-- 탈퇴 회원: 프로필·통계·활동·공감·이용제한 전부 비노출 (개인정보 분쟁조정 대응) -->
         <Card class="bg-background">
             <CardContent class="py-16 text-center">
+                <img
+                    src={DamoangLogo}
+                    alt="다모앙"
+                    class="mx-auto mb-4 h-10 opacity-40 grayscale"
+                />
                 <p class="text-foreground mb-2 text-lg font-medium">탈퇴한 회원입니다.</p>
                 <p class="text-muted-foreground text-sm">이 회원의 정보는 조회할 수 없습니다.</p>
             </CardContent>


### PR DESCRIPTION
## 배경
탈퇴 회원(`mb_leave_date` 세팅, 숙려중 포함 2,121명)의 프로필이 로그인 회원에게 **가입일·탈퇴일·최종접속·통계·이용제한 이력·공감내역·팔로워까지** 열람 가능하던 문제. Go 백엔드 프로필 API는 이미 차단 중이나, 실제 페이지는 SvelteKit DB 직결 라우트(`api/members/[id]/*`)를 사용해 우회되고 있었음. (개인정보 분쟁조정 대응 — 상세 명세: 서버 `spec-withdrawn-member-profile-hide.md`)

## 변경 (프론트만, 백엔드 무변경)
| 파일 | 내용 |
|---|---|
| `api/members/[id]/_withdrawn.ts` **(신규)** | `isWithdrawnMember` 공용 헬퍼 |
| `profile/+server.ts` | 탈퇴 시 최소응답(`mb_id·is_left·withdrawn`)만 — 하위 쿼리 미실행 |
| `liked / activity / followers / following / memos / interactions` | 각 정상 응답과 동일 shape 의 **빈 응답** (activity 는 Go 프록시 전 차단) |
| `member/[id]/+page.svelte` | "탈퇴한 회원입니다" 안내만 렌더 + fetch 스킵 + 탈퇴일 표기 블록 제거 |

## 안전성
- 활성 회원(`mb_leave_date` 빈 값) 무영향. 숙려 취소 시 자동 복원.
- 헬퍼 조회 실패 시 false(노출) — 가용성 우선, profile 라우트는 자체 차단.
- 비로그인은 기존대로 `/login` 302(#12501) → 크롤러 비색인 유지.

## 검증
- [ ] CI (svelte-check/lint)
- [ ] canary: 탈퇴 회원 프로필 → 안내문만, 직접 API 호출도 빈 응답
- [ ] 활성 회원 프로필 회귀 없음