### PR TITLE
앙티티 회원 리뷰 우선 정렬 + 빈 role 유령 처리

### DIFF
--- a/plugins/angtt-review/lib/entities.server.ts
+++ b/plugins/angtt-review/lib/entities.server.ts
@@ -254,7 +254,9 @@ export async function getEntityConnectedPosts(
                 collected.push({
                     boTable: board,
                     wrId: r.wr_id,
-                    role: roleMap.get(`${board}:${r.wr_id}`) ?? 'mention',
+                    // ⛔ ?? 는 빈 문자열('')을 못 잡는다 — role='' 행(2026-07-21 실측 2건)이
+                    //    리뷰도 멘션도 아닌 유령이 되어 UI 에서 사라졌다. || 로 폴백.
+                    role: roleMap.get(`${board}:${r.wr_id}`) || 'mention',
                     subject: r.wr_subject ?? '',
                     name: r.wr_name ?? '',
                     mbId: r.mb_id ?? '',
@@ -269,6 +271,12 @@ export async function getEntityConnectedPosts(
     }
 
     collected.sort((a, b) => {
+        // 회원 리뷰(role='review', 별점 달린 앙TT 리뷰 글) 항상 최상단 — 멘션 86개에
+        // 밀려 slice(limit) 에서 잘리는 문제 방지(2026-07-21: 새 리뷰 7330 이 추천 0이라
+        // best 정렬에서 컷당해 작품 페이지에 안 보였음). 사용자 확정: 회원 리뷰 우선.
+        const ap = a.role === 'review' ? 0 : 1;
+        const bp = b.role === 'review' ? 0 : 1;
+        if (ap !== bp) return ap - bp;
         if (opts.sort === 'best' && b.good !== a.good) return b.good - a.good;
         // datetime은 DATE_FORMAT 문자열이지만, 방어적으로 String 강제(과거 Date 객체 500 재발 방지)
         return String(b.datetime).localeCompare(String(a.datetime));


### PR DESCRIPTION
## 문제

작품 페이지(/angtt/호프)에 **오늘 올라온 회원 리뷰(angtt/7330, 별점 4점)가 안 보임**. 별점은 통합 평균 3.80에 반영되는데 글만 안 보여 "연동이 안 되나?"라는 착시를 만듭니다.

## 원인 2가지

1. **정렬 컷**: 연결글 89개를 best(추천순) 정렬 후 `slice(limit)` — 추천 0인 새 리뷰가 free 멘션 86개에 밀려 잘림
2. **빈 role**: `role ?? 'mention'` 은 `''` 을 못 잡음 — `role=''` 행(실측 2건)이 유령화. 데이터는 백필 완료(angtt→review, free→mention)

## 변경

- **회원 리뷰(role='review') 정렬 1순위 고정** (사용자 확정: 회원 리뷰 우선) → limit 컷에서 항상 생존
- `??` → `||` 폴백으로 빈 role 방어

## 미해결 (별건)

`role=''` 유입 경로 미확정 — 웹 레포 유일한 INSERT는 auto-link('auto')뿐. 폴백으로 증상은 덮이나 재발 시 추적 필요.

## 검증
- 배포 후 /angtt/호프 에 7330·7297 리뷰 2건이 최상단 노출 확인 예정