### PR TITLE
feat(hello): 가입인사 환영 폭죽

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -198,6 +198,7 @@
     let reactionPluginActive = $derived(pluginStore.isPluginActive('da-reaction'));
 
     import TagNav from '$lib/components/ui/tag-nav/tag-nav.svelte';
+    import { launchCelebrationConfetti } from '$lib/utils/confetti.js';
 
     // 동적 import: member-memo 플러그인 컴포넌트
     import type { Component } from 'svelte';
@@ -934,6 +935,34 @@
         return () => {
             window.removeEventListener('hashchange', onHashChange);
         };
+    });
+
+    // 가입인사 환영 폭죽 — 신입이 자기 인사글을 처음 열 때 한 번만.
+    //
+    // 왜 "작성자 + 최초 1회" 인가:
+    //   모든 조회마다 터뜨리면 방해가 된다(가입인사가 하루 36건까지 올라온다).
+    //   환영받아야 할 사람은 글쓴 신입 본인이고, 그 순간은 글을 막 올린 직후다.
+    //   localStorage 로 글당 1회 제한을 걸어 재방문 시에는 조용히 지나간다.
+    //
+    // 접근성: prefers-reduced-motion 사용자에게는 띄우지 않는다.
+    // 구현: 기존 launchCelebrationConfetti(2주년·승급 축하에서 쓰던 것) 재사용.
+    onMount(() => {
+        if (boardId !== 'hello' || !isAuthor) return;
+        if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
+
+        const key = `dm_hello_welcome_${data.post.id}`;
+        try {
+            if (localStorage.getItem(key)) return;
+            localStorage.setItem(key, '1');
+        } catch {
+            // localStorage 불가(시크릿 모드 등)면 중복 방지를 포기하고 그냥 띄운다
+        }
+
+        // 페이지가 자리를 잡은 뒤 터뜨린다
+        const t = setTimeout(() => {
+            void launchCelebrationConfetti();
+        }, 600);
+        return () => clearTimeout(t);
     });
 
     // 날짜 포맷 헬퍼


### PR DESCRIPTION
## 무엇

신입이 **자기 가입인사 글을 처음 열 때** 축하 폭죽을 띄웁니다.

## 발동 조건을 좁게 잡은 이유

| 조건 | 이유 |
|---|---|
| `boardId === 'hello'` | 가입인사 전용 |
| **작성자 본인만** | 환영받아야 할 사람은 글쓴 신입 |
| **글당 1회** (localStorage) | 재방문 시 조용히 지나감 |
| `prefers-reduced-motion` 제외 | 접근성 |

모든 조회마다 터뜨리면 방해가 됩니다 — 가입인사가 **하루 36건**까지 올라옵니다. 일반 회원이 인사글을 둘러볼 때마다 폭죽이 터지면 피로합니다.

## 구현

기존 `launchCelebrationConfetti`(2주년 팝업·승급 축하에서 쓰던 것)를 **그대로 재사용**했습니다. 새 라이브러리·에셋 추가 없고, `canvas-confetti`는 이미 dynamic import 구조라 초기 번들에 영향이 없습니다.

## 배경

타 커뮤니티 유입으로 신규 가입이 급증하고 있습니다:

| 날짜 | 신규 가입 | 인사글 |
|---|---|---|
| 평시(7/10~17) | 10~30 | 1~8 |
| 7/19 | 71 | 14 |
| **7/20** | **144** | **36** |

환영 경험을 다듬을 시점입니다.

## 검증

- `svelte-check` 에러 0
- `prettier` 통과
- 카나리에서 실제 인사글 작성 후 폭죽 확인 예정