### PR TITLE
feat(reaction): 이모지 리액션 닉네임 공개 (7/12 시행, 소급 제외)

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -15,6 +15,8 @@
     } from '$lib/config/reaction-config.js';
     import { loadPluginLib } from '$lib/utils/plugin-optional-loader';
     import SmilePlus from '@lucide/svelte/icons/smile-plus';
+    import Users from '@lucide/svelte/icons/users';
+    import ReactionReactorsDialog from './reaction-reactors-dialog.svelte';
     import {
         canUseCertifiedAction,
         getCertificationBlockedMessage,
@@ -190,6 +192,9 @@
         reactions = initialReactions ?? [];
     });
 
+    // 리액션 사용자 목록 다이얼로그 (이모지 닉네임 공개, 2026-07-12 시행)
+    let reactorsDialogOpen = $state(false);
+
     onMount(() => {
         void loadReactionPolicy();
         document.addEventListener('click', handleClickOutside);
@@ -222,6 +227,19 @@
             <span class="font-medium">{item.count}</span>
         </button>
     {/each}
+
+    <!-- 리액션 사용자 목록 (닉네임 공개, 2026-07-12 시행) -->
+    {#if reactions.length > 0 && authStore.isAuthenticated}
+        <button
+            type="button"
+            onclick={() => (reactorsDialogOpen = true)}
+            class="border-border bg-muted/50 text-muted-foreground hover:border-primary/30 hover:bg-primary/5 inline-flex items-center rounded-full border px-2 py-1 transition-all"
+            title="리액션한 사람 보기"
+            aria-label="리액션한 사람 보기"
+        >
+            <Users class="h-4 w-4" />
+        </button>
+    {/if}
 
     <!-- 리액션 추가 버튼 -->
     <button
@@ -311,6 +329,14 @@
             </div>
         </div>
     </div>
+{/if}
+
+{#if reactorsDialogOpen}
+    <ReactionReactorsDialog
+        bind:open={reactorsDialogOpen}
+        {targetId}
+        onClose={() => (reactorsDialogOpen = false)}
+    />
 {/if}
 
 <style>

--- a/apps/web/src/lib/components/features/reaction/reaction-reactors-dialog.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-reactors-dialog.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+    /**
+     * 리액션 사용자 목록 다이얼로그 (이모지 닉네임 공개, 2026-07-12 시행).
+     * 시행일 이후 리액션만 닉네임이 공개되고, 이전 리액션은 익명 건수로만 표시된다.
+     * (공지 free/6678912 — comment-likers-dialog 패턴 재사용)
+     */
+    import * as Dialog from '$lib/components/ui/dialog/index.js';
+    import { getAvatarUrl } from '$lib/utils/member-icon.js';
+    import { getReactionDisplay } from '$lib/types/reaction.js';
+    import { formatDateTime } from '$lib/utils/format-date.js';
+
+    interface ReactorInfo {
+        mb_id: string;
+        mb_nick: string;
+        mb_image?: string;
+        mb_image_updated_at?: string;
+        reaction: string;
+        reacted_at: string;
+    }
+
+    interface Props {
+        open: boolean;
+        targetId: string;
+        onClose: () => void;
+    }
+
+    let { open = $bindable(), targetId, onClose }: Props = $props();
+
+    let reactors = $state<ReactorInfo[]>([]);
+    let anonymousCount = $state(0);
+    let isLoading = $state(false);
+    let loadError = $state(false);
+
+    $effect(() => {
+        if (open && targetId) {
+            void loadReactors();
+        }
+    });
+
+    async function loadReactors(): Promise<void> {
+        isLoading = true;
+        loadError = false;
+        try {
+            const res = await fetch(
+                `/api/reactions/reactors?targetId=${encodeURIComponent(targetId)}&limit=100`
+            );
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const json = await res.json();
+            reactors = json.data?.reactors ?? [];
+            anonymousCount = json.data?.anonymousCount ?? 0;
+        } catch (err) {
+            console.error('Failed to load reactors:', err);
+            loadError = true;
+        } finally {
+            isLoading = false;
+        }
+    }
+</script>
+
+<Dialog.Root
+    bind:open
+    onOpenChange={(isOpen) => {
+        if (!isOpen) onClose();
+    }}
+>
+    <Dialog.Content class="max-w-md">
+        <Dialog.Header>
+            <Dialog.Title>리액션한 사람들</Dialog.Title>
+            <Dialog.Description>
+                2026년 7월 12일부터 누른 리액션은 닉네임이 함께 표시됩니다.
+            </Dialog.Description>
+        </Dialog.Header>
+
+        <div class="max-h-80 space-y-1 overflow-y-auto">
+            {#if isLoading}
+                <p class="text-muted-foreground py-6 text-center text-sm">불러오는 중…</p>
+            {:else if loadError}
+                <p class="text-muted-foreground py-6 text-center text-sm">
+                    목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+                </p>
+            {:else}
+                {#each reactors as reactor (reactor.mb_id + reactor.reaction + reactor.reacted_at)}
+                    {@const display = getReactionDisplay(reactor.reaction)}
+                    {@const avatar = getAvatarUrl(reactor.mb_image, reactor.mb_image_updated_at)}
+                    <div class="hover:bg-muted/50 flex items-center gap-3 rounded-md px-2 py-1.5">
+                        {#if avatar}
+                            <img
+                                src={avatar}
+                                alt={reactor.mb_nick}
+                                class="h-8 w-8 rounded-full object-cover"
+                                loading="lazy"
+                            />
+                        {:else}
+                            <div
+                                class="bg-muted text-muted-foreground flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium"
+                            >
+                                {reactor.mb_nick.charAt(0)}
+                            </div>
+                        {/if}
+                        <div class="min-w-0 flex-1">
+                            <a
+                                href={`/member/${reactor.mb_id}`}
+                                class="hover:text-primary truncate text-sm font-medium"
+                            >
+                                {reactor.mb_nick}
+                            </a>
+                            {#if reactor.reacted_at}
+                                <p class="text-muted-foreground text-xs">
+                                    {formatDateTime(reactor.reacted_at)}
+                                </p>
+                            {/if}
+                        </div>
+                        {#if display.renderType === 'image' && display.url}
+                            <img
+                                src={display.url}
+                                alt={display.label}
+                                class="h-6 w-6 object-scale-down"
+                            />
+                        {:else}
+                            <span class="text-lg leading-none">{display.emoji}</span>
+                        {/if}
+                    </div>
+                {:else}
+                    {#if anonymousCount === 0}
+                        <p class="text-muted-foreground py-6 text-center text-sm">
+                            아직 공개 대상 리액션이 없습니다.
+                        </p>
+                    {/if}
+                {/each}
+
+                {#if anonymousCount > 0}
+                    <p class="text-muted-foreground border-t px-2 pb-1 pt-3 text-center text-xs">
+                        공개 시행(7월 12일) 이전의 리액션 {anonymousCount}개는 익명으로 유지됩니다.
+                    </p>
+                {/if}
+            {/if}
+        </div>
+    </Dialog.Content>
+</Dialog.Root>

--- a/apps/web/src/routes/api/reactions/reactors/+server.ts
+++ b/apps/web/src/routes/api/reactions/reactors/+server.ts
@@ -1,0 +1,96 @@
+/**
+ * 리액션 사용자 목록 API (이모지 닉네임 공개, 2026-07-12 시행)
+ * GET /api/reactions/reactors?targetId=document:free:123&limit=50
+ *
+ * 시행일(REACTOR_REVEAL_SINCE) 이후의 리액션만 닉네임을 공개하고,
+ * 그 이전 리액션은 익명 약속대로 소급 공개하지 않고 건수만 집계해 반환한다.
+ * (공지 free/6678912 · 건의 bug/12482, bug/12804)
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+import { getAuthUser } from '$lib/server/auth';
+
+/** 공개 시행 시점 — g5_da_reaction_choose.created_at 은 KST 로 저장되므로 그대로 비교. */
+export const REACTOR_REVEAL_SINCE = '2026-07-12 00:00:00';
+
+const MAX_LIMIT = 100;
+const TARGET_ID_RE = /^(document|comment):[a-z0-9_]+:\d+$/;
+
+function toSafeIso(raw: unknown): string {
+    const s = typeof raw === 'string' ? raw : raw == null ? '' : String(raw);
+    if (!s || s.startsWith('0000')) return '';
+    return s.replace(' ', 'T') + 'Z';
+}
+
+interface ReactorRow extends RowDataPacket {
+    member_id: string;
+    mb_nick: string;
+    mb_name: string;
+    mb_image_url: string;
+    mb_image_updated_at: string | null;
+    reaction: string;
+    created_at: string;
+}
+
+interface CountRow extends RowDataPacket {
+    cnt: number;
+}
+
+export const GET: RequestHandler = async ({ url, cookies }) => {
+    const targetId = url.searchParams.get('targetId') || '';
+    if (!TARGET_ID_RE.test(targetId)) {
+        return json({ success: false, message: 'targetId가 올바르지 않습니다.' }, { status: 400 });
+    }
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 50, MAX_LIMIT);
+
+    // 추천자 목록과 동일 기준: 회원에게만 목록 공개
+    const user = await getAuthUser(cookies).catch(() => null);
+    if (!user) {
+        return json({ success: false, message: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    try {
+        const [[rows], [anonRows]] = await Promise.all([
+            pool.query<ReactorRow[]>(
+                `SELECT c.member_id, m.mb_nick, m.mb_name,
+                        COALESCE(m.mb_image_url, '') AS mb_image_url,
+                        m.mb_image_updated_at,
+                        c.reaction, c.created_at
+                 FROM g5_da_reaction_choose c
+                 JOIN g5_member m ON c.member_id = m.mb_id
+                 WHERE c.target_id = ? AND c.created_at >= ?
+                 ORDER BY c.created_at DESC
+                 LIMIT ?`,
+                [targetId, REACTOR_REVEAL_SINCE, limit]
+            ),
+            pool.query<CountRow[]>(
+                `SELECT COUNT(*) AS cnt FROM g5_da_reaction_choose
+                 WHERE target_id = ? AND created_at < ?`,
+                [targetId, REACTOR_REVEAL_SINCE]
+            )
+        ]);
+
+        const anonymousCount = Number(anonRows[0]?.cnt ?? 0);
+        return json({
+            success: true,
+            data: {
+                reactors: rows.map((r) => ({
+                    mb_id: r.member_id,
+                    mb_nick: r.mb_nick || r.mb_name || r.member_id,
+                    mb_image: r.mb_image_url || '',
+                    mb_image_updated_at: r.mb_image_updated_at || undefined,
+                    reaction: r.reaction,
+                    reacted_at: toSafeIso(r.created_at)
+                })),
+                anonymousCount,
+                total: rows.length + anonymousCount,
+                revealSince: REACTOR_REVEAL_SINCE
+            }
+        });
+    } catch (err) {
+        console.error('[reactions/reactors] 조회 실패:', err);
+        return json({ success: false, message: '조회에 실패했습니다.' }, { status: 500 });
+    }
+};


### PR DESCRIPTION
## 배경
익명 이모지 악용(특정 회원 조롱·여론 왜곡) 대응 — 공지 https://damoang.net/free/6678912 · 건의 bug/12482, bug/12804. **2026-07-12(토) 시행분부터** 추천 기능처럼 리액션 사용자의 닉네임을 공개합니다. 시행일 이전 리액션은 익명 약속대로 **소급 공개하지 않습니다**.

## 구현
| 구성 | 내용 |
|---|---|
| API | `GET /api/reactions/reactors?targetId=document:free:123` — `g5_da_reaction_choose` JOIN `g5_member`, `created_at >= '2026-07-12'`(KST 저장)만 신원 포함, 이전분은 `anonymousCount` 집계. 회원 전용(401) |
| UI | 리액션 바 끝에 👥 '리액션한 사람 보기' 버튼(로그인+리액션 존재 시) → 다이얼로그(아바타·닉네임·누른 이모지·시각 + "시행 이전 N개는 익명 유지" 안내) |
| 범위 | reaction-bar 사용처 전체 = 전 게시판 글 상세(basic/report) + 댓글 — 자동 적용 |
| 소급 방지 | 컷오프 상수 `REACTOR_REVEAL_SINCE` 단일 지점 |

## 정책 매트릭스 확인
신규 표면(리액션 사용자 목록): 이용제한·차단·익명메시지 정책과 무관(회원 신원은 본 기능의 목적상 공개 대상), 탈퇴 회원은 g5_member JOIN 유지되나 프로필 링크는 기존 탈퇴 카드 정책이 커버. 비로그인 익명 표면 아님(401).

## 검증
- `pnpm check` 0 errors / 유닛 476 passed
- canary: 시행일 전이라 목록은 '익명 유지 N개'만 표시됨(정상), 7/12 이후 신규 리액션부터 닉네임 노출
- 배포: 토요일 새벽 정기 배포 탑승 시 시행일과 일치