### PR TITLE
fix(seo): comment.author 프로필 url — GSC 토론포럼 개선 제안 대응

### DIFF
--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -29,7 +29,13 @@ export function createQAPageJsonLd(options: {
     dateCreated?: string;
     /** 전체 답변(댓글) 수 */
     answerCount: number;
-    answers: Array<{ text: string; author?: string; dateCreated?: string; upvoteCount?: number }>;
+    answers: Array<{
+        text: string;
+        author?: string;
+        authorUrl?: string;
+        dateCreated?: string;
+        upvoteCount?: number;
+    }>;
 }): JsonLdQAPage | null {
     if (!options.name?.trim()) return null;
     const answers = options.answers
@@ -41,7 +47,13 @@ export function createQAPageJsonLd(options: {
             ...(a.dateCreated ? { dateCreated: a.dateCreated } : {}),
             ...(a.upvoteCount !== undefined ? { upvoteCount: a.upvoteCount } : {}),
             ...(a.author?.trim()
-                ? { author: { '@type': 'Person' as const, name: a.author.trim() } }
+                ? {
+                      author: {
+                          '@type': 'Person' as const,
+                          name: a.author.trim(),
+                          ...(a.authorUrl ? { url: a.authorUrl } : {})
+                      }
+                  }
                 : {})
         }));
     if (!answers.length) return null;
@@ -193,7 +205,13 @@ export function createDiscussionForumPostingJsonLd(options: {
     upvoteCount?: number;
     image?: string;
     /** 상위 댓글 (Google 포럼 리치 결과의 comment 노드, 최대 3개 출력) */
-    comments?: Array<{ text: string; author: string; datePublished?: string }>;
+    comments?: Array<{
+        text: string;
+        author: string;
+        /** 작성자 프로필 URL — GSC "comment.author 의 url 누락" 개선 제안 대응 */
+        authorUrl?: string;
+        datePublished?: string;
+    }>;
 }): JsonLdDiscussionForumPosting {
     const data: JsonLdDiscussionForumPosting = {
         '@type': 'DiscussionForumPosting',
@@ -220,7 +238,11 @@ export function createDiscussionForumPostingJsonLd(options: {
             .map((c) => ({
                 '@type': 'Comment' as const,
                 text: c.text.trim(),
-                author: { '@type': 'Person' as const, name: c.author.trim() },
+                author: {
+                    '@type': 'Person' as const,
+                    name: c.author.trim(),
+                    ...(c.authorUrl ? { url: c.authorUrl } : {})
+                },
                 ...(c.datePublished ? { datePublished: c.datePublished } : {})
             }));
         if (validComments.length) data.comment = validComments;

--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -323,3 +323,30 @@ describe('SEO P3 — Discover + QAPage', () => {
         expect(createQAPageJsonLd({ ...base, name: ' ' })).toBeNull();
     });
 });
+
+describe('comment.author url (GSC 개선 제안)', () => {
+    it('DiscussionForumPosting comment author 에 프로필 url 포함, 없으면 생략', () => {
+        const ld = createDiscussionForumPostingJsonLd({
+            headline: 't',
+            author: '글쓴이',
+            datePublished: '2026-07-10',
+            url: 'https://test.com/free/1',
+            comments: [
+                { text: '댓글', author: '앙님', authorUrl: 'https://test.com/member/ang' },
+                { text: '익명댓글', author: '누군가' }
+            ]
+        });
+        expect(ld.comment?.[0].author.url).toBe('https://test.com/member/ang');
+        expect(ld.comment?.[1].author.url).toBeUndefined();
+    });
+
+    it('QAPage answer author 에 프로필 url 포함', async () => {
+        const { createQAPageJsonLd } = await import('./json-ld');
+        const ld = createQAPageJsonLd({
+            name: '질문',
+            answerCount: 1,
+            answers: [{ text: '답변', author: '앙님', authorUrl: 'https://test.com/member/ang' }]
+        });
+        expect(ld?.mainEntity.suggestedAnswer?.[0].author?.url).toBe('https://test.com/member/ang');
+    });
+});

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -110,7 +110,7 @@ export interface JsonLdDiscussionForumPosting {
     comment?: Array<{
         '@type': 'Comment';
         text: string;
-        author: { '@type': 'Person'; name: string };
+        author: { '@type': 'Person'; name: string; url?: string };
         datePublished?: string;
     }>;
 }
@@ -149,7 +149,7 @@ export interface JsonLdQAPage {
             text: string;
             dateCreated?: string;
             upvoteCount?: number;
-            author?: { '@type': 'Person'; name: string };
+            author?: { '@type': 'Person'; name: string; url?: string };
         }>;
     };
 }

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1765,6 +1765,8 @@
                       answers: safeTopComments.map((c) => ({
                           text: truncateText(c.content.replace(/<[^>]+>/g, '').trim(), 300),
                           author: c.author,
+                          // GSC "comment.author 의 url 누락" 개선 — 프로필 URL
+                          authorUrl: c.author_id ? `${siteUrl}/member/${c.author_id}` : undefined,
                           dateCreated: c.created_at,
                           upvoteCount: c.likes ?? 0
                       }))
@@ -1814,6 +1816,10 @@
                           comments: safeTopComments.map((c) => ({
                               text: truncateText(c.content.replace(/<[^>]+>/g, '').trim(), 200),
                               author: c.author,
+                              // GSC "comment.author 의 url 누락" 개선 — 프로필 URL
+                              authorUrl: c.author_id
+                                  ? `${siteUrl}/member/${c.author_id}`
+                                  : undefined,
                               datePublished: c.created_at
                           }))
                       }),


### PR DESCRIPTION
## 배경
GSC 알림(비심각): **"'url' 입력란이 누락되었습니다 (경로: comment.author)"** — 지난주 추가한 Comment 노드의 author 에 프로필 링크가 없다는 개선 제안입니다.

## 변경
- DiscussionForumPosting **Comment** 노드와 QAPage **Answer** 노드의 author(Person)에 회원 프로필 URL(`/member/{author_id}`) 포함
- author_id 가 없는 경우(익명 등)는 기존처럼 url 생략 — 빈 값 출력 금지 원칙 유지 (breadcrumb fix 계열과 동일 철학)

## 검증
- vitest 33 passed (신규 2건 포함) / svelte-check 0 errors
- 배포 후 글 상세 JSON-LD 에서 comment.author.url 실측 + GSC 수정 확인 요청