### PR TITLE
메모 색상 이름표 커스텀 (#13013)

### DIFF
--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -56,6 +56,8 @@ export interface UiSettings {
     blurMemo: boolean;
     /** 목록에서 메모 배지를 넓게(반응형) 표시 (기본 true) */
     expandMemoInList: boolean;
+    /** 메모 색상별 사용자 지정 이름표 (color→label). 빈 값은 기본 이름 사용 (#13013) */
+    memoColorLabels: Record<string, string>;
 }
 
 const DEFAULTS: UiSettings = {
@@ -85,7 +87,8 @@ const DEFAULTS: UiSettings = {
     hideMemo: false,
     hideMemoInList: false,
     blurMemo: false,
-    expandMemoInList: true
+    expandMemoInList: true,
+    memoColorLabels: {}
 };
 
 const LINE_HEIGHT_VALUES: Record<LineHeight, string> = {
@@ -404,6 +407,9 @@ function createUiSettingsStore() {
         get expandMemoInList() {
             return settings.expandMemoInList;
         },
+        get memoColorLabels() {
+            return settings.memoColorLabels;
+        },
 
         setTitleBold(v: boolean) {
             settings.titleBold = v;
@@ -460,6 +466,15 @@ function createUiSettingsStore() {
         },
         setExpandMemoInList(v: boolean) {
             settings.expandMemoInList = v;
+            save();
+        },
+        /** 색상 이름표 설정. 빈 문자열이면 해당 색상 라벨 제거(기본 이름 사용). */
+        setMemoColorLabel(color: string, label: string) {
+            const trimmed = label.trim().slice(0, 10);
+            const next = { ...settings.memoColorLabels };
+            if (trimmed) next[color] = trimmed;
+            else delete next[color];
+            settings.memoColorLabels = next;
             save();
         },
 

--- a/apps/web/src/routes/api/my/ui-settings/+server.ts
+++ b/apps/web/src/routes/api/my/ui-settings/+server.ts
@@ -45,7 +45,8 @@ const ALLOWED_KEYS = new Set<string>([
     'hideMemo',
     'hideMemoInList',
     'blurMemo',
-    'expandMemoInList'
+    'expandMemoInList',
+    'memoColorLabels'
 ]);
 
 /** 남용 방어 상한 */

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -62,6 +62,14 @@
 
     type Tab = 'layout' | 'board' | 'shortcut' | 'notification' | 'etc';
     const validTabs: Tab[] = ['layout', 'board', 'shortcut', 'notification', 'etc'];
+    // 메모 색상 이름표(#13013) — 색상은 고정, 이름만 사용자 지정. premium 미의존(로컬 정의).
+    const MEMO_COLORS: { key: string; name: string; bg: string }[] = [
+        { key: 'yellow', name: '노랑', bg: '#ffe69c' },
+        { key: 'green', name: '초록', bg: '#d1e7dd' },
+        { key: 'purple', name: '보라', bg: '#e2d9f3' },
+        { key: 'red', name: '빨강', bg: '#f8d7da' },
+        { key: 'blue', name: '파랑', bg: '#cfe2ff' }
+    ];
     const urlTab = $derived($page.url.searchParams.get('tab'));
     let activeTab = $state<Tab>('layout');
 
@@ -1394,6 +1402,35 @@
                             checked={uiSettingsStore.expandMemoInList}
                             onCheckedChange={(v) => uiSettingsStore.setExpandMemoInList(v)}
                         />
+                    </div>
+                    <Separator />
+                    <div>
+                        <Label>메모 색상 이름표</Label>
+                        <p class="text-muted-foreground text-xs">
+                            색상마다 나만의 이름을 붙여 메모 작성 시 헷갈리지 않게 합니다 (비우면
+                            기본 이름)
+                        </p>
+                        <div class="mt-3 space-y-2">
+                            {#each MEMO_COLORS as c (c.key)}
+                                <div class="flex items-center gap-2">
+                                    <span
+                                        class="inline-block h-5 w-5 shrink-0 rounded-full border"
+                                        style="background-color: {c.bg}"
+                                    ></span>
+                                    <Input
+                                        value={uiSettingsStore.memoColorLabels[c.key] ?? ''}
+                                        placeholder={c.name}
+                                        maxlength={10}
+                                        class="h-8"
+                                        onchange={(e) =>
+                                            uiSettingsStore.setMemoColorLabel(
+                                                c.key,
+                                                e.currentTarget.value
+                                            )}
+                                    />
+                                </div>
+                            {/each}
+                        </div>
                     </div>
                 </CardContent>
             </Card>


### PR DESCRIPTION
## 배경 (#13013, 코파니코피나)
메모 시 5색 중 선택하는데 색상별 개인 규칙(빨강=차단대상 등)을 자꾸 까먹어 색 선택이 중구난방 → **색상마다 나만의 이름표**.

## 변경 (core)
- `UiSettings.memoColorLabels: Record<color,string>`(기본 {}) + getter + `setMemoColorLabel(color,label)`(trim·10자·빈값 제거) + 서버 `ALLOWED_KEYS` → 크로스기기 동기화
- 설정 UI 메모 카드에 **'메모 색상 이름표'** 5색 입력(스와치 + placeholder=기본이름)
- 색상 값(color) 자체 불변 — **이름만** 커스텀. 기존 메모 무영향

## 동반
- **premium PR**(memo-inline-editor 선택기가 커스텀 라벨 표시) + 배포 배치

## 검증
- [ ] 설정서 색상 이름 입력·저장·persist(로컬+서버)
- [ ] 미설정 색은 기본 이름 / 빈값 저장 시 기본 복귀
- [ ] 10자 상한, 크로스기기 반영