### PR TITLE
fix(discipline): 게시판 내 검색 이용제한 근거 글 마스킹 (#12943)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -16,6 +16,7 @@ import { createCache } from '$lib/server/cache.js';
 import { getCachedBoard, resolveCanonicalBoardId } from '$lib/server/board-cache.js';
 import { resolveGivingMeta } from '$lib/features/giving/model.js';
 import { searchByBoard } from '$lib/server/sphinx-search.js';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
 import { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { applyFilter } from '$lib/hooks/registry.js';
@@ -488,6 +489,9 @@ export const load: PageServerLoad = async ({
                     )
                 ]);
                 const rows = postRows[0];
+                // #12943: 게시판 내 검색은 sphinx→DB 직조회라 백엔드 목록 마스킹을
+                // 우회한다 — 이용제한 근거 글 제목·본문을 여기서도 마스킹(P2 공용 헬퍼).
+                const disciplinedIds = await findDisciplinedIds(boardId, refetchIds);
                 const boNotice = String(noticeRows[0]?.[0]?.bo_notice ?? '');
                 const noticeIds = new Set(
                     boNotice
@@ -501,12 +505,17 @@ export const load: PageServerLoad = async ({
                 const rowMap = new Map(
                     rows.map((r) => {
                         const deleted = Number(r.is_deleted_parent) === 1;
+                        const disciplined = disciplinedIds.has(Number(r.id));
                         return [
                             r.id,
                             {
                                 ...r,
-                                title: deleted ? '[삭제된 글입니다]' : r.title,
-                                content: deleted ? '' : r.content,
+                                title: deleted
+                                    ? '[삭제된 글입니다]'
+                                    : disciplined
+                                      ? DISCIPLINED_TITLE
+                                      : r.title,
+                                content: deleted || disciplined ? '' : r.content,
                                 is_notice: noticeIds.has(Number(r.id))
                             }
                         ];


### PR DESCRIPTION
## 증상 (bug/12943, 취미생활자님)
이용제한 근거 글이 프로필 최근 글·소명게시판에서는 `[이용제한 근거 글]`로 마스킹되는데, **[게시판 내 검색] 결과 목록에서는 원문 제목이 그대로 노출**됩니다.

## 원인
게시판 내 검색(`[boardId]/+page.server.ts` → `fetchPostsViaSphinx`)은 sphinx 인덱스 → DB 직조회 경로라, 백엔드(Go) 목록 마스킹(be#542)과 P2 표면 마스킹(fe#1726: 통합검색·피드·소모임·스크랩·RSS)을 **모두 우회**하는 유일한 잔여 표면이었습니다.

## 수정
검색 결과 매핑에 P2 공용 헬퍼(`findDisciplinedIds`) 적용 — 제목 → `[이용제한 근거 글]`, 본문 발췌 비움 (통합검색과 동일 규칙, auth 무관이라 캐시 안전).

## 검증
- `pnpm check` 0 errors
- canary에서 해당 회원 게시판 내 검색 → 마스킹 표시 확인 예정