### PR TITLE
이용제한 상세: 외부 공개 안내문(public_description) 카드

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -89,6 +89,7 @@ export interface DisciplineLogDetail {
     reported_items?: ReportedItem[];
     memo?: string;
     member_reason?: string; // 회원 공개 사유 (운영자 입력 시에만 노출)
+    public_description?: string; // 외부 공개용 안내문 (운영자 입력 시에만 노출)
     created_by: string;
     created_at: string;
     status: 'pending' | 'approved' | 'rejected';

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -11,6 +11,7 @@
     import User from '@lucide/svelte/icons/user';
     import FileText from '@lucide/svelte/icons/file-text';
     import Info from '@lucide/svelte/icons/info';
+    import Megaphone from '@lucide/svelte/icons/megaphone';
     import ExternalLink from '@lucide/svelte/icons/external-link';
     import History from '@lucide/svelte/icons/history';
     import {
@@ -192,6 +193,21 @@
                 </Card.Header>
                 <Card.Content>
                     <p class="whitespace-pre-line text-sm">{log.member_reason}</p>
+                </Card.Content>
+            </Card.Root>
+        {/if}
+
+        <!-- 안내: 회원 공개용 외부 안내문 (운영자가 입력한 경우에만 표시) -->
+        {#if log.public_description && log.public_description.trim()}
+            <Card.Root class="mb-4">
+                <Card.Header>
+                    <Card.Title class="flex items-center gap-2">
+                        <Megaphone class="text-muted-foreground h-5 w-5" />
+                        안내
+                    </Card.Title>
+                </Card.Header>
+                <Card.Content>
+                    <p class="whitespace-pre-line text-sm">{log.public_description}</p>
                 </Card.Content>
             </Card.Root>
         {/if}


### PR DESCRIPTION
## 개요
이용제한(disciplinelog) 상세 페이지에 **외부 공개 안내문** 카드를 추가합니다. (백엔드 PR: damoang/angple-backend#560)

## 변경
- `disciplinelog/[id]/+page.svelte`: '기타 사유'(member_reason) 아래에 '📢 안내'(public_description) 카드 추가 — 값 있을 때만 표시
- `discipline-log.ts`: `DisciplineLogDetail.public_description?: string` 추가
- Megaphone 아이콘 import

## 계층 (공개 3 + 내부 1)
- 제재 사유(sg_type) / 기타 사유(member_reason) / **안내(public_description)** = 공개
- memo = 비공개

## 하위호환
필드 없으면 미표시. 기존 member_reason·memo 동작 불변. 백엔드 #560 배포 후 값 노출.