### PR TITLE
fix(member-memo): 목록 회원 메모 간헐 미표시 — 인증 레이스 해소

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -449,6 +449,12 @@
 
     // 목록 데이터 반영 시 메모 배치 로드 + 훅 발행
     $effect(() => {
+        // 회원 메모 간헐 미표시 fix: 지연 스케줄된 메모 로더가 인증 확립 전에
+        // 발화하면 목록을 비운 채 종료하는데, 이 effect 가 인증 상태를 추적하지
+        // 않아 재시도가 없었다(보였다 안 보였다). 인증 상태를 반응형으로 읽어
+        // 늦은 인증 확립 시 로드를 재스케줄한다.
+        const authed = authStore.isAuthenticated;
+        void authed;
         const result = data.postsData;
         if (!result) return;
 


### PR DESCRIPTION
## 증상 (운영자 제보)
게시판 목록에서 회원 메모가 **보였다가 안 보였다가** 함 (간헐).

## 원인
목록 메모 배치 로드는 `requestIdleCallback(timeout 1500)`/`setTimeout(250)` 으로 지연 스케줄되는데, 클라 인증 확립이 그보다 늦으면 `loadBoardListMemos` 가 미인증 조기 반환하며 `memoByAuthorId` 를 비움. 이후 로드 $effect 의 의존성에 `authStore.isAuthenticated` 가 없어 인증이 확립돼도 재실행되지 않음 → 그 페이지에서 메모가 계속 안 뜸. 브라우저 idle 상태에 따라 레이스 승자가 달라져 간헐 증상. (#12825 차단 스토어 깜박임과 동일 계열의 '지연 로더 vs 인증' 레이스)

## 수정
로드 $effect 가 `authStore.isAuthenticated` 를 반응형으로 읽도록 1줄(+주석) — 늦은 인증 확립 시 effect 재실행으로 메모 로드가 재스케줄됨.

## 검증
- `pnpm check` 0 errors
- canary: 강력 새로고침 반복 시 메모 표시 일관성 확인 예정

## 후속(비차단)
클래식 목록도 카드처럼 SSR 인라인 `author_memo`(memo-store)를 소비하면 별도 배치 fetch 와 레이스가 구조적으로 제거됨 — 별도 PR 후보.