### PR TITLE
chore(affiliate): 죽은 필터 스텁 제거 + 배너 rel sponsored

### DIFF
--- a/apps/web/src/lib/components/features/board/economy-shopping-banner.svelte
+++ b/apps/web/src/lib/components/features/board/economy-shopping-banner.svelte
@@ -39,7 +39,7 @@
             <a
                 href={shop.href}
                 target="_blank"
-                rel="nofollow noreferrer"
+                rel="nofollow noreferrer sponsored"
                 class="border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground inline-flex items-center rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
             >
                 {shop.name}

--- a/plugins/affiliate-link-private/hooks/comment-content-filter.ts
+++ b/plugins/affiliate-link-private/hooks/comment-content-filter.ts
@@ -1,3 +1,0 @@
-export default async function commentContentFilter(content: string): Promise<string> {
-    return content;
-}

--- a/plugins/affiliate-link-private/hooks/post-content-filter.ts
+++ b/plugins/affiliate-link-private/hooks/post-content-filter.ts
@@ -1,3 +1,0 @@
-export default async function postContentFilter(content: string): Promise<string> {
-    return content;
-}

--- a/plugins/affiliate-link-private/index.ts
+++ b/plugins/affiliate-link-private/index.ts
@@ -23,7 +23,5 @@ export {
     resolveAffiliateRedirectRecord
 } from './lib/redirect-store.server';
 
-export { default as postContentFilter } from './hooks/post-content-filter';
-export { default as commentContentFilter } from './hooks/comment-content-filter';
 export { default as postLinkFieldFilter } from './hooks/post-link-field-filter';
 export { default as commentLinkFieldFilter } from './hooks/comment-link-field-filter';

--- a/plugins/affiliate-link-private/plugin.json
+++ b/plugins/affiliate-link-private/plugin.json
@@ -12,18 +12,6 @@
     "main": "index.ts",
     "hooks": [
         {
-            "name": "post_content",
-            "type": "filter",
-            "callback": "hooks/post-content-filter.ts",
-            "priority": 15
-        },
-        {
-            "name": "comment_content",
-            "type": "filter",
-            "callback": "hooks/comment-content-filter.ts",
-            "priority": 15
-        },
-        {
             "name": "post_link_field",
             "type": "filter",
             "callback": "hooks/post-link-field-filter.ts",


### PR DESCRIPTION
## 배경 (2026-07-10 전체 점검 후속)
- `affiliate-link-private` 의 post_content/comment_content 필터가 **no-op 스텁**(원문 그대로 반환)으로 남아 있어, 점검 때 '본문 변환이 안 되는 원인'으로 오인하게 만들었습니다. 실제 본문 변환은 `transformedPostContent`(글 상세 로더 스트리밍) 경로로 동작 중 — 스텁과 훅 등록을 제거합니다.
- economy 쇼핑 배너의 제휴 링크 rel 에 `sponsored` 를 추가합니다 (Google 유료 링크 가이드).

## 변경
- plugin.json hooks 4→2 (link field 필터 2종만 유지)
- hooks/{post,comment}-content-filter.ts 삭제, index.ts export 정리
- economy-shopping-banner.svelte rel="nofollow noreferrer sponsored"

## 검증
- `pnpm check` 0 errors, 스텁 참조 전무 확인