### PR TITLE
fix(comment): 댓글 삭제 시 알림에 남는 본문 스니펫 소거

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/+server.ts
@@ -70,6 +70,24 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
             safeCommentId
         ]);
 
+        // 알림에 남은 본문 스니펫 소거.
+        // soft delete 는 wr_content 를 지우지 않고 렌더링에서 가리는 방식이라,
+        // g5_na_noti.rel_msg 에 복사돼 있던 본문이 수신자 알림함에 그대로 남는다.
+        // (2026-07-20 실측: 삭제된 댓글의 원문이 30명 알림함에 119건 잔존 → 백필로 소거)
+        // 파생 표면을 함께 지우지 않으면 soft delete 는 무의미해진다.
+        // rel_bo_table/rel_wr_id 쌍이 본문 스니펫을 담는다(bo_table/wr_id 쌍은 "○○님이
+        // 댓글을 남겼습니다" 안내 문구라 대상 아님).
+        await pool
+            .query(
+                `UPDATE g5_na_noti SET rel_msg = ''
+                  WHERE rel_bo_table = ? AND rel_wr_id = ? AND rel_msg <> ''`,
+                [safeBoardId, safeCommentId]
+            )
+            .catch((err) => {
+                // 알림 정리 실패가 삭제 자체를 되돌리면 안 된다 — 로그만 남긴다.
+                console.error('Comment DELETE: notification snippet cleanup failed:', err);
+            });
+
         return json({ message: '삭제 완료' });
     } catch (error) {
         console.error('Comment DELETE error:', error);


### PR DESCRIPTION
## 문제

댓글 soft delete 는 `wr_content` 를 지우지 않고 **렌더링에서 가리는** 방식입니다. 댓글 목록 API 는 비관리자에게 `content=''` 로 내려주어 정상 동작합니다.

그런데 `g5_na_noti.rel_msg` 에는 알림 생성 시점의 **본문 스니펫이 복사**돼 있어, 회원이 댓글을 지워도 **수신자 알림함에는 내용이 그대로 남았습니다.**

## 실측 (2026-07-20)

| 게시판 | 잔존 |
|---|---|
| free | 84 |
| bug | 13 |
| car | 11 |
| hello | 4 |
| promotion · stock | 각 3 |
| qa | 1 |
| **합계** | **119건 / 댓글 71개 / 수신자 30명** |

**전부 미읽음** 상태였습니다(읽은 알림은 14일 후 삭제 정책이라 미읽음만 잔존). 즉 지금 알림함을 열면 삭제된 댓글 내용이 보이는 상태였습니다.

기존분은 백필 SQL(`triage/fix_noti_snippet_deleted_comments.sql`, 72개 게시판 커버·멱등)로 소거 완료했고, **이 PR 은 재발을 막습니다.**

## 선례

Discourse 도 삭제된 글이 **인용(quote)** 과 **번역 기능** 경로로 전문 노출된 버그가 있었습니다. 본문만 가리고 파생 표면을 방치하면 soft delete 는 무의미해집니다.

## 대상 컬럼 — 주의

`g5_na_noti` 에는 컬럼 쌍이 둘 있고 의미가 다릅니다:

| 쌍 | `rel_msg` 내용 | 대상 |
|---|---|---|
| `rel_bo_table` / `rel_wr_id` | **본문 스니펫** | ✅ 소거 |
| `bo_table` / `wr_id` | "○○님이 댓글을 남겼습니다" 안내 문구 | ❌ 무해 |

후자로 조회하면 2,457건이 잡히지만 **내용을 대조해보면 안내 문구**입니다. 건수만 보고 오판할 뻔했으나 실제 값을 확인해 범위를 확정했습니다.

## 안전성

알림 정리 실패가 삭제 자체를 되돌리면 안 되므로 `.catch()` 로 로그만 남깁니다.

## 미점검 표면 (후속)

알림에서 실제로 샜으므로 다른 파생 표면도 의심됩니다 — **검색 인덱스(Manticore), 활동 피드, `parent_subject`(원글 제목)**. 별도 조사 예정입니다.