### PR TITLE
feat(angtt): 앙티티 커넥트 카드 — 태그 「앙티티」+작품명 → 별점 카드

### DIFF
--- a/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
+++ b/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+    /**
+     * 앙티티 커넥트 카드 (Phase 1)
+     *
+     * 규약: 글 태그에 「앙티티」 + 작품명 → 글 하단(댓글 직전)에 작품 카드.
+     * 서버(+page.server.ts)에서 사전 매칭·별점을 확정해 SSR 렌더한다 (내부링크 SEO).
+     *
+     * - 매칭: 포스터(2:3 소형) + 작품명 + ★평점 + [⭐ 별점 주러 가기] → /angtt/{wrId}
+     * - 미등록: 등록 유도 + [✍️ 첫 등록하고 별점 열기] → /angtt
+     *   (글쓰기 라우트에 제목 프리필 쿼리 미지원 — Phase 2 에서 프리필 연동)
+     * - 스포일러 안전: 포스터·평점·링크만 노출 (줄거리류 텍스트 없음)
+     * - GA4: 카드 노출(angtt_card_impression) / CTA 클릭(angtt_card_cta_click)
+     */
+    import { onMount } from 'svelte';
+    import { trackEvent } from '$lib/services/ga4';
+    import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
+
+    /** 서버 AngttMatch(lib/server/angtt-dictionary.ts)와 구조 동일 — $lib/server 는 클라 import 불가라 별도 선언 */
+    type AngttCardMatch =
+        | {
+              wrId: number;
+              title: string;
+              thumbnail: string;
+              rating: { avg: number; count: number } | null;
+          }
+        | { notFound: true; query: string };
+
+    let {
+        match,
+        boardId,
+        postId
+    }: {
+        match: AngttCardMatch;
+        boardId: string;
+        postId: number | string;
+    } = $props();
+
+    const matched = $derived(!('notFound' in match));
+    const posterUrl = $derived('notFound' in match ? '' : toThumbnailUrl(match.thumbnail));
+
+    onMount(() => {
+        trackEvent('angtt_card_impression', {
+            board_id: boardId,
+            post_id: String(postId),
+            matched: matched ? 'yes' : 'no',
+            work_id: 'notFound' in match ? '' : String(match.wrId)
+        });
+    });
+
+    function onCtaClick(cta: 'rate' | 'register'): void {
+        trackEvent('angtt_card_cta_click', {
+            board_id: boardId,
+            post_id: String(postId),
+            cta,
+            work_id: 'notFound' in match ? '' : String(match.wrId)
+        });
+    }
+</script>
+
+<div class="bg-card my-4 flex items-center gap-3 rounded-lg border p-3">
+    {#if 'notFound' in match}
+        <div
+            class="bg-muted flex aspect-[2/3] w-11 shrink-0 items-center justify-center rounded text-lg"
+            aria-hidden="true"
+        >
+            🎬
+        </div>
+        <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-medium">「{match.query}」 — 앙티티에 아직 없어요</p>
+            <p class="text-muted-foreground text-xs">다모앙 추천작 — 앙티티</p>
+        </div>
+        <a
+            href="/angtt"
+            class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
+            onclick={() => onCtaClick('register')}
+        >
+            ✍️ 첫 등록하고 별점 열기
+        </a>
+    {:else}
+        {#if posterUrl}
+            <img
+                src={posterUrl}
+                alt="{match.title} 포스터"
+                class="aspect-[2/3] w-11 shrink-0 rounded object-cover"
+                loading="lazy"
+            />
+        {:else}
+            <div
+                class="bg-muted flex aspect-[2/3] w-11 shrink-0 items-center justify-center rounded text-lg"
+                aria-hidden="true"
+            >
+                🎬
+            </div>
+        {/if}
+        <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-medium">{match.title}</p>
+            <p class="text-muted-foreground text-xs">
+                다모앙 추천작 — 앙티티
+                {#if match.rating && match.rating.count > 0}
+                    <span class="text-amber-600 dark:text-amber-400">
+                        · ★{match.rating.avg.toFixed(1)} · 앙님 {match.rating.count}명
+                    </span>
+                {:else if match.rating}
+                    <span>· 아직 별점이 없어요</span>
+                {/if}
+            </p>
+        </div>
+        <a
+            href="/angtt/{match.wrId}"
+            class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
+            onclick={() => onCtaClick('rate')}
+        >
+            ⭐ 별점 주러 가기
+        </a>
+    {/if}
+</div>

--- a/apps/web/src/lib/server/angtt-dictionary-logic.test.ts
+++ b/apps/web/src/lib/server/angtt-dictionary-logic.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+    ANGTT_TAG,
+    normalizeWorkTitle,
+    hasAngttTag,
+    buildDictionary,
+    matchWorkFromTags
+} from './angtt-dictionary-logic';
+
+describe('normalizeWorkTitle — 정규화 (trim + 연속 공백 1개화 + 소문자)', () => {
+    it('앞뒤 공백을 제거한다', () => {
+        expect(normalizeWorkTitle('  듄: 파트 2  ')).toBe('듄: 파트 2');
+    });
+
+    it('연속 공백을 1개로 합친다 (탭/개행 포함)', () => {
+        expect(normalizeWorkTitle('듄:   파트\t\t2')).toBe('듄: 파트 2');
+        expect(normalizeWorkTitle('듄:\n파트 2')).toBe('듄: 파트 2');
+    });
+
+    it('영문은 소문자로 통일한다', () => {
+        expect(normalizeWorkTitle('DUNE: Part Two')).toBe('dune: part two');
+    });
+
+    it('빈 문자열/공백만은 빈 문자열이 된다', () => {
+        expect(normalizeWorkTitle('')).toBe('');
+        expect(normalizeWorkTitle('   ')).toBe('');
+    });
+});
+
+describe('hasAngttTag — 「앙티티」 옵트인 스위치 판별', () => {
+    it('앙티티 태그가 있으면 true', () => {
+        expect(hasAngttTag(['앙티티', '듄'])).toBe(true);
+    });
+
+    it('공백이 섞여도 정규화 비교로 인식한다', () => {
+        expect(hasAngttTag([' 앙티티 ', '듄'])).toBe(true);
+    });
+
+    it('없으면 false', () => {
+        expect(hasAngttTag(['듄', '영화'])).toBe(false);
+        expect(hasAngttTag([])).toBe(false);
+    });
+});
+
+describe('buildDictionary — angtt 글 목록 → 정규화 사전', () => {
+    it('정규화 제목을 키로 등록한다', () => {
+        const dict = buildDictionary([{ wrId: 10, title: '  듄:  파트 2 ', thumbnail: 't.jpg' }]);
+        expect(dict.get('듄: 파트 2')).toEqual({
+            wrId: 10,
+            title: '듄:  파트 2',
+            thumbnail: 't.jpg'
+        });
+    });
+
+    it('동명 작품은 최신 글(wr_id 큰 쪽)이 우선한다 — 입력 순서 무관', () => {
+        const newer = { wrId: 20, title: '괴물', thumbnail: 'new.jpg' };
+        const older = { wrId: 5, title: '괴물', thumbnail: 'old.jpg' };
+        expect(buildDictionary([older, newer]).get('괴물')?.wrId).toBe(20);
+        expect(buildDictionary([newer, older]).get('괴물')?.wrId).toBe(20);
+    });
+
+    it('빈 제목은 건너뛴다', () => {
+        const dict = buildDictionary([{ wrId: 1, title: '   ', thumbnail: '' }]);
+        expect(dict.size).toBe(0);
+    });
+});
+
+describe('matchWorkFromTags — 태그 → 작품 매칭 규약', () => {
+    const dict = buildDictionary([
+        { wrId: 100, title: '듄: 파트 2', thumbnail: 'dune.jpg' },
+        { wrId: 200, title: 'The Bear', thumbnail: 'bear.jpg' }
+    ]);
+
+    it('앙티티 태그는 후보에서 제외하고, 사전 일치 태그로 작품을 찾는다', () => {
+        const result = matchWorkFromTags([ANGTT_TAG, '듄: 파트 2'], dict);
+        expect(result).toEqual({
+            work: { wrId: 100, title: '듄: 파트 2', thumbnail: 'dune.jpg' }
+        });
+    });
+
+    it('대소문자·공백 차이가 있어도 정확 일치로 매칭한다', () => {
+        const result = matchWorkFromTags(['앙티티', ' the  BEAR '], dict);
+        expect(result).toEqual({
+            work: { wrId: 200, title: 'The Bear', thumbnail: 'bear.jpg' }
+        });
+    });
+
+    it('여러 후보 중 첫 번째 일치 태그를 쓴다', () => {
+        const result = matchWorkFromTags(['앙티티', '미등록작', '듄: 파트 2'], dict);
+        expect(result && 'work' in result && result.work.wrId).toBe(100);
+    });
+
+    it('일치 없으면 첫 번째 후보 태그를 query 로 반환한다 (원문 트림 유지)', () => {
+        const result = matchWorkFromTags(['앙티티', ' 어떤작품 ', '다른태그'], dict);
+        expect(result).toEqual({ query: '어떤작품' });
+    });
+
+    it('앙티티 외 태그가 없으면 null (카드 미표시)', () => {
+        expect(matchWorkFromTags(['앙티티'], dict)).toBeNull();
+        expect(matchWorkFromTags(['앙티티', '  '], dict)).toBeNull();
+    });
+
+    it('자유 텍스트 부분 일치는 하지 않는다 (정확 일치만)', () => {
+        expect(matchWorkFromTags(['앙티티', '듄'], dict)).toEqual({ query: '듄' });
+    });
+});

--- a/apps/web/src/lib/server/angtt-dictionary-logic.ts
+++ b/apps/web/src/lib/server/angtt-dictionary-logic.ts
@@ -1,0 +1,82 @@
+/**
+ * 앙티티 커넥트 — 작품 사전 순수 로직 (Phase 1)
+ *
+ * 규약: 아무 게시판 글에 태그 「앙티티」(옵트인 스위치) + 작품명 태그가 달리면
+ * 작품명 태그를 앙티티 작품 사전과 "정확 일치" 매칭한다 (자유 텍스트 매칭 없음 — 오탐 원천 차단).
+ *
+ * 이 파일은 서버 의존성(fetch/cache) 없는 순수 함수만 담아 단위 테스트 대상으로 분리한다.
+ * (post-rating-logic.ts 분리 관례)
+ */
+
+/** 옵트인 스위치 태그 */
+export const ANGTT_TAG = '앙티티';
+
+/** 사전 항목: angtt 게시판 작품 글 1건 */
+export interface AngttWork {
+    /** angtt 게시판 글 번호 (wr_id) — /angtt/{wrId} 링크 대상 */
+    wrId: number;
+    /** 원본 제목 (표시용) */
+    title: string;
+    /** 포스터 썸네일 원본 URL (없으면 '') */
+    thumbnail: string;
+}
+
+/** 정규화 사전: 정규화 제목 → 작품 */
+export type AngttDictionary = Map<string, AngttWork>;
+
+/**
+ * 작품 제목 정규화: 앞뒤 공백 제거 + 연속 공백 1개화 + 소문자.
+ * 태그와 사전 양쪽에 동일 적용 후 정확 일치 비교한다.
+ */
+export function normalizeWorkTitle(title: string): string {
+    return title.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/** 태그 배열에 「앙티티」 옵트인 태그가 있는지 (정규화 비교) */
+export function hasAngttTag(tags: readonly string[]): boolean {
+    const angtt = normalizeWorkTitle(ANGTT_TAG);
+    return tags.some((t) => normalizeWorkTitle(t) === angtt);
+}
+
+/**
+ * angtt 글 목록 → 정규화 사전 생성.
+ * 동명 작품(정규화 제목 중복)은 최신 글(wr_id 큰 쪽) 우선.
+ */
+export function buildDictionary(
+    posts: readonly { wrId: number; title: string; thumbnail: string }[]
+): AngttDictionary {
+    const dict: AngttDictionary = new Map();
+    for (const post of posts) {
+        const key = normalizeWorkTitle(post.title);
+        if (!key) continue;
+        const existing = dict.get(key);
+        if (existing && existing.wrId >= post.wrId) continue;
+        dict.set(key, { wrId: post.wrId, title: post.title.trim(), thumbnail: post.thumbnail });
+    }
+    return dict;
+}
+
+/** 태그 매칭 결과: 일치 작품 / 미등록(유도 카드용 질의) / 후보 태그 없음(null) */
+export type TagMatchResult = { work: AngttWork } | { query: string } | null;
+
+/**
+ * 태그 목록에서 작품을 찾는다. 「앙티티」 태그 자신은 후보에서 제외.
+ *
+ * - 첫 번째로 사전과 일치하는 태그 → { work }
+ * - 후보 태그는 있으나 일치 없음 → { query: 첫 번째 후보 태그(트림, 원문 유지) }
+ * - 「앙티티」 외 태그가 아예 없음 → null (카드 미표시)
+ */
+export function matchWorkFromTags(tags: readonly string[], dict: AngttDictionary): TagMatchResult {
+    const angtt = normalizeWorkTitle(ANGTT_TAG);
+    const candidates = tags
+        .map((t) => ({ raw: t.trim(), key: normalizeWorkTitle(t) }))
+        .filter((c) => c.key && c.key !== angtt);
+
+    if (candidates.length === 0) return null;
+
+    for (const c of candidates) {
+        const work = dict.get(c.key);
+        if (work) return { work };
+    }
+    return { query: candidates[0].raw };
+}

--- a/apps/web/src/lib/server/angtt-dictionary.ts
+++ b/apps/web/src/lib/server/angtt-dictionary.ts
@@ -1,0 +1,168 @@
+/**
+ * 앙티티 커넥트 — 작품 사전 서버 모듈 (Phase 1)
+ *
+ * angtt 게시판 최근 글 목록을 백엔드 API 로 수집해 "정규화 제목 → 작품" 사전을 만든다.
+ * celebration.ts 등 $lib/server 인메모리 캐시 관례: TTL 5분 + singleflight(getOrSet)
+ * + 실패 시 stale 유지 / 빈 Map fallback.
+ *
+ * 성능 계약 (페이지 로드 절대 블록 금지):
+ * - 모든 백엔드 fetch 는 2s 타임아웃 (member-activity SSR 관례)
+ * - 실패는 내부 catch 로 수렴 — resolveAngttMatch 는 reject 하지 않고 undefined 반환
+ */
+import { backendFetch } from './backend-fetch.js';
+import { createCache } from './cache.js';
+import {
+    buildDictionary,
+    hasAngttTag,
+    matchWorkFromTags,
+    type AngttDictionary
+} from './angtt-dictionary-logic.js';
+
+export {
+    ANGTT_TAG,
+    normalizeWorkTitle,
+    hasAngttTag,
+    buildDictionary,
+    matchWorkFromTags
+} from './angtt-dictionary-logic.js';
+export type { AngttWork, AngttDictionary } from './angtt-dictionary-logic.js';
+
+/** 글 상세 SSR 에 내려가는 카드 데이터 (일치 / 미등록 유도) */
+export type AngttMatch =
+    | {
+          /** angtt 작품 글 번호 — /angtt/{wrId} 링크 대상 */
+          wrId: number;
+          title: string;
+          thumbnail: string;
+          /** 별점 집계 — 조회 실패 시 null (카드는 별점 줄만 생략) */
+          rating: { avg: number; count: number } | null;
+      }
+    | {
+          notFound: true;
+          /** 첫 번째 비「앙티티」 태그 — 등록 유도 카드 표기용 */
+          query: string;
+      };
+
+/** 사전 수집 상한: 최근 500글 (100 x 5페이지) */
+const PAGE_LIMIT = 100;
+const MAX_PAGES = 5;
+
+/** 백엔드 fetch 타임아웃 — SSR 블로킹 방지 (member-activity 관례) */
+const FETCH_TIMEOUT_MS = 2_000;
+
+/** 사전 캐시: TTL 5분 */
+const DICT_CACHE_KEY = 'angtt-dictionary';
+const dictCache = createCache<AngttDictionary>({ ttl: 5 * 60_000, maxSize: 2 });
+
+/** 백엔드 목록 응답의 글 항목 (필요 필드만) */
+interface BackendListPost {
+    id?: number;
+    title?: string;
+    thumbnail?: string;
+    thumbnail_raw?: string;
+    images?: string[];
+}
+
+/** 목록 응답 파싱: data 가 배열(index-widgets 관례) 또는 {items} 페이지네이션 둘 다 수용 */
+function extractListItems(json: unknown): BackendListPost[] {
+    const data = (json as { data?: unknown })?.data;
+    if (Array.isArray(data)) return data as BackendListPost[];
+    const items = (data as { items?: unknown })?.items;
+    if (Array.isArray(items)) return items as BackendListPost[];
+    return [];
+}
+
+/** angtt 글 목록을 페이지 순회로 수집해 사전 생성. 1페이지 실패는 throw(→stale fallback). */
+async function fetchDictionary(): Promise<AngttDictionary> {
+    const posts: { wrId: number; title: string; thumbnail: string }[] = [];
+
+    for (let page = 1; page <= MAX_PAGES; page++) {
+        try {
+            const res = await backendFetch(
+                `/api/v1/boards/angtt/posts?page=${page}&limit=${PAGE_LIMIT}`,
+                { timeout: FETCH_TIMEOUT_MS }
+            );
+            if (!res.ok) throw new Error(`angtt list API error: ${res.status}`);
+
+            const items = extractListItems(await res.json());
+            for (const item of items) {
+                if (!item?.id || !item.title) continue;
+                posts.push({
+                    wrId: item.id,
+                    title: item.title,
+                    // 포스터 원본 우선 (poster-gallery 관례) — 컴포넌트에서 toThumbnailUrl 적용
+                    thumbnail: item.thumbnail_raw || item.thumbnail || item.images?.[0] || ''
+                });
+            }
+            if (items.length < PAGE_LIMIT) break; // 마지막 페이지
+        } catch (err) {
+            if (page === 1) throw err; // 전체 실패 → stale/빈 Map fallback 은 호출부에서
+            break; // 부분 수집으로 진행
+        }
+    }
+
+    return buildDictionary(posts);
+}
+
+/** 사전 조회 (5분 캐시 + singleflight). 실패 시 stale 유지, 그것도 없으면 빈 Map. */
+export async function getAngttDictionary(): Promise<AngttDictionary> {
+    try {
+        return await dictCache.getOrSet(DICT_CACHE_KEY, fetchDictionary);
+    } catch {
+        return dictCache.getStale(DICT_CACHE_KEY) ?? new Map();
+    }
+}
+
+/** 작품 글 별점 집계 조회 (공개 API). 실패 시 null — 카드는 별점 줄만 생략. */
+export async function fetchAngttRating(
+    wrId: number
+): Promise<{ avg: number; count: number } | null> {
+    try {
+        const res = await backendFetch(`/api/v1/boards/angtt/posts/${wrId}/rating`, {
+            timeout: FETCH_TIMEOUT_MS
+        });
+        if (!res.ok) return null;
+        const json = (await res.json()) as { data?: { avg?: number; count?: number } };
+        if (typeof json?.data?.avg !== 'number' || typeof json?.data?.count !== 'number') {
+            return null;
+        }
+        return { avg: json.data.avg, count: json.data.count };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * 글 태그에서 앙티티 카드 데이터를 해석한다.
+ *
+ * - 「앙티티」 태그 없음 → undefined (필드 자체 미포함)
+ * - 「앙티티」 + 사전 일치 태그 → 작품 카드 (+별점, 실패 시 null)
+ * - 「앙티티」 + 비일치 태그 → 등록 유도 카드
+ * - 「앙티티」 태그만 단독 → undefined
+ *
+ * 내부 실패는 전부 catch — 절대 reject 하지 않는다.
+ */
+export async function resolveAngttMatch(tags: unknown): Promise<AngttMatch | undefined> {
+    try {
+        if (!Array.isArray(tags) || tags.length === 0) return undefined;
+        const strTags = tags.filter((t): t is string => typeof t === 'string');
+        if (!hasAngttTag(strTags)) return undefined;
+
+        const dict = await getAngttDictionary();
+        const match = matchWorkFromTags(strTags, dict);
+        if (!match) return undefined;
+
+        if ('work' in match) {
+            const rating = await fetchAngttRating(match.work.wrId);
+            return {
+                wrId: match.work.wrId,
+                title: match.work.title,
+                thumbnail: match.work.thumbnail,
+                rating
+            };
+        }
+        return { notFound: true, query: match.query };
+    } catch {
+        return undefined;
+    }
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -31,6 +31,7 @@ import { BackendUnavailableError } from '$lib/server/backend-fetch.js';
 import { applyFilter } from '$lib/hooks/registry.js';
 import { buildHookContext } from '$lib/hooks/context.js';
 import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
+import { resolveAngttMatch, type AngttMatch } from '$lib/server/angtt-dictionary.js';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -251,6 +252,15 @@ export const load: PageServerLoad = async ({
                 return emptyActivity;
             }
         })();
+
+        // 앙티티 커넥트(Phase 1): 태그 「앙티티」 옵트인 글에만 작품 사전 매칭 + 별점 조회.
+        // 사전=인메모리 5분 캐시(+실패 시 stale/빈 Map), fetch 는 2s 타임아웃 + 내부 catch —
+        // 실패는 undefined 수렴이라 페이지 로드를 절대 블록하지 않는다.
+        // 앙티티 게시판 자기 글에는 미표시. return 직전 await → SSR 렌더 (내부링크 SEO).
+        const angttMatchPromise: Promise<AngttMatch | undefined> =
+            boardId === 'angtt' || post.deleted_at
+                ? Promise.resolve(undefined)
+                : resolveAngttMatch(post.tags).catch(() => undefined);
 
         // 게시글 작성자 프로필 이미지 즉시 조회 (1단계 — 본문 렌더에 필요)
         // 작성자 탈퇴 여부 — 닉네임 취소선 표시용(5분 캐시라 활동 게이트 조회와 중복돼도 저렴).
@@ -741,6 +751,9 @@ export const load: PageServerLoad = async ({
         // 페이지 로드를 추가로 블록하지 않는다. 익명·탈퇴는 상위 가드에서 null 수렴.
         const memberActivity = post.deleted_at ? null : await memberActivityPromise;
 
+        // 앙티티 커넥트 카드 데이터 — 위에서 병렬 시작한 promise 를 여기서 확정 (reject 없음).
+        const angttMatch = await angttMatchPromise;
+
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).
         // 미설치 시 pass-through. (premium PR #43 기준 stub)
         // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달.
@@ -766,6 +779,8 @@ export const load: PageServerLoad = async ({
             recentPosts,
             /** SEO 내부링크(#83): 작성자 활동 패널 SSR 확정 데이터 */
             memberActivity,
+            /** 앙티티 커넥트(Phase 1): 태그 「앙티티」+작품명 → 작품 카드 (없으면 undefined) */
+            angttMatch,
             /** 스트리밍: Promise로 반환 → 클라이언트에서 $effect로 수신 */
             streamed: {
                 auxiliaryData: auxiliaryDataPromise

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -42,6 +42,7 @@
     import CommentList from '$lib/components/features/board/comment-list.svelte';
     import AuthorActivityPanel from '$lib/components/features/board/author-activity-panel.svelte';
     import RecentPosts from '$lib/components/features/board/recent-posts.svelte';
+    import AngttConnectCard from '$lib/components/features/board/angtt-connect-card.svelte';
     import { BOARD_LIST_PAGE_SIZE } from '$lib/constants/board';
     import { ReportDialog } from '$lib/components/features/report/index.js';
     import type { FreeComment, FreePost, LikerInfo, PostRevision } from '$lib/api/types.js';
@@ -2209,6 +2210,11 @@
                     {/each}
                 </div>
             </div>
+        {/if}
+
+        <!-- 앙티티 커넥트 카드 (Phase 1): 태그 「앙티티」+작품명 규약 — 서버 매칭, SSR 렌더 -->
+        {#if data.angttMatch}
+            <AngttConnectCard match={data.angttMatch} {boardId} postId={data.post.id} />
         {/if}
 
         {#each beforeCommentsSlots as slot (slot.component)}


### PR DESCRIPTION
## 개요

앙티티 커넥트 Phase 1 구현입니다 (설계: angtt-connect-design-20260714 4장, Phase 0 #1803 후속).

아무 게시판 글에 태그 **「앙티티」 + 작품명** 이 달리면, 글 하단(댓글 직전)에 해당 작품의 앙티티 카드(포스터 · 평점 · 별점 주러 가기)를 SSR 로 렌더합니다. 앙티티 참여 루프 + 내부링크 SEO 목적입니다.

## 규약 (오탐 원천 차단)

- 「앙티티」 태그 = **명시적 옵트인 스위치**. 이 태그가 없으면 어떤 매칭도 하지 않습니다.
- 나머지 태그를 앙티티 작품 사전과 **정규화 후 정확 일치** 매칭합니다 (정규화 = trim + 연속 공백 1개화 + 소문자). 제목·본문 자유 텍스트 매칭은 하지 않습니다.
- 동명 작품 중복 시 최신 글(wr_id 큰 쪽) 우선입니다.
- 매칭 실패 시 첫 번째 비「앙티티」 태그로 **등록 유도 카드**를 표시합니다. 「앙티티」 태그 단독이면 카드를 표시하지 않습니다.
- 앙티티 게시판 자기 글에는 카드를 표시하지 않습니다 (boardId === 'angtt' 스킵).
- 스포일러 안전: 포스터 · 평점 · 링크만 노출하고 줄거리류 텍스트는 없습니다.

## 캐시 전략

- `$lib/server/angtt-dictionary.ts` — angtt 글 목록 API 로 최근 500글(100 x 5페이지) 수집 → `Map(정규화제목 → {wrId, title, thumbnail})`.
- 인메모리 캐시 **TTL 5분** + singleflight(`createCache.getOrSet`) — celebration 등 기존 `$lib/server` 캐시 관례를 따랐습니다.
- 갱신 실패 시 **stale 사전 유지**, stale 도 없으면 빈 Map fallback 입니다.

## 성능 (페이지 로드 블록 금지)

- 모든 백엔드 fetch 는 **2s 타임아웃** + 내부 catch (member-activity SSR 관례). `resolveAngttMatch` 는 절대 reject 하지 않고 undefined 로 수렴합니다.
- 사전 조회 promise 는 기존 memberActivity 관례대로 1단계 직후 병렬 시작 → return 직전 await 합니다. 사전 캐시 히트 시 추가 fetch 는 별점 1건(매칭 시)뿐입니다.
- 별점 조회(`GET /api/v1/boards/angtt/posts/{wrId}/rating`) 실패 시 카드는 별점 줄만 생략합니다.

## 카드 UI

- 매칭: 포스터 썸네일(2:3 소형) + 작품명 + "★{avg} · 앙님 {count}명" (0명이면 "아직 별점이 없어요") + **[⭐ 별점 주러 가기]** → `/angtt/{wrId}`
- 미등록: "🎬 「{query}」 — 앙티티에 아직 없어요" + **[✍️ 첫 등록하고 별점 열기]** → `/angtt`
- 기존 카드 디자인 언어(rounded-lg border + shadcn 토큰)라 다크모드가 자동 적용됩니다.
- GA4: 카드 노출 `angtt_card_impression` / CTA 클릭 `angtt_card_cta_click` (board_id, post_id, matched, work_id, cta).

## 알려진 제약

- **글쓰기 제목 프리필 미지원**: `[boardId]/write` 라우트는 현재 `repost`(promotion 전용) 프리필만 지원하고 `?title=` 쿼리를 읽지 않습니다. 등록 유도 CTA 는 `/angtt` 링크로 폴백했으며, 프리필 연동은 Phase 2(글쓰기 보조)에서 다루는 것이 좋겠습니다.
- 사전은 최근 500글 상한이라, 그보다 오래된 작품 글은 매칭되지 않습니다 (필요 시 상한 조정).

## 변경 파일

| 파일 | 내용 |
|---|---|
| `apps/web/src/lib/server/angtt-dictionary-logic.ts` | 신규 — 정규화 · 사전 생성 · 태그 매칭 순수 함수 |
| `apps/web/src/lib/server/angtt-dictionary.ts` | 신규 — 사전 수집/캐시 + 별점 조회 + `resolveAngttMatch` |
| `apps/web/src/lib/server/angtt-dictionary-logic.test.ts` | 신규 — 단위 테스트 16건 |
| `apps/web/src/lib/components/features/board/angtt-connect-card.svelte` | 신규 — 카드 컴포넌트 (매칭/등록 유도) |
| `apps/web/src/routes/[boardId]/[postId]/+page.server.ts` | 「앙티티」 태그 시 `angttMatch` 서버 확정 |
| `apps/web/src/routes/[boardId]/[postId]/+page.svelte` | beforeCommentsSlots 직전 카드 삽입 |

## 검증

- `pnpm check` — **0 errors** (122 warnings 는 기존과 동일)
- `pnpm vitest run` — **531/531 통과** (신규 16건 포함)
- Sprint Contract 체크리스트(설계 6장)의 ①~⑤는 카나리에서 실측 검증이 필요합니다: ① 앙티티+등록작품 태그 = 카드+정확 평점 ② 앙티티+미등록 = 유도 카드 ③ 앙티티 태그 없음 = 무표시 ④ 태그 없는 일반 글 회귀 0 ⑤ SSR HTML 에 앵커 포함
