### PR TITLE
feat(privacy): 개인정보 처리방침 버전 관리 — 이력·이전버전·대조표·예고 + 시행일 자동 승격

### DIFF
--- a/apps/web/src/lib/server/content.ts
+++ b/apps/web/src/lib/server/content.ts
@@ -57,3 +57,193 @@ export function replaceContentVariables(content: string, siteTitle: string): str
         .replace(/\{\{홈페이지제목\}\}/g, siteTitle)
         .replace(/\{\{사이트명\}\}/g, siteTitle);
 }
+
+/* ------------------------------------------------------------------ *
+ * 콘텐츠 버전 관리 (g5_content_version)
+ *
+ * g5_content 는 "현재 활성본" 포인터로 유지되고, 모든 버전 스냅샷은
+ * g5_content_version 에 보관된다. (테이블 DDL/데이터는 운영에서 수동 선반영)
+ * ------------------------------------------------------------------ */
+
+/** g5_content_version 단일 버전(전문 포함) */
+export interface ContentVersion {
+    id: number;
+    co_id: string;
+    version_no: number;
+    effective_date: string;
+    status: string;
+    title: string;
+    content: string;
+    note: string;
+    created_at: string;
+}
+
+/** g5_content_version 목록용 요약(전문 content 제외 — 페이로드 절감) */
+export interface ContentVersionSummary {
+    id: number;
+    co_id: string;
+    version_no: number;
+    effective_date: string;
+    status: string;
+    title: string;
+    note: string;
+}
+
+/**
+ * 특정 co_id 의 공개 가능한 버전 목록(effective_date 내림차순).
+ * draft 는 제외하고 active/archived/scheduled 만 반환한다.
+ * content 전문은 목록에서 제외한다.
+ */
+export async function getContentVersions(coId: string): Promise<ContentVersionSummary[]> {
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT id, co_id, version_no,
+                DATE_FORMAT(effective_date, '%Y-%m-%d') AS effective_date,
+                status, title, note
+           FROM g5_content_version
+          WHERE co_id = ? AND status IN ('active', 'archived', 'scheduled')
+          ORDER BY effective_date DESC, version_no DESC`,
+        [coId]
+    );
+    return rows.map((row) => ({
+        id: Number(row.id ?? 0),
+        co_id: String(row.co_id ?? ''),
+        version_no: Number(row.version_no ?? 0),
+        effective_date: String(row.effective_date ?? ''),
+        status: String(row.status ?? ''),
+        title: String(row.title ?? ''),
+        note: String(row.note ?? '')
+    }));
+}
+
+/**
+ * 단일 버전 전문 조회. draft 는 반환하지 않는다(공개 라우트에서 404 처리).
+ */
+export async function getContentVersion(id: number): Promise<ContentVersion | null> {
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT id, co_id, version_no,
+                DATE_FORMAT(effective_date, '%Y-%m-%d') AS effective_date,
+                status, title, content, note,
+                DATE_FORMAT(created_at, '%Y-%m-%d %H:%i:%s') AS created_at
+           FROM g5_content_version
+          WHERE id = ? AND status IN ('active', 'archived', 'scheduled')
+          LIMIT 1`,
+        [id]
+    );
+    const row = rows[0];
+    if (!row) return null;
+
+    return {
+        id: Number(row.id ?? 0),
+        co_id: String(row.co_id ?? ''),
+        version_no: Number(row.version_no ?? 0),
+        effective_date: String(row.effective_date ?? ''),
+        status: String(row.status ?? ''),
+        title: String(row.title ?? ''),
+        content: String(row.content ?? ''),
+        note: String(row.note ?? ''),
+        created_at: String(row.created_at ?? '')
+    };
+}
+
+/**
+ * 가장 이른 미래 scheduled 버전 1건(예고용). 없으면 null.
+ */
+export async function getScheduledVersion(coId: string): Promise<ContentVersionSummary | null> {
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT id, co_id, version_no,
+                DATE_FORMAT(effective_date, '%Y-%m-%d') AS effective_date,
+                status, title, note
+           FROM g5_content_version
+          WHERE co_id = ? AND status = 'scheduled' AND effective_date > CURDATE()
+          ORDER BY effective_date ASC, version_no ASC
+          LIMIT 1`,
+        [coId]
+    );
+    const row = rows[0];
+    if (!row) return null;
+
+    return {
+        id: Number(row.id ?? 0),
+        co_id: String(row.co_id ?? ''),
+        version_no: Number(row.version_no ?? 0),
+        effective_date: String(row.effective_date ?? ''),
+        status: String(row.status ?? ''),
+        title: String(row.title ?? ''),
+        note: String(row.note ?? '')
+    };
+}
+
+/**
+ * 지연 승격(lazy promote): 시행일이 도래한 scheduled 버전을 active 로 승격한다.
+ *
+ * - effective_date <= CURDATE() AND status='scheduled' 인 버전을 effective_date
+ *   오름차순으로 순차 적용 → 기존 active 는 archived, 해당 버전은 active,
+ *   g5_content(co_subject/co_content) 를 그 버전 내용으로 UPDATE.
+ * - 트랜잭션으로 원자성 보장. 실패해도 읽기 흐름을 깨지 않도록 swallow.
+ * - 1시간 가드로 매 요청 트랜잭션을 방지(모듈 스코프 Map).
+ */
+const promoteGuard = new Map<string, number>();
+const PROMOTE_GUARD_MS = 60 * 60 * 1000; // 1시간
+
+export async function promoteDuePolicyVersions(coId: string): Promise<void> {
+    const now = Date.now();
+    const last = promoteGuard.get(coId) ?? 0;
+    if (now - last < PROMOTE_GUARD_MS) return;
+    // 동시 요청이 모두 트랜잭션에 진입하지 않도록 실행 전 가드 설정
+    promoteGuard.set(coId, now);
+
+    const conn = await pool.getConnection();
+    try {
+        await conn.beginTransaction();
+
+        const [dueRows] = await conn.query<RowDataPacket[]>(
+            `SELECT id, title, content
+               FROM g5_content_version
+              WHERE co_id = ? AND status = 'scheduled' AND effective_date <= CURDATE()
+              ORDER BY effective_date ASC, version_no ASC`,
+            [coId]
+        );
+
+        if (dueRows.length === 0) {
+            await conn.rollback();
+            return;
+        }
+
+        for (const row of dueRows) {
+            // 기존 active → archived
+            await conn.query(
+                `UPDATE g5_content_version
+                    SET status = 'archived', updated_at = NOW()
+                  WHERE co_id = ? AND status = 'active'`,
+                [coId]
+            );
+            // 해당 scheduled → active
+            await conn.query(
+                `UPDATE g5_content_version
+                    SET status = 'active', updated_at = NOW()
+                  WHERE id = ?`,
+                [row.id]
+            );
+            // g5_content 활성본 포인터 갱신
+            await conn.query(
+                `UPDATE g5_content
+                    SET co_subject = ?, co_content = ?
+                  WHERE co_id = ?`,
+                [String(row.title ?? ''), String(row.content ?? ''), coId]
+            );
+        }
+
+        await conn.commit();
+    } catch (err) {
+        try {
+            await conn.rollback();
+        } catch {
+            /* rollback 실패는 무시 */
+        }
+        // 일시적 실패는 다음 요청에서 재시도할 수 있도록 가드 해제
+        promoteGuard.delete(coId);
+        console.error('[content] promoteDuePolicyVersions 실패:', err);
+    } finally {
+        conn.release();
+    }
+}

--- a/apps/web/src/routes/privacy/+page.server.ts
+++ b/apps/web/src/routes/privacy/+page.server.ts
@@ -1,7 +1,15 @@
 import type { PageServerLoad } from './$types';
-import { getContent, getSiteTitle, replaceContentVariables } from '$lib/server/content.js';
+import {
+    getContent,
+    getSiteTitle,
+    replaceContentVariables,
+    promoteDuePolicyVersions
+} from '$lib/server/content.js';
 
 export const load: PageServerLoad = async () => {
+    // 시행일이 도래한 예약 버전을 자동 승격(지연 승격). 실패해도 읽기 흐름은 유지됨.
+    await promoteDuePolicyVersions('privacy');
+
     const [content, siteTitle] = await Promise.all([getContent('privacy'), getSiteTitle()]);
 
     return {

--- a/apps/web/src/routes/privacy/+page.svelte
+++ b/apps/web/src/routes/privacy/+page.svelte
@@ -6,3 +6,16 @@
 </script>
 
 <ContentPage title={data.title} content={data.content} />
+
+<div class="mx-auto max-w-4xl px-4 pb-8">
+    <div
+        class="text-muted-foreground border-border flex flex-wrap gap-x-4 gap-y-1 border-t pt-4 text-sm"
+    >
+        <a href="/privacy/history" class="hover:text-foreground underline underline-offset-4">
+            이전 버전 처리방침
+        </a>
+        <a href="/privacy/compare" class="hover:text-foreground underline underline-offset-4">
+            신구 대조표
+        </a>
+    </div>
+</div>

--- a/apps/web/src/routes/privacy/compare/+page.server.ts
+++ b/apps/web/src/routes/privacy/compare/+page.server.ts
@@ -1,0 +1,60 @@
+import type { PageServerLoad } from './$types';
+import {
+    getContentVersion,
+    getContentVersions,
+    getSiteTitle,
+    replaceContentVariables,
+    type ContentVersion
+} from '$lib/server/content.js';
+
+interface CompareSide {
+    id: number;
+    version_no: number;
+    effective_date: string;
+    status: string;
+    title: string;
+    content: string;
+}
+
+function toSide(version: ContentVersion | null, siteTitle: string): CompareSide | null {
+    if (!version) return null;
+    return {
+        id: version.id,
+        version_no: version.version_no,
+        effective_date: version.effective_date,
+        status: version.status,
+        title: version.title,
+        content: replaceContentVariables(version.content, siteTitle)
+    };
+}
+
+export const load: PageServerLoad = async ({ url }) => {
+    const fromParam = url.searchParams.get('from');
+    const toParam = url.searchParams.get('to');
+
+    const siteTitle = await getSiteTitle();
+
+    let fromVer: ContentVersion | null = null;
+    let toVer: ContentVersion | null = null;
+
+    if (fromParam && toParam) {
+        [fromVer, toVer] = await Promise.all([
+            getContentVersion(Number(fromParam)),
+            getContentVersion(Number(toParam))
+        ]);
+    } else {
+        // 기본값: to = 현재 active, from = 직전 archived(가장 최근 보관본)
+        const versions = await getContentVersions('privacy'); // effective_date DESC
+        const active = versions.find((v) => v.status === 'active');
+        const latestArchived = versions.find((v) => v.status === 'archived');
+        [toVer, fromVer] = await Promise.all([
+            active ? getContentVersion(active.id) : Promise.resolve(null),
+            latestArchived ? getContentVersion(latestArchived.id) : Promise.resolve(null)
+        ]);
+    }
+
+    return {
+        from: toSide(fromVer, siteTitle),
+        to: toSide(toVer, siteTitle)
+    };
+};

--- a/apps/web/src/routes/privacy/compare/+page.svelte
+++ b/apps/web/src/routes/privacy/compare/+page.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+    import { dompurify as DOMPurify } from '$lib/utils/dompurify.js';
+    import { SeoHead } from '$lib/seo/index.js';
+    import type { SeoConfig } from '$lib/seo/types.js';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    const fromHtml = $derived(data.from ? DOMPurify.sanitize(data.from.content) : '');
+    const toHtml = $derived(data.to ? DOMPurify.sanitize(data.to.content) : '');
+
+    function statusLabel(status: string): string {
+        if (status === 'active') return '현재 적용중';
+        if (status === 'scheduled') return '시행 예정';
+        if (status === 'archived') return '이전 버전';
+        return status;
+    }
+
+    const seo: SeoConfig = {
+        meta: {
+            title: '개인정보 처리방침 — 신구 대조표',
+            description: '개인정보 처리방침의 이전 버전과 현재/예정 버전을 나란히 비교합니다.'
+        },
+        og: { title: '개인정보 처리방침 — 신구 대조표', type: 'website' }
+    };
+</script>
+
+<SeoHead config={seo} />
+
+<div class="mx-auto max-w-6xl px-4 py-8">
+    <h1 class="text-foreground mb-2 text-3xl font-bold">개인정보 처리방침 — 신구 대조표</h1>
+    <p class="text-muted-foreground mb-6 text-sm">
+        두 버전을 나란히 비교합니다.
+        <a href="/privacy/history" class="hover:text-foreground underline underline-offset-4">
+            버전 목록으로
+        </a>
+    </p>
+
+    {#if !data.from && !data.to}
+        <div class="text-muted-foreground py-12 text-center">
+            <p>비교할 버전을 찾을 수 없습니다.</p>
+        </div>
+    {:else}
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <section class="border-border rounded-lg border">
+                <header class="border-border bg-muted/40 border-b px-4 py-3">
+                    {#if data.from}
+                        <div class="text-foreground font-semibold">
+                            제{data.from.version_no}판 · {statusLabel(data.from.status)}
+                        </div>
+                        <div class="text-muted-foreground text-sm">
+                            시행 {data.from.effective_date}
+                        </div>
+                    {:else}
+                        <div class="text-muted-foreground font-semibold">이전 버전 없음</div>
+                    {/if}
+                </header>
+                {#if fromHtml}
+                    <div class="prose dark:prose-invert max-w-none px-4 py-4">
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                        {@html fromHtml}
+                    </div>
+                {:else}
+                    <div class="text-muted-foreground px-4 py-12 text-center">
+                        비교 대상이 없습니다.
+                    </div>
+                {/if}
+            </section>
+
+            <section class="border-border rounded-lg border">
+                <header class="border-border bg-muted/40 border-b px-4 py-3">
+                    {#if data.to}
+                        <div class="text-foreground font-semibold">
+                            제{data.to.version_no}판 · {statusLabel(data.to.status)}
+                        </div>
+                        <div class="text-muted-foreground text-sm">
+                            시행 {data.to.effective_date}
+                        </div>
+                    {:else}
+                        <div class="text-muted-foreground font-semibold">비교 버전 없음</div>
+                    {/if}
+                </header>
+                {#if toHtml}
+                    <div class="prose dark:prose-invert max-w-none px-4 py-4">
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                        {@html toHtml}
+                    </div>
+                {:else}
+                    <div class="text-muted-foreground px-4 py-12 text-center">
+                        비교 대상이 없습니다.
+                    </div>
+                {/if}
+            </section>
+        </div>
+    {/if}
+</div>

--- a/apps/web/src/routes/privacy/history/+page.server.ts
+++ b/apps/web/src/routes/privacy/history/+page.server.ts
@@ -1,0 +1,9 @@
+import type { PageServerLoad } from './$types';
+import { promoteDuePolicyVersions, getContentVersions } from '$lib/server/content.js';
+
+export const load: PageServerLoad = async () => {
+    // 이력 조회 시에도 시행일 도래 버전을 자동 승격
+    await promoteDuePolicyVersions('privacy');
+    const versions = await getContentVersions('privacy');
+    return { versions };
+};

--- a/apps/web/src/routes/privacy/history/+page.svelte
+++ b/apps/web/src/routes/privacy/history/+page.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+    import * as Card from '$lib/components/ui/card/index.js';
+    import { Badge } from '$lib/components/ui/badge/index.js';
+    import { SeoHead } from '$lib/seo/index.js';
+    import type { SeoConfig } from '$lib/seo/types.js';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    /** 'YYYY-MM-DD' 의 전날 문자열 */
+    function prevDay(d: string): string {
+        const dt = new Date(d + 'T00:00:00Z');
+        dt.setUTCDate(dt.getUTCDate() - 1);
+        return dt.toISOString().slice(0, 10);
+    }
+
+    // 적용기간 계산: 자신보다 늦게 시행된 active/archived 버전이 후속본.
+    // 후속본이 없으면 '현재 적용중'. scheduled 는 '시행 예정'.
+    const rows = $derived(
+        data.versions.map((v) => {
+            if (v.status === 'scheduled') {
+                return { ...v, periodText: '시행 예정', scheduled: true };
+            }
+            const successor = data.versions
+                .filter((o) => o.status !== 'scheduled' && o.effective_date > v.effective_date)
+                .sort((a, b) => a.effective_date.localeCompare(b.effective_date))[0];
+            const periodText = successor
+                ? `시행 ${v.effective_date} ~ ${prevDay(successor.effective_date)}`
+                : `시행 ${v.effective_date} ~ 현재 적용중`;
+            return { ...v, periodText, scheduled: false };
+        })
+    );
+
+    const seo: SeoConfig = {
+        meta: {
+            title: '개인정보 처리방침 — 이전 버전',
+            description: '개인정보 처리방침의 개정 이력과 이전 버전을 열람할 수 있습니다.'
+        },
+        og: { title: '개인정보 처리방침 — 이전 버전', type: 'website' }
+    };
+</script>
+
+<SeoHead config={seo} />
+
+<div class="mx-auto max-w-4xl px-4 py-8">
+    <h1 class="text-foreground mb-2 text-3xl font-bold">개인정보 처리방침 — 이전 버전</h1>
+    <p class="text-muted-foreground mb-6 text-sm">
+        개정 이력과 각 버전의 전문을 상시 열람할 수 있습니다.
+        <a href="/privacy/compare" class="hover:text-foreground underline underline-offset-4">
+            신구 대조표 보기
+        </a>
+    </p>
+
+    {#if rows.length === 0}
+        <div class="text-muted-foreground py-12 text-center">
+            <p>등록된 버전이 없습니다.</p>
+        </div>
+    {:else}
+        <div class="flex flex-col gap-3">
+            {#each rows as v (v.id)}
+                <Card.Root>
+                    <Card.Header>
+                        <div class="flex flex-wrap items-center gap-2">
+                            <Card.Title class="text-lg">제{v.version_no}판</Card.Title>
+                            {#if v.scheduled}
+                                <Badge variant="secondary">시행 예정</Badge>
+                            {:else if v.status === 'active'}
+                                <Badge>현재 적용중</Badge>
+                            {/if}
+                        </div>
+                        <Card.Description>{v.periodText}</Card.Description>
+                    </Card.Header>
+                    {#if v.note}
+                        <Card.Content>
+                            <p class="text-muted-foreground text-sm">{v.note}</p>
+                        </Card.Content>
+                    {/if}
+                    <Card.Footer>
+                        {#if v.scheduled}
+                            <a
+                                href="/privacy/preview/{v.id}"
+                                class="text-primary text-sm underline underline-offset-4"
+                            >
+                                미리보기
+                            </a>
+                        {:else}
+                            <a
+                                href="/privacy/versions/{v.id}"
+                                class="text-primary text-sm underline underline-offset-4"
+                            >
+                                전문 보기
+                            </a>
+                        {/if}
+                    </Card.Footer>
+                </Card.Root>
+            {/each}
+        </div>
+    {/if}
+</div>

--- a/apps/web/src/routes/privacy/preview/[id]/+page.server.ts
+++ b/apps/web/src/routes/privacy/preview/[id]/+page.server.ts
@@ -1,0 +1,30 @@
+import type { PageServerLoad } from './$types';
+import { error, redirect } from '@sveltejs/kit';
+import { getContentVersion, getSiteTitle, replaceContentVariables } from '$lib/server/content.js';
+
+export const load: PageServerLoad = async ({ params }) => {
+    const id = Number(params.id);
+    if (!Number.isFinite(id)) {
+        error(404, { message: '버전을 찾을 수 없습니다.' });
+    }
+
+    const [version, siteTitle] = await Promise.all([getContentVersion(id), getSiteTitle()]);
+    if (!version) {
+        error(404, { message: '버전을 찾을 수 없습니다.' });
+    }
+    // 예고(scheduled) 버전만 미리보기 대상. 이미 시행된 버전은 정식 열람으로 이동.
+    if (version.status !== 'scheduled') {
+        redirect(302, `/privacy/versions/${id}`);
+    }
+
+    return {
+        version: {
+            id: version.id,
+            version_no: version.version_no,
+            effective_date: version.effective_date,
+            status: version.status,
+            title: version.title,
+            content: replaceContentVariables(version.content, siteTitle)
+        }
+    };
+};

--- a/apps/web/src/routes/privacy/preview/[id]/+page.svelte
+++ b/apps/web/src/routes/privacy/preview/[id]/+page.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import ContentPage from '$lib/components/features/content/content-page.svelte';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+</script>
+
+<div class="mx-auto max-w-4xl px-4 pt-8">
+    <a
+        href="/privacy/history"
+        class="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4"
+    >
+        ← 이전 버전 목록
+    </a>
+    <div
+        class="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-300"
+    >
+        제{data.version.version_no}판 · {data.version.effective_date} 시행 예정 — 미리보기
+    </div>
+</div>
+
+<ContentPage title={data.version.title || '개인정보처리방침'} content={data.version.content} />

--- a/apps/web/src/routes/privacy/versions/[id]/+page.server.ts
+++ b/apps/web/src/routes/privacy/versions/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import { getContentVersion, getSiteTitle, replaceContentVariables } from '$lib/server/content.js';
 
 export const load: PageServerLoad = async ({ params }) => {
@@ -11,6 +11,11 @@ export const load: PageServerLoad = async ({ params }) => {
     const [version, siteTitle] = await Promise.all([getContentVersion(id), getSiteTitle()]);
     if (!version) {
         error(404, { message: '버전을 찾을 수 없습니다.' });
+    }
+
+    // 시행 예정(scheduled) 버전은 preview 로 일관 노출 (history 도 preview 로만 링크).
+    if (version.status === 'scheduled') {
+        redirect(302, `/privacy/preview/${id}`);
     }
 
     return {

--- a/apps/web/src/routes/privacy/versions/[id]/+page.server.ts
+++ b/apps/web/src/routes/privacy/versions/[id]/+page.server.ts
@@ -1,0 +1,26 @@
+import type { PageServerLoad } from './$types';
+import { error } from '@sveltejs/kit';
+import { getContentVersion, getSiteTitle, replaceContentVariables } from '$lib/server/content.js';
+
+export const load: PageServerLoad = async ({ params }) => {
+    const id = Number(params.id);
+    if (!Number.isFinite(id)) {
+        error(404, { message: '버전을 찾을 수 없습니다.' });
+    }
+
+    const [version, siteTitle] = await Promise.all([getContentVersion(id), getSiteTitle()]);
+    if (!version) {
+        error(404, { message: '버전을 찾을 수 없습니다.' });
+    }
+
+    return {
+        version: {
+            id: version.id,
+            version_no: version.version_no,
+            effective_date: version.effective_date,
+            status: version.status,
+            title: version.title,
+            content: replaceContentVariables(version.content, siteTitle)
+        }
+    };
+};

--- a/apps/web/src/routes/privacy/versions/[id]/+page.svelte
+++ b/apps/web/src/routes/privacy/versions/[id]/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import ContentPage from '$lib/components/features/content/content-page.svelte';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    const bannerText = $derived(
+        data.version.status === 'scheduled'
+            ? `이 방침은 ${data.version.effective_date} 부터 적용될 예정입니다.`
+            : `이 방침은 ${data.version.effective_date} 부터 적용되었습니다.`
+    );
+</script>
+
+<div class="mx-auto max-w-4xl px-4 pt-8">
+    <a
+        href="/privacy/history"
+        class="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4"
+    >
+        ← 이전 버전 목록
+    </a>
+    <div
+        class="border-primary/40 bg-primary/5 text-foreground mt-3 rounded-lg border px-4 py-3 text-sm"
+    >
+        제{data.version.version_no}판 · {bannerText}
+    </div>
+</div>
+
+<ContentPage title={data.version.title || '개인정보처리방침'} content={data.version.content} />


### PR DESCRIPTION
## 배경

개정 개인정보 처리방침 제14조는 **이전 버전 처리방침의 상시 열람**과, 개정 **시행 전(예고 단계)부터의 신구 대조표 공개**를 요구합니다. 현재 `g5_content(co_id='privacy')` 는 단일 레코드라 개정하면 이전 문안이 사라집니다.

본 PR은 privacy 전용이 아니라 운영정책·약관 등 모든 방침 콘텐츠에 재사용 가능한 **범용 콘텐츠 버전 관리(프론트 + 시행일 자동 승격)** 를 추가합니다. 설계서: `docs/design-policy-versioning.html`.

## 변경 내용

- **`$lib/server/content.ts` 헬퍼 추가** (SvelteKit DB 직결, 백엔드 변경 없음)
  - `getContentVersions(coId)` — 공개 가능한 버전 목록(effective_date DESC, 전문 제외)
  - `getContentVersion(id)` — 단일 버전 전문 (draft 반환 금지 → 공개 라우트 404)
  - `getScheduledVersion(coId)` — 가장 이른 미래 scheduled 1건(예고용)
  - `promoteDuePolicyVersions(coId)` — **시행일 자동 승격(지연 승격)**. 트랜잭션으로 `scheduled→active`, 기존 `active→archived`, `g5_content(co_subject/co_content)` 갱신. 1시간 가드(모듈 스코프 Map)로 매 요청 트랜잭션 방지, try/catch 로 실패해도 읽기 흐름 유지.
- **공개 라우트 신규**
  - `/privacy/history` — 버전 목록(적용기간 계산·개정요지·"시행 예정" 배지)
  - `/privacy/versions/[id]` — 이전 버전 전문 열람 + 적용일 배너 (없으면 404)
  - `/privacy/preview/[id]` — scheduled 예고 미리보기 (scheduled 아니면 versions 로 302)
  - `/privacy/compare?from=&to=` — 신구 대조표 좌/우 2단 비교(모바일 세로 스택). from/to 누락 시 to=현재 active, from=직전 archived 자동
- **`/privacy` (기존)** — 읽기 경로 무변경. 로드 시 `promoteDuePolicyVersions('privacy')` 트리거 + 하단 "이전 버전 처리방침 · 신구 대조표" 링크만 추가

## 전제 (배포 전 필수)

⚠️ **`g5_content_version` 테이블 DDL 및 초기 데이터(v1 백필 + v2 등록)는 운영 DB에 수동 선반영이 필요합니다.** 코드는 이 테이블이 존재한다고 가정하고 SELECT/UPDATE 만 수행하며 CREATE TABLE 을 하지 않습니다. DDL 먼저 → 코드 배포 순서.

DDL 참고 (설계서):

```sql
CREATE TABLE g5_content_version (
  id BIGINT AUTO_INCREMENT PRIMARY KEY,
  co_id VARCHAR(20) NOT NULL,
  version_no INT NOT NULL,
  effective_date DATE NOT NULL,
  status ENUM('draft','scheduled','active','archived') NOT NULL DEFAULT 'draft',
  title VARCHAR(255) NOT NULL DEFAULT '',
  content LONGTEXT NOT NULL,
  note VARCHAR(500) NOT NULL DEFAULT '',
  created_by VARCHAR(191) NOT NULL DEFAULT '',
  created_at DATETIME NOT NULL,
  updated_at DATETIME NOT NULL,
  UNIQUE KEY uq_co_ver (co_id, version_no),
  KEY idx_co_status_eff (co_id, status, effective_date)
);
```

## 검증 체크리스트

- [ ] DDL·백필 선반영 후 `/privacy` 출력이 개정 전과 100% 동일(회귀 0)
- [ ] scheduled 버전이 시행 전 `/privacy` 에 노출되지 않음 (preview/compare 로만)
- [ ] `/privacy/history` 목록 정상, "시행 예정" 배지·적용기간 표시
- [ ] `/privacy/versions/[id]` 이전 버전 전문 열람, 없는 id → 404, draft → 404
- [ ] `/privacy/preview/[id]` scheduled 미리보기, 비-scheduled → versions 리다이렉트
- [ ] `/privacy/compare` 기본값(active↔직전 archived) 및 `?from=&to=` 정상
- [ ] effective_date 도래 후 첫 접근에서 active 승격 + g5_content 갱신 + 이전본 archived
- [ ] 배포 후 Error 1054 스팟체크 / `pnpm check`

> worktree 환경에 node_modules 가 없어 `pnpm check` 는 로컬에서 실행하지 못했습니다. import 경로(`.js` suffix)·타입 정합·Svelte 5 runes 문법은 self-check 완료했으며 타입 체크는 CI 에 위임합니다.
