### PR TITLE
쪽지 게이트 mb_level 5+ 예외 (canSendMessage)

### DIFF
--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -12,7 +12,7 @@
     import Ban from '@lucide/svelte/icons/ban';
     import UserPlus from '@lucide/svelte/icons/user-plus';
     import UserMinus from '@lucide/svelte/icons/user-minus';
-    import { canUseCertifiedAction, goToCertification } from '$lib/utils/certification-gate.js';
+    import { canSendMessage, goToCertification } from '$lib/utils/certification-gate.js';
     import type { Snippet } from 'svelte';
 
     interface Props {
@@ -123,7 +123,7 @@
             authStore.redirectToLogin();
             return;
         }
-        if (!canUseCertifiedAction(authStore.user, null)) {
+        if (!canSendMessage(authStore.user)) {
             goToCertification();
             return;
         }
@@ -257,9 +257,7 @@
                     <DropdownMenu.Item
                         class="cursor-pointer gap-2"
                         onclick={handleMessage}
-                        title={!canUseCertifiedAction(authStore.user, null)
-                            ? '실명인증'
-                            : undefined}
+                        title={!canSendMessage(authStore.user) ? '실명인증' : undefined}
                     >
                         <Mail class="h-3.5 w-3.5" />
                         쪽지 보내기

--- a/apps/web/src/lib/utils/certification-gate.ts
+++ b/apps/web/src/lib/utils/certification-gate.ts
@@ -19,6 +19,17 @@ export function canUseCertifiedAction(
     return isCertificationExemptBoard(boardId) || isCertifiedUser(user);
 }
 
+/**
+ * 쪽지 발송 가능 여부 — 실명인증(mb_certify) 또는 mb_level 5+ (유료 광고주 등급·관리자).
+ * mb_level(등급, XP as_level 아님)=5 는 결제 기간에만 부여되므로 강등 시 권한 자동 소멸.
+ * 쪽지 전용 게이트 — 글쓰기·댓글 등 다른 실명 행위엔 canUseCertifiedAction 을 그대로 쓴다.
+ */
+export function canSendMessage(
+    user: { mb_certify?: string | null; mb_level?: number } | null | undefined
+): boolean {
+    return isCertifiedUser(user) || (user?.mb_level ?? 0) >= 5;
+}
+
 export function getCertificationBlockedMessage(boardId?: string | null): string {
     if (isCertificationExemptBoard(boardId)) {
         return '';

--- a/apps/web/src/routes/messages/+page.svelte
+++ b/apps/web/src/routes/messages/+page.svelte
@@ -21,7 +21,7 @@
     import User from '@lucide/svelte/icons/user';
     import ArrowLeft from '@lucide/svelte/icons/arrow-left';
     import {
-        canUseCertifiedAction,
+        canSendMessage,
         getCertificationBlockedMessage,
         goToCertification
     } from '$lib/utils/certification-gate.js';
@@ -161,7 +161,7 @@
 
     // 쪽지 보내기
     async function handleSendMessage(): Promise<void> {
-        if (!canUseCertifiedAction(authStore.user, null)) {
+        if (!canSendMessage(authStore.user)) {
             sendError = getCertificationBlockedMessage();
             goToCertification();
             return;
@@ -243,13 +243,13 @@
         </div>
         <Button
             onclick={() => {
-                if (!canUseCertifiedAction(authStore.user, null)) {
+                if (!canSendMessage(authStore.user)) {
                     goToCertification();
                     return;
                 }
                 showSendDialog = true;
             }}
-            title={!canUseCertifiedAction(authStore.user, null) ? '실명인증' : undefined}
+            title={!canSendMessage(authStore.user) ? '실명인증' : undefined}
         >
             <PenSquare class="mr-2 h-4 w-4" />
             쪽지 쓰기


### PR DESCRIPTION
## 배경
쪽지 UI가 실명인증 게이트(`canUseCertifiedAction`)로 막혀, mb_level 5+ 광고주도 발송 버튼이 비활성. 백엔드 예외(angple-backend)에 맞춰 프론트도 쪽지 게이트만 완화.

## 변경
- `certification-gate.ts`: 신규 `canSendMessage(user) = 실명인증 || mb_level>=5` (mb_level=등급, XP 아님).
- `messages/+page.svelte`·`author-link.svelte`: 쪽지 게이트 3+2곳을 `canSendMessage` 로 전환.
- **범용 `canUseCertifiedAction`(글쓰기·댓글·공감)은 불변** — 쪽지만 예외.

## 검증
- mb_level 5+ 실명미인증 → 쪽지 쓰기 버튼 활성·발송 가능. 그 외 → 종전대로 실명인증 유도.
- 글쓰기/댓글/공감 실명 게이트 무영향.

## 동반
- 백엔드 PR(damoang/angple-backend) 필수 동반(집행). 함께 배포.