### PR TITLE
perf(reaction): 반응자 목록 회원별 묶기 + target 인덱스 대응

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-reactors-dialog.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-reactors-dialog.svelte
@@ -14,7 +14,7 @@
         mb_nick: string;
         mb_image?: string;
         mb_image_updated_at?: string;
-        reaction: string;
+        reactions: string[];
         reacted_at: string;
     }
 
@@ -79,8 +79,7 @@
                     목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
                 </p>
             {:else}
-                {#each reactors as reactor (reactor.mb_id + reactor.reaction + reactor.reacted_at)}
-                    {@const display = getReactionDisplay(reactor.reaction)}
+                {#each reactors as reactor (reactor.mb_id)}
                     {@const avatar = getAvatarUrl(reactor.mb_image, reactor.mb_image_updated_at)}
                     <div class="hover:bg-muted/50 flex items-center gap-3 rounded-md px-2 py-1.5">
                         {#if avatar}
@@ -110,15 +109,24 @@
                                 </p>
                             {/if}
                         </div>
-                        {#if display.renderType === 'image' && display.url}
-                            <img
-                                src={display.url}
-                                alt={display.label}
-                                class="h-6 w-6 object-scale-down"
-                            />
-                        {:else}
-                            <span class="text-lg leading-none">{display.emoji}</span>
-                        {/if}
+                        <!-- 한 회원이 누른 이모지 여러 개를 한 줄에 나열 -->
+                        <div class="flex flex-shrink-0 flex-wrap items-center justify-end gap-1">
+                            {#each reactor.reactions as reaction (reaction)}
+                                {@const display = getReactionDisplay(reaction)}
+                                {#if display.renderType === 'image' && display.url}
+                                    <img
+                                        src={display.url}
+                                        alt={display.label}
+                                        title={display.label}
+                                        class="h-6 w-6 object-scale-down"
+                                    />
+                                {:else}
+                                    <span class="text-lg leading-none" title={display.label}
+                                        >{display.emoji}</span
+                                    >
+                                {/if}
+                            {/each}
+                        </div>
                     </div>
                 {:else}
                     {#if anonymousCount === 0}

--- a/apps/web/src/routes/api/reactions/reactors/+server.ts
+++ b/apps/web/src/routes/api/reactions/reactors/+server.ts
@@ -73,17 +73,41 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
         ]);
 
         const anonymousCount = Number(anonRows[0]?.cnt ?? 0);
-        return json({
-            success: true,
-            data: {
-                reactors: rows.map((r) => ({
+
+        // 회원별로 묶어 한 줄에 이모지 여러 개로 표시.
+        // rows 는 created_at DESC → 회원 첫 등장이 그 회원의 최신 시각.
+        // (member,target,reaction) 은 u_reaction UNIQUE 라 회원별 reaction 중복 없음.
+        const byMember = new Map<
+            string,
+            {
+                mb_id: string;
+                mb_nick: string;
+                mb_image: string;
+                mb_image_updated_at: string | undefined;
+                reactions: string[];
+                reacted_at: string;
+            }
+        >();
+        for (const r of rows) {
+            const existing = byMember.get(r.member_id);
+            if (existing) {
+                existing.reactions.push(r.reaction);
+            } else {
+                byMember.set(r.member_id, {
                     mb_id: r.member_id,
                     mb_nick: r.mb_nick || r.mb_name || r.member_id,
                     mb_image: r.mb_image_url || '',
                     mb_image_updated_at: r.mb_image_updated_at || undefined,
-                    reaction: r.reaction,
+                    reactions: [r.reaction],
                     reacted_at: toSafeIso(r.created_at)
-                })),
+                });
+            }
+        }
+
+        return json({
+            success: true,
+            data: {
+                reactors: [...byMember.values()],
                 anonymousCount,
                 total: rows.length + anonymousCount,
                 revealSince: REACTOR_REVEAL_SINCE

--- a/apps/web/src/routes/api/reactions/reactors/+server.ts
+++ b/apps/web/src/routes/api/reactions/reactors/+server.ts
@@ -38,6 +38,21 @@ interface CountRow extends RowDataPacket {
     cnt: number;
 }
 
+interface MemberRow extends RowDataPacket {
+    member_id: string;
+    latest: string;
+}
+
+/** 회원 1명 = 한 줄, 이모지 여러 개 */
+interface ReactorEntry {
+    mb_id: string;
+    mb_nick: string;
+    mb_image: string;
+    mb_image_updated_at: string | undefined;
+    reactions: string[];
+    reacted_at: string;
+}
+
 export const GET: RequestHandler = async ({ url, cookies }) => {
     const targetId = url.searchParams.get('targetId') || '';
     if (!TARGET_ID_RE.test(targetId)) {
@@ -52,16 +67,16 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
     }
 
     try {
-        const [[rows], [anonRows]] = await Promise.all([
-            pool.query<ReactorRow[]>(
-                `SELECT c.member_id, m.mb_nick, m.mb_name,
-                        COALESCE(m.mb_image_url, '') AS mb_image_url,
-                        m.mb_image_updated_at,
-                        c.reaction, c.created_at
-                 FROM g5_da_reaction_choose c
-                 JOIN g5_member m ON c.member_id = m.mb_id
-                 WHERE c.target_id = ? AND c.created_at >= ?
-                 ORDER BY c.created_at DESC
+        // limit 은 "distinct 회원 수" 기준. 집계-후-상세 2단계로 회원 경계에서 잘라,
+        // 표시되는 각 회원의 이모지가 절대 잘리지 않게 한다(choose-row LIMIT 의 split 회피).
+        // ① 최근 반응한 회원 선정 + ③ 익명(7/12 이전) 건수 — 병렬
+        const [[memberRows], [anonRows]] = await Promise.all([
+            pool.query<MemberRow[]>(
+                `SELECT member_id, MAX(created_at) AS latest
+                 FROM g5_da_reaction_choose
+                 WHERE target_id = ? AND created_at >= ?
+                 GROUP BY member_id
+                 ORDER BY latest DESC
                  LIMIT ?`,
                 [targetId, REACTOR_REVEAL_SINCE, limit]
             ),
@@ -73,21 +88,36 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
         ]);
 
         const anonymousCount = Number(anonRows[0]?.cnt ?? 0);
+        const memberIds = memberRows.map((r) => r.member_id);
 
-        // 회원별로 묶어 한 줄에 이모지 여러 개로 표시.
-        // rows 는 created_at DESC → 회원 첫 등장이 그 회원의 최신 시각.
+        if (memberIds.length === 0) {
+            return json({
+                success: true,
+                data: {
+                    reactors: [],
+                    anonymousCount,
+                    total: anonymousCount,
+                    revealSince: REACTOR_REVEAL_SINCE
+                }
+            });
+        }
+
+        // ② 선정된 회원들의 리액션 상세 전량(이모지 잘림 없음)
+        const [rows] = await pool.query<ReactorRow[]>(
+            `SELECT c.member_id, m.mb_nick, m.mb_name,
+                    COALESCE(m.mb_image_url, '') AS mb_image_url,
+                    m.mb_image_updated_at,
+                    c.reaction, c.created_at
+             FROM g5_da_reaction_choose c
+             JOIN g5_member m ON c.member_id = m.mb_id
+             WHERE c.target_id = ? AND c.created_at >= ? AND c.member_id IN (?)
+             ORDER BY c.created_at DESC`,
+            [targetId, REACTOR_REVEAL_SINCE, memberIds]
+        );
+
+        // 회원별로 묶기. rows 는 created_at DESC → 회원 첫 등장이 그 회원의 최신 시각.
         // (member,target,reaction) 은 u_reaction UNIQUE 라 회원별 reaction 중복 없음.
-        const byMember = new Map<
-            string,
-            {
-                mb_id: string;
-                mb_nick: string;
-                mb_image: string;
-                mb_image_updated_at: string | undefined;
-                reactions: string[];
-                reacted_at: string;
-            }
-        >();
+        const byMember = new Map<string, ReactorEntry>();
         for (const r of rows) {
             const existing = byMember.get(r.member_id);
             if (existing) {
@@ -104,12 +134,17 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
             }
         }
 
+        // ①의 최신순 회원 순서로 출력(집계 정렬과 일치)
+        const reactors = memberIds
+            .map((id) => byMember.get(id))
+            .filter((v): v is ReactorEntry => v != null);
+
         return json({
             success: true,
             data: {
-                reactors: [...byMember.values()],
+                reactors,
                 anonymousCount,
-                total: rows.length + anonymousCount,
+                total: reactors.length + anonymousCount,
                 revealSince: REACTOR_REVEAL_SINCE
             }
         });


### PR DESCRIPTION
## 배경
이모지 리액션 닉네임 공개(7/12 시행) 팝업 `/api/reactions/reactors` 개선.

## 문제
1. **성능**: `g5_da_reaction_choose`(405,239행)에 `target_id` 선두 인덱스 없음 → 팝업마다 풀스캔 2회.
   실측(hot target 1,644행): reveal 쿼리 `type=ALL rows≈400k + filesort` 242ms, anon count 185ms.
2. **표시**: 한 회원이 이모지 여러 개 누르면 다이얼로그에 회원이 여러 줄로 중복.

## 변경
- **서버**: 조회 후 `member_id`로 묶어 회원 1명당 `reactions: string[]` 반환.
  SQL은 인덱스 레인지 스캔 유지(GROUP BY를 SQL에 넣지 않아 filesort 회피 → DB 부하 최소).
- **UI**: 회원 한 줄에 누른 이모지 여러 개를 `flex flex-wrap`로 나열.

## 선행 DDL (배포 전 적용 필요)
```sql
ALTER TABLE g5_da_reaction_choose ADD INDEX idx_target_created (target_id, created_at);
```
- reveal/anon-count 쿼리 모두 인덱스 레인지로 전환(filesort 제거), 온라인 DDL 무중단.

## 불변(범위 밖)
- REACTOR_REVEAL_SINCE 소급 비공개 정책, 카운트·토글 API, reaction-bar 배지/피커.

## 체크리스트
- [ ] DDL 적용 후 EXPLAIN `type=range`, filesort 제거, 각 <10ms
- [ ] 회원 이모지 N개 → 응답 회원 1개 + reactions 길이 N
- [ ] 7/12 이전 anonymousCount 집계 불변
- [ ] pnpm check 통과