### PR TITLE
fix(auth): 회원 탈퇴 시 계정 식별값(mb_dupinfo) 보존

### DIFF
--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -144,7 +144,11 @@ export async function saveCertResult(
         [dupinfo, adult, mbId]
     );
 
-    // 인증 이력 저장
+    // 인증 이력 저장.
+    // ⚠️ ch_ci 컬럼에는 원본 CI가 아니라 dupinfo(단방향 해시)를 저장한다 — 의도된 설계.
+    //    checkDupinfo()도 이 값으로 중복을 조회하며, 이 이력은 탈퇴 시에도 삭제되지
+    //    않아 사실상 DI 영구백업 역할을 한다(원본 CI는 어디에도 저장하지 않음).
+    //    실제 CI로 바꾸지 말 것 — 중복차단(dedup)이 깨지고 DI 복구 경로가 사라진다.
     await pool.query(
         `INSERT INTO g5_member_cert_history (mb_id, ch_type, ch_ci, ch_datetime) VALUES (?, 'simple', ?, NOW())`,
         [mbId, dupinfo]

--- a/apps/web/src/lib/server/auth/member-leave.ts
+++ b/apps/web/src/lib/server/auth/member-leave.ts
@@ -21,8 +21,12 @@ function prependLeaveMemo(existingMemo: string, leaveDate: string): string {
  * 회원 탈퇴 처리 (소프트 삭제)
  * 1. mb_leave_date = YYYYMMDD
  * 2. mb_memo 앞에 "YYYYMMDD 탈퇴함" 기록
- * 3. 본인인증/중복가입 관련 값 초기화
+ * 3. 본인인증 표식 초기화(mb_certify·mb_adult)
  * 4. 소셜 프로필 삭제
+ *
+ * ⚠️ mb_dupinfo(DI)는 삭제하지 않는다 — 부정 이용 방지(재가입 중복차단)를
+ *    위한 단방향 식별값으로 영구 보존한다. (backend withdrawal_grace.go 의
+ *    'DI 등 식별자 미삭제' 정책과 일치)
  */
 export async function processMemberLeave(
     mbId: string
@@ -41,14 +45,14 @@ export async function processMemberLeave(
     const leaveDate = formatLeaveDate();
     const nextMemo = prependLeaveMemo(member.mb_memo ?? '', leaveDate);
 
-    // 소프트 삭제: PHP member_leave.php 호환 필드 반영
+    // 소프트 삭제: 본인인증 표식만 초기화.
+    // DI(mb_dupinfo)는 재가입 중복차단을 위해 의도적으로 보존한다(삭제 금지).
     await pool.query<ResultSetHeader>(
         `UPDATE g5_member
             SET mb_leave_date = ?,
                 mb_memo = ?,
                 mb_certify = '',
-                mb_adult = 0,
-                mb_dupinfo = ''
+                mb_adult = 0
           WHERE mb_id = ?`,
         [leaveDate, nextMemo, mbId]
     );


### PR DESCRIPTION
## 변경
회원 탈퇴 처리(`member-leave.ts`)에서 계정 식별값(`mb_dupinfo`)을 초기화하던
부분을 제거해, 백엔드 `withdrawal_grace.go`의 '식별자 미삭제' 정책과 일치시킵니다.
(기존에는 이 프론트 경로에서만 초기화되어 백엔드 정책과 불일치했습니다.)

- `member-leave.ts`: 탈퇴 UPDATE에서 `mb_dupinfo=''` 제거.
- `cert-inicis.ts`: 인증 이력 저장 컬럼의 의도를 주석으로 명시(값 변경 금지 경고).

## 영향
- 실제 라이브 탈퇴 흐름은 백엔드로 위임되며, 이 함수는 현재 미사용 경로입니다.
  본 변경은 해당 함수를 백엔드 정책과 문서/코드 수준에서 정합화하는 성격입니다.
- 탈퇴 동작(soft delete, memo 기록, 소셜 프로필 삭제)·단위테스트 영향 없음.