### PR TITLE
feat(content): 본문 단독 유튜브 링크 자동 임베드 복원 + VideoObject 연동

### DIFF
--- a/apps/web/src/lib/hooks/builtin/content-video.ts
+++ b/apps/web/src/lib/hooks/builtin/content-video.ts
@@ -5,6 +5,7 @@
 import { registerHook } from '../registry';
 import {
     transformVideos,
+    transformStandaloneYoutubeLinks,
     transformCodeBlocks,
     transformOembed,
     transformEscapedMedia,
@@ -40,6 +41,17 @@ export function initContentVideo(): void {
         'post_content',
         (html: unknown) => transformVideos(html as string),
         5, // auto-embed(10)보다 먼저 실행
+        'core',
+        'filter'
+    );
+
+    // 본문 단독 유튜브 링크 자동 임베드 복원 (구 나리야 자동임베드 동작 복원)
+    // GSC "동영상이 보기 페이지에 없음" 1,000건+ 대응 — 옛 글의 <p><a href="유튜브"> 단독
+    // 문단을 플레이어로 변환. {video:}(5) 이후, auto-embed(10) 이전에 실행
+    registerHook(
+        'post_content',
+        (html: unknown) => transformStandaloneYoutubeLinks(html as string),
+        6,
         'core',
         'filter'
     );

--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -12,6 +12,10 @@ import type {
     JsonLdQAPage,
     JsonLdVideoObject
 } from './types';
+import {
+    STANDALONE_ANCHOR_PARAGRAPH_SOURCE,
+    YOUTUBE_URL_ID_PATTERN
+} from '$lib/utils/content-transform';
 
 /**
  * QAPage JSON-LD 생성 — 질문/답변 게시판(qa) 리치 결과
@@ -98,9 +102,11 @@ const YOUTUBE_EMBED_ID_RE =
 /**
  * 본문 HTML 에서 동영상을 추출 (VideoObject 구조화 데이터용)
  *
- * 단순 링크(<a href>)는 플레이어가 아니므로 제외하고, 실제 재생 요소만 본다:
+ * 실제 페이지에서 플레이어로 렌더되는 요소만 본다:
  * - <iframe src="...youtube.com/embed/ID...">  (tiptap Youtube 임베드)
  * - <video src="..."> 또는 <video><source src="..."></video>  (업로드 동영상)
+ * - 단독 문단 유튜브 앵커 (<p><a href="유튜브"> 하나만) — transformStandaloneYoutubeLinks
+ *   가 렌더 시 플레이어로 바꾸므로 포함. 문장 속 인라인 링크는 여전히 제외
  */
 export function extractVideosFromContent(html: string): ExtractedVideo[] {
     if (!html) return [];
@@ -109,6 +115,17 @@ export function extractVideosFromContent(html: string): ExtractedVideo[] {
 
     for (const m of html.matchAll(/<iframe[^>]*\ssrc\s*=\s*["']([^"']+)["']/gi)) {
         const id = m[1].match(YOUTUBE_EMBED_ID_RE)?.[1];
+        if (id && !seen.has(`yt:${id}`)) {
+            seen.add(`yt:${id}`);
+            videos.push({ type: 'youtube', id });
+        }
+    }
+
+    // 단독 문단 유튜브 앵커 — 구 그누보드(나리야) 글의 맨 유튜브 링크.
+    // GSC "동영상이 보기 페이지에 없음" 대응. 판정 regex 는 본문 변환기와 공유해 항상 일치
+    for (const m of html.matchAll(new RegExp(STANDALONE_ANCHOR_PARAGRAPH_SOURCE, 'gi'))) {
+        const href = m[1].replace(/&amp;/g, '&');
+        const id = href.match(YOUTUBE_URL_ID_PATTERN)?.[1];
         if (id && !seen.has(`yt:${id}`)) {
             seen.add(`yt:${id}`);
             videos.push({ type: 'youtube', id });

--- a/apps/web/src/lib/seo/meta-helper.test.ts
+++ b/apps/web/src/lib/seo/meta-helper.test.ts
@@ -249,6 +249,28 @@ describe('VideoObject (GSC 동영상 색인 — 썸네일 필수)', () => {
         ]);
     });
 
+    it('단독 문단 유튜브 앵커에서 videoId 수집 (나리야 자동임베드 복원 연동)', async () => {
+        const { extractVideosFromContent } = await import('./json-ld');
+        const html = `
+            <p><a target="_blank" href="https://www.youtube.com/watch?v=QSWsno8FsC4" rel="nofollow noreferrer noopener">https://www.youtube.com/watch?v=QSWsno8FsC4</a></p>`;
+        expect(extractVideosFromContent(html)).toEqual([{ type: 'youtube', id: 'QSWsno8FsC4' }]);
+    });
+
+    it('문장 속 인라인 유튜브 앵커는 수집하지 않음 (단독 문단만)', async () => {
+        const { extractVideosFromContent } = await import('./json-ld');
+        const html = `
+            <p>문장 속 <a href="https://youtu.be/dQw4w9WgXcQ">인라인 링크</a>는 제외됩니다</p>`;
+        expect(extractVideosFromContent(html)).toEqual([]);
+    });
+
+    it('단독 문단 앵커와 iframe 이 같은 영상이면 중복 제거', async () => {
+        const { extractVideosFromContent } = await import('./json-ld');
+        const html = `
+            <iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"></iframe>
+            <p><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a></p>`;
+        expect(extractVideosFromContent(html)).toEqual([{ type: 'youtube', id: 'dQw4w9WgXcQ' }]);
+    });
+
     it('createVideoObjectJsonLd: 필수값(name·thumbnailUrl·uploadDate·재생URL) 미충족 시 null', async () => {
         const { createVideoObjectJsonLd } = await import('./json-ld');
         const base = {

--- a/apps/web/src/lib/utils/content-transform.test.ts
+++ b/apps/web/src/lib/utils/content-transform.test.ts
@@ -10,6 +10,7 @@ import {
     transformInlineMarkdown,
     transformEmoticons,
     transformVideos,
+    transformStandaloneYoutubeLinks,
     transformBracketImages
 } from './content-transform';
 
@@ -242,6 +243,85 @@ describe('transformVideos - 태그 제거 보안', () => {
     it('패턴이 아닌 텍스트는 그대로 반환', () => {
         const input = '일반 텍스트입니다';
         expect(transformVideos(input)).toBe(input);
+    });
+});
+
+describe('transformStandaloneYoutubeLinks - 단독 문단 유튜브 링크 자동 임베드 (나리야 복원)', () => {
+    it('단독 문단 앵커를 임베드로 변환 (/free/4616449 실례)', () => {
+        const input =
+            '<p><a target="_blank" href="https://www.youtube.com/watch?v=QSWsno8FsC4" rel="nofollow noreferrer noopener">https://www.youtube.com/watch?v=QSWsno8FsC4</a></p>';
+        const result = transformStandaloneYoutubeLinks(input);
+        expect(result).toContain('class="embed-container"');
+        expect(result).toContain('data-platform="youtube"');
+        expect(result).toContain('youtube-nocookie.com/embed/QSWsno8FsC4');
+        expect(result).not.toContain('<a ');
+        expect(result).not.toContain('</p>');
+    });
+
+    it('문장 속 인라인 유튜브 링크는 변환하지 않음', () => {
+        const input =
+            '<p>이 영상 <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">여기</a> 좋아요</p>';
+        expect(transformStandaloneYoutubeLinks(input)).toBe(input);
+    });
+
+    it('t= 파라미터를 start=로, list=는 유지', () => {
+        const input =
+            '<p><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ&amp;t=90s&amp;list=PLxyz_-123">https://www.youtube.com/watch?v=dQw4w9WgXcQ&amp;t=90s&amp;list=PLxyz_-123</a></p>';
+        const result = transformStandaloneYoutubeLinks(input);
+        expect(result).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ?start=90&list=PLxyz_-123');
+    });
+
+    it('shorts는 세로 비율(177.78%)로 변환', () => {
+        const input =
+            '<p><a href="https://www.youtube.com/shorts/dQw4w9WgXcQ">https://www.youtube.com/shorts/dQw4w9WgXcQ</a></p>';
+        const result = transformStandaloneYoutubeLinks(input);
+        expect(result).toContain('data-platform="youtube-shorts"');
+        expect(result).toContain('--aspect-ratio: 177.78%');
+        expect(result).toContain('--max-width: 400px');
+    });
+
+    it('유튜브가 아닌 단독 문단 앵커는 변환하지 않음', () => {
+        const input =
+            '<p>youtube 얘기</p><p><a href="https://vimeo.com/123456789">https://vimeo.com/123456789</a></p>';
+        expect(transformStandaloneYoutubeLinks(input)).toBe(input);
+    });
+
+    it('&nbsp;/<br>가 낀 단독 문단도 변환 (앵커 텍스트가 제목이어도)', () => {
+        const input =
+            '<p>&nbsp;<br><a href="https://youtu.be/dQw4w9WgXcQ">영상 제목입니다</a><br /> </p>';
+        const result = transformStandaloneYoutubeLinks(input);
+        expect(result).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ');
+        expect(result).not.toContain('<a ');
+    });
+
+    it('여러 문단 중 단독 유튜브 문단만 변환, 주변 콘텐츠 보존', () => {
+        const input =
+            '<p>앞 문단</p><p><a href="https://youtu.be/dQw4w9WgXcQ">https://youtu.be/dQw4w9WgXcQ</a></p><p>뒤에 <a href="https://youtu.be/abc123XYZ_-">인라인</a> 링크</p>';
+        const result = transformStandaloneYoutubeLinks(input);
+        expect(result).toContain('<p>앞 문단</p>');
+        expect(result).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ');
+        expect(result).toContain(
+            '<p>뒤에 <a href="https://youtu.be/abc123XYZ_-">인라인</a> 링크</p>'
+        );
+        expect(result).not.toContain('embed/abc123XYZ_-');
+    });
+
+    it('live 경로도 변환', () => {
+        const input =
+            '<p><a href="https://www.youtube.com/live/dQw4w9WgXcQ">https://www.youtube.com/live/dQw4w9WgXcQ</a></p>';
+        expect(transformStandaloneYoutubeLinks(input)).toContain(
+            'youtube-nocookie.com/embed/dQw4w9WgXcQ'
+        );
+    });
+
+    it('유튜브 URL이 없으면 원본 반환 (빠른 종료 가드)', () => {
+        const input = '<p><a href="https://example.com">https://example.com</a></p>';
+        expect(transformStandaloneYoutubeLinks(input)).toBe(input);
+    });
+
+    it('빈/null 입력', () => {
+        expect(transformStandaloneYoutubeLinks('')).toBe('');
+        expect(transformStandaloneYoutubeLinks(null as unknown as string)).toBe(null);
     });
 });
 

--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -77,6 +77,69 @@ export function transformBracketImages(text: string): string {
     );
 }
 
+/**
+ * 유튜브 URL 판정 공통 규칙 — watch / embed / shorts / live / youtu.be, 11자 videoId
+ * transformVideos · transformStandaloneYoutubeLinks · extractVideosFromContent(json-ld)가 공유
+ */
+export const YOUTUBE_URL_ID_PATTERN =
+    /(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+/**
+ * "단독 문단 앵커" 공통 패턴 — <p> 안에 공백/&nbsp;/<br> 외에 앵커 하나만 있는 경우.
+ * 문장 속 인라인 링크는 매치되지 않는다. 캡처 그룹 1 = href.
+ * transformStandaloneYoutubeLinks 와 extractVideosFromContent(json-ld)가 동일 규칙을 사용한다.
+ */
+export const STANDALONE_ANCHOR_PARAGRAPH_SOURCE = String.raw`<p(?:\s[^>]*)?>(?:\s|&nbsp;|<br\s*/?>)*<a\s[^>]*\bhref\s*=\s*["']([^"']+)["'][^>]*>[^<]*</a>(?:\s|&nbsp;|<br\s*/?>)*</p>`;
+
+/**
+ * 유튜브 URL → 임베드 플레이어 HTML 공통 헬퍼
+ * - youtube-nocookie embed, t= → start=, list= 유지, shorts 세로 비율(177.78%)
+ * - 유튜브 URL이 아니면 null (출력에는 검증된 videoId·숫자 start·[\w-] list만 삽입되므로 XSS 안전)
+ */
+export function youtubeUrlToEmbedHtml(url: string): string | null {
+    const ytMatch = url.match(YOUTUBE_URL_ID_PATTERN);
+    if (!ytMatch) return null;
+    const isShorts = url.includes('/shorts/');
+    let embedSrc = `https://www.youtube-nocookie.com/embed/${ytMatch[1]}`;
+    const embedParams: string[] = [];
+    const timeMatch = url.match(/[?&]t=(\d+)/);
+    if (timeMatch) embedParams.push(`start=${timeMatch[1]}`);
+    const listMatch = url.match(/[?&]list=([a-zA-Z0-9_-]+)/);
+    if (listMatch) embedParams.push(`list=${listMatch[1]}`);
+    if (embedParams.length > 0) embedSrc += '?' + embedParams.join('&');
+    const platform = isShorts ? 'youtube-shorts' : 'youtube';
+    const aspectRatio = isShorts ? '177.78%' : '56.25%';
+    const maxWidth = isShorts ? '400px' : '560px';
+    return `<div class="embed-container" data-platform="${platform}" style="--aspect-ratio: ${aspectRatio}; --max-width: ${maxWidth};"><iframe src="${embedSrc}" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; picture-in-picture" style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div>`;
+}
+
+/**
+ * 본문 단독 유튜브 링크 자동 임베드 복원
+ *
+ * 배경: 구 그누보드(나리야)는 본문에 맨 유튜브 링크만 쓰면 자동으로 플레이어로
+ * 바꿔줬는데, 신규 변환기는 {video} 마커·oembed 만 처리해 옛 글 수천 개의
+ * 동영상이 링크로만 남았다 → GSC "동영상이 보기 페이지에 없음" 1,000건+.
+ *
+ * 보수적 규칙 (전 글에 적용되는 경로라 오탐 제로가 목표):
+ * - "단독 문단"만 변환: <p> 안에 공백/&nbsp;/<br> 외에 유튜브 앵커 하나만 있는 경우
+ * - 문장 속 인라인 링크는 절대 건드리지 않음
+ * - 앵커 텍스트가 URL이 아닌 제목 텍스트여도 단독 문단이면 임베드
+ * - href가 유튜브가 아니면 무변
+ */
+export function transformStandaloneYoutubeLinks(html: string): string {
+    if (!html || !html.includes('youtu')) return html;
+
+    return html.replace(
+        new RegExp(STANDALONE_ANCHOR_PARAGRAPH_SOURCE, 'gi'),
+        (match, href: string) => {
+            // 에디터가 URL 내 & 를 &amp; 로 인코딩하므로 t=/list= 판정 전에 복원
+            const url = href.replace(/&amp;/g, '&').trim();
+            const embedded = youtubeUrlToEmbedHtml(url);
+            return embedded ?? match;
+        }
+    );
+}
+
 export function transformVideos(html: string): string {
     if (!html || (!html.includes('{video') && !html.includes('{동영상'))) return html;
 
@@ -99,24 +162,9 @@ export function transformVideos(html: string): string {
 
         if (!url) return '';
 
-        // YouTube
-        const ytMatch = url.match(
-            /(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
-        );
-        if (ytMatch) {
-            const isShorts = url.includes('/shorts/');
-            let embedSrc = `https://www.youtube-nocookie.com/embed/${ytMatch[1]}`;
-            const embedParams: string[] = [];
-            const timeMatch = url.match(/[?&]t=(\d+)/);
-            if (timeMatch) embedParams.push(`start=${timeMatch[1]}`);
-            const listMatch = url.match(/[?&]list=([a-zA-Z0-9_-]+)/);
-            if (listMatch) embedParams.push(`list=${listMatch[1]}`);
-            if (embedParams.length > 0) embedSrc += '?' + embedParams.join('&');
-            const platform = isShorts ? 'youtube-shorts' : 'youtube';
-            const aspectRatio = isShorts ? '177.78%' : '56.25%';
-            const maxWidth = isShorts ? '400px' : '560px';
-            return `<div class="embed-container" data-platform="${platform}" style="--aspect-ratio: ${aspectRatio}; --max-width: ${maxWidth};"><iframe src="${embedSrc}" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; picture-in-picture" style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div>`;
-        }
+        // YouTube (공통 헬퍼 재사용)
+        const ytEmbed = youtubeUrlToEmbedHtml(url);
+        if (ytEmbed) return ytEmbed;
 
         // Vimeo
         const vimeoMatch = url.match(/vimeo\.com\/(\d+)/);


### PR DESCRIPTION
## 배경

GSC에 "동영상이 보기 페이지에 없음" 항목이 약 1,000건 누적되어 있습니다. 구 그누보드(나리야)는 본문에 맨 유튜브 링크만 적으면 자동으로 플레이어로 변환해 주었으나, 신규 프론트 변환기(`content-transform.ts`)는 `{video}` 마커·oembed·이스케이프 복원만 처리하고 순수 `<a href="유튜브">` 링크는 링크로 남겨 두어, 옛 글 수천 개의 동영상이 화면에서 사라진 상태입니다 (UX 회귀 + 동영상 색인 제외).

실례: `/free/4616449` 본문 = `<p><a target="_blank" href="https://www.youtube.com/watch?v=QSWsno8FsC4" ...>https://www.youtube.com/watch?v=QSWsno8FsC4</a></p>` → 링크로만 노출.

## 변경 내용

### 1. 공통 헬퍼 추출 — `youtubeUrlToEmbedHtml` (`content-transform.ts`)
기존 `transformVideos`의 유튜브 분기를 그대로 헬퍼로 추출해 양쪽에서 재사용합니다 (코드 중복 없음).
- watch / embed / shorts / live / youtu.be, 11자 videoId
- youtube-nocookie embed, `t=` → `start=`, `list=` 유지
- shorts 세로 비율(177.78%) + 동일한 `<div class="embed-container" data-platform=...>` 마크업

### 2. `transformStandaloneYoutubeLinks` 신설 — 보수적 패턴
전 글에 적용되는 경로라 **오탐 제로**를 목표로, "단독 문단"만 변환합니다.
- 대상: `<p>` 안에 공백/`&nbsp;`/`<br>` 외에 **유튜브 앵커 하나만** 있는 경우
- 문장 속 인라인 링크는 절대 건드리지 않습니다
- 앵커 텍스트가 URL이 아닌 제목 텍스트여도 단독 문단이면 임베드, href가 유튜브가 아니면 무변
- 빠른 종료 가드: `html.includes('youtu')` 아니면 원문 즉시 반환
- 출력에는 검증된 videoId(`[a-zA-Z0-9_-]{11}`)·숫자 start·`[\w-]` list만 삽입되어 XSS 안전

### 3. 훅 등록 (`hooks/builtin/content-video.ts`)
`post_content` 필터 priority **6** — `transformVideos`(5) 이후, auto-embed(10) 이전. 먼저 변환되므로 auto-embed와의 이중 처리도 없습니다.

### 4. SSR 구조화 데이터 연동 (`seo/json-ld.ts`)
`extractVideosFromContent`에 같은 단독 문단 앵커 규칙을 추가해 `{type:'youtube', id}`로 수집합니다.
- 판정 regex(`STANDALONE_ANCHOR_PARAGRAPH_SOURCE`, `YOUTUBE_URL_ID_PATTERN`)를 변환기와 **공유**해 렌더와 VideoObject가 항상 일치합니다
- 기존 `seen` 셋이 iframe과의 중복을 제거합니다 (테스트로 확인)

### 댓글 파이프라인 제외 사유
`comment-content.ts`는 이번 범위에서 제외했습니다. 본문 대비 노출 빈도·레이아웃 영향이 달라 blast radius를 줄이기 위함이며, 필요 시 후속 PR로 진행하겠습니다.

## 테스트

- `content-transform.test.ts` +10 케이스: 실례(/free/4616449) 임베드 / 인라인 링크 무변 / `t=90s`·`list=` 보존 / shorts 세로 비율 / 비유튜브 앵커 무변 / `&nbsp;`·`<br>` 낀 단독 문단 / live 경로 / 주변 문단 보존 / 빠른 종료 가드 / 빈·null 입력
- `meta-helper.test.ts` +3 케이스: 단독 앵커 videoId 수집 / 인라인 앵커 미수집 / iframe과 중복 제거
- 결과: **`pnpm vitest run` 49 files, 503 tests 전부 통과** (기존 케이스 포함 전량 유지)
- **`pnpm check` 0 errors** (경고는 기존 파일 기존 건)
- prettier 통과, 변경 라인 eslint 이슈 없음
