### PR TITLE
feat(comments): 자진 삭제글의 댓글 스레드 유지 노출 (#12965)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -157,9 +157,15 @@ export const load: PageServerLoad = async ({
             post.videos = [];
             post.downloads = [];
             post.files = [];
-            // 삭제글은 댓글도 노출하지 않는다(#12711). 댓글 API(부모 삭제 시 빈 배열 반환)와
-            // 정합을 맞추기 위해 권위 카운트도 0으로 — 헤더 카운트 라벨/SSR total/클라 backfill 게이트 일치.
-            post.comments_count = 0;
+            // 자진삭제(작성자 본인 삭제, deleted_by == 작성자)면 본문만 가리고 그 아래
+            // 댓글 스레드는 유지한다(#12965 — 댓글은 각 댓글 작성자의 소유·책임).
+            // 타인 삭제(관리자/징계 등) 또는 삭제자 미상이면 댓글도 가린다(#12711).
+            // 삭제 사유(자진/징계)는 문구로 구분하지 않는다. 댓글 API 게이트와 정합.
+            const selfDeleted = !!post.deleted_by && post.deleted_by === post.author_id;
+            if (!selfDeleted) {
+                // 헤더 카운트 라벨/SSR total/클라 backfill 게이트 일치를 위해 권위 카운트 0.
+                post.comments_count = 0;
+            }
             setHeaders({ 'X-Robots-Tag': 'noindex, noarchive' });
         }
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -136,7 +136,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
         // 부모 글 조회 — 삭제 여부(#12711) + 마음메시지 익명 판정에 사용.
         // 익명 마음메시지는 PublishToGnuboard() 에서 wr_name="" 로 저장된다.
         const [parentRows] = await pool.query<RowDataPacket[]>(
-            `SELECT wr_deleted_at, mb_id, wr_name FROM ?? WHERE wr_id = ? AND wr_is_comment = 0 LIMIT 1`,
+            `SELECT wr_deleted_at, wr_deleted_by, mb_id, wr_name FROM ?? WHERE wr_id = ? AND wr_is_comment = 0 LIMIT 1`,
             [tableName, safePostId]
         );
         const parent = parentRows[0];
@@ -150,10 +150,18 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             (parent.wr_name ?? '').toString().trim() === '';
         const anonymousAuthorId = postIsAnonymousMessage ? String(parent.mb_id ?? '') : '';
 
-        // 부모 글 삭제 여부 확인 — 삭제된 글은 본문이 "[삭제된 게시물]"로 가려지므로
-        // 그 아래 댓글도 노출하지 않는다. 관리자는 조정 목적상 계속 열람 가능.
+        // 부모 글 삭제 여부 확인.
+        // - 자진삭제(작성자 본인이 삭제, wr_deleted_by == 원글 mb_id): 댓글은 각 댓글
+        //   작성자의 것이므로 그 아래 댓글 스레드를 계속 노출한다(#12965).
+        // - 타인 삭제(관리자/징계 등, wr_deleted_by != 원글 mb_id) 또는 삭제자 미상:
+        //   콘텐츠 정책상 댓글도 가린다. 삭제 사유(징계 여부)는 노출하지 않는다.
+        // 관리자는 조정 목적상 항상 열람 가능.
+        const parentSelfDeleted =
+            !!parent?.wr_deleted_at &&
+            !!parent?.wr_deleted_by &&
+            String(parent.wr_deleted_by) === String(parent.mb_id);
         if (!isAdmin) {
-            if (!parent || parent.wr_deleted_at) {
+            if (!parent || (parent.wr_deleted_at && !parentSelfDeleted)) {
                 return json(
                     {
                         success: true,


### PR DESCRIPTION
## 배경
글 작성자가 자기 글을 스스로 삭제하면, 그 아래 다른 회원이 단 댓글까지 함께 가려지던
동작을 개선합니다. 댓글은 각 댓글 작성자의 소유이므로, 글 작성자의 자진 삭제가 다른
회원의 댓글을 가려서는 안 된다는 제보(#12965)에 따른 것입니다.

## 변경 (1단계: 글 상세 + 댓글 API)
- **판별 기준**: 원글의 `wr_deleted_by`가 원글 작성자 본인이면 '자진 삭제'로 보고
  댓글 스레드를 유지 노출합니다. 그 외(타인이 삭제) 또는 삭제자 미상이면 기존대로
  댓글을 가립니다.
- **삭제 문구 통일**: 삭제 사유를 문구로 구분하지 않습니다(본문은 동일하게 삭제 처리).
- **댓글 API**: 부모가 자진 삭제면 댓글을 반환, 타인 삭제면 빈 배열(현행 유지).
- **글 상세 SSR**: 자진 삭제면 `comments_count`를 보존해 댓글 스레드를 로드하되,
  본문은 그대로 가립니다.

## 불변(회귀 없음)
- 관리자 열람, 삭제된 '댓글' 자체 표시('삭제된 댓글입니다'), 이용제한/신고 누적 가림.

## 후속(2단계 예정, 별도 PR)
- 댓글 작성자 검색 결과 포함, 프로필 최근 댓글 표시.

Sprint Contract: 자진 삭제글 댓글 유지 노출(징계·타인 삭제 제외).