### PR TITLE
댓글 수정 배지 미표시 수정 + 수정횟수 비정규화

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -36,6 +36,8 @@ interface CommentRow extends RowDataPacket {
     wr_name: string;
     wr_ip: string;
     wr_datetime: string;
+    wr_edit_count: number;
+    wr_last_edited_at: string | null;
     wr_deleted_at: string | null;
     wr_deleted_by: string | null;
     wr_7: string | null;
@@ -43,11 +45,6 @@ interface CommentRow extends RowDataPacket {
 
 interface CountRow extends RowDataPacket {
     total: number;
-}
-
-interface EditCountRow extends RowDataPacket {
-    wr_id: number;
-    cnt: number;
 }
 
 interface CommentResponseItem {
@@ -65,6 +62,7 @@ interface CommentResponseItem {
     depth: number;
     parent_id: number;
     created_at: string;
+    updated_at?: string;
     is_secret: boolean;
     deleted_at: string | null;
     deleted_by: string | null;
@@ -191,6 +189,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
         const [rows] = await pool.query<CommentRow[]>(
             `SELECT wr_id, wr_parent, wr_comment, wr_comment_reply, wr_content, wr_link1, wr_link2, wr_option,
 			        wr_good, wr_nogood, mb_id, wr_name, wr_ip, wr_datetime,
+			        wr_edit_count, wr_last_edited_at,
 			        wr_deleted_at, wr_deleted_by, wr_7
 			 FROM ??
 			 WHERE wr_parent = ? AND wr_is_comment = 1
@@ -220,18 +219,9 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             }
         }
 
-        // 댓글별 수정 횟수 배치 조회 (g5_write_revisions)
+        // 댓글 수정 횟수/최근 수정 시각은 비정규화 컬럼(wr_edit_count·wr_last_edited_at)에서
+        // 직접 읽는다 — 매 조회 g5_write_revisions COUNT 제거(읽기 쿼리 0). 게시글 상세와 동일 정책.
         const commentIds = rows.map((r) => r.wr_id);
-        const editCountMap = new Map<number, number>();
-        if (commentIds.length > 0) {
-            const [editCounts] = await pool.query<EditCountRow[]>(
-                `SELECT wr_id, COUNT(*) AS cnt FROM g5_write_revisions WHERE board_id = ? AND wr_id IN (?) GROUP BY wr_id`,
-                [safeBoardId, commentIds]
-            );
-            for (const ec of editCounts) {
-                editCountMap.set(ec.wr_id, ec.cnt);
-            }
-        }
 
         // 이용제한 근거 댓글 식별 (g5_na_singo.discipline_log_id IS NOT NULL)
         // INDEX hit: (sg_table, sg_id) — idx_singo_table_id / idx_table_id_time.
@@ -309,10 +299,11 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             depth: row.wr_comment_reply.length,
             parent_id: row.wr_parent,
             created_at: row.wr_datetime,
+            updated_at: row.wr_last_edited_at || undefined,
             is_secret: row.wr_option?.includes('secret') || false,
             deleted_at: row.wr_deleted_at || null,
             deleted_by: row.wr_deleted_by || null,
-            edit_count: editCountMap.get(row.wr_id) || 0,
+            edit_count: row.wr_edit_count || 0,
             ...(row.mb_id && blockedSet.has(String(row.mb_id)) ? { is_blocked: true } : {}),
             ...(row.mb_id && withdrawnSet.has(String(row.mb_id)) ? { is_left: true } : {}),
             ...(disciplineSet.has(row.wr_id) ? { is_discipline_related: true } : {}),


### PR DESCRIPTION
## 증상
수정한 댓글에 `· 수정됨 (N회)` 배지가 **전혀 안 뜸**. 게시글 배지는 정상.

## 원인
게시글과 댓글이 **다른 코드 경로**를 사용:
- 게시글 배지 = Go 백엔드 응답(`post.edit_count`/`post.last_edited_at`) → 정상
- 댓글 = **SvelteKit 프록시**(`api/boards/[boardId]/posts/[postId]/comments/+server.ts`)가 DB 직접 쿼리로 생성. 이 프록시가:
  1. **`updated_at` 필드를 응답에 안 실음** → 배지 조건(`comment.updated_at`, comment-list.svelte:1336)이 항상 거짓 → 배지 영영 미표시 ← 직접 원인
  2. edit_count 를 `change_type` 필터 **없는** per-request COUNT 로 계산 → create 리비전 포함 **과다계수** + 부하

즉 앞선 Go 백엔드 비정규화(PR be#559)가 댓글의 실제 표시 경로에는 미적용이었음.

## 수정 (게시글과 동일한 A+B 비정규화)
- 메인 SELECT 에 `wr_edit_count·wr_last_edited_at` 추가 (DDL 로 157 보드 보유)
- `updated_at = wr_last_edited_at` (배지 조건 충족, 미수정 댓글은 null→미표시=grace)
- `edit_count = wr_edit_count` (update 리비전 기준, 과다계수 해소)
- **per-request g5_write_revisions COUNT 제거** (읽기 쿼리 0, 댓글 SSR 경로도 일관 적용)

## 검증
- [ ] 카나리 SSR: free/6720216 댓글 6720971(6회,169분) → `수정됨 (6회)` 표시
- [ ] 미수정/작성직후(<5min) 댓글 배지 없음(grace)
- [ ] 조회수·차단·이용제한 enrich 무영향(commentIds·safeBoardId 유지)