### PR TITLE
feat(rating): 글 별점 위젯 + 포스터 갤러리 별점 오버레이 (앙티티 Phase 0)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -49,6 +49,7 @@ import type {
     RegisterRequest,
     RegisterResponse,
     PostRevision,
+    PostRating,
     Scrap,
     BoardGroup,
     CommentReportInfo,
@@ -1233,6 +1234,61 @@ class ApiClient {
         const json = await res.json();
         if (!json.success) return { likes: 0, user_liked: false };
         return json.data;
+    }
+
+    // ========================================
+    // 게시글 별점 (features.rating 보드 — 앙티티 Phase 0)
+    // ========================================
+
+    /**
+     * 별점 응답 정규화 — 계약은 bare {avg, count, my} 이지만
+     * 표준 {success, data: {...}} 래핑으로 내려와도 수용한다.
+     */
+    private normalizeRating(response: ApiResponse<PostRating>): PostRating {
+        const body = (
+            response &&
+            typeof response === 'object' &&
+            response.data &&
+            typeof response.data === 'object'
+                ? response.data
+                : response
+        ) as Partial<PostRating> | null | undefined;
+        return {
+            avg: typeof body?.avg === 'number' ? body.avg : 0,
+            count: typeof body?.count === 'number' ? body.count : 0,
+            my: typeof body?.my === 'number' ? body.my : 0
+        };
+    }
+
+    /**
+     * 게시글 별점 집계 조회 (avg/count/my). 비로그인 my=0.
+     * features.rating 미설정 보드는 403.
+     */
+    async getPostRating(boardId: string, postId: number | string): Promise<PostRating> {
+        const response = await this.request<PostRating>(
+            `/boards/${boardId}/posts/${postId}/rating`
+        );
+        return this.normalizeRating(response);
+    }
+
+    /**
+     * 게시글 별점 등록/수정 (1~5, 재투표 허용)
+     * 🔒 인증 필요 (앙님💛 이상) — 401 / 403(레벨·비활성 보드) / 400(범위 밖) 가능
+     */
+    async putPostRating(
+        boardId: string,
+        postId: number | string,
+        rating: number
+    ): Promise<PostRating> {
+        const response = await this.request<PostRating>(
+            `/boards/${boardId}/posts/${postId}/rating`,
+            {
+                method: 'PUT',
+                body: JSON.stringify({ rating })
+            },
+            WRITE_REQUEST_CONFIG
+        );
+        return this.normalizeRating(response);
     }
 
     /**

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -82,6 +82,8 @@ export interface FreePost {
     } | null;
     is_left?: boolean; // 작성자 탈퇴 여부 (SSR enrichment)
     report_count?: number | string; // wr_7 값: 숫자(신고수) 또는 "lock"(잠김)
+    // 별점 집계 (features.rating 보드에서만 백엔드가 동봉 — 없으면 위젯 미표시)
+    rating?: PostRating;
     // 확장 필드 (PHP wr_1~wr_10 매핑)
     extra_1?: string; // wr_1 - 회원전용 등
     extra_2?: string; // wr_2 - 나눔: 포인트/숫자
@@ -654,6 +656,14 @@ export interface CreateCommentRequest {
 // 댓글 수정 요청
 export interface UpdateCommentRequest {
     content: string; // 필수, 1자 이상
+}
+
+// 게시글 별점 집계 (features.rating 보드 — 앙티티 Phase 0)
+// 계약: GET/PUT /api/v1/boards/:slug/posts/:id/rating → {avg, count, my}
+export interface PostRating {
+    avg: number; // 평균 별점 (0~5)
+    count: number; // 참여 인원
+    my: number; // 내 별점 (1~5, 비로그인/미투표 0)
 }
 
 // 추천/비추천 응답

--- a/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/poster-gallery.svelte
@@ -101,15 +101,26 @@
                 </div>
             </div>
 
-            <!-- 카테고리 뱃지 (좌상단) -->
-            {#if post.category}
-                <div class="absolute left-2 top-2">
-                    <Badge
-                        variant="secondary"
-                        class="bg-black/50 text-xs text-white backdrop-blur-sm"
-                    >
-                        {post.category}
-                    </Badge>
+            <!-- 카테고리 · 별점 뱃지 (좌상단) -->
+            {#if post.category || (post.rating && post.rating.count > 0)}
+                <div class="absolute left-2 top-2 flex flex-col items-start gap-1">
+                    {#if post.category}
+                        <Badge
+                            variant="secondary"
+                            class="bg-black/50 text-xs text-white backdrop-blur-sm"
+                        >
+                            {post.category}
+                        </Badge>
+                    {/if}
+                    <!-- 별점 오버레이 (앙티티 Phase 0): 목록 응답에 rating 동봉 시에만 -->
+                    {#if post.rating && post.rating.count > 0}
+                        <Badge
+                            variant="secondary"
+                            class="bg-black/50 text-xs text-amber-300 backdrop-blur-sm"
+                        >
+                            ★ {post.rating.avg.toFixed(1)}
+                        </Badge>
+                    {/if}
                 </div>
             {/if}
 

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -45,6 +45,7 @@
     import Pin from '@lucide/svelte/icons/pin';
     import ShareButton from '$lib/components/post/share-button.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
+    import PostRatingWidget from '../../post-rating.svelte';
     import type { ViewLayoutProps } from '../types.js';
 
     const FONT_SIZES: Record<ContentFontSize, string> = {
@@ -334,6 +335,12 @@
                 >
             </div>
         </div>
+
+        <!-- 별점 위젯 (앙티티 Phase 0): features.rating 보드에서만 백엔드가
+             post.rating 을 동봉 → 없으면 렌더 0 (전 게시판 회귀 0) -->
+        {#if post.rating}
+            <PostRatingWidget {boardId} postId={post.id} initial={post.rating} />
+        {/if}
     </CardHeader>
     <CardContent class="space-y-6">
         <!-- 진실의방: 원본 게시글/댓글 링크 -->

--- a/apps/web/src/lib/components/features/board/post-rating-logic.test.ts
+++ b/apps/web/src/lib/components/features/board/post-rating-logic.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+    RATING_MIN_LEVEL,
+    clampRating,
+    starFillPercent,
+    applyOptimisticRating
+} from './post-rating-logic';
+
+describe('starFillPercent — 별 채움 계산', () => {
+    it('avg 4.3 → 1~4번째 별 100%, 5번째 별 30%', () => {
+        expect(starFillPercent(4.3, 1)).toBe(100);
+        expect(starFillPercent(4.3, 2)).toBe(100);
+        expect(starFillPercent(4.3, 3)).toBe(100);
+        expect(starFillPercent(4.3, 4)).toBe(100);
+        expect(starFillPercent(4.3, 5)).toBe(30);
+    });
+
+    it('avg 0 → 모든 별 0%', () => {
+        for (const star of [1, 2, 3, 4, 5]) {
+            expect(starFillPercent(0, star)).toBe(0);
+        }
+    });
+
+    it('avg 5 → 모든 별 100%', () => {
+        for (const star of [1, 2, 3, 4, 5]) {
+            expect(starFillPercent(5, star)).toBe(100);
+        }
+    });
+
+    it('경계: avg 2.5 → 3번째 별 50%, 4번째 별 0%', () => {
+        expect(starFillPercent(2.5, 3)).toBe(50);
+        expect(starFillPercent(2.5, 4)).toBe(0);
+    });
+
+    it('비정상 값(NaN/Infinity)은 0%', () => {
+        expect(starFillPercent(NaN, 1)).toBe(0);
+        expect(starFillPercent(Infinity, 1)).toBe(0);
+    });
+});
+
+describe('clampRating — 별점 값 클램프', () => {
+    it('1~5 범위로 클램프한다', () => {
+        expect(clampRating(0)).toBe(1);
+        expect(clampRating(3)).toBe(3);
+        expect(clampRating(7)).toBe(5);
+        expect(clampRating(NaN)).toBe(1);
+    });
+});
+
+describe('applyOptimisticRating — 낙관적 갱신 + 롤백 안전성', () => {
+    it('첫 투표: count+1, 평균 재계산', () => {
+        // (4*2 + 1) / 3 = 3
+        const next = applyOptimisticRating({ avg: 4, count: 2, my: 0 }, 1);
+        expect(next).toEqual({ avg: 3, count: 3, my: 1 });
+    });
+
+    it('첫 투표: 참여 0명 글에 5점 → avg 5, count 1', () => {
+        const next = applyOptimisticRating({ avg: 0, count: 0, my: 0 }, 5);
+        expect(next).toEqual({ avg: 5, count: 1, my: 5 });
+    });
+
+    it('재투표: count 불변, 이전 내 별점을 빼고 새 별점을 더한다', () => {
+        // 합계 8 → 8 - 3 + 5 = 10 → avg 5
+        const next = applyOptimisticRating({ avg: 4, count: 2, my: 3 }, 5);
+        expect(next).toEqual({ avg: 5, count: 2, my: 5 });
+    });
+
+    it('입력 객체를 변이하지 않는다 → 실패 시 이전 객체로 롤백 가능', () => {
+        const prev = { avg: 4.5, count: 10, my: 0 };
+        const snapshot = { ...prev };
+        const optimistic = applyOptimisticRating(prev, 5);
+        expect(prev).toEqual(snapshot); // 원본 그대로 = 롤백 대상 보존
+        expect(optimistic).not.toBe(prev);
+    });
+
+    it('범위 밖 입력은 클램프해서 반영한다', () => {
+        const next = applyOptimisticRating({ avg: 0, count: 0, my: 0 }, 9);
+        expect(next.my).toBe(5);
+    });
+});
+
+describe('RATING_MIN_LEVEL', () => {
+    it('앙님💛 = mb_level 3 (as_level 아님)', () => {
+        expect(RATING_MIN_LEVEL).toBe(3);
+    });
+});

--- a/apps/web/src/lib/components/features/board/post-rating-logic.ts
+++ b/apps/web/src/lib/components/features/board/post-rating-logic.ts
@@ -1,0 +1,42 @@
+import type { PostRating } from '$lib/api/types.js';
+
+/**
+ * 별점 투표 최소 등급 — 앙님💛 (mb_level 3).
+ * ⚠️ mb_level(등급) 기준. as_level(활동 레벨)을 넣지 말 것.
+ */
+export const RATING_MIN_LEVEL = 3;
+
+/** 별점 값을 1~5 정수로 클램프 */
+export function clampRating(value: number): number {
+    if (!Number.isFinite(value)) return 1;
+    return Math.min(5, Math.max(1, Math.round(value)));
+}
+
+/**
+ * n번째 별(1~5)의 채움 비율(0~100%) 계산.
+ * 예: value 4.3 → 1~4번째 별 100%, 5번째 별 30%.
+ */
+export function starFillPercent(value: number, star: number): number {
+    if (!Number.isFinite(value)) return 0;
+    const fill = Math.min(Math.max(value - (star - 1), 0), 1);
+    return Math.round(fill * 100);
+}
+
+/**
+ * 낙관적 갱신: 서버 응답 전에 내 투표를 집계에 미리 반영한 새 객체를 반환.
+ * 입력 객체는 변이하지 않는다 — 실패 시 이전 객체로 그대로 롤백하기 위함.
+ *
+ * - 첫 투표(my=0): count+1, 합계에 내 별점 추가
+ * - 재투표(my>0): count 불변, 합계에서 이전 내 별점을 빼고 새 별점을 더함
+ */
+export function applyOptimisticRating(current: PostRating, next: number): PostRating {
+    const my = clampRating(next);
+    if (current.my > 0) {
+        const count = Math.max(current.count, 1);
+        const sum = current.avg * count - current.my + my;
+        return { avg: sum / count, count, my };
+    }
+    const count = current.count + 1;
+    const sum = current.avg * current.count + my;
+    return { avg: sum / count, count, my };
+}

--- a/apps/web/src/lib/components/features/board/post-rating.svelte
+++ b/apps/web/src/lib/components/features/board/post-rating.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+    /**
+     * 게시글 별점 위젯 (앙티티 Phase 0 — features.rating 보드)
+     *
+     * post.rating 이 글 상세 응답에 동봉된 게시글에서만 렌더된다
+     * (부모에서 {#if post.rating} 가드 — 프론트에 별도 보드 설정 조회 없음).
+     *
+     * - 평균 별점 채움(부분 채움 포함) + "★4.3 · 앙님 21명" 요약
+     * - 로그인 + 앙님💛(mb_level 3) 이상: 별 클릭으로 투표 (PUT, 낙관적 갱신 + 실패 롤백)
+     * - 내 별점은 채움색(primary)으로 구분
+     * - 레벨 미달 클릭: 기존 등급 안내 문구(buildGradeDeniedMessage) 재사용
+     *
+     * 계약: GET/PUT /api/v1/boards/:slug/posts/:id/rating → {avg, count, my}
+     */
+    import Star from '@lucide/svelte/icons/star';
+    import { toast } from 'svelte-sonner';
+    import { apiClient } from '$lib/api/client.js';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { buildGradeDeniedMessage } from '$lib/utils/board-permissions.js';
+    import type { PostRating } from '$lib/api/types.js';
+    import {
+        RATING_MIN_LEVEL,
+        applyOptimisticRating,
+        starFillPercent
+    } from './post-rating-logic.js';
+
+    let {
+        boardId,
+        postId,
+        initial
+    }: {
+        boardId: string;
+        postId: number | string;
+        initial: PostRating;
+    } = $props();
+
+    const STARS = [1, 2, 3, 4, 5];
+
+    // 의도적 초기값 스냅샷: SSR 동봉 집계를 시작점으로 쓰고 이후엔 위젯이 소유
+    // svelte-ignore state_referenced_locally
+    let rating = $state<PostRating>({ ...initial });
+    let submitting = $state(false);
+    let hoverValue = $state(0);
+
+    const canVote = $derived(
+        authStore.isAuthenticated && (authStore.user?.mb_level ?? 1) >= RATING_MIN_LEVEL
+    );
+
+    // 호버 미리보기 중이면 호버 값, 아니면 평균 채움
+    const displayValue = $derived(hoverValue > 0 ? hoverValue : rating.avg);
+
+    /** 내 별점 채움색 구분: 미리보기 중이 아닐 때, 내가 준 별까지 primary 색 */
+    function isMyFill(star: number): boolean {
+        return hoverValue === 0 && rating.my > 0 && star <= rating.my;
+    }
+
+    async function vote(star: number): Promise<void> {
+        if (submitting) return;
+        if (!authStore.isAuthenticated) {
+            toast.error('별점을 남기려면 로그인이 필요해요.');
+            return;
+        }
+        const level = authStore.user?.mb_level ?? 1;
+        if (level < RATING_MIN_LEVEL) {
+            toast.error(buildGradeDeniedMessage('별점 남기기', RATING_MIN_LEVEL, level));
+            return;
+        }
+
+        const prev = { ...rating };
+        rating = applyOptimisticRating(prev, star); // 낙관적 갱신
+        hoverValue = 0;
+        submitting = true;
+        try {
+            rating = await apiClient.putPostRating(boardId, postId, star);
+            toast.success(prev.my > 0 ? '별점을 수정했어요.' : '별점을 남겼어요.');
+        } catch (err) {
+            rating = prev; // 실패 롤백
+            toast.error(err instanceof Error ? err.message : '별점 등록에 실패했어요.');
+        } finally {
+            submitting = false;
+        }
+    }
+</script>
+
+<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+    <div class="flex items-center" role="radiogroup" aria-label="별점 선택 (1~5점)">
+        {#each STARS as star (star)}
+            <button
+                type="button"
+                class="p-0.5 transition-transform {canVote
+                    ? 'cursor-pointer hover:scale-110'
+                    : 'cursor-default'}"
+                disabled={submitting}
+                role="radio"
+                aria-checked={rating.my === star}
+                aria-label="별점 {star}점"
+                onclick={() => vote(star)}
+                onmouseenter={() => {
+                    if (canVote) hoverValue = star;
+                }}
+                onmouseleave={() => (hoverValue = 0)}
+                onfocus={() => {
+                    if (canVote) hoverValue = star;
+                }}
+                onblur={() => (hoverValue = 0)}
+            >
+                <span class="relative block h-5 w-5">
+                    <Star class="text-muted-foreground/40 h-5 w-5" />
+                    <span
+                        class="absolute inset-y-0 left-0 overflow-hidden"
+                        style="width: {starFillPercent(displayValue, star)}%"
+                    >
+                        <Star
+                            class="h-5 w-5 {isMyFill(star)
+                                ? 'fill-primary text-primary'
+                                : 'fill-amber-400 text-amber-400'}"
+                        />
+                    </span>
+                </span>
+            </button>
+        {/each}
+    </div>
+    <span class="text-muted-foreground text-sm">
+        {#if rating.count > 0}
+            <span class="text-foreground font-medium">★{rating.avg.toFixed(1)}</span>
+            · 앙님 {rating.count.toLocaleString()}명
+        {:else}
+            첫 별점을 남겨주세요
+        {/if}
+        {#if rating.my > 0}
+            <span class="text-primary ml-1">내 별점 ★{rating.my}</span>
+        {/if}
+    </span>
+</div>


### PR DESCRIPTION
## 개요

앙티티(/angtt) 별점 시스템 Phase 0 의 프론트엔드 구현입니다 (angtt-connect 설계 Phase 0).

⚠️ **backend rating API PR(angple-backend) 이 먼저 배포되어야 동작합니다.** backend 는 병렬 개발 중이며, 본 PR 은 아래 API 계약을 확정본으로 간주하고 구현했습니다. backend 배포 전까지 draft 를 유지해 주세요.

## API 계약 (확정본 기준)

- `GET /api/v1/boards/:slug/posts/:id/rating` → `{"avg":4.3,"count":21,"my":0}` (비로그인 `my=0`)
- `PUT` 같은 경로, body `{"rating":1~5}` → 같은 응답. `401`/`403`(레벨·비활성 보드)/`400` 가능
- 글 상세 응답에 `post.rating?: {avg, count, my}` 동봉 (features.rating 보드에서만) — **없으면 위젯 미렌더 폴백**

## 변경 내용

### 글 상세 별점 위젯 (신규 `post-rating.svelte`)

- `post.rating` 이 응답에 존재할 때만 렌더 — 프론트에 별도 보드 설정 조회 없음, 미동봉 게시판은 렌더 0 (전 게시판 회귀 없음)
- 평균 별점 부분 채움(★★★★☆) + "★4.3 · 앙님 21명" 요약, 기존 카드 헤더 디자인 언어 유지
- 로그인 + 앙님💛(mb_level ≥ 3): 별 클릭 투표 — PUT, 낙관적 갱신 + 실패 롤백 + 토스트
- 내 별점은 채움색(primary)으로 구분, 재투표 허용
- 레벨 미달 클릭 시 기존 `buildGradeDeniedMessage` 등급 안내 문구 재사용 (mb_level 기준, as_level 미사용)
- 삽입 위치: `layouts/view/basic.svelte` 제목/메타 아래 (CardHeader 내부)

### 포스터 갤러리 오버레이 (`layouts/list/poster-gallery.svelte`)

- 목록 응답에 `post.rating` 동봉 + 참여 1명 이상일 때만 "★4.3" 배지 오버레이 (좌상단, 카테고리 배지와 스택)
- 목록 응답에 rating 이 없으면 자연히 미표시 (조건부 렌더만) — backend 목록 집계는 후속 PR 예정이라 그때까지 무해

### API client / 타입

- `client.ts`: `getPostRating` / `putPostRating` — bare 응답과 `{data}` 래핑 모두 수용하는 정규화 포함
- `types.ts`: `PostRating` 인터페이스 + `FreePost.rating?: PostRating`

### 로직 분리 + 단위 테스트

- `post-rating-logic.ts`: 별 채움 계산(`starFillPercent`)·낙관적 갱신(`applyOptimisticRating`, 입력 비변이 → 롤백 안전) 순수 함수
- `post-rating-logic.test.ts`: 12건 (채움 계산·첫 투표/재투표 집계·롤백 안전성·클램프)

## 검증

- `pnpm check`: **0 errors** (경고는 기존 코드의 pre-existing 만 — 본 PR 로 늘어난 경고 0)
- `pnpm vitest run`: **50 files / 515 tests 전체 통과** (신규 12건 포함)
- prettier / eslint: 변경 파일 전부 0 errors

## 배포 순서

1. backend rating API (angple-backend) DDL 적용·배포
2. 앙티티 보드 extended settings 에서 `features.rating` 활성
3. 본 PR 머지·배포
