### PR TITLE
승급 시 v2_users.level 이중 갱신 — 앱 사용자 등급 desync 해소

### DIFF
--- a/apps/web/src/lib/server/auth/auto-promotion.ts
+++ b/apps/web/src/lib/server/auth/auto-promotion.ts
@@ -195,6 +195,17 @@ export async function checkAndPromoteMember(
             return null;
         }
 
+        // 등급은 v2_users.level 에도 이중 저장된다 — v2 인증(앱 로그인)의 JWT 가
+        // RefreshToken 때 이 값을 읽는다. 여기서 같이 갱신하지 않으면 승급할 때마다
+        // 한 단계씩 뒤처져, 앱 사용자는 승급 후에도 옛 등급으로 게시판이 잠긴다
+        // (2026-07-21 실측: 불일치 47명 중 40명이 v2 쪽이 낮았고 38명이 g5=3/v2=2).
+        // v2_users 에 행이 없는 회원(2,846명 존재)은 영향 0 행 — 정상이며 실패가 아니다.
+        // 같은 트랜잭션이므로 g5_member 갱신과 함께 커밋/롤백된다.
+        await conn.query<ResultSetHeader>(`UPDATE v2_users SET level = ? WHERE username = ?`, [
+            applicableRule.toLevel,
+            mbId
+        ]);
+
         try {
             await insertMemberLevelHistory(conn, {
                 mbId: member.mb_id,


### PR DESCRIPTION
## 문제

등급이 **두 테이블에 이중 저장**됩니다.

| 테이블 | 역할 | 승급 시 갱신 |
|---|---|---|
| `g5_member.mb_level` | 진실의 원천 | ✅ |
| `v2_users.level` | **v2 인증(앱)의 JWT 클레임 출처** — `RefreshToken` 이 `FindByID → user.Level` 로 읽음 | ⛔ **없음** |

자동 승급은 웹 레포 `auto-promotion.ts:190` **한 곳**뿐인데(`git grep "SET mb_level"` 전수 확인) `g5_member` 만 UPDATE 합니다. **승급할 때마다 v2 가 한 단계씩 뒤처집니다.**

## 실측 (2026-07-21)

| | |
|---|---|
| 불일치 | **47명** |
| └ v2 가 낮음 (피해) | **40명** — 38명이 g5=3/v2=2 |
| └ v2 가 높음 | 7명 — **백필 제외** (아래) |

앱 사용자는 승급해도 JWT 에 옛 등급이 박혀 **등급 3 게시판이 잠깁니다.** `#13055`(웹 `user_basic` 쿠키, fe#1838 수정)와 **같은 병의 다른 갈래**입니다 — 웹은 쿠키가, 앱은 v2 테이블이 낡습니다.

## 변경

`g5_member` UPDATE 직후 **같은 트랜잭션**에서 `v2_users.level` 도 갱신:

- 둘 다 성공하거나 둘 다 롤백
- `v2_users` 에 행이 없는 회원(활성 2,846명 존재)은 영향 0 행 — 정상 처리, 실패 아님
- 파라미터 바인딩이라 collation 충돌 없음

## ⛔ v2 가 높은 7명은 백필 제외

6명은 **v2=5 = 광고앙💚(광고주 전용 등급)** — 의도값일 수 있어 내리면 광고 기능이 깨질 수 있습니다. 1명은 `ai` 시스템 계정. 백필은 **v2 < g5 인 40명만 올립니다** (별도 SQL, 백업 포함).

## 후속 (범위 밖)

- `v2_users` 에 없는 활성회원 **2,846명** — 앱 로그인 불가 가능성, 별건 조사
- 등급 단일 출처화 — 2축 재설계(#1494)와 함께 판단

계획서: `triage/fix-plan-v2users-level-desync.html`