### PR TITLE
fix(discipline): 소명 버튼이 영구제재·제재당일에 안 뜨는 문제 (#12973)

### DIFF
--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -72,19 +72,23 @@
         return `/${item.table}/${item.id}`;
     }
 
-    // 소명 가능 여부: 1일 이상 이용제한만 가능
+    // 소명 가능 여부: 주의(0)만 제외 — 정지(>=1)와 영구(-1) 모두 소명 대상.
+    // (기존 `>= 1` 은 영구제재 -1 을 배제해, 영구 이용제한 회원이 소명 진입점 자체를
+    //  볼 수 없던 문제(#12973)를 바로잡는다.)
     function isAppealablePenalty(log: DisciplineLogDetail): boolean {
-        return log.penalty_period >= 1;
+        return log.penalty_period === -1 || log.penalty_period >= 1;
     }
 
-    // 소명 기간 내 여부: 제재 시작 후 1일 경과 ~ 15일 이내
+    // 소명 기간 내 여부: 제재 당일(0일)부터 15일 이내.
+    // (기존 `>= 1` 은 제재 당일 소명을 막아, 징계 직후 바로 소명하려는 회원이
+    //  소명 버튼을 볼 수 없던 문제(#12973)를 바로잡는다. 미래 일자 제재는 음수라 제외.)
     function isWithinAppealPeriod(log: DisciplineLogDetail): boolean {
         const penaltyDate = new Date(log.penalty_date_from);
         const now = new Date();
         const diffDays = Math.floor(
             (now.getTime() - penaltyDate.getTime()) / (1000 * 60 * 60 * 24)
         );
-        return diffDays >= 1 && diffDays <= 15;
+        return diffDays >= 0 && diffDays <= 15;
     }
 
     // 본인 확인


### PR DESCRIPTION
## 문제
이용제한 회원이 소명게시판에 소명하려 해도, 이용제한 안내 페이지의 **소명 안내 카드/
소명하기 버튼 자체가 렌더링되지 않는** 경우가 있었습니다. (제보: 징계 직후 소명하려
했으나 글을 쓸 수 없었다 — #12973)

## 원인 (프론트 게이트 2가지)
1. `isAppealablePenalty`: `penalty_period >= 1` 만 허용 → **영구제재(-1) 배제**.
   함수 주석('영구(-1)·정지 모두 표시')과 모순. 영구 이용제한 회원은 소명 진입 불가.
2. `isWithinAppealPeriod`: `diffDays >= 1` 요구 → **제재 당일(0일) 소명 차단**.
   징계 직후 바로 소명하려는 회원이 버튼을 못 봄.

## 변경
- (1) 영구(-1) 포함, 주의(0)만 제외.
- (2) 제재 당일(0일)부터 15일 이내 허용(미래 일자 제재는 음수라 제외).

## 참고
- 백엔드 `ban_check`(claim 보드 예외)·claim write_level·write-permission 은 모두 정상.
  차단은 이 프론트 게이트 단일 원인이었습니다.
- 영구제재의 15일 소명 상한 유지 여부는 별도 정책 사안(이번 PR 범위 밖).