### PR TITLE
fix(affiliate): LinkPrice a_id 단일 출처화 + [-6] 승인거부 은폐 차단

### DIFF
--- a/plugins/affiliate-link-private/lib/platforms/linkprice.ts
+++ b/plugins/affiliate-link-private/lib/platforms/linkprice.ts
@@ -11,8 +11,16 @@ function sanitizeAffiliateId(raw: string | undefined): string {
     return (raw || '').trim().replace(/^['"]+|['"]+$/g, '');
 }
 
+/**
+ * a_id 출처는 AFFI_AFFILIATE_ID **하나**다.
+ *
+ * 과거 `AFFI_LINKPRICE_AFF_ID || AFFI_AFFILIATE_ID` 폴백을 뒀다가, 우선순위가 높은 쪽에
+ * 미승인 ID가 들어가 승인된 값을 **조용히 가리는** 사고가 두 번 났다(2026-03·07). 값이 틀린 게
+ * 아니라 "가릴 수 있는 두 번째 변수가 존재하는 것" 자체가 사고 기계이므로 변수를 하나로 고정한다.
+ * 크리덴셜에 폴백을 다시 추가하지 말 것.
+ */
 export function getLinkPriceAffiliateId(): string {
-    return sanitizeAffiliateId(env.AFFI_LINKPRICE_AFF_ID || env.AFFI_AFFILIATE_ID);
+    return sanitizeAffiliateId(env.AFFI_AFFILIATE_ID);
 }
 
 export function createLinkPriceFailureDecision(
@@ -40,9 +48,17 @@ export function createLinkPriceFailureDecision(
     };
 }
 
-/** LP 응답이 설정 오류(a_id 형식/미승인 계정 등)인지 — 머천트 거부와 구분해야 은폐되지 않는다. */
+/**
+ * LP 응답이 설정 오류(a_id 형식/미승인 계정 등)인지 — 머천트 거부와 구분해야 은폐되지 않는다.
+ *
+ * 계정(a_id) 단위 실패 코드:
+ *   [-3] a_id 형식오류 (값에 따옴표 등)        — 2026-07-10 사고
+ *   [-6] 승인거부 (해당 a_id 가 미승인 계정)   — 2026-03·07-16 사고. 이 코드가 분류에서 빠져
+ *        있어 merchant_denied 로 위장됐고, 설정오류 경보가 3일간 발화하지 않았다.
+ * 두 코드 모두 "우리 계정 문제"라 개별 머천트 거부와 달리 즉시 사람이 개입해야 한다.
+ */
 function isConfigError(upstreamError: string): boolean {
-    return /\[-3\]|a_id/i.test(upstreamError);
+    return /\[-3\]|\[-6\]|a_id/i.test(upstreamError);
 }
 
 export function classifyLinkPriceFailure(input: {

--- a/plugins/affiliate-link-private/tests/linkprice-config.test.ts
+++ b/plugins/affiliate-link-private/tests/linkprice-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getLinkPriceAffiliateId, classifyLinkPriceFailure } from '../lib/platforms/linkprice';
+
+/**
+ * 2026-03 / 2026-07-16 두 차례 "LinkPrice 전량 변환 실패 → 수익 0" 사고의 재발 방지.
+ *
+ * 사고 메커니즘:
+ *   M1. a_id 출처가 두 개(AFFI_LINKPRICE_AFF_ID || AFFI_AFFILIATE_ID)라, 우선순위가 높은 쪽에
+ *       미승인 ID가 들어가면 승인된 값을 조용히 가렸다.
+ *   M2. [-6](승인거부)이 설정오류 분류에서 빠져 merchant_denied 로 위장 → 경보 미발화 → 무성 출혈.
+ */
+describe('LinkPrice a_id 단일 출처 (M1 재발 방지)', () => {
+    // 모듈이 `const env = process.env` 로 참조를 캡처하므로 객체를 교체하지 말고 제자리에서 복구한다.
+    const saved = { ...process.env };
+    const restore = () => {
+        for (const k of ['AFFI_AFFILIATE_ID', 'AFFI_LINKPRICE_AFF_ID']) {
+            if (saved[k] === undefined) delete process.env[k];
+            else process.env[k] = saved[k];
+        }
+    };
+    beforeEach(() => {
+        delete process.env.AFFI_AFFILIATE_ID;
+        delete process.env.AFFI_LINKPRICE_AFF_ID;
+    });
+    afterEach(restore);
+
+    it('AFFI_AFFILIATE_ID 를 a_id 로 쓴다', () => {
+        process.env.AFFI_AFFILIATE_ID = 'A100694456';
+        expect(getLinkPriceAffiliateId()).toBe('A100694456');
+    });
+
+    it('AFFI_LINKPRICE_AFF_ID 는 무시한다 — 폴백을 되살리면 이 테스트가 깨진다', () => {
+        process.env.AFFI_AFFILIATE_ID = 'A100694456';
+        process.env.AFFI_LINKPRICE_AFF_ID = 'A100698498'; // 과거 사고에서 승인 ID를 가렸던 미승인 값
+        expect(getLinkPriceAffiliateId()).toBe('A100694456');
+    });
+
+    it('AFFI_LINKPRICE_AFF_ID 만 있으면 a_id 없음으로 본다 (가릴 변수 자체가 없어야 한다)', () => {
+        process.env.AFFI_LINKPRICE_AFF_ID = 'A100698498';
+        expect(getLinkPriceAffiliateId()).toBe('');
+    });
+
+    it('따옴표째 들어와도 정제한다 (2026-07-10 [-3] 사고)', () => {
+        process.env.AFFI_AFFILIATE_ID = "'A100694456'";
+        expect(getLinkPriceAffiliateId()).toBe('A100694456');
+    });
+});
+
+describe('LinkPrice 실패 분류 (M2 은폐 방지)', () => {
+    const saved = { ...process.env };
+    beforeEach(() => {
+        process.env.AFFI_AFFILIATE_ID = 'A100694456';
+    });
+    afterEach(() => {
+        if (saved.AFFI_AFFILIATE_ID === undefined) delete process.env.AFFI_AFFILIATE_ID;
+        else process.env.AFFI_AFFILIATE_ID = saved.AFFI_AFFILIATE_ID;
+    });
+
+    const classify = (upstreamError: string) =>
+        classifyLinkPriceFailure({
+            originalUrl: 'https://product.kyobobook.co.kr/detail/S000220429584',
+            normalizedUrl: 'https://product.kyobobook.co.kr/detail/S000220429584',
+            upstreamError
+        }).reasonCode;
+
+    it('[-6] 승인거부 = 계정 문제 → config_error (merchant_denied 로 위장되면 안 된다)', () => {
+        expect(classify('denied: LinkPrice F: [-6] 승인거부')).toBe('config_error');
+    });
+
+    it('[-3] a_id 형식오류 → config_error', () => {
+        expect(classify('LinkPrice F: [-3] a_id 형식오류')).toBe('config_error');
+    });
+
+    it('개별 머천트 거부는 merchant_denied 로 유지 (과잉 경보 방지)', () => {
+        expect(classify('LinkPrice F: 제휴 종료된 머천트')).toBe('merchant_denied');
+    });
+
+    it('a_id 미설정이면 env_missing', () => {
+        delete process.env.AFFI_AFFILIATE_ID;
+        expect(classify('LinkPrice F: whatever')).toBe('env_missing');
+    });
+});

--- a/plugins/affiliate-link/lib/platforms/linkprice.ts
+++ b/plugins/affiliate-link/lib/platforms/linkprice.ts
@@ -60,9 +60,7 @@ async function callLinkPriceApi(
     originalUrl: string,
     context?: ConvertContext
 ): Promise<string | null> {
-    const affiliateId = sanitizeLinkPriceAffiliateId(
-        env.AFFI_LINKPRICE_AFF_ID || env.AFFI_AFFILIATE_ID
-    );
+    const affiliateId = sanitizeLinkPriceAffiliateId(env.AFFI_AFFILIATE_ID);
 
     if (!affiliateId) {
         console.warn('[LinkPrice] Affiliate ID가 설정되지 않음');


### PR DESCRIPTION
## 사고
알뜰구매 `economy/77570`(교보) 링크 3개 전부 `[-6] 승인거부` → 수익 0. **2026-03에 이어 두 번째 재발.**

## 실측 증거 (같은 URL, ID만 교체)
| a_id | LP 응답 |
|---|---|
| `A100694456` (= `AFFI_AFFILIATE_ID`, 승인) | **result=S** → `click.linkprice.com/...m=kbbook&a=A100694456` |
| `A100698498` (= `AFFI_LINKPRICE_AFF_ID`, 라이브가 쓰던 값) | **result=F** |

교보 측 문제가 아니라 **우리 설정**이었다. 7/14 22:25까지 29건 정상 변환 → 7/16부터 전량 거절.

## 원인 (구조)
- **M1 — a_id 출처 이중화**: `AFFI_LINKPRICE_AFF_ID || AFFI_AFFILIATE_ID`. 우선순위 높은 쪽에 미승인 ID가 들어가면 **승인된 값을 조용히 가린다**. 값 교정(손패치)은 매니페스트 apply 에 덮여 되돌아왔다(3회).
- **M2 — `[-6]` 분류 누락**: `isConfigError = /\[-3\]|a_id/` 라 `[-6] 승인거부`가 `merchant_denied`로 **위장** → 설정오류 경보 미발화 → 3일 무성 출혈.

## 수정
- a_id 출처를 **`AFFI_AFFILIATE_ID` 하나로 고정** (public·private 플러그인 양쪽). 가릴 변수 자체를 없앤다.
- `isConfigError` 에 `[-6]` 포함 — `[-3]/[-6]` 은 개별 머천트 거부가 아니라 **계정 단위 실패**.

## 검증
- 회귀 테스트 **8/8 통과** (`plugins/affiliate-link-private/tests/linkprice-config.test.ts`)
  - `AFFI_LINKPRICE_AFF_ID 는 무시한다 — 폴백을 되살리면 깨진다`
  - `[-6] → config_error` / `[-3] → config_error` / 개별 머천트 거부는 `merchant_denied` 유지
- 운영 복구 실증: secret 교정 + 재처리 후 `economy/77570` 3링크 전부 `converted`

## 남은 조치 (이 PR 밖)
1. ⚠️ **매니페스트에서 `AFFI_LINKPRICE_AFF_ID` 삭제** (`angple-k8s` SOPS) — 안 하면 또 부활. 현재는 손패치 상태.
2. 프로브가 파일 env 를 읽어 "정상" 오보 → 라이브 값 기준으로 변경
3. 24h 전량거절 경보 + 매니페스트↔라이브 드리프트 감시

설계: `/home/angple/triage/improvements/linkprice-aid-permanent-fix.md`