### PR TITLE
feat(seo): VideoObject 구조화 데이터 — GSC 동영상 색인 '썸네일 URL 없음' 해소

### DIFF
--- a/apps/web/src/lib/seo/index.ts
+++ b/apps/web/src/lib/seo/index.ts
@@ -24,8 +24,11 @@ export {
 export {
     createOrganizationJsonLd,
     createDiscussionForumPostingJsonLd,
-    createFAQPageJsonLd
+    createFAQPageJsonLd,
+    createVideoObjectJsonLd,
+    extractVideosFromContent
 } from './json-ld';
+export type { ExtractedVideo } from './json-ld';
 
 export type {
     SeoConfig,
@@ -37,6 +40,7 @@ export type {
     JsonLdDiscussionForumPosting,
     JsonLdFAQPage,
     JsonLdFAQItem,
+    JsonLdVideoObject,
     PaginationSeo
 } from './types';
 

--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -8,8 +8,78 @@ import type {
     JsonLdOrganization,
     JsonLdDiscussionForumPosting,
     JsonLdFAQPage,
-    JsonLdFAQItem
+    JsonLdFAQItem,
+    JsonLdVideoObject
 } from './types';
+
+/** 본문에서 추출된 동영상 (유튜브 임베드 또는 업로드 파일) */
+export type ExtractedVideo = { type: 'youtube'; id: string } | { type: 'file'; url: string };
+
+// 유튜브 임베드 iframe 의 videoId — tiptap Youtube 확장이 embed/ 형태로 저장하지만,
+// 과거 글의 nocookie·shorts 변형도 수용
+const YOUTUBE_EMBED_ID_RE =
+    /(?:youtube(?:-nocookie)?\.com\/(?:embed|shorts)\/|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+/**
+ * 본문 HTML 에서 동영상을 추출 (VideoObject 구조화 데이터용)
+ *
+ * 단순 링크(<a href>)는 플레이어가 아니므로 제외하고, 실제 재생 요소만 본다:
+ * - <iframe src="...youtube.com/embed/ID...">  (tiptap Youtube 임베드)
+ * - <video src="..."> 또는 <video><source src="..."></video>  (업로드 동영상)
+ */
+export function extractVideosFromContent(html: string): ExtractedVideo[] {
+    if (!html) return [];
+    const videos: ExtractedVideo[] = [];
+    const seen = new Set<string>();
+
+    for (const m of html.matchAll(/<iframe[^>]*\ssrc\s*=\s*["']([^"']+)["']/gi)) {
+        const id = m[1].match(YOUTUBE_EMBED_ID_RE)?.[1];
+        if (id && !seen.has(`yt:${id}`)) {
+            seen.add(`yt:${id}`);
+            videos.push({ type: 'youtube', id });
+        }
+    }
+
+    // <video src> 와 <video> 내부 <source src> — 에디터가 두 형태 모두 생성
+    for (const m of html.matchAll(/<(?:video|source)[^>]*\ssrc\s*=\s*["']([^"']+)["']/gi)) {
+        const url = m[1];
+        if (url && !seen.has(`file:${url}`)) {
+            seen.add(`file:${url}`);
+            videos.push({ type: 'file', url });
+        }
+    }
+
+    return videos;
+}
+
+/**
+ * VideoObject JSON-LD 생성
+ *
+ * Google 동영상 색인은 name·thumbnailUrl·uploadDate 가 필수 — 하나라도 없으면
+ * "제공된 썸네일 URL 없음" 류의 색인 제외가 되므로, 미충족 시 블록 자체를 생략(null)
+ */
+export function createVideoObjectJsonLd(options: {
+    name: string;
+    description?: string;
+    thumbnailUrl?: string;
+    uploadDate: string;
+    embedUrl?: string;
+    contentUrl?: string;
+}): JsonLdVideoObject | null {
+    if (!options.name?.trim() || !options.thumbnailUrl || !options.uploadDate) return null;
+    if (!options.embedUrl && !options.contentUrl) return null;
+
+    const data: JsonLdVideoObject = {
+        '@type': 'VideoObject',
+        name: options.name.trim(),
+        thumbnailUrl: options.thumbnailUrl,
+        uploadDate: options.uploadDate
+    };
+    if (options.description) data.description = options.description;
+    if (options.embedUrl) data.embedUrl = options.embedUrl;
+    if (options.contentUrl) data.contentUrl = options.contentUrl;
+    return data;
+}
 
 /**
  * Organization JSON-LD 생성

--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -223,3 +223,46 @@ describe('SEO meta-helper', () => {
         });
     });
 });
+
+describe('VideoObject (GSC 동영상 색인 — 썸네일 필수)', () => {
+    it('유튜브 임베드 iframe 에서 videoId 추출 (embed·nocookie·중복 제거)', async () => {
+        const { extractVideosFromContent } = await import('./json-ld');
+        const html = `
+            <div data-youtube-video><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0"></iframe></div>
+            <iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"></iframe>
+            <iframe src="https://www.youtube.com/embed/abc123XYZ_-"></iframe>`;
+        expect(extractVideosFromContent(html)).toEqual([
+            { type: 'youtube', id: 'dQw4w9WgXcQ' },
+            { type: 'youtube', id: 'abc123XYZ_-' }
+        ]);
+    });
+
+    it('업로드 동영상: <video src> 와 <video><source src> 모두 추출, 단순 링크는 제외', async () => {
+        const { extractVideosFromContent } = await import('./json-ld');
+        const html = `
+            <video src="https://r2.damoang.net/data/editor/a.mp4" controls></video>
+            <video controls><source src="https://r2.damoang.net/data/file/b.mp4" /></video>
+            <a href="https://youtu.be/dQw4w9WgXcQ">링크만</a>`;
+        expect(extractVideosFromContent(html)).toEqual([
+            { type: 'file', url: 'https://r2.damoang.net/data/editor/a.mp4' },
+            { type: 'file', url: 'https://r2.damoang.net/data/file/b.mp4' }
+        ]);
+    });
+
+    it('createVideoObjectJsonLd: 필수값(name·thumbnailUrl·uploadDate·재생URL) 미충족 시 null', async () => {
+        const { createVideoObjectJsonLd } = await import('./json-ld');
+        const base = {
+            name: '제목',
+            thumbnailUrl: 'https://i.ytimg.com/vi/x/hqdefault.jpg',
+            uploadDate: '2026-07-10T00:00:00+09:00',
+            embedUrl: 'https://www.youtube.com/embed/x'
+        };
+        expect(createVideoObjectJsonLd(base)).toMatchObject({
+            '@type': 'VideoObject',
+            name: '제목'
+        });
+        expect(createVideoObjectJsonLd({ ...base, thumbnailUrl: undefined })).toBeNull();
+        expect(createVideoObjectJsonLd({ ...base, name: '  ' })).toBeNull();
+        expect(createVideoObjectJsonLd({ ...base, embedUrl: undefined })).toBeNull();
+    });
+});

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -134,13 +134,25 @@ export interface JsonLdFAQItem {
     answer: string;
 }
 
+/** JSON-LD 구조화 데이터 - VideoObject (Google 동영상 색인은 thumbnailUrl 필수) */
+export interface JsonLdVideoObject {
+    '@type': 'VideoObject';
+    name: string;
+    description?: string;
+    thumbnailUrl: string;
+    uploadDate: string;
+    embedUrl?: string;
+    contentUrl?: string;
+}
+
 export type JsonLdData =
     | JsonLdWebSite
     | JsonLdArticle
     | JsonLdBreadcrumb
     | JsonLdOrganization
     | JsonLdDiscussionForumPosting
-    | JsonLdFAQPage;
+    | JsonLdFAQPage
+    | JsonLdVideoObject;
 
 /** 페이지네이션 SEO 정보 */
 export interface PaginationSeo {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -67,6 +67,8 @@
         createArticleJsonLd,
         createBreadcrumbJsonLd,
         createDiscussionForumPostingJsonLd,
+        createVideoObjectJsonLd,
+        extractVideosFromContent,
         getSiteUrl,
         truncateText
     } from '$lib/seo/index.js';
@@ -1659,6 +1661,49 @@
             ? `${safeOgImage}${safeOgImage.includes('?') ? '&' : '?'}v=${new Date(data.post.updated_at || data.post.created_at).getTime()}`
             : fallbackOgImage;
 
+        // VideoObject — GSC "제공된 썸네일 URL 없음"(동영상 색인 제외) 해소.
+        // 유튜브 임베드는 i.ytimg.com 썸네일이 항상 존재. 업로드 mp4 는 자체 포스터가
+        // 없으므로 글 대표이미지가 있을 때만 출력 (thumbnailUrl 없는 VideoObject 는
+        // 그 자체가 오류라 생략이 정답 — 헬퍼가 null 반환, buildJsonLd 가 필터)
+        const videoJsonLds =
+            data.post.is_secret || data.post.deleted_at
+                ? []
+                : [
+                      ...extractVideosFromContent(renderedPostContent),
+                      ...(data.post.videos ?? []).map((v) => ({
+                          type: 'file' as const,
+                          url: v.url
+                      }))
+                  ]
+                      .slice(0, 3)
+                      .map((v) => {
+                          const name = data.post.title?.trim() || boardTitle;
+                          if (v.type === 'youtube') {
+                              return createVideoObjectJsonLd({
+                                  name,
+                                  description: postDescription || undefined,
+                                  thumbnailUrl: `https://i.ytimg.com/vi/${v.id}/hqdefault.jpg`,
+                                  uploadDate: data.post.created_at,
+                                  embedUrl: `https://www.youtube.com/embed/${v.id}`
+                              });
+                          }
+                          let contentUrl: string | undefined;
+                          try {
+                              const parsed = new URL(v.url, siteUrl);
+                              if (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+                                  contentUrl = parsed.href;
+                          } catch {
+                              contentUrl = undefined;
+                          }
+                          return createVideoObjectJsonLd({
+                              name,
+                              description: postDescription || undefined,
+                              thumbnailUrl: safeOgImage,
+                              uploadDate: data.post.created_at,
+                              contentUrl
+                          });
+                      });
+
         return {
             meta: {
                 title: `${data.post.title} - ${boardTitle}`,
@@ -1725,7 +1770,9 @@
                     { name: '홈', url: siteUrl },
                     { name: boardTitle, url: `${siteUrl}/${boardId}` },
                     { name: data.post.title }
-                ])
+                ]),
+                // VideoObject — 본문 유튜브 임베드·업로드 동영상 (최대 3개, null 은 필터됨)
+                ...videoJsonLds
             ]
         };
     });


### PR DESCRIPTION
## 배경
Search Console 알림: **동영상 색인 생성되지 않음 — 제공된 썸네일 URL 없음**

글 상세에 동영상(유튜브 임베드, 업로드 mp4)이 있어도 VideoObject 구조화 데이터가 전혀 없어, Google 이 동영상 페이지로 감지하고도 썸네일을 알 수 없어 색인에서 제외하고 있었습니다.

## 변경 내용
- `extractVideosFromContent(html)`: 본문에서 실제 재생 요소만 추출 — 유튜브 임베드 iframe(embed/nocookie/shorts)과 `<video src>`·`<video><source src>`. 단순 링크(`<a href>`)는 플레이어가 아니므로 제외, 중복 제거
- `createVideoObjectJsonLd`: Google 필수값(name·thumbnailUrl·uploadDate·embedUrl/contentUrl) 미충족 시 **null 반환 → 블록 생략** (breadcrumb fix 와 동일 철학: 빈/불완전 출력은 그 자체가 오류)
- 글 상세 페이지: 
  - 유튜브 → 썸네일 `i.ytimg.com/vi/{id}/hqdefault.jpg` (항상 존재) + embedUrl
  - 업로드 mp4 → 자체 포스터가 없으므로 **글 대표이미지가 있을 때만** 출력 (없으면 생략이 정답)
  - 비밀글·삭제글 제외(noIndex 와 일관), 글당 최대 3개
- 단위 테스트 3건 추가 (총 27개 통과), svelte-check 0 errors

## 검증
- `pnpm vitest run src/lib/seo/meta-helper.test.ts` → 27 passed
- `pnpm check` → 0 errors
- 배포 후: 유튜브 임베드 글에서 VideoObject JSON-LD 출력 + Rich Results Test 확인 예정

## 한계 (후속)
업로드 mp4 이면서 글에 이미지가 하나도 없는 글은 여전히 썸네일 제공 불가 — 동영상 포스터 프레임 생성(Lambda)은 별도 작업으로 분리합니다.