### PR TITLE
남은 승급 안내 오류 정정 (가입 페이지·초대 완료)

### DIFF
--- a/apps/web/src/routes/register/+page.svelte
+++ b/apps/web/src/routes/register/+page.svelte
@@ -169,14 +169,21 @@
                         승급됩니다.
                     </p>
                     <p class="text-muted-foreground">
-                        글쓰기와 댓글 작성은 <span class="text-foreground font-medium">앙님💛</span
-                        >부터 이용하실 수 있습니다.
+                        자유게시판을 비롯한 대부분의 게시판은 <span
+                            class="text-foreground font-medium">앙님💛</span
+                        >부터 글쓰기와 댓글 작성을 이용하실 수 있습니다.
                     </p>
                     <p class="text-muted-foreground mt-2">
-                        현재 시스템 안정화로 인해 자동 승급은 일시 중단되었으며, 매주 일요일
-                        수동으로 등급을 상향 조정해드리고 있습니다.
+                        승급 조건은 <span class="text-foreground font-medium">본인확인</span>과
+                        <span class="text-foreground font-medium">로그인 7일</span>이며, 조건을
+                        채우면 자동으로 올라갑니다. 따로 신청하지 않으셔도 됩니다.
                     </p>
-                    <p class="text-muted-foreground">이용에 불편을 드려 죄송합니다.</p>
+                    <p class="text-foreground mt-2 font-medium">
+                        기다리시는 동안 <a href="/hello" class="underline underline-offset-4"
+                            >가입인사</a
+                        >를 남겨보세요. <span class="font-semibold">앙님❤️</span>도 바로 쓰실 수
+                        있는 게시판입니다.
+                    </p>
                 </div>
             {/if}
 

--- a/apps/web/src/routes/register/invite-complete/+page.svelte
+++ b/apps/web/src/routes/register/invite-complete/+page.svelte
@@ -46,8 +46,9 @@
                     이용하실 수 있습니다.
                 </p>
                 <p class="text-muted-foreground mt-2">
-                    현재 시스템 안정화로 인해 자동 승급은 일시 중단되었으며, 매주 일요일 수동으로
-                    등급을 상향 조정해드리고 있습니다.
+                    승급 조건은 <span class="text-foreground font-medium">본인확인</span>과
+                    <span class="text-foreground font-medium">로그인 7일</span>이며, 조건을 채우면
+                    자동으로 올라갑니다. 따로 신청하지 않으셔도 됩니다.
                 </p>
             </div>
 


### PR DESCRIPTION
## 배경 — #1832 가 불완전했습니다

#1832 에서 `/register/cert` 만 고쳤는데, **같은 잘못된 문구가 두 곳 더** 있었습니다.

| 위치 | 대상 |
|---|---|
| `routes/register/+page.svelte:176` | **회원가입 페이지** — 신규 회원이 가장 먼저 보는 곳 |
| `routes/register/invite-complete/+page.svelte:49` | 초대 완료(광고주) |

"자동 승급은 일시 중단되었으며, 매주 일요일 수동으로 조정"은 **사실이 아닙니다.** 승급은 매일 자동으로 돌고 있습니다(최근 7일 98건).

## 어떻게 발견했나

카나리 배포 후 **빌드 산출물을 grep** 했더니 제거했어야 할 문구가 남아 있었습니다.

```
$ kubectl exec <canary-pod> -- grep -rl '매주 일요일' /app
/app/build/client/_app/immutable/bundle.CE4WY5lG.js
/app/build/server/chunks/_page.svelte-1eFbEoKn.js
```

소스에서 한 곳 고치고 "완료"로 판단한 것이 잘못이었습니다. **문구 변경은 전수 grep 이 필수**입니다.

## 변경

- `register`: 실제 조건(본인확인 + 로그인 7일) 명시 + 가입인사 안내
- `invite-complete`: 광고주 대상이라 사실 정정만 (가입인사 링크 없음)

## 검증

- `grep -rn '매주 일요일\|일시 중단' apps/web/src premium` → **0건**
- svelte-check 변경 파일 오류 0 / prettier 통과