### PR TITLE
메모 내용 흐리게(blurMemo) 목록 배지 미적용 수정 (#13010)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -257,6 +257,7 @@
                             <span
                                 class="memo-badge memo-color--{memo.color || 'yellow'} shrink-0"
                                 class:memo-badge--expand={uiSettingsStore.expandMemoInList}
+                                class:memo-badge--blur={uiSettingsStore.blurMemo}
                                 title={memo.content}
                                 onclick={(e: MouseEvent) => {
                                     e.stopPropagation();
@@ -498,6 +499,14 @@
     /* 넓게 표시(기본) — 화면 폭에 반응형: 모바일 좁게 ~ 데스크톱 넓게 */
     .memo-badge--expand {
         max-width: clamp(6rem, 22vw, 14rem);
+    }
+    /* 메모 내용 흐리게(호버 시 원래대로) — UI설정 blurMemo (#13010) */
+    .memo-badge--blur {
+        filter: blur(4px);
+        transition: filter 0.15s;
+    }
+    .memo-badge--blur:hover {
+        filter: none;
     }
 
     :global(.memo-color--yellow) {


### PR DESCRIPTION
## 배경 (#13010, 에스까르고)
UI설정 '메모 내용 흐리게'를 켜도 적용되지 않음(Firefox 152 데스크톱). '배지 가리기'는 정상.

## 원인
`blurMemo`는 여러 곳에서 `<MemoBadge blur={...}/>`로 전달되지만 **MemoBadge에 blur 미구현**(→별도 premium PR). 그리고 **게시판 목록(classic.svelte) 인라인 배지는 blur를 아예 적용 안 함**(hideMemoInList만 체크).

## 변경 (core 목록)
- classic.svelte 메모 배지에 `class:memo-badge--blur={uiSettingsStore.blurMemo}` + CSS `filter:blur(4px)`, 호버 시 `filter:none`(설정 설명 '호버 시 표시'와 일치)

## 동반
- **premium PR**(MemoBadge blur 구현) — 상세·댓글·회원·공감자 전반. 함께 배포
- Phase 2(#1789)와 배포 묶음

## 검증
- [ ] blurMemo on → 목록 메모 흐림, 호버 시 선명
- [ ] off → 정상 / hideMemoInList와 독립 동작