### PR TITLE
feat(ux): 등급/활동레벨 착시 해소 — 거부 메시지·온보딩·내 등급 안내

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -11,6 +11,7 @@
     } from '$lib/utils/certification-gate.js';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { getGradeName } from '$lib/utils/grade.js';
+    import { getPromotionHint } from '$lib/utils/board-permissions.js';
     import type { BoardPermissions } from '$lib/api/types.js';
     import { apiClient } from '$lib/api/index.js';
     import { stripAdminMentions } from '$lib/utils/sanitize-mentions.js';
@@ -77,7 +78,10 @@
         if (isRestricted) return '이용제한 중에는 댓글을 작성할 수 없습니다.';
         const need = `${getGradeName(requiredCommentLevel)}(Lv.${requiredCommentLevel}) 이상 작성 가능`;
         const lv = authStore.user?.mb_level;
-        return lv != null ? `${need} · 현재 ${getGradeName(lv)}(Lv.${lv})` : need;
+        if (lv == null) return need;
+        // 승급 경로 안내 (hello/27814: 배지≠등급 착시) — mb_level 기준, as_level 아님
+        const promo = getPromotionHint(requiredCommentLevel, lv);
+        return `${need} · 현재 ${getGradeName(lv)}(Lv.${lv})${promo ? ` · ${promo}` : ''}`;
     });
 
     let commentAvatarUrl = $derived(

--- a/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
+++ b/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
@@ -87,7 +87,8 @@
                         >이면 자동으로
                         <span class="font-semibold text-amber-600 dark:text-amber-400">앙님💛</span
                         >으로 승급해 글쓰기·댓글·공감이 모두 열려요 — 오늘부터 도장 꾹, 첫걸음은
-                        인사가 딱이에요!
+                        인사가 딱이에요! (참, 닉네임 옆 숫자 배지는 활동 레벨이라 등급과는 달라요
+                        🙂)
                     </p>
                 </div>
                 <div class="flex shrink-0 flex-wrap items-center gap-2">

--- a/apps/web/src/lib/utils/board-permissions.test.ts
+++ b/apps/web/src/lib/utils/board-permissions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getPermissionMessage,
+    buildGradeDeniedMessage,
+    getPromotionHint,
+    BADGE_GRADE_NOTE
+} from './board-permissions';
+import type { DamoangUser } from '$lib/api/types.js';
+
+/** 테스트용 최소 사용자 객체 (mb_level 만 의미 있음) */
+function makeUser(mbLevel: number): DamoangUser {
+    return { mb_id: 'tester', mb_name: '테스터', mb_level: mbLevel } as DamoangUser;
+}
+
+describe('getPromotionHint — 승급 경로 안내 (hello/27814)', () => {
+    it('필요 등급 3(앙님💛), 현재 1 → 출석 7일 안내를 반환한다', () => {
+        expect(getPromotionHint(3, 1)).toContain('매일 출석 7일');
+        expect(getPromotionHint(3, 1)).toContain('앙님💛');
+    });
+
+    it('필요 등급 2, 현재 1 → 자동 승급으로 도달 가능하므로 안내를 반환한다', () => {
+        expect(getPromotionHint(2, 1)).toContain('매일 출석 7일');
+    });
+
+    it('필요 등급 4 이상 → 출석만으로 도달 불가하므로 null', () => {
+        expect(getPromotionHint(4, 3)).toBeNull();
+        expect(getPromotionHint(10, 1)).toBeNull();
+    });
+
+    it('이미 충족(현재 ≥ 필요) → null', () => {
+        expect(getPromotionHint(3, 3)).toBeNull();
+        expect(getPromotionHint(2, 5)).toBeNull();
+    });
+});
+
+describe('buildGradeDeniedMessage — 등급 부족 거부 문구', () => {
+    it('앙님💛 필요·현재 1 → 등급명 + 승급 경로 + 배지≠등급 안내를 모두 담는다', () => {
+        const msg = buildGradeDeniedMessage('글쓰기', 3, 1);
+        expect(msg).toContain('앙님💛');
+        expect(msg).toContain('매일 출석 7일');
+        expect(msg).toContain(BADGE_GRADE_NOTE);
+        // 옛 문구("레벨 N 이상")로 회귀하지 않는다 — 숫자 레벨 표기가 착시의 원인
+        expect(msg).not.toContain('레벨 3 이상');
+    });
+
+    it('출석 승급으로 도달 불가한 등급 → 승급 경로 없이 현재 등급만 안내한다', () => {
+        const msg = buildGradeDeniedMessage('글쓰기', 6, 3);
+        expect(msg).toContain('운영자');
+        expect(msg).toContain('현재 등급: 앙님💛');
+        expect(msg).not.toContain('매일 출석 7일');
+        expect(msg).toContain(BADGE_GRADE_NOTE);
+    });
+});
+
+describe('getPermissionMessage', () => {
+    const board = { write_level: 3, comment_level: 3 };
+
+    it('비로그인 → 로그인 안내 (기존 동작 유지)', () => {
+        expect(getPermissionMessage(board, 'can_write', null)).toBe(
+            '글쓰기을(를) 하려면 로그인이 필요합니다.'
+        );
+    });
+
+    it('레벨 부족 → 승급 경로 안내 문구로 교체된다', () => {
+        const msg = getPermissionMessage(board, 'can_write', makeUser(1));
+        expect(msg).toContain('글쓰기');
+        expect(msg).toContain('앙님💛 등급부터 가능해요');
+        expect(msg).toContain('매일 출석 7일');
+        expect(msg).toContain(BADGE_GRADE_NOTE);
+    });
+
+    it('댓글 액션도 동일한 안내를 사용한다', () => {
+        const msg = getPermissionMessage(board, 'can_comment', makeUser(2));
+        expect(msg).toContain('댓글 작성');
+        expect(msg).toContain('매일 출석 7일');
+    });
+});

--- a/apps/web/src/lib/utils/board-permissions.ts
+++ b/apps/web/src/lib/utils/board-permissions.ts
@@ -67,6 +67,44 @@ export function checkPermission(
 }
 
 /**
+ * 자동 승급(매일 출석 7일)으로 도달하는 등급 — 앙님💛 (mb_level 3)
+ */
+const AUTO_PROMOTE_LEVEL = 3;
+
+/**
+ * 배지≠등급 착시 해소 문구 (hello/27814)
+ * 닉네임 옆 숫자 배지(as_level, 활동 레벨)를 등급(mb_level)으로 오해하는 사례가 많다.
+ */
+export const BADGE_GRADE_NOTE = '닉네임 옆 숫자 배지는 활동 레벨이라 등급과는 달라요';
+
+/**
+ * 승급 경로 안내 문구. 자동 승급(출석 7일)으로 필요 등급에 도달 가능할 때만 반환.
+ * mb_level(등급) 기준 — as_level(활동 레벨)을 넣지 말 것.
+ */
+export function getPromotionHint(requiredLevel: number, currentLevel: number): string | null {
+    if (currentLevel >= requiredLevel) return null;
+    if (requiredLevel > AUTO_PROMOTE_LEVEL || currentLevel >= AUTO_PROMOTE_LEVEL) return null;
+    return '매일 출석 7일이면 자동으로 앙님💛 승급돼요!';
+}
+
+/**
+ * 등급(mb_level) 부족 거부 안내 문구 생성.
+ * 승급 경로(출석 7일 → 앙님💛)와 배지≠등급 구분을 함께 안내한다. (hello/27814)
+ */
+export function buildGradeDeniedMessage(
+    actionName: string,
+    requiredLevel: number,
+    currentLevel: number
+): string {
+    const requiredGrade = getGradeName(requiredLevel);
+    const promo = getPromotionHint(requiredLevel, currentLevel);
+    if (promo) {
+        return `${actionName}은(는) ${requiredGrade} 등급부터 가능해요. ${promo} (${BADGE_GRADE_NOTE})`;
+    }
+    return `${actionName}은(는) ${requiredGrade} 등급부터 가능해요. (현재 등급: ${getGradeName(currentLevel)} · ${BADGE_GRADE_NOTE})`;
+}
+
+/**
  * 권한 부족 시 안내 메시지 생성
  */
 export function getPermissionMessage(
@@ -82,7 +120,8 @@ export function getPermissionMessage(
         return `${actionName}을(를) 하려면 로그인이 필요합니다.`;
     }
 
-    return `${actionName} 권한이 없습니다. 레벨 ${requiredLevel} 이상이 필요합니다. (현재 레벨: ${user.mb_level ?? 1})`;
+    // 레벨(등급) 부족 사유 — 승급 경로와 배지≠등급 구분을 함께 안내
+    return buildGradeDeniedMessage(actionName, requiredLevel, user.mb_level ?? 1);
 }
 
 /**

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -9,6 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
+import { buildGradeDeniedMessage } from '$lib/utils/board-permissions';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 import { protectClientIp } from '$lib/server/ip-protection';
@@ -236,7 +237,10 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
 
     if ((user.mb_level ?? 0) < 3) {
         return json(
-            { success: false, message: '레벨 3 이상부터 추천/비추천이 가능합니다.' },
+            {
+                success: false,
+                message: buildGradeDeniedMessage('추천/비추천', 3, user.mb_level ?? 0)
+            },
             { status: 403 }
         );
     }

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -9,6 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket, ResultSetHeader } from 'mysql2';
 import pool from '$lib/server/db';
+import { buildGradeDeniedMessage } from '$lib/utils/board-permissions';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 import { protectClientIp } from '$lib/server/ip-protection';
@@ -230,7 +231,10 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
     // 레벨 체크 (레벨 3 미만은 추천/비추천 불가)
     if ((user.mb_level ?? 0) < 3) {
         return json(
-            { success: false, message: '레벨 3 이상부터 추천/비추천이 가능합니다.' },
+            {
+                success: false,
+                message: buildGradeDeniedMessage('추천/비추천', 3, user.mb_level ?? 0)
+            },
             { status: 403 }
         );
     }

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -137,6 +137,13 @@
                             {getGradeName(authStore.user.mb_level)}
                         </p>
                     </div>
+                    <!-- 등급 승급 경로 안내 (hello/27814: 배지≠등급 착시) — mb_level 기준 -->
+                    {#if authStore.user.mb_level >= 1 && authStore.user.mb_level < 3}
+                        <p class="text-muted-foreground mt-0.5 text-xs">
+                            현재 등급: {getGradeName(authStore.user.mb_level)} · 매일 출석 7일이면 자동으로
+                            앙님💛 (숫자 배지는 활동 레벨이에요)
+                        </p>
+                    {/if}
                     {#if authStore.user.mb_id}
                         <p class="text-muted-foreground mt-0.5 text-sm">
                             아이디 {authStore.user.mb_id}


### PR DESCRIPTION
## 배경

다모앙에는 레벨이 2종 있습니다.

| | mb_level (등급) | as_level (활동 레벨) |
|---|---|---|
| 용도 | 글쓰기·공감 등 권한 (3=앙님💛부터) | XP 기반 활동 진행도 표시 |
| 노출 | 등급명 (앙님💛 등) | 닉네임 옆 숫자 배지 |

신규 회원이 닉네임 옆 활동 레벨 배지 "Lv 3"을 보고 등급 3인 줄 알고 "레벨 3인데 왜 글쓰기가 안 되냐"고 질문하는 착시가 실제로 발생했습니다 (hello/27814, 회원 kakao_903f0914). 기존 거부 메시지가 "권한이 없습니다. 레벨 3 이상이 필요합니다. (현재 레벨: 1)"처럼 숫자 레벨만 안내해 혼란을 키우는 구조였습니다.

이 PR은 착시가 폭발하는 3개 지점의 안내 문구·표시만 개선합니다. 두 레벨 시스템의 로직에는 일절 손대지 않았습니다 (권한 판정은 계속 mb_level, 배지는 계속 as_level).

## 변경 내용

### 1. 권한 거부 메시지 개선
- `apps/web/src/lib/utils/board-permissions.ts`
  - `buildGradeDeniedMessage` / `getPromotionHint` / `BADGE_GRADE_NOTE` 신설
  - `getPermissionMessage` 레벨 부족 문구 교체:
    - 기존: `글쓰기 권한이 없습니다. 레벨 3 이상이 필요합니다. (현재 레벨: 1)`
    - 개선: `글쓰기은(는) 앙님💛 등급부터 가능해요. 매일 출석 7일이면 자동으로 앙님💛 승급돼요! (닉네임 옆 숫자 배지는 활동 레벨이라 등급과는 달라요)`
    - 출석 승급으로 도달할 수 없는 등급(4 이상)이 필요한 경우에는 승급 경로 없이 필요/현재 등급명만 안내합니다
  - 비로그인 문구와 함수 시그니처는 그대로여서 기존 사용처(글 상세·목록·글쓰기 페이지, permission-gate) 모두 코드 변경 없이 개선이 적용됩니다
- 공감(추천/비추천) 403 토스트 — `.../posts/[postId]/like/+server.ts`, `.../comments/[commentId]/like/+server.ts`
  - `레벨 3 이상부터 추천/비추천이 가능합니다.` → 위 헬퍼로 등급명+승급 경로 안내 (판정 로직은 기존 그대로 `mb_level < 3`)
- 댓글폼 안내 — `comment-form.svelte`: 기존 `앙님💛(Lv.3) 이상 작성 가능 · 현재 앙님💔(Lv.1)` 뒤에 승급 경로 힌트만 덧붙였습니다

### 2. 온보딩 카드 한 줄 보강
- `welcome-onboarding.svelte`: 기존 문구 끝에 `(참, 닉네임 옆 숫자 배지는 활동 레벨이라 등급과는 달라요 🙂)` 한 문장을 추가했습니다

### 3. 내 등급 진행 표시 (구현 완료)
- 마이페이지 진입부(`routes/my/+page.svelte`) — LevelBadge(as_level)와 등급명(mb_level)이 나란히 노출되는 바로 그 지점 아래에, `1 ≤ mb_level < 3`일 때만 한 줄 표시:
  - `현재 등급: 앙님💔 · 매일 출석 7일이면 자동으로 앙님💛 (숫자 배지는 활동 레벨이에요)`
- 헤더 아바타는 드롭다운이 아니라 `/my` 링크여서 마이페이지 진입부를 선택했습니다. 출석 누적일 데이터가 프론트에 없어 남은 일수 계산은 생략하고 정적 안내만 했습니다 (새 API 없음).

## 안전 확인
- as_level을 권한 판정에 사용한 곳 없음 / mb_level을 LevelBadge에 넘긴 곳 없음 / 두 시스템 혼합 없음
- 중고거래 글쓰기 as_level 요건 분기(`write/+page.svelte`)는 의도된 as_level 로직이라 건드리지 않았습니다

## 검증
- `pnpm check`: 0 errors (122 warnings는 기존과 동일)
- `pnpm test:unit -- --run`: 49 files / 490 tests 전부 통과
- 신규 단위 테스트 `board-permissions.test.ts` 9건 추가 (승급 힌트 경계값, 옛 문구 회귀 방지, 비로그인 문구 유지)
