### PR TITLE
fix(api-proxy): fp 엔드포인트를 damoang-backend 로 라우팅 (수집 0건 해결)

### DIFF
--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -15,8 +15,16 @@ import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/int
  */
 
 const BACKEND_URL = env.BACKEND_URL || 'http://localhost:8090';
+// 디바이스 지문(fp) 수집/조회 엔드포인트는 ops 백엔드(damoang-backend)에만 존재.
+// 그 외 /api/v1/* 은 angple-backend(BACKEND_URL). 미설정 시 BACKEND_URL 로 폴백(무해).
+const DAMOANG_BACKEND_URL = env.DAMOANG_BACKEND_URL || BACKEND_URL;
 const PROXY_TIMEOUT_MS = 4_000;
 const INTERNAL_ONLY_V1_PREFIXES = ['my/', 'admin/'];
+
+/** fp 수집(/api/v1/fingerprint) · fp 조회(/api/v1/admin/fingerprint/*)는 damoang-backend 로 라우팅 */
+function isFingerprintPath(path: string): boolean {
+    return path === 'fingerprint' || path.startsWith('admin/fingerprint');
+}
 
 function buildOptionalFallback(path: string): Response | null {
     if (path === 'my/favorites') {
@@ -301,7 +309,8 @@ async function proxyRequest(
 ): Promise<Response> {
     const path = params.path || '';
     const url = new URL(request.url);
-    const targetUrl = `${BACKEND_URL}/api/v1/${path}${url.search}`;
+    const backendBase = isFingerprintPath(path) ? DAMOANG_BACKEND_URL : BACKEND_URL;
+    const targetUrl = `${backendBase}/api/v1/${path}${url.search}`;
     const isInternalRequest = isInternalAppRequest(request);
 
     if (


### PR DESCRIPTION
## 증상
디바이스 지문(fp) 수집이 **0건**. 프론트·백엔드 FINGERPRINT 플래그 다 켜졌는데 `g5_da_device_fp` 비어있음.

## 원인
웹 프록시 `routes/api/v1/[...path]/+server.ts` 가 **모든 `/api/v1/*` → BACKEND_URL(angple-backend)** 로 전송. 그러나 fp 수집 엔드포인트(`POST /api/v1/fingerprint`)는 **damoang-backend(:8090)에만** 존재 → fp POST가 fp 핸들러/테이블에 안 닿음. **라우팅 브리지 부재**.

## 수정
`fingerprint`·`admin/fingerprint` 경로만 `DAMOANG_BACKEND_URL` 로 분기. 그 외는 기존대로 angple-backend.
- 미설정 시 BACKEND_URL 폴백(무해)
- damoang_jwt 쿠키는 프록시가 이미 전달 → `DamoangCookieAuth` mb_id 추출 정상

## 필요 env (별도 PR: angple-k8s)
angple-web `DAMOANG_BACKEND_URL=http://damoang-backend-svc.damoang.svc.cluster.local:8090`

## 배포 순서
1. angple-k8s env PR(DAMOANG_BACKEND_URL) apply → 2. 이 PR(웹 이미지) 배포 → 3. 실사용자 로그인 트래픽 → g5_da_device_fp 적재 확인