### PR TITLE
fix(upload): 이미지 업로드 blob 데드엔드 회복 + 타임아웃/계측 (bug#12981)

### DIFF
--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -430,11 +430,15 @@ if (typeof window !== 'undefined') {
     //
     // console.error 를 감싸되 원본 동작은 그대로 유지한다. 하이드레이션 관련 메시지만
     // 골라 보내고, 기존 guardedSend 의 중복 스로틀·레이트리밋을 그대로 탄다.
+    // bug/12981: '[upload-fail]' prefix 도 함께 수집 — 업로드/스왑 실패가 전부 무음 catch 로
+    // console.error 에만 남아 js_errors 가 30일간 0건이던 관측 공백을 메운다.
     const originalConsoleError = console.error;
     console.error = function (...args: unknown[]) {
         try {
             const first = String(args[0] ?? '');
-            if (first.includes('hydrat')) {
+            const isHydration = first.includes('hydrat');
+            const isUploadFail = first.startsWith('[upload-fail]');
+            if (isHydration || isUploadFail) {
                 const detail = args
                     .slice(1)
                     .map((a) => (a instanceof Error ? `${a.name}: ${a.message}` : String(a)))
@@ -442,7 +446,7 @@ if (typeof window !== 'undefined') {
                     .slice(0, 300);
                 const err = args.find((a): a is Error => a instanceof Error);
                 guardedSend({
-                    type: 'hydration_error',
+                    type: isHydration ? 'hydration_error' : 'upload_fail',
                     message: `${first} ${detail}`.trim().slice(0, 400),
                     stack: err?.stack?.slice(0, 1500) || '(no stack)',
                     url: window.location.href,

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1715,12 +1715,40 @@ class ApiClient {
             headers['Authorization'] = `Bearer ${token}`;
         }
 
-        const response = await fetch('/api/media/images', {
-            method: 'POST',
-            headers,
-            body: formData,
-            credentials: 'include'
-        });
+        // bug/12981: 자매 uploadImage(아래)와 동일한 타임아웃+재시도 — 모바일 회선에서
+        // POST 가 stall 하면 무기한 hang 해 에디터 blob 이 잔존하던 비대칭 해소.
+        // 동영상은 파일이 커서 30초로는 정상 업로드도 끊길 수 있어 여유를 둔다.
+        const MAX_RETRIES = 2;
+        const UPLOAD_TIMEOUT_MS = file.type.startsWith('video/') ? 120_000 : 30_000;
+        let lastError: Error | null = null;
+        let response: Response | null = null;
+
+        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                const controller = new AbortController();
+                const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+
+                response = await fetch('/api/media/images', {
+                    method: 'POST',
+                    headers,
+                    body: formData,
+                    credentials: 'include',
+                    signal: controller.signal
+                });
+                clearTimeout(timeoutId);
+                break;
+            } catch (err) {
+                lastError = err instanceof Error ? err : new Error('업로드 실패');
+                if (attempt < MAX_RETRIES) {
+                    await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+                    continue;
+                }
+            }
+        }
+
+        if (!response) {
+            throw lastError ?? new Error('파일 업로드에 실패했습니다. 네트워크를 확인해 주세요.');
+        }
 
         if (!response.ok) {
             const errorBody = await response.text().catch(() => '');
@@ -1755,6 +1783,8 @@ class ApiClient {
             filename: data.filename,
             original_filename: data.filename,
             url: data.cdn_url || data.url,
+            // S3 직행 URL — CDN 경로 지연 시 에디터 폴백 스왑 후보 (bug/12981)
+            origin_url: data.origin_url || undefined,
             // 동영상 포스터 — 서버가 Lambda 처리 확인 후에만 내려줌 (404 URL 박제 방지)
             thumbnail_url: data.poster_url || undefined,
             size: data.size,

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -832,6 +832,8 @@ export interface UploadedFile {
     filename: string;
     original_filename: string;
     url: string;
+    /** S3 직행 URL — CDN 경로 지연 시 에디터 폴백 스왑 후보 (bug/12981) */
+    origin_url?: string;
     thumbnail_url?: string;
     size: number;
     mime_type: string;

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -12,6 +12,7 @@
     import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
     import XIcon from '@lucide/svelte/icons/x';
     import { stripAdminMentions } from '$lib/utils/sanitize-mentions.js';
+    import { stripBlobMedia } from '$lib/utils/strip-blob-media.js';
     import type {
         FreePost,
         CreatePostRequest,
@@ -179,16 +180,19 @@
     }
 
     // 에디터 미디어 업로드 핸들러 (이미지 + 동영상, 드래그앤드롭 / 붙여넣기 / 다이얼로그)
-    async function handleEditorImageUpload(file: File): Promise<string | null> {
+    async function handleEditorImageUpload(
+        file: File
+    ): Promise<{ url: string; originUrl?: string } | null> {
         if (!boardId) return null;
         try {
             const postIdNum = post?.id ? Number(post.id) : undefined;
             const result = await apiClient.uploadFile(boardId, file, postIdNum);
             // 에디터에서 업로드한 이미지는 본문에 직접 삽입되므로
             // uploadedFiles에 추가하지 않음 (submit 시 중복 삽입 방지)
-            return result.url;
+            // originUrl 은 CDN 경로 지연 시 에디터의 폴백 스왑 후보 (bug/12981)
+            return { url: result.url, originUrl: result.origin_url };
         } catch (err) {
-            console.error('Media upload failed:', err);
+            console.error('[upload-fail] media-upload:', err);
             return null;
         }
     }
@@ -206,7 +210,7 @@
             const result = await apiClient.uploadFile(boardId, file, postIdNum, poster);
             return { url: result.url, posterUrl: result.thumbnail_url };
         } catch (err) {
-            console.error('Video upload failed:', err);
+            console.error('[upload-fail] video-upload:', err);
             return null;
         }
     }
@@ -245,7 +249,9 @@
         isSaving = true;
         const draft: DraftData = {
             title,
-            content,
+            // bug/12981: blob: 은 세션 한정 URL — draft 에 박제되면 복원 시 죽은 이미지가
+            // 부활해 제출 가드에 영구히 막힌다. 저장 전 제거.
+            content: stripBlobMedia(content),
             category,
             isSecret,
             tags,
@@ -305,7 +311,8 @@
         const draft = loadDraft();
         if (draft) {
             title = draft.title;
-            content = draft.content;
+            // bug/12981: 스트립 이전에 저장된 기존 draft 의 죽은 blob: 도 복원 시 걷어낸다
+            content = stripBlobMedia(draft.content);
             category = draft.category;
             isSecret = draft.isSecret;
             tags = draft.tags || [];
@@ -447,6 +454,8 @@
             isSubmitting = false;
             // 대기 후에도 blob 이 남으면(변환 지연/실패) 저장 시 깨지므로 안내하고 중단.
             if (content.includes('blob:')) {
+                // bug/12981 계측: 이 경로가 사용자가 본 "이미지 변환이 지연" 데드엔드
+                console.error('[upload-fail] submit-blocked: blob 잔존으로 제출 차단');
                 alert('이미지 변환이 지연되고 있습니다. 잠시 후 다시 시도해 주세요.');
                 return;
             }

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -518,7 +518,9 @@
         const candidates = originUrl && originUrl !== dataUrl ? [dataUrl, originUrl] : [dataUrl];
         while (Date.now() - start < IMAGE_RECOVER_MAX_MS) {
             await sleep(IMAGE_RECOVER_INTERVAL_MS);
-            if (!editor) return;
+            // onDestroy 는 editor 를 null 로 되돌리지 않으므로 isDestroyed 로 이탈을 감지 —
+            // 페이지를 떠난 뒤 최대 4.7분 잔존 프로브가 도는 것을 막는다.
+            if (!editor || editor.isDestroyed) return;
             if (!hasImageBySrc(blobUrl)) {
                 // 사용자가 해당 이미지를 지움 — 회복 불필요
                 URL.revokeObjectURL(blobUrl);

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -88,7 +88,13 @@
          */
         contentFormat?: 'html' | 'markdown';
         onUpdate?: (value: string) => void;
-        onImageUpload?: (file: File) => Promise<string | null>;
+        /**
+         * 이미지 업로드 — CDN URL 문자열 또는 { url, originUrl } 반환.
+         * originUrl(S3 직행)은 CDN 경로가 계속 실패할 때의 폴백 스왑 후보 (bug/12981).
+         */
+        onImageUpload?: (
+            file: File
+        ) => Promise<string | { url: string; originUrl?: string } | null>;
         /**
          * 동영상 전용 업로드 — 포스터(첫 프레임) URL 을 함께 반환할 수 있다.
          * 미제공 시 onImageUpload 폴백 (포스터 없이 현행 동작).
@@ -115,7 +121,8 @@
     async function uploadVideo(file: File): Promise<{ url: string; posterUrl?: string } | null> {
         if (onVideoUpload) return onVideoUpload(file);
         if (!onImageUpload) return null;
-        const url = await onImageUpload(file);
+        const res = await onImageUpload(file);
+        const url = typeof res === 'string' ? res : res?.url;
         return url ? { url } : null;
     }
 
@@ -435,6 +442,12 @@
     // → 올리는 즉시 blob 미리보기(0초, 안 깨짐) 삽입 후, data URL 이 실제 로드 가능해질 때까지
     //   백그라운드 preload(재시도) → 준비되면 해당 노드 src 만 교체. 제출 가드(post-form)가 blob 잔존 차단.
     const IMAGE_SWAP_MAX_MS = 20000;
+    // bug/12981: 1차 20초 내 미준비 시 종전엔 blob 이 영구 잔존해 제출 가드에 계속 막혔다
+    // (탈출 경로 없음). 이제 저빈도 백그라운드 재프로브로 회복한다.
+    const IMAGE_RECOVER_INTERVAL_MS = 10000;
+    const IMAGE_RECOVER_MAX_MS = 280000;
+
+    const sleep = (ms: number) => new Promise<void>((r) => window.setTimeout(r, ms));
 
     // data URL 이 실제 200 으로 로드될 때까지 preload 재시도(지수백오프). 성공 시 true.
     // CDN 이 변환 전 404 를 max-age=300 으로 캐시할 수 있어 프로브엔 캐시버스터를 붙인다.
@@ -457,6 +470,69 @@
             };
             tryLoad();
         });
+    }
+
+    // 단발 프로브 — preloadImage 와 달리 내부 재시도 없이 1회만 확인 (회복 루프용).
+    // 이미지 로드가 onload/onerror 어느 쪽도 안 오는 stall 대비 8초 안전 타임아웃.
+    function probeImageOnce(url: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            const timer = window.setTimeout(() => resolve(false), 8000);
+            const img = new Image();
+            img.onload = () => {
+                window.clearTimeout(timer);
+                resolve(true);
+            };
+            img.onerror = () => {
+                window.clearTimeout(timer);
+                resolve(false);
+            };
+            img.src = url + (url.includes('?') ? '&' : '?') + '_p=' + Date.now();
+        });
+    }
+
+    // 문서에 src 가 일치하는 image 노드가 남아있는지 확인 (회복 루프 조기 종료용).
+    function hasImageBySrc(src: string): boolean {
+        if (!editor) return false;
+        let found = false;
+        editor.state.doc.descendants((node) => {
+            if (found) return false;
+            if (node.type.name === 'image' && node.attrs.src === src) {
+                found = true;
+                return false;
+            }
+            return undefined;
+        });
+        return found;
+    }
+
+    // bug/12981: 1차 preload(20초) 실패 후 백그라운드 회복 루프.
+    // CDN URL 을 계속 재프로브하고, 계속 실패하면 originUrl(S3 직행 — CDN 의 캐시된 403 을
+    // 우회)도 후보로 확인한다. **실제 로드가 확인된 URL 로만 스왑** — 죽은 URL 을 본문에
+    // 박는 일은 없다. 끝내 실패하면 blob 유지(제출 가드가 데이터 유실 방지, 종전과 동일).
+    async function recoverImageSwap(
+        blobUrl: string,
+        dataUrl: string,
+        originUrl?: string
+    ): Promise<void> {
+        const start = Date.now();
+        const candidates = originUrl && originUrl !== dataUrl ? [dataUrl, originUrl] : [dataUrl];
+        while (Date.now() - start < IMAGE_RECOVER_MAX_MS) {
+            await sleep(IMAGE_RECOVER_INTERVAL_MS);
+            if (!editor) return;
+            if (!hasImageBySrc(blobUrl)) {
+                // 사용자가 해당 이미지를 지움 — 회복 불필요
+                URL.revokeObjectURL(blobUrl);
+                return;
+            }
+            for (const candidate of candidates) {
+                if (await probeImageOnce(candidate)) {
+                    swapImageSrc(blobUrl, candidate);
+                    URL.revokeObjectURL(blobUrl);
+                    return;
+                }
+            }
+        }
+        console.error('[upload-fail] image-swap-timeout: 변환본 5분 미준비, blob 잔존 —', dataUrl);
     }
 
     // 문서에서 src 가 oldSrc 인 image 노드를 찾아 newSrc 로 교체 (위치는 교체 시점 기준 재탐색).
@@ -503,21 +579,30 @@
         pendingUploads++;
         void (async () => {
             try {
-                const dataUrl = await onImageUpload!(file);
+                const res = await onImageUpload!(file);
+                const dataUrl = typeof res === 'string' ? res : res?.url;
                 if (!dataUrl) {
                     removeImageBySrc(blobUrl);
                     URL.revokeObjectURL(blobUrl);
                     return;
                 }
+                const originUrl = typeof res === 'string' ? undefined : res?.originUrl;
                 const ready = await preloadImage(dataUrl);
-                if (ready && swapImageSrc(blobUrl, dataUrl)) {
+                if (ready) {
+                    // 스왑 실패(false)는 사용자가 이미지를 이미 지운 경우 — blob 만 정리
+                    swapImageSrc(blobUrl, dataUrl);
                     URL.revokeObjectURL(blobUrl);
                 } else {
-                    // 변환 지연(>20s, 드묾): 로컬 미리보기 유지. 제출 가드가 blob 차단 → 데이터 유실 방지.
-                    console.warn('[image] 변환본 준비 지연 — 로컬 미리보기 유지:', dataUrl);
+                    // 변환 지연(>20s): 로컬 미리보기 유지하되, 백그라운드 회복 루프로 탈출 경로 제공
+                    // (bug/12981 — 종전엔 여기서 포기해 blob 이 영구 잔존, 제출 불가 데드엔드).
+                    console.error(
+                        '[upload-fail] image-swap-delayed: 변환본 20초 미준비, 백그라운드 회복 시작 —',
+                        dataUrl
+                    );
+                    void recoverImageSwap(blobUrl, dataUrl, originUrl);
                 }
             } catch (err) {
-                console.error('Image upload failed:', err);
+                console.error('[upload-fail] editor-upload:', err);
                 removeImageBySrc(blobUrl);
                 URL.revokeObjectURL(blobUrl);
             } finally {

--- a/apps/web/src/lib/utils/strip-blob-media.test.ts
+++ b/apps/web/src/lib/utils/strip-blob-media.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { stripBlobMedia } from './strip-blob-media.js';
+
+describe('stripBlobMedia', () => {
+    it('blob: 없는 본문은 그대로 반환', () => {
+        const html = '<p>hello</p><img src="https://cdn.damoang.net/data/editor/2607/a.webp">';
+        expect(stripBlobMedia(html)).toBe(html);
+    });
+
+    it('빈 문자열은 그대로 반환', () => {
+        expect(stripBlobMedia('')).toBe('');
+    });
+
+    it('blob: img 태그 제거, 정상 img 는 유지', () => {
+        const html =
+            '<p>글</p><img src="blob:https://damoang.net/abc-123"><img src="https://cdn.damoang.net/data/editor/2607/a.webp"><p>끝</p>';
+        expect(stripBlobMedia(html)).toBe(
+            '<p>글</p><img src="https://cdn.damoang.net/data/editor/2607/a.webp"><p>끝</p>'
+        );
+    });
+
+    it('src 앞에 다른 속성이 있어도 제거', () => {
+        const html = '<img class="x" alt="사진" src="blob:https://damoang.net/abc" width="100">';
+        expect(stripBlobMedia(html)).toBe('');
+    });
+
+    it('작은따옴표 src 도 제거', () => {
+        expect(stripBlobMedia("<img src='blob:https://damoang.net/abc'>")).toBe('');
+    });
+
+    it('self-closing img 제거', () => {
+        expect(stripBlobMedia('<img src="blob:https://damoang.net/abc" />')).toBe('');
+    });
+
+    it('blob: video 태그(닫는 태그 포함) 제거', () => {
+        const html =
+            '<p>a</p><video src="blob:https://damoang.net/v1" controls playsinline></video><p>b</p>';
+        expect(stripBlobMedia(html)).toBe('<p>a</p><p>b</p>');
+    });
+
+    it('마크다운 blob 이미지 제거', () => {
+        const md = '본문\n\n![사진](blob:https://damoang.net/abc-123)\n\n끝';
+        expect(stripBlobMedia(md)).toBe('본문\n\n\n\n끝');
+    });
+
+    it('마크다운 정상 이미지는 유지', () => {
+        const md = '![사진](https://cdn.damoang.net/data/editor/2607/a.webp)';
+        expect(stripBlobMedia(md)).toBe(md);
+    });
+
+    it('blob 이미지 여러 개 전부 제거', () => {
+        const html =
+            '<img src="blob:https://damoang.net/1"><p>중간</p><img src="blob:https://damoang.net/2">';
+        expect(stripBlobMedia(html)).toBe('<p>중간</p>');
+    });
+
+    it('본문 텍스트에 blob: 단어가 있어도 태그가 아니면 유지', () => {
+        const html = '<p>blob: URL 이란 무엇인가</p>';
+        expect(stripBlobMedia(html)).toBe(html);
+    });
+});

--- a/apps/web/src/lib/utils/strip-blob-media.ts
+++ b/apps/web/src/lib/utils/strip-blob-media.ts
@@ -1,0 +1,20 @@
+/**
+ * 본문에서 blob: URL 미디어를 제거한다 (bug/12981).
+ *
+ * blob: 은 세션 한정 URL — localStorage draft 에 그대로 저장되면 복원 시 절대 로드될 수
+ * 없는 죽은 이미지가 부활하고, 제출 가드(blob 잔존 차단)에 영구히 막힌다.
+ * 저장 직전과 복원 직후 양쪽에서 걷어내 이미 오염된 기존 draft 도 구제한다.
+ */
+export function stripBlobMedia(content: string): string {
+    if (!content || !content.includes('blob:')) return content;
+    return (
+        content
+            // HTML: src 가 blob: 인 img/video/source 태그 제거 (닫는 태그가 바로 붙으면 함께)
+            .replace(
+                /<(img|video|source)\b[^>]*\bsrc=["']blob:[^"']*["'][^>]*\/?>(?:<\/\1>)?/gi,
+                ''
+            )
+            // Markdown: ![alt](blob:...) 제거
+            .replace(/!\[[^\]]*\]\(blob:[^)]*\)/g, '')
+    );
+}


### PR DESCRIPTION
bug#12981 (아이폰/전브라우저 이미지 업로드 실패 — "이미지 변환이 지연되고 있습니다" 데드엔드) 수정.

RCA 요지: Lambda raw/→data/ 변환이 20초를 넘는 시간대(저녁 피크)에 업로드하면 에디터 preload 가 1회성으로 포기 → blob: 미리보기가 본문에 영구 잔존 → 제출 가드가 매번 차단, 탈출 경로 없음. 자동저장이 그 blob 을 draft 에 박제해 세션이 바뀌어도 실패가 지속. 7/14 재발은 446KB 순수 JPEG 라 HEIC fix(#1778)만으로는 미해소.

### 수정 내역

**1. preload 포기 후 회복 경로 (tiptap-editor.svelte)** — 주원인(H1)
- 20초 1차 실패 시 포기 대신 백그라운드 회복 루프 시작: 10초 간격, 최대 5분간 CDN URL 재프로브(캐시버스터).
- CDN 이 계속 실패하면 `origin_url`(S3 직행)도 후보로 프로브 — CDN 엣지에 캐시된 오류 응답을 우회하는 폴백.
- 안전 속성: **실제 로드가 확인된 URL 로만 스왑** — 죽은 URL 이 본문에 박제되는 일은 없음. 사용자가 이미지를 지우면 조기 종료, 끝내 실패하면 blob 유지(제출 가드가 데이터 유실 방지, 종전과 동일한 최악 경로).
- 참고: 서버 응답의 `origin_url` 은 raw/ 가 아니라 **data/ 키의 S3 직행 URL** (`api/media/images/+server.ts:230`) — 조사 보고서의 "raw/ 즉시 존재" 가정과 달리 이 역시 변환 완료 후에 생기므로, 무조건 스왑이 아닌 프로브 확인 후 스왑으로 설계함.

**2. draft 자동저장의 blob 박제 차단 (post-form.svelte + strip-blob-media.ts)** — 지속 요인(H2)
- 저장 직전 `stripBlobMedia()` 로 blob: src 미디어(img/video/source, 마크다운 `![](blob:)`) 제거.
- 복원 시에도 스트립 — 이미 오염된 기존 draft 사용자도 복원 시점에 구제됨.
- 순수 함수로 분리, vitest 11케이스 추가 (`strip-blob-media.test.ts`).

**3. uploadFile 타임아웃 + 재시도 (client.ts)** — 기여 요인(H4)
- 자매 함수 `uploadImage` 에만 있던 30초 AbortController + 2회 재시도를 `uploadFile`(에디터 경로)에 동일 적용. 모바일 회선 stall 시 무기한 hang → blob 잔존 경로 해소.
- 동영상은 파일이 커 30초로는 정상 업로드도 끊길 수 있어 120초로 차등.

**4. 실패 계측 (hooks.client.ts + 각 catch 지점)** — 관측 공백
- 업로드/스왑 실패 전 지점(에디터 업로드 실패, 20초 스왑 지연, 5분 회복 실패, 제출 차단)에 `[upload-fail]` prefix 의 console.error.
- hooks.client.ts 의 기존 console.error 수집 래퍼(하이드레이션용)를 확장해 이 prefix 를 `type=upload_fail` 로 js_errors 에 전송. console.error 단독으로는 수집되지 않는 구조라 수집기 확장이 필요했음. 기존 스로틀·레이트리밋 그대로 적용.

### 검증
- `stripBlobMedia` 로직: node 직접 실행 프로브 13/13 통과 (blob img/video/마크다운 제거, 정상 URL 보존, 본문 텍스트 "blob:" 오탐 없음, 실제 URL 내 blob: 문자열 비제거).
- 회복 루프 제어 흐름 시뮬레이션 12/12 통과 (CDN 지연 회복, origin 폴백, 이미지 삭제 시 조기 종료+revoke, 전부 실패 시 5분 내 종료·죽은 URL 스왑 없음, 구형 문자열 반환 호환).
- `onImageUpload` 시그니처는 `string | {url, originUrl} | null` 유니온으로 확장 — 문자열을 반환하는 기존 호출부와 하위 호환.

### 범위 밖 (별도 인프라 건)
- RCA H5: CDN(s3-proxy)이 변환 전 4xx 응답을 `max-age=31536000, immutable` 로 캐시하는 문제 — 오류 응답에 `no-store` 또는 짧은 max-age 적용 필요. 인프라 저장소 별도 처리 대상 (#12697류 재발 방지 겸).
