### PR TITLE
fix: 쪽지만 차단 회원의 댓글 숨김 처리 수정 (#12934)

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -242,12 +242,13 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
         // 요청자가 차단한 작성자 집합 (#12825). 서버에서 is_blocked 를 판정해 내려주면
         // 클라이언트 차단 스토어가 비동기 로드되기 전에도 첫 렌더부터 접힘 상태로 표시되어
         // "보였다 숨었다" 깜박임이 사라진다. 실패는 무시(클라 스토어가 fallback).
+        // "쪽지만 차단"(block_scope='message')은 콘텐츠 숨김 대상이 아니다 (#12916, #12934).
         const blockedSet = new Set<string>();
         const viewerId = locals.user?.id;
         if (viewerId) {
             try {
                 const [bRows] = await pool.query<RowDataPacket[]>(
-                    `SELECT blocked_mb_id FROM g5_member_block WHERE mb_id = ?`,
+                    `SELECT blocked_mb_id FROM g5_member_block WHERE mb_id = ? AND block_scope <> 'message'`,
                     [viewerId]
                 );
                 for (const b of bRows) {


### PR DESCRIPTION
## 증상 (bug/12934)
쪽지만 차단(block_scope='message')한 회원의 **게시글은 정상 노출되지만 댓글은 접힘(차단 회원 댓글) 처리**됩니다.

## 원인
댓글 API(`comments/+server.ts`)의 서버측 차단 집합(blockedSet) 조회가 `block_scope` 를 필터하지 않았습니다. 클라이언트 차단 스토어는 #12916 에서 이미 scope='message' 를 콘텐츠 숨김에서 제외했으나, 서버 SSR enrich(is_blocked 플래그) 경로만 누락되어 첫 렌더부터 접힘 상태가 됐습니다.

## 수정
차단 집합 쿼리에 `AND block_scope <> 'message'` 1줄 추가 — 클라 스토어와 기준 일치. 기존 데이터는 backfill('all') 완료 상태라 NULL/빈값 영향 없음('' 도 message 가 아니므로 기존 의미(전체 차단) 유지).

## 검증
- 운영 DB 실측: 제보자의 차단 행이 scope='message' 단 1건으로, 증상과 정확히 일치
- 전수 감사: 서버측 `g5_member_block` 조회 중 scope 미필터는 이 1곳뿐(백엔드 block_repo 는 정상)