### PR TITLE
fix(seo): GSC 후속 — VideoObject description 폴백 + QAPage url/text 보강

### DIFF
--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -26,11 +26,15 @@ export function createQAPageJsonLd(options: {
     /** 질문 본문 요약 */
     text?: string;
     author?: string;
+    /** 질문 작성자 프로필 URL — GSC "mainEntity.author 의 url 누락" 대응 */
+    authorUrl?: string;
     dateCreated?: string;
     /** 전체 답변(댓글) 수 */
     answerCount: number;
     answers: Array<{
         text: string;
+        /** 답변(댓글) 앵커 URL — GSC "suggestedAnswer 의 url 누락" 대응 */
+        url?: string;
         author?: string;
         authorUrl?: string;
         dateCreated?: string;
@@ -44,6 +48,7 @@ export function createQAPageJsonLd(options: {
         .map((a) => ({
             '@type': 'Answer' as const,
             text: a.text.trim(),
+            ...(a.url ? { url: a.url } : {}),
             ...(a.dateCreated ? { dateCreated: a.dateCreated } : {}),
             ...(a.upvoteCount !== undefined ? { upvoteCount: a.upvoteCount } : {}),
             ...(a.author?.trim()
@@ -67,7 +72,13 @@ export function createQAPageJsonLd(options: {
             answerCount: Math.max(options.answerCount, answers.length),
             ...(options.dateCreated ? { dateCreated: options.dateCreated } : {}),
             ...(options.author?.trim()
-                ? { author: { '@type': 'Person' as const, name: options.author.trim() } }
+                ? {
+                      author: {
+                          '@type': 'Person' as const,
+                          name: options.author.trim(),
+                          ...(options.authorUrl ? { url: options.authorUrl } : {})
+                      }
+                  }
                 : {}),
             suggestedAnswer: answers
         }

--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -350,3 +350,29 @@ describe('comment.author url (GSC 개선 제안)', () => {
         expect(ld?.mainEntity.suggestedAnswer?.[0].author?.url).toBe('https://test.com/member/ang');
     });
 });
+
+describe('QAPage url 보강 (GSC Q&A 4건)', () => {
+    it('question author url + answer url 출력, 미제공 시 생략', async () => {
+        const { createQAPageJsonLd } = await import('./json-ld');
+        const ld = createQAPageJsonLd({
+            name: '질문',
+            text: '본문',
+            author: '질문자',
+            authorUrl: 'https://test.com/member/asker',
+            answerCount: 2,
+            answers: [
+                {
+                    text: '답변1',
+                    url: 'https://test.com/qa/1#c_10',
+                    author: '앙님',
+                    authorUrl: 'https://test.com/member/ang'
+                },
+                { text: '답변2' }
+            ]
+        });
+        expect(ld?.mainEntity.author?.url).toBe('https://test.com/member/asker');
+        expect(ld?.mainEntity.text).toBe('본문');
+        expect(ld?.mainEntity.suggestedAnswer?.[0].url).toBe('https://test.com/qa/1#c_10');
+        expect(ld?.mainEntity.suggestedAnswer?.[1].url).toBeUndefined();
+    });
+});

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -143,10 +143,11 @@ export interface JsonLdQAPage {
         text?: string;
         answerCount: number;
         dateCreated?: string;
-        author?: { '@type': 'Person'; name: string };
+        author?: { '@type': 'Person'; name: string; url?: string };
         suggestedAnswer?: Array<{
             '@type': 'Answer';
             text: string;
+            url?: string;
             dateCreated?: string;
             upvoteCount?: number;
             author?: { '@type': 'Person'; name: string; url?: string };

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1714,7 +1714,9 @@
                           if (v.type === 'youtube') {
                               return createVideoObjectJsonLd({
                                   name,
-                                  description: postDescription || undefined,
+                                  // 본문 텍스트 없는 동영상 글 — GSC "description 누락" 방지 (제목 폴백)
+                                  description:
+                                      postDescription || data.post.title?.trim() || boardTitle,
                                   thumbnailUrl: `https://i.ytimg.com/vi/${v.id}/hqdefault.jpg`,
                                   uploadDate: data.post.created_at,
                                   embedUrl: `https://www.youtube.com/embed/${v.id}`
@@ -1733,7 +1735,8 @@
                           };
                           return createVideoObjectJsonLd({
                               name,
-                              description: postDescription || undefined,
+                              // 본문 텍스트 없는 동영상 글 — GSC "description 누락" 방지 (제목 폴백)
+                              description: postDescription || data.post.title?.trim() || boardTitle,
                               // 썸네일 우선순위: ①본문 poster 속성(업로드 시 캡처)
                               // ②관례 키 도출 — backfill 로 기존 동영상 2,339건 포스터 생성
                               //   완료(2026-07-10)라 도출 URL 이 실존 ③글 대표이미지
@@ -1764,12 +1767,17 @@
             boardId === 'qa' && !data.post.deleted_at && !data.post.is_secret
                 ? createQAPageJsonLd({
                       name: data.post.title?.trim() || boardTitle,
-                      text: postDescription || undefined,
+                      // 본문이 이미지뿐인 글은 제목이 곧 질문 — GSC "text 누락" 방지
+                      text: postDescription || data.post.title?.trim() || boardTitle,
                       author: data.post.author,
+                      // GSC "mainEntity.author 의 url 누락" — 질문 작성자 프로필
+                      authorUrl,
                       dateCreated: data.post.created_at,
                       answerCount: comments.length,
                       answers: safeTopComments.map((c) => ({
                           text: truncateText(c.content.replace(/<[^>]+>/g, '').trim(), 300),
+                          // GSC "suggestedAnswer 의 url 누락" — 실제 댓글 DOM 앵커(c_{id})
+                          url: c.id ? `${postUrl}#c_${c.id}` : undefined,
                           author: c.author,
                           // GSC "comment.author 의 url 누락" 개선 — 프로필 URL
                           authorUrl: c.author_id ? `${siteUrl}/member/${c.author_id}` : undefined,


### PR DESCRIPTION
## 배경
GSC 비심각 알림 2종(동영상·Q&A) 대응입니다. 모두 새로 심은 구조화 데이터가 인식되면서 나온 후속 개선 제안입니다.

## 변경
| GSC 지적 | 수정 |
|---|---|
| 동영상 'description' 누락 | 본문 텍스트 없는 동영상 글 → 제목 폴백 (유튜브·업로드 두 분기) |
| Q&A mainEntity.author.url | 질문 작성자 프로필 URL 추가 |
| Q&A suggestedAnswer.url | 답변에 실제 댓글 앵커 `{글URL}#c_{댓글id}` (복사링크와 동일 형식) |
| Q&A mainEntity.text | 본문 없는 글 → 제목 폴백 (제목이 곧 질문) |
| Q&A suggestedAnswer.author.url | **#1760 으로 이미 라이브** — 크롤 시점차, 조치 없음 |

토론포럼 comment.author.url 검증은 1,108페이지 통과 진행 중(잔여=재크롤 대기)이라 조치 불필요합니다.

## 검증
- vitest 34 passed / svelte-check 0 errors
- 배포 후 /qa 답변 있는 글 JSON-LD 실측 + GSC 수정 확인 요청 예정