### PR TITLE
fix(promotion): 프로모션 게시판 stale-while-revalidate 로 에러 제거

### DIFF
--- a/apps/web/src/lib/server/ads/promotion.ts
+++ b/apps/web/src/lib/server/ads/promotion.ts
@@ -11,9 +11,16 @@ import { getRedis } from '$lib/server/redis';
 
 const PROMOTION_CACHE_TTL_SEC = 86_400; // 24시간 (글 작성 시 무효화)
 const PROMOTION_POSTS_TIMEOUT_MS = 500;
-const PROMOTION_BOARD_TIMEOUT_MS = 1_500;
+// 백그라운드 갱신은 SSR 응답을 블로킹하지 않으므로 ads 서버의 실제 소요(수 초~십수 초)를 감당할 만큼 넉넉히.
+const PROMOTION_BOARD_BG_TIMEOUT_MS = 30_000;
+// 갱신 단일화(전 Pod) 락 TTL — 갱신 소요보다 약간 길게.
+const PROMOTION_REFRESH_LOCK_TTL_SEC = 35;
 
 const REDIS_KEY_BOARD = 'promotion:board_posts';
+// 만료 없는 마지막-정상본. fresh 미스/ads 지연 시에도 에러 대신 이걸 서빙한다.
+const REDIS_KEY_BOARD_STALE = 'promotion:board_posts:stale';
+// 전 Pod 갱신 단일화 락.
+const REDIS_KEY_BOARD_LOCK = 'promotion:board_posts:refresh_lock';
 const REDIS_KEY_POSTS = 'promotion:posts';
 
 const EMPTY_RESPONSE = { success: false, data: { posts: [] } };
@@ -43,43 +50,102 @@ interface PromotionBoardPost {
     file_count: number;
 }
 
-const EMPTY_BOARD_RESPONSE: PromotionBoardPostsResponse = {
-    success: false,
+// 빈 목록이지만 success:true — 로더가 하드 에러("게시글을 불러오는데 실패") 대신
+// 빈 게시판을 렌더하게 한다. 최초 1회(stale 부재) 외에는 거의 도달하지 않는다.
+const EMPTY_BOARD_OK: PromotionBoardPostsResponse = {
+    success: true,
     data: [],
     meta: { total: 0, advertiser_count: 0 }
 };
 
+// 같은 Pod 내 백그라운드 갱신 중복 방지 플래그.
+let refreshInFlight = false;
+
+/**
+ * ads 서버에서 최신 목록을 받아 fresh + stale 캐시에 저장.
+ * SSR 응답 경로에서 await 하지 않고 fire-and-forget 으로 호출한다(요청을 절대 블로킹하지 않음).
+ * 전 Pod 단일화를 위해 Redis 락(NX)을 사용한다.
+ */
+async function triggerBackgroundRefresh(): Promise<void> {
+    if (refreshInFlight) return;
+    refreshInFlight = true;
+    let hasLock = false;
+    try {
+        try {
+            const redis = getRedis();
+            const locked = await redis.set(
+                REDIS_KEY_BOARD_LOCK,
+                '1',
+                'EX',
+                PROMOTION_REFRESH_LOCK_TTL_SEC,
+                'NX'
+            );
+            hasLock = locked === 'OK';
+            if (!hasLock) return; // 다른 Pod가 이미 갱신 중
+        } catch {
+            // Redis 락 실패 시에도 로컬 플래그로만 단일화하고 진행
+        }
+
+        const res = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-board-posts`, {
+            signal: AbortSignal.timeout(PROMOTION_BOARD_BG_TIMEOUT_MS)
+        });
+        if (!res.ok) return;
+        const data = (await res.json()) as PromotionBoardPostsResponse;
+        if (!data?.success || !Array.isArray(data?.data)) return;
+
+        try {
+            const redis = getRedis();
+            const payload = JSON.stringify(data);
+            await redis.set(REDIS_KEY_BOARD, payload, 'EX', PROMOTION_CACHE_TTL_SEC);
+            await redis.set(REDIS_KEY_BOARD_STALE, payload); // 만료 없음: 마지막-정상본 보존
+        } catch {
+            // Redis 저장 실패 무시
+        }
+    } catch (err) {
+        console.error(
+            '[promotion] background refresh failed:',
+            err instanceof Error ? err.message : err
+        );
+    } finally {
+        refreshInFlight = false;
+        if (hasLock) {
+            try {
+                await getRedis().del(REDIS_KEY_BOARD_LOCK);
+            } catch {
+                // 락 해제 실패는 TTL로 자동 만료됨
+            }
+        }
+    }
+}
+
+/**
+ * 프로모션 게시판 목록 조회 (stale-while-revalidate).
+ * 1) fresh 캐시 히트 → 반환
+ * 2) 미스 → 백그라운드 갱신을 fire-and-forget 으로 트리거하고, SSR은 절대 ads 를 기다리지 않는다
+ * 3) stale(마지막-정상본) 즉시 반환 → ads 가 느려도 사용자는 에러 대신 직전 목록을 본다
+ * 4) stale 도 없으면(최초 1회) 빈 목록(success:true) → 하드 에러 방지
+ */
 export async function fetchPromotionBoardPosts(): Promise<PromotionBoardPostsResponse> {
     try {
         const redis = getRedis();
         const cached = await redis.get(REDIS_KEY_BOARD);
         if (cached) return JSON.parse(cached);
     } catch {
-        // Redis 실패 시 ads 서버 직접 호출
+        // Redis 실패 시 아래 stale/빈 목록 경로로 진행
     }
+
+    // fresh 미스 — 요청 경로를 블로킹하지 않고 백그라운드 갱신만 시작
+    void triggerBackgroundRefresh();
 
     try {
-        const res = await fetch(`${getAdsServerUrl()}/api/v1/serve/promotion-board-posts`, {
-            signal: AbortSignal.timeout(PROMOTION_BOARD_TIMEOUT_MS)
-        });
-        if (!res.ok) return EMPTY_BOARD_RESPONSE;
-        const data = await res.json();
-
-        try {
-            const redis = getRedis();
-            await redis.set(REDIS_KEY_BOARD, JSON.stringify(data), 'EX', PROMOTION_CACHE_TTL_SEC);
-        } catch {
-            // Redis 저장 실패 무시
-        }
-
-        return data;
-    } catch (err) {
-        console.error(
-            '[promotion] board posts fetch failed:',
-            err instanceof Error ? err.message : err
-        );
-        return EMPTY_BOARD_RESPONSE;
+        const redis = getRedis();
+        const stale = await redis.get(REDIS_KEY_BOARD_STALE);
+        if (stale) return JSON.parse(stale);
+    } catch {
+        // 무시
     }
+
+    return EMPTY_BOARD_OK;
 }
 
 export type { PromotionBoardPost, PromotionBoardPostsResponse };

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -373,8 +373,12 @@ export const load: PageServerLoad = async ({
                     return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
                 });
             } else {
-                console.error('프로모션 게시판 로딩 에러:', promoBoardResult);
-                error = '게시글을 불러오는데 실패했습니다.';
+                // fetchPromotionBoardPosts 는 stale-while-revalidate 로 항상 success:true(stale/빈 목록)를
+                // 반환하므로 여기 도달은 예외적(promise reject 등). 하드 에러 대신 빈 목록으로 우아하게 저하 —
+                // 백그라운드 갱신이 곧 캐시를 채운다.
+                console.error('프로모션 게시판 로딩 저하(빈 목록 서빙):', promoBoardResult);
+                posts = [];
+                error = null;
             }
 
             const notices = noticesResult.status === 'fulfilled' ? noticesResult.value : [];


### PR DESCRIPTION
## 증상
`/promotion` 게시판에서 **'게시글을 불러오는데 실패했습니다'** 지속 발생.

## 원인 (측정)
- ads 서버 `promotion-board-posts` 응답이 **13.7초**(광고주 홍보글 3,754건의 wr_content 32MB를 썸네일 추출용으로 전부 fetch — 실제 쓰는 건 26건)
- 웹 타임아웃 `PROMOTION_BOARD_TIMEOUT_MS=1.5초` < 13.7초 → 매 요청 중단
- 웹은 **성공해야** Redis 캐시를 채우는데 항상 타임아웃 → 캐시 영영 미충전 → 캐시 무효화(새 홍보글/TTL) 순간부터 **스탬피드 + 지속 에러**

## 수정 (웹 회복력 — 이 PR)
- `fetchPromotionBoardPosts` → **stale-while-revalidate**
  - fresh 히트 → 반환
  - 미스 → SSR은 ads 를 **기다리지 않고** 백그라운드 갱신(fire-and-forget, 30s)만 트리거 + **stale(마지막-정상본, 만료없음)** 즉시 서빙
  - stale 부재(최초 1회) → `success:true` 빈 목록 → **하드 에러 방지**
- 갱신 **단일화**: Pod 내 플래그 + 전 Pod **Redis NX 락** → 스탬피드 차단
- 로더 promo 분기: 하드 에러 대신 빈 목록으로 우아하게 저하

## 별도 (근본 성능)
ads 쿼리 13.7s→**0.64s** 재작성(윈도우 함수로 광고주별 상위 N개만 content 조회)은 **damoang-ads** repo 소관 — 검증된 패치 별도 전달(쓰기권한/다른 세션 작업 중).

## 완화
운영 Redis `promotion:board_posts` 수동 워밍으로 현재 에러는 이미 해소됨(임시).