### PR TITLE
fix(emoticon): 이대통령 앙티콘 선택창에서 숨김

### DIFF
--- a/apps/web/src/routes/api/emoticons/list/+server.ts
+++ b/apps/web/src/routes/api/emoticons/list/+server.ts
@@ -64,7 +64,10 @@ const ALLOWED_EXTENSIONS = new Set(['gif', 'png', 'jpg', 'jpeg', 'webp']);
 // 2026-07-21 재개했다. 이모지 리액션에 닉네임이 공개되면서(#1761, 7/12 시행)
 // 익명 사용이 불가능해져 차단 근거가 해소됐다는 판단.
 const SKIP_FILES = new Set(['onion-license.txt']);
-const HIDDEN_PACKS = new Set(['southsky']);
+// 이대통령(lee-president) 팩은 선택창에서 숨긴다. 정치 인물 이모티콘의 사이트
+// 리스크를 고려한 조치이며, 이미 사용된 글의 인라인 이미지는 그대로 렌더된다
+// (파일은 계속 서빙). 선택창에서만 신규 사용을 막는다.
+const HIDDEN_PACKS = new Set(['southsky', 'lee-president']);
 
 interface EmoticonItem {
     file: string;


### PR DESCRIPTION
## 배경

회원 제보(free/6773255): 이대통령(이재명) 앙티콘 5종이 등록돼 있고, 김민석과 함께 웃는 것 등 제거 요청.

정치 인물 이모티콘이 "출처: 다모앙"으로 외부 확산될 경우 사이트에 정치·법적 리스크가 될 수 있어, 선택창에서 신규 사용을 막습니다.

## 변경

`apps/web/src/routes/api/emoticons/list/+server.ts`

```diff
-const HIDDEN_PACKS = new Set(['southsky']);
+const HIDDEN_PACKS = new Set(['southsky', 'lee-president']);
```

- 선택창 목록에서 `lee-president` 팩(001~005) 제외
- **기존 게시물은 건드리지 않음** — 이미 삽입된 인라인 이미지는 그대로 렌더(파일은 nginx alias로 계속 서빙). 앞으로의 신규 삽입만 차단
- 별도 `president`('대통령') 팩은 이번 범위 밖

## 검증

- [ ] CI 빌드
- [ ] 카나리: 이모티콘 선택창에 '이대통령' 팩 미표시 확인
- [ ] 카나리: 기존 글의 lee-president 이미지 정상 렌더 확인