### PR TITLE
fix(onboarding): 승급 경로 안내 — 매일 출석 7일 = 자동 앙님💛

### DIFF
--- a/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
+++ b/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
@@ -82,9 +82,12 @@
                 <div class="min-w-0 flex-1">
                     <p class="text-foreground text-base font-bold">앙님, 어서오세요! 💛</p>
                     <p class="text-muted-foreground mt-0.5 text-sm leading-relaxed">
-                        가입인사를 남기면 앙님들이 우르르 반겨줘요. 게시판 글쓰기는 닉네임 옆에
+                        가입인사를 남기면 앙님들이 우르르 반겨줘요. <b class="font-semibold"
+                            >매일 출석 7일</b
+                        >이면 자동으로
                         <span class="font-semibold text-amber-600 dark:text-amber-400">앙님💛</span
-                        >이 생기면 열리니, 첫걸음은 인사가 딱이에요!
+                        >으로 승급해 글쓰기·댓글·공감이 모두 열려요 — 오늘부터 도장 꾹, 첫걸음은
+                        인사가 딱이에요!
                     </p>
                 </div>
                 <div class="flex shrink-0 flex-wrap items-center gap-2">


### PR DESCRIPTION
## 배경
hello/27776 "레벨 3으로 업하려면 어떻게 해야할지 궁금합니다" — 신규 회원이 승급 방법을 몰라 질문하는 사례가 나왔습니다. 온보딩 카드가 "앙님💛이 되면 글쓰기가 열린다"고만 안내하고 **되는 방법을 알려주지 않던 갭**입니다.

## 변경
웰컴 온보딩 카드 문구 한 줄 보강:
> 가입인사를 남기면 앙님들이 우르르 반겨줘요. **매일 출석 7일**이면 자동으로 **앙님💛**으로 승급해 글쓰기·댓글·공감이 모두 열려요 — 오늘부터 도장 꾹, 첫걸음은 인사가 딱이에요!

## 검증
svelte-check 0 errors. 배포 후 신규 계정 조건에서 카드 문구 확인