### PR TITLE
feat(board): 과거 글 탐색 — 날짜로 이동 UI (#12975 ②)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -32,6 +32,9 @@ interface PostsCacheData {
         total?: number;
         totalPages?: number;
         hasNext?: boolean;
+        // #12975 날짜 이동: 커서 기반 '다음' + 날짜 모드 여부.
+        nextCursor?: { wrNum: number; wrReply: string } | null;
+        dateMode?: boolean;
     };
     error: string | null;
 }
@@ -163,7 +166,8 @@ export const load: PageServerLoad = async ({
     params,
     locals,
     getClientAddress,
-    isDataRequest
+    isDataRequest,
+    setHeaders
 }) => {
     const canonicalBoardId = await resolveCanonicalBoardId(params.boardId);
     if (canonicalBoardId !== params.boardId) {
@@ -180,6 +184,16 @@ export const load: PageServerLoad = async ({
     const searchSort = url.searchParams.get('sort') || null;
     const tag = url.searchParams.get('tag') || null;
     const category = url.searchParams.get('category') || null;
+    // #12975: 날짜 기반 아카이브 이동. before_date 로 시점 점프, 이후 '다음'은 커서로 이어감.
+    const beforeDate = url.searchParams.get('before_date') || null;
+    const cursorWrNumRaw = url.searchParams.get('cursor_wr_num');
+    const cursorWrNum = cursorWrNumRaw !== null && cursorWrNumRaw !== '' ? cursorWrNumRaw : null;
+    const cursorWrReply = url.searchParams.get('cursor_wr_reply') ?? '';
+    const isDateMode = !!beforeDate || cursorWrNum !== null;
+    // 날짜/커서 아카이브 뷰는 검색엔진 색인 대상이 아니다(무한 커서 크롤 방지). 목록 1페이지·상세는 영향 없음.
+    if (isDateMode) {
+        setHeaders({ 'X-Robots-Tag': 'noindex, follow' });
+    }
     const rawMessagePeriod = boardId === 'message' ? url.searchParams.get('period') : null;
     const messagePeriod =
         boardId === 'message' &&
@@ -293,6 +307,13 @@ export const load: PageServerLoad = async ({
         }
         if (useSummaryListResponse) {
             queryParams.set('summary', '1');
+        }
+        // 날짜 이동: 첫 진입은 before_date, '다음'은 커서(cursor_wr_num/reply)로 이어감.
+        if (cursorWrNum !== null) {
+            queryParams.set('cursor_wr_num', cursorWrNum);
+            queryParams.set('cursor_wr_reply', cursorWrReply);
+        } else if (beforeDate) {
+            queryParams.set('before_date', beforeDate);
         }
         return `/api/v1/boards/${boardId}/posts?${queryParams.toString()}`;
     };
@@ -579,7 +600,16 @@ export const load: PageServerLoad = async ({
                     typeof meta.total === 'number' && meta.limit
                         ? Math.ceil(meta.total / meta.limit)
                         : undefined,
-                hasNext: meta.has_next === true
+                hasNext: meta.has_next === true,
+                // 날짜 이동 커서: '다음' 페이지를 위한 next_cursor(#12975).
+                nextCursor:
+                    meta.next_cursor_wr_num !== undefined && meta.next_cursor_wr_num !== null
+                        ? {
+                              wrNum: Number(meta.next_cursor_wr_num),
+                              wrReply: String(meta.next_cursor_wr_reply ?? '')
+                          }
+                        : null,
+                dateMode: isDateMode
             };
         } else {
             console.error('게시판 로딩 에러:', boardId, postsResult.reason);

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -729,6 +729,52 @@
         url.searchParams.set('page', String(pageNum));
         goto(url.pathname + url.search);
     }
+
+    // #12975 날짜 기반 아카이브 이동 — 페이지 번호 대신 날짜로 점프, 이후 커서로 과거로 이어감.
+    const dateMode = $derived(pagination.dateMode ?? false);
+    const archiveNextCursor = $derived(pagination.nextCursor ?? null);
+    const archiveDateNavEnabled = $derived(
+        !isSearching && (boardId === 'free' || boardId === 'hello')
+    );
+    // 연/월 옵션(개설연도 근사 2024 ~ 올해).
+    const archiveMonthOptions = $derived.by(() => {
+        const now = new Date();
+        const opts: { value: string; label: string }[] = [];
+        for (let y = now.getFullYear(); y >= 2024; y--) {
+            const mMax = y === now.getFullYear() ? now.getMonth() + 1 : 12;
+            for (let m = mMax; m >= 1; m--) {
+                opts.push({ value: `${y}-${String(m).padStart(2, '0')}`, label: `${y}년 ${m}월` });
+            }
+        }
+        return opts;
+    });
+
+    function jumpToArchiveMonth(ym: string): void {
+        if (!ym) return;
+        const url = new URL(window.location.href);
+        url.searchParams.delete('page');
+        url.searchParams.delete('cursor_wr_num');
+        url.searchParams.delete('cursor_wr_reply');
+        url.searchParams.set('before_date', ym);
+        goto(url.pathname + url.search);
+    }
+
+    function goToArchiveNext(): void {
+        if (!archiveNextCursor) return;
+        const url = new URL(window.location.href);
+        url.searchParams.delete('page');
+        url.searchParams.set('cursor_wr_num', String(archiveNextCursor.wrNum));
+        url.searchParams.set('cursor_wr_reply', archiveNextCursor.wrReply);
+        goto(url.pathname + url.search);
+    }
+
+    function exitArchive(): void {
+        const url = new URL(window.location.href);
+        for (const k of ['before_date', 'cursor_wr_num', 'cursor_wr_reply', 'page']) {
+            url.searchParams.delete(k);
+        }
+        goto(url.pathname + url.search);
+    }
 </script>
 
 <!-- 특수 게시판: 플러그인 레지스트리 기반 동적 로딩 -->
@@ -1478,7 +1524,7 @@
             </div>
 
             <!-- 페이지네이션 -->
-            {#if shouldShowPagination}
+            {#if shouldShowPagination && !dateMode}
                 <div class="mt-8 flex items-center justify-center gap-1 sm:gap-2">
                     <!-- #11941: 첫페이지 단축 — 항상 노출 (1페이지일 때만 비활성) -->
                     <Button
@@ -1533,6 +1579,39 @@
                         />
                     </div>
                 {/if}
+            {/if}
+            {#if dateMode}
+                <!-- #12975 날짜 아카이브: 커서 기반 과거 이동 (페이지 번호 무관·고속) -->
+                <div class="mt-8 flex flex-wrap items-center justify-center gap-2">
+                    <Button variant="outline" size="sm" onclick={exitArchive}
+                        >&laquo; 최신 목록</Button
+                    >
+                    <span class="text-muted-foreground text-sm">과거 글 보기 · 아카이브</span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={!archiveNextCursor}
+                        onclick={goToArchiveNext}>이전 글 더보기 &raquo;</Button
+                    >
+                </div>
+            {/if}
+            {#if archiveDateNavEnabled}
+                <!-- 날짜로 이동(연/월) — 과거 글 탐색 -->
+                <div class="mt-3 flex items-center justify-center gap-2">
+                    <label for="archive-date-jump" class="text-muted-foreground text-xs"
+                        >📅 날짜로 이동</label
+                    >
+                    <select
+                        id="archive-date-jump"
+                        class="border-input bg-background rounded-md border px-2 py-1 text-sm"
+                        onchange={(e) => jumpToArchiveMonth(e.currentTarget.value)}
+                    >
+                        <option value="">이동할 월 선택</option>
+                        {#each archiveMonthOptions as o (o.value)}
+                            <option value={o.value}>{o.label}</option>
+                        {/each}
+                    </select>
+                </div>
             {/if}
         </div>
     {/if}


### PR DESCRIPTION
## 배경
깊은 페이지 붕괴(#12975)의 UX 해법. 연/월로 임의 시점 점프 + 커서로 과거 이동.

## 변경
- `+page.server.ts`: before_date/cursor 파라미터 플러밍, next_cursor·dateMode 반환,
  날짜/커서 뷰 noindex. 기존 page 경로 무영향(additive).
- `+page.svelte`: free/hello 목록에 '📅 날짜로 이동'(연/월) + 날짜모드 커서 네비.

백엔드: damoang/angple-backend#(feat/archive-date-navigation) 함께 배포. 제보: #12975