### PR TITLE
첫 댓글 넛지 — 권한 게이트 + 죽은 API 교체 (실험 B, #1754 대체)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -23,6 +23,7 @@
     import Loader2 from '@lucide/svelte/icons/loader-2';
     import type { Component } from 'svelte';
     import CommentToolbar from './comment-toolbar.svelte';
+    import FirstCommentNudge from '$lib/components/features/onboarding/first-comment-nudge.svelte';
     import { trackEvent } from '$lib/services/ga4.js';
 
     interface Props {
@@ -263,6 +264,15 @@
 </script>
 
 {#if canComment}
+    <!--
+        ⛔ 넛지는 반드시 이 canComment 블록 안에 둘 것.
+        자유게시판은 bo_comment_level=3 이라 신규(등급 2)는 댓글을 못 단다.
+        권한 없는 곳에서 "첫 댓글을 남겨보세요" 를 띄우면 권해놓고 막는 꼴이다.
+        답글 모드에서는 띄우지 않는다(첫 댓글 유도 취지에 안 맞음).
+    -->
+    {#if !isReplyMode}
+        <FirstCommentNudge />
+    {/if}
     <form onsubmit={handleSubmit} class="space-y-2">
         {#if showRating && !isReplyMode}
             <!-- 리뷰 별점 (리뷰=댓글+별점): 원댓글에만, 선택(무평점 가능) -->

--- a/apps/web/src/lib/components/features/onboarding/first-comment-nudge.svelte
+++ b/apps/web/src/lib/components/features/onboarding/first-comment-nudge.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+    /**
+     * 눈팅 신규회원 첫 댓글 넛지 배너 (성장 엔진 축B — 실험 B)
+     *
+     * 목표: 가입 후 아무 기여도 하지 않는 신규 회원의 첫 댓글을 유도한다.
+     * 최근 2주 가입자 589명 중 449명(76%)이 기여 0 이다.
+     *
+     * ⛔ 반드시 `comment-form` 의 `{#if canComment}` 블록 **안에서** 렌더할 것.
+     *    자유게시판은 bo_comment_level=3 이라 신규(등급 2)는 댓글을 못 단다.
+     *    권한 없는 곳에서 "첫 댓글을 남겨보세요" 를 띄우면 권해놓고 막는 꼴이라
+     *    안 하느니만 못하다. 등급 장벽 자체는 분란 목적 가입을 거르는 장치라
+     *    낮추지 않는다 — 막힐 일을 권하지 않는 것이 이 컴포넌트의 책임이다.
+     *
+     * 노출 조건 (전부 만족):
+     *  1) 로그인
+     *  2) 가입 5~21일 (0~5일은 실험 A 홈 온보딩 카드 구간이라 겹치지 않게 제외)
+     *  3) 공개 기여 0건
+     *  4) 닫기 안 누름 (localStorage)
+     *
+     * ⚠️ 상태 조회는 `/api/me/onboarding-status` 만 쓴다.
+     *    이전 구현은 `apiClient.getMemberProfile()` 을 썼는데 이 백엔드 경로는
+     *    죽어 있다 — 실존 회원과 없는 ID 가 똑같이 `{"data":null,"success":true}`
+     *    를 반환한다(200). 그러면 예외 → catch → 조용히 미노출이라 노출이 0 이
+     *    된다. 실험 A 가 11일간 겪은 실패가 정확히 이것이다.
+     */
+    import { authStore } from '$lib/stores/auth.svelte.js';
+
+    const DISMISS_KEY = 'angple_first_comment_nudge_dismissed';
+    const MIN_DAYS = 5;
+    const MAX_DAYS = 21;
+
+    let show = $state(false);
+    let checked = $state(false);
+
+    $effect(() => {
+        const user = authStore.user;
+        if (checked || !user) return;
+        checked = true;
+
+        try {
+            if (localStorage.getItem(DISMISS_KEY)) return;
+        } catch {
+            // localStorage 불가 환경 — 조용히 미노출
+            return;
+        }
+
+        void (async () => {
+            try {
+                const res = await fetch('/api/me/onboarding-status');
+                if (!res.ok) return;
+                const data = (await res.json()) as {
+                    signup_at: string | null;
+                    last_contribution_at: string | null;
+                };
+                // 이미 기여한 회원에겐 띄우지 않는다.
+                if (data.last_contribution_at) return;
+                if (!data.signup_at) return;
+
+                const signedAt = Date.parse(data.signup_at);
+                if (Number.isNaN(signedAt)) return;
+
+                const daysSince = (Date.now() - signedAt) / 86400000;
+                if (daysSince >= MIN_DAYS && daysSince <= MAX_DAYS) {
+                    show = true;
+                }
+            } catch {
+                // 조회 실패 시 조용히 미노출 (넛지는 있으면 좋은 기능)
+            }
+        })();
+    });
+
+    function dismiss() {
+        show = false;
+        try {
+            localStorage.setItem(DISMISS_KEY, String(Date.now()));
+        } catch {
+            /* localStorage 불가 환경 — 세션 내 숨김만 */
+        }
+    }
+</script>
+
+{#if show}
+    <div
+        class="mb-2 flex items-center gap-2 rounded-lg border border-sky-200 bg-gradient-to-r from-sky-50 to-emerald-50 px-3 py-2 text-sm dark:border-sky-800/40 dark:from-sky-950/40 dark:to-emerald-950/30"
+    >
+        <span class="shrink-0" aria-hidden="true">💬</span>
+        <p class="text-muted-foreground min-w-0 flex-1 leading-snug">
+            첫 댓글을 남겨보세요 — 앙님들이 반겨줘요! 작은 한마디면 충분해요 💛
+        </p>
+        <button
+            type="button"
+            onclick={dismiss}
+            class="text-muted-foreground hover:text-foreground shrink-0 rounded-full p-1 leading-none transition-colors"
+            aria-label="첫 댓글 안내 닫기"
+        >
+            ✕
+        </button>
+    </div>
+{/if}


### PR DESCRIPTION
## 배경

가입 14일 이내 **589명 중 449명(76%)이 기여 0** 입니다. 여기에 넛지를 붙이려고 `#1754` 를 살펴봤는데 **그대로 배포하면 안 되는 상태**였습니다.

원본 브랜치는 오래돼 별점 등 최근 기능을 되돌리므로 머지하지 않고 컴포넌트만 현재 main 위에 다시 썼습니다.

## 원본의 결함 3가지

### 1. 죽은 API — 배포해도 노출 0

`apiClient.getMemberProfile()` 이 때리는 `/api/v1/members/{id}` 는 죽어 있습니다. 실측:

| 경로 | 응답 |
|---|---|
| `/api/v1/members/admin` (실존) | 200 `{"data":null,"success":true}` |
| `/api/v1/members/__bogus__` (가짜) | 200 `{"data":null,"success":true}` |

**실존 회원과 없는 ID 를 구별할 수 없습니다.** `profile.mb_datetime` 에서 예외 → `catch` → 조용히 미노출. **실험 A 가 11일간 노출 0 이었던 원인이 정확히 이것입니다.**

→ 동작이 검증된 `/api/me/onboarding-status` 로 교체했습니다. 생존 확인:

| 경로 | 응답 | 판정 |
|---|---|---|
| `/api/me/onboarding-status` | **401** 로그인 필요 | ✅ 살아있음 |
| `/api/me/__bogus_route__` | 404 | ✅ 라우팅 정상 |

### 2. 이미 폐기된 `as_level` 게이트

`as_level <= 1` 조건이 있었는데, 이건 **2026-07-20 실험 A 에서 제거된 바로 그 게이트**입니다 — 대상 358명 중 199명을 배제한다는 실측이 근거였습니다. B 가 그대로 답습하고 있었습니다.

→ 제거. 가입일 + 기여 유무 단일 소스로 판단합니다.

### 3. 권한 없는 곳에서 댓글을 권함

넛지가 `comment-form` 에 붙는데 **댓글 권한 검사가 없었습니다.**

| 게시판 | `bo_comment_level` | 신규(등급 2) |
|---|---|---|
| hello | 1 | ✅ 가능 |
| free | **3** | ❌ 불가 |
| qa | **3** | ❌ 불가 |

자유게시판에서 "첫 댓글을 남겨보세요" 를 보고 시도하면 막힙니다. **권해놓고 막는 건 안 하느니만 못합니다.**

→ `comment-form` 의 `{#if canComment}` 블록 **안에** 배치했습니다. 별도 권한 로직 없이 구조적으로 보장됩니다. 답글 모드는 제외(첫 댓글 유도 취지에 안 맞음).

## 등급 장벽은 건드리지 않습니다

7일 출석 조건은 가입 직후 분란을 거르는 의도된 장치입니다(클리앙 등은 더 엄격). **장벽을 낮추는 게 아니라, 장벽에 막힐 일을 권하지 않는 것**이 이 PR 의 취지입니다.

## 노출 조건

로그인 + 가입 5~21일 + 공개 기여 0 + 댓글 권한 있음 + 닫기 안 누름
(0~5일은 실험 A 홈 온보딩 카드 구간이라 겹치지 않게 제외)

> 등급 3+ 라도 기여가 0 이고 가입 5~21일이면 노출됩니다. 게이트를 등급이 아니라 **기여 유무**로 둔 것은 의도입니다 — 눈팅 중인 회원이 대상이므로.

## 검증

- svelte-check 변경 파일 오류 0 / prettier 통과
- `as_level`·`getMemberProfile` 실사용 참조 0 (설명 주석만 남김)
- 카나리 검증 후 승격 예정

## 후속

`#1754` 는 이 PR 로 대체되므로 닫습니다.