### PR TITLE
fix(write): 글 수정 시 링크1/2 삭제 불가 (#13043)

### DIFF
--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -458,8 +458,10 @@
                       content: finalContent,
                       category: category || undefined,
                       tags: tags.length > 0 ? tags : undefined,
-                      link1: link1.trim() || undefined,
-                      link2: link2.trim() || undefined,
+                      // 수정 시엔 빈 문자열('')을 보내야 백엔드가 링크를 삭제한다.
+                      // undefined(생략)면 백엔드가 '변경 없음'(nil)으로 처리해 기존 링크가 남는다. (#13043)
+                      link1: link1.trim(),
+                      link2: link2.trim(),
                       files: fileAttachments
                   };
 


### PR DESCRIPTION
제보 #13043(예지): 링크1 제거 후 저장해도 안 지워짐. 원인=post-form 수정분기가 빈 링크를 undefined(생략)로 보내 백엔드가 '변경없음'으로 처리. 수정분기에서 빈 문자열('') 전송하도록 변경(백엔드 post_service는 ''=삭제 이미 지원). link1 자동임베드는 표시시점 렌더라 함께 사라짐.