### PR TITLE
신규 회원 승급 안내 정확화 + 하이드레이션 감사 마무리

### DIFF
--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -335,7 +335,13 @@
         }, 300);
     }
 
+    // ⛔ localStorage 기반 설정을 {#if} 구조 조건에 그대로 쓰면 하이드레이션이 깨진다.
+    // SSR 은 DEFAULTS, 클라이언트는 저장값이라 구조가 갈린다(#1829 listView 동종).
+    // 마운트 이후에 반영한다.
+    let hydrated = $state(false);
+
     onMount(() => {
+        hydrated = true;
         loadSubscriptions();
         loadFollowing();
         loadNotiPrefs();
@@ -768,7 +774,7 @@
                             추가
                         </Button>
                     </div>
-                    {#if uiSettingsStore.muteKeywords.length > 0}
+                    {#if hydrated && uiSettingsStore.muteKeywords.length > 0}
                         <div class="flex flex-wrap gap-1.5">
                             {#each uiSettingsStore.muteKeywords as keyword (keyword)}
                                 <Badge variant="secondary" class="gap-1 pr-1">
@@ -1027,7 +1033,7 @@
                             onCheckedChange={(v) => uiSettingsStore.setShowShortcutButtons(v)}
                         />
                     </div>
-                    {#if uiSettingsStore.showShortcutButtons}
+                    {#if hydrated && uiSettingsStore.showShortcutButtons}
                         <Separator />
                         <div>
                             <Label class="mb-2 block">버튼 크기</Label>
@@ -1074,7 +1080,7 @@
                             onCheckedChange={(v) => uiSettingsStore.setEnableTouchGestures(v)}
                         />
                     </div>
-                    {#if uiSettingsStore.enableTouchGestures}
+                    {#if hydrated && uiSettingsStore.enableTouchGestures}
                         <Separator />
                         <div class="grid grid-cols-2 gap-4">
                             <div>

--- a/apps/web/src/routes/my/memos/+page.svelte
+++ b/apps/web/src/routes/my/memos/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from 'svelte';
     import { goto, invalidate } from '$app/navigation';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
@@ -47,7 +48,15 @@
     const isSearching = $derived(
         !!(data.search?.color || data.search?.memo || data.search?.detail || data.search?.target)
     );
-    let showSearch = $state(uiSettingsStore.pinMemoSearch);
+    // ⛔ pinMemoSearch(localStorage) 를 SSR 초기값으로 쓰면 하이드레이션이 깨진다.
+    // SSR 은 기본값 false, 클라이언트는 저장값이라 구조가 갈린다(#1829 listView 동종).
+    // 마운트 이후에 반영한다.
+    let hydrated = $state(false);
+    onMount(() => {
+        hydrated = true;
+    });
+    let showSearch = $state(false);
+    const pinMemoSearchReady = $derived(hydrated && uiSettingsStore.pinMemoSearch);
 
     function handleSearch() {
         // eslint-disable-next-line svelte/prefer-svelte-reactivity
@@ -230,7 +239,7 @@
                 <Search class="h-3.5 w-3.5" />
                 검색
             </Button>
-            {#if showSearch || isSearching || uiSettingsStore.pinMemoSearch}
+            {#if showSearch || isSearching || pinMemoSearchReady}
                 <Button
                     variant="outline"
                     size="sm"
@@ -306,7 +315,7 @@
         </div>
     {/if}
 
-    {#if showSearch || isSearching || uiSettingsStore.pinMemoSearch}
+    {#if showSearch || isSearching || pinMemoSearchReady}
         <div class="mb-6" transition:slide={{ duration: 200 }}>
             <Card class="bg-background">
                 <CardContent class="pt-6">

--- a/apps/web/src/routes/register/cert/+page.server.ts
+++ b/apps/web/src/routes/register/cert/+page.server.ts
@@ -10,7 +10,17 @@ import type { RowDataPacket } from 'mysql2';
 
 interface MemberCertRow extends RowDataPacket {
     mb_certify: string;
+    mb_level: number;
+    login_days: number;
 }
+
+/**
+ * 앙님💛(등급 3) 승급에 필요한 로그인 일수.
+ * `auto-promotion.ts` 의 DEFAULT_PROMOTION_RULES 와 같은 값이어야 한다.
+ * (XP 조건도 있으나 실측상 아무도 XP 에서 막히지 않아 안내하지 않는다 —
+ *  등급 2 정체 회원 673명 중 'XP만 미달' 0명.)
+ */
+const PROMOTE_LOGIN_DAYS = 7;
 
 interface BoardSubjectRow extends RowDataPacket {
     bo_subject: string;
@@ -29,14 +39,21 @@ export const load: PageServerLoad = async ({ locals, url }) => {
         redirect(302, '/');
     }
 
-    // 이미 인증 완료 여부 확인
+    // 이미 인증 완료 여부 + 승급 진행 상황
     const [rows] = await readPool.query<MemberCertRow[]>(
-        'SELECT mb_certify FROM g5_member WHERE mb_id = ?',
+        `SELECT mb_certify, COALESCE(mb_level, 0) AS mb_level,
+                COALESCE(mb_login_days, 0) AS login_days
+           FROM g5_member WHERE mb_id = ?`,
         [locals.user.id]
     );
 
     const mbCertify = rows[0]?.mb_certify || '';
     const isCertified = !!mbCertify;
+
+    // 승급까지 남은 로그인 일수. 이미 등급 3 이상이면 안내하지 않는다.
+    const mbLevel = rows[0]?.mb_level ?? 0;
+    const loginDays = rows[0]?.login_days ?? 0;
+    const promoteDaysLeft = mbLevel >= 3 ? null : Math.max(0, PROMOTE_LOGIN_DAYS - loginDays);
 
     // 글쓰기에서 막혀 넘어온 경우 게시판 이름을 함께 보여준다.
     // board 값은 URL 파라미터라 신뢰하지 않고 DB 에 실재하는 게시판일 때만 사용한다.
@@ -55,6 +72,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
         isCertified,
         certRequired: certConfig.certReq === 1,
         fromWrite,
-        blockedBoardName
+        blockedBoardName,
+        promoteDaysLeft
     };
 };

--- a/apps/web/src/routes/register/cert/+page.svelte
+++ b/apps/web/src/routes/register/cert/+page.svelte
@@ -128,14 +128,43 @@
                         >앙님💛</span
                     >부터 글쓰기와 댓글 작성을 이용하실 수 있습니다.
                 </p>
-                <p class="text-foreground mt-2 font-medium">
-                    다만 <a href="/hello" class="underline underline-offset-4">가입인사</a>는
-                    <span class="font-semibold">앙님❤️</span>도 바로 쓰실 수 있습니다. 본인확인만
-                    마치시면 됩니다.
-                </p>
                 <p class="text-muted-foreground mt-2">
-                    현재 시스템 안정화로 인해 자동 승급은 일시 중단되었으며, 매주 일요일 수동으로
-                    등급을 상향 조정해드리고 있습니다.
+                    승급 조건은 <span class="text-foreground font-medium">본인확인</span>과
+                    <span class="text-foreground font-medium">로그인 7일</span>이며, 조건을 채우면
+                    자동으로 올라갑니다. 따로 신청하지 않으셔도 됩니다.
+                </p>
+
+                {#if data.promoteDaysLeft !== null}
+                    <div class="border-border/60 mt-3 rounded-md border border-dashed px-3 py-2">
+                        {#if data.promoteDaysLeft > 0}
+                            <p class="text-foreground font-medium">
+                                앙님💛까지 <span class="text-primary"
+                                    >로그인 {data.promoteDaysLeft}일</span
+                                > 남았습니다.
+                            </p>
+                            <p class="text-muted-foreground mt-0.5 text-xs">
+                                하루에 한 번만 들러 주시면 됩니다.
+                            </p>
+                        {:else}
+                            <p class="text-foreground font-medium">
+                                로그인 일수는 이미 채우셨습니다.
+                            </p>
+                            <p class="text-muted-foreground mt-0.5 text-xs">
+                                {#if data.isCertified}
+                                    곧 자동으로 승급됩니다.
+                                {:else}
+                                    본인확인만 마치시면 곧 승급됩니다.
+                                {/if}
+                            </p>
+                        {/if}
+                    </div>
+                {/if}
+
+                <p class="text-foreground mt-3 font-medium">
+                    기다리시는 동안 <a href="/hello" class="underline underline-offset-4"
+                        >가입인사</a
+                    >를 남겨보세요. <span class="font-semibold">앙님❤️</span>도 바로 쓰실 수 있는
+                    게시판입니다.
                 </p>
             </div>
 


### PR DESCRIPTION
가입이 8배 늘어난 상황(7/20 153명, 평시 15~20명)에서 온보딩 이탈 지점을 실측하고 고쳤습니다.

## 실측 — 자유게시판 활동 0명

| 7/20 코호트 | 인원 | 전환 |
|---|---|---|
| 가입 | 153 | — |
| 본인확인 | 116 | 76% |
| 가입인사 | 38 | 25% |
| **자유게시판 활동** | **0** | **0%** |

7/14~7/21 **전 코호트가 0명**입니다. `free` 는 `bo_write_level=3`(앙님💛)인데 신규는 등급 2라 승급 전까지 참여가 불가능합니다.

등급 2 정체 673명을 승급 조건(`로그인 7일 + XP 3000 + 본인확인`)으로 분해하면:

| 막힌 지점 | 인원 | 평균 로그인 |
|---|---|---|
| 본인확인 안 함 | 224 (33%) | 3.2일 |
| 로그인일 미달 | 432 (64%) | **1.8일** |
| **XP만 미달** | **0** | — |

**XP는 병목이 아닙니다.** 진짜 장벽은 시간이고, 평균 로그인 1.8일(최빈값 1일 311명)은 대부분 가입하고 안 돌아온다는 뜻입니다.

## 안내가 사실과 달랐습니다

인증 페이지에 "자동 승급은 일시 중단되었으며, 매주 일요일 수동으로 조정"이라고 쓰여 있는데, **실제로는 매일 자동으로 돌고 있습니다**(최근 7일 98건: `auto_promote_login_web` 88 + `auto_promote_login_social` 10). 신규 회원에겐 기약 없는 대기로 읽힙니다.

## 변경 — 온보딩

- 잘못된 "일시 중단 / 매주 일요일 수동" 문구 제거 → **실제 조건(본인확인 + 로그인 7일)** 명시
- **"앙님💛까지 로그인 N일 남았습니다"** 진행 상황 표시 (`mb_login_days` 기반)
- 등급 3 이상이면 미노출
- 기다리는 동안 쓸 수 있는 곳으로 **가입인사만** 안내

> XP 조건(3000)은 일부러 **안내하지 않았습니다.** 아무도 거기서 막히지 않는데 언급하면 장벽만 커 보입니다.

## 변경 — 하이드레이션 감사 마무리

localStorage 값을 `{#if}` 구조 조건에 쓰는 5곳 수정(#1829 listView 동종):

| 파일 | 설정 |
|---|---|
| `my/memos` 2곳 | `pinMemoSearch` — `showSearch` 초기값도 같은 값이라 두 변수가 동시에 갈렸음 |
| `settings/ui` 3곳 | `muteKeywords`, `showShortcutButtons`, `enableTouchGestures` |

두 라우트 모두 인증 가드 없이 SSR 렌더됨을 확인했습니다. class 표현식에 쓰인 것들은 **속성이라 무해**하므로 건드리지 않았습니다.

### 감사 정정 — `hideMyProfile` P0 는 오탐

어젯밤 P0 로 올렸던 `hideMyProfile` 6곳은 **안전**합니다. 정규식 분류가 상위 가드를 못 봤습니다.

- `header.svelte` — 운영 `SSR_STRIP_USER=true` → `authResolving=true` → SSR·하이드레이션 양쪽 다 스켈레톤
- `user-widget.svelte` — `{#if isLoading && !loadingTimedOut}` 선행

계측(#1827) 기준 최근 12시간 하이드레이션 오류 **0건**이며, 파이프라인 생존은 확인했습니다(시간당 4~7만 건, 커스텀 type 유통).

## 검증

- 잔여일 계산 실측 대조: 로그인 3일 → **4일 남음** ✅ / 등급 3+ 80명 미노출 ✅
- svelte-check 변경 파일 오류 0 (기존 7건은 tiptap-editor·types)
- prettier 통과

## 별건 — 게시판 권한 구멍

`bo_write_level<=2` 로 열린 게시판이 **21개**이고 그중 6개가 테스트/레거시(`image` 이미지 테스트, `milkdown` [복사본] 자유게시판, `editor`, `mine`, `good`, `release`)입니다. 등급 2 작성 실적은 3개월간 0건(의도된 `verification` 4건 제외)이라 지금 악용되진 않지만, 가입 폭증기에 스팸 진입로가 될 수 있습니다. 운영 DB 변경이라 별도 SQL 로 드립니다.