### PR TITLE
사이드바 '다모앙 마을 만들기' 카드 제거

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -13,7 +13,6 @@
     import { menuStore } from '$lib/stores/menu.svelte';
 
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
-    import House from '@lucide/svelte/icons/house';
     import { getIcon } from '$lib/utils/icon-map';
 
     import UserWidget from './user-widget.svelte';
@@ -428,16 +427,6 @@
     <!-- 사이드바 메뉴 아래 광고 -->
     <div class={compact ? 'space-y-2 px-1' : 'space-y-2 px-2'}>
         {#if !compact}
-            <!-- 다모앙 마을 만들기(첨성대) 1줄 카드 — 후원하기 위 -->
-            <a
-                href="/brickang"
-                class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
-            >
-                <span class="flex items-center gap-1.5"
-                    ><House class="size-4" /> 다모앙 마을 만들기</span
-                >
-                <span aria-hidden="true" class="leading-none">→</span>
-            </a>
             <!-- 데스크톱: 메뉴 ↔ (카카오)광고 사이 후원하기 1줄 카드 (benecent). 광고 on/off 무관 항상 노출. -->
             <a
                 href="https://damoang.benecent.org"
@@ -491,16 +480,6 @@
             </div>
             <!-- 드로워: 마음메시지 -->
             <CelebrationRolling />
-            <!-- 다모앙 마을 만들기(첨성대) 1줄 카드 — 후원하기 위 -->
-            <a
-                href="/brickang"
-                class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
-            >
-                <span class="flex items-center gap-1.5"
-                    ><House class="size-4" /> 다모앙 마을 만들기</span
-                >
-                <span aria-hidden="true" class="leading-none">→</span>
-            </a>
             <!-- 마음메시지 아래: 후원하기 1줄 카드 (benecent). 강조색으로 눈에 띄게, 1줄로 작게. -->
             <a
                 href="https://damoang.benecent.org"


### PR DESCRIPTION
사이드바의 브리캉 유도 카드 2곳(데스크톱·드로워)을 제거합니다(사용자 요청).

- 하단 푸터의 **'벽돌한장' 텍스트 링크는 별도 요소라 유지** — 함께 제거할지는 확인 필요
- `House` 아이콘은 이 카드 전용이었으므로 임포트도 정리
- `/brickang` 라우트 자체는 그대로 (직접 URL 접근 가능)