### PR TITLE
게시글 수정 배지 표시 결함 수정 (리비전 기반)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -45,6 +45,8 @@ export interface FreePost {
     comments_count: number;
     created_at: string;
     updated_at?: string;
+    edit_count?: number; // 실제 수정 횟수 (change_type='update' 리비전, 백엔드 주입)
+    last_edited_at?: string; // 최종 수정 시각 (리비전 기반, 백엔드 주입)
     has_file?: boolean;
     has_video?: boolean;
     has_image?: boolean;

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -295,22 +295,16 @@
                         </p>
                         <p class="text-secondary-foreground" style="font-size: 0.9em;">
                             {formatDate(post.created_at)}
-                            {#if post.updated_at && post.updated_at !== post.created_at && formatTimeShort && new Date(post.updated_at).getTime() - new Date(post.created_at).getTime() > 5 * 60 * 1000}
-                                {#if editCount > 0}
-                                    <span class="text-muted-foreground/70"
-                                        >· 수정 {editCount}회({formatTimeShort(
-                                            post.updated_at,
-                                            post.created_at
-                                        )})</span
-                                    >
-                                {:else}
-                                    <span class="text-muted-foreground/70"
-                                        >· 수정됨({formatTimeShort(
-                                            post.updated_at,
-                                            post.created_at
-                                        )})</span
-                                    >
-                                {/if}
+                            <!-- 수정 배지: 리비전 기반 edit_count/last_edited_at (백엔드 주입) 사용.
+                                 게시글 수정 시 wr_last 미갱신이라 post.updated_at 대신 이 값을 쓴다.
+                                 5분 grace: 작성 직후(<5분) 수정은 숨김(댓글과 일관). -->
+                            {#if post.edit_count && post.edit_count > 0 && post.last_edited_at && formatTimeShort && new Date(post.last_edited_at).getTime() - new Date(post.created_at).getTime() > 5 * 60 * 1000}
+                                <span class="text-muted-foreground/70"
+                                    >· 수정 {post.edit_count}회({formatTimeShort(
+                                        post.last_edited_at,
+                                        post.created_at
+                                    )})</span
+                                >
                             {/if}
                             {#if post.deleted_at && formatTimeShort}
                                 <span class="text-red-500/70"

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -361,22 +361,15 @@
                     </p>
                     <p class="text-secondary-foreground" style="font-size: 0.9em;">
                         {formatDate(post.created_at)}
-                        {#if post.updated_at && post.updated_at !== post.created_at && formatTimeShort && new Date(post.updated_at).getTime() - new Date(post.created_at).getTime() > 5 * 60 * 1000}
-                            {#if editCount > 0}
-                                <span class="text-muted-foreground/70"
-                                    >· 수정 {editCount}회({formatTimeShort(
-                                        post.updated_at,
-                                        post.created_at
-                                    )})</span
-                                >
-                            {:else}
-                                <span class="text-muted-foreground/70"
-                                    >· 수정됨({formatTimeShort(
-                                        post.updated_at,
-                                        post.created_at
-                                    )})</span
-                                >
-                            {/if}
+                        <!-- 수정 배지: 리비전 기반 edit_count/last_edited_at(백엔드 주입). 게시글은
+                             wr_last 미갱신이라 post.updated_at 대신 사용. 5분 grace 유지. -->
+                        {#if post.edit_count && post.edit_count > 0 && post.last_edited_at && formatTimeShort && new Date(post.last_edited_at).getTime() - new Date(post.created_at).getTime() > 5 * 60 * 1000}
+                            <span class="text-muted-foreground/70"
+                                >· 수정 {post.edit_count}회({formatTimeShort(
+                                    post.last_edited_at,
+                                    post.created_at
+                                )})</span
+                            >
                         {/if}
                         {#if post.deleted_at && formatTimeShort}
                             <span class="text-red-500/70"


### PR DESCRIPTION
## 배경
게시글 수정 배지가 `post.updated_at`(=wr_last, **게시글 수정 시 미갱신**)에 게이팅돼 리비전 데이터가 있어도 **안 뜸**. (댓글은 wr_last 갱신되어 정상)

## 변경
- `layouts/view/basic.svelte`·`report.svelte`: 배지를 백엔드가 주입하는 `post.edit_count`/`post.last_edited_at`(update 기준, 이미 타입 존재) 기반으로 전환. `post.updated_at` 의존 제거.
- '수정됨'(count 없음) 브랜치 제거 → edit_count>0 보장이므로 항상 '수정 N회 (시각)'. 5분 grace 유지(작성 직후 수정 숨김).
- 댓글 프론트 무변경(백엔드 count 필터만으로 정확).

## 동반
- 백엔드 PR(damoang/angple-backend) 필수 동반(post.edit_count/last_edited_at 주입). 백엔드 먼저 배포 권장.

## 검증
- 수정한 글 상세 '수정 N회 (시각)' 표시(현재 미표시), 미수정 글 미표시. 카나리 실측.
- 관리자 리비전 이력/복원 UI 무영향.