### PR TITLE
feat(home): 위젯 순서 조정 — 숨은보석 메인 제거·소모임 상단 이동

### DIFF
--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -9,17 +9,28 @@
 
 import type { WidgetConfig } from '$lib/stores/widget-layout.svelte';
 
-/** 기본 메인 위젯 레이아웃 */
+/** 기본 메인 위젯 레이아웃
+ *
+ * 주의: _mergeNewDefaults 가 이 배열의 position 을 최종 순서 권위로 재정렬하므로
+ * 홈 순서 변경은 여기서 한다 (DB 저장 레이아웃의 position 은 기본 위젯엔 무시됨).
+ * 2026-07-13: hidden-gems 메인 제거(사이드바 유지) + 소모임(group)을 ad-top 아래로.
+ */
 export const DEFAULT_WIDGETS: WidgetConfig[] = [
     { id: 'tag-nav', type: 'tag-nav', position: 0, enabled: true },
     { id: 'empathy-explore-row', type: 'empathy-explore-row', position: 1, enabled: true },
-    { id: 'hidden-gems', type: 'hidden-gems', position: 2, enabled: true },
     {
         id: 'ad-top',
         type: 'ad-slot',
-        position: 3,
+        position: 2,
         enabled: true,
         settings: { position: 'index-top' }
+    },
+    {
+        id: 'group',
+        type: 'post-list',
+        position: 3,
+        enabled: true,
+        settings: { boardId: 'group', layout: 'card', sortBy: 'date', count: 10, showTitle: true }
     },
     {
         id: 'ad-middle-1',
@@ -50,22 +61,15 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
         settings: { position: 'index-middle-2' }
     },
     {
-        id: 'group',
-        type: 'post-list',
-        position: 8,
-        enabled: true,
-        settings: { boardId: 'group', layout: 'card', sortBy: 'date', count: 10, showTitle: true }
-    },
-    {
         id: 'celebration',
         type: 'celebration',
-        position: 9,
+        position: 8,
         enabled: true
     },
     {
         id: 'ad-bottom',
         type: 'ad-slot',
-        position: 10,
+        position: 9,
         enabled: true,
         settings: { position: 'index-bottom' }
     }


### PR DESCRIPTION
## 배경
운영 결정: 홈에서 ①"이런 게시판도 있어요"(hidden-gems) 제거 ②상단 광고(ad-top) 유지 ③소모임(group)을 그 바로 아래로.

## 변경
- `DEFAULT_WIDGETS`: hidden-gems 메인 제거(사이드바 유지) + group 을 position 3(ad-top 아래)으로
- 발견 사실 문서화: `_mergeNewDefaults` 가 이 배열의 position 을 **최종 순서 권위**로 재정렬 — DB 저장 레이아웃의 position 은 기본 위젯에 무시됨 (주석 추가). DB `widget_layout` 값은 광고 슬롯 보존 + hidden-gems enabled:false 로 이미 갱신·백업(`widget_layout_backup_20260713`) 완료

## 검증
- svelte-check 0 errors. 배포 후 홈 순서 실측 예정: 공감글·모아보기 → 광고 → 소모임 → 정보광장 → …