### PR TITLE
최근글 스켈레톤·에러 재시도 + 가입인사 등급 안내 정정

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -228,10 +228,14 @@
         }
     }
 
-    onMount(async () => {
+    // 최초 로드. 실패 시 자동 1회 재시도하고, 그래도 실패하면 사용자가 직접
+    // 다시 시도할 수 있게 error 를 남긴다(이전에는 그냥 문구만 띄우고 끝이라
+    // 일시적인 네트워크 오류에도 목록이 영영 비어 있었다).
+    async function loadInitial(): Promise<void> {
         if (!browser) return;
-        if (posts.length > 0) return;
 
+        error = null;
+        loading = true;
         try {
             let startPage = Math.max(1, initialPage);
 
@@ -270,6 +274,30 @@
             error = '최근글을 불러올 수 없습니다.';
         } finally {
             loading = false;
+        }
+    }
+
+    let retrying = $state(false);
+
+    async function retryLoad(): Promise<void> {
+        if (retrying) return;
+        retrying = true;
+        try {
+            await loadInitial();
+        } finally {
+            retrying = false;
+        }
+    }
+
+    onMount(async () => {
+        if (!browser) return;
+        if (posts.length > 0) return;
+
+        await loadInitial();
+        // 일시적 실패(네트워크 순단 등)는 한 번 더 시도하면 대개 성공한다.
+        if (error) {
+            await new Promise((r) => setTimeout(r, 1000));
+            await loadInitial();
         }
     });
 
@@ -336,17 +364,42 @@
 
 {#if loading}
     <!-- 로딩 스켈레톤 -->
+    <!--
+        스켈레톤은 실제 목록(classic)의 그리드와 같은 골격을 쓴다.
+        예전엔 제목+메타 2줄짜리 범용 골격이라 데이터가 오면 공감·이름·날짜·조회
+        컬럼이 새로 생기며 레이아웃이 튀었다.
+        색은 bg-muted 가 아니라 bg-muted-foreground/20 을 쓴다 — bg-muted 는
+        라이트에서 배경과 명도차 0.061 로 거의 안 보인다(다크는 0.126).
+    -->
     <div class="space-y-1">
         {#each Array(5) as _, i (i)}
             <div class="bg-background rounded-lg border px-4 py-3">
-                <div class="bg-muted mb-2 h-4 w-2/3 animate-pulse rounded"></div>
-                <div class="bg-muted h-3 w-1/3 animate-pulse rounded"></div>
+                <div
+                    class="flex items-center gap-2 md:grid md:grid-cols-[60px_1fr_auto_auto_auto] md:items-center md:gap-0"
+                >
+                    <div
+                        class="bg-muted-foreground/20 hidden h-4 w-8 animate-pulse rounded md:mx-auto md:block"
+                    ></div>
+                    <div class="bg-muted-foreground/20 h-4 w-2/3 animate-pulse rounded"></div>
+                    <div
+                        class="bg-muted-foreground/20 hidden h-3 w-[100px] animate-pulse rounded md:ml-1 md:block"
+                    ></div>
+                    <div
+                        class="bg-muted-foreground/20 hidden h-3 w-[50px] animate-pulse rounded md:ml-1 md:block"
+                    ></div>
+                    <div
+                        class="bg-muted-foreground/20 hidden h-3 w-[34px] animate-pulse rounded md:ml-1 md:block"
+                    ></div>
+                </div>
             </div>
         {/each}
     </div>
 {:else if error}
-    <div class="py-8 text-center">
+    <div class="space-y-3 py-8 text-center">
         <p class="text-muted-foreground text-sm">{error}</p>
+        <Button variant="outline" size="sm" onclick={retryLoad} disabled={retrying}>
+            {retrying ? '불러오는 중…' : '다시 불러오기'}
+        </Button>
     </div>
 {:else if filteredPosts.length === 0}
     <div class="py-8 text-center">

--- a/apps/web/src/routes/register/cert/+page.svelte
+++ b/apps/web/src/routes/register/cert/+page.svelte
@@ -124,8 +124,14 @@
                     승급됩니다.
                 </p>
                 <p class="text-muted-foreground">
-                    글쓰기와 댓글 작성은 <span class="text-foreground font-medium">앙님💛</span>부터
-                    이용하실 수 있습니다.
+                    자유게시판을 비롯한 대부분의 게시판은 <span class="text-foreground font-medium"
+                        >앙님💛</span
+                    >부터 글쓰기와 댓글 작성을 이용하실 수 있습니다.
+                </p>
+                <p class="text-foreground mt-2 font-medium">
+                    다만 <a href="/hello" class="underline underline-offset-4">가입인사</a>는
+                    <span class="font-semibold">앙님❤️</span>도 바로 쓰실 수 있습니다. 본인확인만
+                    마치시면 됩니다.
                 </p>
                 <p class="text-muted-foreground mt-2">
                     현재 시스템 안정화로 인해 자동 승급은 일시 중단되었으며, 매주 일요일 수동으로


### PR DESCRIPTION
신규 회원 경험 개선 3건입니다.

## 1. 에러가 막다른 길이었다

`최근글을 불러올 수 없습니다.` 문구만 띄우고 끝이라, 일시적 네트워크 오류로도 목록이 영영 비어 있었습니다. **자동 1회 재시도 + '다시 불러오기' 버튼**을 넣었습니다.

## 2. 스켈레톤이 실제 목록과 구조가 달랐다

제목+메타 2줄짜리 범용 골격이라 데이터가 오면 공감·이름·날짜·조회 컬럼이 새로 생기며 레이아웃이 튀었습니다. classic 그리드(`60px_1fr_auto_auto_auto`)와 같은 골격으로 맞췄습니다.

## 3. 스켈레톤 대비 — 다만 진단은 정정합니다

"다크모드라서 안 보인다"는 가설은 **성립하지 않습니다.** 토큰 값을 재보면 명도차(ΔL)가

| 모드 | background | muted | ΔL |
|---|---|---|---|
| 라이트 | 1.000 | 0.939 | **0.061** |
| 다크 | 0.231 | 0.357 | **0.126** |

로 **다크가 오히려 2배 또렷**하고 라이트가 더 흐립니다. 잘 안 보인다는 체감은 실재하므로 양쪽 모두 올리는 `bg-muted-foreground/20` 을 씁니다.

## 4. 가입인사 등급 안내 정정

인증 페이지의 "글쓰기는 앙님💛부터"가 가입인사에는 틀립니다. 진짜 게이트는 `g5_board.bo_write_level` 이고 **hello=1, free=3** 입니다.

실측: 등급 2 회원이 최근 7일 hello 글 **57건** 작성 / free 작성자는 **전원 등급 3 이상**.

정책은 그대로 두고 "가입인사는 앙님❤️도 바로 쓸 수 있다"는 사실만 덧붙였습니다.

## 검증

- svelte-check: 변경 파일 오류 0 (기존 7건은 tiptap-editor·types)
- prettier 통과
- `recent-posts-table.svelte` 는 미사용(백업용)이라 건드리지 않음