### PR TITLE
feat(auth): 네이티브 앱 소셜 로그인 브리지 (app=1 모드)

### DIFF
--- a/apps/web/src/lib/server/auth/jwt.ts
+++ b/apps/web/src/lib/server/auth/jwt.ts
@@ -54,6 +54,32 @@ export async function generateAccessToken(user: {
         .sign(secret);
 }
 
+/**
+ * 네이티브 앱 로그인 코드 생성 (60초 단명)
+ * 소셜 OAuth 콜백 성공 후 앱 스킴(damoang://oauth-callback)으로 전달되며,
+ * 앱이 Go 백엔드 POST /api/v2/auth/app-exchange 로 v2 토큰쌍과 교환한다.
+ * aud=app-login 으로 일반 access/refresh 토큰과 용도를 분리한다.
+ */
+export async function generateAppLoginCode(user: {
+    mb_id: string;
+    mb_nick: string;
+    mb_level: number;
+    mb_email: string;
+}): Promise<string> {
+    return new SignJWT({
+        nickname: user.mb_nick,
+        level: user.mb_level,
+        email: user.mb_email
+    })
+        .setSubject(user.mb_id)
+        .setAudience('app-login')
+        .setProtectedHeader({ alg: 'HS256' })
+        .setIssuedAt()
+        .setExpirationTime('60s')
+        .setIssuer('angple')
+        .sign(secret);
+}
+
 /** Refresh Token 생성 (7일) + DB 저장 */
 export async function generateRefreshToken(
     mbId: string,

--- a/apps/web/src/lib/server/auth/oauth/state.ts
+++ b/apps/web/src/lib/server/auth/oauth/state.ts
@@ -21,7 +21,8 @@ export function createOAuthState(
     cookies: Cookies,
     provider: SocialProvider,
     redirectUrl: string,
-    linkTo?: string
+    linkTo?: string,
+    appMode?: boolean
 ): string {
     const state = generateRandomState();
 
@@ -30,7 +31,8 @@ export function createOAuthState(
         provider,
         redirect: redirectUrl,
         timestamp: Date.now(),
-        ...(linkTo ? { linkTo } : {})
+        ...(linkTo ? { linkTo } : {}),
+        ...(appMode ? { appMode: true } : {})
     };
 
     cookies.set(STATE_COOKIE_NAME, JSON.stringify(data), {

--- a/apps/web/src/lib/server/auth/oauth/types.ts
+++ b/apps/web/src/lib/server/auth/oauth/types.ts
@@ -89,4 +89,10 @@ export interface OAuthStateData {
      * 콜백에서 `locals.user.id === linkTo` 를 재검증한다.
      */
     linkTo?: string;
+    /**
+     * 네이티브 앱 로그인 모드 (/auth/start?app=1).
+     * 콜백 성공 시 웹 리다이렉트 대신 단명 app-login 코드를 발급해
+     * damoang://oauth-callback 앱 스킴으로 복귀한다.
+     */
+    appMode?: boolean;
 }

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -27,7 +27,7 @@ import {
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_MAX_AGE
 } from '$lib/server/auth/session-store.js';
-import { generateRefreshToken } from '$lib/server/auth/jwt.js';
+import { generateRefreshToken, generateAppLoginCode } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { AppleProvider } from '$lib/server/auth/oauth/providers/apple.js';
 import { TwitterProvider } from '$lib/server/auth/oauth/providers/twitter.js';
@@ -205,11 +205,16 @@ async function handleCallback(
             if (profile.email) {
                 const existingByEmail = await findMemberByEmail(profile.email);
                 if (existingByEmail) {
+                    if (stateData.appMode) {
+                        redirect(302, 'damoang://oauth-callback?error=email_exists');
+                    }
                     redirect(302, '/login?error=email_exists');
                 }
             }
 
-            if (isInviteFlow(stateData.redirect)) {
+            if (isInviteFlow(stateData.redirect) || stateData.appMode) {
+                // 초대 플로우·네이티브 앱 로그인: /register 로 보내지 않고 임시 계정 즉시 생성
+                // (앱 모드에서 /register 로 이동하면 앱 스킴 복귀가 끊겨 로그인이 중단됨)
                 const baseMbId = generateSocialMbId(providerName, profile.identifier);
                 const existingTemp = await findExistingTempAccount(baseMbId);
 
@@ -314,6 +319,10 @@ async function handleCallback(
                     });
                     redirect(302, '/member/leave/cancel');
                 }
+                if (stateData.appMode) {
+                    // 앱 모드: 비활성/이용제한 계정은 앱으로 에러 복귀 (임시계정 우회 생성 금지)
+                    redirect(302, 'damoang://oauth-callback?error=account_inactive');
+                }
                 redirect(302, '/login?error=account_inactive');
             }
         }
@@ -396,6 +405,7 @@ async function handleCallback(
         const skipCertification =
             isInviteFlow(stateData.redirect) ||
             isPromotionRedirectFlow(stateData.redirect) ||
+            stateData.appMode === true ||
             Number(member.mb_level ?? 0) >= 5;
 
         // 직접홍보/광고주 로그인은 실명인증 없이 진행
@@ -408,6 +418,17 @@ async function handleCallback(
             } catch (certErr) {
                 if (certErr && typeof certErr === 'object' && 'status' in certErr) throw certErr;
             }
+        }
+
+        // 네이티브 앱 모드: 단명 app-login 코드를 발급해 앱 스킴으로 복귀
+        if (stateData.appMode) {
+            const appLoginCode = await generateAppLoginCode({
+                mb_id: member.mb_id,
+                mb_nick: member.mb_nick,
+                mb_level: Number(member.mb_level ?? 1),
+                mb_email: member.mb_email || ''
+            });
+            redirect(302, `damoang://oauth-callback?code=${encodeURIComponent(appLoginCode)}`);
         }
 
         // 원래 페이지로 리다이렉트

--- a/apps/web/src/routes/auth/start/+server.ts
+++ b/apps/web/src/routes/auth/start/+server.ts
@@ -22,6 +22,8 @@ export const GET: RequestHandler = async ({ url, cookies, request, locals }) => 
     // 추가 연결(link) 모드 — 쿼리 파라미터는 단순 플래그이며,
     // 실제 연결 대상 mb_id 는 서버 세션에서만 결정한다 (#12037).
     const isLinkMode = url.searchParams.get('link') === '1';
+    // 네이티브 앱 로그인 모드 — 콜백 성공 시 앱 스킴으로 단명 코드 전달
+    const isAppMode = url.searchParams.get('app') === '1';
 
     if (!providerParam || !isValidProvider(providerParam)) {
         return new Response('지원하지 않는 로그인 방식입니다', { status: 400 });
@@ -42,7 +44,7 @@ export const GET: RequestHandler = async ({ url, cookies, request, locals }) => 
     try {
         const origin = resolveOrigin(request);
         const provider = await getProvider(providerName, origin);
-        const state = createOAuthState(cookies, providerName, redirectUrl, linkTo);
+        const state = createOAuthState(cookies, providerName, redirectUrl, linkTo, isAppMode);
 
         // Twitter는 PKCE 사용
         if (provider instanceof TwitterProvider) {


### PR DESCRIPTION
## 개요
다모앙 iOS/Android 앱의 소셜 로그인 복구를 위한 웹 절반. (백엔드: damoang/angple-backend#547)

앱이 `/auth/start?provider=X&app=1` 을 ASWebAuthenticationSession 으로 열면, 기존 웹 OAuth(7종: kakao/naver/google/payco/facebook/twitter/apple)를 그대로 사용해 로그인하고, 콜백 성공 시 단명(60초, aud=app-login) 코드를 발급해 `damoang://oauth-callback?code=...` 앱 스킴으로 복귀한다. 앱은 코드를 Go `POST /api/v2/auth/app-exchange` 에서 v2 토큰쌍으로 교환.

## 변경사항
- `/auth/start`: `app=1` 파라미터 → OAuth state 에 appMode 저장
- 콜백: appMode 성공 시 `generateAppLoginCode()`(jose, 공유 JWT_SECRET) 발급 후 앱 스킴 리다이렉트
- appMode 신규 소셜 회원: 초대 플로우와 동일한 임시 계정 즉시 생성 (/register 이동 시 앱 복귀 단절 방지)
- appMode 실명인증(cert) 리다이렉트 스킵
- appMode 에러(email_exists, account_inactive)는 앱 스킴으로 복귀 (비활성 계정 임시계정 우회 생성 금지)

## 테스트
- 서버 단위테스트 471개 전부 통과
- svelte-check: 기존(main과 동일) 11개 에러 외 신규 에러 없음, 변경 파일 lint/prettier 통과

## 배경
Apple App Store 심사 반려(2.1a) 해소.