### PR TITLE
fix(editor): 모바일 툴바 1줄 가로스크롤 — 안드로이드 글쓰기 가림 해소 (#13037)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -1151,7 +1151,7 @@
 <div class="tiptap-editor border-input relative rounded-md border {className}">
     <!-- 툴바 -->
     <div
-        class="border-border bg-muted/50 sticky top-[64px] z-30 flex flex-wrap items-center gap-1 rounded-t-md border-b p-2"
+        class="border-border bg-muted/50 sticky top-[64px] z-30 flex flex-nowrap items-center gap-1 overflow-x-auto overscroll-x-contain rounded-t-md border-b p-2 sm:flex-wrap sm:overflow-x-visible [&>*]:shrink-0"
         role="toolbar"
         aria-label="텍스트 편집 도구"
     >
@@ -1502,7 +1502,7 @@
             </Button>
             {#if showTableMenu}
                 <div
-                    class="bg-popover border-border absolute left-0 top-full z-50 mt-1 rounded-md border p-2 shadow-md"
+                    class="bg-popover border-border fixed inset-x-2 bottom-2 z-50 rounded-md border p-2 shadow-md sm:absolute sm:inset-x-auto sm:bottom-auto sm:left-0 sm:top-full sm:mt-1"
                 >
                     <div class="flex flex-col gap-1">
                         <button


### PR DESCRIPTION
## 제보
bug/13037 — 안드로이드에서 키보드가 올라오면 에디터 툴바에 가려 글씨를 쓸 수 없음 (댓글 c_13039: 플로팅 대신 본문 포함 요청).

## 원인
툴바가 `sticky + flex-wrap` 인데 모바일 폭(~412px)에서 26개 버튼이 **5줄(~250px)** 로 wrap → 키보드 오픈 시 가시 영역(~400px)을 헤더(64px)+툴바가 전부 점유, 본문 입력 영역 0px.

## 변경 (A안: 1줄 가로스크롤 + sticky 유지)
- 툴바 컨테이너: 모바일 `flex-nowrap + overflow-x-auto + [&>*]:shrink-0`, `sm+` 는 기존 `flex-wrap` 유지 — 데스크톱 무변화
- 테이블 드롭다운: 스크롤 컨테이너에 잘리지 않게 모바일에서 하단 시트(fixed bottom)로 — 이모지 피커(기존 1477행)와 동일 패턴

## 효과
모바일 sticky 블록 높이 ~250px → ~48px. 키보드 오픈 시에도 본문 3~4줄 이상 확보.

## 검증
- svelte-check 0 errors
- canary 배포 후 안드로이드 실기기 확인 요청 예정 (제보자 안내 댓글)