### PR TITLE
feat(seo): 글 상세 작성자 최근 글 SSR — 내부링크 강화 (#83)

### DIFF
--- a/apps/web/src/lib/components/features/board/author-recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/author-recent-posts.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+    /**
+     * 작성자 최근 글 SSR 섹션 (SEO 내부링크 강화, #83)
+     *
+     * +page.server.ts 에서 await 로 확정한 데이터를 그대로 렌더한다.
+     * 크롤러가 내부링크를 발견하는 것이 목적이므로 클라이언트 전용
+     * 게이트($effect/onMount/browser)를 두지 않는다 — 서버 HTML 에
+     * 앵커가 반드시 포함되어야 한다.
+     */
+    import { formatDateCompact } from '$lib/utils/format-date.js';
+
+    interface AuthorRecentPost {
+        bo_table: string;
+        wr_id: number;
+        wr_subject: string;
+        wr_datetime: string;
+        href: string;
+    }
+
+    interface Props {
+        authorName: string;
+        posts: AuthorRecentPost[];
+    }
+
+    let { authorName, posts }: Props = $props();
+</script>
+
+{#if posts.length > 0}
+    <section class="mb-6 rounded-lg border p-4" aria-label="작성자의 최근 글">
+        <h3 class="text-foreground mb-2 text-sm font-semibold">
+            ✍️ {authorName}님의 최근 글
+        </h3>
+        <ul class="divide-border divide-y">
+            {#each posts as p (`${p.bo_table}_${p.wr_id}`)}
+                <li class="py-1.5">
+                    <a
+                        href={p.href}
+                        class="text-foreground hover:text-primary flex min-w-0 items-baseline gap-2 text-sm"
+                    >
+                        <span class="min-w-0 flex-1 truncate">
+                            {p.wr_subject || '(제목 없음)'}
+                        </span>
+                        <span class="text-muted-foreground shrink-0 text-xs">
+                            {formatDateCompact(p.wr_datetime)}
+                        </span>
+                    </a>
+                </li>
+            {/each}
+        </ul>
+    </section>
+{/if}

--- a/apps/web/src/lib/server/author-recent-posts.ts
+++ b/apps/web/src/lib/server/author-recent-posts.ts
@@ -1,0 +1,70 @@
+/**
+ * 작성자 최근 글 SSR 셀렉터 (SEO 내부링크 강화, #83)
+ *
+ * member-activity(fetchMemberActivity) 결과에서 글 상세 하단에 노출할
+ * "작성자의 최근 글"을 고른다. 선택 결과는 +page.server.ts 에서 await 되어
+ * SSR HTML 앵커로 렌더된다 — 크롤러가 클라이언트 fetch 없이 내부링크를
+ * 발견할 수 있게 하는 것이 목적.
+ *
+ * 필터 규칙:
+ * - 현재 보고 있는 글 제외
+ * - 삭제된 글(deleted_at) 제외
+ * - 익명 게시판(message) 글 제외 — 마음메시지 익명 유출 전례(#1729) 방어
+ * (비밀글은 백엔드 activity feed 동기화 단계에서 이미 제외됨 — member_activity_sync)
+ */
+import type { MemberActivity } from '$lib/server/member-activity';
+
+/** SSR 섹션에 렌더되는 작성자 최근 글 1건 */
+export interface AuthorRecentPost {
+    bo_table: string;
+    wr_id: number;
+    wr_subject: string;
+    wr_datetime: string;
+    href: string;
+}
+
+/** 작성자 프로필이 노출되면 안 되는 익명 게시판 */
+const ANONYMOUS_BOARDS = new Set(['message']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+/**
+ * 활동 데이터에서 SSR 노출 대상 최근 글 limit개를 선별한다.
+ * 입력이 비정형이어도 크래시 없이 빈 배열로 수렴한다.
+ */
+export function selectAuthorRecentPosts(
+    activity: MemberActivity,
+    currentBoardId: string,
+    currentPostId: string,
+    limit = 3
+): AuthorRecentPost[] {
+    const result: AuthorRecentPost[] = [];
+
+    for (const raw of activity.recentPosts) {
+        if (result.length >= limit) break;
+        if (!isRecord(raw)) continue;
+
+        const boTable = typeof raw.bo_table === 'string' ? raw.bo_table : '';
+        const wrId = Number(raw.wr_id);
+        if (!boTable || !Number.isFinite(wrId) || wrId <= 0) continue;
+
+        // 삭제된 글 제외
+        if (raw.deleted_at) continue;
+        // 익명 게시판 글 제외
+        if (ANONYMOUS_BOARDS.has(boTable)) continue;
+        // 현재 글 제외
+        if (boTable === currentBoardId && String(wrId) === currentPostId) continue;
+
+        result.push({
+            bo_table: boTable,
+            wr_id: wrId,
+            wr_subject: typeof raw.wr_subject === 'string' ? raw.wr_subject : '',
+            wr_datetime: typeof raw.wr_datetime === 'string' ? raw.wr_datetime : '',
+            href: typeof raw.href === 'string' && raw.href ? raw.href : `/${boTable}/${wrId}`
+        });
+    }
+
+    return result;
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -24,7 +24,9 @@ import { fetchMemberImagesWithTimestamp } from '$lib/server/member-images.js';
 import { fetchCommentLikeStatuses } from '$lib/server/comment-likes.js';
 
 import { fetchPostLikeStatus } from '$lib/server/post-like-status.js';
-import { fetchMemberActivity } from '$lib/server/member-activity.js';
+import { fetchMemberActivity, type MemberActivity } from '$lib/server/member-activity.js';
+import { selectAuthorRecentPosts, type AuthorRecentPost } from '$lib/server/author-recent-posts.js';
+import { fetchWithdrawnMemberIds } from '$lib/server/withdrawn-members.js';
 import { fetchTruthroomPostId, fetchTruthroomCommentMap } from '$lib/server/truthroom.js';
 import { BackendUnavailableError } from '$lib/server/backend-fetch.js';
 import { applyFilter } from '$lib/hooks/registry.js';
@@ -227,6 +229,23 @@ export const load: PageServerLoad = async ({
             post.author_id = '';
             post.author = '익명';
         }
+
+        // 작성자 최근 활동 — 단일 fetch 를 여기서 시작해 두 소비처에서 재사용:
+        // (1) SEO 내부링크 섹션(#83): return 직전 await → SSR HTML 앵커로 포함
+        // (2) 작성자 활동 패널: streamed auxiliaryData 로 전달 (기존 동작 유지)
+        // 탈퇴 회원은 활동 비노출 — 프록시(/api/members/[id]/activity)와 동일 가드.
+        // fetchMemberActivity 는 내부 catch + 2s 타임아웃이라 절대 reject 하지 않는다.
+        const emptyActivity: MemberActivity = { recentPosts: [], recentComments: [] };
+        const memberActivityPromise: Promise<MemberActivity> = (async () => {
+            if (!post.author_id) return emptyActivity;
+            try {
+                const withdrawn = await fetchWithdrawnMemberIds([post.author_id]);
+                if (withdrawn.has(post.author_id)) return emptyActivity;
+                return await fetchMemberActivity(post.author_id, 5);
+            } catch {
+                return emptyActivity;
+            }
+        })();
 
         // 게시글 작성자 프로필 이미지 즉시 조회 (1단계 — 본문 렌더에 필요)
         if (post.author_id && !post.author_image) {
@@ -551,12 +570,8 @@ export const load: PageServerLoad = async ({
                     );
                 })(),
                 // 작성자 최근 활동 (SSR 직접 조회 — 클릭 없이 표시, 클라이언트 API 요청 제거)
-                post.author_id
-                    ? fetchMemberActivity(post.author_id, 5).catch(() => ({
-                          recentPosts: [],
-                          recentComments: []
-                      }))
-                    : Promise.resolve({ recentPosts: [], recentComments: [] })
+                // 1단계에서 시작한 단일 fetch 재사용 (SEO 섹션 #83 과 공유, 중복 호출 방지)
+                memberActivityPromise
             ]);
 
             // 프로모션 사잇광고: board_exception에 포함된 게시판은 제외
@@ -705,6 +720,17 @@ export const load: PageServerLoad = async ({
             page: recentPostsPage
         };
 
+        // SEO 내부링크: 작성자 최근 글 3개 (#83) — SSR HTML 에 앵커로 포함되어야
+        // 하므로 streamed 가 아닌 await 로 확정한다. memberActivityPromise 는
+        // 1단계 직후 시작되어 댓글 SSR fetch(최대 2.5s)와 병렬로 진행됐고 자체
+        // 타임아웃(2s)+내부 catch 가 있어 페이지 로드를 추가로 블록하지 않는다.
+        // 익명 글(author_id 없음)·삭제글·탈퇴 회원은 위 가드에서 이미 빈 배열로 수렴.
+        let authorRecentPosts: AuthorRecentPost[] = [];
+        if (!post.deleted_at) {
+            const activity = await memberActivityPromise;
+            authorRecentPosts = selectAuthorRecentPosts(activity, boardId, postId, 3);
+        }
+
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).
         // 미설치 시 pass-through. (premium PR #43 기준 stub)
         // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달.
@@ -728,6 +754,8 @@ export const load: PageServerLoad = async ({
             truthroomPostId,
             originalPostLink,
             recentPosts,
+            /** SEO 내부링크: 작성자 최근 글 (SSR 앵커, #83) */
+            authorRecentPosts,
             /** 스트리밍: Promise로 반환 → 클라이언트에서 $effect로 수신 */
             streamed: {
                 auxiliaryData: auxiliaryDataPromise

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -41,6 +41,7 @@
     import CommentForm from '$lib/components/features/board/comment-form.svelte';
     import CommentList from '$lib/components/features/board/comment-list.svelte';
     import AuthorActivityPanel from '$lib/components/features/board/author-activity-panel.svelte';
+    import AuthorRecentPosts from '$lib/components/features/board/author-recent-posts.svelte';
     import RecentPosts from '$lib/components/features/board/recent-posts.svelte';
     import { BOARD_LIST_PAGE_SIZE } from '$lib/constants/board';
     import { ReportDialog } from '$lib/components/features/report/index.js';
@@ -2157,6 +2158,12 @@
                 </div>
             </div>
         {/if}
+
+        <!-- SEO 내부링크: 작성자 최근 글 (SSR 앵커, #83) — 본문 아래·댓글 위 -->
+        <AuthorRecentPosts
+            authorName={data.post.author || ''}
+            posts={data.authorRecentPosts ?? []}
+        />
 
         {#each beforeCommentsSlots as slot (slot.component)}
             {@const SlotComponent = slot.component}


### PR DESCRIPTION
## 배경 (SEO P3, #83)

글 상세 페이지에 내부링크가 부족해 크롤 발견성·체류시간이 약했습니다. 본문 아래·댓글 위에 "✍️ {작성자}님의 최근 글" 3개를 **SSR 앵커**로 렌더합니다. 기존 작성자 활동 패널은 streamed auxiliaryData 를 `$effect` 로 소비하는 클라이언트 렌더라 초기 HTML 에 앵커가 없었고, 이번 섹션은 서버 로드에서 await 로 확정해 크롤러가 클라이언트 fetch 없이 링크를 발견할 수 있습니다.

## 구현

- **`$lib/server/author-recent-posts.ts` (신규)**: 기존 `fetchMemberActivity`(백엔드 `/api/v1/members/{id}/activity`, Redis 60s 캐시·2s 타임아웃) 결과에서 노출 대상을 선별하는 순수 함수. 현재 글·삭제글(`deleted_at`)·익명 게시판(`message`) 글 제외, 최대 3개. 비밀글은 백엔드 activity feed 동기화 단계에서 이미 제외되어 있습니다(`member_activity_sync`).
- **`+page.server.ts`**: 작성자 활동 fetch 를 1단계 직후 단일 promise 로 승격해 (1) SEO 섹션(await → SSR HTML 포함) (2) 작성자 활동 패널(streamed) 양쪽이 공유합니다 — 백엔드 호출 수는 기존과 동일(+0). 탈퇴 회원 가드(`fetchWithdrawnMemberIds`)를 프록시 라우트(`/api/members/[id]/activity`)와 동일하게 적용했습니다 — 기존 SSR 스트리밍 경로에는 이 가드가 없었어서 패널 경로도 함께 보강됩니다. 익명 글(마음메시지 익명 마스킹으로 `author_id=''`)·삭제글은 로드 자체를 건너뜁니다.
- **`author-recent-posts.svelte` (신규)**: 클라이언트 게이트(`$effect`/`onMount`/`browser`) 없는 순수 SSR 섹션. 데이터 없으면 섹션 자체 미출력. 기존 하단 섹션과 동일한 디자인 언어(border card, divide-y, truncate, `formatDateCompact`).

## 성능 고려

- 상세 페이지 서버 로드에 추가 백엔드 호출 없음(기존 활동 fetch 재사용). await 시점은 댓글 SSR fetch(최대 2.5s)와 병렬로 진행된 뒤라, 자체 타임아웃 2s + 내부 catch(실패 시 빈 배열)로 페이지 로드를 추가로 블록하지 않습니다.
- 탈퇴 조회는 `withdrawn-members` 인메모리 캐시(300s TTL) + 배치 SELECT 1회입니다.

## 검증 결과

- `pnpm check`: **0 errors** (116 warnings 는 기존과 동일, 변경 파일 신규 경고 없음), Prettier 통과
- 로컬 `pnpm dev` + 실서비스 API(`api.damoang.net`) 대상 SSR HTML 실측:
  - `/free/6674637`: 초기 HTML 에 섹션 렌더 확인 — 앵커 3개(`/free/6674314`, `/free/6673832`, `/free/6673326`), 현재 글 제외 확인, 렌더 1.8s
  - 익명 마음메시지(`/message/1835`, `author=''`): 섹션 미출력 확인
  - 기명 마음메시지(`/message/144`): 섹션 링크에 `/message/` 글 미포함 확인 (익명 게시판 필터)
  - streamed `memberActivity`(작성자 활동 패널 경로) 정상 유지 확인
