### PR TITLE
fix(reaction): reactors 라우트 비허용 export 제거 (canary 빌드 실패 수정)

### DIFF
--- a/apps/web/src/routes/api/reactions/reactors/+server.ts
+++ b/apps/web/src/routes/api/reactions/reactors/+server.ts
@@ -13,7 +13,7 @@ import pool from '$lib/server/db';
 import { getAuthUser } from '$lib/server/auth';
 
 /** 공개 시행 시점 — g5_da_reaction_choose.created_at 은 KST 로 저장되므로 그대로 비교. */
-export const REACTOR_REVEAL_SINCE = '2026-07-12 00:00:00';
+const REACTOR_REVEAL_SINCE = '2026-07-12 00:00:00';
 
 const MAX_LIMIT = 100;
 const TARGET_ID_RE = /^(document|comment):[a-z0-9_]+:\d+$/;


### PR DESCRIPTION
#1761 의 `+server.ts` 에서 `REACTOR_REVEAL_SINCE` 상수를 export 해 SvelteKit 라우트 export 검증에 걸려 canary 빌드가 실패했습니다 (`Invalid export 'REACTOR_REVEAL_SINCE'`). 모듈 내부 const 로 전환 — 동작 변화 없음. svelte-check 로는 잡히지 않고 빌드에서만 검출되는 유형입니다.