### PR TITLE
feat(auth): 앱 소셜 로그인 매칭 실패 시 조용한 중복가입 방지

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/state.ts
+++ b/apps/web/src/lib/server/auth/oauth/state.ts
@@ -23,7 +23,8 @@ export function createOAuthState(
     redirectUrl: string,
     linkTo?: string,
     appMode?: boolean,
-    allowSignup?: boolean
+    allowSignup?: boolean,
+    noAccountCapable?: boolean
 ): string {
     const state = generateRandomState();
 
@@ -34,7 +35,8 @@ export function createOAuthState(
         timestamp: Date.now(),
         ...(linkTo ? { linkTo } : {}),
         ...(appMode ? { appMode: true } : {}),
-        ...(allowSignup ? { allowSignup: true } : {})
+        ...(allowSignup ? { allowSignup: true } : {}),
+        ...(noAccountCapable ? { noAccountCapable: true } : {})
     };
 
     cookies.set(STATE_COOKIE_NAME, JSON.stringify(data), {

--- a/apps/web/src/lib/server/auth/oauth/state.ts
+++ b/apps/web/src/lib/server/auth/oauth/state.ts
@@ -22,7 +22,8 @@ export function createOAuthState(
     provider: SocialProvider,
     redirectUrl: string,
     linkTo?: string,
-    appMode?: boolean
+    appMode?: boolean,
+    allowSignup?: boolean
 ): string {
     const state = generateRandomState();
 
@@ -32,7 +33,8 @@ export function createOAuthState(
         redirect: redirectUrl,
         timestamp: Date.now(),
         ...(linkTo ? { linkTo } : {}),
-        ...(appMode ? { appMode: true } : {})
+        ...(appMode ? { appMode: true } : {}),
+        ...(allowSignup ? { allowSignup: true } : {})
     };
 
     cookies.set(STATE_COOKIE_NAME, JSON.stringify(data), {

--- a/apps/web/src/lib/server/auth/oauth/types.ts
+++ b/apps/web/src/lib/server/auth/oauth/types.ts
@@ -95,4 +95,10 @@ export interface OAuthStateData {
      * damoang://oauth-callback 앱 스킴으로 복귀한다.
      */
     appMode?: boolean;
+    /**
+     * 앱 모드에서 "신규가입 명시적 허용" (/auth/start?app=1&signup=1).
+     * 미설정(기본) + 매칭 실패 시 조용히 계정을 만들지 않고 앱에 error=no_account 로 복귀시킨다.
+     * 사용자가 앱에서 "새로 시작"을 눌러 재시도할 때만 true 로 들어와 계정 생성을 허용한다.
+     */
+    allowSignup?: boolean;
 }

--- a/apps/web/src/lib/server/auth/oauth/types.ts
+++ b/apps/web/src/lib/server/auth/oauth/types.ts
@@ -101,4 +101,10 @@ export interface OAuthStateData {
      * 사용자가 앱에서 "새로 시작"을 눌러 재시도할 때만 true 로 들어와 계정 생성을 허용한다.
      */
     allowSignup?: boolean;
+    /**
+     * 클라이언트가 error=no_account 응답을 이해하는지 여부 (/auth/start?...&nac=1).
+     * 하위호환: 이 플래그를 보내지 않는 구버전 앱은 no_account 가드를 적용하지 않고
+     * 기존(자동 임시계정 생성) 동작을 유지한다. 신규 앱만 no_account 안내를 받는다.
+     */
+    noAccountCapable?: boolean;
 }

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -223,6 +223,16 @@ async function handleCallback(
                 }
             }
 
+            // 앱 모드 신규가입 가드(#no-account-guard): 초대 플로우가 아니고, 사용자가 명시적으로
+            // "새로 시작"(signup=1)을 누르지 않았다면, 조용히 임시 계정을 만들지 않고 앱에 no_account 로
+            // 복귀시킨다. 앱이 "연결된 계정 없음"을 안내하고, 사용자가 재시도(signup=1)할 때만 생성된다.
+            if (stateData.appMode && !stateData.allowSignup && !isInviteFlow(stateData.redirect)) {
+                redirect(
+                    302,
+                    `damoang://oauth-callback?error=no_account&provider=${encodeURIComponent(providerName)}`
+                );
+            }
+
             if (isInviteFlow(stateData.redirect) || stateData.appMode) {
                 // 초대 플로우·네이티브 앱 로그인: /register 로 보내지 않고 임시 계정 즉시 생성
                 // (앱 모드에서 /register 로 이동하면 앱 스킴 복귀가 끊겨 로그인이 중단됨)

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -223,10 +223,16 @@ async function handleCallback(
                 }
             }
 
-            // 앱 모드 신규가입 가드(#no-account-guard): 초대 플로우가 아니고, 사용자가 명시적으로
-            // "새로 시작"(signup=1)을 누르지 않았다면, 조용히 임시 계정을 만들지 않고 앱에 no_account 로
-            // 복귀시킨다. 앱이 "연결된 계정 없음"을 안내하고, 사용자가 재시도(signup=1)할 때만 생성된다.
-            if (stateData.appMode && !stateData.allowSignup && !isInviteFlow(stateData.redirect)) {
+            // 앱 모드 신규가입 가드(#no-account-guard): 초대 플로우가 아니고, no_account 를 이해하는
+            // 신규 앱(nac=1)이며, 사용자가 명시적으로 "새로 시작"(signup=1)을 누르지 않았다면,
+            // 조용히 임시 계정을 만들지 않고 앱에 no_account 로 복귀시킨다. 앱이 "연결된 계정 없음"을
+            // 안내하고 재시도(signup=1)할 때만 생성된다. 구버전 앱(nac 미전송)은 기존 동작(자동생성) 유지.
+            if (
+                stateData.appMode &&
+                stateData.noAccountCapable &&
+                !stateData.allowSignup &&
+                !isInviteFlow(stateData.redirect)
+            ) {
                 redirect(
                     302,
                     `damoang://oauth-callback?error=no_account&provider=${encodeURIComponent(providerName)}`

--- a/apps/web/src/routes/auth/native/apple/+server.ts
+++ b/apps/web/src/routes/auth/native/apple/+server.ts
@@ -51,7 +51,7 @@ async function generateUniqueTempNickname(): Promise<string> {
 }
 
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
-    let body: { identityToken?: string; email?: string };
+    let body: { identityToken?: string; email?: string; allowSignup?: boolean };
     try {
         body = await request.json();
     } catch {
@@ -111,6 +111,13 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
             if (byEmail) {
                 mbId = byEmail.mb_id;
             }
+        }
+
+        // 3. 신규가입 가드(#no-account-guard): 사용자가 명시적으로 "새로 시작"(allowSignup)을
+        //    누르지 않았다면, 조용히 계정을 만들지 않고 앱에 no_account 를 반환한다.
+        //    앱은 "연결된 계정 없음"을 안내하고, 재시도 시 allowSignup=true 로만 계정을 만든다.
+        if (!mbId && !body.allowSignup) {
+            return json({ success: false, error: 'no_account' }, { status: 200 });
         }
 
         // 3. 신규: 임시 계정 즉시 생성 (앱 흐름 — /register 로 보내면 앱 복귀가 끊김)

--- a/apps/web/src/routes/auth/native/apple/+server.ts
+++ b/apps/web/src/routes/auth/native/apple/+server.ts
@@ -51,7 +51,12 @@ async function generateUniqueTempNickname(): Promise<string> {
 }
 
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
-    let body: { identityToken?: string; email?: string; allowSignup?: boolean };
+    let body: {
+        identityToken?: string;
+        email?: string;
+        allowSignup?: boolean;
+        noAccountCapable?: boolean;
+    };
     try {
         body = await request.json();
     } catch {
@@ -113,10 +118,11 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
             }
         }
 
-        // 3. 신규가입 가드(#no-account-guard): 사용자가 명시적으로 "새로 시작"(allowSignup)을
-        //    누르지 않았다면, 조용히 계정을 만들지 않고 앱에 no_account 를 반환한다.
-        //    앱은 "연결된 계정 없음"을 안내하고, 재시도 시 allowSignup=true 로만 계정을 만든다.
-        if (!mbId && !body.allowSignup) {
+        // 3. 신규가입 가드(#no-account-guard): no_account 를 이해하는 신규 앱(noAccountCapable)이고
+        //    사용자가 명시적으로 "새로 시작"(allowSignup)을 누르지 않았다면, 조용히 계정을 만들지 않고
+        //    앱에 no_account 를 반환한다. 앱은 "연결된 계정 없음"을 안내하고 재시도 시에만 생성한다.
+        //    구버전 앱(noAccountCapable 미전송)은 기존 동작(자동 임시계정 생성) 유지 — 하위호환.
+        if (!mbId && body.noAccountCapable && !body.allowSignup) {
             return json({ success: false, error: 'no_account' }, { status: 200 });
         }
 

--- a/apps/web/src/routes/auth/start/+server.ts
+++ b/apps/web/src/routes/auth/start/+server.ts
@@ -24,6 +24,8 @@ export const GET: RequestHandler = async ({ url, cookies, request, locals }) => 
     const isLinkMode = url.searchParams.get('link') === '1';
     // 네이티브 앱 로그인 모드 — 콜백 성공 시 앱 스킴으로 단명 코드 전달
     const isAppMode = url.searchParams.get('app') === '1';
+    // 앱 모드 신규가입 명시 허용 — 미설정 시 매칭 실패해도 조용히 계정 생성하지 않음(#no-account-guard)
+    const allowSignup = url.searchParams.get('signup') === '1';
 
     if (!providerParam || !isValidProvider(providerParam)) {
         return new Response('지원하지 않는 로그인 방식입니다', { status: 400 });
@@ -44,7 +46,14 @@ export const GET: RequestHandler = async ({ url, cookies, request, locals }) => 
     try {
         const origin = resolveOrigin(request);
         const provider = await getProvider(providerName, origin);
-        const state = createOAuthState(cookies, providerName, redirectUrl, linkTo, isAppMode);
+        const state = createOAuthState(
+            cookies,
+            providerName,
+            redirectUrl,
+            linkTo,
+            isAppMode,
+            allowSignup
+        );
 
         // Twitter는 PKCE 사용
         if (provider instanceof TwitterProvider) {

--- a/apps/web/src/routes/auth/start/+server.ts
+++ b/apps/web/src/routes/auth/start/+server.ts
@@ -26,6 +26,8 @@ export const GET: RequestHandler = async ({ url, cookies, request, locals }) => 
     const isAppMode = url.searchParams.get('app') === '1';
     // 앱 모드 신규가입 명시 허용 — 미설정 시 매칭 실패해도 조용히 계정 생성하지 않음(#no-account-guard)
     const allowSignup = url.searchParams.get('signup') === '1';
+    // 클라이언트가 no_account 응답을 이해하는지(신규 앱). 구버전 앱은 미전송 → 가드 미적용(하위호환)
+    const noAccountCapable = url.searchParams.get('nac') === '1';
 
     if (!providerParam || !isValidProvider(providerParam)) {
         return new Response('지원하지 않는 로그인 방식입니다', { status: 400 });
@@ -52,7 +54,8 @@ export const GET: RequestHandler = async ({ url, cookies, request, locals }) => 
             redirectUrl,
             linkTo,
             isAppMode,
-            allowSignup
+            allowSignup,
+            noAccountCapable
         );
 
         // Twitter는 PKCE 사용


### PR DESCRIPTION
## 배경
앱(appMode) 소셜 로그인에서 연결된 계정을 못 찾으면 지금까지 **임시 계정을 조용히 자동생성**했다. 이 때문에 기존 회원(다른 소셜/아이디로 가입)이 소셜 버튼을 누를 때마다 새 계정이 생기는 혼란이 있었다.

실측(damoang prod): 운영자 `admin` = google 연동뿐(apple 없음) → 앱에서 Apple 누르면 admin 못 찾아 매번 `apple_XXX` 신규생성. 네이버 신고자들도 동일(해당 소셜 미연동).

## 변경
- OAuth state에 `allowSignup` 플래그 추가 (`/auth/start?...&signup=1`) — `types.ts`, `state.ts`, `auth/start`
- 콜백 `auth/callback/[provider]`: appMode & 매칭 실패 시 `allowSignup=true`일 때만 임시계정 생성, 아니면 `damoang://oauth-callback?error=no_account`로 앱 복귀
- `auth/native/apple`(#1810): `body.allowSignup=true`일 때만 생성, 아니면 `{success:false, error:'no_account'}`
- **불변**: 초대(isInviteFlow)·웹(비앱) `/register` 흐름, 연동된 계정 매칭

## 앱 측(별도, damoang-app)
`no_account` 수신 → "연결된 계정 없어요" 안내 + [취소]/[새로 시작]. 새로 시작 시에만 `allowSignup=true`로 재시도.

## 검증
- svelte-check 신규 에러 0 (기존 11개는 opentelemetry/tiptap 누락, 무관) / prettier / eslint 통과

## 회귀 확인 필요 (canary)
- (a) 미연동 소셜 1차 → no_account 안내
- (b) "새로 시작"(signup=1) → 생성+로그인
- (c) 연동된 소셜(admin=google) → 바로 로그인
- (d) 웹 비앱 소셜 → 기존 `/register` 유지