### PR TITLE
fp 수집기 재시도·성공판정·세션 재수집 (커버리지 P1)

### DIFF
--- a/apps/web/src/lib/fingerprint/device-fingerprint.ts
+++ b/apps/web/src/lib/fingerprint/device-fingerprint.ts
@@ -15,6 +15,7 @@ import { env } from '$env/dynamic/public';
 
 const DEVICE_ID_KEY = 'da_device_id';
 const LAST_SENT_KEY = 'da_fp_sent_at';
+const SESSION_SENT_KEY = 'da_fp_session_sent'; // 이 브라우저 세션 성공 전송 마커(재로그인 재수집용)
 const SEND_THROTTLE_MS = 24 * 60 * 60 * 1000; // 기기당 1일 1회
 const ENDPOINT = '/api/v1/fingerprint';
 
@@ -147,34 +148,89 @@ async function sha256(s: string): Promise<string> {
     }
 }
 
+/** 안전한 storage 접근 (사생활 모드 등에서 throw 가능) */
+function safeGet(store: Storage | undefined, key: string): string | null {
+    try {
+        return store ? store.getItem(key) : null;
+    } catch {
+        return null;
+    }
+}
+function safeSet(store: Storage | undefined, key: string, val: string): void {
+    try {
+        store?.setItem(key, val);
+    } catch {
+        // 저장 불가 — 무해(throttle 우회가 계속될 뿐)
+    }
+}
+
+/** 1회 전송 시도. 'skip'=이번 세션 이미 성공+throttle 이내, 'ok'/'fail'=전송 결과. */
+async function attemptSend(): Promise<'ok' | 'fail' | 'skip'> {
+    // 24h throttle 은 유지하되, 이 브라우저 세션에서 아직 성공 전송한 적 없으면(sessionStorage
+    // 마커 부재) throttle 을 우회해 1회 재전송한다 — 재로그인/새 세션마다 최신 IP 갱신 +
+    // 이전 세션 실패 만회. (#13022 트랙: fp 커버리지 P1)
+    const sentThisSession =
+        safeGet(
+            typeof sessionStorage !== 'undefined' ? sessionStorage : undefined,
+            SESSION_SENT_KEY
+        ) === '1';
+    const last = Number(safeGet(localStorage, LAST_SENT_KEY) || 0);
+    if (sentThisSession && Date.now() - last < SEND_THROTTLE_MS) return 'skip';
+
+    const components = collectComponents();
+    const deviceId = getOrCreateDeviceId();
+    const fpHash = await sha256(stableString(components));
+
+    const res = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+            fp_hash: fpHash,
+            device_id: deviceId,
+            ua: components.ua,
+            components // 서버는 해시/요약만 저장; 원시는 미보관
+        })
+    });
+    // ⚠️ 서버는 저장 실패·비활성 시에도 HTTP 200 + {success:false} 를 준다(재시도 폭주 방지).
+    // res.ok 만으로 성공 판정하면 실패에도 throttle 이 걸려 조용히 유실됨 → body 로 확정.
+    let ok = false;
+    if (res.ok) {
+        try {
+            const body = await res.json();
+            ok = body?.success === true;
+        } catch {
+            ok = false;
+        }
+    }
+    if (ok) {
+        safeSet(localStorage, LAST_SENT_KEY, String(Date.now()));
+        safeSet(
+            typeof sessionStorage !== 'undefined' ? sessionStorage : undefined,
+            SESSION_SENT_KEY,
+            '1'
+        );
+    }
+    return ok ? 'ok' : 'fail';
+}
+
 /**
- * 핑거프린트를 수집해 서버에 1일 1회 전송.
+ * 핑거프린트를 수집해 서버에 전송(성공 시 기기당 1일 1회, 새 세션마다 재확인).
+ * 전송 실패 시 세션 내 백오프로 최대 3회 재시도 — 토큰 레이스·일시 오류로 인한 유실 방지.
  * 인증된 사용자에 대해서만 호출(서버가 토큰에서 mb_id 추출).
  */
 export async function collectAndReportFingerprint(): Promise<void> {
     if (typeof window === 'undefined') return; // SSR 가드
     if (!COLLECTION_ENABLED) return; // 기본 비활성 — 법률검토·공시 후 PUBLIC_FINGERPRINT_ENABLED=true
-    try {
-        const last = Number(localStorage.getItem(LAST_SENT_KEY) || 0);
-        if (Date.now() - last < SEND_THROTTLE_MS) return; // throttle
-
-        const components = collectComponents();
-        const deviceId = getOrCreateDeviceId();
-        const fpHash = await sha256(stableString(components));
-
-        const res = await fetch(ENDPOINT, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({
-                fp_hash: fpHash,
-                device_id: deviceId,
-                ua: components.ua,
-                components // 서버는 해시/요약만 저장; 원시는 미보관
-            })
-        });
-        if (res.ok) localStorage.setItem(LAST_SENT_KEY, String(Date.now()));
-    } catch {
-        // 탐지 보조 기능 — 실패해도 서비스 흐름에 영향 없음(조용히 무시)
+    const backoffMs = [0, 3000, 15000]; // 즉시 → 3s → 15s
+    for (let i = 0; i < backoffMs.length; i++) {
+        try {
+            if (backoffMs[i] > 0) await new Promise((r) => setTimeout(r, backoffMs[i]));
+            const r = await attemptSend();
+            if (r === 'ok' || r === 'skip') return; // 성공 또는 이미 전송됨
+        } catch {
+            // 네트워크 예외 — 다음 백오프에서 재시도
+        }
     }
+    // 3회 모두 실패 — throttle 미설정이므로 다음 페이지 로드/세션에서 다시 시도됨
 }


### PR DESCRIPTION
## 배경
fp 수집 커버리지가 30일 활성 로그인 회원의 **60.7%**(10,464/17,239)에 그침. 클라이언트 측 원인 3가지 수정(P1). 설계=triage(비-VC).

## 원인·수정 (`device-fingerprint.ts` 단일)
1. **성공 판정**: 서버는 저장 실패·비활성 시에도 `200 + {success:false}` 반환 → 클라가 `res.ok` 만 보고 24h throttle 설정 → 실패에도 하루 재수집 skip(조용한 유실). → `res.ok && body.success===true` 일 때만 throttle.
2. **재시도**: 전송 실패 시 세션 내 백오프(0/3s/15s, 최대 3회) — 토큰 레이스·일시 오류 유실 방지.
3. **세션 재수집**: 24h throttle 이라도 이 브라우저 세션 미성공이면 1회 재전송(sessionStorage) → 재로그인/새 세션 최신 IP 갱신 + 이전 실패 만회.

storage 접근 `safeGet/safeSet` 방어. **발화(+layout)·수집 로직 무변경.**

## 검증
- ⚠️ canary web 엔 `PUBLIC_FINGERPRINT_ENABLED` 미주입 → 카나리선 fp 미발화. 검증=유닛로직 + prod 배포 후 커버리지 60.7%→추이 관측.
- svelte-check(CI).