### PR TITLE
fix(auth): 세션 만료 시 stale 로그인 UI 정리 (#12971)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -317,6 +317,12 @@ class ApiClient {
                     if (refreshed) {
                         return this.request<T>(endpoint, options, retryConfig, true);
                     }
+                    // #12971: refresh 실패 = access+refresh 양 토큰 만료(세션 종료).
+                    // UI가 로그인 상태로 남아(닉네임 표시) 실제 작성은 실패하는 stale 상태를
+                    // 막기 위해 세션 만료를 전파한다. 스토어 리스너가 auth 정리 + 재로그인 안내.
+                    if (browser) {
+                        window.dispatchEvent(new CustomEvent('auth:session-expired'));
+                    }
                 }
                 let errorMessage = '요청 실패';
                 let errorCode: string | undefined;

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
     import { page } from '$app/stores';
     import { configureSeo } from '$lib/seo';
     import { authActions, authStore } from '$lib/stores/auth.svelte';
+    import { toast } from 'svelte-sonner';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { collectAndReportFingerprint } from '$lib/fingerprint/device-fingerprint';
     import { themeStore } from '$lib/stores/theme.svelte';
@@ -523,6 +524,21 @@
             consumePendingAuthEvent();
         }
     }
+
+    // #12971: 세션 만료(access+refresh 양 토큰 만료) 시 UI가 로그인 상태로 남아
+    // 닉네임은 보이는데 작성은 실패하는 stale 상태를 방지한다. client.ts 가 refresh
+    // 실패 시 'auth:session-expired' 를 전파하면, auth 상태를 정리(닉네임 제거)하고
+    // 재로그인을 안내한다. (이미 로그아웃 상태면 중복 안내하지 않음)
+    $effect(() => {
+        if (!browser) return;
+        const handleSessionExpired = () => {
+            if (!authStore.isAuthenticated) return;
+            authActions.resetAuth();
+            toast.error('세션이 만료되어 로그아웃되었습니다. 다시 로그인해 주세요.');
+        };
+        window.addEventListener('auth:session-expired', handleSessionExpired);
+        return () => window.removeEventListener('auth:session-expired', handleSessionExpired);
+    });
 
     onMount(() => {
         // 디바이스 핑거프린트 수집 (로그인 사용자 한정, 1일 1회 throttle).


### PR DESCRIPTION
## 문제
access+refresh 양 토큰이 만료되면 401 자동 refresh(#12463)도 실패하는데, 그때 auth
상태를 정리하지 않아 **UI는 로그인 상태(닉네임 표시)로 남고 작성만 실패**했습니다.
사용자는 로그인된 줄 알고 댓글을 달지만 실패하고, 닉네임을 눌러야 세션 만료를 인지.

## 변경
- `client.ts`: 401 + 자동 refresh 실패(비-auth 엔드포인트 한정) 시 `auth:session-expired` 전파.
- `+layout.svelte`: 이벤트 수신 → `resetAuth()`(닉네임 제거) + 재로그인 안내 토스트.
  이미 로그아웃 상태면 무시(중복 방지), $effect 로 리스너 자동 정리.

## 효과
세션 만료 시 닉네임이 사라지고 안내가 떠, 사용자가 로그아웃 상태를 인지하고 재로그인.
(제보: #12971 크리넥스소프트)