### PR TITLE
에디터 이미지 크기 컨트롤 — 본문 폭 맞춤/원본 (Phase 2)

### DIFF
--- a/apps/web/src/lib/components/features/editor/linked-image.ts
+++ b/apps/web/src/lib/components/features/editor/linked-image.ts
@@ -15,7 +15,15 @@ export const LinkedImage = Image.extend({
             // 이미지를 감싸는 <a> 태그의 href
             href: { default: null },
             // <a> 태그의 target 속성
-            linkTarget: { default: null }
+            linkTarget: { default: null },
+            // 작성자가 '본문 폭 맞춤'을 명시적으로 선택했는지. class="dm-fit-width" 로 저장·복원.
+            // (렌더 시점 추측 없이, 저장된 의도만 존중 — content-image-sizing-architecture)
+            fitWidth: {
+                default: false,
+                parseHTML: (el: HTMLElement) => el.classList?.contains('dm-fit-width') ?? false,
+                renderHTML: (attrs: { fitWidth?: boolean }) =>
+                    attrs.fitWidth ? { class: 'dm-fit-width' } : {}
+            }
         };
     },
 

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -155,7 +155,9 @@
         orderedList: false,
         blockquote: false,
         codeBlock: false,
-        link: false
+        link: false,
+        image: false,
+        imageFitWidth: false
     });
 
     let canUndo = $state(false);
@@ -212,7 +214,9 @@
             orderedList: e.isActive('orderedList'),
             blockquote: e.isActive('blockquote'),
             codeBlock: e.isActive('codeBlock'),
-            link: e.isActive('link')
+            link: e.isActive('link'),
+            image: e.isActive('image'),
+            imageFitWidth: e.getAttributes('image').fitWidth === true
         };
         const undo = e.can().undo();
         const redo = e.can().redo();
@@ -795,6 +799,21 @@
         editor?.chain().focus().updateAttributes('image', { href: null, linkTarget: null }).run();
         showImageLinkDialog = false;
         imageLinkUrl = '';
+    }
+
+    // 이미지 크기: '본문 폭 맞춤'(dm-fit-width) 토글 / '원본 크기'(width·fitWidth 해제)
+    function toggleImageFitWidth(): void {
+        if (!editor) return;
+        const current = editor.getAttributes('image').fitWidth === true;
+        editor.chain().focus().updateAttributes('image', { fitWidth: !current }).run();
+    }
+
+    function resetImageSize(): void {
+        editor
+            ?.chain()
+            .focus()
+            .updateAttributes('image', { fitWidth: false, width: null, height: null })
+            .run();
     }
 
     // 이미지 삽입
@@ -1397,6 +1416,33 @@
             >
                 <ImageIcon class="h-4 w-4" />
             </Button>
+            {#if isActive.image}
+                <!-- 이미지 선택 시에만: 크기 컨트롤 (저장된 의도만 존중, 렌더 추측 없음) -->
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onclick={toggleImageFitWidth}
+                    {disabled}
+                    class="h-8 whitespace-nowrap px-2 text-xs {getButtonClass(
+                        isActive.imageFitWidth
+                    )}"
+                    title="이미지를 본문 폭에 맞춰 채웁니다"
+                >
+                    ↔ 본문 폭
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onclick={resetImageSize}
+                    {disabled}
+                    class="h-8 whitespace-nowrap px-2 text-xs"
+                    title="이미지를 원본 크기로 되돌립니다"
+                >
+                    원본
+                </Button>
+            {/if}
             <Button
                 type="button"
                 variant="ghost"
@@ -1904,11 +1950,16 @@
         margin: 1.5rem 0;
     }
 
-    /* 이미지 스타일 */
+    /* 이미지 스타일 — 기본은 원본 크기 + 컨테이너 상한(업스케일 없음, 뷰 prose 와 동일) */
     :global(.tiptap-content .tiptap img) {
         max-width: 100%;
         height: auto;
         margin: 0.75rem 0;
+    }
+
+    /* 작성자가 '본문 폭 맞춤'을 선택한 이미지만 전폭 (뷰의 .prose img.dm-fit-width 와 일치) */
+    :global(.tiptap-content .tiptap img.dm-fit-width) {
+        width: 100%;
     }
 
     /* 이미지 링크 표시 (에디터 내 링크 있는 이미지) */


### PR DESCRIPTION
## 배경
Phase 1(#1788)이 렌더 시점 '이미지 크기로 의도 추측'(dm-portrait/landscape-fill)을 제거해 **기본은 원본 크기**가 됐습니다. 이제 **작성자가 크기를 직접 지정**하는 수단을 추가해 설계를 완성합니다. (설계: `docs/content-image-sizing-architecture.html`)

→ 이걸로 '세로 스샷을 크게 보고 싶던' 사용자(#1645)도 명시적으로 넓힐 수 있어, 자동확대 폐지로 인한 새 제보 위험을 막습니다.

## 변경
- **LinkedImage**: `fitWidth` 속성 추가 — `class="dm-fit-width"`로 저장·복원(parseHTML/renderHTML). 명시 의도만 HTML에 남김
- **툴바**: 이미지 선택 시 `↔ 본문 폭`(토글)·`원본` 버튼 노출. 무의존, 단일 `flex-wrap` 툴바라 **모바일도 동일 동작**
- **에디터 CSS**: `.tiptap img.dm-fit-width{width:100%}` — 뷰의 `.prose img.dm-fit-width`(Phase 1 배포됨)와 일치 = WYSIWYG

## 동작
- 기본 삽입 = 원본 크기(추측 없음)
- 이미지 선택 → **↔ 본문 폭** = 전폭(`dm-fit-width` 저장 → 뷰에서 `width:100%`)
- **원본** = fitWidth 해제 → 원본 크기 복귀
- 저장 HTML은 명시 의도(class)만. 렌더는 그대로 존중(추측 없음)

## 검증 체크리스트
- [ ] 이미지 선택 시에만 크기 버튼 노출, 토글 active 표시 정상
- [ ] '본문 폭' → 저장 HTML에 `class="dm-fit-width"`, 뷰에서 전폭
- [ ] '원본' → 클래스 제거, 원본 크기
- [ ] 링크 이미지(`<a><img>`)에도 정상 적용
- [ ] 모바일 툴바(wrap)에서 동일 동작
- [ ] `pnpm check` 통과