### PR TITLE
승급해도 옛 등급으로 동작 — user_basic 쿠키 갱신 조건 보완 (#13055)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -507,19 +507,33 @@ async function authenticateSSR(event: Parameters<Handle>[0]['event']): Promise<v
                     // 쿠키에 반드시 담아야 한다(#12789 incident: certified 누락 → 미인증 오판 →
                     // 전원 실명인증 유도). PII 없이 boolean 만.
                     const memberCertified = !!member.mb_certify;
+                    const memberNickname = member.mb_nick || member.mb_name;
+                    const memberLevel = member.mb_level ?? 0;
+                    const memberAsLevel = member.as_level ?? 0;
                     const existingBasic = parseUserBasicCookie(event.cookies.get('user_basic'));
+                    // ⛔ 쿠키에 담는 값은 전부 여기서 비교해야 한다.
+                    //    PUBLIC_USER_BASIC_CLIENT_READ=true 면 클라이언트가 /api/auth/me 대신
+                    //    이 쿠키를 읽으므로(+layout.svelte), 비교에서 빠진 필드는 쿠키 수명
+                    //    30일 동안 옛 값으로 남는다.
+                    //    mb_level 이 빠져 있어 승급해도 옛 등급으로 동작했다(#13055):
+                    //    등급 3 회원이 등급 2 로 취급돼 자유게시판 글쓰기가 잠겼고,
+                    //    쿠키는 기기별이라 "폰은 되는데 태블릿은 안 되는" 증상으로 나타났다.
+                    //    최근 30일 승급자 322명이 영향 범위였다.
                     if (
                         !existingBasic ||
                         existingBasic.id !== member.mb_id ||
                         existingBasic.mb_image_updated_at !== memberImageTs ||
-                        existingBasic.certified !== memberCertified
+                        existingBasic.certified !== memberCertified ||
+                        existingBasic.mb_level !== memberLevel ||
+                        existingBasic.as_level !== memberAsLevel ||
+                        existingBasic.nickname !== memberNickname
                     ) {
                         issueUserBasicCookie(event.cookies, {
                             id: member.mb_id,
                             mb_no: member.mb_no,
-                            nickname: member.mb_nick || member.mb_name,
-                            mb_level: member.mb_level ?? 0,
-                            as_level: member.as_level ?? 0,
+                            nickname: memberNickname,
+                            mb_level: memberLevel,
+                            as_level: memberAsLevel,
                             mb_image: member.mb_image_url || null,
                             mb_image_updated_at: memberImageTs,
                             certified: memberCertified


### PR DESCRIPTION
## 제보

`bug/13055` — 같은 계정(등급 3, 인증 완료)인데 폰에서는 글쓰기가 되고 태블릿에서는 "권한 없음"이 뜬다. 데스크탑은 또 된다.

제보자 추가 답변으로 패턴이 확정됐습니다:

| 게시판 | 필요 등급 | 태블릿 |
|---|---|---|
| 가입인사 | 1 | ✅ 열림 |
| 해외인증 | 2 | ✅ 열림 |
| 자유·유지관리 | **3** | ❌ 잠김 |

**등급 3 계정이 등급 2로 취급**되고 있었습니다. 13인치 여부는 우연이었습니다.

## 원인

운영은 `PUBLIC_USER_BASIC_CLIENT_READ=true` 라 클라이언트가 `/api/auth/me` 를 호출하지 않고 **`user_basic` 쿠키**에서 사용자 정보를 읽습니다(`+layout.svelte:670`).

그런데 쿠키 재발급 조건에 **`mb_level` 비교가 없었습니다**:

```ts
// hooks.server.ts:511 (수정 전)
if (
    !existingBasic ||
    existingBasic.id !== member.mb_id ||
    existingBasic.mb_image_updated_at !== memberImageTs ||
    existingBasic.certified !== memberCertified
    // ⛔ mb_level 없음
) { issueUserBasicCookie(...) }
```

쿠키 수명이 **30일**이라, 승급 후에도 아바타를 바꾸거나 본인확인을 새로 하지 않는 한 **최대 30일간 옛 등급**이 유지됩니다. **쿠키는 기기별**이므로 "폰은 되는데 태블릿은 안 되는" 증상이 됩니다.

**영향: 최근 30일 승급자 322명** (7/20 22명, 7/21 15명 — 가입이 8배로 늘어 계속 증가 중)

## 변경

쿠키에 담는 값은 **전부** 비교 대상에 넣습니다 — `mb_level`, `as_level`, `nickname`.

> 등급만 고치면 XP 레벨·닉네임 변경에서 **같은 버그를 다시** 만납니다.

배포되면 **기존 피해자도 다음 요청 한 번으로 자동 복구**됩니다(백필 불필요). `member` 는 이미 조회 중이라 추가 쿼리는 없습니다.

## 배제한 가설

| 가설 | 판정 | 근거 |
|---|---|---|
| 화면 크기별 반응형 분기 | 배제 | 데스크탑 버튼과 모바일 FAB 이 **같은 `canWrite`** 사용 |
| 인증 확정 전 렌더 | 배제 | 미확정이면 버튼이 **아예 안 뜸**. 제보는 자물쇠가 **보인다**고 함 |
| JWT 캐시 fast-path | 배제 | `USER_BASIC_FAST_PATH=false` (운영 env 실측) |
| `v2_users.level` desync | **별건** | 실재하나(47명) **제보자는 `v2_users` 행 자체가 없음** |

## 검증 (카나리)

1. 승급 이력 계정 → 자유게시판 글쓰기 버튼 **활성**
2. 옛 쿠키 상태 브라우저에서도 첫 요청 후 **활성 전환**
3. 등급 2 계정은 자유게시판 **여전히 잠김**(과도 허용 없음)
4. 가입인사는 등급 1·2 **열림 유지**
5. 값이 같으면 **재발급 안 함**(Set-Cookie 미발생)

## 별건 후속

- `auto-promotion.ts:190` 이 `g5_member` 만 UPDATE → `v2_users.level` 어긋남(47명, 40명이 v2 가 낮음)
- 활성 회원 59,280명 중 **2,846명이 `v2_users` 에 없음**

계획서: `triage/fix-plan-stale-level-cookie.html`