### PR TITLE
iOS Safari 뒤로가기 목록 맨밑 스크롤 버그 수정 (#13022)

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -314,14 +314,77 @@
     </head>
     <body>
         <div style="display: contents">%sveltekit.body%</div>
-        <!-- Safari bfcache 복원 시 stale 상태 방지 -->
+        <!-- Safari bfcache 복원 시 stale 상태 방지 (#303) + 스크롤 위치 보존 (#13022) -->
         <script>
-            window.addEventListener('pageshow', function (e) {
-                if (e.persisted) {
-                    // bfcache에서 복원됨 — SvelteKit 라우터 상태 갱신 위해 리로드
-                    location.reload();
-                }
-            });
+            (function () {
+                var KEY = 'dm_bfcache_scroll';
+                // bfcache 복원 시: stale 방지를 위해 리로드하되, 복원된 스크롤 위치를 저장한다.
+                // 리로드는 SvelteKit 클라이언트 내비게이션이 아니라 페이지 snapshot 복원이 실행되지
+                // 않으므로(#9401 우회), 여기서 직접 저장→로드 후 복원한다. 긴 글 열람 후 iOS Safari
+                // 가 탭을 bfcache 폐기 후 복원할 때 목록이 맨 밑으로 떨어지던 현상 방지.
+                window.addEventListener('pageshow', function (e) {
+                    if (e.persisted) {
+                        try {
+                            sessionStorage.setItem(
+                                KEY,
+                                JSON.stringify({
+                                    y: window.scrollY,
+                                    u: location.href,
+                                    t: Date.now()
+                                })
+                            );
+                        } catch (err) {}
+                        location.reload();
+                    }
+                });
+                // 리로드 직후 저장된 스크롤 위치 복원. 이미지/광고로 문서 높이가 뒤늦게 확장되는
+                // 경우까지 커버(rAF + ResizeObserver). 문서가 목표 높이에 못 미치는 동안에는
+                // scrollTo 를 호출하지 않는다 — 짧은 문서에 scrollTo 하면 맨 밑으로 clamp 되기 때문.
+                try {
+                    var raw = sessionStorage.getItem(KEY);
+                    if (raw) {
+                        sessionStorage.removeItem(KEY);
+                        var d = JSON.parse(raw);
+                        if (d && d.u === location.href && Date.now() - (d.t || 0) < 10000) {
+                            var target = d.y || 0;
+                            if (target > 0) {
+                                var done = false;
+                                var tries = 0;
+                                var maxTries = 180; // ~3s
+                                var tryScroll = function () {
+                                    var maxScroll =
+                                        document.documentElement.scrollHeight - window.innerHeight;
+                                    if (maxScroll >= target - 2) {
+                                        window.scrollTo(0, target);
+                                        if (Math.abs(window.scrollY - target) <= 2) done = true;
+                                    }
+                                };
+                                var attempt = function () {
+                                    if (done) return;
+                                    tryScroll();
+                                    if (!done && tries++ < maxTries) requestAnimationFrame(attempt);
+                                };
+                                requestAnimationFrame(attempt);
+                                if (typeof ResizeObserver !== 'undefined') {
+                                    var ro = new ResizeObserver(function () {
+                                        if (done) {
+                                            ro.disconnect();
+                                            return;
+                                        }
+                                        tryScroll();
+                                        if (done) ro.disconnect();
+                                    });
+                                    ro.observe(document.documentElement);
+                                    setTimeout(function () {
+                                        done = true;
+                                        ro.disconnect();
+                                    }, 5000);
+                                }
+                            }
+                        }
+                    }
+                } catch (err) {}
+            })();
         </script>
         <!-- Raw JSON 감지: JS 로드 실패 시 __data.json이 화면에 표시되는 것 방지 -->
         <script>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -12,7 +12,7 @@
 
             let tries = 0;
             let done = false;
-            const maxTries = 60; // ~2s 에 걸쳐 33ms 간격
+            const maxTries = 60; // requestAnimationFrame 60프레임 (~1s). 이후는 ResizeObserver 가 커버
 
             // 문서가 목표 높이에 못 미치는 동안에는 scrollTo 를 호출하지 않는다.
             // 짧은 문서(이미지/광고 로드 전)에 scrollTo(target) 하면 맨 밑으로 clamp 되고,

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -14,16 +14,19 @@
             let done = false;
             const maxTries = 60; // ~2s 에 걸쳐 33ms 간격
 
+            // 문서가 목표 높이에 못 미치는 동안에는 scrollTo 를 호출하지 않는다.
+            // 짧은 문서(이미지/광고 로드 전)에 scrollTo(target) 하면 맨 밑으로 clamp 되고,
+            // 높이가 끝내 안 따라오면 그 상태로 고착돼 "목록이 맨 밑으로" 현상이 된다(#13022).
+            const tryScroll = () => {
+                const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+                if (maxScroll >= target - 2) {
+                    window.scrollTo(0, target);
+                    if (Math.abs(window.scrollY - target) <= 2) done = true;
+                }
+            };
             const attempt = () => {
                 if (done) return;
-                window.scrollTo(0, target);
-                // 목표 위치 ± 2px 도달 + 문서 높이가 충분하면 완료
-                if (
-                    Math.abs(window.scrollY - target) <= 2 &&
-                    document.documentElement.scrollHeight >= target + window.innerHeight - 1
-                ) {
-                    done = true;
-                }
+                tryScroll();
                 tries++;
                 if (!done && tries < maxTries) requestAnimationFrame(attempt);
             };
@@ -32,7 +35,12 @@
             // 이미지/광고가 로드돼 문서 높이가 변경될 때마다 재시도
             if (typeof ResizeObserver !== 'undefined') {
                 const ro = new ResizeObserver(() => {
-                    if (!done) window.scrollTo(0, target);
+                    if (done) {
+                        ro.disconnect();
+                        return;
+                    }
+                    tryScroll();
+                    if (done) ro.disconnect();
                 });
                 ro.observe(document.documentElement);
                 setTimeout(() => {


### PR DESCRIPTION
## 증상
긴 글 / 댓글 많은 글을 읽고 **스와이프로 뒤로가면 목록이 맨 밑으로** 떨어짐. iPhone Safari. **수개월 반복 제보**(#13022·12286·11821 …), #9401 부분수정 있었으나 재발.

## 근본 원인 (2차 분석)
두 경로가 서로를 우회하며 재발:
1. **bfcache 리로드**(app.html, #303 stale 방지): `pageshow(e.persisted)` → `location.reload()`. 리로드는 SvelteKit 클라이언트 내비게이션이 아니라 **페이지 snapshot 복원(#9401)이 실행되지 않고**, 리로드 전 스크롤 저장도 없어 **위치 완전 유실**. 긴 글=메모리 압박 → iOS 가 탭을 bfcache 폐기→복원 → 이 경로 발동(그래서 '긴 글일 때'만 재현).
2. **목록 snapshot 복원 clamp**: 문서 높이가 목표에 못 미치는 동안 `scrollTo(0,target)` 를 **무조건 호출** → 짧은 문서 **맨 밑으로 clamp**, 높이가 끝내 안 따라오면 고착.

## 수정
1. app.html: 리로드 전 `scrollY`+URL 을 `sessionStorage` 저장 → 로드 후 복원(rAF + ResizeObserver, **문서가 충분히 길 때만 scrollTo**). **stale 방지(리로드)는 유지** — 무회귀.
2. `[boardId]/+page.svelte` snapshot: `maxScroll >= target` 일 때만 scrollTo(짧을 땐 미이동 = 최악도 맨 위, 맨 밑 아님).

## ⚠️ 검증
iOS Safari **실기기 스와이프**에서만 재현 → **카나리에서 아이폰으로 직접 확인 필수**(머신 검증 불가).
- [ ] 카나리: 긴 글 → 스와이프 뒤로 → 목록이 클릭 위치 부근 복원(맨 밑 아님)
- [ ] 짧은 글/일반 뒤로가기 회귀 없음
- [ ] bfcache stale 방지(최신 데이터 갱신) 유지

## 범위 외
크로스플랫폼 '하단 페이지 표시 1페이지' 버그(#12367·12413)는 별개 원인 — 후속.