### PR TITLE
fix(affiliate): 링크프라이스 a_id env 오염 방어 + 실패 사유 관측성

### DIFF
--- a/apps/web/src/lib/server/affiliate-links.ts
+++ b/apps/web/src/lib/server/affiliate-links.ts
@@ -104,6 +104,24 @@ function extractMerchantDomain(url: string): string {
     }
 }
 
+/**
+ * 실패/거부 사유를 upstream 메시지까지 포함해 기록한다.
+ * "[-3] a_id 형식오류" 같은 설정 오류가 'denied' 한 단어로 뭉개져
+ * 장기간 은폐됐던 사고(2026-07-10)의 재발 방지.
+ */
+function buildLastError(status: AffiliateStatus, decision: AffiliateDecision): string | null {
+    const upstream =
+        typeof decision.metadata?.upstreamError === 'string' ? decision.metadata.upstreamError : '';
+    if (status === 'failed') {
+        const base = decision.reasonCode || 'conversion_failed';
+        return upstream && upstream !== base ? `${base}: ${upstream}` : base;
+    }
+    if (decision.status === 'denied') {
+        return upstream ? `denied: ${upstream}` : 'denied';
+    }
+    return null;
+}
+
 function mapDecisionToRow(
     entityType: AffiliateEntityType,
     linkIndex: number,
@@ -122,12 +140,7 @@ function mapDecisionToRow(
         status,
         reasonCode: decision.reasonCode || '',
         attemptCount: 1,
-        lastError:
-            status === 'failed'
-                ? decision.reasonCode || 'conversion_failed'
-                : decision.status === 'denied'
-                  ? 'denied'
-                  : null
+        lastError: buildLastError(status, decision)
     };
 }
 

--- a/plugins/affiliate-link-private/lib/platforms/linkprice.ts
+++ b/plugins/affiliate-link-private/lib/platforms/linkprice.ts
@@ -2,8 +2,17 @@ import type { AffiliateDecision, AffiliateNetwork, AffiliateReasonCode } from '.
 
 const env = process.env;
 
+/**
+ * env 값 정제: 둘러싼 따옴표·공백 제거.
+ * env 파일에 값이 따옴표째 저장되면 LP API가 "[-3] a_id 형식오류"로 전량 거부한다
+ * (2026-07-10 전면 변환 실패 사고의 근본 원인).
+ */
+function sanitizeAffiliateId(raw: string | undefined): string {
+    return (raw || '').trim().replace(/^['"]+|['"]+$/g, '');
+}
+
 export function getLinkPriceAffiliateId(): string {
-    return env.AFFI_LINKPRICE_AFF_ID || env.AFFI_AFFILIATE_ID || '';
+    return sanitizeAffiliateId(env.AFFI_LINKPRICE_AFF_ID || env.AFFI_AFFILIATE_ID);
 }
 
 export function createLinkPriceFailureDecision(
@@ -12,11 +21,13 @@ export function createLinkPriceFailureDecision(
     reasonCode: Extract<
         AffiliateReasonCode,
         | 'env_missing'
+        | 'config_error'
         | 'merchant_denied'
         | 'api_error'
         | 'rebind_not_supported'
         | 'rebind_failed_upstream_blocked'
-    >
+    >,
+    upstreamError?: string
 ): AffiliateDecision {
     const network: AffiliateNetwork = 'linkprice';
     return {
@@ -24,8 +35,14 @@ export function createLinkPriceFailureDecision(
         reasonCode,
         network,
         originalUrl,
-        normalizedUrl
+        normalizedUrl,
+        ...(upstreamError ? { metadata: { upstreamError } } : {})
     };
+}
+
+/** LP 응답이 설정 오류(a_id 형식/미승인 계정 등)인지 — 머천트 거부와 구분해야 은폐되지 않는다. */
+function isConfigError(upstreamError: string): boolean {
+    return /\[-3\]|a_id/i.test(upstreamError);
 }
 
 export function classifyLinkPriceFailure(input: {
@@ -41,13 +58,31 @@ export function classifyLinkPriceFailure(input: {
         );
     }
 
-    if (input.upstreamError === 'Conversion failed') {
+    const upstream = input.upstreamError || '';
+
+    if (isConfigError(upstream)) {
         return createLinkPriceFailureDecision(
             input.originalUrl,
             input.normalizedUrl,
-            'merchant_denied'
+            'config_error',
+            upstream
         );
     }
 
-    return createLinkPriceFailureDecision(input.originalUrl, input.normalizedUrl, 'api_error');
+    // 'Conversion failed' = 구 변환기 일반 실패, 'LinkPrice F: ...' = err_msg 전파형 거부
+    if (upstream === 'Conversion failed' || upstream.startsWith('LinkPrice ')) {
+        return createLinkPriceFailureDecision(
+            input.originalUrl,
+            input.normalizedUrl,
+            'merchant_denied',
+            upstream
+        );
+    }
+
+    return createLinkPriceFailureDecision(
+        input.originalUrl,
+        input.normalizedUrl,
+        'api_error',
+        upstream || undefined
+    );
 }

--- a/plugins/affiliate-link-private/lib/resolver.server.ts
+++ b/plugins/affiliate-link-private/lib/resolver.server.ts
@@ -2,7 +2,12 @@ import {
     convertAffiliateLinksDetailed,
     convertAffiliateUrl
 } from '../../affiliate-link/lib/affiliate-api.server';
-import { detectPlatform, extractHost, normalizeUrl, mergeMerchantDomains } from '../../affiliate-link/lib/domain-matcher';
+import {
+    detectPlatform,
+    extractHost,
+    normalizeUrl,
+    mergeMerchantDomains
+} from '../../affiliate-link/lib/domain-matcher';
 import pool from '$lib/server/db.js';
 import { buildAffiliateRedirectRecord, attachRedirectToDecision } from './redirect-store.server';
 import { createErrorDecision, createPassthroughDecision } from './policies';
@@ -31,9 +36,7 @@ async function _syncMerchants(): Promise<void> {
         const [rows] = await pool.query(
             "SELECT domain FROM affiliate_merchants WHERE platform = 'linkprice' AND is_active = 1"
         );
-        mergeMerchantDomains(
-            (rows as Array<{ domain: string }>).map((r) => r.domain)
-        );
+        mergeMerchantDomains((rows as Array<{ domain: string }>).map((r) => r.domain));
     } catch {
         // DB 미연결 시 하드코딩 폴백
     }
@@ -111,7 +114,8 @@ function getRebindFailureReason(input: {
 
     if (
         input.inputKind === 'affiliate_url_rebindable' &&
-        input.upstreamError === 'Conversion failed'
+        (input.upstreamError === 'Conversion failed' ||
+            input.upstreamError?.startsWith('LinkPrice '))
     ) {
         return 'rebind_failed_upstream_blocked';
     }

--- a/plugins/affiliate-link-private/lib/types.ts
+++ b/plugins/affiliate-link-private/lib/types.ts
@@ -24,17 +24,12 @@ export type AffiliateReasonCode =
     | 'already_affiliate'
     | 'invalid_url'
     | 'env_missing'
+    | 'config_error'
     | 'merchant_denied'
     | 'api_error'
     | 'unknown';
 
-export type AffiliateNetwork =
-    | 'linkprice'
-    | 'aliexpress'
-    | 'coupang'
-    | 'amazon'
-    | 'kkday'
-    | 'none';
+export type AffiliateNetwork = 'linkprice' | 'aliexpress' | 'coupang' | 'amazon' | 'kkday' | 'none';
 
 export type LinkFieldName = 'link1' | 'link2';
 

--- a/plugins/affiliate-link/lib/platforms/linkprice.ts
+++ b/plugins/affiliate-link/lib/platforms/linkprice.ts
@@ -4,7 +4,12 @@
  */
 
 import type { PlatformConverter, ConvertContext } from '../types';
-import { PLATFORM_DOMAINS, matchesPlatform, LINKPRICE_MERCHANTS, extractHost } from '../domain-matcher';
+import {
+    PLATFORM_DOMAINS,
+    matchesPlatform,
+    LINKPRICE_MERCHANTS,
+    extractHost
+} from '../domain-matcher';
 const env = process.env;
 
 const API_ENDPOINT = 'https://api.linkprice.com/ci/service/custom_link_xml';
@@ -15,123 +20,153 @@ const API_TIMEOUT_MS = 2_500;
  * 형식: u{mb_no}_{bo_table}_{wr_id} 또는 {bo_table}_{wr_id}
  */
 function generateClickId(context?: ConvertContext): string {
-	const parts: string[] = [];
+    const parts: string[] = [];
 
-	if (context?.mb_no) {
-		parts.push(`u${context.mb_no}`);
-	}
+    if (context?.mb_no) {
+        parts.push(`u${context.mb_no}`);
+    }
 
-	if (context?.bo_table) {
-		parts.push(context.bo_table);
-	}
+    if (context?.bo_table) {
+        parts.push(context.bo_table);
+    }
 
-	if (context?.wr_id) {
-		parts.push(String(context.wr_id));
-	}
+    if (context?.wr_id) {
+        parts.push(String(context.wr_id));
+    }
 
-	return parts.join('_') || 'direct';
+    return parts.join('_') || 'direct';
+}
+
+/**
+ * env 값 정제: 둘러싼 따옴표·공백 제거.
+ * env 파일에 값이 따옴표째 저장되면 LP API가 "[-3] a_id 형식오류"로 전량 거부한다
+ * (2026-07-10 전면 변환 실패 사고의 근본 원인).
+ */
+export function sanitizeLinkPriceAffiliateId(raw: string | undefined): string {
+    const cleaned = (raw || '').trim().replace(/^['"]+|['"]+$/g, '');
+    if (cleaned && !/^A\d+$/.test(cleaned)) {
+        console.warn(
+            '[LinkPrice] a_id 형식 경고 (A+숫자 아님):',
+            cleaned.replace(/[A-Za-z0-9]/g, 'x')
+        );
+    }
+    return cleaned;
 }
 
 /**
  * 링크프라이스 API 호출
  */
-async function callLinkPriceApi(originalUrl: string, context?: ConvertContext): Promise<string | null> {
-	const affiliateId = env.AFFI_LINKPRICE_AFF_ID || env.AFFI_AFFILIATE_ID;
+async function callLinkPriceApi(
+    originalUrl: string,
+    context?: ConvertContext
+): Promise<string | null> {
+    const affiliateId = sanitizeLinkPriceAffiliateId(
+        env.AFFI_LINKPRICE_AFF_ID || env.AFFI_AFFILIATE_ID
+    );
 
-	if (!affiliateId) {
-		console.warn('[LinkPrice] Affiliate ID가 설정되지 않음');
-		return null;
-	}
+    if (!affiliateId) {
+        console.warn('[LinkPrice] Affiliate ID가 설정되지 않음');
+        return null;
+    }
 
-	const clickId = generateClickId(context);
-	const encodedUrl = encodeURIComponent(originalUrl);
+    const clickId = generateClickId(context);
+    const encodedUrl = encodeURIComponent(originalUrl);
 
-	const apiUrl = `${API_ENDPOINT}?a_id=${affiliateId}&url=${encodedUrl}&u_id=${clickId}&mode=json`;
+    const apiUrl = `${API_ENDPOINT}?a_id=${affiliateId}&url=${encodedUrl}&u_id=${clickId}&mode=json`;
 
-	try {
-		const response = await fetch(apiUrl, {
-			method: 'GET',
-			signal: AbortSignal.timeout(API_TIMEOUT_MS),
-			headers: {
-				'User-Agent': 'Mozilla/5.0 (compatible; DamoangBot/1.0)'
-			}
-		});
+    try {
+        const response = await fetch(apiUrl, {
+            method: 'GET',
+            signal: AbortSignal.timeout(API_TIMEOUT_MS),
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (compatible; DamoangBot/1.0)'
+            }
+        });
 
-		if (!response.ok) {
-			console.error(`[LinkPrice] API 오류: ${response.status}`);
-			return null;
-		}
+        if (!response.ok) {
+            console.error(`[LinkPrice] API 오류: ${response.status}`);
+            return null;
+        }
 
-		const data = await response.json();
+        const data = await response.json();
 
-		// 응답 구조: { result: 'S', url: '변환된 URL' }
-		if (data.result === 'S' && data.url) {
-			let linkpriceUrl = data.url;
+        // 응답 구조: { result: 'S', url: '변환된 URL' }
+        if (data.result === 'S' && data.url) {
+            let linkpriceUrl = data.url;
 
-			// u_id가 없으면 수동 추가
-			if (!linkpriceUrl.includes('&u=') && !linkpriceUrl.includes('?u=')) {
-				const separator = linkpriceUrl.includes('?') ? '&' : '?';
-				linkpriceUrl += `${separator}u=${encodeURIComponent(clickId)}`;
-			}
+            // u_id가 없으면 수동 추가
+            if (!linkpriceUrl.includes('&u=') && !linkpriceUrl.includes('?u=')) {
+                const separator = linkpriceUrl.includes('?') ? '&' : '?';
+                linkpriceUrl += `${separator}u=${encodeURIComponent(clickId)}`;
+            }
 
-			return linkpriceUrl;
-		}
+            return linkpriceUrl;
+        }
 
-		// 승인거부(-6), 유효하지 않은 URL(-4) 등은 정상 응답 — 로그 생략
-		if (isLinkPriceMerchant(originalUrl)) {
-			console.warn('[LinkPrice] conversion miss', {
-				originalUrl,
-				clickId,
-				result: data?.result,
-				message: data?.message || data?.msg || null
-			});
-		}
-		return null;
-	} catch (error) {
-		if (error instanceof Error && error.name === 'TimeoutError') {
-			console.warn('[LinkPrice] API timeout', {
-				originalUrl,
-				clickId,
-				timeoutMs: API_TIMEOUT_MS
-			});
-			return null;
-		}
-		console.error('[LinkPrice] API 호출 실패:', error);
-		return null;
-	}
+        // 변환 거부 — 사유(err_msg)를 상위로 전파해 last_error 에 남긴다.
+        // "[-3] a_id 형식오류" 같은 설정 오류가 일반 거부로 위장되는 것을 방지 (2026-07-10 사고).
+        const upstreamMsg = data?.err_msg || data?.message || data?.msg || '';
+        if (isLinkPriceMerchant(originalUrl)) {
+            console.warn('[LinkPrice] conversion miss', {
+                originalUrl,
+                clickId,
+                result: data?.result,
+                message: upstreamMsg || null
+            });
+        }
+        const missError = new Error(
+            `LinkPrice ${data?.result ?? 'F'}${upstreamMsg ? `: ${upstreamMsg}` : ''}`
+        );
+        missError.name = 'LinkPriceConversionError';
+        throw missError;
+    } catch (error) {
+        if (error instanceof Error && error.name === 'LinkPriceConversionError') {
+            throw error;
+        }
+        if (error instanceof Error && error.name === 'TimeoutError') {
+            console.warn('[LinkPrice] API timeout', {
+                originalUrl,
+                clickId,
+                timeoutMs: API_TIMEOUT_MS
+            });
+            return null;
+        }
+        console.error('[LinkPrice] API 호출 실패:', error);
+        return null;
+    }
 }
 
 /**
  * URL이 링크프라이스 머천트인지 확인
  */
 function isLinkPriceMerchant(url: string): boolean {
-	// 이미 링크프라이스 단축 URL인 경우
-	if (matchesPlatform(url, 'linkprice')) {
-		return true;
-	}
+    // 이미 링크프라이스 단축 URL인 경우
+    if (matchesPlatform(url, 'linkprice')) {
+        return true;
+    }
 
-	// 머천트 도메인 확인
-	const host = extractHost(url);
-	if (!host) return false;
+    // 머천트 도메인 확인
+    const host = extractHost(url);
+    if (!host) return false;
 
-	for (const merchant of LINKPRICE_MERCHANTS) {
-		if (host === merchant || host.endsWith('.' + merchant)) {
-			return true;
-		}
-	}
+    for (const merchant of LINKPRICE_MERCHANTS) {
+        if (host === merchant || host.endsWith('.' + merchant)) {
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 export const linkpriceConverter: PlatformConverter = {
-	platform: 'linkprice',
-	info: PLATFORM_DOMAINS.linkprice,
+    platform: 'linkprice',
+    info: PLATFORM_DOMAINS.linkprice,
 
-	matches(url: string): boolean {
-		return isLinkPriceMerchant(url);
-	},
+    matches(url: string): boolean {
+        return isLinkPriceMerchant(url);
+    },
 
-	async convert(url: string, context?: ConvertContext): Promise<string | null> {
-		return callLinkPriceApi(url, context);
-	}
+    async convert(url: string, context?: ConvertContext): Promise<string | null> {
+        return callLinkPriceApi(url, context);
+    }
 };


### PR DESCRIPTION
## 배경 (2026-07-10 전체 점검)
링크프라이스 변환 성공률이 0.3%(1/331)로 사실상 전면 붕괴 상태였습니다. 근본 원인은 env `AFFI_AFFILIATE_ID` 값에 **따옴표가 값의 일부로 저장**되어 LP API가 `[-3] a_id 형식오류`로 전량 거부한 것입니다(실측: 오염값 → result F, 순수값 → result S 정상 변환). 코드가 이 실패를 `merchant_denied`/`denied` 로 뭉개 기록해 설정 오류가 장기간 은폐됐습니다.

## 변경
1. **sanitize**: env 값의 둘러싼 따옴표·공백 제거 + `A숫자` 형식 검증 경고(마스킹) — 공개/프라이빗 플러그인 양쪽. secret 원천 정정과 무관하게 코드만으로 복구됩니다.
2. **관측성**: LP `err_msg` 를 변환기에서 상위로 전파(마커 예외) → `g5_affiliate_links.last_error` 에 실제 사유 기록. `[-3]`/a_id 계열은 신설 `config_error` 로 분류해 merchant_denied 와 분리.

## 검증
- `pnpm check` 0 errors / 유닛 476 passed
- LP API 실측: 오염 a_id 재현(`[-3]`) → sanitize 값 → `result:S` (교보 상품 URL)
- 배포 후 계획: 최근 30일 denied 행 backfill 재처리 → converted 전환 확인