### PR TITLE
feat(angtt): 작성폼 작품 제안 칩 + 작성자 태그→작품 링크

### DIFF
--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -99,6 +99,7 @@
     $effect(() => {
         const current = title.trim();
         if (!ANGTT_SUGGEST_BOARDS.has(boardId) || isClaimBoard || current.length < 2) {
+            angttSeq++; // 이미 발사된 늦은 응답이 빈 제목 상태에 칩을 띄우지 않게 무효화
             angttSuggestion = null;
             return;
         }

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -79,6 +79,67 @@
     let link2 = $state(post?.link2 || initialLink2 || '');
     let errors = $state<{ title?: string; content?: string; category?: string }>({});
 
+    // ── 앙티티 작품 제안 칩 ──────────────────────────────────────────────
+    // 제목에서 작품명이 감지되면 태그 연결을 "제안"한다. 자동 부착이 아니라
+    // 작성자 확인(클릭)을 거치므로 참교육류 일반어 오탐이 커뮤니티를 오염시키지 않는다.
+    const ANGTT_SUGGEST_BOARDS = new Set(['free', 'angtt']);
+    const ANGTT_TAG_NAME = '앙티티';
+
+    interface AngttSuggestion {
+        slug: string;
+        title: string;
+        posterUrl: string | null;
+    }
+
+    let angttSuggestion = $state<AngttSuggestion | null>(null);
+    /** [무시]했거나 이미 [연결]한 작품 — 같은 세션에서 다시 제안하지 않는다 */
+    let angttDismissed = new Set<string>();
+    let angttSeq = 0;
+
+    $effect(() => {
+        const current = title.trim();
+        if (!ANGTT_SUGGEST_BOARDS.has(boardId) || isClaimBoard || current.length < 2) {
+            angttSuggestion = null;
+            return;
+        }
+
+        const seq = ++angttSeq;
+        const timer = setTimeout(async () => {
+            try {
+                const res = await fetch(`/api/angtt/detect?title=${encodeURIComponent(current)}`);
+                if (!res.ok || seq !== angttSeq) return;
+                const body = (await res.json()) as { match: AngttSuggestion | null };
+                if (seq !== angttSeq) return;
+                const match = body.match;
+                if (match && !angttDismissed.has(match.slug) && !tags.includes(match.slug)) {
+                    angttSuggestion = match;
+                } else {
+                    angttSuggestion = null;
+                }
+            } catch {
+                // 감지 실패는 무시 — 칩만 안 뜬다
+            }
+        }, 600);
+
+        return () => clearTimeout(timer);
+    });
+
+    function acceptAngttSuggestion(): void {
+        if (!angttSuggestion) return;
+        const next = [...tags];
+        if (!next.includes(ANGTT_TAG_NAME)) next.push(ANGTT_TAG_NAME);
+        if (!next.includes(angttSuggestion.slug)) next.push(angttSuggestion.slug);
+        tags = next;
+        angttDismissed.add(angttSuggestion.slug);
+        angttSuggestion = null;
+    }
+
+    function dismissAngttSuggestion(): void {
+        if (!angttSuggestion) return;
+        angttDismissed.add(angttSuggestion.slug);
+        angttSuggestion = null;
+    }
+
     // 파일 업로드 상태 (이미지 + 파일 통합)
     let uploadedFiles = $state<UploadedFile[]>([]);
 
@@ -659,6 +720,45 @@
                         <p class="text-destructive text-sm">{errors.title}</p>
                     {/if}
                     <p class="text-muted-foreground text-xs">{title.length}/200</p>
+
+                    {#if angttSuggestion}
+                        <div
+                            class="bg-muted/60 flex items-center gap-3 rounded-md border px-3 py-2"
+                        >
+                            {#if angttSuggestion.posterUrl}
+                                <img
+                                    src={angttSuggestion.posterUrl}
+                                    alt=""
+                                    class="h-10 w-7 shrink-0 rounded object-cover"
+                                    loading="lazy"
+                                />
+                            {:else}
+                                <span class="text-lg">🎬</span>
+                            {/if}
+                            <p class="min-w-0 flex-1 text-sm">
+                                <span class="font-medium">「{angttSuggestion.title}」</span>
+                                작품 이야기라면 태그로 연결할 수 있어요
+                            </p>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onclick={acceptAngttSuggestion}
+                                disabled={isLoading}
+                            >
+                                작품과 연결
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                onclick={dismissAngttSuggestion}
+                                aria-label="제안 무시"
+                            >
+                                <XIcon class="h-4 w-4" />
+                            </Button>
+                        </div>
+                    {/if}
                 </div>
             {/if}
 

--- a/apps/web/src/lib/server/angtt-auto-link.ts
+++ b/apps/web/src/lib/server/angtt-auto-link.ts
@@ -17,6 +17,7 @@ import pool from '$lib/server/db';
 import {
     ANGTT_TAG,
     scanAliasesInTitle,
+    matchAliasFromTags,
     normalizeWorkTitle,
     type EntityAlias
 } from './angtt-dictionary-logic';
@@ -29,13 +30,26 @@ const SYSTEM_TAG_MB_ID = 'ai';
 
 /** 별칭 사전 캐시 (작품 수가 적고 변경이 드물어 짧은 TTL 로 충분) */
 const ALIAS_TTL_MS = 5 * 60_000;
-let aliasCache: { at: number; aliases: EntityAlias[]; slugToId: Map<string, number> } | null = null;
+
+/** 캐시에 함께 담는 작품 표시 정보 (detect API 응답용) */
+interface EntityInfo {
+    id: number;
+    title: string;
+    posterUrl: string | null;
+}
+
+let aliasCache: {
+    at: number;
+    aliases: EntityAlias[];
+    slugToInfo: Map<string, EntityInfo>;
+} | null = null;
 
 interface EntityRow {
     id: number;
     slug: string;
     canonical_title: string;
     aliases: unknown;
+    poster_url: string | null;
     meta: unknown;
 }
 
@@ -71,16 +85,20 @@ async function loadAliases() {
     if (aliasCache && now - aliasCache.at < ALIAS_TTL_MS) return aliasCache;
 
     const [rows] = await pool.query(
-        `SELECT id, slug, canonical_title, aliases, meta
+        `SELECT id, slug, canonical_title, aliases, poster_url, meta
            FROM angple_entities
           WHERE status = 'active'`
     );
 
     const aliases: EntityAlias[] = [];
-    const slugToId = new Map<string, number>();
+    const slugToInfo = new Map<string, EntityInfo>();
 
     for (const r of rows as EntityRow[]) {
-        slugToId.set(r.slug, Number(r.id));
+        slugToInfo.set(r.slug, {
+            id: Number(r.id),
+            title: r.canonical_title,
+            posterUrl: r.poster_url || null
+        });
         const meta = asObject(r.meta);
         // 기본은 false — 작품별로 명시 옵트인해야만 자동 연결된다
         const autoLink = meta.auto_link === true;
@@ -99,8 +117,82 @@ async function loadAliases() {
         }
     }
 
-    aliasCache = { at: now, aliases, slugToId };
+    aliasCache = { at: now, aliases, slugToInfo };
     return aliasCache;
+}
+
+/** 작성폼 제안 칩의 감지 결과 */
+export interface AngttDetectMatch {
+    slug: string;
+    title: string;
+    posterUrl: string | null;
+    /** true 면 저장 시 서버가 어차피 자동 연결한다(칩은 안내 성격) */
+    canAutoLink: boolean;
+}
+
+/**
+ * 제목에서 작품을 감지한다 — 작성폼 제안 칩 전용 (read-only, 부작용 0).
+ *
+ * 자동연결과 같은 별칭 캐시·스캐너를 쓰되, canAutoLink=false 인 히트(옵트인 안 된
+ * 작품·문맥어 불충족)도 돌려준다. 그 케이스가 바로 "작성자 확인" 제안의 대상이다.
+ * ⛔ 글 상세/목록 read 경로에서 호출 금지 — 작성폼 debounce 입력 전용.
+ */
+export async function detectEntityFromTitle(title: string): Promise<AngttDetectMatch | null> {
+    const trimmed = title?.trim();
+    if (!trimmed || trimmed.length < 2) return null;
+
+    const { aliases, slugToInfo } = await loadAliases();
+    const hit = scanAliasesInTitle(trimmed, aliases);
+    if (!hit) return null;
+
+    const info = slugToInfo.get(hit.entitySlug);
+    if (!info) return null;
+
+    return {
+        slug: hit.entitySlug,
+        title: info.title,
+        posterUrl: info.posterUrl,
+        canAutoLink: hit.canAutoLink
+    };
+}
+
+/**
+ * 글의 태그(작성자가 확정한 것)를 보고 작품 링크를 만든다.
+ *
+ * 「앙티티」+ 별칭 정확 일치 태그가 있으면 entity_posts 에 role='mention' 을
+ * INSERT IGNORE 한다 — 이미 auto/review/mention 행이 있으면 무변화(PK: bo_table,
+ * wr_id, entity_id). 태그는 건드리지 않고(작성자 소유) 링크만 **추가**한다.
+ * 제안 칩 [연결]·수동 태그 입력 양쪽이 이 경로로 작품페이지에 연결된다.
+ *
+ * @returns 링크한 작품 slug, 대상 아니면 null
+ */
+export async function linkEntityFromTags(boardId: string, wrId: number): Promise<string | null> {
+    if (!AUTO_LINK_BOARDS.has(boardId)) return null;
+    if (!/^[a-zA-Z0-9_-]+$/.test(boardId)) return null;
+
+    const [tagRows] = await pool.query(
+        `SELECT tag FROM g5_na_tag_log WHERE bo_table = ? AND wr_id = ?`,
+        [boardId, wrId]
+    );
+    const tags = (tagRows as { tag?: string }[])
+        .map((r) => r.tag ?? '')
+        .filter((t) => t.length > 0);
+    if (tags.length === 0) return null;
+
+    const { aliases, slugToInfo } = await loadAliases();
+    const hit = matchAliasFromTags(tags, aliases);
+    if (!hit) return null;
+
+    const info = slugToInfo.get(hit.entitySlug);
+    if (!info) return null;
+
+    await pool.execute(
+        `INSERT IGNORE INTO angple_entity_posts (entity_id, bo_table, wr_id, role, created_at)
+         VALUES (?, ?, ?, 'mention', NOW(3))`,
+        [info.id, boardId, wrId]
+    );
+
+    return hit.entitySlug;
 }
 
 /** 태그 이름 → tag_id (없으면 생성) */
@@ -215,11 +307,11 @@ export async function autoLinkAngttEntity(
     const title = titleArg ?? (await fetchTitle(boardId, wrId));
     if (!title?.trim()) return null;
 
-    const { aliases, slugToId } = await loadAliases();
+    const { aliases, slugToInfo } = await loadAliases();
     const hit = scanAliasesInTitle(title, aliases);
     if (!hit || !hit.canAutoLink) return null;
 
-    const entityId = slugToId.get(hit.entitySlug);
+    const entityId = slugToInfo.get(hit.entitySlug)?.id;
     if (!entityId) return null;
 
     // 작품명 태그는 canonical slug 를 쓴다(별칭으로 달면 표기가 흩어진다)

--- a/apps/web/src/lib/server/angtt-dictionary-logic.test.ts
+++ b/apps/web/src/lib/server/angtt-dictionary-logic.test.ts
@@ -6,6 +6,7 @@ import {
     buildDictionary,
     matchWorkFromTags,
     scanAliasesInTitle,
+    matchAliasFromTags,
     type EntityAlias
 } from './angtt-dictionary-logic';
 
@@ -226,5 +227,48 @@ describe('scanAliasesInTitle — 제목 내 작품 별칭 스캔 (티어 B)', ()
             { aliasNorm: '동궁 시즌2', entitySlug: 'donggung-s2', autoLink: true }
         ];
         expect(scanAliasesInTitle('동궁 시즌2 후기', withLonger)?.entitySlug).toBe('donggung-s2');
+    });
+});
+
+describe('matchAliasFromTags — 태그 정확 일치로 작품 찾기 (쓰기 훅용)', () => {
+    const ALIASES: EntityAlias[] = [
+        { aliasNorm: '호프', entitySlug: 'hope', autoLink: true, contextTerms: ['영화'] },
+        { aliasNorm: 'hope', entitySlug: 'hope', autoLink: true },
+        { aliasNorm: '참교육', entitySlug: 'chamgyoyuk', autoLink: false }
+    ];
+
+    it('「앙티티」 태그가 없으면 null (옵트인 필수)', () => {
+        expect(matchAliasFromTags(['호프'], ALIASES)).toBeNull();
+    });
+
+    it('앙티티 + 별칭 정확 일치 → 작품 반환', () => {
+        expect(matchAliasFromTags([ANGTT_TAG, '호프'], ALIASES)?.entitySlug).toBe('hope');
+    });
+
+    it('정규화 비교 — 대소문자/공백 차이를 흡수한다', () => {
+        expect(matchAliasFromTags(['앙티티', '  HOPE '], ALIASES)?.entitySlug).toBe('hope');
+    });
+
+    it('부분일치는 절대 매칭하지 않는다', () => {
+        expect(matchAliasFromTags([ANGTT_TAG, '호프집 후기'], ALIASES)).toBeNull();
+    });
+
+    it('autoLink=false 작품도 태그로는 연결된다 (작성자 확인이 곧 사람의 승인)', () => {
+        expect(matchAliasFromTags([ANGTT_TAG, '참교육'], ALIASES)?.entitySlug).toBe('chamgyoyuk');
+    });
+
+    it('autoLink 문맥어 조건은 태그 매칭에 적용되지 않는다', () => {
+        // 제목 스캔과 달리 태그는 명시 선택이므로 문맥어 없이도 통과
+        expect(matchAliasFromTags([ANGTT_TAG, '호프'], ALIASES)?.entitySlug).toBe('hope');
+    });
+
+    it('태그 입력 순서 존중 — 첫 일치 반환', () => {
+        expect(matchAliasFromTags([ANGTT_TAG, '참교육', '호프'], ALIASES)?.entitySlug).toBe(
+            'chamgyoyuk'
+        );
+    });
+
+    it('「앙티티」 태그 자신은 후보에서 제외', () => {
+        expect(matchAliasFromTags([ANGTT_TAG], ALIASES)).toBeNull();
     });
 });

--- a/apps/web/src/lib/server/angtt-dictionary-logic.ts
+++ b/apps/web/src/lib/server/angtt-dictionary-logic.ts
@@ -239,6 +239,34 @@ export function scanAliasesInTitle(
     return null;
 }
 
+/**
+ * 태그 목록에서 작품 별칭 정확 일치를 찾는다 (쓰기 훅용 · 부분일치 없음).
+ *
+ * 「앙티티」 옵트인 태그가 있어야 하고, 나머지 태그를 normalize 해 별칭과 정확 비교한다.
+ * 태그 입력 순서를 존중해 첫 일치를 반환한다. autoLink/contextTerms 는 보지 않는다 —
+ * 작성자가 직접 단 태그는 그 자체가 사람의 확인이기 때문이다.
+ */
+export function matchAliasFromTags(
+    tags: readonly string[],
+    aliases: readonly EntityAlias[]
+): EntityAlias | null {
+    if (!hasAngttTag(tags)) return null;
+
+    const angtt = normalizeWorkTitle(ANGTT_TAG);
+    const byNorm = new Map<string, EntityAlias>();
+    for (const a of aliases) {
+        if (!byNorm.has(a.aliasNorm)) byNorm.set(a.aliasNorm, a);
+    }
+
+    for (const t of tags) {
+        const key = normalizeWorkTitle(t);
+        if (!key || key === angtt) continue;
+        const hit = byNorm.get(key);
+        if (hit) return hit;
+    }
+    return null;
+}
+
 /** 태그 매칭 결과: 일치 작품 / 미등록(유도 카드용 질의) / 후보 태그 없음(null) */
 export type TagMatchResult = { work: AngttWork } | { query: string } | null;
 

--- a/apps/web/src/routes/api/angtt/detect/+server.ts
+++ b/apps/web/src/routes/api/angtt/detect/+server.ts
@@ -1,0 +1,26 @@
+/**
+ * GET /api/angtt/detect?title=...
+ *
+ * 작성폼 제안 칩 전용 — 제목에서 작품을 감지해 돌려준다 (read-only, 부작용 0).
+ * 별칭 사전은 5분 캐시라 히트 시 DB 쿼리 0개, 스캔은 문자열 연산뿐이다.
+ *
+ * ⛔ 글 상세/목록 등 read 경로에서 이 API 를 호출하지 말 것 — 감지는 쓰기(작성) 문맥
+ *    1회로 제한한다는 앙티티 성능 규약. 클라이언트는 제목 입력 debounce 로만 부른다.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { detectEntityFromTitle } from '$lib/server/angtt-auto-link';
+
+export const GET: RequestHandler = async ({ url }) => {
+    const title = (url.searchParams.get('title') ?? '').slice(0, 200);
+
+    let match = null;
+    try {
+        match = await detectEntityFromTitle(title);
+    } catch (err) {
+        // 감지 실패는 기능 저하일 뿐 — 칩만 안 뜨고 작성 흐름엔 영향 없다.
+        console.error('[angtt detect] error:', err);
+    }
+
+    return json({ match }, { headers: { 'cache-control': 'private, max-age=30' } });
+};

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -6,7 +6,7 @@ import type { RowDataPacket } from 'mysql2';
 import { invalidateBoardCache } from '$lib/server/ssr-cache.js';
 import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/internal-api.js';
 import { checkCertification } from '$lib/server/certification';
-import { autoLinkAngttEntity } from '$lib/server/angtt-auto-link';
+import { autoLinkAngttEntity, linkEntityFromTags } from '$lib/server/angtt-auto-link';
 
 /**
  * API v1 프록시 핸들러
@@ -360,6 +360,20 @@ async function autoLinkAngtt(path: string, response: Response): Promise<void> {
     if (!wrId) return;
 
     await autoLinkAngttEntity(postMatch[1], wrId);
+    // 작성자가 확정한 태그(제안 칩 [연결] 또는 수동 입력) → 작품 링크.
+    // 자동 연결과 별개 경로: 태그가 있으면 role='mention' 을 추가한다(IGNORE 로 중복 무해).
+    await linkEntityFromTags(postMatch[1], wrId);
+}
+
+/**
+ * 글 수정 시 태그→작품 링크만 동기화한다.
+ * ⛔ 제목 스캔(autoLinkAngttEntity)은 수정 경로에서 절대 재실행하지 않는다 —
+ *    작성자가 unlink 로 해제한 자동 태그가 수정 저장 때 되살아나는 사고 방지.
+ */
+async function linkAngttOnEdit(path: string): Promise<void> {
+    const editMatch = path.match(/^boards\/([a-zA-Z0-9_-]+)\/posts\/(\d+)$/);
+    if (!editMatch) return;
+    await linkEntityFromTags(editMatch[1], Number(editMatch[2]));
 }
 
 // 공통 프록시 로직
@@ -540,6 +554,11 @@ async function proxyRequest(
         if (method === 'PUT' && response.status >= 200 && response.status < 300) {
             syncCelebrationBanner(path).catch((err) => {
                 console.error('[API Proxy] celebration sync error:', err);
+            });
+
+            // 수정 시 태그→앙티티 링크 동기화(추가만, 제목 스캔 없음)
+            linkAngttOnEdit(path).catch((err) => {
+                console.error('[API Proxy] angtt edit-link error:', err);
             });
         }
 


### PR DESCRIPTION
## 무엇
앙티티 태깅 2단계 — 자동연결이 저장하지 못하는 `canAutoLink=false` 감지(옵트인 안 된 작품, 문맥어 불충족)를 **작성자 확인 제안**으로 살립니다.

- `GET /api/angtt/detect?title=` — read-only 감지 API (별칭 5분 캐시 재사용, 캐시 히트 시 DB 쿼리 0)
- 작성폼(free/angtt) 제목 debounce 600ms → 제안 칩: **[작품과 연결]** = 태그에 앙티티+slug 추가(기존 저장 경로 그대로), **[무시]** = 세션 내 재제안 없음
- `linkEntityFromTags` — 저장 후 글 태그에 앙티티+별칭 **정확일치**가 있으면 `entity_posts role='mention'` INSERT IGNORE. 지금까지 수동 SQL로만 만들던 작품페이지 연결이 작성자 태그로 자동 생성됩니다
- PUT(수정)은 태그→링크만 수행 — **제목 스캔 재실행 금지**(작성자가 unlink한 자동 태그가 수정 저장 때 되살아나는 사고 방지)

## 안전
- 부분일치 저장 금지(정확일치만), 태그는 INSERT-only(Go SetPostTags 전량교체 미사용)
- read 경로(글 상세/목록) 변경 0 — 감지는 작성폼 입력 시에만
- 실패는 전부 fire-and-forget — 글 작성/수정 흐름에 영향 없음

## 실측 (라이브 별칭 × 자유게시판 최근 2,000제목)
히트 28건 = auto 19 + 제안 9, **오탐 0**. 제안 티어가 "HOPE 저는 극호", "호프 블루레이 출시" 등 문맥어 없는 진짜 작품 글을 정확히 건짐.

## 테스트
`matchAliasFromTags` vitest 8케이스(옵트인 필수·정규화·부분일치 거부·순서 존중 등) 추가.