### PR TITLE
본인확인 차단 시 사유 안내 (신규 회원)

### DIFF
--- a/apps/web/src/routes/[boardId]/write/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/write/+page.server.ts
@@ -29,7 +29,9 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 
     const certError = await checkCertification(boardId, locals.user.id);
     if (certError) {
-        redirect(302, '/register/cert');
+        // 사유를 함께 넘긴다. 그냥 튕기면 신규 회원은 왜 막혔는지 알 수 없어
+        // "신규회원은 글을 못 쓰는구나"로 오해한다(#가입인사 제보).
+        redirect(302, `/register/cert?from=write&board=${encodeURIComponent(boardId)}`);
     }
 
     // 게시판 정보 조회 → write_level 권한 체크

--- a/apps/web/src/routes/register/cert/+page.server.ts
+++ b/apps/web/src/routes/register/cert/+page.server.ts
@@ -12,7 +12,11 @@ interface MemberCertRow extends RowDataPacket {
     mb_certify: string;
 }
 
-export const load: PageServerLoad = async ({ locals }) => {
+interface BoardSubjectRow extends RowDataPacket {
+    bo_subject: string;
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
     // 로그인 필수
     if (!locals.user) {
         redirect(303, '/login');
@@ -34,8 +38,23 @@ export const load: PageServerLoad = async ({ locals }) => {
     const mbCertify = rows[0]?.mb_certify || '';
     const isCertified = !!mbCertify;
 
+    // 글쓰기에서 막혀 넘어온 경우 게시판 이름을 함께 보여준다.
+    // board 값은 URL 파라미터라 신뢰하지 않고 DB 에 실재하는 게시판일 때만 사용한다.
+    let blockedBoardName: string | null = null;
+    const fromWrite = url.searchParams.get('from') === 'write';
+    const boardParam = (url.searchParams.get('board') || '').replace(/[^a-zA-Z0-9_-]/g, '');
+    if (fromWrite && boardParam) {
+        const [boardRows] = await readPool.query<BoardSubjectRow[]>(
+            'SELECT bo_subject FROM g5_board WHERE bo_table = ?',
+            [boardParam]
+        );
+        blockedBoardName = boardRows[0]?.bo_subject || null;
+    }
+
     return {
         isCertified,
-        certRequired: certConfig.certReq === 1
+        certRequired: certConfig.certReq === 1,
+        fromWrite,
+        blockedBoardName
     };
 };

--- a/apps/web/src/routes/register/cert/+page.svelte
+++ b/apps/web/src/routes/register/cert/+page.svelte
@@ -95,6 +95,24 @@
             </CardDescription>
         </CardHeader>
         <CardContent class="space-y-6">
+            {#if data.fromWrite && !data.isCertified}
+                <div
+                    class="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm leading-6 dark:border-blue-800 dark:bg-blue-950"
+                >
+                    <p class="font-semibold text-blue-900 dark:text-blue-100">
+                        {#if data.blockedBoardName}
+                            「{data.blockedBoardName}」에 글을 쓰시려면 본인확인이 필요합니다
+                        {:else}
+                            글을 쓰시려면 본인확인이 필요합니다
+                        {/if}
+                    </p>
+                    <p class="mt-1 text-blue-800 dark:text-blue-200">
+                        등급이나 가입 기간 때문이 아닙니다. 아래에서 본인확인을 마치시면 바로
+                        작성하실 수 있습니다.
+                    </p>
+                </div>
+            {/if}
+
             <div class="border-border bg-muted/40 rounded-lg border p-4 text-sm leading-6">
                 <p class="font-semibold">등급 안내</p>
                 <p class="text-muted-foreground mt-2">


### PR DESCRIPTION
## 문제

신규 회원이 글쓰기를 누르면 `/register/cert` 로 **아무 설명 없이** 튕깁니다. 인증 페이지에는 "글쓰기와 댓글 작성은 앙님💛부터"라는 등급 문구만 있어, 실제 차단 사유(본인확인)를 가입 기간 제한으로 오해하게 됩니다.

실제 제보: `hello/26511#c_28306` — "신규회원은 바로 가입인사가 안되나보네요 ㅋ"

측정: 어제 가입자 153명 중 **38명이 미인증**. hello 게시글 작성자는 7/5~7/21 내내 **100% 인증자**입니다.

## 변경

- 글쓰기 리다이렉트에 `?from=write&board=<id>` 전달
- 인증 페이지 상단에 사유 배너: 「가입인사」에 글을 쓰시려면 본인확인이 필요합니다 + "등급이나 가입 기간 때문이 아닙니다"
- `board` 파라미터는 신뢰하지 않고 `g5_board` 에 실재하는 경우에만 이름 사용

## 검증

- svelte-check: 변경 파일 오류 0 (기존 오류 7건은 tiptap-editor·types)
- prettier 통과

## 남은 확인 (별건)

인증 페이지의 "글쓰기는 앙님💛부터" 문구가 실제 권한과 어긋납니다 — level 2(앙님❤️) 회원이 최근 7일 hello 글 **57건**을 작성했습니다. 문구 정정은 정책 확인 후 별도로 진행하겠습니다.