### PR TITLE
메모 목록 표시 확대(반응형) + 로딩 지연 개선

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -256,15 +256,14 @@
                             <!-- svelte-ignore a11y_no_static_element_interactions -->
                             <span
                                 class="memo-badge memo-color--{memo.color || 'yellow'} shrink-0"
+                                class:memo-badge--expand={uiSettingsStore.expandMemoInList}
                                 title={memo.content}
                                 onclick={(e: MouseEvent) => {
                                     e.stopPropagation();
                                     e.preventDefault();
                                 }}
                             >
-                                {memo.content.length > 6
-                                    ? memo.content.slice(0, 6) + '\u2026'
-                                    : memo.content}
+                                {memo.content}
                             </span>
                         {/if}
                     {/if}
@@ -490,6 +489,15 @@
         font-size: 0.6875rem;
         line-height: 1.25rem;
         white-space: nowrap;
+        /* 컨테이너 공간껏 동적 표시 + 넘치면 … (호버 시 title 전체) */
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: bottom;
+        max-width: 4.5rem;
+    }
+    /* 넓게 표시(기본) — 화면 폭에 반응형: 모바일 좁게 ~ 데스크톱 넓게 */
+    .memo-badge--expand {
+        max-width: clamp(6rem, 22vw, 14rem);
     }
 
     :global(.memo-color--yellow) {

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -54,6 +54,8 @@ export interface UiSettings {
     hideMemo: boolean;
     hideMemoInList: boolean;
     blurMemo: boolean;
+    /** 목록에서 메모 배지를 넓게(반응형) 표시 (기본 true) */
+    expandMemoInList: boolean;
 }
 
 const DEFAULTS: UiSettings = {
@@ -82,7 +84,8 @@ const DEFAULTS: UiSettings = {
     doubleTapInterval: 300,
     hideMemo: false,
     hideMemoInList: false,
-    blurMemo: false
+    blurMemo: false,
+    expandMemoInList: true
 };
 
 const LINE_HEIGHT_VALUES: Record<LineHeight, string> = {
@@ -450,6 +453,10 @@ function createUiSettingsStore() {
         },
         setBlurMemo(v: boolean) {
             settings.blurMemo = v;
+            save();
+        },
+        setExpandMemoInList(v: boolean) {
+            settings.expandMemoInList = v;
             save();
         },
 

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -401,6 +401,9 @@ function createUiSettingsStore() {
         get blurMemo() {
             return settings.blurMemo;
         },
+        get expandMemoInList() {
+            return settings.expandMemoInList;
+        },
 
         setTitleBold(v: boolean) {
             settings.titleBold = v;

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -431,12 +431,14 @@
             void loadBoardListMemos(uniqueAuthorIds);
         };
 
+        // 초기 렌더 비블로킹은 유지하되, 지연 상한을 짧게(300ms) 잡아
+        // 바쁜 페이지에서 idle 이 늦게 와 메모가 뒤늦게 뜨는 현상 방지.
         if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
-            memoScheduleToken = window.requestIdleCallback(loadTask, { timeout: 1500 });
+            memoScheduleToken = window.requestIdleCallback(loadTask, { timeout: 300 });
             return;
         }
 
-        memoScheduleToken = globalThis.setTimeout(loadTask, 250);
+        memoScheduleToken = globalThis.setTimeout(loadTask, 100);
     }
 
     onMount(() => {

--- a/apps/web/src/routes/api/my/ui-settings/+server.ts
+++ b/apps/web/src/routes/api/my/ui-settings/+server.ts
@@ -44,7 +44,8 @@ const ALLOWED_KEYS = new Set<string>([
     'pinMemoSearch',
     'hideMemo',
     'hideMemoInList',
-    'blurMemo'
+    'blurMemo',
+    'expandMemoInList'
 ]);
 
 /** 남용 방어 상한 */

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -1382,6 +1382,19 @@
                             onCheckedChange={(v) => uiSettingsStore.setBlurMemo(v)}
                         />
                     </div>
+                    <Separator />
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <Label>목록 메모 배지 넓게 표시</Label>
+                            <p class="text-muted-foreground text-xs">
+                                게시판 목록에서 메모를 화면 폭에 맞춰 넓게 보여줍니다 (끄면 좁게)
+                            </p>
+                        </div>
+                        <Switch
+                            checked={uiSettingsStore.expandMemoInList}
+                            onCheckedChange={(v) => uiSettingsStore.setExpandMemoInList(v)}
+                        />
+                    </div>
                 </CardContent>
             </Card>
         {/if}


### PR DESCRIPTION
## 배경
- **#13002**: 게시판 목록에서 메모가 **6자로 고정 잘려** 한눈에 안 보임 → 넓게 표시 요청
- **간헐 로딩 지연**(사용자 관측): 메모 배지가 뒤늦게 뜸

## 변경
1. **목록 메모 배지 동적 표시**: `slice(0,6)` 고정 truncate 폐기 → CSS 반응형(`max-width` + `text-overflow:ellipsis`). 컨테이너 폭껏 표시, 넘치면 …, **호버 시 전체(title)**
2. **UiSettings `expandMemoInList` 토글**(기본 **on**=넓게) — 설정 UI 스위치 + localStorage + 서버(`ALLOWED_KEYS`) 동기화. 끄면 좁게(≈기존)
3. **로딩 지연 개선**: 메모 배치 fetch `requestIdleCallback` 상한 **1500ms→300ms** (초기 렌더 비블로킹 유지, 바쁜 페이지에서 idle 지연으로 늦게 뜨던 문제 완화)

## 범위 밖
- 메모 로딩 SSR 이관: 고트래픽에선 요청마다 서버부하↑(개인화라 CDN 캐시 불가) → 비블로킹 클라 유지가 모범사례, 이번 스코프 밖
- card/상세 슬롯의 메모 배지 확대 = **프리미엄 repo 별도 PR**(angple-premium#, 동시 반영)

## 검증 체크리스트
- [ ] classic 목록: 기본(토글 on) 메모 넓게, off 시 좁게
- [ ] 설정 UI 토글 노출·동작·persist(로컬+서버)
- [ ] 호버 전체표시·색상 배지 무손상
- [ ] 비로그인/메모없음/플러그인 비활성 시 정상
- [ ] 로딩 비블로킹 유지, 중복요청 가드 유지
- [ ] `pnpm check` 통과