### PR TITLE
feat(auth): app-login 코드에 jti 부여 (1회용 replay 차단)

### DIFF
--- a/apps/web/src/lib/server/auth/jwt.ts
+++ b/apps/web/src/lib/server/auth/jwt.ts
@@ -73,6 +73,7 @@ export async function generateAppLoginCode(user: {
     })
         .setSubject(user.mb_id)
         .setAudience('app-login')
+        .setJti(crypto.randomUUID()) // 1회용: 백엔드 app-exchange 가 jti 로 replay 차단
         .setProtectedHeader({ alg: 'HS256' })
         .setIssuedAt()
         .setExpirationTime('60s')


### PR DESCRIPTION
generateAppLoginCode에 setJti(randomUUID) 추가. 백엔드 app-exchange(angple-backend #570)가 jti로 60초창 내 코드 재사용 차단. 백엔드는 jti 없으면 무시(하위호환).