### PR TITLE
fix(notification): 알림 조회 타임아웃 4.5s→10s (#13033 간헐 로딩 실패)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -80,12 +80,15 @@ const WRITE_REQUEST_CONFIG: Partial<RetryConfig> = {
     timeout: 30000
 };
 
-// 알림 조회는 백엔드가 무거울 수 있어(대량 누적 회원) 재시도 시 동일 쿼리를 중복
-// 발사하면 백엔드/DB 커넥션 풀을 굶긴다(#12954: 알림 무한 스피너 + 댓글 10개 고착).
-// 프록시 타임아웃(4s)에 맞춰 빠르게 실패시키고 재시도하지 않는다.
+// 알림 조회는 재시도 금지(maxRetries 0): 동일 쿼리 중복 발사가 백엔드/DB 커넥션
+// 풀을 굶긴다(#12954: 알림 무한 스피너 + 댓글 10개 고착).
+// 타임아웃은 브라우저→CF→SSR 전 구간 예산이다. 4.5s 는 느린 모바일 회선에서
+// 정상 응답도 끊어 간헐 "알림을 불러오지 못했습니다"를 만든다(#13033).
+// 백엔드는 g5_na_noti 정리 후 수십 ms(SSR→백엔드 프록시 타임아웃 4s 별도)라
+// 네트워크 여유분만 늘린다.
 const NOTIFICATION_READ_CONFIG: Partial<RetryConfig> = {
     maxRetries: 0,
-    timeout: 4500
+    timeout: 10000
 };
 
 // v2 API URL은 세션 기반 인증에서는 SvelteKit 프록시가 내부 JWT를 주입하므로


### PR DESCRIPTION
## 제보
bug/13033 — 알림 클릭 시 스피너 후 "알림을 불러오지 못했습니다", 재시도하면 가끔 성공 (모바일).

## 원인
`NOTIFICATION_READ_CONFIG` 타임아웃 4.5s 는 #12954(백엔드 알림 쿼리 지연) 때 프록시 4s 에 맞춘 값. 이후 g5_na_noti 정리(950만→328만)로 백엔드는 6~38ms 로 회복됐고(운영 로그 실측, 전부 200), 이제 4.5s 예산을 소진하는 건 **느린 모바일 회선의 왕복 시간**입니다 — 간헐 실패·재시도 성공 패턴과 일치.

## 변경
- 타임아웃 4500→10000ms (브라우저 전 구간 예산 확대)
- `maxRetries: 0` 유지 — #12954 커넥션 풀 스탬피드 가드 보존
- SSR→백엔드 프록시 타임아웃(4s)은 별개 구간이라 그대로

## 검증
- svelte-check 0 errors / api 단위 테스트 통과
- 토요일 배치 배포 후 제보자 재확인 요청 예정