### PR TITLE
fix(pwa): static/manifest.json 아이콘 갱신 (#12988 후속)

### DIFF
--- a/apps/web/static/manifest.json
+++ b/apps/web/static/manifest.json
@@ -10,6 +10,11 @@
     "categories": ["social", "news"],
     "icons": [
         {
+            "src": "/icons/icon.svg",
+            "sizes": "any",
+            "type": "image/svg+xml"
+        },
+        {
             "src": "/icons/icon-192.png",
             "sizes": "192x192",
             "type": "image/png"
@@ -20,7 +25,7 @@
             "type": "image/png"
         },
         {
-            "src": "/icons/icon-512.png",
+            "src": "/icons/icon-maskable-512.png",
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "maskable"


### PR DESCRIPTION
## 배경
`/manifest.json` 은 `static/manifest.json`(물리 파일)이 동적 라우트 `routes/manifest.json/+server.ts` 를 **가려서** 서빙된다(응답에 Last-Modified/ETag = 정적 서빙). #1782에서 `+server.ts`만 수정해 maskable·svg 항목이 실제로 반영되지 않았다(canary 실측으로 발견).

## 변경
실제 서빙되는 `static/manifest.json` 갱신:
- `icon.svg`(any) 추가
- maskable → 전용 `icon-maskable-512.png` 연결(기존 투명 512 재사용 → 부적합했음)

## 참고
apple-touch 불투명 타일 + 크리스프 icon-192/512(=#1782 핵심)는 이미 canary 정상 확인됨. 이 PR은 PWA 설치 아이콘(maskable/svg) 보강.