### PR TITLE
feat(reaction): 똥 앙티콘(emo-001) 재활성화

### DIFF
--- a/apps/web/src/lib/config/reaction-config.ts
+++ b/apps/web/src/lib/config/reaction-config.ts
@@ -59,7 +59,7 @@ const EMOJIS: EmoticonDef[] = [
 // 앙티콘 세트 (다모앙 커스텀 GIF)
 const ANGTICON_IDS = [
     'emo-000',
-    // 'emo-001' (똥 모양) 비활성화 — 신규 선택 차단. 기존 반응은 reaction.ts url 빌더로 계속 렌더.
+    'emo-001', // 똥 모양 재활성화 — 이모지 닉네임 공개(2026-07-12) 이후 악용 억지가 생겨 복원.
     'emo-002',
     'emo-003',
     'emo-004',


### PR DESCRIPTION
## 배경
이모지 닉네임 공개 시행(2026-07-12) 이후 익명 악용 억지가 생겨, 과거 재미 요소로 숨겨뒀던 **똥 앙티콘(emo-001)**을 선택 목록에 복원합니다. ⭕❌❓ 재활성화와 같은 맥락입니다.

## 변경
`reaction-config.ts` 의 `ANGTICON_IDS` 에 `'emo-001'` 복원(주석 → 활성). 이미지 파일은 실존(운영 200 확인), 기존 반응은 계속 렌더되던 상태라 신규 선택만 열립니다.

## 검증
- `pnpm check` 0 errors
- 이미지 실존: /api/emoticons/nariya/damoang-emo-001.gif → 200