### PR TITLE
feat(cert): 글/댓글 실명인증 강제 + DI 강화(키 fail-closed·충돌 감사)

### DIFF
--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -6,6 +6,7 @@ import pool, { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { createHash, randomBytes } from 'crypto';
 import { env } from '$env/dynamic/private';
+import { formatLeaveDate } from './member-leave.js';
 
 /** SEED IV를 base64로 반환 (런타임에 env 읽기) */
 export function getSeedIV(): string {
@@ -128,12 +129,113 @@ export function isValidInicisUrl(url: string): boolean {
     return url.startsWith('https://kssa.inicis.com') || url.startsWith('https://fcsa.inicis.com');
 }
 
+interface DupCollisionRow extends RowDataPacket {
+    mb_id: string;
+    mb_level: number;
+    mb_intercept_date: string;
+    mb_leave_date: string;
+}
+
+/**
+ * DI(mb_dupinfo) 충돌 하드닝(구멍②).
+ *
+ * 동일 dupinfo 를 가진 다른 계정을 조회한다. mb_dupinfo = 본인확인(CI)의 단방향 해시라
+ * 충돌 = 동일인. 매칭 계정이 **제재중(mb_intercept_date≠'') 또는 탈퇴(mb_leave_date≠'')**면
+ * 징계회피/다중이 재가입 정황 → durable 운영 플래그를 재인증 시도 계정 mb_memo 에 기록하고
+ * `blocked=true` 를 반환한다(호출부가 본인인증 거부·dupinfo 미저장에 사용).
+ *
+ * ⚠️ 밴/탈퇴 "유효" 판정은 코드베이스 관례와 일치 — 값이 비어있지 않으면 제재/탈퇴로 본다.
+ *    (제재: api/members/search/+server.ts:49, admin/members/[mbId]/+page.svelte:187 /
+ *     탈퇴: auth/oauth/member.ts:142 isMemberActive, auth/password-reset.ts:26)
+ *    어디에서도 현재시각과 날짜비교를 하지 않고 '비어있지 않음'만으로 판정하므로 동일 기준 사용.
+ *
+ * ⚠️ 정상(활성) 계정 매칭은 여기서 추가 차단하지 않는다 — 차단은 호출부 checkDupinfo 가
+ *    이미 1차 게이트로 담당하며(정상회원 회귀 방지), 이 함수는 감사 로그만 남긴다.
+ *
+ * 운영 플래그 기록처: mb_memo 앞줄 prepend (member-leave.ts 의 처리와 동일한 durable
+ *    per-member 운영 메모, 관리자 회원관리 화면에 노출). 별도 audit/security 테이블은
+ *    web 코드베이스에 없어(grep 0건) mb_memo 를 재사용한다.
+ */
+export async function flagDupinfoCollision(
+    mbId: string,
+    dupinfo: string
+): Promise<{ matched: boolean; blocked: boolean }> {
+    const [rows] = await readPool.query<DupCollisionRow[]>(
+        `SELECT mb_id, mb_level,
+                COALESCE(mb_intercept_date, '') AS mb_intercept_date,
+                COALESCE(mb_leave_date, '')     AS mb_leave_date
+           FROM g5_member
+          WHERE mb_dupinfo = ? AND mb_id <> ?`,
+        [dupinfo, mbId]
+    );
+
+    if (rows.length === 0) {
+        return { matched: false, blocked: false };
+    }
+
+    // 코드베이스 관례: mb_intercept_date/mb_leave_date 가 비어있지 않으면 제재/탈퇴.
+    const blockingRows = rows.filter(
+        (r) => (r.mb_intercept_date ?? '') !== '' || (r.mb_leave_date ?? '') !== ''
+    );
+
+    if (blockingRows.length === 0) {
+        // 정상(활성) 계정 매칭: 추가 차단 없이 감사 로그만.
+        console.warn('[Cert][DI-guard] DI collision with active account(s) — logged only', {
+            mbId,
+            dupinfoPrefix: dupinfo.slice(0, 16),
+            collisions: rows.map((r) => r.mb_id)
+        });
+        return { matched: true, blocked: false };
+    }
+
+    const flaggedAt = formatLeaveDate();
+    const detail = blockingRows
+        .map((r) => `${r.mb_id}(${(r.mb_leave_date ?? '') !== '' ? '탈퇴' : '제재'})`)
+        .join(', ');
+    const memo = `${flaggedAt} [DI충돌차단] 동일 본인확인정보 계정 ${detail} 존재 — 재인증 거부(다중이/징계회피 정황)`;
+
+    // durable 운영 플래그: 재인증 시도 계정 mb_memo 앞줄에 기록(관리자 회원관리 화면 노출).
+    // 실패해도 차단 판정 자체는 유지(로그만).
+    try {
+        await pool.query(
+            `UPDATE g5_member
+                SET mb_memo = CONCAT(?, IF(mb_memo IS NULL OR mb_memo = '', '', CONCAT('\n', mb_memo)))
+              WHERE mb_id = ?`,
+            [memo, mbId]
+        );
+    } catch (e) {
+        console.error('[Cert][DI-guard] mb_memo flag write failed:', e);
+    }
+
+    console.warn('[Cert][DI-guard] blocked re-certification on DI collision', {
+        mbId,
+        dupinfoPrefix: dupinfo.slice(0, 16),
+        collisions: blockingRows.map((r) => ({
+            mb_id: r.mb_id,
+            mb_level: r.mb_level,
+            banned: (r.mb_intercept_date ?? '') !== '',
+            withdrawn: (r.mb_leave_date ?? '') !== ''
+        }))
+    });
+
+    return { matched: true, blocked: true };
+}
+
 /** 인증 결과를 DB에 저장 (g5_member 업데이트 + 인증 이력) */
 export async function saveCertResult(
     mbId: string,
     dupinfo: string,
     birthDay: string
 ): Promise<void> {
+    // DI 충돌 하드닝(구멍②) — 방어선(defense-in-depth).
+    // 호출부(cert/inicis/result)는 이미 checkDupinfo 로 모든 dupinfo 충돌을 1차 차단하지만,
+    // 그 게이트가 우회되더라도 제재/탈퇴 계정과 동일 DI 인 경우 dupinfo 를 절대 저장하지 않는다.
+    // 정상 저장(충돌 없음/활성계정만)은 기존과 100% 동일하게 진행된다.
+    const { blocked } = await flagDupinfoCollision(mbId, dupinfo);
+    if (blocked) {
+        throw new Error('DI_COLLISION_BLOCKED');
+    }
+
     const adult_day = new Date();
     adult_day.setFullYear(adult_day.getFullYear() - 19);
     const adultDayStr = adult_day.toISOString().slice(0, 10).replace(/-/g, '');

--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -14,9 +14,20 @@ export function getSeedIV(): string {
     return raw ? Buffer.from(raw).toString('base64') : '';
 }
 
-/** dupinfo 생성용 키 (런타임에 env 읽기) */
+/**
+ * dupinfo 생성용 키 (런타임에 env 읽기) — fail-closed.
+ * ⛔ 빈 문자열 폴백 금지: 키가 없으면 buildDupinfo가 SHA256(ci+'')로 **다른 DI**를 만들어
+ * 재가입 중복차단(checkDupinfo)이 통째로 무력화된다(같은 사람=다른 DI). 조용한 오염 대신 즉시 throw.
+ * ⛔ 이 키는 절대 rotate 금지 — 바뀌면 기존 회원 전원의 DI가 달라진다. 주입=k8s secret `angple-secrets`.
+ */
 function getCertTokenKey(): string {
-    return env.CERT_TOKEN_ENCRYPTION_KEY || '';
+    const key = env.CERT_TOKEN_ENCRYPTION_KEY;
+    if (!key) {
+        throw new Error(
+            'CERT_TOKEN_ENCRYPTION_KEY 미설정 — 실명인증(DI 생성) 차단(fail-closed). 빈 키로 DI를 만들면 재가입 중복차단이 무력화됩니다.'
+        );
+    }
+    return key;
 }
 
 interface CertConfigRow extends RowDataPacket {

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -5,6 +5,7 @@ import pool from '$lib/server/db';
 import type { RowDataPacket } from 'mysql2';
 import { invalidateBoardCache } from '$lib/server/ssr-cache.js';
 import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/internal-api.js';
+import { checkCertification } from '$lib/server/certification';
 
 /**
  * API v1 프록시 핸들러
@@ -259,6 +260,43 @@ async function syncCelebrationBanner(path: string): Promise<void> {
 }
 
 /**
+ * 댓글 작성 시 실명인증(본인확인) enforcement (DI 강화 구멍①).
+ *
+ * 댓글 생성은 브라우저 apiClient.createComment → `/api/v1/boards/{boardId}/posts/{postId}/comments`
+ * POST 로 이 프록시를 거쳐 Go 백엔드로 전달된다. 좋아요·리액션 핸들러가
+ * checkCertification 으로 미인증 회원을 차단하는 것과 동일하게, 댓글 작성도
+ * bo_use_cert='cert' 게시판에서는 미인증(mb_certify='') 회원을 백엔드 도달 전에 차단한다.
+ *
+ * - admin(mb_level≥10) 바이패스·EXEMPT_BOARDS 면제는 checkCertification 내부가 처리(위임).
+ * - 통과(null) 또는 인증 불필요 게시판은 기존 흐름 그대로(회귀 없음).
+ * - 게시글 작성(boards/{boardId}/posts)은 이 함수 대상 아님(Go 경로, 이번 범위 밖).
+ *
+ * @returns 미인증 차단 시 403 Response, 그 외 null(정상 진행)
+ */
+async function checkCommentCreateCertification(
+    path: string,
+    method: string,
+    locals: App.Locals
+): Promise<Response | null> {
+    if (method !== 'POST') return null;
+
+    const match = path.match(/^boards\/([a-zA-Z0-9_-]+)\/posts\/\d+\/comments$/);
+    if (!match) return null;
+
+    const boardId = match[1].replace(/[^a-zA-Z0-9_-]/g, '');
+    // locals.user?.id 는 g5_member.mb_id 문자열. 비로그인이면 undefined →
+    // checkCertification 이 인증필요 게시판에서 로그인 안내 메시지 반환.
+    const certError = await checkCertification(boardId, locals.user?.id);
+    if (certError) {
+        return new Response(JSON.stringify({ error: certError }), {
+            status: 403,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+    return null;
+}
+
+/**
  * 글/댓글 작성 성공 시 g5_board_new에 INSERT
  * angple-backend의 Create()에 이 로직이 빠져있어 SvelteKit에서 보완
  */
@@ -346,6 +384,12 @@ async function proxyRequest(
                 return authorCheckResult; // 403 Response
             }
         }
+    }
+
+    // 댓글 작성 시 실명인증 enforcement (DI 강화 구멍①). 백엔드 도달 전 차단.
+    const certCheckResult = await checkCommentCreateCertification(path, method, locals);
+    if (certCheckResult) {
+        return certCheckResult; // 403 Response
     }
 
     try {

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -260,27 +260,29 @@ async function syncCelebrationBanner(path: string): Promise<void> {
 }
 
 /**
- * 댓글 작성 시 실명인증(본인확인) enforcement (DI 강화 구멍①).
+ * 글·댓글 작성 시 실명인증(본인확인) enforcement (DI 강화 구멍①).
  *
- * 댓글 생성은 브라우저 apiClient.createComment → `/api/v1/boards/{boardId}/posts/{postId}/comments`
- * POST 로 이 프록시를 거쳐 Go 백엔드로 전달된다. 좋아요·리액션 핸들러가
- * checkCertification 으로 미인증 회원을 차단하는 것과 동일하게, 댓글 작성도
- * bo_use_cert='cert' 게시판에서는 미인증(mb_certify='') 회원을 백엔드 도달 전에 차단한다.
+ * 게시글 작성(apiClient.createPost → `/api/v1/boards/{boardId}/posts`)과
+ * 댓글 작성(apiClient.createComment → `/api/v1/boards/{boardId}/posts/{postId}/comments`)
+ * 둘 다 이 프록시(POST)를 거쳐 Go 백엔드로 전달된다(게시글도 Go 별도경로가 아니라 이 프록시).
+ * 좋아요·리액션과 동일하게 bo_use_cert='cert' 게시판에서 미인증(mb_certify='') 회원을
+ * 백엔드 도달 전에 차단한다. hello(가입인사)도 게시글이라 hello가 cert면 자동 포함.
  *
  * - admin(mb_level≥10) 바이패스·EXEMPT_BOARDS 면제는 checkCertification 내부가 처리(위임).
  * - 통과(null) 또는 인증 불필요 게시판은 기존 흐름 그대로(회귀 없음).
- * - 게시글 작성(boards/{boardId}/posts)은 이 함수 대상 아님(Go 경로, 이번 범위 밖).
+ * - 매칭 대상은 **작성(생성)만**: 글 수정/삭제(posts/{id})·댓글 수정(comments/{id})·파일 등은 제외.
  *
  * @returns 미인증 차단 시 403 Response, 그 외 null(정상 진행)
  */
-async function checkCommentCreateCertification(
+async function checkWriteCertification(
     path: string,
     method: string,
     locals: App.Locals
 ): Promise<Response | null> {
     if (method !== 'POST') return null;
 
-    const match = path.match(/^boards\/([a-zA-Z0-9_-]+)\/posts\/\d+\/comments$/);
+    // boards/{id}/posts (게시글 작성) 또는 boards/{id}/posts/{n}/comments (댓글 작성) — 생성만
+    const match = path.match(/^boards\/([a-zA-Z0-9_-]+)\/posts(?:\/\d+\/comments)?$/);
     if (!match) return null;
 
     const boardId = match[1].replace(/[^a-zA-Z0-9_-]/g, '');
@@ -386,8 +388,8 @@ async function proxyRequest(
         }
     }
 
-    // 댓글 작성 시 실명인증 enforcement (DI 강화 구멍①). 백엔드 도달 전 차단.
-    const certCheckResult = await checkCommentCreateCertification(path, method, locals);
+    // 글/댓글 작성 시 실명인증 enforcement (DI 강화 구멍①). 백엔드 도달 전 차단.
+    const certCheckResult = await checkWriteCertification(path, method, locals);
     if (certCheckResult) {
         return certCheckResult; // 403 Response
     }

--- a/apps/web/src/routes/cert/inicis/result/+server.ts
+++ b/apps/web/src/routes/cert/inicis/result/+server.ts
@@ -9,6 +9,7 @@ import {
     isValidInicisUrl,
     saveCertResult,
     checkDupinfo,
+    flagDupinfoCollision,
     getCertPendingMbId
 } from '$lib/server/auth/cert-inicis.js';
 
@@ -135,6 +136,12 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
         existingId
     });
     if (existingId) {
+        // DI 충돌 하드닝(구멍②): 충돌 계정이 제재/탈퇴면 재인증 시도를 durable 운영 플래그로
+        // 기록(다중이/징계회피 감사용). 차단 자체는 위 checkDupinfo 로 이미 성립하므로,
+        // 플래그 기록 실패가 응답 흐름을 막지 않도록 방어적으로 처리한다.
+        await flagDupinfoCollision(mbId, mbDupinfo).catch((e) => {
+            console.error('[Cert] DI 충돌 플래그 기록 실패:', e);
+        });
         return certResultPage(false, '입력하신 본인확인 정보로 이미 가입된 내역이 존재합니다.');
     }
 


### PR DESCRIPTION
DI 강화 구멍①②③. 게시글+댓글 작성 실명인증 enforcement(웹 프록시, cert 보드만·admin 바이패스). DI 생성키 fail-closed(빈 키 폴백 제거). 재가입 DI충돌 감사기록. ⚠️미인증 차단은 bo_use_cert DDL 플립 시 발동(코드는 inert). Evaluator 검증 통과.