### PR TITLE
신규 회원 답글 차단 수정 + 이용제한 답글 우회 차단

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -10,7 +10,7 @@
     } from '$lib/components/ui/dialog/index.js';
     import { RestrictedBadge } from '$lib/components/ui/restricted-badge/index.js';
     import { DisciplinedContent } from '$lib/components/ui/discipline-related/index.js';
-    import type { FreeComment } from '$lib/api/types.js';
+    import type { FreeComment, BoardPermissions } from '$lib/api/types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
@@ -108,6 +108,13 @@
         initialDislikedCommentIds?: number[]; // SSR에서 전달된 비추천한 댓글 ID 목록
         truthroomCommentMap?: Record<number, number>; // 잠긴 댓글 → 진실의방 글 ID 매핑
         isRestricted?: boolean; // 제한된 유저 (영구정지 등)
+        // ⛔ 답글 폼에 반드시 전달해야 하는 권한 정보 (#hello-reply).
+        //    전달하지 않으면 CommentForm 이 permissions 없이 렌더되어 폴백
+        //    `userLevel >= requiredCommentLevel(기본 3)` 을 타고, 등급 2(앙님❤️)
+        //    회원은 게시판 reply_level 이 1 이어도 답글을 못 단다.
+        //    실제로 가입인사에서 등급 2 의 대댓글이 0건이었다(일반 댓글은 217건).
+        permissions?: BoardPermissions;
+        requiredReplyLevel?: number; // 답글 폴백 기준 등급 (게시판 reply_level)
         // 기대 댓글 수 (SSR 메타의 comments_count). comments 가 아직 비어도 이 값이 0보다 크면
         // "댓글 없음" 대신 "불러오는 중"을 표시 — SPA 네비/하이드레이션 갭의 거짓 empty 방지 (#12663·#12668)
         expectedTotal?: number;
@@ -134,6 +141,8 @@
         initialDislikedCommentIds = [],
         truthroomCommentMap = {},
         isRestricted = false,
+        permissions,
+        requiredReplyLevel = 3,
         expectedTotal = 0,
         // 댓글 수정 정책 (사용자 확정 2026-05-22):
         // - 대댓글 없는 댓글: 항상 무료 수정 (grace 무관)
@@ -590,6 +599,9 @@
 
     // 답글 모드 시작
     function startReply(comment: FreeComment): void {
+        // 이용제한 중에는 답글도 막는다. 원댓글은 CommentForm 의 isRestricted 로
+        // 막히는데 답글 경로만 검사가 빠져 있었다(startReport 에만 있었음).
+        if (isRestricted) return;
         replyingToCommentId = String(comment.id);
         editingCommentId = null; // 수정 모드 해제
     }
@@ -1953,6 +1965,9 @@
                                 isReplyMode={true}
                                 isLoading={isReplying}
                                 {boardId}
+                                {permissions}
+                                requiredCommentLevel={requiredReplyLevel}
+                                {isRestricted}
                             />
                         </div>
                     {/if}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2416,6 +2416,8 @@
                             {initialDislikedCommentIds}
                             {truthroomCommentMap}
                             isRestricted={data.isRestricted}
+                            permissions={data.board?.permissions}
+                            requiredReplyLevel={data.board?.reply_level ?? 3}
                             expectedTotal={commentsTotal}
                             editPolicy={commentEditPolicy}
                         />


### PR DESCRIPTION
## 제보

가입인사 게시판에서 신규 회원들이 같은 말을 반복했습니다. 버그 신고가 아니라 **이모지로 우회하며 적응해버린** 형태였습니다.

> `hello/28518` (7/21 10:33) — "반갑습니다 ㅎ **답글은 안되지만** 댓글에 스마일 표시 누르면 이모티콘은 가능합니다"
> `hello/28514` (7/21 10:31) — "**답글은 안되지만** 댓글에 이모티콘 남기는 건 되더라고요"

둘 다 등급 2(앙님❤️)입니다.

## 실측

| 7월 hello | 등급 2 | 등급 3 | 등급 4 |
|---|---|---|---|
| 일반 댓글 | **217** | 300 | 507 |
| 대댓글 | **0** | 23 | 0 |

등급 2 는 댓글은 쓰는데 **대댓글만 0건**입니다.

## 원인

답글 폼이 `permissions` 없이 렌더됩니다.

```svelte
<!-- comment-list.svelte — 답글 폼 (수정 전) -->
<CommentForm onSubmit={handleReply} parentId={comment.id} isReplyMode={true} {boardId} />
```

`CommentForm` 은 `permissions` 가 없으면 폴백을 탑니다:

```ts
if (permissions) return isReplyMode ? permissions.can_reply : permissions.can_comment;
const userLevel = authStore.user?.mb_level ?? 1;
return userLevel >= requiredCommentLevel;   // ← 이 prop 기본값이 3
```

게시판 `reply_level` 이 1 이어도 폴백 기준이 **3** 이라 등급 2 는 차단됩니다. 원댓글 폼은 페이지가 `permissions` 를 넘기므로 정상 동작했고, 그래서 "댓글은 되는데 답글만 안 되는" 증상이 나왔습니다.

**`bo_reply_level` 을 고쳐도 소용없던 이유가 이것입니다** — 그 값을 아예 보지 않습니다.

## 부수 발견 — 이용제한 우회

`startReply()` 에 `isRestricted` 검사가 없었습니다(`startReport` 에만 존재). 이용제한 중인 회원이 답글 폼을 열 수 있었습니다. 서버 차단 여부와 별개로 UI 에서도 막습니다.

## 변경

- `comment-list`: `permissions`·`requiredReplyLevel` prop 추가 → 답글 폼에 전달
- `comment-list`: `startReply` 에 `isRestricted` 가드
- 페이지: `permissions={data.board?.permissions}`, `requiredReplyLevel={data.board?.reply_level ?? 3}` 전달

폴백 기본값 3 은 그대로 둡니다 — 권한 검사는 실패 시 닫히는(fail-closed) 쪽이 맞고, 이제 `permissions` 가 전달되므로 폴백을 타지 않습니다.

## 검증

- svelte-check 변경 파일 오류 0 / prettier 통과
- `<CommentList>` 사용처는 1곳뿐 — 누락 없음
- 카나리에서 등급 2 계정으로 답글 실측 예정