### PR TITLE
fp 수집기 발화 안 되던 문제 — onMount→$effect 이관

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -268,6 +268,17 @@
         loadPluginLib('member-memo', 'memo-store').catch(() => {});
     });
 
+    // 디바이스 핑거프린트 수집(로그인 1회, 수집기 내부 1일 throttle). 위와 동일 사유로
+    // onMount 시점엔 auth 미하이드레이션(isAuthenticated=false)이라 스킵되므로, $effect 로
+    // 로그인 확정 시점에 1회 발화한다. (기존 onMount 호출은 사실상 미발화 = fp 0건 원인)
+    let fpReported = false;
+    $effect(() => {
+        if (fpReported) return;
+        if (!browser || !authStore.isAuthenticated) return;
+        fpReported = true;
+        void collectAndReportFingerprint();
+    });
+
     // 메뉴 데이터 변경 시 키보드 단축키 빌드 (모듈 로드 후 활성화)
     $effect(() => {
         if (!keyboardShortcutsMod) return;
@@ -541,9 +552,8 @@
     });
 
     onMount(() => {
-        // 디바이스 핑거프린트 수집 (로그인 사용자 한정, 1일 1회 throttle).
-        // 기본 비활성 — PUBLIC_FINGERPRINT_ENABLED=true + 처리방침 공시·법률검토 후에만 동작.
-        if (browser && authStore.isAuthenticated) void collectAndReportFingerprint();
+        // 디바이스 핑거프린트 수집은 상단 $effect(로그인 확정 후 발화)로 이관.
+        // (onMount 는 auth 하이드레이션 전이라 isAuthenticated=false → 스킵되던 문제)
 
         // 로그인 회원 서버 read-set(L2, Redis) 병합 — 크로스기기 읽음 표시.
         // localStorage(L1)에 없는 항목만 추가(기존 로컬 timestamp 보존).


### PR DESCRIPTION
## 증상
디바이스 핑거프린트(fp)가 **한 번도 수집 안 됨**: `g5_da_device_fp` 0행, damoang-backend 최근 6h fingerprint 요청 **0건**(실측).

## 오진 배제 (실증)
- 플래그 정상: 파드 `PUBLIC_FINGERPRINT_ENABLED=true`, **SSR이 클라에 `"PUBLIC_FINGERPRINT_ENABLED":"true"` 주입**(`$env/dynamic/public`, adapterNode, prerender=false) → 빌드타임 고정/함정 아님
- 프록시 정상: `isFingerprintPath`→`DAMOANG_BACKEND_URL`(#1786) 배포됨, 파드 env 설정됨, Cookie 헤더 전달됨
- 백엔드 정상: damoang-backend fp 라우트 존재(무인증 POST→401), 파드 Running

## 진짜 원인
fp 수집이 **`onMount` 안에서 `authStore.isAuthenticated` 게이트**로 호출됨. 그러나 **onMount 시점엔 auth 하이드레이션 전이라 isAuthenticated=false → 항상 스킵**. 코드베이스 자체 주석(`memoChunksPrefetched` $effect)도 "onMount 로는 프리로드 시점에 isAuthenticated 가 아직 false → 스킵된다"며 $effect 패턴을 쓰는데, **fp만 onMount에 남아 있었음**.

## 수정
- fp 수집 호출을 `onMount` → **`$effect`(로그인 확정 시 1회 발화, `fpReported` 가드)** 로 이관. 기존 `memoChunksPrefetched` $effect와 동일 패턴
- 수집기 내부 24h throttle·SSR 가드·COLLECTION_ENABLED 유지

## 검증(배포 후)
- [ ] 카나리 로그인 → `POST /api/v1/fingerprint` 발생, `g5_da_device_fp` 신규 행
- [ ] 24h 재발화 억제(throttle) 동작
- [ ] 비로그인 미발화

## 참고 (별도)
같은 onMount의 `read-posts`(550)·`blocked-users`(566)도 동일 게이트 → 동일 레이스 가능성. 이번 스코프 밖, 후속 점검 권장.