### PR TITLE
feat(growth): 첫 댓글 넛지 배너 — 눈팅 신규회원 (실험 B)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -22,6 +22,7 @@
     import Loader2 from '@lucide/svelte/icons/loader-2';
     import type { Component } from 'svelte';
     import CommentToolbar from './comment-toolbar.svelte';
+    import FirstCommentNudge from '$lib/components/features/onboarding/first-comment-nudge.svelte';
     import { trackEvent } from '$lib/services/ga4.js';
 
     interface Props {
@@ -248,6 +249,10 @@
 </script>
 
 {#if canComment}
+    {#if !isReplyMode}
+        <!-- 실험 B: 눈팅 신규회원 첫 댓글 넛지 — 최상위 댓글 입력창에만 (답글 모드 제외) -->
+        <FirstCommentNudge />
+    {/if}
     <form onsubmit={handleSubmit} class="space-y-2">
         {#if isReplyMode}
             <div class="text-muted-foreground flex items-center gap-2 text-sm">

--- a/apps/web/src/lib/components/features/onboarding/first-comment-nudge.svelte
+++ b/apps/web/src/lib/components/features/onboarding/first-comment-nudge.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+    /**
+     * 눈팅 신규회원 첫 댓글 넛지 배너 (성장 엔진 축B — 실험 B)
+     *
+     * 목표: 가입→첫 기여 전환율(12주 실측 14.2%) 개선.
+     * 첫 기여가 댓글인 회원은 평균 13.5일이 걸린다 — 읽던 글의 댓글창 위에서
+     * 부드럽게 첫 댓글을 유도해 이 소요일을 줄이는 것이 목표.
+     *
+     * 노출 조건 (전부 만족 시에만 — 실험 A welcome-onboarding 게이트 패턴 재사용):
+     *  1) 로그인 && as_level ≤ 1 (XP 거의 없음 = 활동 전 — 프로필 조회 게이트)
+     *  2) 내 프로필: 가입 5~21일 && 글/댓글 0 (눈팅만 하는 신규 미기여 회원)
+     *     — 가입 직후 5일은 실험 A(홈 온보딩 카드) 구간이라 겹치지 않게 제외
+     *  3) 닫기 안 누름 (localStorage)
+     * 첫 기여를 하면 post_count/comment_count > 0 이 되어 자연히 사라진다.
+     * 프로필 조회 실패 시 조용히 미노출 (넛지는 있으면 좋은 기능).
+     *
+     * 측정: 배포 주 이후 가입 코호트의 "댓글 첫 기여 소요일"(기준 13.5일)을
+     * 주간 growth 리포트로 비교 — 코드 내 별도 이벤트 추적은 두지 않는다.
+     */
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { apiClient } from '$lib/api/index.js';
+
+    const DISMISS_KEY = 'angple_first_comment_nudge_dismissed';
+    const MIN_DAYS = 5;
+    const MAX_DAYS = 21;
+
+    let show = $state(false);
+    let checked = $state(false);
+
+    $effect(() => {
+        const user = authStore.user;
+        if (checked || !user) return;
+        if ((user.as_level ?? 1) > 1) {
+            checked = true;
+            return;
+        }
+        try {
+            if (localStorage.getItem(DISMISS_KEY)) {
+                checked = true;
+                return;
+            }
+        } catch {
+            checked = true;
+            return;
+        }
+        checked = true;
+        void (async () => {
+            try {
+                const profile = await apiClient.getMemberProfile(user.mb_id);
+                const signedAt = new Date(profile.mb_datetime).getTime();
+                const daysSince = (Date.now() - signedAt) / 86400000;
+                const contributed = (profile.post_count ?? 0) + (profile.comment_count ?? 0) > 0;
+                if (
+                    !Number.isNaN(signedAt) &&
+                    daysSince >= MIN_DAYS &&
+                    daysSince <= MAX_DAYS &&
+                    !contributed
+                ) {
+                    show = true;
+                }
+            } catch {
+                // 프로필 조회 실패 시 조용히 미노출
+            }
+        })();
+    });
+
+    function dismiss() {
+        show = false;
+        try {
+            localStorage.setItem(DISMISS_KEY, String(Date.now()));
+        } catch {
+            /* localStorage 불가 환경 — 세션 내 숨김만 */
+        }
+    }
+</script>
+
+{#if show}
+    <div
+        class="mb-2 flex items-center gap-2 rounded-lg border border-sky-200 bg-gradient-to-r from-sky-50 to-emerald-50 px-3 py-2 text-sm dark:border-sky-800/40 dark:from-sky-950/40 dark:to-emerald-950/30"
+    >
+        <span class="shrink-0" aria-hidden="true">💬</span>
+        <p class="text-muted-foreground min-w-0 flex-1 leading-snug">
+            첫 댓글을 남겨보세요 — 앙님들이 반겨줘요! 작은 한마디면 충분해요 💛
+        </p>
+        <button
+            type="button"
+            onclick={dismiss}
+            class="text-muted-foreground hover:text-foreground shrink-0 rounded-full p-1 leading-none transition-colors"
+            aria-label="첫 댓글 안내 닫기"
+        >
+            ✕
+        </button>
+    </div>
+{/if}


### PR DESCRIPTION
## 배경

- 가입→첫 기여 전환율이 12주 실측 기준 **14.2%**로 성장 병목입니다.
- 첫 기여가 댓글인 회원은 첫 댓글까지 평균 **13.5일**이 걸립니다. 눈팅 중인 신규 회원이 읽던 글의 댓글창에서 자연스럽게 첫 댓글을 남기도록 부드럽게 유도하는 실험 B입니다.

## 변경 내용

- 신규: `apps/web/src/lib/components/features/onboarding/first-comment-nudge.svelte`
  - 댓글 입력창 위 슬림 한 줄 배너 (파스텔 스카이/민트 톤, 💬 이모지, 닫기 ✕ 버튼 aria-label 포함)
  - 실험 A(`welcome-onboarding.svelte`)의 게이트 패턴을 그대로 재사용했습니다 (`checked` 플래그로 1회만 검사하는 `$effect` 패턴).
- 수정: `apps/web/src/lib/components/features/board/comment-form.svelte`
  - `canComment && !isReplyMode`일 때만 `<FirstCommentNudge />` 렌더 — 로그인한 사용자의 최상위 댓글 입력창에만 노출되고, 비로그인·답글 모드·이용제한 상태에서는 노출되지 않습니다.

## 노출 게이트 (전부 만족 시에만)

1. 로그인 && `(user.as_level ?? 1) <= 1`
2. localStorage `angple_first_comment_nudge_dismissed` 없음 (닫기 시 영구 숨김)
3. `apiClient.getMemberProfile(mb_id)` 기준 가입(`mb_datetime`) **5~21일** && `post_count + comment_count === 0`
   - 프로필 조회 실패 시 조용히 미노출합니다.
   - 가입 직후 0~5일은 실험 A(홈 온보딩 카드) 구간과 겹치지 않도록 제외했습니다.
   - 첫 기여를 하면 카운트가 올라가 배너가 자연히 사라집니다.

## 실험 A와의 관계

- 실험 A(가입 직후 홈 온보딩 카드, fe#1742)가 현재 라이브 중입니다. 효과의 원인 귀속을 위해 **실험 A 판정 이후 순차 배포** 예정이며, 그때까지 draft 상태를 유지합니다.

## 측정

- 배포 주 이후 가입 코호트의 "댓글 첫 기여 소요일"(기준 13.5일)을 주간 growth 리포트로 비교합니다. 코드 내 별도 이벤트 추적은 추가하지 않았습니다.

## 검증

- `pnpm check` (svelte-check): **0 errors** (116 warnings는 기존 파일들의 pre-existing, 변경 파일 관련 0건)
- 관련 unit test `src/lib/utils/comment-insert.test.ts`: 7/7 통과
- 새 unit test는 게이트 로직이 컴포넌트 내부(`$effect`)에 있어 생략했습니다.
