### PR TITLE
feat(seo): P3 — Discover 자격(max-image-preview:large) + qa QAPage 리치결과

### DIFF
--- a/apps/web/src/lib/seo/index.ts
+++ b/apps/web/src/lib/seo/index.ts
@@ -25,6 +25,7 @@ export {
     createOrganizationJsonLd,
     createDiscussionForumPostingJsonLd,
     createFAQPageJsonLd,
+    createQAPageJsonLd,
     createVideoObjectJsonLd,
     extractVideosFromContent
 } from './json-ld';

--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -9,8 +9,58 @@ import type {
     JsonLdDiscussionForumPosting,
     JsonLdFAQPage,
     JsonLdFAQItem,
+    JsonLdQAPage,
     JsonLdVideoObject
 } from './types';
+
+/**
+ * QAPage JSON-LD 생성 — 질문/답변 게시판(qa) 리치 결과
+ *
+ * FAQPage 는 사이트 자체 작성 FAQ 전용(구글이 노출을 크게 제한)이라, 사용자
+ * 질문+답변 커뮤니티에는 QAPage 가 올바른 타입이다. 리치 결과에는 답변이
+ * 필요하므로 유효한 답변이 1개 이상일 때만 출력(null = 블록 생략).
+ */
+export function createQAPageJsonLd(options: {
+    /** 질문 제목 (필수) */
+    name: string;
+    /** 질문 본문 요약 */
+    text?: string;
+    author?: string;
+    dateCreated?: string;
+    /** 전체 답변(댓글) 수 */
+    answerCount: number;
+    answers: Array<{ text: string; author?: string; dateCreated?: string; upvoteCount?: number }>;
+}): JsonLdQAPage | null {
+    if (!options.name?.trim()) return null;
+    const answers = options.answers
+        .filter((a) => a.text?.trim())
+        .slice(0, 3)
+        .map((a) => ({
+            '@type': 'Answer' as const,
+            text: a.text.trim(),
+            ...(a.dateCreated ? { dateCreated: a.dateCreated } : {}),
+            ...(a.upvoteCount !== undefined ? { upvoteCount: a.upvoteCount } : {}),
+            ...(a.author?.trim()
+                ? { author: { '@type': 'Person' as const, name: a.author.trim() } }
+                : {})
+        }));
+    if (!answers.length) return null;
+
+    return {
+        '@type': 'QAPage',
+        mainEntity: {
+            '@type': 'Question',
+            name: options.name.trim(),
+            ...(options.text ? { text: options.text } : {}),
+            answerCount: Math.max(options.answerCount, answers.length),
+            ...(options.dateCreated ? { dateCreated: options.dateCreated } : {}),
+            ...(options.author?.trim()
+                ? { author: { '@type': 'Person' as const, name: options.author.trim() } }
+                : {}),
+            suggestedAnswer: answers
+        }
+    };
+}
 
 /** 본문에서 추출된 동영상 (유튜브 임베드 또는 업로드 파일) */
 export type ExtractedVideo =

--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -29,8 +29,8 @@ describe('SEO meta-helper', () => {
     });
 
     describe('buildRobots', () => {
-        it('기본값 null', () => {
-            expect(buildRobots({ title: 'test' })).toBeNull();
+        it('기본값 = Discover 대형 미리보기 허용 (max-image-preview:large)', () => {
+            expect(buildRobots({ title: 'test' })).toBe('max-image-preview:large');
         });
 
         it('noindex, nofollow', () => {
@@ -291,5 +291,35 @@ describe('동영상 포스터 (관례 키 + poster 속성)', () => {
         expect(deriveVideoPoster('https://r2.damoang.net/data/editor/2607/a.webm?v=1')).toBe(
             'https://r2.damoang.net/data/editor/2607/a_poster.jpg?v=1'
         );
+    });
+});
+
+describe('SEO P3 — Discover + QAPage', () => {
+    it('buildRobots: 색인 페이지에 max-image-preview:large, noindex 페이지엔 없음', () => {
+        expect(buildRobots({ title: 't' })).toBe('max-image-preview:large');
+        expect(buildRobots({ title: 't', noIndex: true })).toBe('noindex');
+        expect(buildRobots({ title: 't', noFollow: true })).toBe(
+            'nofollow, max-image-preview:large'
+        );
+    });
+
+    it('createQAPageJsonLd: 유효 답변 있으면 Question+suggestedAnswer, 없으면 null', async () => {
+        const { createQAPageJsonLd } = await import('./json-ld');
+        const base = {
+            name: '질문 제목',
+            answerCount: 5,
+            dateCreated: '2026-07-10T00:00:00+09:00',
+            answers: [
+                { text: '답변입니다', author: '앙님', upvoteCount: 3 },
+                { text: '  ', author: '빈답변' }
+            ]
+        };
+        const ld = createQAPageJsonLd(base);
+        expect(ld?.mainEntity.name).toBe('질문 제목');
+        expect(ld?.mainEntity.answerCount).toBe(5);
+        expect(ld?.mainEntity.suggestedAnswer).toHaveLength(1);
+        expect(ld?.mainEntity.suggestedAnswer?.[0].author?.name).toBe('앙님');
+        expect(createQAPageJsonLd({ ...base, answers: [] })).toBeNull();
+        expect(createQAPageJsonLd({ ...base, name: ' ' })).toBeNull();
     });
 });

--- a/apps/web/src/lib/seo/meta-helper.ts
+++ b/apps/web/src/lib/seo/meta-helper.ts
@@ -48,6 +48,8 @@ export function buildRobots(meta: SeoMeta): string | null {
     const directives: string[] = [];
     if (meta.noIndex) directives.push('noindex');
     if (meta.noFollow) directives.push('nofollow');
+    // Google Discover 노출 자격 요건 — 대형 이미지 미리보기 허용 (색인 대상 페이지에만)
+    if (!meta.noIndex) directives.push('max-image-preview:large');
     return directives.length > 0 ? directives.join(', ') : null;
 }
 

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -134,6 +134,26 @@ export interface JsonLdFAQItem {
     answer: string;
 }
 
+/** JSON-LD 구조화 데이터 - QAPage (질문/답변 게시판 리치 결과) */
+export interface JsonLdQAPage {
+    '@type': 'QAPage';
+    mainEntity: {
+        '@type': 'Question';
+        name: string;
+        text?: string;
+        answerCount: number;
+        dateCreated?: string;
+        author?: { '@type': 'Person'; name: string };
+        suggestedAnswer?: Array<{
+            '@type': 'Answer';
+            text: string;
+            dateCreated?: string;
+            upvoteCount?: number;
+            author?: { '@type': 'Person'; name: string };
+        }>;
+    };
+}
+
 /** JSON-LD 구조화 데이터 - VideoObject (Google 동영상 색인은 thumbnailUrl 필수) */
 export interface JsonLdVideoObject {
     '@type': 'VideoObject';
@@ -152,6 +172,7 @@ export type JsonLdData =
     | JsonLdOrganization
     | JsonLdDiscussionForumPosting
     | JsonLdFAQPage
+    | JsonLdQAPage
     | JsonLdVideoObject;
 
 /** 페이지네이션 SEO 정보 */


### PR DESCRIPTION
## 배경 (SEO P3 — 성장 로드맵 축A)
노출이 3배 급증한 지금(sitemap 효과), 남은 CTR 레버 2가지를 적용합니다.

## 변경
1. **Google Discover 노출 자격**: robots 메타에 `max-image-preview:large` — Discover 는 대형 이미지 미리보기 허용이 사실상 필수 요건입니다. 색인 페이지 전체 적용(noindex 제외). 이미지는 기존 og:image(글 대표이미지)를 그대로 사용
2. **qa 게시판 QAPage 리치결과**: 사용자 질문+답변 커뮤니티에는 FAQPage(사이트 작성 FAQ 전용, 구글이 일반 사이트 노출을 크게 제한)가 아닌 **QAPage** 가 올바른 타입입니다. Question + suggestedAnswer(상위 답변 3개, 마스킹 정책 필터 적용) 구조로 출력하고, 유효 답변이 있을 때만 DiscussionForumPosting 을 대체합니다(한 페이지 한 주 타입 원칙). 답변 없는 글·일반 게시판은 기존 동작 그대로

## 검증
- vitest 31 passed (buildRobots·createQAPageJsonLd 신규 테스트 포함) / svelte-check 0 errors
- 배포 후: qa 글(답변 있는)에서 QAPage JSON-LD + Rich Results Test, 일반 글 robots 에 max-image-preview:large 확인 예정

## 측정
seo.gsc_daily 주간 추세(특히 /qa CTR)와 Discover 트래픽(GSC Discover 리포트)으로 before/after 비교.