### PR TITLE
feat(angtt): 댓글 별점 (리뷰=댓글+별점)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -115,6 +115,8 @@ export interface FreeComment {
     is_blocked?: boolean;
     /** 작성자 탈퇴 여부 — 닉네임 취소선 표시용. */
     is_left?: boolean;
+    /** 리뷰 별점(리뷰=댓글+별점): 작성자가 이 댓글에 남긴 리뷰 점수(1~5). 별점 게시판만. */
+    review_rating?: number;
     link1?: string;
     link2?: string;
     link1_display?: string;

--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -30,7 +30,8 @@
             content: string,
             parentId?: string | number,
             isSecret?: boolean,
-            images?: string[]
+            images?: string[],
+            rating?: number
         ) => Promise<void>;
         onCancel?: () => void;
         placeholder?: string;
@@ -45,6 +46,8 @@
         boardId?: string;
         onRefresh?: () => void;
         isRefreshing?: boolean;
+        /** 별점(리뷰) 게시판에서 원댓글에 별점 입력 노출 (angtt 등). 리뷰=댓글+별점 */
+        showRating?: boolean;
     }
 
     let {
@@ -61,8 +64,13 @@
         isRestricted = false,
         boardId = 'free',
         onRefresh,
-        isRefreshing = false
+        isRefreshing = false,
+        showRating = false
     }: Props = $props();
+
+    // 별점(리뷰=댓글+별점): 원댓글에서만, 작성자 본인의 리뷰 점수 (1~5, 0=무평점)
+    let rating = $state(0);
+    let hoverRating = $state(0);
 
     const canComment = $derived.by(() => {
         if (!authStore.isAuthenticated) return false;
@@ -172,9 +180,12 @@
 
         try {
             const submitContent = await stripAdminMentions(convertEmoticonImages(content.trim()));
-            await onSubmit(submitContent, parentId, false);
+            // 별점은 원댓글(리뷰)에만 — 대댓글/비rating 보드는 undefined
+            const reviewRating = showRating && !isReplyMode && rating > 0 ? rating : undefined;
+            await onSubmit(submitContent, parentId, false, undefined, reviewRating);
             trackEvent('comment_write', { board_id: boardId, is_reply: isReplyMode });
             content = '';
+            rating = 0;
             editorRef?.clear();
         } catch (err) {
             error = err instanceof Error ? err.message : '댓글 작성에 실패했습니다.';
@@ -253,6 +264,38 @@
 
 {#if canComment}
     <form onsubmit={handleSubmit} class="space-y-2">
+        {#if showRating && !isReplyMode}
+            <!-- 리뷰 별점 (리뷰=댓글+별점): 원댓글에만, 선택(무평점 가능) -->
+            <div class="flex items-center gap-2">
+                <span class="text-muted-foreground text-sm">별점</span>
+                <div
+                    class="inline-flex items-center"
+                    role="radiogroup"
+                    aria-label="리뷰 별점 선택 (1~5점, 선택)"
+                    onmouseleave={() => (hoverRating = 0)}
+                >
+                    {#each [1, 2, 3, 4, 5] as star (star)}
+                        <button
+                            type="button"
+                            role="radio"
+                            aria-checked={rating === star}
+                            aria-label={`별점 ${star}점`}
+                            class="p-0.5 text-xl leading-none transition-colors {(hoverRating ||
+                                rating) >= star
+                                ? 'text-amber-400'
+                                : 'text-muted-foreground/40'}"
+                            onmouseenter={() => (hoverRating = star)}
+                            onclick={() => (rating = rating === star ? 0 : star)}
+                        >
+                            ★
+                        </button>
+                    {/each}
+                </div>
+                {#if rating > 0}
+                    <span class="text-muted-foreground text-xs">{rating}.0</span>
+                {/if}
+            </div>
+        {/if}
         {#if isReplyMode}
             <div class="text-muted-foreground flex items-center gap-2 text-sm">
                 <CornerDownRight class="h-4 w-4" />

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1226,6 +1226,23 @@
                         </p>
                     {/if}
 
+                    <!-- 리뷰 별점(리뷰=댓글+별점): 작성자가 이 댓글에 남긴 점수 -->
+                    {#if comment.review_rating && comment.review_rating > 0}
+                        <div
+                            class="mb-1 inline-flex items-center gap-1 text-sm"
+                            aria-label={`리뷰 별점 ${comment.review_rating}점`}
+                        >
+                            <span class="text-amber-400" aria-hidden="true"
+                                >{'★'.repeat(Math.round(comment.review_rating))}{'☆'.repeat(
+                                    Math.max(0, 5 - Math.round(comment.review_rating))
+                                )}</span
+                            >
+                            <span class="text-muted-foreground text-xs"
+                                >{comment.review_rating.toFixed(1)}</span
+                            >
+                        </div>
+                    {/if}
+
                     <!-- Chat: 버블 래퍼 (비채팅은 투명) -->
                     <div
                         class={commentLayout === 'chat'

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1493,7 +1493,8 @@
         content: string,
         parentId?: string | number,
         isSecret?: boolean,
-        images?: string[]
+        images?: string[],
+        rating?: number
     ): Promise<void> {
         if (!authStore.user) {
             throw new Error('로그인이 필요합니다.');
@@ -1508,6 +1509,16 @@
                 is_secret: isSecret,
                 images
             });
+
+            // 리뷰 별점(리뷰=댓글+별점): 댓글 저장 후 그 댓글 wr_id 에 작성자 본인 별점 기록.
+            // be#562 별점 API 재사용(댓글 wr_id 수용 확인). 실패해도 댓글 작성은 성공 유지.
+            if (rating && rating > 0 && newComment?.id) {
+                try {
+                    await apiClient.putPostRating(boardId, String(newComment.id), rating);
+                } catch (ratingErr) {
+                    console.error('리뷰 별점 저장 실패(댓글은 작성됨):', ratingErr);
+                }
+            }
 
             // Optimistic update: 서버 응답 즉시 목록에 추가 (#11946)
             let optimisticComment: FreeComment | null = null;
@@ -2393,6 +2404,7 @@
                                     {boardId}
                                     onRefresh={refreshComments}
                                     isRefreshing={isRefreshingComments}
+                                    showRating={data.post.rating !== undefined}
                                 />
                             {/key}
                         {/if}

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -77,6 +77,8 @@ interface CommentResponseItem {
     is_blocked?: boolean;
     /** 작성자가 탈퇴 회원인지 — 닉네임 취소선 표시용. */
     is_left?: boolean;
+    /** 리뷰 별점(리뷰=댓글+별점): 작성자가 이 댓글에 남긴 리뷰 점수(1~5). 별점 게시판만. */
+    review_rating?: number;
 }
 
 interface DisciplineRow extends RowDataPacket {
@@ -240,6 +242,24 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             }
         }
 
+        // 리뷰 별점(리뷰=댓글+별점): angple_post_ratings 에서 댓글 wr_id 별 평균(작성자 리뷰 점수).
+        // 초경량 테이블 + PK(bo_table,wr_id) 인덱스 seek. 비rating 보드는 결과 0(무해). 실패 무시.
+        const reviewRatingMap = new Map<number, number>();
+        if (commentIds.length > 0) {
+            try {
+                const [rrRows] = await pool.query<RowDataPacket[]>(
+                    `SELECT wr_id, ROUND(AVG(rating), 1) AS avg_rating
+                     FROM angple_post_ratings
+                     WHERE bo_table = ? AND wr_id IN (?)
+                     GROUP BY wr_id`,
+                    [safeBoardId, commentIds]
+                );
+                for (const r of rrRows) reviewRatingMap.set(Number(r.wr_id), Number(r.avg_rating));
+            } catch (e) {
+                console.warn('[review-rating] enrich(comments) failed:', e);
+            }
+        }
+
         // 요청자가 차단한 작성자 집합 (#12825). 서버에서 is_blocked 를 판정해 내려주면
         // 클라이언트 차단 스토어가 비동기 로드되기 전에도 첫 렌더부터 접힘 상태로 표시되어
         // "보였다 숨었다" 깜박임이 사라진다. 실패는 무시(클라 스토어가 fallback).
@@ -307,6 +327,9 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             ...(row.mb_id && blockedSet.has(String(row.mb_id)) ? { is_blocked: true } : {}),
             ...(row.mb_id && withdrawnSet.has(String(row.mb_id)) ? { is_left: true } : {}),
             ...(disciplineSet.has(row.wr_id) ? { is_discipline_related: true } : {}),
+            ...(reviewRatingMap.has(row.wr_id)
+                ? { review_rating: reviewRatingMap.get(row.wr_id) }
+                : {}),
             ...(isAdmin && row.wr_7
                 ? {
                       report_count:


### PR DESCRIPTION
## 배경
앙티티 리뷰 플랫폼 — 글단위 별점(be#562/fe#1803, 오늘 angtt 활성화)에 더해 **댓글 별점**(리뷰=댓글+별점, 레터박스드 방식). 레거시 앙티티도 댓글에 별점이 있었음(wr_6). 설계=`triage/harness` 승인 플랜.

## 핵심: 백엔드 무변경
- be#562 별점 API(`PUT/GET /boards/:slug/posts/:id/rating`)가 **댓글 wr_id 를 수용**함 실측(GET→200). gnuboard wr_id 는 글·댓글 전역 유니크 → `angple_post_ratings`(PK bo_table,wr_id,mb_id)에 댓글 wr_id 로 넣어도 글별점과 안 섞임.
- **DDL·Go 백엔드·be#562 무변경.** web-only.

## 변경 (web)
- `comment-form.svelte`: 별점 게시판(`showRating`) 원댓글에 별점 입력(선택, 무평점 가능). `onSubmit` 에 rating 전달.
- `+page.svelte handleCreateComment`: 댓글 저장 후 그 wr_id 에 `putPostRating`(작성자 리뷰 점수). 별점 실패해도 댓글은 성공.
- `comments/+server.ts` GET: `angple_post_ratings` 배치 조회(defensive, PK seek, 비rating 보드 0건) → `review_rating` 동봉.
- `comment-list.svelte`: 댓글에 별점 배지.
- `showRating = post.rating !== undefined`(be#562 features.rating 보드). 대댓글 제외.

## 검증
- svelte-check 0 err, prettier 클린.
- ⚠️ **배포는 토요일 4시 배치**(#1807)에 편승(동시세션 클로버 방지).
- 독립 Evaluator 예정.