### PR TITLE
본문 이미지 사이징 근본 수정 — 렌더 시점 크기 추측 제거 (#13007)

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -334,43 +334,9 @@
         });
     });
 
-    // 세로(portrait) 본문 이미지를 본문 너비에 맞춰 채움.
-    // max-w-full(=max-width:100%)은 상한만 지정하므로 자연 너비가 좁은 세로 이미지가
-    // 작게 표시되어 가독성이 떨어진다. 로드 후 naturalHeight>naturalWidth면 width:100%를 적용한다.
-    // (가로/정사각 이미지는 영향 없음. 자연 너비가 본문보다 큰 세로 이미지는 어차피 100%라 동일.)
-    $effect(() => {
-        void renderedHtml;
-        if (!browser || !proseEl) return;
-        tick().then(() => {
-            const imgs = proseEl.querySelectorAll<HTMLImageElement>(
-                'img:not(.emoticon-inline):not([src*="/emoticons/"])'
-            );
-            imgs.forEach((img) => {
-                const applyOrientation = () => {
-                    if (img.naturalWidth === 0) return;
-                    const isPortrait = img.naturalHeight > img.naturalWidth;
-                    img.classList.toggle('dm-portrait-fill', isPortrait);
-                    // 가로 이미지가 본문 폭에 근접(자연폭 ≥ 컨테이너 60%)하면 본문 폭에 맞춰 채운다.
-                    // "거의 꽉 찼는데 안 채워지는" 애매한 이미지를 잡되, 명확히 작은 이미지
-                    // (이모지·로고·썸네일, 대개 50% 미만)는 그대로 자연 크기 유지(#12895).
-                    // 컨테이너보다 크거나 같은 이미지는 상위 max-width:100% 가 처리하므로 제외.
-                    const parentW = img.parentElement?.offsetWidth ?? 0;
-                    img.classList.toggle(
-                        'dm-landscape-fill',
-                        !isPortrait &&
-                            parentW > 0 &&
-                            img.naturalWidth >= parentW * 0.6 &&
-                            img.naturalWidth < parentW
-                    );
-                };
-                if (img.complete && img.naturalWidth > 0) {
-                    applyOrientation();
-                } else {
-                    img.addEventListener('load', applyOrientation, { once: true });
-                }
-            });
-        });
-    });
+    // 본문 이미지 표시 크기는 저장된 HTML(작성 시점 리사이즈로 지정된 width)만 존중한다.
+    // 렌더 시점에 이미지 치수로 의도를 추측(세로→전폭 등)하지 않으며, 원본보다 크게 늘리지 않는다.
+    // 크기 미지정 = 자연 크기 + 상위 .prose img 의 max-width:100% 상한. (근본 설계: content-image-sizing-architecture)
 </script>
 
 <!--
@@ -389,14 +355,8 @@
 </div>
 
 <style>
-    /* 세로 이미지: 본문 너비 100%로 채움 (좁은 세로 스크린샷이 작게 보이는 문제 해결) */
-    .prose :global(img.dm-portrait-fill) {
-        width: 100%;
-        height: auto;
-    }
-
-    /* 가로 이미지 중 본문 폭에 근접한 것(자연폭 ≥ 컨테이너 60%)만 채움. 로드 후 JS 판정. */
-    .prose :global(img.dm-landscape-fill) {
+    /* 작성자가 명시적으로 '본문 폭 맞춤'을 지정한 이미지만 전폭. (렌더 시점 추측 없음) */
+    .prose :global(img.dm-fit-width) {
         width: 100%;
         height: auto;
     }
@@ -519,9 +479,8 @@
     }
 
     /* 백엔드 썸네일 변환된 이미지: 블록 레이아웃만 지정.
-       가로 폭 강제(width:100%)는 제거 — 작은/가로 이미지가 컨테이너 폭까지 확대되던 문제(#12895).
-       세로 이미지 채움은 로드 후 orientation 판정으로 .dm-portrait-fill 이 담당(#1645).
-       가로 상한은 상위 .prose img 규칙의 max-width:100% 로 유지. */
+       가로 폭 강제(width:100%)는 제거 — 작은/세로 이미지가 컨테이너 폭까지 확대(업스케일)되던 문제(#12895·#13007).
+       표시 크기는 저장된 width(작성 시 리사이즈)만 존중, 상한은 상위 .prose img 의 max-width:100% 로 유지. */
     .prose :global(img[data-original]) {
         display: block;
     }


### PR DESCRIPTION
## 배경 — 반복 재발(#12858 → #12895 → #13007)
본문 이미지가 '마음대로 가로 꽉 채워진다'는 제보가 3회 반복. 근본 원인은 **렌더 시점에 이미지 픽셀 치수로 작성자 의도를 추측**하던 휴리스틱 누적:
- `dm-portrait-fill`(#1645): 세로 이미지(h>w)면 무조건 `width:100%` → **작은 세로 이미지까지 업스케일**
- `dm-landscape-fill`(#1721): 가로 60%+면 전폭

제보자 실이미지 400×870·300×318 = 둘 다 세로 → 강제 전폭(왜곡). 400×870이 '확대 원하는 긴 스샷'인지 '원본 유지할 그래픽'인지는 **픽셀로 구분 불가** → 무한 두더지잡기.

## 설계 원칙 (근본)
> 크기는 **작성 시점에 저장**, 렌더는 **저장된 것만 존중**, **추측 안 함**, **업스케일 안 함**.

전체 아키텍처: `docs/content-image-sizing-architecture.html`

## 변경 (Phase 1)
- ❌ `dm-portrait-fill`/`dm-landscape-fill` `$effect`(치수 측정+클래스 토글) **제거**
- ❌ 관련 CSS 2개 제거 → `.prose img { max-width:100% }` **단일 규칙**(상한만, 업스케일 없음)
- ✅ 명시적 전폭 의도용 `.prose img.dm-fit-width` **옵트인 규칙 추가**(Phase 2 UI 대비)
- 렌더 순수·결정적 → CLS·깜빡임 감소, 제보 한 부류 영구 소멸

## 효과
- 제보자 세로 이미지 → **원본 크기**로 표시(전폭 아님). 큰 이미지는 여전히 `max-width:100%`로 전폭. 비디오/iframe 임베드 무영향.
- **비파괴**: 레거시 소급 마이그레이션 불필요(대부분 크기 미지정 → 자연 크기).

## ⚠️ Phase 2 필수 (별도 PR)
현재 에디터엔 **이미지 리사이즈 핸들이 없음**(`resizable:true`는 Table 전용). '세로 스샷을 크게 보고 싶던' 사용자층(#1645) 확대 수단 부재 → **이미지 리사이즈/‘본문 폭 맞춤’(`dm-fit-width`) 버튼 추가 필요**. (당장은 클릭 라이트박스로 확대 가능)

## 검증 체크리스트
- [ ] 카나리: 400×870·300×318 세로 이미지 원본 크기 렌더(전폭 아님)
- [ ] 큰 이미지 전폭 유지 / `dm-fit-width` 이미지 전폭
- [ ] 모바일 오버플로우 없음 / 비디오·유튜브 회귀 없음
- [ ] DOM에 `dm-portrait-fill`/`dm-landscape-fill` 미출현
- [ ] `pnpm check` 통과