### PR TITLE
fix(comment): 모바일 키보드 내려감 계측 추가 + bfcache 리로드를 Apple 한정으로

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -322,8 +322,20 @@
                 // 리로드는 SvelteKit 클라이언트 내비게이션이 아니라 페이지 snapshot 복원이 실행되지
                 // 않으므로(#9401 우회), 여기서 직접 저장→로드 후 복원한다. 긴 글 열람 후 iOS Safari
                 // 가 탭을 bfcache 폐기 후 복원할 때 목록이 맨 밑으로 떨어지던 현상 방지.
+                // ⛔ Apple(WebKit) 한정. #303·#13022 모두 Safari/iOS 고유 문제인데
+                // 그동안 플랫폼 게이트 없이 **모든 브라우저**에서 돌아, 안드로이드에서도
+                // 뒤로가기·bfcache 복원마다 전체 리로드가 일어나고 있었다(데이터·성능 낭비 +
+                // 작성 중이던 입력 파괴 위험). Chromium 계열 UA 는 "Safari" 문자열을 포함하므로
+                // 삼성 인터넷/크롬을 제외하는 방식으로 판별한다.
+                var isAppleWebKit = (function () {
+                    var ua = navigator.userAgent;
+                    if (/iPad|iPhone|iPod/.test(ua)) return true;
+                    var isChromiumLike =
+                        /Chrome|Chromium|Android|SamsungBrowser|Edg\/|OPR\/|CriOS|FxiOS/.test(ua);
+                    return /Safari/.test(ua) && !isChromiumLike;
+                })();
                 window.addEventListener('pageshow', function (e) {
-                    if (e.persisted) {
+                    if (e.persisted && isAppleWebKit) {
                         try {
                             sessionStorage.setItem(
                                 KEY,

--- a/apps/web/src/lib/components/features/board/comment-editor.svelte
+++ b/apps/web/src/lib/components/features/board/comment-editor.svelte
@@ -9,6 +9,7 @@
     import Placeholder from '@tiptap/extension-placeholder';
     import Mention from '@tiptap/extension-mention';
     import { mentionSuggestion } from '$lib/components/features/editor/mention-suggestion';
+    import { watchCommentInput, stopWatch } from '$lib/services/comment-input-telemetry';
     import Bold from '@lucide/svelte/icons/bold';
     import Italic from '@lucide/svelte/icons/italic';
 
@@ -115,6 +116,11 @@
             onUpdate: ({ editor: e }) => {
                 onUpdate?.(e.getHTML());
             },
+            onFocus: () => {
+                // #12939/#13045 — 작성 중 키보드가 내려가는 현상 진단.
+                // 포커스 중에만 관측하고, 이상 이탈일 때만 1회 전송한다(평상시 비용 0).
+                if (editorElement) watchCommentInput(editorElement);
+            },
             onTransaction: ({ editor: e }) => {
                 // ProseMirror 트랜잭션은 Svelte 렌더/effect 중 동기 호출될 수 있어, 여기서
                 // $state 를 직접 변이하면 state_unsafe_mutation 발생(/free·홈 다수). microtask 로
@@ -134,6 +140,7 @@
     });
 
     onDestroy(() => {
+        stopWatch();
         editor?.destroy();
     });
 

--- a/apps/web/src/lib/services/comment-input-telemetry.ts
+++ b/apps/web/src/lib/services/comment-input-telemetry.ts
@@ -1,0 +1,170 @@
+/**
+ * 댓글 입력 이상 계측 — 모바일에서 작성 중 키보드가 내려가는 현상(#12939 / #13045) 진단용.
+ *
+ * ## 왜 필요한가
+ * 이 실패 모드는 **예외를 던지지 않는다.** 그래서 `error_logs.js_errors` 에 아무것도 남지 않고,
+ * 열흘 동안 세운 가설 다섯 개가 전부 추측이었다가 하나씩 반증됐다:
+ *   - 앙티티 카드 지연 삽입 → SSR 이라 늦게 도착하지 않음
+ *   - 광고 갱신/폴백 스왑 → 제보자가 광고차단 미사용
+ *   - 지연로딩 경합       → 제보자가 진입 한참 뒤에 작성
+ *   - pageshow 리로드      → 초안 보존이 없어 텍스트가 유실됐어야 함(신고 없음)
+ *   - 서비스워커 stale 청크 → 삼성 인터넷 청크 에러 0.5%
+ *
+ * 추측으로 고치면 2026-07-10 과 같은 실패("고쳤다" → 열흘 뒤 재발)를 반복한다.
+ * 그래서 고치기 전에 **다음 재발이 원인을 말하게** 만든다.
+ *
+ * ## 설계 원칙
+ * - **에디터에 포커스가 있는 동안에만** 관측한다. 평상시 비용 0.
+ * - 정상 이탈(제출/사용자가 다른 곳 클릭)은 보내지 않는다. **이상 이탈만** 1회.
+ * - 페이지당 1회만 전송(중복 방지).
+ * - PII 없음 — 입력 내용은 절대 담지 않고, 길이/시각/레이아웃 수치만 담는다.
+ */
+
+const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
+
+/** 페이지당 1회만 전송 */
+let sent = false;
+
+interface WatchState {
+    focusAt: number;
+    scrollY: number;
+    docHeight: number;
+    vvHeight: number;
+    /** 포커스 중 관측된 최대 문서 높이 변화량(px) — 레이아웃 이동 크기 */
+    maxDocDelta: number;
+    /** 포커스 중 DOM 변경 횟수 */
+    mutations: number;
+    /** 마지막 DOM 변경 요약(태그/클래스만, 내용 없음) */
+    lastMutation: string;
+    /** 마지막 DOM 변경 시각 */
+    lastMutationAt: number;
+    /** visualViewport 높이가 크게 늘어난 시각 = 키보드 닫힘 추정 */
+    keyboardClosedAt: number;
+    cleanup: () => void;
+}
+
+let state: WatchState | null = null;
+
+function send(reason: string, extra: Record<string, unknown>): void {
+    if (sent) return;
+    sent = true;
+    try {
+        const payload = {
+            message: 'comment_input_anomaly',
+            type: 'comment_input_telemetry',
+            reason,
+            url: location.href,
+            userAgent: navigator.userAgent,
+            ts: Date.now(),
+            ...extra
+        };
+        const body = JSON.stringify(payload);
+        if (typeof navigator.sendBeacon === 'function') {
+            const blob = new Blob([body], { type: 'application/json' });
+            if (navigator.sendBeacon(DANTRY_URL, blob)) return;
+        }
+        fetch(DANTRY_URL, {
+            mode: 'cors',
+            credentials: 'include',
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+            keepalive: true
+        }).catch(() => {});
+    } catch {
+        // 계측 실패는 무시 — 사용자 동작에 절대 영향을 주지 않는다
+    }
+}
+
+/** 요소를 내용 없이 요약 (PII 차단) */
+function describe(node: Node | null): string {
+    if (!node) return '';
+    const el = node.nodeType === 1 ? (node as Element) : node.parentElement;
+    if (!el) return node.nodeName;
+    const cls = (el.className || '').toString().split(/\s+/).slice(0, 3).join('.');
+    return `${el.tagName.toLowerCase()}${cls ? '.' + cls : ''}`;
+}
+
+/**
+ * 댓글 에디터가 포커스를 얻었을 때 호출. 포커스를 잃으면 자동으로 해제된다.
+ * 이상 이탈이면 1회 전송한다.
+ */
+export function watchCommentInput(editorEl: HTMLElement): void {
+    if (typeof window === 'undefined' || sent) return;
+    stopWatch();
+
+    const vv = window.visualViewport;
+    const s: WatchState = {
+        focusAt: Date.now(),
+        scrollY: window.scrollY,
+        docHeight: document.documentElement.scrollHeight,
+        vvHeight: vv?.height ?? window.innerHeight,
+        maxDocDelta: 0,
+        mutations: 0,
+        lastMutation: '',
+        lastMutationAt: 0,
+        keyboardClosedAt: 0,
+        cleanup: () => {}
+    };
+
+    // 입력창 위쪽에서 일어나는 DOM 변경만 본다 — 아래쪽 변경은 입력창을 밀지 않는다.
+    const mo = new MutationObserver((records) => {
+        for (const r of records) {
+            const target = r.target as Element;
+            if (target === editorEl || editorEl.contains(target)) continue; // 자기 입력은 제외
+            s.mutations++;
+            s.lastMutation = describe(target);
+            s.lastMutationAt = Date.now();
+        }
+        const delta = Math.abs(document.documentElement.scrollHeight - s.docHeight);
+        if (delta > s.maxDocDelta) s.maxDocDelta = delta;
+    });
+    mo.observe(document.body, { childList: true, subtree: true, attributes: true });
+
+    // visualViewport 높이가 크게 늘면 키보드가 닫힌 것으로 본다
+    const onVvResize = () => {
+        const h = vv?.height ?? window.innerHeight;
+        if (h - s.vvHeight > 80) s.keyboardClosedAt = Date.now();
+        s.vvHeight = Math.max(s.vvHeight, h);
+    };
+    vv?.addEventListener('resize', onVvResize);
+
+    const onBlur = () => {
+        const now = Date.now();
+        const heldMs = now - s.focusAt;
+        // 키보드가 닫힌 정황이 있고, 사용자가 다른 입력요소로 이동한 게 아니면 이상으로 본다.
+        const next = document.activeElement;
+        const movedToAnotherInput = !!next?.closest?.(
+            '.ProseMirror, [contenteditable="true"], textarea, input, button, a'
+        );
+        const keyboardDropped = s.keyboardClosedAt > 0 && now - s.keyboardClosedAt < 1500;
+
+        if (keyboardDropped && !movedToAnotherInput) {
+            send('keyboard_dropped', {
+                held_ms: heldMs,
+                mutations: s.mutations,
+                last_mutation: s.lastMutation,
+                ms_since_last_mutation: s.lastMutationAt ? now - s.lastMutationAt : -1,
+                max_doc_delta: s.maxDocDelta,
+                scroll_delta: window.scrollY - s.scrollY,
+                next_active: describe(next),
+                editor_connected: editorEl.isConnected ? 1 : 0
+            });
+        }
+        stopWatch();
+    };
+    editorEl.addEventListener('focusout', onBlur);
+
+    s.cleanup = () => {
+        mo.disconnect();
+        vv?.removeEventListener('resize', onVvResize);
+        editorEl.removeEventListener('focusout', onBlur);
+    };
+    state = s;
+}
+
+/** 관측 해제 */
+export function stopWatch(): void {
+    state?.cleanup();
+    state = null;
+}


### PR DESCRIPTION
## 배경 — 왜 고치지 않고 계측부터 넣는가

#12939(7/10) / #13045(7/20) — 모바일에서 **댓글 작성 중 키보드가 내려간다**는 제보가 두 번 있었습니다. 7/10 에 원인을 짚어 고쳤지만 열흘 뒤 재발했습니다.

이 실패 모드는 **예외를 던지지 않습니다.** `error_logs.js_errors` 에 아무 흔적이 없어, 이번에 세운 가설 다섯 개가 전부 추측이었고 하나씩 반증됐습니다:

| 가설 | 무엇이 반증했나 |
|---|---|
| 앙티티 카드 지연 삽입 | SSR 렌더라 늦게 도착하지 않음 |
| 광고 갱신/폴백 스왑 | 제보자가 **광고차단 미사용** |
| 지연로딩 경합 | 제보자가 **진입 한참 뒤에 작성** |
| `pageshow` 리로드 | 초안 보존이 없어 **텍스트가 유실됐어야 함**(그런 신고 없음) |
| 서비스워커 stale 청크 | 삼성 인터넷 청크 에러 **0.5%**(사파리 81%) |

여기서 여섯 번째 가설로 코드를 고치면 7/10 과 같은 실패를 반복합니다. **원인을 특정하기 전에 다음 재발이 원인을 말하게** 만드는 것이 이 PR입니다.

## 1. 계측 (`comment-input-telemetry.ts`)

- **에디터에 포커스가 있는 동안에만** 관측 → 평상시 비용 0
- 정상 이탈(제출·다른 입력요소로 이동)은 보내지 않고 **이상 이탈만 페이지당 1회**
- 담는 것: 키보드 닫힘 직전의 DOM 변경 요약·문서 높이 변화·스크롤 이동·포커스 유지 시간·다음 포커스 대상·에디터 DOM 연결 여부
- **입력 내용은 담지 않습니다** (PII 0). 요소는 태그/클래스로만 요약

## 2. bfcache 리로드를 Apple 한정으로

`pageshow(persisted) → location.reload()` 가 **플랫폼 게이트 없이 모든 브라우저**에서 돌고 있었습니다. #303·#13022 는 Safari/iOS 고유 문제인데, 안드로이드에서도 뒤로가기·bfcache 복원마다 전체 리로드가 일어나 데이터·성능을 낭비하고 작성 중 입력을 파괴할 위험이 있었습니다.

Chromium 계열 UA 는 `Safari` 문자열을 포함하므로 삼성 인터넷/크롬을 제외하는 방식으로 판별합니다. UA 5종 검증:

```
리로드 X  Samsung Internet     ← 제보자 환경
리로드 O  iOS Safari           ← #13022 보존
리로드 O  macOS Safari         ← #303 보존
리로드 X  Android Chrome
리로드 X  Desktop Chrome
```

> ⚠️ **이것이 위 버그의 원인이라는 근거는 없습니다.** iOS 전용 우회를 전 플랫폼에 돌리는 것이 그 자체로 잘못이라 정리하는 것이며, "#13045 수정"으로 보아서는 안 됩니다.

## 검증

- `svelte-check` 에러 0
- UA 게이트 5종 판별 확인(위 표)