### PR TITLE
검색창 고정 설정의 하이드레이션 불일치 수정

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -285,7 +285,15 @@
 
     // 읽은 글 표시 지연 — SSR에서는 모든 글이 "안읽음"으로 렌더링되므로,
     // 하이드레이션 직후 즉시 변경하면 깜빡임 발생. 2프레임 대기 후 부드럽게 전환.
-    let showSearch = $state(uiSettingsStore.pinSearch);
+    // ⛔ pinSearch(localStorage) 를 SSR 초기값으로 쓰면 하이드레이션이 깨진다.
+    // SSR 은 기본값 false 로 검색폼을 안 그리는데 클라이언트는 저장값 true 로 그려서
+    // 구조가 갈리고, 앵커가 어긋나면 'Failed to hydrate: HierarchyRequestError' 로
+    // 목록이 죽는다(#1829 의 listView 와 같은 유형). 마운트 이후에 반영한다.
+    let hydrated = $state(false);
+    onMount(() => {
+        hydrated = true;
+    });
+    let showSearch = $state(false);
     let showReadState = $state(false);
     let memoByAuthorId = $state<Record<string, { content: string; color: string } | null>>({});
     let lastMemoRequestKey = $state('');
@@ -1022,7 +1030,8 @@
 
             <!-- 검색 폼 (토글 or 검색 중 or 핀 고정) -->
             <!-- #12455: 로그인 사용자는 PC(md+)에서 빠른필터 행 검색이 대체 → 상단 SearchForm 숨김 (비로그인/모바일은 유지) -->
-            {#if showSearch || isSearching || uiSettingsStore.pinSearch}
+            <!-- hydrated 게이트: pinSearch 는 localStorage 라 SSR 과 값이 갈린다. 위 주석 참고. -->
+            {#if showSearch || isSearching || (hydrated && uiSettingsStore.pinSearch)}
                 <div
                     class="mb-3 {authStore.isAuthenticated ? 'md:hidden' : ''}"
                     transition:slide={{ duration: 200 }}


### PR DESCRIPTION
## 배경 — 감사 결과 정정

어젯밤 감사에서 `hideMyProfile` 6곳을 **P0** 로 올렸는데 **오탐이었습니다.** 정규식 기반 분류가 상위 가드를 못 봤습니다.

| 위치 | 실제 판정 | 근거 |
|---|---|---|
| `header.svelte` | ✅ 안전 | 운영 `SSR_STRIP_USER=true` → `$page.data.user`=null → `authResolving=true` → SSR·하이드레이션 **양쪽 다 스켈레톤** |
| `user-widget.svelte` | ✅ 안전 | `{#if isLoading && !loadingTimedOut}` 가 먼저 걸림 |

`hideMyProfile` 분기는 인증이 풀린 **하이드레이션 이후**에 도달하므로 일반 반응성 업데이트입니다.

## 진짜 결함 — pinSearch

```svelte
let showSearch = $state(uiSettingsStore.pinSearch);   // SSR false / 클라 저장값
...
{#if showSearch || isSearching || uiSettingsStore.pinSearch}
```

"검색창 고정"을 켠 사용자는 **게시판 목록(최대 트래픽 경로)** 에서 SSR 에 없던 검색폼이 클라이언트에서 생겨 구조가 갈립니다. `transition:slide` 까지 붙어 있어 더 취약합니다.

## 변경

`hydrated` 게이트로 마운트 이후 반영. `transition:slide` 가 살아 있어 켠 사용자에겐 자연스럽게 나타납니다.

class 표현식의 `pinSearch`(971·983·995)는 **속성이라 무해**하므로 건드리지 않았습니다.

## 검증

- svelte-check 변경 파일 오류 0 / prettier 통과
- 계측(#1827) 기준 최근 12시간 하이드레이션 오류 **0건** — 수집 파이프라인은 정상(시간당 4~7만 건, 커스텀 type `comment_input_telemetry` 유통 확인). 즉 현재 터지고 있진 않은 **잠재 결함 정리**입니다.

## 배포

**낮 시간이라 배포하지 않았습니다.** 야간에 승인 받고 올리겠습니다.