### PR TITLE
feat(member): 탈퇴 회원 닉네임 취소선 — 글 상세·댓글 확대

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -109,6 +109,8 @@ export interface FreeComment {
     is_discipline_related?: boolean;
     /** 요청자가 이 댓글 작성자를 차단했는지(서버 판정). 클라 스토어 로드 전 깜박임 방지(#12825). */
     is_blocked?: boolean;
+    /** 작성자 탈퇴 여부 — 닉네임 취소선 표시용. */
+    is_left?: boolean;
     link1?: string;
     link2?: string;
     link1_display?: string;

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1201,6 +1201,7 @@
                             <AuthorLink
                                 authorId={comment.author_id}
                                 authorName={comment.author}
+                                isWithdrawn={!!comment.is_left}
                                 expandTouchArea
                             />
                             <LevelBadge level={memberLevelStore.getLevel(comment.author_id)} />
@@ -1295,6 +1296,7 @@
                                         <AuthorLink
                                             authorId={comment.author_id}
                                             authorName={comment.author}
+                                            isWithdrawn={!!comment.is_left}
                                             expandTouchArea
                                         />
                                         <LevelBadge

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -275,7 +275,11 @@
                     <div>
                         <p class="text-foreground flex items-center gap-1.5 font-medium">
                             <LevelBadge level={memberLevelStore.getLevel(post.author_id)} />
-                            <AuthorLink authorId={post.author_id} authorName={post.author} />
+                            <AuthorLink
+                                authorId={post.author_id}
+                                authorName={post.author}
+                                isWithdrawn={!!post.is_left}
+                            />
                             {#if authStore.isAuthenticated && memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                                 <MemoBadge
                                     memberId={post.author_id}

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -346,7 +346,11 @@
                 <div>
                     <p class="text-foreground flex items-center gap-1.5 font-medium">
                         <LevelBadge level={memberLevelStore.getLevel(post.author_id)} />
-                        <AuthorLink authorId={post.author_id} authorName={post.author} />
+                        <AuthorLink
+                            authorId={post.author_id}
+                            authorName={post.author}
+                            isWithdrawn={!!post.is_left}
+                        />
                         {#if authStore.isAuthenticated && memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                             <MemoBadge
                                 memberId={post.author_id}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -247,6 +247,16 @@ export const load: PageServerLoad = async ({
         })();
 
         // 게시글 작성자 프로필 이미지 즉시 조회 (1단계 — 본문 렌더에 필요)
+        // 작성자 탈퇴 여부 — 닉네임 취소선 표시용(5분 캐시라 활동 게이트 조회와 중복돼도 저렴).
+        if (post.author_id) {
+            try {
+                const w = await fetchWithdrawnMemberIds([post.author_id]);
+                post.is_left = w.has(post.author_id);
+            } catch {
+                // 실패 시 취소선만 생략
+            }
+        }
+
         if (post.author_id && !post.author_image) {
             try {
                 const imgMap = await fetchMemberImagesWithTimestamp([post.author_id]);

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -18,6 +18,7 @@ import {
 } from '$lib/server/affiliate-links';
 import { isLinkProcessingPluginEnabled } from '$lib/server/link-processing/runtime';
 import { isInternalAppRequest } from '$lib/server/internal-api.js';
+import { fetchWithdrawnMemberIds } from '$lib/server/withdrawn-members.js';
 import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 
 interface CommentRow extends RowDataPacket {
@@ -76,6 +77,8 @@ interface CommentResponseItem {
     is_discipline_related?: boolean;
     /** 요청자가 이 댓글 작성자를 차단했는지(서버 판정). 클라 스토어 로드 전 깜박임 방지용(#12825). */
     is_blocked?: boolean;
+    /** 작성자가 탈퇴 회원인지 — 닉네임 취소선 표시용. */
+    is_left?: boolean;
 }
 
 interface DisciplineRow extends RowDataPacket {
@@ -259,6 +262,12 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             }
         }
 
+        // 탈퇴 회원 작성자 집합 — 닉네임 취소선 표시용(배치 조회, 5분 캐시).
+        const authorIds = Array.from(new Set(rows.map((r) => String(r.mb_id)).filter(Boolean)));
+        const withdrawnSet = await fetchWithdrawnMemberIds(authorIds).catch(
+            () => new Set<string>()
+        );
+
         const comments: CommentResponseItem[] = rows.map((row) => ({
             id: row.wr_id,
             content: row.wr_deleted_at ? (isAdmin ? row.wr_content : '') : row.wr_content,
@@ -297,6 +306,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             deleted_by: row.wr_deleted_by || null,
             edit_count: editCountMap.get(row.wr_id) || 0,
             ...(row.mb_id && blockedSet.has(String(row.mb_id)) ? { is_blocked: true } : {}),
+            ...(row.mb_id && withdrawnSet.has(String(row.mb_id)) ? { is_left: true } : {}),
             ...(disciplineSet.has(row.wr_id) ? { is_discipline_related: true } : {}),
             ...(isAdmin && row.wr_7
                 ? {


### PR DESCRIPTION
## 배경 (사장님 지시)
탈퇴 회원 닉네임을 모든 표시에서 취소선으로 구분. 목록·프로필은 이미 적용돼 있었고(post.is_left + AuthorLink의 line-through), 미적용이던 **글 상세 작성자 + 댓글 작성자** 표면을 채웁니다.

## 변경 (데이터 주입만 — 컴포넌트·CSS 재사용)
- **댓글 API**(`comments/+server.ts`): 기존 blockedSet 배치 옆에 `fetchWithdrawnMemberIds` 배치 조회 추가 → `is_left` 내장. 초기 SSR 댓글도 이 API를 프록시로 부르고 backfill도 동일 → **한 곳으로 전 댓글 커버**. 5분 캐시.
- **글 상세 로더**: `post.is_left` 세팅(활동 게이트 조회와 중복돼도 5분 캐시라 저렴) → `view/basic`·`view/report` AuthorLink 에 `isWithdrawn` 전달.
- 판정 기준: `mb_leave_date`(탈퇴자 2,126명). 대량 목록은 배치(200 ID/호출)라 비용 무시.

## 검증
- `pnpm check` 0 errors
- canary: 탈퇴 회원 글/댓글에서 닉네임 취소선 확인 예정

## 후속(비긴급)
공감자/추천자 다이얼로그(comment-likers-dialog)는 AuthorLink 미사용이라 별도 처리 — 우선순위 낮아 이번 범위 제외.