### PR TITLE
feat(widget): 발견 엔진 1단 — 숨은 보석 + 오늘의 앙모지

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -487,12 +487,27 @@ export interface GroupTabsData {
     month: GroupPost[];
 }
 
+// 앙모지 리더보드 항목 (24h 리액션 상위 글/댓글)
+export interface EmojiAwardPost {
+    id: number;
+    title: string;
+    board: string;
+    board_name: string;
+    author: string;
+    url: string;
+    is_comment: boolean;
+    reaction_total: number;
+    top_reaction: string;
+    top_reaction_count: number;
+}
+
 // 전체 위젯 데이터
 export interface IndexWidgetsData {
     news_tabs: NewsPost[];
     economy_tabs: EconomyPost[];
     gallery: GalleryPost[];
     group_tabs: GroupTabsData;
+    emoji_awards?: EmojiAwardPost[];
 }
 
 // 사이드바 메뉴 타입

--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -22,6 +22,7 @@
     import NoticeWidget from '../../../../../../widgets/notice/index.svelte';
     import ImageTextBannerWidget from '../../../../../../widgets/image-text-banner/index.svelte';
     import HiddenGemsWidget from '../../../../../../widgets/hidden-gems/index.svelte';
+    import EmojiAwardsWidget from '../../../../../../widgets/emoji-awards/index.svelte';
     import RecommendedWidget from '../../../../../../widgets/recommended/index.svelte';
     import ExploreWidget from '../../../../../../widgets/explore/index.svelte';
     import GivingWidget from '../../../../../../widgets/giving/index.svelte';
@@ -50,6 +51,7 @@
         notice: NoticeWidget,
         'image-text-banner': ImageTextBannerWidget,
         'hidden-gems': HiddenGemsWidget,
+        'emoji-awards': EmojiAwardsWidget,
         recommended: RecommendedWidget,
         explore: ExploreWidget,
         giving: GivingWidget

--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -21,6 +21,7 @@
     import PostListWidget from '../../../../../../widgets/post-list/index.svelte';
     import NoticeWidget from '../../../../../../widgets/notice/index.svelte';
     import ImageTextBannerWidget from '../../../../../../widgets/image-text-banner/index.svelte';
+    import HiddenGemsWidget from '../../../../../../widgets/hidden-gems/index.svelte';
     import RecommendedWidget from '../../../../../../widgets/recommended/index.svelte';
     import ExploreWidget from '../../../../../../widgets/explore/index.svelte';
     import GivingWidget from '../../../../../../widgets/giving/index.svelte';
@@ -48,6 +49,7 @@
         'post-list': PostListWidget,
         notice: NoticeWidget,
         'image-text-banner': ImageTextBannerWidget,
+        'hidden-gems': HiddenGemsWidget,
         recommended: RecommendedWidget,
         explore: ExploreWidget,
         giving: GivingWidget

--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -13,25 +13,26 @@ import type { WidgetConfig } from '$lib/stores/widget-layout.svelte';
 export const DEFAULT_WIDGETS: WidgetConfig[] = [
     { id: 'tag-nav', type: 'tag-nav', position: 0, enabled: true },
     { id: 'empathy-explore-row', type: 'empathy-explore-row', position: 1, enabled: true },
+    { id: 'hidden-gems', type: 'hidden-gems', position: 2, enabled: true },
     {
         id: 'ad-top',
         type: 'ad-slot',
-        position: 2,
+        position: 3,
         enabled: true,
         settings: { position: 'index-top' }
     },
     {
         id: 'ad-middle-1',
         type: 'ad-slot',
-        position: 3,
+        position: 4,
         enabled: true,
         settings: { position: 'index-middle-1' }
     },
-    { id: 'news-economy-row', type: 'news-economy-row', position: 4, enabled: true },
+    { id: 'news-economy-row', type: 'news-economy-row', position: 5, enabled: true },
     {
         id: 'gallery',
         type: 'post-list',
-        position: 5,
+        position: 6,
         enabled: true,
         settings: {
             boardId: 'gallery',
@@ -44,27 +45,27 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
     {
         id: 'ad-middle-2',
         type: 'ad-slot',
-        position: 6,
+        position: 7,
         enabled: true,
         settings: { position: 'index-middle-2' }
     },
     {
         id: 'group',
         type: 'post-list',
-        position: 7,
+        position: 8,
         enabled: true,
         settings: { boardId: 'group', layout: 'card', sortBy: 'date', count: 10, showTitle: true }
     },
     {
         id: 'celebration',
         type: 'celebration',
-        position: 8,
+        position: 9,
         enabled: true
     },
     {
         id: 'ad-bottom',
         type: 'ad-slot',
-        position: 9,
+        position: 10,
         enabled: true,
         settings: { position: 'index-bottom' }
     }
@@ -73,11 +74,12 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
 /** 기본 사이드바 위젯 레이아웃 */
 export const DEFAULT_SIDEBAR_WIDGETS: WidgetConfig[] = [
     { id: 'notice', type: 'notice', position: 0, enabled: true },
-    { id: 'celebration', type: 'celebration', position: 1, enabled: true },
+    { id: 'hidden-gems', type: 'hidden-gems', position: 1, enabled: true },
+    { id: 'celebration', type: 'celebration', position: 2, enabled: true },
     {
         id: 'sidebar-ad-2',
         type: 'ad-slot',
-        position: 2,
+        position: 3,
         enabled: true,
         settings: { position: 'sidebar-2', type: 'image-text', format: 'grid' }
     }

--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -74,12 +74,13 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
 /** 기본 사이드바 위젯 레이아웃 */
 export const DEFAULT_SIDEBAR_WIDGETS: WidgetConfig[] = [
     { id: 'notice', type: 'notice', position: 0, enabled: true },
-    { id: 'hidden-gems', type: 'hidden-gems', position: 1, enabled: true },
-    { id: 'celebration', type: 'celebration', position: 2, enabled: true },
+    { id: 'emoji-awards', type: 'emoji-awards', position: 1, enabled: true },
+    { id: 'hidden-gems', type: 'hidden-gems', position: 2, enabled: true },
+    { id: 'celebration', type: 'celebration', position: 3, enabled: true },
     {
         id: 'sidebar-ad-2',
         type: 'ad-slot',
-        position: 3,
+        position: 4,
         enabled: true,
         settings: { position: 'sidebar-2', type: 'image-text', format: 'grid' }
     }

--- a/apps/web/src/lib/server/index-widgets-builder.ts
+++ b/apps/web/src/lib/server/index-widgets-builder.ts
@@ -52,7 +52,8 @@ const EMPTY_RESULT: IndexWidgetsData = {
     news_tabs: [],
     economy_tabs: [],
     gallery: [],
-    group_tabs: { all: [], '24h': [], week: [], month: [] }
+    group_tabs: { all: [], '24h': [], week: [], month: [] },
+    emoji_awards: []
 };
 
 /** 인메모리 캐시 */
@@ -77,7 +78,8 @@ export async function buildIndexWidgets(_backendUrl: string): Promise<IndexWidge
             news_tabs: (json.news_tabs ?? []) as NewsPost[],
             economy_tabs: (json.economy_tabs ?? []) as EconomyPost[],
             gallery: (json.gallery ?? []) as GalleryPost[],
-            group_tabs: (json.group_tabs ?? EMPTY_RESULT.group_tabs) as GroupTabsData
+            group_tabs: (json.group_tabs ?? EMPTY_RESULT.group_tabs) as GroupTabsData,
+            emoji_awards: (json.emoji_awards ?? []) as IndexWidgetsData['emoji_awards']
         };
 
         // 데이터가 있을 때만 캐시

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -5,6 +5,7 @@ import { buildIndexWidgets } from '$lib/server/index-widgets-builder';
 import { getDefaultPeriod, loadRecommendedData } from '$lib/server/recommended-loader';
 import { getCachedCelebrations } from '$lib/server/celebration';
 import { loadExploreData, buildExplorePreviewData } from '$lib/server/explore-loader';
+import type { ExplorePost } from '$lib/api/types';
 import { env } from '$env/dynamic/private';
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
@@ -17,6 +18,8 @@ interface HomePageData {
     recommendedData: Awaited<ReturnType<typeof loadRecommendedData>> | null;
     recommendedPeriod: ReturnType<typeof getDefaultPeriod>;
     exploreData: ReturnType<typeof buildExplorePreviewData> | null;
+    // 숨은 보석 위젯용 — explore new 풀(24h 크로스보드)에서 대형 게시판 제외 풀
+    hiddenGems: ExplorePost[];
     celebrationRecent: Awaited<ReturnType<typeof getCachedCelebrations>> | null;
     // 인덱스 최상단 배너용 오늘자 마음메시지 (하이드레이션 즉시 스토어 시드 → 빈 공간 제거).
     celebrationToday: Awaited<ReturnType<typeof getCachedCelebrations>> | null;
@@ -70,6 +73,11 @@ async function buildHomePageData(): Promise<HomePageData> {
         celebrationTodayResult.status === 'fulfilled' ? celebrationTodayResult.value : null;
     const exploreRaw = exploreResult.status === 'fulfilled' ? exploreResult.value : null;
     const exploreData = exploreRaw ? buildExplorePreviewData(exploreRaw) : null;
+    // 숨은 보석: 트래픽이 몰리는 대형 게시판을 제외한 24h 신규 글 풀(위젯이 클라에서 랜덤 샘플)
+    const HIDDEN_GEM_EXCLUDED = new Set(['free', 'humor', 'photo', 'economy', 'qa', 'new']);
+    const hiddenGems = ((exploreRaw?.modes.new.posts ?? []) as ExplorePost[])
+        .filter((p) => p.board && !HIDDEN_GEM_EXCLUDED.has(p.board))
+        .slice(0, 20);
 
     if (indexWidgetsResult.status === 'rejected') {
         console.error('[SSR] Failed to load index widgets:', indexWidgetsResult.reason);
@@ -82,6 +90,7 @@ async function buildHomePageData(): Promise<HomePageData> {
         recommendedData: recommendedResult.status === 'fulfilled' ? recommendedResult.value : null,
         recommendedPeriod,
         exploreData,
+        hiddenGems,
         celebrationRecent,
         celebrationToday
     };
@@ -105,6 +114,7 @@ function emptyHomePageData(): HomePageData {
         recommendedData: null,
         recommendedPeriod: getDefaultPeriod(),
         exploreData: null,
+        hiddenGems: [],
         celebrationRecent: null,
         celebrationToday: null
     };

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -101,6 +101,7 @@
                 : undefined,
             explore: data.exploreData ? { data: data.exploreData } : undefined,
             'hidden-gems': { posts: data.hiddenGems ?? [] },
+            'emoji-awards': { entries: data.indexWidgets?.emoji_awards ?? [] },
             // 결합 위젯(공감글+모아보기 2단)이 실제 홈 레이아웃에 쓰이므로 이 키로도 SSR 데이터를
             // 매핑해야 함. 누락 시 empathy-explore-row 의 prefetchData 가 undefined → RecommendedPosts
             // 가 SSR 에서 스켈레톤(loading=true)으로 렌더되어 CDN 캐시 → 전 방문자가 스켈레톤+재fetch.

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -100,6 +100,7 @@
                 ? { data: data.recommendedData, period: data.recommendedPeriod }
                 : undefined,
             explore: data.exploreData ? { data: data.exploreData } : undefined,
+            'hidden-gems': { posts: data.hiddenGems ?? [] },
             // 결합 위젯(공감글+모아보기 2단)이 실제 홈 레이아웃에 쓰이므로 이 키로도 SSR 데이터를
             // 매핑해야 함. 누락 시 empathy-explore-row 의 prefetchData 가 undefined → RecommendedPosts
             // 가 SSR 에서 스켈레톤(loading=true)으로 렌더되어 CDN 캐시 → 전 방문자가 스켈레톤+재fetch.

--- a/widgets/emoji-awards/index.svelte
+++ b/widgets/emoji-awards/index.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+    /**
+     * 오늘의 앙모지 — 24h 리액션 리더보드 (발견 엔진 1단-A, 계획 2026-07-10).
+     * Go recommend-system 이 5분마다 집계한 emoji_awards 를 표시한다.
+     * (이용제한·삭제·비밀 글은 수집 단계에서 제외됨 — 정책 매트릭스 준수)
+     */
+    import type { WidgetProps } from '$lib/types/widget-props';
+    import type { EmojiAwardPost } from '$lib/api/types';
+    import Trophy from '@lucide/svelte/icons/trophy';
+    import { getReactionDisplay } from '$lib/types/reaction.js';
+    import { trackEvent } from '$lib/services/ga4.js';
+
+    let { config, prefetchData }: WidgetProps = $props();
+
+    const itemCount = $derived(
+        Number((config?.settings as Record<string, unknown> | undefined)?.item_count ?? 5)
+    );
+
+    const entries = $derived(
+        (
+            ((prefetchData as { entries?: EmojiAwardPost[] })?.entries ?? []) as EmojiAwardPost[]
+        ).slice(0, itemCount)
+    );
+
+    function handleClick(entry: EmojiAwardPost): void {
+        trackEvent('emoji_award_click', {
+            board: entry.board,
+            post_id: entry.id
+        });
+    }
+</script>
+
+{#if entries.length > 0}
+    <div class="bg-card rounded-lg border p-4">
+        <div class="mb-3 flex items-center justify-between">
+            <h3 class="flex items-center gap-1.5 text-sm font-semibold">
+                <Trophy class="h-4 w-4 text-amber-500" />
+                오늘의 앙모지
+            </h3>
+            <span class="text-muted-foreground text-xs">최근 24시간</span>
+        </div>
+        <ol class="space-y-2">
+            {#each entries as entry, i (entry.board + entry.id)}
+                {@const display = getReactionDisplay(entry.top_reaction)}
+                <li class="min-w-0">
+                    <a
+                        href={entry.url}
+                        class="group flex items-center gap-2"
+                        onclick={() => handleClick(entry)}
+                    >
+                        <span class="text-muted-foreground w-4 shrink-0 text-center text-xs">
+                            {i + 1}
+                        </span>
+                        {#if display.renderType === 'image' && display.url}
+                            <img
+                                src={display.url}
+                                alt={display.label}
+                                class="h-5 w-5 shrink-0 object-scale-down"
+                            />
+                        {:else}
+                            <span class="shrink-0 text-base leading-none">{display.emoji}</span>
+                        {/if}
+                        <span class="group-hover:text-primary truncate text-sm">
+                            {entry.title}
+                        </span>
+                        <span class="text-muted-foreground shrink-0 text-xs">
+                            {entry.reaction_total}
+                        </span>
+                    </a>
+                </li>
+            {/each}
+        </ol>
+    </div>
+{/if}

--- a/widgets/emoji-awards/widget.json
+++ b/widgets/emoji-awards/widget.json
@@ -1,0 +1,21 @@
+{
+    "id": "emoji-awards",
+    "name": "오늘의 앙모지",
+    "version": "1.0.0",
+    "description": "최근 24시간 리액션(이모지)을 가장 많이 받은 글·댓글 리더보드",
+    "author": { "name": "Angple" },
+    "category": "content",
+    "slots": ["main", "sidebar"],
+    "icon": "Trophy",
+    "allowMultiple": false,
+    "main": "index.svelte",
+    "settings": {
+        "item_count": {
+            "type": "number",
+            "label": "표시 개수",
+            "default": 5,
+            "min": 3,
+            "max": 10
+        }
+    }
+}

--- a/widgets/hidden-gems/index.svelte
+++ b/widgets/hidden-gems/index.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+    /**
+     * 숨은 보석 — 자유게시판 편중 완화용 발견 위젯.
+     * explore new 풀(24h 크로스보드)에서 대형 게시판을 제외한 글을
+     * 방문마다 랜덤 로테이션으로 소개한다. (발견 엔진 1단, 계획 2026-07-10)
+     */
+    import type { WidgetProps } from '$lib/types/widget-props';
+    import type { ExplorePost } from '$lib/api/types';
+    import Gem from '@lucide/svelte/icons/gem';
+    import { trackEvent } from '$lib/services/ga4.js';
+
+    let { config, prefetchData }: WidgetProps = $props();
+
+    const itemCount = $derived(
+        Number((config?.settings as Record<string, unknown> | undefined)?.item_count ?? 4)
+    );
+
+    const pool = $derived(
+        ((prefetchData as { posts?: ExplorePost[] })?.posts ?? []) as ExplorePost[]
+    );
+
+    // 방문(마운트)마다 다른 조합 — 서버 30초 캐시와 무관하게 클라에서 셔플
+    let picks = $state<ExplorePost[]>([]);
+    $effect(() => {
+        const source = [...pool];
+        for (let i = source.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [source[i], source[j]] = [source[j], source[i]];
+        }
+        picks = source.slice(0, itemCount);
+    });
+
+    function handleClick(post: ExplorePost): void {
+        trackEvent('hidden_gem_click', {
+            board: post.board,
+            post_id: post.id
+        });
+    }
+</script>
+
+{#if picks.length > 0}
+    <div class="bg-card rounded-lg border p-4">
+        <div class="mb-3 flex items-center justify-between">
+            <h3 class="flex items-center gap-1.5 text-sm font-semibold">
+                <Gem class="text-primary h-4 w-4" />
+                이런 게시판도 있어요
+            </h3>
+            <a href="/explore" class="text-muted-foreground hover:text-primary text-xs">
+                더 둘러보기
+            </a>
+        </div>
+        <ul class="space-y-2">
+            {#each picks as post (post.board + post.id)}
+                <li class="min-w-0">
+                    <a
+                        href={`/${post.board}/${post.id}`}
+                        class="group flex items-baseline gap-2"
+                        onclick={() => handleClick(post)}
+                    >
+                        <span
+                            class="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[11px]"
+                        >
+                            {post.board_name}
+                        </span>
+                        <span class="group-hover:text-primary truncate text-sm">
+                            {post.title}
+                        </span>
+                        {#if post.comment_count > 0}
+                            <span class="text-muted-foreground shrink-0 text-xs"
+                                >{post.comment_count}</span
+                            >
+                        {/if}
+                    </a>
+                </li>
+            {/each}
+        </ul>
+    </div>
+{/if}

--- a/widgets/hidden-gems/widget.json
+++ b/widgets/hidden-gems/widget.json
@@ -1,0 +1,21 @@
+{
+    "id": "hidden-gems",
+    "name": "숨은 보석",
+    "version": "1.0.0",
+    "description": "자유게시판 밖 다른 게시판의 최근 24시간 글을 로테이션으로 소개하는 발견 위젯",
+    "author": { "name": "Angple" },
+    "category": "content",
+    "slots": ["main", "sidebar"],
+    "icon": "Gem",
+    "allowMultiple": false,
+    "main": "index.svelte",
+    "settings": {
+        "item_count": {
+            "type": "number",
+            "label": "표시 개수",
+            "default": 4,
+            "min": 2,
+            "max": 8
+        }
+    }
+}


### PR DESCRIPTION
## 배경 (발견 엔진 로드맵 1단, 계획 2026-07-10)
자유게시판 트래픽 편중 완화 + 이모지 닉네임 공개(7/12)로 승격된 리액션 신호의 첫 활용.

## B. 숨은 보석 (`widgets/hidden-gems`)
- **신규 쿼리 0**: 기존 explore.json new 풀(24h 크로스보드)에서 대형 게시판(free·humor·photo·economy·qa·new) 제외 20건 → 위젯이 방문마다 클라 셔플로 3~5개 소개
- 배치: 홈 main(공감글 아래) + 사이드바. GA4 `hidden_gem_click`

## A. 오늘의 앙모지 (`widgets/emoji-awards`)
- Go recommend-system 신규 `emoji_awards` 슬롯(호스트 반영 완료, 드라이런 검증 — 실데이터 10건·제목 조인·정책 제외 정상)이 5분마다 24h 리액션 상위 글·댓글 집계
- **정책 매트릭스 준수**: 이용제한 근거 글(g5_na_singo)·삭제·비밀 글은 수집 단계에서 제외
- 위젯은 순위·대표 이모지·리액션 수 표시, 데이터 없으면 미렌더(Go 미배포 환경 안전). GA4 `emoji_award_click`
- 배치: 사이드바(공지 아래)

## 검증
- `pnpm check` 0 errors (baseline 경고 유지)
- Go 드라이런: emoji_awards 10건 생성 확인(자유게시판 정치글 상위 — 24h 실데이터)
- canary: 두 위젯 렌더·랜덤성·GA4 이벤트 확인 예정