### PR TITLE
회원 프로필에 별명(닉네임) 변경 이력 표시 (#13026)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -55,6 +55,11 @@ interface CountRow extends RowDataPacket {
     days: number;
 }
 
+interface NickHistoryRow extends RowDataPacket {
+    old_nick: string;
+    changed_at: string;
+}
+
 // Level thresholds (cumulative exp required for each level) — synced with backend
 const levelThresholds = [
     0, 1000, 3000, 6000, 10000, 15000, 21000, 28000, 36000, 45000, 55000, 66000, 78000, 91000,
@@ -250,6 +255,19 @@ export const GET: RequestHandler = async ({ params, locals }) => {
             // 테이블 없으면 무시
         }
 
+        // 닉네임 변경 이력 (공개, 최근순 — #13026). g5_member_nick_history 에 적재됨.
+        // member.mb_id(정본) 기준 — 슬러그가 닉일 수 있어 memberId(슬러그) 대신 사용.
+        let nickHistory: NickHistoryRow[] = [];
+        try {
+            [nickHistory] = await pool.query<NickHistoryRow[]>(
+                `SELECT old_nick, changed_at FROM g5_member_nick_history
+                 WHERE mb_id = ? ORDER BY changed_at DESC LIMIT 30`,
+                [member.mb_id]
+            );
+        } catch {
+            // 테이블 없으면 무시
+        }
+
         // 이미지 URL: 원본 값 그대로 전달 (프론트에서 getAvatarUrl로 CDN URL 변환)
         const imageUrl = member.mb_image_url || '';
 
@@ -295,7 +313,12 @@ export const GET: RequestHandler = async ({ params, locals }) => {
                 discipline_history: disciplineHistory,
                 // 팔로우
                 follower_count: followerRows[0]?.count ?? 0,
-                following_count: followingRows[0]?.count ?? 0
+                following_count: followingRows[0]?.count ?? 0,
+                // 닉네임 변경 이력 (과거 별명, 최근순) — #13026
+                nick_history: nickHistory.map((h) => ({
+                    old_nick: h.old_nick,
+                    changed_at: h.changed_at
+                }))
             }
         });
     } catch (error) {

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -585,6 +585,19 @@
                                     <span>{formatDate(p.mb_nick_date)} 닉네임 수정</span>
                                 </div>
                             {/if}
+                            {#if p.nick_history && p.nick_history.length > 0}
+                                <!-- 과거 별명(닉네임) 이력 — 공개(#13026). old_nick = 그 시점 변경 전 별명. -->
+                                <div class="flex items-start gap-2">
+                                    <User class="mt-0.5 h-4 w-4 shrink-0" />
+                                    <span>
+                                        이전 별명:
+                                        {#each p.nick_history as h, i (i)}<span
+                                                title={`${formatDate(h.changed_at)} 변경`}
+                                                >{h.old_nick}</span
+                                            >{i < p.nick_history.length - 1 ? ', ' : ''}{/each}
+                                    </span>
+                                </div>
+                            {/if}
                             {#if p.mb_level < 10}
                                 <div class="flex items-center gap-2">
                                     <Clock class="h-4 w-4 shrink-0" />


### PR DESCRIPTION
## 요청 (#13026)
닉네임 변경 시 **날짜는 보이는데 과거 어떤 닉이었는지 이력이 안 보임** → 공개 프로필에 과거 별명 표시 요청.

## 분석
- 이력 데이터 **이미 적재 중**: `g5_member_nick_history`(old_nick·new_nick·changed_at), 변경 시 `member-update.ts` 가 INSERT. 244건·236명(4/20~).
- 현재 프로필은 **마지막 변경 날짜(mb_nick_date)만** 표시, 이력 표출 UI 전무.
- → 데이터는 있고 **표출만** 추가.

## 변경 (표출 범위=공개, SDK 결정)
- `api/members/[id]/profile/+server.ts`: `g5_member_nick_history` 최근순 조회(member.mb_id, LIMIT 30) → 응답 `nick_history`.
- `member/[id]/+page.svelte`: '이전 별명: …' 목록(각 항목 title=변경 시각).

## 개인정보 가드
- **탈퇴/익명화 회원**: `isLeft` 조기 반환으로 nick_history 미노출(탈퇴 프로필 비노출 정책 준수).
- profile API **로그인 필수** → 비로그인/크롤러 노출 없음.

## 검증
- 닉 변경 이력 있는 회원 프로필에 과거 별명 표시, 없는 회원 미표시.
- 탈퇴 회원 프로필에 미노출.
- svelte-check(CI).