### PR TITLE
fix(angtt): 작품페이지 500 (mysql2 DATE 객체 문자열화)

### DIFF
--- a/apps/web/src/routes/angtt/[slug=entityslug]/+page.svelte
+++ b/apps/web/src/routes/angtt/[slug=entityslug]/+page.svelte
@@ -75,7 +75,7 @@
         exhibition: '전시'
     };
     const typeLabel = $derived(TYPE_LABEL[entity.type] ?? entity.type);
-    const releaseYear = $derived(entity.releaseDate ? entity.releaseDate.slice(0, 4) : '');
+    const releaseYear = $derived(entity.releaseDate ? String(entity.releaseDate).slice(0, 4) : '');
 
     /** 외부 점수 칩 (external_ids 가 있을 때만 "참고용"으로 하단 표시) */
     const externalChips = $derived.by(() => {

--- a/plugins/angtt-review/lib/entities.server.ts
+++ b/plugins/angtt-review/lib/entities.server.ts
@@ -140,7 +140,8 @@ function toEntity(row: EntityRow): AngttEntity {
 }
 
 const ENTITY_COLUMNS = `id, type, canonical_title, slug, aliases, poster_url, external_ids,
-    meta, release_date, status, rating_count, rating_avg, review_post_count`;
+    meta, DATE_FORMAT(release_date, '%Y-%m-%d') AS release_date, status,
+    rating_count, rating_avg, review_post_count`;
 
 async function getEntityById(entityId: number): Promise<AngttEntity | null> {
     const [rows] = await pool.query(
@@ -242,7 +243,8 @@ export async function getEntityConnectedPosts(
         const tableName = `g5_write_${board}`;
         try {
             const [rowResult] = await pool.query(
-                `SELECT wr_id, wr_subject, wr_name, mb_id, wr_good, wr_datetime
+                `SELECT wr_id, wr_subject, wr_name, mb_id, wr_good,
+                        DATE_FORMAT(wr_datetime, '%Y-%m-%d %H:%i:%s') AS wr_datetime
                  FROM ??
                  WHERE wr_id IN (?) AND wr_is_comment = 0 AND wr_deleted_at IS NULL`,
                 [tableName, wrIds]
@@ -268,7 +270,8 @@ export async function getEntityConnectedPosts(
 
     collected.sort((a, b) => {
         if (opts.sort === 'best' && b.good !== a.good) return b.good - a.good;
-        return b.datetime.localeCompare(a.datetime);
+        // datetime은 DATE_FORMAT 문자열이지만, 방어적으로 String 강제(과거 Date 객체 500 재발 방지)
+        return String(b.datetime).localeCompare(String(a.datetime));
     });
 
     return collected.slice(0, limit);


### PR DESCRIPTION
카나리에서 /angtt/{slug} 500 발견: getEntityConnectedPosts 정렬이 mysql2 DATE 객체에 localeCompare 호출로 throw. wr_datetime·release_date를 DATE_FORMAT 문자열화 + 방어. 섀도잉 수정(#1811)의 런타임 후속.