### PR TITLE
perf(detail): 비로그인 댓글 SWR 캐시 + 앙티콘 낙관적 UI

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -104,6 +104,47 @@
     }
 
     // 리액션 추가/토글
+    // 낙관적 업데이트 계산: 누르는 즉시 카운트/선택 상태를 반영한다.
+    // 서버 응답(data.result)으로 권위값 재조정하고, 실패 시 스냅샷으로 롤백한다.
+    function computeOptimistic(
+        list: ReactionItem[],
+        reaction: string,
+        mode: string
+    ): ReactionItem[] {
+        const idx = list.findIndex((r) => r.reaction === reaction);
+        if (idx >= 0) {
+            const item = list[idx];
+            if (item.choose && mode !== 'add') {
+                // 이미 선택됨 + 토글 → 해제(카운트-1, 0이면 제거)
+                const nextCount = item.count - 1;
+                if (nextCount <= 0) return list.filter((_, i) => i !== idx);
+                return list.map((r, i) =>
+                    i === idx ? { ...r, count: nextCount, choose: false } : r
+                );
+            }
+            if (!item.choose) {
+                // 미선택 → 선택(카운트+1)
+                return list.map((r, i) =>
+                    i === idx ? { ...r, count: r.count + 1, choose: true } : r
+                );
+            }
+            // 이미 선택됨 + add 모드 → 변화 없음
+            return list;
+        }
+        // 신규 리액션 추가
+        const ci = reaction.indexOf(':');
+        return [
+            ...list,
+            {
+                reaction,
+                category: ci >= 0 ? reaction.substring(0, ci) : reaction,
+                reactionId: ci >= 0 ? reaction.substring(ci + 1) : reaction,
+                count: 1,
+                choose: true
+            }
+        ];
+    }
+
     async function react(reaction: string, mode: string = 'add'): Promise<void> {
         if (!authStore.isAuthenticated) {
             authStore.redirectToLogin();
@@ -125,6 +166,10 @@
             return;
         }
 
+        // 낙관적 반영: 서버 왕복(정책·인증·다중쿼리)을 기다리지 않고 즉시 UI 갱신.
+        const snapshot = reactions;
+        reactions = computeOptimistic(reactions, finalReaction, mode);
+
         try {
             const res = await fetch('/api/reactions', {
                 method: 'POST',
@@ -138,11 +183,16 @@
             });
             const data = await res.json();
             if (data.status === 'success' && data.result[targetId]) {
+                // 서버 권위값으로 재조정(동시 리액션 등으로 낙관값과 다를 수 있음).
                 reactions = data.result[targetId];
                 trackEvent('reaction', { board_id: boardId, reaction: finalReaction, target });
+            } else {
+                // 서버 거부(정책·한도 초과 등) → 롤백.
+                reactions = snapshot;
             }
         } catch (err) {
             console.error('Failed to react:', err);
+            reactions = snapshot; // 네트워크 실패 → 롤백
         } finally {
             isReacting = false;
         }

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -414,8 +414,15 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
                 }
             },
             {
-                // 댓글 작성 후 refetch 시 stale 응답 차단 (#12548)
-                headers: { 'Cache-Control': 'private, no-cache, no-store, must-revalidate' }
+                // 로그인 사용자: 작성 후 refetch stale 차단(#12548) + 뷰어별 is_blocked 개인화 → private.
+                // 비로그인: 개인화 없음(공개) + 댓글을 쓰지 않음 → 짧은 SWR 캐시로 SPA backfill
+                //   스켈레톤을 near-instant 로 (신규 댓글은 최대 10초 지연). 리액션 GET 과 동일 패턴 —
+                //   CloudFront 가 쿠키 기준으로 로그인/비로그인 캐시를 분리하므로 개인화 누출 없음.
+                headers: {
+                    'Cache-Control': locals.user?.id
+                        ? 'private, no-cache, no-store, must-revalidate'
+                        : 'public, s-maxage=10, stale-while-revalidate=30'
+                }
             }
         );
     } catch (error) {

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -293,18 +293,19 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
             await revokeReaction(user.mb_id, safeReaction, safeTargetId);
         }
 
-        // 업데이트된 리액션 반환
-        const [updatedReactions] = await pool.query<ReactionRow[]>(
-            `SELECT target_id, reaction, reaction_count FROM g5_da_reaction
+        // 업데이트된 리액션 반환 — 두 조회는 서로 독립이므로 병렬 실행(왕복 2→1).
+        const [[updatedReactions], [updatedChoices]] = await Promise.all([
+            pool.query<ReactionRow[]>(
+                `SELECT target_id, reaction, reaction_count FROM g5_da_reaction
 			 WHERE target_id = ? ORDER BY id ASC`,
-            [safeTargetId]
-        );
-
-        const [updatedChoices] = await pool.query<ChooseRow[]>(
-            `SELECT target_id, reaction FROM g5_da_reaction_choose
+                [safeTargetId]
+            ),
+            pool.query<ChooseRow[]>(
+                `SELECT target_id, reaction FROM g5_da_reaction_choose
 			 WHERE member_id = ? AND target_id = ?`,
-            [user.mb_id, safeTargetId]
-        );
+                [user.mb_id, safeTargetId]
+            )
+        ]);
 
         const chosenSet = new Set(updatedChoices.map((r) => r.reaction));
         const result: Record<string, ReturnType<typeof parseReaction>[]> = {


### PR DESCRIPTION
## 배경
상세페이지 로딩 체감 이슈 분석(`triage/improvements/detail-loading-latency-analysis.md`) 중 **고임팩트 2종** 구현. 메모(플러그인 청크)·공감목록(온디맨드)은 마진/리스크 대비 낮아 이번 범위 제외(분석은 완료).

## 1. 비로그인 댓글 backfill near-instant
- 비로그인 SPA 이동 시 댓글이 SSR에서 제외돼(캐시안전) 클라 backfill → 스켈레톤 지속이 근본.
- 댓글 proxy GET 응답 캐시헤더를 뷰어별 분기: **비로그인 `public, s-maxage=10, stale-while-revalidate=30`** / 로그인 `private, no-cache`(현행).
- 비로그인 응답은 개인화(is_blocked) 없음=공개, 댓글 미작성이라 #12548 무관. **리액션 GET과 동일 패턴**(CloudFront가 쿠키로 로그인/비로그인 캐시 분리).
- 효과: 스켈레톤이 캐시 히트로 near-instant. 트레이드오프: 비로그인 신규 댓글 최대 10초 지연(로그인은 항상 최신).

## 2. 앙티콘(리액션) 낙관적 UI
- 기존 `react()`는 서버 왕복(정책·인증·다중 직렬쿼리) 완료 후에야 카운트 갱신 → 느림.
- 누르는 즉시 낙관적 반영(count/choose) → 서버 응답 권위값으로 재조정 → 실패 시 롤백.
- 서버 POST 후처리 조회 2건 `Promise.all` 병렬화.

## 검증
- svelte-check 0 errors, prettier 통과.
- 카나리에서 비로그인 댓글 캐시헤더 + 앙티콘 즉시반응/롤백 실측 예정.
- 독립 Evaluator 검증.