### PR TITLE
fix(growth): 실험 A 온보딩 카드 부활 — 죽은 API 게이트 교체 + 도달률 회복

### DIFF
--- a/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
+++ b/apps/web/src/lib/components/features/onboarding/welcome-onboarding.svelte
@@ -4,32 +4,58 @@
      *
      * 목표: 가입→첫 기여 전환율 개선 (12주 실측 14.2%).
      * 노출 조건 (전부 만족 시에만):
-     *  1) 로그인 && as_level ≤ 1 (XP 거의 없음 = 활동 전 — 프로필 조회 게이트)
-     *  2) 내 프로필: 가입 14일 이내 && 글/댓글 0 (정확한 "신규 미기여" 판별)
-     *  3) 닫기 안 누름 (localStorage)
-     * 첫 기여를 하면 post_count/comment_count > 0 이 되어 자연히 사라진다.
+     *  1) 로그인 && as_level ≤ 1 (XP 거의 없음 = 활동 전 — 값싼 1차 게이트)
+     *  2) 가입 14일 이내 && 기여 이력 0 (정확한 "신규 미기여" 판별)
+     *  3) 닫기 안 누름 (localStorage, 회원별 스코프)
+     * 첫 기여를 하면 last_contribution_at 이 채워져 자연히 사라진다.
      *
      * 첫 기여 유도는 가입인사(/hello) 게시판으로 — 자유게시판 등은 신규에게
      * 글쓰기가 제한될 수 있어, 항상 열려 있는 인사 게시판이 첫걸음으로 적합.
+     *
+     * ⚠️ 2026-07-20 수정: 기존 게이트가 `apiClient.getMemberProfile()` 을 썼는데 이 API 는
+     *    백엔드에 라우트가 없다(`/api/v1/members/{id}` → 존재하지 않는 경로와 똑같이 `{"data":null}`).
+     *    `null` 역참조 예외를 아래 catch 가 삼켜 **이 카드는 7/9 라이브 이후 한 번도 노출되지 않았다.**
+     *    (그래서 "실험 A 효과" 로 본 코호트 변동은 처치가 아니라 자연 변동이다.)
+     *    이제 동작이 검증된 `/api/me/onboarding-status` 단일 소스를 쓴다.
      */
     import { authStore } from '$lib/stores/auth.svelte.js';
-    import { apiClient } from '$lib/api/index.js';
+    import { trackEvent } from '$lib/services/ga4';
 
-    const DISMISS_KEY = 'angple_welcome_onboarding_dismissed';
+    const DISMISS_KEY_PREFIX = 'angple_welcome_onboarding_dismissed';
+    const SETTLED_KEY_PREFIX = 'angple_welcome_onboarding_settled';
     const NEW_MEMBER_DAYS = 14;
 
     let show = $state(false);
     let checked = $state(false);
 
+    /** 닫기 상태는 회원별로 — 공유 기기에서 다른 회원의 닫기를 상속하면 조용히 미노출된다. */
+    function dismissKey(mbId: string): string {
+        return `${DISMISS_KEY_PREFIX}:${mbId}`;
+    }
+
+    /**
+     * "이 회원은 더 이상 신규가 아니다" 라는 확정 판정.
+     * 가입일은 불변이라 14일이 지나면 다시 자격을 얻는 일이 없다 → 영구 기록해
+     * 다음 방문부터 API 호출 자체를 하지 않는다. as_level 사전 게이트를 제거한 대신
+     * 이 캐시가 홈 트래픽의 호출량을 억제한다.
+     */
+    function settledKey(mbId: string): string {
+        return `${SETTLED_KEY_PREFIX}:${mbId}`;
+    }
+
     $effect(() => {
         const user = authStore.user;
         if (checked || !user) return;
-        if ((user.as_level ?? 1) > 1) {
-            checked = true;
-            return;
-        }
+        // ⚠️ as_level ≤ 1 사전 게이트 제거(2026-07-20). 실측 결과 "가입 14일 이내 + 기여 0" 인
+        //    회원 중 as_level ≥ 2 가 199명으로 통과자(159명)보다 많았다 — XP 는 기여 없이도
+        //    출석 등으로 오르기 때문. 값싼 근사치였던 이 게이트가 진짜 타깃의 56% 를 잘라
+        //    실험 검정력을 반토막 냈다. 이제 last_contribution_at 이라는 정확한 판별자가 있다.
         try {
-            if (localStorage.getItem(DISMISS_KEY)) {
+            if (
+                localStorage.getItem(dismissKey(user.mb_id)) ||
+                localStorage.getItem(DISMISS_KEY_PREFIX) || // 구 전역 키 존중(이미 닫은 사람)
+                localStorage.getItem(settledKey(user.mb_id))
+            ) {
                 checked = true;
                 return;
             }
@@ -40,15 +66,32 @@
         checked = true;
         void (async () => {
             try {
-                const profile = await apiClient.getMemberProfile(user.mb_id);
-                const signedAt = new Date(profile.mb_datetime).getTime();
+                const res = await fetch('/api/me/onboarding-status');
+                if (!res.ok) return;
+                const status = (await res.json()) as {
+                    signup_at: string | null;
+                    last_contribution_at: string | null;
+                };
+                const signedAt = new Date(status.signup_at ?? '').getTime();
+                if (Number.isNaN(signedAt)) return;
                 const daysSince = (Date.now() - signedAt) / 86400000;
-                const contributed = (profile.post_count ?? 0) + (profile.comment_count ?? 0) > 0;
-                if (!Number.isNaN(signedAt) && daysSince <= NEW_MEMBER_DAYS && !contributed) {
+                if (daysSince > NEW_MEMBER_DAYS) {
+                    try {
+                        localStorage.setItem(settledKey(user.mb_id), '1');
+                    } catch {
+                        /* localStorage 불가 — 캐시 없이 동작 */
+                    }
+                    return;
+                }
+                if (status.last_contribution_at === null) {
                     show = true;
+                    // 노출 0 이 곧 신호가 되도록 계측한다 — 이번처럼 조용히 죽는 일을 막는다.
+                    trackEvent('onboarding_impression', {
+                        days_since_signup: Math.floor(daysSince)
+                    });
                 }
             } catch {
-                // 프로필 조회 실패 시 조용히 미노출 (온보딩은 있으면 좋은 기능)
+                // 조회 실패 시 조용히 미노출 (온보딩은 있으면 좋은 기능)
             }
         })();
     });
@@ -56,7 +99,7 @@
     function dismiss() {
         show = false;
         try {
-            localStorage.setItem(DISMISS_KEY, String(Date.now()));
+            localStorage.setItem(dismissKey(authStore.user?.mb_id ?? ''), String(Date.now()));
         } catch {
             /* localStorage 불가 환경 — 세션 내 숨김만 */
         }
@@ -94,6 +137,7 @@
                 <div class="flex shrink-0 flex-wrap items-center gap-2">
                     <a
                         href="/hello"
+                        onclick={() => trackEvent('onboarding_cta_click', { target: 'hello' })}
                         class="inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-4 py-2 text-sm font-bold text-white shadow-sm transition-all hover:-translate-y-0.5 hover:bg-amber-600 hover:shadow-md"
                     >
                         💌 가입인사 남기기
@@ -101,6 +145,7 @@
                     <!-- 운영 안내글: 환영 안내(20754) — 새내기 필독 -->
                     <a
                         href="/hello/20754"
+                        onclick={() => trackEvent('onboarding_cta_click', { target: 'guide' })}
                         class="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 rounded-full border border-amber-200 px-3 py-2 text-xs font-semibold transition-colors hover:border-amber-400 dark:border-amber-800/50"
                     >
                         📖 새내기 안내

--- a/apps/web/src/routes/api/me/onboarding-status/+server.ts
+++ b/apps/web/src/routes/api/me/onboarding-status/+server.ts
@@ -1,0 +1,78 @@
+/**
+ * 내 온보딩/재활성 게이트 상태 — GET /api/me/onboarding-status
+ *
+ * 성장 카드(실험 A 온보딩 · R1 웰컴백)가 노출 여부를 판정하는 **단일 권위 소스**.
+ *
+ * 왜 신설했나: 두 카드가 쓰던 `apiClient.getMemberProfile()` 은 백엔드에 라우트가 없는
+ * 죽은 메서드였다(`/api/v1/members/{id}` 가 존재하지 않는 경로와 똑같이 `{"data":null}` 반환).
+ * 클라이언트가 `null` 을 역참조하며 던진 예외를 컴포넌트 catch 가 삼켜, 실험 A 카드는
+ * 라이브 이후 노출된 적이 없다. 게이트는 동작이 검증된 경로 하나로 모은다.
+ *
+ * 응답:
+ *   signup_at            가입 시각 (ISO)
+ *   last_contribution_at 마지막 글/댓글 시각 (ISO) — 기여 이력이 없으면 null
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+interface MemberRow extends RowDataPacket {
+    mb_datetime: Date | string | null;
+}
+
+interface ActivityRow extends RowDataPacket {
+    source_created_at: Date | string | null;
+}
+
+function toIso(value: Date | string | null): string | null {
+    if (!value) return null;
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString();
+    // mysql2 가 문자열로 주는 경우 — DB 저장값은 KST 이므로 타임존을 명시해야
+    // 서버 로컬 타임존에 따라 9시간 어긋나지 않는다.
+    const m = String(value)
+        .trim()
+        .match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/);
+    if (!m) return null;
+    const t = Date.parse(`${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}+09:00`);
+    return Number.isNaN(t) ? null : new Date(t).toISOString();
+}
+
+export const GET: RequestHandler = async ({ locals, setHeaders }) => {
+    const userId = locals.user?.id;
+    if (!userId) {
+        return json({ error: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    try {
+        const [memberRows] = await pool.query<MemberRow[]>(
+            'SELECT mb_datetime FROM g5_member WHERE mb_id = ? LIMIT 1',
+            [userId]
+        );
+        if (!memberRows[0]) {
+            return json({ error: '회원을 찾을 수 없습니다.' }, { status: 404 });
+        }
+
+        // (member_id, is_public, is_deleted, source_created_at) 인덱스를 그대로 타는 형태.
+        // EXPLAIN: ref const,const,const + Using index (커버링) — 헤비 유저도 즉시 응답.
+        const [activityRows] = await pool.query<ActivityRow[]>(
+            `SELECT source_created_at FROM member_activity_feed
+              WHERE member_id = ? AND is_public = 1 AND is_deleted = 0
+              ORDER BY source_created_at DESC LIMIT 1`,
+            [userId]
+        );
+
+        // 개인화 응답이라 공유 캐시 금지. hooks.server.ts 가 no-store 는 보존하고
+        // 그 외는 `private, max-age=2` 로 덮으므로, 의도를 남기려면 no-store 로 명시해야 한다.
+        // 호출량 억제는 서버 캐시가 아니라 클라이언트의 settled 마커가 담당한다.
+        setHeaders({ 'cache-control': 'no-store' });
+
+        return json({
+            signup_at: toIso(memberRows[0].mb_datetime),
+            last_contribution_at: activityRows[0] ? toIso(activityRows[0].source_created_at) : null
+        });
+    } catch (err) {
+        console.error('[onboarding-status]', err);
+        return json({ error: '상태를 확인할 수 없습니다.' }, { status: 500 });
+    }
+};


### PR DESCRIPTION
## 무슨 일이 있었나
실험 A 온보딩 카드(7/9 prod 라이브)는 게이트로 `apiClient.getMemberProfile()` 을 쓰는데, **이 API 는 백엔드에 라우트가 없습니다.**

```
/api/v1/members/{id}   → 200 {"data":null,"success":true}   ← 라우트 없음
/api/v1/zzz/bogus      → 200 {"data":null,"success":true}   ← 대조군, 응답 동일
/api/v1/my/stats       → 401                                  ← 라우트 있음
```

백엔드가 없는 경로에 404 가 아니라 `200 {"data":null}` 을 주기 때문에, `profile.mb_datetime` 에서 TypeError 가 나고 컴포넌트 `catch` 가 그대로 삼킵니다. → **카드는 라이브 이후 한 번도 노출되지 않았습니다.**

즉 "실험 A 효과"로 관측하던 코호트 변동(7/6 14.8% 등)은 **처치가 아니라 자연 변동**이며, 7/27 판정 계획도 이 수정 없이는 의미가 없습니다.

## 변경
1. **`/api/me/onboarding-status` 신설** — 두 성장 카드(실험 A · R1 웰컴백)의 단일 권위 소스
   - `g5_member.mb_datetime` + `member_activity_feed` 최신 공개 활동
   - EXPLAIN 실측: `idx_member_public_deleted_created`, `ref=const,const,const`, `Using index`(커버링) — 헤비 유저도 즉시
   - 인증 필수(401), 파라미터 바인딩, 남의 데이터 조회 불가
2. **게이트 교체 + 계측** — `onboarding_impression` / `onboarding_cta_click`. **"노출 0" 자체가 신호**가 되게 해 같은 침묵을 반복하지 않습니다
3. **`as_level ≤ 1` 사전 게이트 제거** — 실측: 가입 14일 이내 + 기여 0 인 회원 중 `as_level ≥ 2` 가 **199명**으로 통과자(**159명**)보다 많습니다. XP 는 기여 없이도(출석 등) 오르므로 근사치가 틀렸고, 이 게이트가 실험 검정력을 반토막 냈습니다. 이제 `last_contribution_at` 이라는 정확한 판별자가 있습니다. 호출량은 클라이언트 `settled` 마커(가입 14일 경과 = 영구 확정)로 억제합니다
4. dismiss 키 회원별 스코프 (구 전역 키는 계속 존중 — 이미 닫은 사람 재노출 없음)

## 검증
- Evaluator 독립 검증: 배포 가능 판정. 라우트 등록(`.svelte-kit/types` 생성 + check 0 errors), `locals.user.id` 필드명 정합, 타임존(`+09:00` 부착이 옳음 — 컬럼값이 KST 벽시계임을 실측), `is_public=0` 오판 위험 0(해당 코호트 0명), zero-date fail-closed
- svelte-check 0 errors / prettier 통과
- **예상 도달**: 죽은 API 시절 0명 → 현재 조건 충족 회원 실측 **약 358명**(159 + as_level 게이트 제거분 199)

## 다음
배포 후 `onboarding_impression` 이 실제로 발생하는지 확인 → 코호트 관측 → 그 다음 R1 웰컴백(#1823) 순서로 진행합니다.