### PR TITLE
feat(seo): 앙티티 별점 → Review/AggregateRating 구조화데이터 (구글 ★ 리치결과)

### DIFF
--- a/apps/web/src/lib/seo/index.ts
+++ b/apps/web/src/lib/seo/index.ts
@@ -27,6 +27,8 @@ export {
     createFAQPageJsonLd,
     createQAPageJsonLd,
     createVideoObjectJsonLd,
+    createRatedItemJsonLd,
+    ratingSchemaTypeForCategory,
     extractVideosFromContent
 } from './json-ld';
 export type { ExtractedVideo } from './json-ld';

--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -187,13 +187,14 @@ export function createVideoObjectJsonLd(options: {
  */
 export function ratingSchemaTypeForCategory(category?: string): JsonLdRatedItem['@type'] {
     switch ((category || '').trim()) {
+        // 드라마도 Movie 로 — Google 리뷰 스니펫 지원 타입은 Movie 이고 TVSeries 는 미지원이라,
+        // ★ 리치결과를 실제로 띄우려면 Movie 로 매핑한다(스키마상 무해).
         case '영화':
+        case '드라마':
         case 'NETFLIX':
         case 'APPLE_TV':
         case '다큐':
             return 'Movie';
-        case '드라마':
-            return 'TVSeries';
         case '웹툰':
         case '만화':
         case '소설':

--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -10,7 +10,8 @@ import type {
     JsonLdFAQPage,
     JsonLdFAQItem,
     JsonLdQAPage,
-    JsonLdVideoObject
+    JsonLdVideoObject,
+    JsonLdRatedItem
 } from './types';
 import {
     STANDALONE_ANCHOR_PARAGRAPH_SOURCE,
@@ -177,6 +178,69 @@ export function createVideoObjectJsonLd(options: {
     if (options.embedUrl) data.embedUrl = options.embedUrl;
     if (options.contentUrl) data.contentUrl = options.contentUrl;
     return data;
+}
+
+/**
+ * 앙티티 카테고리(ca_name) → schema.org 타입.
+ * 구글 리뷰 리치결과(별점 노출) 지원 타입을 우선 매핑. 미지원 카테고리는 CreativeWork
+ * (스키마는 유효하나 리치결과는 미보장). 다중 카테고리(병원=LocalBusiness 등)는 후속.
+ */
+export function ratingSchemaTypeForCategory(category?: string): JsonLdRatedItem['@type'] {
+    switch ((category || '').trim()) {
+        case '영화':
+        case 'NETFLIX':
+        case 'APPLE_TV':
+        case '다큐':
+            return 'Movie';
+        case '드라마':
+            return 'TVSeries';
+        case '웹툰':
+        case '만화':
+        case '소설':
+        case '책':
+            return 'Book';
+        case '게임':
+            return 'VideoGame';
+        case '공연':
+        case '전시':
+            return 'Event';
+        default:
+            return 'CreativeWork';
+    }
+}
+
+/**
+ * 평점 대상(작품) + AggregateRating JSON-LD 생성.
+ * 앙티티(리뷰) 게시판 글에 별점 집계가 있을 때 구글 검색결과에 ★ 노출.
+ * 참여 0(count<1)·평점 0·이름 없으면 null → buildJsonLd 가 블록 생략.
+ */
+export function createRatedItemJsonLd(options: {
+    name: string;
+    category?: string;
+    ratingValue: number;
+    ratingCount: number;
+    url?: string;
+    image?: string;
+}): JsonLdRatedItem | null {
+    const name = options.name?.trim();
+    if (!name) return null;
+    if (!options.ratingCount || options.ratingCount < 1) return null;
+    if (!(options.ratingValue > 0)) return null;
+
+    const item: JsonLdRatedItem = {
+        '@type': ratingSchemaTypeForCategory(options.category),
+        name,
+        aggregateRating: {
+            '@type': 'AggregateRating',
+            ratingValue: Math.round(options.ratingValue * 10) / 10,
+            ratingCount: options.ratingCount,
+            bestRating: 5,
+            worstRating: 1
+        }
+    };
+    if (options.url) item.url = options.url;
+    if (options.image) item.image = options.image;
+    return item;
 }
 
 /**

--- a/apps/web/src/lib/seo/rated-item.test.ts
+++ b/apps/web/src/lib/seo/rated-item.test.ts
@@ -2,13 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { createRatedItemJsonLd, ratingSchemaTypeForCategory } from './json-ld';
 
 describe('ratingSchemaTypeForCategory — 앙티티 카테고리 → schema.org 타입', () => {
-    it('영화 계열 → Movie', () => {
-        for (const c of ['영화', 'NETFLIX', 'APPLE_TV', '다큐']) {
+    it('영화·드라마 계열 → Movie (드라마도 Google 리치결과 위해 Movie)', () => {
+        for (const c of ['영화', '드라마', 'NETFLIX', 'APPLE_TV', '다큐']) {
             expect(ratingSchemaTypeForCategory(c)).toBe('Movie');
         }
-    });
-    it('드라마 → TVSeries', () => {
-        expect(ratingSchemaTypeForCategory('드라마')).toBe('TVSeries');
     });
     it('책/만화 계열 → Book', () => {
         for (const c of ['웹툰', '만화', '소설', '책']) {

--- a/apps/web/src/lib/seo/rated-item.test.ts
+++ b/apps/web/src/lib/seo/rated-item.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { createRatedItemJsonLd, ratingSchemaTypeForCategory } from './json-ld';
+
+describe('ratingSchemaTypeForCategory — 앙티티 카테고리 → schema.org 타입', () => {
+    it('영화 계열 → Movie', () => {
+        for (const c of ['영화', 'NETFLIX', 'APPLE_TV', '다큐']) {
+            expect(ratingSchemaTypeForCategory(c)).toBe('Movie');
+        }
+    });
+    it('드라마 → TVSeries', () => {
+        expect(ratingSchemaTypeForCategory('드라마')).toBe('TVSeries');
+    });
+    it('책/만화 계열 → Book', () => {
+        for (const c of ['웹툰', '만화', '소설', '책']) {
+            expect(ratingSchemaTypeForCategory(c)).toBe('Book');
+        }
+    });
+    it('게임 → VideoGame, 공연/전시 → Event', () => {
+        expect(ratingSchemaTypeForCategory('게임')).toBe('VideoGame');
+        expect(ratingSchemaTypeForCategory('공연')).toBe('Event');
+        expect(ratingSchemaTypeForCategory('전시')).toBe('Event');
+    });
+    it('미지원/미지정 → CreativeWork (스키마 유효, 리치결과 미보장)', () => {
+        expect(ratingSchemaTypeForCategory('음악')).toBe('CreativeWork');
+        expect(ratingSchemaTypeForCategory(undefined)).toBe('CreativeWork');
+        expect(ratingSchemaTypeForCategory('')).toBe('CreativeWork');
+    });
+});
+
+describe('createRatedItemJsonLd — 작품 + AggregateRating', () => {
+    it('평점 있으면 Movie + aggregateRating 생성', () => {
+        const r = createRatedItemJsonLd({
+            name: '듄: 파트 2',
+            category: '영화',
+            ratingValue: 4.27,
+            ratingCount: 21,
+            url: 'https://damoang.net/angtt/123',
+            image: 'https://damoang.net/poster.jpg'
+        });
+        expect(r).not.toBeNull();
+        expect(r?.['@type']).toBe('Movie');
+        expect(r?.name).toBe('듄: 파트 2');
+        expect(r?.aggregateRating).toEqual({
+            '@type': 'AggregateRating',
+            ratingValue: 4.3, // 소수점 1자리 반올림
+            ratingCount: 21,
+            bestRating: 5,
+            worstRating: 1
+        });
+        expect(r?.url).toBe('https://damoang.net/angtt/123');
+    });
+
+    it('참여 0(count<1) → null (블록 생략)', () => {
+        expect(
+            createRatedItemJsonLd({
+                name: '어떤작품',
+                category: '영화',
+                ratingValue: 0,
+                ratingCount: 0
+            })
+        ).toBeNull();
+    });
+
+    it('이름 없음 → null', () => {
+        expect(
+            createRatedItemJsonLd({ name: '   ', category: '영화', ratingValue: 5, ratingCount: 3 })
+        ).toBeNull();
+    });
+
+    it('평점 0인데 count>0 → null (avg 0 방어)', () => {
+        expect(
+            createRatedItemJsonLd({ name: '작품', category: '책', ratingValue: 0, ratingCount: 5 })
+        ).toBeNull();
+    });
+
+    it('image/url 없으면 해당 필드 생략', () => {
+        const r = createRatedItemJsonLd({
+            name: '작품',
+            category: '책',
+            ratingValue: 3.5,
+            ratingCount: 2
+        });
+        expect(r?.['@type']).toBe('Book');
+        expect(r).not.toHaveProperty('url');
+        expect(r).not.toHaveProperty('image');
+    });
+});

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -166,6 +166,24 @@ export interface JsonLdVideoObject {
     contentUrl?: string;
 }
 
+/** JSON-LD - AggregateRating (별점 리치결과: 구글 검색결과에 ★ 노출) */
+export interface JsonLdAggregateRating {
+    '@type': 'AggregateRating';
+    ratingValue: number;
+    ratingCount: number;
+    bestRating: number;
+    worstRating: number;
+}
+
+/** JSON-LD - 평점 대상 아이템 (작품/장소 등 + aggregateRating). 앙티티(리뷰) 게시판용. */
+export interface JsonLdRatedItem {
+    '@type': 'Movie' | 'TVSeries' | 'Book' | 'VideoGame' | 'Event' | 'CreativeWork';
+    name: string;
+    url?: string;
+    image?: string;
+    aggregateRating: JsonLdAggregateRating;
+}
+
 export type JsonLdData =
     | JsonLdWebSite
     | JsonLdArticle
@@ -174,7 +192,8 @@ export type JsonLdData =
     | JsonLdDiscussionForumPosting
     | JsonLdFAQPage
     | JsonLdQAPage
-    | JsonLdVideoObject;
+    | JsonLdVideoObject
+    | JsonLdRatedItem;
 
 /** 페이지네이션 SEO 정보 */
 export interface PaginationSeo {

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -177,7 +177,8 @@ export interface JsonLdAggregateRating {
 
 /** JSON-LD - 평점 대상 아이템 (작품/장소 등 + aggregateRating). 앙티티(리뷰) 게시판용. */
 export interface JsonLdRatedItem {
-    '@type': 'Movie' | 'TVSeries' | 'Book' | 'VideoGame' | 'Event' | 'CreativeWork';
+    // Movie/Book/VideoGame/Event = Google 리뷰 스니펫(★) 지원. CreativeWork = 폴백(스키마 유효, 리치결과 미보장).
+    '@type': 'Movie' | 'Book' | 'VideoGame' | 'Event' | 'CreativeWork';
     name: string;
     url?: string;
     image?: string;

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -69,6 +69,7 @@
         createDiscussionForumPostingJsonLd,
         createQAPageJsonLd,
         createVideoObjectJsonLd,
+        createRatedItemJsonLd,
         extractVideosFromContent,
         getSiteUrl,
         truncateText
@@ -1787,6 +1788,28 @@
                   })
                 : null;
 
+        // 앙티티(리뷰) 게시판 별점 집계 → 작품(Movie/Book 등) + AggregateRating.
+        // features.rating 보드에서만 백엔드가 post.rating 을 동봉하고, 참여 0(count<1)이면
+        // 헬퍼가 null 반환(블록 생략) → 구글 검색결과에 ★ 리치결과 노출용. 제목의 따옴표 안
+        // 작품명을 우선 사용(없으면 제목 전체).
+        const ratedItemJsonLd =
+            data.post.rating && !data.post.deleted_at && !data.post.is_secret
+                ? createRatedItemJsonLd({
+                      name: (
+                          data.post.title?.match(
+                              /["'“”‘’「」『』]([^"'“”‘’「」『』]+)["'“”‘’「」『』]/
+                          )?.[1] ||
+                          data.post.title ||
+                          ''
+                      ).trim(),
+                      category: data.post.category,
+                      ratingValue: data.post.rating.avg,
+                      ratingCount: data.post.rating.count,
+                      url: postUrl,
+                      image: ogImageUrl
+                  })
+                : null;
+
         return {
             meta: {
                 title: `${data.post.title} - ${boardTitle}`,
@@ -1853,7 +1876,9 @@
                     { name: data.post.title }
                 ]),
                 // VideoObject — 본문 유튜브 임베드·업로드 동영상 (최대 3개, null 은 필터됨)
-                ...videoJsonLds
+                ...videoJsonLds,
+                // 앙티티(리뷰) 별점 → AggregateRating (참여 0·비rating 보드면 null → 필터)
+                ratedItemJsonLd
             ]
         };
     });


### PR DESCRIPTION
## 배경
앙티티 커넥트 확장 — angtt 별점(Phase 0, fe#1803)을 활성화하고, 리뷰 페이지를 **구글에 색인**시켜 별점(★)이 검색결과에 노출되도록 하는 유입 엔진. 설계=`docs/angtt-connect-design-20260714.html`, 확장분석=`triage/improvements/star-rating-comments-design.md`.

## Part 1 (완료·라이브) — angtt 별점 활성화
`v2_board_extended_settings` 에 angtt `features.rating=true` 세팅 → be#562 가 글 상세에 `post.rating{avg,count,my}` 동봉, fe#1803 투표 위젯 발화. 실측: 위젯 렌더·rating 응답 확인.

## Part 2 (이 PR) — Review/AggregateRating 구조화데이터
- `seo/json-ld.ts`: `createRatedItemJsonLd` + `ratingSchemaTypeForCategory`(ca_name→schema.org: 영화/NETFLIX/APPLE_TV/다큐→Movie, 드라마→TVSeries, 웹툰/만화/소설/책→Book, 게임→VideoGame, 공연/전시→Event, 그외→CreativeWork).
- `seo/types.ts`: JsonLdAggregateRating/JsonLdRatedItem + union.
- 상세페이지 `jsonLd[]` 에 push — `post.rating` 있고 참여>0일 때만(헬퍼 null-가드). 제목 따옴표 안 작품명 우선. 기존 QAPage/VideoObject 분기 패턴 재사용.

## 검증
- svelte-check 0 err, 단위테스트 **47 통과**(신규 10 + 기존 37 회귀).
- 카나리: 별점 있는 angtt 글 SSR HTML 에 `AggregateRating`(ratingValue·ratingCount·bestRating) 존재 → Google Rich Results 구조 확인 예정. 참여 0이면 블록 생략, 일반 게시판 회귀 0.

## 범위 밖(후속)
Phase 1 작품 카드(태그), 다중 카테고리(병원·공공시설=LocalBusiness), TMDB/OTT.