### PR TITLE
fix(angtt): 앙TT 게시판 글쓰기 404 — 작품 slug 매처가 /write 를 섀도잉

### DIFF
--- a/apps/web/src/params/entityslug.test.ts
+++ b/apps/web/src/params/entityslug.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { match } from './entityslug';
+
+describe('entityslug 매처 — /angtt/[slug] 가 다른 라우트를 섀도잉하지 않아야 한다', () => {
+    it('작품 slug 는 매칭된다', () => {
+        expect(match('호프')).toBe(true);
+        expect(match('동궁')).toBe(true);
+        expect(match('movie-1987')).toBe(true);
+    });
+
+    it('숫자 ID 는 매칭되지 않는다 (angtt 게시판 글 URL 보호)', () => {
+        expect(match('7297')).toBe(false);
+        expect(match('13')).toBe(false);
+    });
+
+    // 2026-07-20 실장애: /angtt/write 가 작품 페이지로 잡혀 글쓰기가 404 였다.
+    it('⛔ [boardId] 아래 정적 라우트 이름은 매칭되지 않는다 — 글쓰기 404 방지', () => {
+        expect(match('write')).toBe(false);
+        expect(match('WRITE')).toBe(false);
+    });
+
+    it('빈 문자열은 매칭되지 않는다', () => {
+        expect(match('')).toBe(false);
+    });
+});

--- a/apps/web/src/params/entityslug.ts
+++ b/apps/web/src/params/entityslug.ts
@@ -2,11 +2,25 @@ import type { ParamMatcher } from '@sveltejs/kit';
 
 /**
  * 앙티티 작품 페이지 slug 매처.
+ *
  * ⚠️ /angtt/{숫자}는 angtt "게시판 글"(gnuboard g5_write_angtt, [boardId]/[postId])이므로,
  * 작품 페이지(/angtt/{slug})는 **비숫자 slug만** 매칭시켜 게시판 글 URL을 섀도잉하지 않게 한다.
  * → /angtt/7297 = 게시판 글(폴스루), /angtt/호프 = 작품 페이지.
  * ⛔ 엔티티 slug는 절대 순수 숫자로 만들지 말 것(예: "1987" 영화 → "movie-1987" 등).
+ *
+ * ⛔ 그리고 [boardId] 아래의 **정적 하위 라우트 이름도 반드시 제외**해야 한다.
+ * SvelteKit 라우트 우선순위상 /angtt/[slug=entityslug] 가 /[boardId]/write 보다 앞서므로,
+ * 여기서 걸러내지 않으면 /angtt/write 가 작품 페이지로 잡혀 **글쓰기가 404** 가 된다.
+ * (2026-07-20 실장애: 앙TT 게시판 글쓰기 버튼 → "페이지를 찾을 수 없습니다")
+ *
+ * 👉 apps/web/src/routes/[boardId]/ 아래에 정적 디렉터리를 새로 만들면
+ *    그 이름을 RESERVED 에 반드시 추가할 것.
  */
+const RESERVED = new Set(['write']);
+
 export const match: ParamMatcher = (param) => {
-    return param.length > 0 && !/^\d+$/.test(param);
+    if (param.length === 0) return false;
+    if (/^\d+$/.test(param)) return false;
+    if (RESERVED.has(param.toLowerCase())) return false;
+    return true;
 };


### PR DESCRIPTION
## 장애

앙TT 게시판에서 **글쓰기 버튼 → "페이지를 찾을 수 없습니다"**. 회원 제보(금도리 님).

실측:
```
/angtt/write  404   ← 장애
/free/write   200   ← 정상
/angtt/7297   200
/angtt/호프    200
```

## 원인

`/angtt/[slug=entityslug]` 매처가 **"비숫자면 통과"** 라 `write` 도 작품 slug 로 인정했습니다. SvelteKit 라우트 우선순위상 첫 세그먼트가 정적(`angtt`)인 이 라우트가 `/[boardId]/write`(첫 세그먼트 동적)보다 앞서므로, 존재하지 않는 작품 `write` 를 찾다가 404가 났습니다.

숫자 ID 섀도잉(`/angtt/7297`)은 막았는데 **정적 하위 라우트 이름은 놓쳤습니다.**

## 수정

- `RESERVED` 목록으로 `write` 제외
- **회귀 테스트 추가** — 이 버그는 테스트가 있었으면 잡혔습니다
- `[boardId]/` 아래 정적 디렉터리를 새로 만들면 `RESERVED` 를 갱신하라는 주석 명시

## 검증

- 단위 테스트 4개 통과 (`write`/`WRITE` 거부, `호프`·`movie-1987` 통과, `7297` 거부)
- 카나리에서 `/angtt/write` 200 확인 예정