### PR TITLE
fix(auth): OAuth 콜백 에러를 앱 모드에서 앱 스킴으로 복귀 (전 provider)

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/state.ts
+++ b/apps/web/src/lib/server/auth/oauth/state.ts
@@ -47,6 +47,22 @@ export function createOAuthState(
     return state;
 }
 
+/**
+ * appMode 만 비파괴적으로 확인한다(쿠키 삭제 안 함). 에러 경로에서 앱 복귀 여부 판단용.
+ * state 문자열이 일치하는 경우에만 신뢰한다(만료 여부는 무시 — 에러 리다이렉트 타깃 결정에만 사용).
+ */
+export function peekAppMode(cookies: Cookies, state: string | null): boolean {
+    if (!state) return false;
+    const raw = cookies.get(STATE_COOKIE_NAME);
+    if (!raw) return false;
+    try {
+        const data: OAuthStateData = JSON.parse(raw);
+        return data.state === state && data.appMode === true;
+    } catch {
+        return false;
+    }
+}
+
 export function validateOAuthState(cookies: Cookies, state: string): OAuthStateData | null {
     const raw = cookies.get(STATE_COOKIE_NAME);
     if (!raw) return null;

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -9,7 +9,7 @@ import { env } from '$env/dynamic/private';
 import { normalizeProviderName, getProvider } from '$lib/server/auth/oauth/provider-registry.js';
 import { resolveOrigin } from '$lib/server/auth/oauth/config.js';
 import { safeRedirectUrl } from '$lib/server/safe-redirect.js';
-import { validateOAuthState } from '$lib/server/auth/oauth/state.js';
+import { validateOAuthState, peekAppMode } from '$lib/server/auth/oauth/state.js';
 import {
     findSocialProfile,
     linkSocialProfile,
@@ -97,6 +97,17 @@ async function generateInviteTempNickname(provider: string): Promise<string> {
     throw new Error('초대 임시 닉네임 생성에 실패했습니다.');
 }
 
+/**
+ * 에러 리다이렉트. 네이티브 앱 모드(appMode)면 앱 스킴(damoang://oauth-callback?error=)으로 복귀시켜
+ * 인앱 브라우저가 웹 /login 에 갇히는 것을 방지한다. 아니면 기존대로 웹 로그인으로.
+ */
+function redirectError(errorCode: string, appMode: boolean): never {
+    if (appMode) {
+        redirect(302, `damoang://oauth-callback?error=${encodeURIComponent(errorCode)}`);
+    }
+    redirect(302, `/login?error=${encodeURIComponent(errorCode)}`);
+}
+
 /** 공통 콜백 처리 로직 */
 async function handleCallback(
     providerSlug: string,
@@ -110,17 +121,17 @@ async function handleCallback(
     // 1. URL 경로 파라미터에서 프로바이더 추출
     const providerName = normalizeProviderName(providerSlug);
     if (!providerName) {
-        redirect(302, '/login?error=invalid_provider');
+        redirectError('invalid_provider', peekAppMode(cookies, stateParam));
     }
 
     // 2. state 검증 (CSRF)
     const stateData = validateOAuthState(cookies, stateParam);
     if (!stateData) {
-        redirect(302, '/login?error=invalid_state');
+        redirectError('invalid_state', peekAppMode(cookies, stateParam));
     }
 
     if (stateData.provider !== providerName) {
-        redirect(302, '/login?error=provider_mismatch');
+        redirectError('provider_mismatch', stateData.appMode === true);
     }
 
     try {
@@ -443,7 +454,7 @@ async function handleCallback(
             providerName,
             err instanceof Error ? err.message : 'Unknown error'
         );
-        redirect(302, '/login?error=oauth_error');
+        redirectError('oauth_error', stateData.appMode === true);
     }
 }
 
@@ -461,11 +472,11 @@ export const GET: RequestHandler = async ({
     const errorParam = url.searchParams.get('error');
 
     if (errorParam) {
-        redirect(302, `/login?error=provider_${errorParam}`);
+        redirectError(`provider_${errorParam}`, peekAppMode(cookies, stateParam));
     }
 
     if (!code || !stateParam) {
-        redirect(302, '/login?error=missing_params');
+        redirectError('missing_params', peekAppMode(cookies, stateParam));
     }
 
     const clientIp = getClientAddress();
@@ -487,11 +498,11 @@ export const POST: RequestHandler = async ({
     const errorParam = formData.get('error') as string;
 
     if (errorParam) {
-        redirect(302, `/login?error=provider_${errorParam}`);
+        redirectError(`provider_${errorParam}`, peekAppMode(cookies, stateParam));
     }
 
     if (!code || !stateParam) {
-        redirect(302, '/login?error=missing_params');
+        redirectError('missing_params', peekAppMode(cookies, stateParam));
     }
 
     const clientIp = getClientAddress();


### PR DESCRIPTION
## 문제 (소셜로그인 전수 분석 #1 — 치명)
네이티브 앱(`app=1`) OAuth 콜백에서 **`email_exists`·`account_inactive` 두 경우만** 앱 스킴(`damoang://`)으로 복귀. **그 외 모든 실패**(토큰교환 실패, 상태검증 실패, 프로바이더 거부/동의취소, missing params, JWKS/프로필 오류)는 웹 `/login?error=` 로 리다이렉트 → 인앱 브라우저(ASWebAuthenticationSession)가 `damoang.net/login` 에 갇혀 `damoang://` 로 안 돌아옴 → 앱은 `type==='success'` 를 못 받고 **"로그인이 취소되었습니다"** 오표시.

**7개 provider 전부, 모든 에러 경로에서 발생.** "네이버 로그인 안 됨" 리포트의 유력 원인.

## 수정
- `redirectError(code, appMode)`: appMode 면 `damoang://oauth-callback?error=`, 아니면 기존 웹 `/login?error=`.
- `state.ts peekAppMode()`: 상태 쿠키 비파괴 읽기로 appMode 판정(에러 경로 전용, 쿠키 소비 안 함).
- 적용 경로: invalid_provider / invalid_state / provider_mismatch / 제네릭 oauth_error / GET·POST 의 provider_* · missing_params.

## 검증
- svelte-check: 변경 파일 에러 0 (기존 11 에러/116 경고 그대로, 증가 없음).
- 정상 로그인 흐름·성공 경로 무변경. 웹 로그인 동작 무변경(appMode=false 일 때 기존과 동일).
- 런타임 최종 확인은 앱 device 테스트(에러 유발 시 앱이 깔끔한 에러 표시).