### PR TITLE
feat(media): 동영상 포스터 자동 생성 — 업로드 시 첫 프레임 캡처 (Phase 1)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1617,7 +1617,12 @@ class ApiClient {
      * 파일 업로드 (SvelteKit /api/media/images → S3, IAM Role 인증)
      * 🔒 인증 필요
      */
-    async uploadFile(boardId: string, file: File, postId?: number): Promise<UploadedFile> {
+    async uploadFile(
+        boardId: string,
+        file: File,
+        postId?: number,
+        poster?: File
+    ): Promise<UploadedFile> {
         const { convertHeicIfNeeded } = await import('$lib/utils/image-convert.js');
         file = await convertHeicIfNeeded(file);
 
@@ -1625,6 +1630,10 @@ class ApiClient {
         formData.append('file', file);
         if (postId) {
             formData.append('post_id', String(postId));
+        }
+        // 동영상 포스터(브라우저 캡처 첫 프레임) — 서버가 관례 키(…_poster.jpg)에 저장
+        if (poster) {
+            formData.append('poster', poster);
         }
 
         const headers: Record<string, string> = {};
@@ -1673,6 +1682,8 @@ class ApiClient {
             filename: data.filename,
             original_filename: data.filename,
             url: data.cdn_url || data.url,
+            // 동영상 포스터 — 서버가 Lambda 처리 확인 후에만 내려줌 (404 URL 박제 방지)
+            thumbnail_url: data.poster_url || undefined,
             size: data.size,
             mime_type: data.content_type,
             created_at: new Date().toISOString()

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -22,6 +22,7 @@
     import Download from '@lucide/svelte/icons/download';
     import Paperclip from '@lucide/svelte/icons/paperclip';
     import Video from '@lucide/svelte/icons/video';
+    import { deriveVideoPoster } from '$lib/utils/video-poster.js';
     import Heart from '@lucide/svelte/icons/heart';
     import ThumbsDown from '@lucide/svelte/icons/thumbs-down';
     import Users from '@lucide/svelte/icons/users';
@@ -435,7 +436,15 @@
                         <div class="mt-6 space-y-4">
                             {#each post.videos as video, i (i)}
                                 <div class="overflow-hidden rounded-lg border">
-                                    <video controls preload="none" playsinline class="w-full">
+                                    <!-- poster = 관례 키(…_poster.jpg) 도출. 포스터 없는 옛 동영상은
+                                         404 인데 <video poster> 는 로드 실패를 조용히 무시하므로 무해 -->
+                                    <video
+                                        controls
+                                        preload="none"
+                                        playsinline
+                                        poster={deriveVideoPoster(video.url)}
+                                        class="w-full"
+                                    >
                                         <source src={video.url} />
                                         동영상을 재생할 수 없습니다.
                                     </video>

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -131,6 +131,24 @@
         }
     }
 
+    // 에디터 동영상 업로드 — 첫 프레임을 브라우저에서 캡처해 포스터로 함께 올린다.
+    // 캡처 실패(미지원 코덱 등) 시 포스터 없이 진행 (best effort)
+    async function handleEditorVideoUpload(
+        file: File
+    ): Promise<{ url: string; posterUrl?: string } | null> {
+        if (!boardId) return null;
+        try {
+            const postIdNum = post?.id ? Number(post.id) : undefined;
+            const { captureVideoPoster } = await import('$lib/utils/video-poster.js');
+            const poster = (await captureVideoPoster(file)) ?? undefined;
+            const result = await apiClient.uploadFile(boardId, file, postIdNum, poster);
+            return { url: result.url, posterUrl: result.thumbnail_url };
+        } catch (err) {
+            console.error('Video upload failed:', err);
+            return null;
+        }
+    }
+
     // 자동저장 상태
     let lastSavedAt = $state<Date | null>(null);
     let isSaving = $state(false);
@@ -652,6 +670,7 @@
                     disabled={isLoading}
                     onUpdate={(value) => (content = value)}
                     onImageUpload={handleEditorImageUpload}
+                    onVideoUpload={handleEditorVideoUpload}
                     onUploadingChange={(n) => (uploadingCount = n)}
                     class={errors.content ? 'border-destructive' : ''}
                 />

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -89,6 +89,11 @@
         contentFormat?: 'html' | 'markdown';
         onUpdate?: (value: string) => void;
         onImageUpload?: (file: File) => Promise<string | null>;
+        /**
+         * 동영상 전용 업로드 — 포스터(첫 프레임) URL 을 함께 반환할 수 있다.
+         * 미제공 시 onImageUpload 폴백 (포스터 없이 현행 동작).
+         */
+        onVideoUpload?: (file: File) => Promise<{ url: string; posterUrl?: string } | null>;
         /** 백그라운드 이미지 변환(blob→변환본 스왑) 진행 개수 변화 알림. 0 이면 모두 완료. */
         onUploadingChange?: (count: number) => void;
         class?: string;
@@ -101,9 +106,24 @@
         contentFormat = 'html',
         onUpdate,
         onImageUpload,
+        onVideoUpload,
         onUploadingChange,
         class: className = ''
     }: Props = $props();
+
+    /** 동영상 업로드 — onVideoUpload 우선, 없으면 onImageUpload 폴백 */
+    async function uploadVideo(file: File): Promise<{ url: string; posterUrl?: string } | null> {
+        if (onVideoUpload) return onVideoUpload(file);
+        if (!onImageUpload) return null;
+        const url = await onImageUpload(file);
+        return url ? { url } : null;
+    }
+
+    /** 본문 삽입용 video 태그 — 포스터가 실제 준비된 경우에만 poster 속성 포함 */
+    function buildVideoTag(video: { url: string; posterUrl?: string }): string {
+        const posterAttr = video.posterUrl ? ` poster="${video.posterUrl}"` : '';
+        return `<video src="${video.url}"${posterAttr} controls playsinline preload="metadata" style="max-width:100%;border-radius:8px;"></video>`;
+    }
 
     // 진행 중인 백그라운드 이미지 변환 개수. 제출 측(post-form)이 0 이 될 때까지 자동 대기한다.
     let pendingUploads = $state(0);
@@ -552,8 +572,8 @@
                 if (file.type.startsWith('video/')) {
                     isUploading = true;
                     try {
-                        const videoUrl = await onImageUpload(file);
-                        if (videoUrl) {
+                        const video = await uploadVideo(file);
+                        if (video) {
                             editor
                                 .chain()
                                 .focus()
@@ -561,9 +581,7 @@
                                     type: 'paragraph',
                                     content: []
                                 })
-                                .insertContent(
-                                    `<video src="${videoUrl}" controls playsinline preload="metadata" style="max-width:100%;border-radius:8px;"></video>`
-                                )
+                                .insertContent(buildVideoTag(video))
                                 .run();
                         }
                     } catch (err) {
@@ -971,19 +989,13 @@
 
     // 동영상 파일 업로드 헬퍼
     async function insertVideoFile(file: File): Promise<void> {
-        if (!onImageUpload || !editor) return;
+        if ((!onVideoUpload && !onImageUpload) || !editor) return;
 
         isUploading = true;
         try {
-            const videoUrl = await onImageUpload(file);
-            if (videoUrl) {
-                editor
-                    .chain()
-                    .focus()
-                    .insertContent(
-                        `<video src="${videoUrl}" controls playsinline preload="metadata" style="max-width:100%;border-radius:8px;"></video>`
-                    )
-                    .run();
+            const video = await uploadVideo(file);
+            if (video) {
+                editor.chain().focus().insertContent(buildVideoTag(video)).run();
             }
         } catch (err) {
             console.error('Video upload failed:', err);

--- a/apps/web/src/lib/components/features/uploader/file-uploader.svelte
+++ b/apps/web/src/lib/components/features/uploader/file-uploader.svelte
@@ -152,10 +152,16 @@
             uploadingFiles = [...uploadingFiles, uploadingFile];
 
             try {
+                // 동영상은 첫 프레임을 캡처해 포스터로 함께 업로드 (캡처 실패 시 포스터 없이 진행)
+                let poster: File | undefined;
+                if (file.type.startsWith('video/')) {
+                    const { captureVideoPoster } = await import('$lib/utils/video-poster.js');
+                    poster = (await captureVideoPoster(file)) ?? undefined;
+                }
                 // 이미지 파일이면 uploadImage, 아니면 uploadFile 사용
                 const uploaded = isImageFile(file)
                     ? await apiClient.uploadImage(boardId, file, postId)
-                    : await apiClient.uploadFile(boardId, file, postId);
+                    : await apiClient.uploadFile(boardId, file, postId, poster);
                 uploadingFiles = uploadingFiles.filter((f) => f.id !== uploadingFile.id);
                 uploadedFiles = [...uploadedFiles, uploaded];
                 onUpload?.(uploaded);

--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -13,7 +13,9 @@ import type {
 } from './types';
 
 /** 본문에서 추출된 동영상 (유튜브 임베드 또는 업로드 파일) */
-export type ExtractedVideo = { type: 'youtube'; id: string } | { type: 'file'; url: string };
+export type ExtractedVideo =
+    | { type: 'youtube'; id: string }
+    | { type: 'file'; url: string; poster?: string };
 
 // 유튜브 임베드 iframe 의 videoId — tiptap Youtube 확장이 embed/ 형태로 저장하지만,
 // 과거 글의 nocookie·shorts 변형도 수용
@@ -40,12 +42,18 @@ export function extractVideosFromContent(html: string): ExtractedVideo[] {
         }
     }
 
-    // <video src> 와 <video> 내부 <source src> — 에디터가 두 형태 모두 생성
-    for (const m of html.matchAll(/<(?:video|source)[^>]*\ssrc\s*=\s*["']([^"']+)["']/gi)) {
-        const url = m[1];
+    // <video src> 와 <video> 내부 <source src> — 에디터가 두 형태 모두 생성.
+    // poster 속성(브라우저 캡처 첫 프레임)이 있으면 VideoObject 썸네일로 쓰도록 함께 추출
+    for (const vm of html.matchAll(/<video\b[^>]*>[\s\S]*?(?:<\/video>|$)|<video\b[^>]*\/?>/gi)) {
+        const block = vm[0];
+        const openTag = block.match(/^<video\b[^>]*>/i)?.[0] ?? block;
+        const poster = openTag.match(/\sposter\s*=\s*["']([^"']+)["']/i)?.[1];
+        const url =
+            openTag.match(/\ssrc\s*=\s*["']([^"']+)["']/i)?.[1] ??
+            block.match(/<source\b[^>]*\ssrc\s*=\s*["']([^"']+)["']/i)?.[1];
         if (url && !seen.has(`file:${url}`)) {
             seen.add(`file:${url}`);
-            videos.push({ type: 'file', url });
+            videos.push(poster ? { type: 'file', url, poster } : { type: 'file', url });
         }
     }
 

--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -266,3 +266,30 @@ describe('VideoObject (GSC 동영상 색인 — 썸네일 필수)', () => {
         expect(createVideoObjectJsonLd({ ...base, embedUrl: undefined })).toBeNull();
     });
 });
+
+describe('동영상 포스터 (관례 키 + poster 속성)', () => {
+    it('extractVideosFromContent: video poster 속성 추출', async () => {
+        const { extractVideosFromContent } = await import('./json-ld');
+        const html = `
+            <video src="https://r2.damoang.net/data/editor/2607/a.mp4" poster="https://r2.damoang.net/data/editor/2607/a_poster.jpg" controls></video>
+            <video controls><source src="https://r2.damoang.net/data/file/b.mp4" /></video>`;
+        expect(extractVideosFromContent(html)).toEqual([
+            {
+                type: 'file',
+                url: 'https://r2.damoang.net/data/editor/2607/a.mp4',
+                poster: 'https://r2.damoang.net/data/editor/2607/a_poster.jpg'
+            },
+            { type: 'file', url: 'https://r2.damoang.net/data/file/b.mp4' }
+        ]);
+    });
+
+    it('deriveVideoPoster: 확장자 → _poster.jpg (쿼리스트링 보존)', async () => {
+        const { deriveVideoPoster } = await import('../utils/video-poster');
+        expect(deriveVideoPoster('https://r2.damoang.net/data/editor/2607/a.mp4')).toBe(
+            'https://r2.damoang.net/data/editor/2607/a_poster.jpg'
+        );
+        expect(deriveVideoPoster('https://r2.damoang.net/data/editor/2607/a.webm?v=1')).toBe(
+            'https://r2.damoang.net/data/editor/2607/a_poster.jpg?v=1'
+        );
+    });
+});

--- a/apps/web/src/lib/utils/video-poster.ts
+++ b/apps/web/src/lib/utils/video-poster.ts
@@ -1,0 +1,84 @@
+/**
+ * 동영상 포스터(썸네일) 유틸
+ *
+ * 업로드 시점에 브라우저에서 첫 프레임을 캡처해 포스터 jpg 를 만든다.
+ * 포스터는 동영상 키에서 기계적으로 도출되는 "관례 키"(형제 키)에 저장되므로
+ * DB 스키마 변경 없이 URL 만으로 상호 변환할 수 있다:
+ *   data/editor/2607/abc1234.mp4  →  data/editor/2607/abc1234_poster.jpg
+ */
+
+/** 포스터 캡처 시점(초) — 0초 프레임이 검은 인트로인 경우가 흔해 살짝 뒤로 */
+const CAPTURE_TIME_SEC = 0.1;
+/** 포스터 긴 변 최대 px — 표시·SEO 용도로 충분, 파일 수십 KB 유지 */
+const MAX_DIMENSION = 1280;
+/** 메타데이터 로드·seek 전체 타임아웃 — 초과 시 포스터 없이 진행 */
+const CAPTURE_TIMEOUT_MS = 5000;
+
+/**
+ * 동영상 파일의 첫 프레임을 canvas 로 캡처해 jpg File 로 반환.
+ *
+ * 포스터는 best effort — 브라우저가 재생 못 하는 코덱(mov/avi/mkv 등)이나
+ * 캡처 실패 시 null 을 반환하며, 이 경우에도 동영상 업로드 자체는 정상 진행된다.
+ */
+export async function captureVideoPoster(file: File): Promise<File | null> {
+    if (typeof document === 'undefined' || !file.type.startsWith('video/')) return null;
+
+    const objectUrl = URL.createObjectURL(file);
+    const video = document.createElement('video');
+    video.muted = true;
+    video.playsInline = true;
+    video.preload = 'metadata';
+    video.src = objectUrl;
+
+    try {
+        const blob = await new Promise<Blob | null>((resolve) => {
+            const timer = setTimeout(() => resolve(null), CAPTURE_TIMEOUT_MS);
+            const fail = () => {
+                clearTimeout(timer);
+                resolve(null);
+            };
+
+            video.onerror = fail;
+            video.onloadedmetadata = () => {
+                if (!video.videoWidth || !video.videoHeight) return fail();
+                // duration 이 캡처 시점보다 짧은 초단편은 0초 프레임 사용
+                video.currentTime = Math.min(CAPTURE_TIME_SEC, video.duration || 0);
+            };
+            video.onseeked = () => {
+                try {
+                    const scale = Math.min(
+                        1,
+                        MAX_DIMENSION / Math.max(video.videoWidth, video.videoHeight)
+                    );
+                    const canvas = document.createElement('canvas');
+                    canvas.width = Math.round(video.videoWidth * scale);
+                    canvas.height = Math.round(video.videoHeight * scale);
+                    const ctx = canvas.getContext('2d');
+                    if (!ctx) return fail();
+                    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+                    clearTimeout(timer);
+                    canvas.toBlob((b) => resolve(b), 'image/jpeg', 0.8);
+                } catch {
+                    fail();
+                }
+            };
+        });
+
+        if (!blob || blob.size === 0) return null;
+        return new File([blob], 'poster.jpg', { type: 'image/jpeg' });
+    } finally {
+        video.removeAttribute('src');
+        video.load();
+        URL.revokeObjectURL(objectUrl);
+    }
+}
+
+/**
+ * 동영상 URL → 관례 포스터 URL (확장자를 _poster.jpg 로 치환)
+ *
+ * 포스터가 아직 없는 옛 동영상은 404 가 되지만, <video poster> 는 로드 실패를
+ * 조용히 무시하므로(현행과 동일한 표시) 무해하다. backfill 이 채우면 자동 표시.
+ */
+export function deriveVideoPoster(videoUrl: string): string {
+    return videoUrl.replace(/\.[a-z0-9]+(?=(?:\?|#|$))/i, '_poster.jpg');
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1672,7 +1672,8 @@
                       ...extractVideosFromContent(renderedPostContent),
                       ...(data.post.videos ?? []).map((v) => ({
                           type: 'file' as const,
-                          url: v.url
+                          url: v.url,
+                          poster: undefined as string | undefined
                       }))
                   ]
                       .slice(0, 3)
@@ -1687,20 +1688,24 @@
                                   embedUrl: `https://www.youtube.com/embed/${v.id}`
                               });
                           }
-                          let contentUrl: string | undefined;
-                          try {
-                              const parsed = new URL(v.url, siteUrl);
-                              if (parsed.protocol === 'http:' || parsed.protocol === 'https:')
-                                  contentUrl = parsed.href;
-                          } catch {
-                              contentUrl = undefined;
-                          }
+                          const toHttpUrl = (raw?: string): string | undefined => {
+                              if (!raw) return undefined;
+                              try {
+                                  const parsed = new URL(raw, siteUrl);
+                                  return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+                                      ? parsed.href
+                                      : undefined;
+                              } catch {
+                                  return undefined;
+                              }
+                          };
                           return createVideoObjectJsonLd({
                               name,
                               description: postDescription || undefined,
-                              thumbnailUrl: safeOgImage,
+                              // 업로드 시 캡처된 포스터(본문 poster 속성) 우선, 없으면 글 대표이미지
+                              thumbnailUrl: toHttpUrl(v.poster) ?? safeOgImage,
                               uploadDate: data.post.created_at,
-                              contentUrl
+                              contentUrl: toHttpUrl(v.url)
                           });
                       });
 

--- a/apps/web/src/routes/api/media/images/+server.ts
+++ b/apps/web/src/routes/api/media/images/+server.ts
@@ -146,6 +146,8 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
     // multipart form data 파싱
     const formData = await request.formData();
     const file = formData.get('file');
+    // 동영상 업로드 시 브라우저가 캡처한 포스터(첫 프레임 jpg) — 옵션, 없으면 현행과 동일
+    const poster = formData.get('poster');
 
     if (!file || !(file instanceof File)) {
         error(400, '파일이 필요합니다.');
@@ -174,6 +176,18 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
     const finalKey = rawKeyToFinalKey(rawKey);
     const contentType = file.type || 'application/octet-stream';
 
+    // 포스터는 동영상에 한해, jpeg·2MB 이하만 수용 (남용 방지). 관례 키 = 동영상과
+    // 같은 해시의 형제 키(…/{hash}_poster.jpg). raw/ 로 올려 기존 Lambda 파이프라인
+    // (data/ 변환 + R2 dual-write)을 그대로 태운다 — data/ 직행 시 R2 에 실리지 않음.
+    const hasPoster =
+        poster instanceof File &&
+        isVideoExt(ext) &&
+        poster.type === 'image/jpeg' &&
+        poster.size > 0 &&
+        poster.size <= 2 * 1024 * 1024;
+    const posterRawKey = hasPoster ? rawKey.replace(/\.[a-z0-9]+$/i, '_poster.jpg') : null;
+    const posterFinalKey = posterRawKey ? rawKeyToFinalKey(posterRawKey) : null;
+
     try {
         const buffer = Buffer.from(await file.arrayBuffer());
 
@@ -187,8 +201,24 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
             })
         );
 
-        // Lambda 변환 완료 대기 (최대 3초) — race condition 방지
-        const isReady = await waitForProcessed(finalKey);
+        if (hasPoster && posterRawKey) {
+            const posterBuffer = Buffer.from(await (poster as File).arrayBuffer());
+            await s3.send(
+                new PutObjectCommand({
+                    Bucket: S3_BUCKET,
+                    Key: posterRawKey,
+                    Body: posterBuffer,
+                    ContentType: 'image/jpeg',
+                    CacheControl: 'public, max-age=31536000, immutable'
+                })
+            );
+        }
+
+        // Lambda 변환 완료 대기 — race condition 방지 (포스터는 소형이라 본 파일보다 먼저 끝남)
+        const [isReady, posterReady] = await Promise.all([
+            waitForProcessed(finalKey),
+            posterFinalKey ? waitForProcessed(posterFinalKey) : Promise.resolve(false)
+        ]);
         if (!isReady) {
             console.warn(
                 `[media/images] Lambda processing not confirmed within timeout: ${finalKey}`
@@ -208,7 +238,11 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
                 origin_url: originUrl,
                 filename: file.name,
                 content_type: contentType,
-                size: file.size
+                size: file.size,
+                // 포스터가 실제 준비됐을 때만 내려보냄 — 404 포스터 URL 을 본문에 박제하지 않기 위함
+                ...(posterReady && posterFinalKey
+                    ? { poster_url: `${CDN_BASE}/${posterFinalKey}` }
+                    : {})
             }
         });
     } catch (err) {


### PR DESCRIPTION
## 배경
GSC "동영상 색인 — 제공된 썸네일 URL 없음" 후속. #1747(VideoObject)이 유튜브 임베드를 해결했고, 이 PR 은 **업로드 동영상**의 포스터를 만듭니다. 상세 설계: `/home/damoang/docs/video-poster-design.html`

## 핵심: 관례 키 (DB 스키마 무변경)
동영상 `data/editor/2607/abc.mp4` → 포스터 `data/editor/2607/abc_poster.jpg`. 프론트가 URL 에서 도출하므로 Go 백엔드·g5_board_file 변경 0. 포스터 없는 옛 글은 poster 404 = 브라우저가 조용히 무시(현행과 동일) → backfill 이 채우면 자동 표시.

## 변경
- **`video-poster.ts` 신설**: 브라우저 canvas 로 첫 프레임(0.1s) 캡처 → jpg (긴 변 1280px, 실패 시 null = 업로드는 정상 진행)
- **`/api/media/images`**: 옵션 `poster` 필드(jpeg·2MB↓, 동영상만) — 동영상과 같은 해시의 형제 키로 `raw/` 에 올려 **기존 Lambda 파이프라인(data/ 변환 + R2 dual-write)을 그대로 재사용**. Lambda 처리 확인 후에만 `poster_url` 응답 (404 URL 을 본문에 박제하지 않음)
- **에디터**: `onVideoUpload` 프롭 신설 (기존 `onImageUpload` 폴백 유지) — 삽입 태그에 `poster` 속성
- **첨부**: file-uploader 캡처 동봉, `basic.svelte` `<video poster={deriveVideoPoster(url)}>`
- **SEO**: `extractVideosFromContent` 가 poster 속성 추출 → VideoObject thumbnailUrl 우선순위 = 본문 poster > 글 대표이미지 → **이미지 없는 동영상 글도 색인 가능**

## 검증
- vitest 29 passed / svelte-check 0 errors
- 배포 후 Evaluator: mp4 업로드 → `_poster.jpg` 생성 + 재생 전 포스터 표시 / mov(미지원 코덱) → 포스터 없이 정상 / 이미지 단독 업로드 회귀 0

## 후속 (별개)
Phase 2 backfill: `/home/angple/scripts/video-poster-backfill.sh` 준비 완료 — dry-run 실측 **소급 대상 2,401개**. 배포 후 실행 예정.