### PR TITLE
feat(seo): 작성자 활동 패널 SSR화 — 별도 섹션 없이 내부링크 확보 (#83)

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -39,21 +39,29 @@
 
     let { post, initialActivity = null }: Props = $props();
 
-    let loading = $state(true);
-    let recentPosts = $state<RecentPost[]>([]);
-    let recentComments = $state<RecentComment[]>([]);
+    // SEO 내부링크(#83): 서버 로드가 initialActivity 를 넘겨주면 SSR HTML 에
+    // 최근 글/댓글 앵커가 포함되어야 한다. $effect 는 SSR 에서 실행되지 않으므로
+    // 초기 state 를 props 에서 직접 계산한다 (클라 스트리밍 갱신은 아래 $effect).
+    const hasInitial = !!(
+        initialActivity &&
+        (initialActivity.recentPosts.length > 0 || initialActivity.recentComments.length > 0)
+    );
+
+    let loading = $state(!hasInitial);
+    let recentPosts = $state<RecentPost[]>(hasInitial ? initialActivity!.recentPosts : []);
+    let recentComments = $state<RecentComment[]>(hasInitial ? initialActivity!.recentComments : []);
     let adContainer = $state<HTMLElement | null>(null);
     let clipWrapper = $state<HTMLElement | null>(null);
     let panelEl = $state<HTMLElement | null>(null);
     let mobileExpanded = $state(false);
     let shouldLoad = $state(false);
-    let desktopExpanded = $state(false);
+    let desktopExpanded = $state(hasInitial);
     // SSR(initialActivity)로 이미 채워졌는지 — 클릭 시 클라 API 재fetch 방지 + 펼침 표시
-    let ssrLoaded = $state(false);
+    let ssrLoaded = $state(hasInitial);
 
-    // SSR 스트리밍으로 작성자 활동이 도착하면 클릭 없이 즉시 반영.
-    // 데스크톱은 자동 펼침. 모바일은 공간 절약 위해 접어둠 — 데이터는 preload 라
-    // 탭하면 추가 fetch 없이 즉시 표시(ssrLoaded 가드). (SSR 데이터 없으면 클릭-fetch 폴백)
+    // SSR 스트리밍으로 작성자 활동이 늦게 도착한 경우(서버 확정 데이터가 없던 페이지)
+    // 클릭 없이 즉시 반영. 데스크톱은 자동 펼침. 모바일은 공간 절약 위해 접어둠 —
+    // 데이터는 preload 라 탭하면 추가 fetch 없이 즉시 표시(ssrLoaded 가드).
     $effect(() => {
         if (
             initialActivity &&

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -719,6 +719,12 @@ export const load: PageServerLoad = async ({
             page: recentPostsPage
         };
 
+        // SEO 내부링크(#83): 작성자 최근 활동을 SSR 로 확정 — 활동 패널의 글/댓글
+        // 앵커가 초기 HTML 에 포함되게 한다(별도 섹션 없이 기존 패널 재사용).
+        // memberActivityPromise 는 댓글 fetch 와 병렬 + 2s 타임아웃 + 내부 catch 라
+        // 페이지 로드를 추가로 블록하지 않는다. 익명·탈퇴는 상위 가드에서 null 수렴.
+        const memberActivity = post.deleted_at ? null : await memberActivityPromise;
+
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).
         // 미설치 시 pass-through. (premium PR #43 기준 stub)
         // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달.
@@ -742,6 +748,8 @@ export const load: PageServerLoad = async ({
             truthroomPostId,
             originalPostLink,
             recentPosts,
+            /** SEO 내부링크(#83): 작성자 활동 패널 SSR 확정 데이터 */
+            memberActivity,
             /** 스트리밍: Promise로 반환 → 클라이언트에서 $effect로 수신 */
             streamed: {
                 auxiliaryData: auxiliaryDataPromise

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -369,8 +369,12 @@
     );
     let truthroomCommentMap = $state<Record<number, number>>({});
     let promotionPosts = $state<PromotionPost[]>([]);
-    // 작성자 최근 활동 (auxiliaryData 스트리밍으로 SSR 직접 로딩 — 작성자활동 패널에 주입)
-    let memberActivity = $state<{ recentPosts: unknown[]; recentComments: unknown[] } | null>(null);
+    // 작성자 최근 활동 — 서버 확정(data.memberActivity, SEO 앵커용 #83)으로 초기화하고
+    // 스트리밍(auxiliaryData) 도착 시 갱신. SSR 시점에 값이 있어야 패널 앵커가 HTML 에 포함됨
+    let memberActivity = $state<{ recentPosts: unknown[]; recentComments: unknown[] } | null>(
+        (data.memberActivity as { recentPosts: unknown[]; recentComments: unknown[] } | null) ??
+            null
+    );
     let revisions = $state<PostRevision[]>([]);
     let initialLikedCommentIds = $state<number[]>([]);
     let initialDislikedCommentIds = $state<number[]>([]);
@@ -446,7 +450,10 @@
         initialDislikedCommentIds = [];
         truthroomCommentMap = {};
         scheduledDelete = null;
-        memberActivity = null;
+        // SPA 내비게이션 시 새 글의 서버 확정값으로 리셋 (없으면 null → 스트리밍 대기)
+        memberActivity =
+            (data.memberActivity as { recentPosts: unknown[]; recentComments: unknown[] } | null) ??
+            null;
         auxiliaryLoaded = false;
 
         promise


### PR DESCRIPTION
## 배경
#1763 에서 중복 노출 문제로 '작성자의 최근 글' 섹션을 제거했습니다. 이 PR 은 **기존 작성자 활동 패널 그대로**를 SSR 화해 SEO 내부링크 목적을 회복합니다 — **화면 변화 0**(새 영역 없음), 크롤러가 보는 초기 HTML 에만 글/댓글 앵커가 포함됩니다.

## 구현
- `+page.server.ts`: `memberActivity` 를 await 확정 반환 — 기존 promise 재사용(댓글 fetch 와 병렬·2s 타임아웃·내부 catch)이라 페이지 로드 추가 블록 없음
- `+page.svelte`: state 를 서버 확정값으로 초기화 (SPA 내비게이션 리셋 경로 포함)
- `author-activity-panel.svelte`: **$effect 는 SSR 에서 실행되지 않으므로** 초기 state 를 props 에서 직접 계산 — SSR 시점에 데스크톱 펼침+앵커 렌더. 스트리밍 늦은 도착 폴백 $effect 유지

## 검증
- svelte-check 0 errors (state_referenced_locally 경고는 의도된 초기 캡처 — initFromSSR 패턴)
- 배포 후: 글 상세 SSR HTML(curl)에 활동 패널 앵커 존재 + 화면 동일 확인 예정