### PR TITLE
fix(notification): 알림 무한 로딩 완화 — 타임아웃 정렬 + 재시도 중복 제거 (#12954)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -79,6 +79,14 @@ const WRITE_REQUEST_CONFIG: Partial<RetryConfig> = {
     timeout: 30000
 };
 
+// 알림 조회는 백엔드가 무거울 수 있어(대량 누적 회원) 재시도 시 동일 쿼리를 중복
+// 발사하면 백엔드/DB 커넥션 풀을 굶긴다(#12954: 알림 무한 스피너 + 댓글 10개 고착).
+// 프록시 타임아웃(4s)에 맞춰 빠르게 실패시키고 재시도하지 않는다.
+const NOTIFICATION_READ_CONFIG: Partial<RetryConfig> = {
+    maxRetries: 0,
+    timeout: 4500
+};
+
 // v2 API URL은 세션 기반 인증에서는 SvelteKit 프록시가 내부 JWT를 주입하므로
 // 클라이언트에서 직접 사용할 일이 줄어듦 (exchangeToken 등 레거시 호환용으로 유지)
 
@@ -1865,7 +1873,11 @@ class ApiClient {
      * 읽지 않은 알림 수 조회
      */
     async getUnreadNotificationCount(): Promise<NotificationSummary> {
-        const response = await this.request<NotificationSummary>('/notifications/unread-count');
+        const response = await this.request<NotificationSummary>(
+            '/notifications/unread-count',
+            {},
+            NOTIFICATION_READ_CONFIG
+        );
         return response.data ?? { total_unread: 0 };
     }
 
@@ -1877,7 +1889,9 @@ class ApiClient {
         limit: number = 20
     ): Promise<NotificationListResponse> {
         const response = await this.request<NotificationListResponse>(
-            `/notifications?page=${page}&limit=${limit}`
+            `/notifications?page=${page}&limit=${limit}`,
+            {},
+            NOTIFICATION_READ_CONFIG
         );
         return response.data;
     }
@@ -1920,7 +1934,9 @@ class ApiClient {
         const params = new URLSearchParams({ page: String(page), limit: String(limit) });
         if (filterType) params.set('type', filterType);
         const response = await this.request<GroupedNotificationListResponse>(
-            `/notifications/grouped?${params}`
+            `/notifications/grouped?${params}`,
+            {},
+            NOTIFICATION_READ_CONFIG
         );
         return response.data;
     }

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -32,6 +32,7 @@
     let notifications = $state<GroupedNotification[]>([]);
     let unreadCount = $state(0);
     let isLoading = $state(false);
+    let loadError = $state(false);
     let isOpen = $state(false);
     let unreadPrimed = $state(false);
 
@@ -185,6 +186,7 @@
         if (!authStore.isAuthenticated) return;
 
         isLoading = true;
+        loadError = false;
         try {
             const response = await apiClient.getGroupedNotifications(1, 10);
             notifications = response.items;
@@ -192,6 +194,8 @@
             writeUnreadCache(response.unread_count);
         } catch (err) {
             console.error('Failed to load notifications:', err);
+            // 실패를 '알림이 없습니다' 로 오표시하지 않도록 에러 상태 노출(#12954).
+            if (notifications.length === 0) loadError = true;
         } finally {
             isLoading = false;
         }
@@ -349,6 +353,18 @@
                 <!-- 캐시된 알림이 있으면 스피너로 가리지 않고 즉시 노출 → 재오픈 시 백그라운드 갱신(체감 지연 제거) -->
                 <div class="flex items-center justify-center py-8">
                     <Loader2 class="text-muted-foreground h-6 w-6 animate-spin" />
+                </div>
+            {:else if loadError}
+                <div class="text-muted-foreground flex flex-col items-center gap-2 py-8 text-sm">
+                    <span>알림을 불러오지 못했습니다.</span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        class="h-7 text-xs"
+                        onclick={loadNotifications}
+                    >
+                        다시 시도
+                    </Button>
                 </div>
             {:else if notifications.length === 0}
                 <div class="text-muted-foreground py-8 text-center text-sm">알림이 없습니다</div>


### PR DESCRIPTION
## 증상 (bug/12954)
알림 열람 시 무한 스피너(수초~수분), 그 상태에서 댓글도 10개까지만 표시. 하루 수십 번.

## 조사 결과 (제보자 데이터는 정상)
제보자(kakao_8ff908b9) 알림 14,232건 전부 읽음·쿼리 0.5~19ms·볼륨 131위로 **본인 데이터는 깨끗**. 근본은 (a) Go 알림 핸들러의 대량 로드 의심 + (b) `g5_na_noti` 9.5M행 무purge(회원당 최대 13.7만 건)로 인한 **백엔드/커넥션 풀 간헐 포화**. 알림과 댓글 backfill 이 같은 Go 백엔드(localhost:8090)+풀을 공유해 동시에 증상이 납니다.

## 프론트 개선 (이 PR — 저위험)
- 알림 조회 클라 타임아웃 8s → **4.5s**(v1 프록시 4s에 정렬) + **재시도 0**. 프록시가 abort 한 무거운 쿼리를 클라가 재차 발사해 풀을 굶기던 악순환 차단.
- 드롭다운 로드 실패를 '알림이 없습니다'로 오표시하지 않고 **에러 + 다시 시도 버튼** 노출.

## 근본 원인 (별도 트랙, 레포 밖)
- 백엔드 `/notifications/grouped` 페이지네이션(LIMIT) 점검 — DB 집계는 ms급이라 여기만 고치면 큰 효과
- `g5_na_noti` 보존정책(읽음+N개월 경과분 배치 삭제) — 9.5M행 무purge 구조

## 검증
- `pnpm check` 0 errors / 유닛 통과
- canary: 알림 정상 로드, 실패 시 재시도 버튼 노출 확인 예정