### PR TITLE
목록 헤더 하이드레이션 실패 수정 (HierarchyRequestError)

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -355,9 +355,20 @@
 {:else}
     <div class={wrapperClass}>
         <!-- Classic 레이아웃 헤더 (게시판 목록과 동일) -->
-        {#if listLayoutId === 'classic' && uiSettingsStore.listView !== 'modern'}
+        <!--
+            ⛔ listView 를 {#if} 조건에 넣지 말 것 — 하이드레이션이 깨진다.
+            listView 는 localStorage 기반이라 SSR('classic' 기본값)과 클라이언트
+            (저장값 'modern')가 갈리고, 그러면 SSR 이 그린 DOM 과 구조가 달라져
+            'Failed to hydrate: HierarchyRequestError' 로 목록 전체가 죽는다.
+            구조는 항상 렌더하고 표시 여부만 클래스로 제어한다(속성 차이는 무해).
+            listLayoutId 는 서버 데이터라 조건에 써도 안전하다.
+        -->
+        {#if listLayoutId === 'classic'}
             <div
-                class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium md:block"
+                class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium {uiSettingsStore.listView ===
+                'modern'
+                    ? ''
+                    : 'md:block'}"
             >
                 <div class="grid grid-cols-[60px_1fr_auto_auto_auto] items-center gap-0">
                     <div class="text-center">공감</div>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1309,9 +1309,18 @@
 
             <!-- 게시글 목록 -->
             <div class={wrapperClass}>
-                {#if listLayoutId === 'classic' && uiSettingsStore.listView !== 'modern'}
+                <!--
+                    ⛔ listView 를 {#if} 조건에 넣지 말 것 — 하이드레이션이 깨진다.
+                    localStorage 기반이라 SSR('classic')과 클라이언트('modern')가 갈리고,
+                    구조가 달라지면 'Failed to hydrate: HierarchyRequestError' 로 목록이 죽는다.
+                    구조는 항상 렌더하고 표시만 클래스로 제어한다.
+                -->
+                {#if listLayoutId === 'classic'}
                     <div
-                        class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium md:block"
+                        class="border-border bg-muted/30 text-muted-foreground hidden border-b px-4 py-1.5 text-sm font-medium {uiSettingsStore.listView ===
+                        'modern'
+                            ? ''
+                            : 'md:block'}"
                     >
                         <div class="grid grid-cols-[60px_1fr_auto_auto_auto] items-center gap-0">
                             <div class="text-center">공감</div>


### PR DESCRIPTION
## 원인

제보된 콘솔 오류를 미니파이 번들에서 역추적해 분기를 특정했습니다.

```js
function f(t,e){ if(!Pa) return vs(t);
  var r = vs(An);                       // An = 하이드레이션 앵커
  if (r === null) r = An.appendChild(Ys());  // ← 여기서 HierarchyRequestError
```

앵커가 엘리먼트가 아닐 때(주석/텍스트 노드) `appendChild` 가 예외를 냅니다. 호출자는 `listView === 'modern'` 을 참조하는 목록 컴포넌트였습니다.

`ui-settings.svelte.ts` 는 모듈 로드 시점에 localStorage 를 동기로 읽습니다:

```ts
let settings = $state<UiSettings>(loadSettings());
function loadSettings() {
    if (!browser) return { ...DEFAULTS };      // SSR: 'classic'
    const stored = localStorage.getItem(...);  // 클라: 'modern'
```

따라서 `{#if listLayoutId === 'classic' && listView !== 'modern'}` 가 서버/클라이언트에서 갈려 구조가 어긋납니다. **목록 보기를 modern 으로 바꾼 사용자에게만** 발생합니다.

## 변경

두 곳(`recent-posts.svelte`, `[boardId]/+page.svelte`)에서 헤더 구조는 항상 렌더하고 표시 여부만 클래스로 제어합니다. 속성 차이는 하이드레이션이 패치하므로 안전합니다. `listLayoutId` 는 서버 데이터(`display_settings`)라 조건에 남겨도 됩니다.

재발 방지로 두 곳에 이유를 주석으로 남겼습니다.

## 검증

- svelte-check: 변경 파일 오류 0 (기존 7건은 tiptap-editor·types)
- SSR HTML 잘못된 중첩 검사 13페이지 0건 — 다른 원인 아님을 확인

## 후속 (별건)

localStorage 기반 값을 `{#if}` 구조 조건에 쓰는 곳이 **23곳** 더 있습니다(`hideMyProfile`·`pinSearch`·`hideMemo`·`showShortcutButtons` 등). 같은 유형의 잠재 버그라 별도로 감사하겠습니다 — 이번 스택이 가리킨 곳만 우선 고쳤습니다.