### PR TITLE
닉 이력 — 관리자 전체 타임라인 추가 (#13026 후속)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -57,6 +57,7 @@ interface CountRow extends RowDataPacket {
 
 interface NickHistoryRow extends RowDataPacket {
     old_nick: string;
+    new_nick: string;
     changed_at: string;
 }
 
@@ -260,13 +261,16 @@ export const GET: RequestHandler = async ({ params, locals }) => {
         let nickHistory: NickHistoryRow[] = [];
         try {
             [nickHistory] = await pool.query<NickHistoryRow[]>(
-                `SELECT old_nick, changed_at FROM g5_member_nick_history
+                `SELECT old_nick, new_nick, changed_at FROM g5_member_nick_history
                  WHERE mb_id = ? ORDER BY changed_at DESC LIMIT 30`,
                 [member.mb_id]
             );
         } catch {
             // 테이블 없으면 무시
         }
+
+        // 뷰어가 관리자(level>=10)인지 — 닉 이력 전체 타임라인(new_nick) 노출 게이트.
+        const viewerIsAdmin = (locals.user?.level ?? 0) >= 10;
 
         // 이미지 URL: 원본 값 그대로 전달 (프론트에서 getAvatarUrl로 CDN URL 변환)
         const imageUrl = member.mb_image_url || '';
@@ -314,10 +318,12 @@ export const GET: RequestHandler = async ({ params, locals }) => {
                 // 팔로우
                 follower_count: followerRows[0]?.count ?? 0,
                 following_count: followingRows[0]?.count ?? 0,
-                // 닉네임 변경 이력 (과거 별명, 최근순) — #13026
+                // 닉네임 변경 이력 (과거 별명, 최근순) — #13026.
+                // 회원 공개는 old_nick+시각만. 관리자 뷰어(level>=10)에겐 new_nick 까지(전체 타임라인).
                 nick_history: nickHistory.map((h) => ({
                     old_nick: h.old_nick,
-                    changed_at: h.changed_at
+                    changed_at: h.changed_at,
+                    ...(viewerIsAdmin ? { new_nick: h.new_nick } : {})
                 }))
             }
         });

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -598,6 +598,33 @@
                                     </span>
                                 </div>
                             {/if}
+                            {#if (authStore.user?.mb_level ?? 0) >= 10 && p.nick_history && p.nick_history.length > 0}
+                                <!-- 관리자 전용 전체 타임라인 (날짜·old→new) — 모더레이션(평판 세탁·다중이·사칭). -->
+                                <div
+                                    class="border-border/60 mt-1 rounded-md border border-dashed p-2"
+                                >
+                                    <div
+                                        class="text-muted-foreground mb-1 flex items-center gap-1.5 text-xs font-medium"
+                                    >
+                                        <User class="h-3.5 w-3.5 shrink-0" />
+                                        닉네임 변경 이력 (관리자)
+                                    </div>
+                                    <ul class="space-y-0.5 text-xs">
+                                        {#each p.nick_history as h, i (i)}
+                                            <li class="flex flex-wrap items-center gap-1">
+                                                <span class="text-muted-foreground tabular-nums"
+                                                    >{formatDate(h.changed_at)}</span
+                                                >
+                                                <span>{h.old_nick}</span>
+                                                <span class="text-muted-foreground">→</span>
+                                                <span class="font-medium"
+                                                    >{h.new_nick ?? p.mb_nick}</span
+                                                >
+                                            </li>
+                                        {/each}
+                                    </ul>
+                                </div>
+                            {/if}
                             {#if p.mb_level < 10}
                                 <div class="flex items-center gap-2">
                                     <Clock class="h-4 w-4 shrink-0" />


### PR DESCRIPTION
## 배경
#13026 별명 이력 — SDK 결정: **관리자 전체 + 회원 공개 유지**. 회원 공개(과거 별명 목록)는 이미 라이브, 여기에 **관리자 전용 상세 타임라인** 추가.

## 목적
전체 이력의 진짜 값어치=모더레이션(평판 세탁 방지·다중이·사칭 적발). 이를 관리자에게 주되 프라이버시 부담은 회원 공개 최소 유지로 균형.

## 변경
- profile API: nick_history 에 `new_nick` 조회. **viewerIsAdmin(locals.user.level>=10) 일 때만** 응답에 new_nick 포함(회원 공개는 old_nick+시각만, **무변경**).
- member/[id] 페이지: 공개 블록 아래 **관리자 전용 타임라인**(시각·old→new) 블록. `authStore.user.mb_level>=10` 이중 게이트.

## 가드/무회귀
- 회원 공개 블록 **바이트 동일**(무회귀). 탈퇴회원 isLeft 미노출·로그인 필수 유지.
- new_nick 은 관리자 뷰어에게만 서버가 반환(클라 게이트와 이중).

## 검증
- 관리자 계정으로 프로필 → 타임라인(시각·old→new) 표시. 일반회원은 미표시(공개 목록만).
- 탈퇴회원 미노출.