### PR TITLE
feat(economy): 판매 종료 제보 버튼 — 3인 제보 시 '종료' 전환 + AI 댓글

### DIFF
--- a/apps/web/src/lib/components/features/board/deal-end-report-button.svelte
+++ b/apps/web/src/lib/components/features/board/deal-end-report-button.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+    /**
+     * 알뜰구매 "판매 종료 제보" 버튼.
+     * 서로 다른 회원 3명이 제보하면 서버가 말머리를 '종료'로 전환하고 AI 안내
+     * 댓글을 남긴다. 제보는 회원당 1회, 취소 없음(멱등).
+     */
+    import { Button } from '$lib/components/ui/button/index.js';
+    import PackageX from '@lucide/svelte/icons/package-x';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { toast } from 'svelte-sonner';
+
+    let { boardId, postId, category }: { boardId: string; postId: number; category?: string } =
+        $props();
+
+    let count = $state(0);
+    let threshold = $state(3);
+    let reported = $state(false);
+    let closed = $derived(category === '종료');
+    let submitting = $state(false);
+    let loaded = $state(false);
+
+    $effect(() => {
+        if (!authStore.isAuthenticated || closed) return;
+        void loadState();
+    });
+
+    async function loadState(): Promise<void> {
+        try {
+            const res = await fetch(`/api/boards/${boardId}/posts/${postId}/end-report`);
+            const json = await res.json();
+            if (json.success) {
+                count = json.data.count;
+                threshold = json.data.threshold;
+                reported = json.data.reported;
+                loaded = true;
+            }
+        } catch {
+            // 조회 실패 시 버튼만 기본 상태로 노출
+            loaded = true;
+        }
+    }
+
+    async function submit(): Promise<void> {
+        if (submitting || reported) return;
+        if (!confirm('이 상품이 품절되었거나 판매가 종료되었나요?\n제보는 취소할 수 없습니다.')) {
+            return;
+        }
+        submitting = true;
+        try {
+            const res = await fetch(`/api/boards/${boardId}/posts/${postId}/end-report`, {
+                method: 'POST'
+            });
+            const json = await res.json();
+            if (json.success) {
+                count = json.data.count;
+                reported = true;
+                if (json.data.closed) {
+                    toast.success('제보가 모여 이 딜을 종료로 전환했습니다.');
+                    // 말머리·AI 댓글 반영을 위해 새로고침
+                    setTimeout(() => window.location.reload(), 1200);
+                } else {
+                    toast.success(`종료 제보가 접수되었습니다. (${count}/${threshold})`);
+                }
+            } else if (res.status === 401) {
+                toast.error('로그인 후 이용해 주세요.');
+            } else {
+                toast.error('제보 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+            }
+        } catch {
+            toast.error('제보 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        } finally {
+            submitting = false;
+        }
+    }
+</script>
+
+{#if authStore.isAuthenticated && !closed}
+    <div class="mt-4">
+        <Button
+            variant="outline"
+            size="sm"
+            class="text-muted-foreground gap-1.5"
+            disabled={submitting || reported}
+            onclick={submit}
+        >
+            <PackageX class="h-3.5 w-3.5" />
+            {#if reported}
+                종료 제보됨 ({count}/{threshold})
+            {:else}
+                판매 종료 제보{loaded && count > 0 ? ` (${count}/${threshold})` : ''}
+            {/if}
+        </Button>
+    </div>
+{/if}

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -29,6 +29,7 @@
     import Lock from '@lucide/svelte/icons/lock';
     import Flag from '@lucide/svelte/icons/flag';
     import ScrapButton from '$lib/components/post/scrap-button.svelte';
+    import DealEndReportButton from '$lib/components/features/board/deal-end-report-button.svelte';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { DisciplinedContent } from '$lib/components/ui/discipline-related';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
@@ -430,6 +431,10 @@
                                 제공 받을 수 있습니다.</span
                             >
                         </p>
+                    {/if}
+
+                    {#if boardId === 'economy'}
+                        <DealEndReportButton {boardId} postId={post.id} category={post.category} />
                     {/if}
 
                     {#if post.videos && post.videos.length > 0}

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/end-report/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/end-report/+server.ts
@@ -1,0 +1,193 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import pool from '$lib/server/db';
+
+/**
+ * 알뜰구매 "판매 종료 제보" (#사장님 지시 2026-07-10)
+ *
+ * 서로 다른 회원 THRESHOLD 명이 제보하면 글 카테고리를 '종료'로 전환하고
+ * ai 계정 안내 댓글을 남긴다. 제보는 g5_deal_end_report 에 회원당 1회(UNIQUE).
+ * 댓글 INSERT 는 그누보드 정합성(wr_comment 카운트·board_new·bo_count_comment·
+ * 나리야 알림)을 comment-watcher reply 시맨틱과 동일하게 유지한다.
+ */
+const ALLOWED_BOARDS = new Set(['economy']);
+const THRESHOLD = 3;
+const CLOSED_CATEGORY = '종료';
+const AI_MB_ID = 'ai';
+const AI_NAME = '다모앙';
+
+function noticeContent(count: number): string {
+    return (
+        '[AI 안내]\n\n' +
+        `회원 ${count}분의 품절·판매 종료 제보에 따라 이 글의 말머리를 '${CLOSED_CATEGORY}'로 변경했습니다.\n\n` +
+        '판매가 재개되었거나 잘못 전환된 경우, 글쓴이께서는 글 수정에서 말머리를 다시 변경해 주세요.'
+    );
+}
+
+async function fetchReportState(
+    boardId: string,
+    postId: number,
+    viewerId: string | null
+): Promise<{ count: number; reported: boolean }> {
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT COUNT(*) AS cnt,
+                COALESCE(SUM(mb_id = ?), 0) AS mine
+         FROM g5_deal_end_report WHERE bo_table = ? AND wr_id = ?`,
+        [viewerId || '', boardId, postId]
+    );
+    return { count: Number(rows[0]?.cnt ?? 0), reported: Number(rows[0]?.mine ?? 0) > 0 };
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+    const boardId = params.boardId || '';
+    const postId = Number(params.postId);
+    if (!ALLOWED_BOARDS.has(boardId) || !Number.isFinite(postId)) {
+        return json({ success: false, error: 'unsupported' }, { status: 404 });
+    }
+    try {
+        const state = await fetchReportState(boardId, postId, locals.user?.id ?? null);
+        return json({ success: true, data: { ...state, threshold: THRESHOLD } });
+    } catch (e) {
+        console.error('[end-report] GET failed:', e);
+        return json({ success: false, error: 'internal' }, { status: 500 });
+    }
+};
+
+export const POST: RequestHandler = async ({ params, locals, getClientAddress }) => {
+    const boardId = params.boardId || '';
+    const postId = Number(params.postId);
+    if (!ALLOWED_BOARDS.has(boardId) || !Number.isFinite(postId)) {
+        return json({ success: false, error: 'unsupported' }, { status: 404 });
+    }
+    const viewerId = locals.user?.id;
+    if (!viewerId) {
+        return json({ success: false, error: 'auth_required' }, { status: 401 });
+    }
+
+    const table = `g5_write_${boardId}`;
+    const conn = await pool.getConnection();
+    try {
+        await conn.beginTransaction();
+
+        // 원글 존재·상태 확인 (잠금: 동시 3번째 제보 경합 시 댓글 중복 방지)
+        const [postRows] = await conn.query<RowDataPacket[]>(
+            `SELECT wr_num, ca_name, mb_id, wr_subject FROM ${table}
+             WHERE wr_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL FOR UPDATE`,
+            [postId]
+        );
+        const post = postRows[0];
+        if (!post) {
+            await conn.rollback();
+            return json({ success: false, error: 'not_found' }, { status: 404 });
+        }
+
+        const alreadyClosed = post.ca_name === CLOSED_CATEGORY;
+
+        await conn.query<ResultSetHeader>(
+            `INSERT IGNORE INTO g5_deal_end_report (bo_table, wr_id, mb_id, created_at)
+             VALUES (?, ?, ?, NOW())`,
+            [boardId, postId, viewerId]
+        );
+
+        const [cntRows] = await conn.query<RowDataPacket[]>(
+            `SELECT COUNT(*) AS cnt FROM g5_deal_end_report WHERE bo_table = ? AND wr_id = ?`,
+            [boardId, postId]
+        );
+        const count = Number(cntRows[0]?.cnt ?? 0);
+
+        let closed = alreadyClosed;
+        if (!alreadyClosed && count >= THRESHOLD) {
+            await conn.query(`UPDATE ${table} SET ca_name = ? WHERE wr_id = ?`, [
+                CLOSED_CATEGORY,
+                postId
+            ]);
+            await insertAiComment(conn, boardId, table, postId, post, noticeContent(count));
+            closed = true;
+        }
+
+        await conn.commit();
+        return json({
+            success: true,
+            data: { count, threshold: THRESHOLD, reported: true, closed }
+        });
+    } catch (e) {
+        try {
+            await conn.rollback();
+        } catch {
+            // ignore rollback failure
+        }
+        console.error('[end-report] POST failed:', e);
+        return json({ success: false, error: 'internal' }, { status: 500 });
+    } finally {
+        conn.release();
+        void getClientAddress; // IP 는 저장하지 않음 (회원 단위 제보)
+    }
+};
+
+/** 그누보드 정합성 유지 댓글 INSERT (comment-watcher reply 시맨틱과 동일) */
+async function insertAiComment(
+    conn: Awaited<ReturnType<typeof pool.getConnection>>,
+    boardId: string,
+    table: string,
+    postId: number,
+    post: RowDataPacket,
+    content: string
+): Promise<void> {
+    const [maxRows] = await conn.query<RowDataPacket[]>(
+        `SELECT COALESCE(MAX(wr_comment), 0) AS max_comment FROM ${table} WHERE wr_parent = ?`,
+        [postId]
+    );
+    const nextComment = Number(maxRows[0]?.max_comment ?? 0) + 1;
+
+    const [ins] = await conn.query<ResultSetHeader>(
+        `INSERT INTO ${table} SET
+            ca_name = ?, wr_option = '', wr_num = ?, wr_reply = '', wr_parent = ?,
+            wr_is_comment = 1, wr_comment = ?, wr_comment_reply = '', wr_subject = '',
+            wr_content = ?, mb_id = ?, wr_password = '', wr_name = ?, wr_email = '',
+            wr_homepage = '', wr_datetime = NOW(), wr_last = '', wr_ip = '127.0.0.1',
+            wr_1 = '', wr_2 = '', wr_3 = '', wr_4 = '', wr_5 = '',
+            wr_6 = '', wr_7 = '', wr_8 = '', wr_9 = '', wr_10 = ''`,
+        [CLOSED_CATEGORY, post.wr_num, postId, nextComment, content, AI_MB_ID, AI_NAME]
+    );
+    const commentId = ins.insertId;
+
+    await conn.query(
+        `UPDATE ${table} SET wr_comment = wr_comment + 1, wr_last = NOW() WHERE wr_id = ?`,
+        [postId]
+    );
+    await conn.query(
+        `INSERT INTO g5_board_new (bo_table, wr_id, wr_parent, bn_datetime, mb_id)
+         VALUES (?, ?, ?, NOW(), ?)`,
+        [boardId, commentId, postId, AI_MB_ID]
+    );
+    await conn.query(
+        `UPDATE g5_board SET bo_count_comment = bo_count_comment + 1 WHERE bo_table = ?`,
+        [boardId]
+    );
+
+    // 글쓴이에게 나리야 알림 (ai 본인 글 제외)
+    if (post.mb_id && post.mb_id !== AI_MB_ID) {
+        const relMsg = content.length > 30 ? `${content.slice(0, 30)}…` : content;
+        await conn.query(
+            `INSERT INTO g5_na_noti
+                (ph_to_case, ph_from_case, bo_table, rel_bo_table, wr_id, rel_wr_id,
+                 mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime,
+                 parent_subject, wr_parent)
+             VALUES ('board', 'comment', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'N', NOW(), ?, ?)`,
+            [
+                boardId,
+                boardId,
+                postId,
+                commentId,
+                post.mb_id,
+                AI_MB_ID,
+                AI_NAME,
+                relMsg,
+                `/bbs/board.php?bo_table=${boardId}&wr_id=${postId}#c_${commentId}`,
+                post.wr_subject || '',
+                postId
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## 기능 (운영자 지시 2026-07-10)
알뜰구매(economy) 글 본문 하단에 **판매 종료 제보** 버튼을 추가합니다. 서로 다른 회원 **3명**이 제보하면:
1. 글 말머리를 `종료` 로 전환 (기존 카테고리 `종료|진행중|네이버페이` 중 기존 값 사용 — 목록 필터 탭 호환)
2. ai 계정이 안내 댓글 게시: "회원 3분의 품절·판매 종료 제보에 따라 이 글의 말머리를 '종료'로 변경했습니다. …글쓴이께서는 말머리를 다시 변경해 주세요."
3. 글쓴이에게 나리야 알림

## 구현
- `api/boards/[boardId]/posts/[postId]/end-report` GET(현황)/POST(제보) — economy 한정, 로그인 필수
- 제보 저장: `g5_deal_end_report` (UNIQUE 회원당 1회, INSERT IGNORE 멱등)
- 원글 `FOR UPDATE` 잠금 — 동시 3번째 제보 경합에도 전환·댓글 1회만
- 댓글 INSERT 는 그누보드 정합성 유지(comment-watcher reply 시맨틱: wr_comment·board_new·bo_count_comment·na_noti)
- 이미 종료된 글: 버튼 미노출, 서버도 전환·댓글 생략

## ⚠️ 배포 전 DDL 필요 (운영은 AutoMigrate 없음)
```sql
CREATE TABLE IF NOT EXISTS g5_deal_end_report (
  id BIGINT AUTO_INCREMENT PRIMARY KEY,
  bo_table VARCHAR(20) NOT NULL, wr_id INT NOT NULL, mb_id VARCHAR(191) NOT NULL,
  created_at DATETIME NOT NULL,
  UNIQUE KEY uq_report (bo_table, wr_id, mb_id), KEY idx_target (bo_table, wr_id)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```

## 검증
- `pnpm check` 0 errors. canary 에서 3계정 시나리오 검증 예정(2명=유지, 3명=전환+댓글 1회, 중복 클릭 멱등)