### PR TITLE
사이트맵 filesort 제거 — 크롤러 버스트 DB 마비 (20시 장애)

### DIFF
--- a/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
+++ b/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
@@ -28,14 +28,32 @@ export const GET: RequestHandler = async ({ params, url }) => {
             // 세그먼트 board 는 매니페스트에서 왔지만 방어적으로 재검증.
             if (!/^[a-zA-Z0-9_]+$/.test(seg.board)) continue;
             try {
-                const [posts] = await pool.query<RowDataPacket[]>(
-                    `SELECT wr_id, wr_datetime, wr_last, LEFT(wr_content, 1000) AS content_head
-                     FROM g5_write_${seg.board}
-					 WHERE wr_is_comment = 0
-					 ORDER BY wr_id DESC
-					 LIMIT ? OFFSET ?`,
-                    [seg.limit, seg.offset]
-                );
+                // ⛔ FORCE INDEX (wr_is_comment) 필수 — 옵티마이저가 idx_list_page 를 골라
+                //    138만 행 filesort 를 한다. 크롤러가 사이트맵 여러 페이지를 동시에 당기면
+                //    이 쿼리 100개+ 가 3분씩 물려 DB 커넥션이 고갈되고 사이트 전체가 멎는다
+                //    (2026-07-21 20시 장애: 활성쿼리 170, SELECT 1 이 799ms).
+                //    (wr_is_comment, wr_id) 인덱스는 Backward index scan 으로 filesort 없이
+                //    ORDER BY wr_id DESC 를 소화한다 — 동일 페이지 실측 200s+ → 1.8s.
+                //    인덱스가 없는 테이블(165개 중 4개)은 catch 에서 힌트 없이 재시도한다.
+                const sitemapQuery = (forceIndex: boolean) =>
+                    pool.query<RowDataPacket[]>(
+                        `SELECT wr_id, wr_datetime, wr_last, LEFT(wr_content, 1000) AS content_head
+                         FROM g5_write_${seg.board}${forceIndex ? ' FORCE INDEX (wr_is_comment)' : ''}
+					     WHERE wr_is_comment = 0
+					     ORDER BY wr_id DESC
+					     LIMIT ? OFFSET ?`,
+                        [seg.limit, seg.offset]
+                    );
+                let posts: RowDataPacket[];
+                try {
+                    [posts] = await sitemapQuery(true);
+                } catch (err) {
+                    if (err instanceof Error && err.message.includes('wr_is_comment')) {
+                        [posts] = await sitemapQuery(false);
+                    } else {
+                        throw err;
+                    }
+                }
 
                 for (const post of posts as Array<{
                     wr_id: number;


### PR DESCRIPTION
## 장애 (2026-07-21 20시)

사이트 전체 8초+/타임아웃. 서버 자원은 정상(CPU idle 82%, 스왑 4MB)인데 **DB 활성 쿼리 170개, `SELECT 1` 이 799ms**.

## 원인 — 사이트맵 쿼리 filesort

```sql
SELECT ... FROM g5_write_free WHERE wr_is_comment = 0
ORDER BY wr_id DESC LIMIT 40000 OFFSET 290825
-- EXPLAIN: key=idx_list_page, rows=1,382,534, Using filesort
```

크롤러가 사이트맵 22페이지를 동시에 당기면(실측: 1시간 300요청, **다수 499** = 포기 후 재시도 예정) 이 쿼리 **124개가 3분씩** 물려 커넥션 풀 고갈 → 사이트 전체 마비.

**CF 가 `.xml` 을 기본 캐시하지 않아**(오리진 `max-age=3600` 무시, `cacheStatus=none`) 모든 크롤러 요청이 오리진 직격이었습니다.

## 조치 — 2층 방어

| 층 | 조치 | 상태 |
|---|---|---|
| 쿼리 | **본 PR** — `FORCE INDEX (wr_is_comment)` → Backward index scan, filesort 제거 | CI 대기 |
| CDN | CF 캐시 규칙 — manifest/sw.js 규칙(ttl 3600)에 `/sitemap*` 병합 | ✅ 적용 완료 |
| 응급 | 물린 쿼리 94개 KILL → 활성 170→20, 사이트 0.1s 복구 | ✅ 완료 |

## 검증

- EXPLAIN: `Backward index scan`, filesort 없음
- 동일 페이지 실측: 경합 시 200s+ → **단독 1.8s**
- 인덱스 없는 테이블(165개 중 **4개**)은 catch 폴백으로 힌트 없이 재시도 — Go `write_repo.go` 의 `idx_list_page` 관례와 동일
- CDN 캐시로 오리진 도달이 페이지당 **시간당 1회**로 캡

## 참고

오늘 지운 인덱스(idx_wr_hit·wr_seo_title)와는 무관합니다 — 이 쿼리는 둘 다 쓴 적이 없고, filesort 는 `idx_list_page` 선택 문제입니다.