### PR TITLE
fix(security): CORS preflight 허용 origin 일원화 (damoang.net 계열만)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -933,13 +933,18 @@ export const handle: Handle = async ({ event, resolve }) => {
     // OPTIONS 요청 (CORS preflight) 처리
     if (event.request.method === 'OPTIONS') {
         const origin = event.request.headers.get('origin');
+        // 실응답 CORS 와 동일 기준: 허용 origin(damoang.net 계열)만 preflight 통과.
+        // 임의 origin echo + credentials 는 타 사이트발 non-simple 요청의 서버 도달을
+        // 열어주므로(응답은 못 읽어도 부수효과 위험) 허용 목록으로 일원화한다.
         const headers: Record<string, string> = {
             'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
             'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-CSRF-Token',
             'Access-Control-Max-Age': '86400'
         };
-        // credentials: include 지원을 위해 구체적인 origin 사용
         if (origin) {
+            if (!isAllowedOrigin(origin)) {
+                return new Response(null, { status: 403 });
+            }
             headers['Access-Control-Allow-Origin'] = origin;
             headers['Access-Control-Allow-Credentials'] = 'true';
         } else {


### PR DESCRIPTION
## 배경
운영자 요구: 모든 API 는 damoang.net 에서만 접근 가능해야 함. 점검 결과 **실응답 CORS 는 이미 `isAllowedOrigin`(damoang.net·서브도메인·localhost·ALLOWED_ORIGINS env)으로 게이트**되어 있으나, **OPTIONS preflight 핸들러만 임의 origin echo + credentials 허용**으로 기준이 어긋나 있었습니다.

## 위험도
타 사이트가 브라우저에서 우리 API 를 직접 읽는 것은 이미 불가(실응답에 ACAO 미부착 + SameSite=lax 쿠키). 다만 preflight 무조건 통과는 non-simple 요청이 서버에 도달할 여지(부수효과)를 남기므로 방어깊이 차원에서 일원화합니다.

## 변경
preflight 도 `isAllowedOrigin` 검사 — 비허용 origin 은 403. origin 헤더 없는 요청(서버간·앱)은 기존 동작 유지.

## 검증
- `pnpm check` 0 errors
- canary 에서: damoang.net/canary 정상, 외부 origin preflight 403 확인 예정