### PR TITLE
feat(angtt): 크라우드 제안 — 독자 2명 제안 시 작품 자동 연결

### DIFF
--- a/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
+++ b/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
@@ -10,10 +10,14 @@
      *   (글쓰기 라우트에 제목 프리필 쿼리 미지원 — Phase 2 에서 프리필 연동)
      * - 스포일러 안전: 포스터·평점·링크만 노출 (줄거리류 텍스트 없음)
      * - GA4: 카드 노출(angtt_card_impression) / CTA 클릭(angtt_card_cta_click)
+     * - 크라우드 제안(미연결 분기): 독자가 작품 연결을 제안, 서로 다른 회원 2명이면
+     *   자동 승격. 감지(detect)는 클릭 시에만, 현황(status)은 마운트 후 지연 조회.
      */
     import { onMount } from 'svelte';
     import { trackEvent } from '$lib/services/ga4';
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { SUGGEST_MIN_LEVEL, buildSuggestStatusText } from './angtt-suggest-logic.js';
 
     /** 서버 AngttMatch(lib/server/angtt-dictionary.ts)와 구조 동일 — $lib/server 는 클라 import 불가라 별도 선언 */
     type AngttCardMatch =
@@ -33,11 +37,14 @@
         match,
         boardId,
         postId,
+        postTitle = '',
         isAuthor = false
     }: {
         match: AngttCardMatch;
         boardId: string;
         postId: number | string;
+        /** 글 제목 — 크라우드 제안의 작품 감지(/api/angtt/detect) 입력 */
+        postTitle?: string;
         /** 뷰어가 이 글의 작성자인지 — 자동 연결 해제 권한 */
         isAuthor?: boolean;
     } = $props();
@@ -62,6 +69,117 @@
         }
     }
 
+    // ── 크라우드 제안 (notFound 분기 전용) ─────────────────────────────
+    // 성능 규약: 감지(detect)는 사용자 클릭으로만 호출한다. 현황(status)은 카드
+    // 마운트 후 지연 조회 — 글상세 SSR 은 어느 쪽도 조회하지 않는다.
+    interface SuggestEntry {
+        slug: string;
+        title: string;
+        count: number;
+    }
+    interface SuggestStatusData {
+        suggestions: SuggestEntry[];
+        myVotes: string[];
+        linked: { slug: string; title: string } | null;
+    }
+
+    let suggestStatus = $state<SuggestStatusData | null>(null);
+    let detectCandidate = $state<{ slug: string; title: string } | null>(null);
+    let detectDone = $state(false);
+    let suggestBusy = $state(false);
+    let suggestError = $state('');
+
+    /** 제안 가능 뷰어인가 — 별점과 동일 기준(앙님💛). 미달·비로그인은 상태만 본다. */
+    const canSuggest = $derived(
+        authStore.isAuthenticated && (authStore.user?.mb_level ?? 1) >= SUGGEST_MIN_LEVEL
+    );
+
+    async function loadSuggestStatus() {
+        try {
+            const res = await fetch(
+                `/api/angtt/suggest/status?boardId=${encodeURIComponent(boardId)}&wrId=${encodeURIComponent(String(postId))}`
+            );
+            if (res.ok) suggestStatus = await res.json();
+        } catch {
+            // 현황 조회 실패는 제안 UI 만 생략 — 카드 본체에는 영향 없음
+        }
+    }
+
+    /** [연결 제안] 클릭 → 글 제목으로 작품 감지 (클릭 시에만 detect 호출) */
+    async function handleDetect() {
+        if (suggestBusy) return;
+        suggestBusy = true;
+        suggestError = '';
+        onCtaClick('suggest');
+        try {
+            const res = await fetch(`/api/angtt/detect?title=${encodeURIComponent(postTitle)}`);
+            const data = res.ok ? await res.json() : { match: null };
+            detectCandidate = data.match
+                ? { slug: data.match.slug, title: data.match.title }
+                : null;
+        } catch {
+            detectCandidate = null;
+        } finally {
+            detectDone = true;
+            suggestBusy = false;
+        }
+    }
+
+    async function submitSuggest(slug: string, title: string) {
+        if (suggestBusy) return;
+        suggestBusy = true;
+        suggestError = '';
+        try {
+            const res = await fetch('/api/angtt/suggest', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ boardId, wrId: Number(postId), slug })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                suggestError = data?.error ?? '제안에 실패했어요. 잠시 후 다시 시도해 주세요.';
+                return;
+            }
+            detectCandidate = null;
+            suggestStatus = {
+                suggestions: [{ slug, title, count: data.count }],
+                myVotes: [slug],
+                linked: data.promoted ? { slug, title } : (suggestStatus?.linked ?? null)
+            };
+        } catch {
+            suggestError = '제안에 실패했어요. 잠시 후 다시 시도해 주세요.';
+        } finally {
+            suggestBusy = false;
+        }
+    }
+
+    async function withdrawSuggest(slug: string, title: string) {
+        if (suggestBusy) return;
+        suggestBusy = true;
+        suggestError = '';
+        try {
+            const res = await fetch('/api/angtt/suggest', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ boardId, wrId: Number(postId), slug })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                suggestError = data?.error ?? '철회에 실패했어요. 잠시 후 다시 시도해 주세요.';
+                return;
+            }
+            suggestStatus = {
+                suggestions: data.count > 0 ? [{ slug, title, count: data.count }] : [],
+                myVotes: [],
+                linked: suggestStatus?.linked ?? null
+            };
+        } catch {
+            suggestError = '철회에 실패했어요. 잠시 후 다시 시도해 주세요.';
+        } finally {
+            suggestBusy = false;
+        }
+    }
+
     const matched = $derived(!('notFound' in match));
     const posterUrl = $derived('notFound' in match ? '' : toThumbnailUrl(match.thumbnail));
     // 매칭 카드 CTA 링크: 작품 엔티티가 있으면 작품 페이지, 없으면 기존 angtt 글로 폴백.
@@ -80,9 +198,11 @@
             matched: matched ? 'yes' : 'no',
             work_id: 'notFound' in match ? '' : String(match.wrId)
         });
+        // 미연결 카드만 제안 현황을 지연 조회한다 (SSR 무접촉)
+        if ('notFound' in match) void loadSuggestStatus();
     });
 
-    function onCtaClick(cta: 'rate' | 'register'): void {
+    function onCtaClick(cta: 'rate' | 'register' | 'suggest'): void {
         trackEvent('angtt_card_cta_click', {
             board_id: boardId,
             post_id: String(postId),
@@ -95,79 +215,169 @@
 {#if unlinked}
     <p class="text-muted-foreground my-4 text-xs">작품 연결을 해제했어요.</p>
 {:else}
-    <div class="bg-card my-4 flex items-center gap-3 rounded-lg border p-3">
+    <div class="bg-card my-4 rounded-lg border p-3">
         {#if 'notFound' in match}
-            <div
-                class="bg-muted flex aspect-[2/3] w-11 shrink-0 items-center justify-center rounded text-lg"
-                aria-hidden="true"
-            >
-                🎬
-            </div>
-            <div class="min-w-0 flex-1">
-                <p class="truncate text-sm font-medium">「{match.query}」 — 앙티티에 아직 없어요</p>
-                <p class="text-muted-foreground text-xs">다모앙 추천작 — 앙티티</p>
-            </div>
-            <a
-                href="/angtt"
-                class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
-                onclick={() => onCtaClick('register')}
-            >
-                ✍️ 첫 등록하고 별점 열기
-            </a>
-        {:else}
-            {#if posterUrl}
-                <img
-                    src={posterUrl}
-                    alt="{match.title} 포스터"
-                    class="aspect-[2/3] w-11 shrink-0 rounded object-cover"
-                    loading="lazy"
-                />
-            {:else}
+            <div class="flex items-center gap-3">
                 <div
                     class="bg-muted flex aspect-[2/3] w-11 shrink-0 items-center justify-center rounded text-lg"
                     aria-hidden="true"
                 >
                     🎬
                 </div>
-            {/if}
-            <div class="min-w-0 flex-1">
-                <p class="truncate text-sm font-medium">{match.title}</p>
-                <p class="text-muted-foreground text-xs">
-                    다모앙 추천작 — 앙티티
-                    {#if match.rating && match.rating.count > 0}
-                        <span class="text-amber-600 dark:text-amber-400">
-                            · ★{match.rating.avg.toFixed(1)} · 앙님 {match.rating.count}명
-                        </span>
-                    {:else if match.rating}
-                        <span>· 아직 별점이 없어요</span>
-                    {/if}
+                <div class="min-w-0 flex-1">
+                    <p class="truncate text-sm font-medium">
+                        「{match.query}」 — 앙티티에 아직 없어요
+                    </p>
+                    <p class="text-muted-foreground text-xs">다모앙 추천작 — 앙티티</p>
+                </div>
+                <a
+                    href="/angtt"
+                    class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
+                    onclick={() => onCtaClick('register')}
+                >
+                    ✍️ 첫 등록하고 별점 열기
+                </a>
+            </div>
+
+            <!-- 크라우드 제안: 독자 2명이 같은 작품을 제안하면 자동 연결 (마운트 후 지연 조회) -->
+            {#if suggestStatus?.linked}
+                <p class="text-muted-foreground mt-2 border-t pt-2 text-xs">
+                    앙님들의 제안으로
+                    <a
+                        class="hover:text-foreground underline underline-offset-2"
+                        href={`/angtt/${encodeURIComponent(suggestStatus.linked.slug)}`}
+                    >
+                        「{suggestStatus.linked.title}」
+                    </a>
+                    에 연결됐어요.
                 </p>
-                <!--
+            {:else if suggestStatus && suggestStatus.suggestions.length > 0}
+                <div class="mt-2 space-y-1 border-t pt-2">
+                    {#each suggestStatus.suggestions as s (s.slug)}
+                        <div class="flex items-center gap-2 text-xs">
+                            <span class="text-muted-foreground min-w-0 flex-1 truncate">
+                                「{s.title}」 {buildSuggestStatusText(s.count)}
+                            </span>
+                            {#if canSuggest}
+                                {#if suggestStatus.myVotes.includes(s.slug)}
+                                    <button
+                                        type="button"
+                                        class="text-muted-foreground hover:text-foreground shrink-0 underline underline-offset-2 disabled:opacity-50"
+                                        onclick={() => withdrawSuggest(s.slug, s.title)}
+                                        disabled={suggestBusy}
+                                    >
+                                        철회
+                                    </button>
+                                {:else}
+                                    <button
+                                        type="button"
+                                        class="text-primary shrink-0 font-medium underline underline-offset-2 disabled:opacity-50"
+                                        onclick={() => submitSuggest(s.slug, s.title)}
+                                        disabled={suggestBusy}
+                                    >
+                                        나도 제안
+                                    </button>
+                                {/if}
+                            {/if}
+                        </div>
+                    {/each}
+                    {#if suggestError}
+                        <p class="text-destructive text-xs">{suggestError}</p>
+                    {/if}
+                </div>
+            {:else if suggestStatus && canSuggest}
+                <div class="mt-2 border-t pt-2">
+                    {#if detectCandidate}
+                        <div class="flex items-center gap-2 text-xs">
+                            <span class="text-muted-foreground min-w-0 flex-1 truncate">
+                                제목에서 「{detectCandidate.title}」을(를) 찾았어요.
+                            </span>
+                            <button
+                                type="button"
+                                class="text-primary shrink-0 font-medium underline underline-offset-2 disabled:opacity-50"
+                                onclick={() =>
+                                    detectCandidate &&
+                                    submitSuggest(detectCandidate.slug, detectCandidate.title)}
+                                disabled={suggestBusy}
+                            >
+                                「{detectCandidate.title}」(으)로 연결 제안
+                            </button>
+                        </div>
+                    {:else if detectDone}
+                        <p class="text-muted-foreground text-xs">
+                            제목에서 제안할 작품을 찾지 못했어요.
+                        </p>
+                    {:else}
+                        <button
+                            type="button"
+                            class="text-muted-foreground hover:text-foreground text-xs underline underline-offset-2 disabled:opacity-50"
+                            onclick={handleDetect}
+                            disabled={suggestBusy}
+                        >
+                            🔗 이 글의 작품 연결 제안
+                        </button>
+                    {/if}
+                    {#if suggestError}
+                        <p class="text-destructive mt-1 text-xs">{suggestError}</p>
+                    {/if}
+                </div>
+            {/if}
+        {:else}
+            <div class="flex items-center gap-3">
+                {#if posterUrl}
+                    <img
+                        src={posterUrl}
+                        alt="{match.title} 포스터"
+                        class="aspect-[2/3] w-11 shrink-0 rounded object-cover"
+                        loading="lazy"
+                    />
+                {:else}
+                    <div
+                        class="bg-muted flex aspect-[2/3] w-11 shrink-0 items-center justify-center rounded text-lg"
+                        aria-hidden="true"
+                    >
+                        🎬
+                    </div>
+                {/if}
+                <div class="min-w-0 flex-1">
+                    <p class="truncate text-sm font-medium">{match.title}</p>
+                    <p class="text-muted-foreground text-xs">
+                        다모앙 추천작 — 앙티티
+                        {#if match.rating && match.rating.count > 0}
+                            <span class="text-amber-600 dark:text-amber-400">
+                                · ★{match.rating.avg.toFixed(1)} · 앙님 {match.rating.count}명
+                            </span>
+                        {:else if match.rating}
+                            <span>· 아직 별점이 없어요</span>
+                        {/if}
+                    </p>
+                    <!--
                 3번째 줄 — 포스터(66px)가 카드 높이를 정하고 텍스트는 2줄(36px)뿐이라
                 이 줄을 넣어도 카드 크기는 변하지 않는다.
             -->
-                {#if !('notFound' in match) && match.autoLinked}
-                    <p class="text-muted-foreground/80 mt-0.5 truncate text-[11px]">
-                        자동으로 연결되었어요{#if isAuthor}
-                            <button
-                                type="button"
-                                class="hover:text-foreground ml-1 underline underline-offset-2 disabled:opacity-50"
-                                onclick={handleUnlink}
-                                disabled={unlinking}
-                            >
-                                {unlinking ? '해제 중…' : '해제'}
-                            </button>
-                        {/if}
-                    </p>
-                {/if}
+                    {#if !('notFound' in match) && match.autoLinked}
+                        <p class="text-muted-foreground/80 mt-0.5 truncate text-[11px]">
+                            자동으로 연결되었어요{#if isAuthor}
+                                <button
+                                    type="button"
+                                    class="hover:text-foreground ml-1 underline underline-offset-2 disabled:opacity-50"
+                                    onclick={handleUnlink}
+                                    disabled={unlinking}
+                                >
+                                    {unlinking ? '해제 중…' : '해제'}
+                                </button>
+                            {/if}
+                        </p>
+                    {/if}
+                </div>
+                <a
+                    href={rateHref}
+                    class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
+                    onclick={() => onCtaClick('rate')}
+                >
+                    ⭐ 별점 주러 가기
+                </a>
             </div>
-            <a
-                href={rateHref}
-                class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
-                onclick={() => onCtaClick('rate')}
-            >
-                ⭐ 별점 주러 가기
-            </a>
         {/if}
     </div>
 {/if}

--- a/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
+++ b/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
@@ -141,11 +141,18 @@
                 return;
             }
             detectCandidate = null;
-            suggestStatus = {
-                suggestions: [{ slug, title, count: data.count }],
-                myVotes: [slug],
-                linked: data.promoted ? { slug, title } : (suggestStatus?.linked ?? null)
-            };
+            if (data.promoted) {
+                // 승격은 서버가 확정한 사실 — 즉시 연결 표시로 전환
+                suggestStatus = {
+                    suggestions: [{ slug, title, count: data.count }],
+                    myVotes: [slug],
+                    linked: { slug, title }
+                };
+            } else {
+                // 내 표 1건으로 통째 교체하면 같은 글의 다른 작품 제안 현황이
+                // 새로고침까지 사라진다 — 서버 현황을 다시 읽는다.
+                await loadSuggestStatus();
+            }
         } catch {
             suggestError = '제안에 실패했어요. 잠시 후 다시 시도해 주세요.';
         } finally {
@@ -168,11 +175,8 @@
                 suggestError = data?.error ?? '철회에 실패했어요. 잠시 후 다시 시도해 주세요.';
                 return;
             }
-            suggestStatus = {
-                suggestions: data.count > 0 ? [{ slug, title, count: data.count }] : [],
-                myVotes: [],
-                linked: suggestStatus?.linked ?? null
-            };
+            // 서버 현황 재조회 — 로컬 교체는 다른 작품 제안 현황을 지운다
+            await loadSuggestStatus();
         } catch {
             suggestError = '철회에 실패했어요. 잠시 후 다시 시도해 주세요.';
         } finally {

--- a/apps/web/src/lib/components/features/board/angtt-suggest-logic.test.ts
+++ b/apps/web/src/lib/components/features/board/angtt-suggest-logic.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+    SUGGEST_MIN_LEVEL,
+    PROMOTE_THRESHOLD,
+    DAILY_SUGGEST_LIMIT,
+    isSuggestableBoard,
+    shouldPromote,
+    remainingToPromote,
+    buildSuggestStatusText
+} from './angtt-suggest-logic';
+import { RATING_MIN_LEVEL } from './post-rating-logic';
+
+describe('상수 — 스펙 값과 단일 소스 유지', () => {
+    it('제안 최소 등급은 별점 기준(RATING_MIN_LEVEL)을 재사용한다', () => {
+        expect(SUGGEST_MIN_LEVEL).toBe(RATING_MIN_LEVEL);
+        expect(SUGGEST_MIN_LEVEL).toBe(3);
+    });
+
+    it('승격 임계는 서로 다른 회원 2명', () => {
+        expect(PROMOTE_THRESHOLD).toBe(2);
+    });
+
+    it('레이트리밋은 회원당 일 10건', () => {
+        expect(DAILY_SUGGEST_LIMIT).toBe(10);
+    });
+});
+
+describe('isSuggestableBoard — free/angtt 한정', () => {
+    it('free, angtt 는 허용', () => {
+        expect(isSuggestableBoard('free')).toBe(true);
+        expect(isSuggestableBoard('angtt')).toBe(true);
+    });
+
+    it('그 외 게시판은 거부', () => {
+        expect(isSuggestableBoard('hello')).toBe(false);
+        expect(isSuggestableBoard('bug')).toBe(false);
+        expect(isSuggestableBoard('')).toBe(false);
+        expect(isSuggestableBoard('FREE')).toBe(false); // 대소문자 정확 일치만
+    });
+});
+
+describe('shouldPromote — 서로 다른 회원 수 임계 판정', () => {
+    it('임계 미만이면 승격하지 않는다', () => {
+        expect(shouldPromote(0)).toBe(false);
+        expect(shouldPromote(1)).toBe(false);
+    });
+
+    it('임계 이상이면 승격한다', () => {
+        expect(shouldPromote(2)).toBe(true);
+        expect(shouldPromote(3)).toBe(true);
+    });
+
+    it('NaN/Infinity 는 승격하지 않는다', () => {
+        expect(shouldPromote(NaN)).toBe(false);
+        expect(shouldPromote(Infinity)).toBe(false);
+    });
+});
+
+describe('remainingToPromote — 승격까지 남은 인원', () => {
+    it('0명이면 임계 전원이 남는다', () => {
+        expect(remainingToPromote(0)).toBe(PROMOTE_THRESHOLD);
+    });
+
+    it('1명이면 1명 남는다', () => {
+        expect(remainingToPromote(1)).toBe(1);
+    });
+
+    it('임계 도달·초과 시 0 (음수 없음)', () => {
+        expect(remainingToPromote(2)).toBe(0);
+        expect(remainingToPromote(5)).toBe(0);
+    });
+
+    it('비정상 입력은 0명 취급', () => {
+        expect(remainingToPromote(NaN)).toBe(PROMOTE_THRESHOLD);
+        expect(remainingToPromote(-3)).toBe(PROMOTE_THRESHOLD);
+    });
+});
+
+describe('buildSuggestStatusText — 카드 상태 문구', () => {
+    it('승격 전에는 남은 인원을 함께 안내한다', () => {
+        expect(buildSuggestStatusText(1)).toBe('1명이 제안했어요 (승격까지 1명)');
+    });
+
+    it('승격 도달 후에는 남은 인원 문구를 생략한다', () => {
+        expect(buildSuggestStatusText(2)).toBe('2명이 제안했어요');
+        expect(buildSuggestStatusText(3)).toBe('3명이 제안했어요');
+    });
+});

--- a/apps/web/src/lib/components/features/board/angtt-suggest-logic.ts
+++ b/apps/web/src/lib/components/features/board/angtt-suggest-logic.ts
@@ -1,0 +1,46 @@
+/**
+ * 앙티티 크라우드 제안 — 순수 로직 (서버 라우트 · 커넥트 카드 공용)
+ *
+ * 작성자가 태그를 안 단 작품 글을 독자들이 제안으로 작품 페이지에 연결한다.
+ * 서로 다른 회원 PROMOTE_THRESHOLD 명이 같은 작품을 제안하면 자동 승격(연결 확정).
+ *
+ * 임계·문구 판정은 전부 이 파일에 모은다 — 서버(승격 판정)와 카드(상태 문구)가
+ * 서로 다른 숫자를 보지 않도록 단일 소스로 유지한다. (vitest 대상)
+ */
+import { RATING_MIN_LEVEL } from './post-rating-logic.js';
+
+/** 제안 가능 최소 등급 — 글·작품 별점과 동일 기준(앙님💛, mb_level 3) 재사용 */
+export const SUGGEST_MIN_LEVEL = RATING_MIN_LEVEL;
+
+/** 서로 다른 회원 몇 명이 제안하면 자동 승격(연결 확정)되는가. 남용 관측 시 3으로 상향 */
+export const PROMOTE_THRESHOLD = 2;
+
+/** 회원당 일(24시간) 제안 상한 — idx_member_recent 인덱스 시크로 카운트 */
+export const DAILY_SUGGEST_LIMIT = 10;
+
+/** 제안을 받는 게시판 — angtt-auto-link 의 AUTO_LINK_BOARDS 와 동일 범위 */
+const SUGGEST_BOARDS = new Set(['free', 'angtt']);
+
+/** 이 게시판 글에 작품 연결 제안을 받을 수 있는가 */
+export function isSuggestableBoard(boardId: string): boolean {
+    return SUGGEST_BOARDS.has(boardId);
+}
+
+/** 서로 다른 제안자 수가 승격 임계에 도달했는가 */
+export function shouldPromote(distinctVoters: number): boolean {
+    return Number.isFinite(distinctVoters) && distinctVoters >= PROMOTE_THRESHOLD;
+}
+
+/** 승격까지 더 필요한 제안자 수 (음수 없음) */
+export function remainingToPromote(distinctVoters: number): number {
+    const n =
+        Number.isFinite(distinctVoters) && distinctVoters > 0 ? Math.floor(distinctVoters) : 0;
+    return Math.max(0, PROMOTE_THRESHOLD - n);
+}
+
+/** 카드 상태 문구 — "N명이 제안했어요 (승격까지 M명)" */
+export function buildSuggestStatusText(count: number): string {
+    const remaining = remainingToPromote(count);
+    if (remaining === 0) return `${count}명이 제안했어요`;
+    return `${count}명이 제안했어요 (승격까지 ${remaining}명)`;
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2279,7 +2279,13 @@
 
         <!-- 앙티티 커넥트 카드 (Phase 1): 태그 「앙티티」+작품명 규약 — 서버 매칭, SSR 렌더 -->
         {#if data.angttMatch}
-            <AngttConnectCard match={data.angttMatch} {boardId} postId={data.post.id} {isAuthor} />
+            <AngttConnectCard
+                match={data.angttMatch}
+                {boardId}
+                postId={data.post.id}
+                postTitle={data.post.title}
+                {isAuthor}
+            />
         {/if}
 
         {#each beforeCommentsSlots as slot (slot.component)}

--- a/apps/web/src/routes/api/angtt/suggest/+server.ts
+++ b/apps/web/src/routes/api/angtt/suggest/+server.ts
@@ -51,12 +51,12 @@ async function parseTarget(request: Request): Promise<SuggestTarget | null> {
     return { boardId, wrId, slug };
 }
 
-/** 이 글·작품 쌍의 서로 다른 제안자 수 (PK 프리픽스 시크) */
+/** 이 글·작품 쌍의 서로 다른 유효(미철회) 제안자 수 (PK 프리픽스 시크) */
 async function countDistinctVoters(target: SuggestTarget, entityId: number): Promise<number> {
     const [rows] = await pool.query(
         `SELECT COUNT(DISTINCT mb_id) AS voters
            FROM angple_entity_post_suggestions
-          WHERE bo_table = ? AND wr_id = ? AND entity_id = ?`,
+          WHERE bo_table = ? AND wr_id = ? AND entity_id = ? AND withdrawn_at IS NULL`,
         [target.boardId, target.wrId, entityId]
     );
     return Number((rows as { voters?: number }[])[0]?.voters ?? 0);
@@ -113,7 +113,9 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
         return json({ error: '이미 작품에 연결된 글이에요.' }, { status: 409 });
     }
 
-    // 레이트리밋 — 회원당 24시간 DAILY_SUGGEST_LIMIT 건 (idx_member_recent 시크)
+    // 레이트리밋 — 회원당 24시간 DAILY_SUGGEST_LIMIT 건 (idx_member_recent 시크).
+    // 철회는 소프트(withdrawn_at)라 행이 남고, 철회 후 재제안은 created_at 을 갱신해
+    // 다시 카운트된다 → 제안↔철회 반복으로 리밋을 리셋할 수 없다.
     const [rateRows] = await pool.query(
         `SELECT COUNT(*) AS cnt FROM angple_entity_post_suggestions
           WHERE mb_id = ? AND created_at >= NOW(3) - INTERVAL 1 DAY`,
@@ -127,17 +129,20 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
         );
     }
 
-    // 1표 등록 — PK 중복(이미 제안)은 멱등 200 으로 수렴
-    try {
-        await pool.execute(
-            `INSERT INTO angple_entity_post_suggestions
-                (bo_table, wr_id, entity_id, mb_id, created_at)
-             VALUES (?, ?, ?, ?, NOW(3))`,
-            [target.boardId, target.wrId, entity.id, mbId]
-        );
-    } catch (e) {
-        if ((e as { code?: string }).code !== 'ER_DUP_ENTRY') throw e;
-    }
+    // 1표 등록 — PK 중복 시:
+    //  - 유효 표가 이미 있으면 무변화(멱등, created_at 유지 → 쿼터 재소모 없음)
+    //  - 철회된 표면 부활시키고 created_at 을 갱신(제안 행위마다 쿼터 소모 →
+    //    제안↔철회 반복 남용이 리밋에 그대로 걸린다)
+    // 대입 순서 주의: created_at 이 withdrawn_at(구값)을 먼저 봐야 하므로 앞에 둔다.
+    await pool.execute(
+        `INSERT INTO angple_entity_post_suggestions
+            (bo_table, wr_id, entity_id, mb_id, created_at)
+         VALUES (?, ?, ?, ?, NOW(3))
+         ON DUPLICATE KEY UPDATE
+            created_at = IF(withdrawn_at IS NULL, created_at, VALUES(created_at)),
+            withdrawn_at = NULL`,
+        [target.boardId, target.wrId, entity.id, mbId]
+    );
 
     // 승격 판정 — 서로 다른 회원 수가 임계에 닿으면 링크 확정.
     // INSERT IGNORE 멱등이라 동시 요청·재시도에도 링크는 정확히 1행이다(별도 트랜잭션 불요).
@@ -155,7 +160,15 @@ export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
     return json({ count: voters, promoted, myVote: true });
 };
 
-export const DELETE: RequestHandler = async ({ request, locals, setHeaders }) => {
+/** 관리자 게이트 — POST 와 동일하게 쓰기 시점 g5_member 실측 */
+async function isAdmin(mbId: string): Promise<boolean> {
+    const [rows] = await pool.query(`SELECT mb_level FROM g5_member WHERE mb_id = ? LIMIT 1`, [
+        mbId
+    ]);
+    return Number((rows as { mb_level?: number }[])[0]?.mb_level ?? 0) >= 10;
+}
+
+export const DELETE: RequestHandler = async ({ request, locals, setHeaders, url }) => {
     setHeaders({ 'Cache-Control': 'private, no-store' });
 
     const mbId = locals.user?.id;
@@ -169,10 +182,32 @@ export const DELETE: RequestHandler = async ({ request, locals, setHeaders }) =>
     const entity = await getEntityBySlug(target.slug);
     if (!entity) return json({ error: '작품을 찾을 수 없습니다.' }, { status: 404 });
 
-    // 본인 표만 삭제. 승격 후에는 entity_posts 링크는 유지된다(해제는 관리자 몫).
+    // 관리자 정리 경로: ?scope=all — 이 글·작품의 제안 전량 + 승격 링크(mention)까지 제거.
+    // 크라우드 오연결의 되돌리기 수단(스펙 규칙표 6행). 일반 auto 해제는 기존 unlink 사용.
+    if (url.searchParams.get('scope') === 'all') {
+        if (!(await isAdmin(mbId))) {
+            return json({ error: '관리자만 정리할 수 있습니다.' }, { status: 403 });
+        }
+        await pool.execute(
+            `DELETE FROM angple_entity_post_suggestions
+              WHERE bo_table = ? AND wr_id = ? AND entity_id = ?`,
+            [target.boardId, target.wrId, entity.id]
+        );
+        await pool.execute(
+            `DELETE FROM angple_entity_posts
+              WHERE bo_table = ? AND wr_id = ? AND entity_id = ? AND role = 'mention'`,
+            [target.boardId, target.wrId, entity.id]
+        );
+        return json({ count: 0, promoted: false, myVote: false });
+    }
+
+    // 본인 표 철회 — 소프트(withdrawn_at). 행을 남겨야 레이트리밋(제안↔철회 반복)이
+    // 유지된다. 승격 후에는 entity_posts 링크는 유지된다(해제는 위 관리자 경로).
     await pool.execute(
-        `DELETE FROM angple_entity_post_suggestions
-          WHERE bo_table = ? AND wr_id = ? AND entity_id = ? AND mb_id = ?`,
+        `UPDATE angple_entity_post_suggestions
+            SET withdrawn_at = NOW(3)
+          WHERE bo_table = ? AND wr_id = ? AND entity_id = ? AND mb_id = ?
+            AND withdrawn_at IS NULL`,
         [target.boardId, target.wrId, entity.id, mbId]
     );
 

--- a/apps/web/src/routes/api/angtt/suggest/+server.ts
+++ b/apps/web/src/routes/api/angtt/suggest/+server.ts
@@ -1,0 +1,181 @@
+/**
+ * 앙티티 크라우드 제안 API — 독자가 미연결 글을 작품에 연결 제안한다.
+ *
+ * POST   제안 등록: 로그인 + 앙님💛(mb_level 3) 이상, free/angtt 글 한정.
+ *        서로 다른 회원 PROMOTE_THRESHOLD(2)명이 같은 작품을 제안하면
+ *        angple_entity_posts 에 role='mention' INSERT IGNORE 로 자동 승격
+ *        (7/22 라이브된 태그→링크와 동일 경로 — read 경로 무접촉).
+ * DELETE 본인 표 철회. 승격 후에는 링크는 유지되고 표만 삭제된다(해제는 관리자).
+ *
+ * 남용 방어:
+ *  - 1인 1표: angple_entity_post_suggestions PK(bo_table, wr_id, entity_id, mb_id)로
+ *    스키마가 강제 — 중복 제안은 ER_DUP_ENTRY 를 삼켜 멱등 200 처리.
+ *  - 레이트리밋: 회원당 24시간 10건 (idx_member_recent 인덱스 시크).
+ *  - 정확일치만: 제안 대상은 실존 active entity slug — 자유텍스트 제안 없음.
+ *
+ * 등급은 g5_member 를 직접 조회한다 — 세션 캐시(user_basic)의 stale 등급으로
+ * 게이트가 어긋나지 않게 쓰기 시점 실측값을 쓴다.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import pool from '$lib/server/db';
+import { getEntityBySlug } from '$plugins/angtt-review/lib/entities.server';
+import {
+    DAILY_SUGGEST_LIMIT,
+    SUGGEST_MIN_LEVEL,
+    isSuggestableBoard,
+    shouldPromote
+} from '$lib/components/features/board/angtt-suggest-logic.js';
+import { buildGradeDeniedMessage } from '$lib/utils/board-permissions.js';
+
+interface SuggestTarget {
+    boardId: string;
+    wrId: number;
+    slug: string;
+}
+
+/** body {boardId, wrId, slug} 공통 검증 — 실패 시 null */
+async function parseTarget(request: Request): Promise<SuggestTarget | null> {
+    let body: { boardId?: unknown; wrId?: unknown; slug?: unknown };
+    try {
+        body = await request.json();
+    } catch {
+        return null;
+    }
+    const boardId = String(body.boardId ?? '');
+    const wrId = Number(body.wrId ?? 0);
+    const slug = String(body.slug ?? '').trim();
+    if (!/^[a-zA-Z0-9_-]+$/.test(boardId)) return null;
+    if (!Number.isInteger(wrId) || wrId <= 0) return null;
+    if (!slug || slug.length > 160) return null;
+    return { boardId, wrId, slug };
+}
+
+/** 이 글·작품 쌍의 서로 다른 제안자 수 (PK 프리픽스 시크) */
+async function countDistinctVoters(target: SuggestTarget, entityId: number): Promise<number> {
+    const [rows] = await pool.query(
+        `SELECT COUNT(DISTINCT mb_id) AS voters
+           FROM angple_entity_post_suggestions
+          WHERE bo_table = ? AND wr_id = ? AND entity_id = ?`,
+        [target.boardId, target.wrId, entityId]
+    );
+    return Number((rows as { voters?: number }[])[0]?.voters ?? 0);
+}
+
+export const POST: RequestHandler = async ({ request, locals, setHeaders }) => {
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    const mbId = locals.user?.id;
+    if (!mbId) {
+        return json({ error: '연결을 제안하려면 로그인이 필요해요.' }, { status: 401 });
+    }
+
+    const target = await parseTarget(request);
+    if (!target) return json({ error: '잘못된 요청입니다.' }, { status: 400 });
+    if (!isSuggestableBoard(target.boardId)) {
+        return json({ error: '이 게시판 글에는 연결을 제안할 수 없어요.' }, { status: 400 });
+    }
+
+    // 등급 게이트 — 별점(RATING_MIN_LEVEL)과 동일 기준. 쓰기 시점 실측값(g5_member).
+    const [levelRows] = await pool.query(`SELECT mb_level FROM g5_member WHERE mb_id = ? LIMIT 1`, [
+        mbId
+    ]);
+    const level = Number((levelRows as { mb_level?: number }[])[0]?.mb_level ?? 0);
+    if (level < SUGGEST_MIN_LEVEL) {
+        return json(
+            { error: buildGradeDeniedMessage('연결 제안', SUGGEST_MIN_LEVEL, level) },
+            { status: 403 }
+        );
+    }
+
+    // 글 존재 확인 — 삭제글·댓글 거부 (동적 테이블, boardId 는 위에서 화이트리스트 검증됨)
+    const [postRows] = await pool.query(
+        `SELECT wr_id FROM ??
+          WHERE wr_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL LIMIT 1`,
+        [`g5_write_${target.boardId}`, target.wrId]
+    );
+    if ((postRows as unknown[]).length === 0) {
+        return json({ error: '글을 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    // 제안 대상은 실존 active 작품만 — 자유텍스트 제안 원천 차단
+    const entity = await getEntityBySlug(target.slug);
+    if (!entity || entity.status !== 'active') {
+        return json({ error: '작품을 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    // 이미 연결된 글(any role)에는 제안 불가 — 카드도 이 경우 버튼을 노출하지 않는다
+    const [linkRows] = await pool.query(
+        `SELECT 1 FROM angple_entity_posts WHERE bo_table = ? AND wr_id = ? LIMIT 1`,
+        [target.boardId, target.wrId]
+    );
+    if ((linkRows as unknown[]).length > 0) {
+        return json({ error: '이미 작품에 연결된 글이에요.' }, { status: 409 });
+    }
+
+    // 레이트리밋 — 회원당 24시간 DAILY_SUGGEST_LIMIT 건 (idx_member_recent 시크)
+    const [rateRows] = await pool.query(
+        `SELECT COUNT(*) AS cnt FROM angple_entity_post_suggestions
+          WHERE mb_id = ? AND created_at >= NOW(3) - INTERVAL 1 DAY`,
+        [mbId]
+    );
+    const recent = Number((rateRows as { cnt?: number }[])[0]?.cnt ?? 0);
+    if (recent >= DAILY_SUGGEST_LIMIT) {
+        return json(
+            { error: '하루에 제안할 수 있는 횟수를 넘었어요. 내일 다시 시도해 주세요.' },
+            { status: 429 }
+        );
+    }
+
+    // 1표 등록 — PK 중복(이미 제안)은 멱등 200 으로 수렴
+    try {
+        await pool.execute(
+            `INSERT INTO angple_entity_post_suggestions
+                (bo_table, wr_id, entity_id, mb_id, created_at)
+             VALUES (?, ?, ?, ?, NOW(3))`,
+            [target.boardId, target.wrId, entity.id, mbId]
+        );
+    } catch (e) {
+        if ((e as { code?: string }).code !== 'ER_DUP_ENTRY') throw e;
+    }
+
+    // 승격 판정 — 서로 다른 회원 수가 임계에 닿으면 링크 확정.
+    // INSERT IGNORE 멱등이라 동시 요청·재시도에도 링크는 정확히 1행이다(별도 트랜잭션 불요).
+    const voters = await countDistinctVoters(target, entity.id);
+    let promoted = false;
+    if (shouldPromote(voters)) {
+        await pool.execute(
+            `INSERT IGNORE INTO angple_entity_posts (entity_id, bo_table, wr_id, role, created_at)
+             VALUES (?, ?, ?, 'mention', NOW(3))`,
+            [entity.id, target.boardId, target.wrId]
+        );
+        promoted = true;
+    }
+
+    return json({ count: voters, promoted, myVote: true });
+};
+
+export const DELETE: RequestHandler = async ({ request, locals, setHeaders }) => {
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    const mbId = locals.user?.id;
+    if (!mbId) {
+        return json({ error: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
+    const target = await parseTarget(request);
+    if (!target) return json({ error: '잘못된 요청입니다.' }, { status: 400 });
+
+    const entity = await getEntityBySlug(target.slug);
+    if (!entity) return json({ error: '작품을 찾을 수 없습니다.' }, { status: 404 });
+
+    // 본인 표만 삭제. 승격 후에는 entity_posts 링크는 유지된다(해제는 관리자 몫).
+    await pool.execute(
+        `DELETE FROM angple_entity_post_suggestions
+          WHERE bo_table = ? AND wr_id = ? AND entity_id = ? AND mb_id = ?`,
+        [target.boardId, target.wrId, entity.id, mbId]
+    );
+
+    const voters = await countDistinctVoters(target, entity.id);
+    return json({ count: voters, promoted: false, myVote: false });
+};

--- a/apps/web/src/routes/api/angtt/suggest/status/+server.ts
+++ b/apps/web/src/routes/api/angtt/suggest/status/+server.ts
@@ -1,0 +1,30 @@
+/**
+ * GET /api/angtt/suggest/status?boardId=&wrId=
+ *
+ * 커넥트 카드의 크라우드 제안 현황 — {suggestions:[{slug,title,count}], myVotes, linked}.
+ *
+ * ⛔ 글상세 SSR 은 이 데이터를 조회하지 않는다(read 경로 무접촉 원칙).
+ *    카드(클라 컴포넌트)가 마운트 후 지연 조회한다. 비로그인은 count 만(myVotes 빈 배열).
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getSuggestionStatus } from '$plugins/angtt-review/lib/entities.server';
+
+export const GET: RequestHandler = async ({ url, locals, setHeaders }) => {
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    const boardId = url.searchParams.get('boardId') ?? '';
+    const wrId = Number(url.searchParams.get('wrId') ?? 0);
+    if (!/^[a-zA-Z0-9_-]+$/.test(boardId) || !Number.isInteger(wrId) || wrId <= 0) {
+        return json({ error: '잘못된 요청입니다.' }, { status: 400 });
+    }
+
+    try {
+        const status = await getSuggestionStatus(boardId, wrId, locals.user?.id);
+        return json(status);
+    } catch (err) {
+        // 현황 조회 실패는 기능 저하일 뿐 — 카드는 제안 UI 만 생략한다.
+        console.error('[angtt suggest status] error:', err);
+        return json({ suggestions: [], myVotes: [], linked: null });
+    }
+};

--- a/plugins/angtt-review/lib/entities.server.ts
+++ b/plugins/angtt-review/lib/entities.server.ts
@@ -351,6 +351,73 @@ export async function getEntityRating(entityId: number, mbId?: string): Promise<
     return { avg, count, my };
 }
 
+/** 크라우드 제안 현황 — 커넥트 카드 표기용 집계 */
+export interface AngttSuggestionStatus {
+    /** 작품별 제안 수 (제안 많은 순) */
+    suggestions: { slug: string; title: string; count: number }[];
+    /** 요청 회원이 제안한 작품 slug 목록 (비로그인이면 빈 배열) */
+    myVotes: string[];
+    /** 이미 작품에 연결된 글이면 그 작품 — 카드는 제안 UI 대신 연결 안내를 띄운다 */
+    linked: { slug: string; title: string } | null;
+}
+
+interface SuggestionRow {
+    slug: string;
+    title: string;
+    mb_id: string;
+}
+
+interface LinkedEntityRow {
+    slug: string;
+    title: string;
+}
+
+/**
+ * 글 1건의 크라우드 제안 현황을 집계한다.
+ *
+ * 쿼리 2개 전부 PK/인덱스 프리픽스 시크: entity_posts PK(bo_table, wr_id, …),
+ * entity_post_suggestions PK(bo_table, wr_id, …). 글상세 SSR 은 이 함수를 호출하지
+ * 않는다 — 카드(클라)가 마운트 후 지연 조회하는 read 경로 무접촉 규약.
+ */
+export async function getSuggestionStatus(
+    boardId: string,
+    wrId: number,
+    mbId?: string
+): Promise<AngttSuggestionStatus> {
+    // 연결 여부 (any role) — 승격은 태그 없이 링크만 생기므로 태그 기반 SSR 매칭이
+    // notFound 여도 링크는 존재할 수 있다. 카드가 그 간극을 이 값으로 메운다.
+    const [linkResult] = await pool.query(
+        `SELECT e.slug, e.canonical_title AS title
+           FROM angple_entity_posts ep
+           JOIN angple_entities e ON e.id = ep.entity_id
+          WHERE ep.bo_table = ? AND ep.wr_id = ?
+          LIMIT 1`,
+        [boardId, wrId]
+    );
+    const linkedRow = (linkResult as LinkedEntityRow[])[0];
+    const linked = linkedRow ? { slug: linkedRow.slug, title: linkedRow.title } : null;
+
+    const [rowsResult] = await pool.query(
+        `SELECT e.slug, e.canonical_title AS title, s.mb_id
+           FROM angple_entity_post_suggestions s
+           JOIN angple_entities e ON e.id = s.entity_id
+          WHERE s.bo_table = ? AND s.wr_id = ?`,
+        [boardId, wrId]
+    );
+
+    const bySlug = new Map<string, { slug: string; title: string; count: number }>();
+    const myVotes: string[] = [];
+    for (const r of rowsResult as SuggestionRow[]) {
+        const cur = bySlug.get(r.slug) ?? { slug: r.slug, title: r.title, count: 0 };
+        cur.count += 1;
+        bySlug.set(r.slug, cur);
+        if (mbId && r.mb_id === mbId) myVotes.push(r.slug);
+    }
+    const suggestions = [...bySlug.values()].sort((a, b) => b.count - a.count);
+
+    return { suggestions, myVotes, linked };
+}
+
 /**
  * 작품 단위 별점 등록/수정(회원당 작품당 1표).
  *

--- a/plugins/angtt-review/lib/entities.server.ts
+++ b/plugins/angtt-review/lib/entities.server.ts
@@ -401,7 +401,7 @@ export async function getSuggestionStatus(
         `SELECT e.slug, e.canonical_title AS title, s.mb_id
            FROM angple_entity_post_suggestions s
            JOIN angple_entities e ON e.id = s.entity_id
-          WHERE s.bo_table = ? AND s.wr_id = ?`,
+          WHERE s.bo_table = ? AND s.wr_id = ? AND s.withdrawn_at IS NULL`,
         [boardId, wrId]
     );
 


### PR DESCRIPTION
## 무엇

작성자가 태그를 안 단 작품 글을 **독자들이 제안**으로 작품 페이지에 연결합니다. 커넥트 카드의 미연결(notFound) 분기에 [이 글의 작품 연결 제안] 버튼을 달고, **서로 다른 회원 2명**이 같은 작품을 제안하면 `angple_entity_posts` `role='mention'` INSERT IGNORE 로 자동 승격(태그→링크와 동일 경로)합니다.

스펙: angtt-crowd-suggest-spec (앙티티 태깅 플랜 3단계). DDL(`angple_entity_post_suggestions`)은 prod 적용 완료 — 코드만 배포하면 동작합니다.

## 구현

| 파일 | 내용 |
|---|---|
| `routes/api/angtt/suggest/+server.ts` (신규) | POST 제안 / DELETE 본인 표 철회 |
| `routes/api/angtt/suggest/status/+server.ts` (신규) | GET 현황 — 카드가 마운트 후 지연 조회 (**글상세 SSR 무접촉**) |
| `plugins/angtt-review/lib/entities.server.ts` | `getSuggestionStatus()` 집계 (PK/인덱스 시크 2쿼리) |
| `angtt-connect-card.svelte` | notFound 분기 확장 + `postTitle` prop (detect 입력) |
| `[boardId]/[postId]/+page.svelte` | `postTitle` 전달 (SSR 경로 무수정) |
| `angtt-suggest-logic.ts` (+test) | 임계·문구 순수 로직 — 서버·카드 단일 소스, vitest |

## 남용 방어 (스펙 규칙 그대로)

- 로그인 + **mb_level ≥ 3** (별점 `RATING_MIN_LEVEL` 재사용, g5_member 쓰기 시점 실측)
- free/angtt 한정, 글 존재(삭제글·댓글 거부), **실존 active entity slug 정확일치만**
- 1인 1표 = PK 강제, 중복 제안은 멱등 200 / 이미 연결(any role) = 409
- 회원당 24시간 10건 = 429 (`idx_member_recent` 시크)
- 철회는 본인 표만 — 승격 후 링크는 유지(해제는 관리자)

## 성능 규약 준수

- detect 는 **사용자 클릭 시에만** 호출, status 는 카드 마운트 후 1회 — 글상세 SSR·목록 경로 접촉 없음
- prod DB EXPLAIN 실측: 레이트리밋 = `idx_member_recent` range(Using index), 제안자 카운트 = `idx_entity` ref(Using index)

## 검증 (prod DB 실측 — 테스트 행 INSERT→검증→전량 DELETE 뒷정리 완료)

- 1표 → voters=1, 2표(다른 회원) → voters=2 → `role='mention'` 생성, 재실행 idempotent(affected 0)
- 같은 회원 재제안 → ER 1062 (라우트에서 멱등 200 수렴)
- 철회 → voters 2→1 감소
- 순수 로직 스모크(node strip-types) + vitest 케이스 전체 통과 조건 확인

## Evaluator 체크리스트 대응

1. 레벨 2 → 403(승급 안내 문구) / 레벨 3 → 성공
2. 같은 회원 재제안 → 무변화 / 다른 회원 2번째 → mention 생성 + 카드 즉시 연결 표시(promoted 응답 → linked 상태 전환)
3. 이미 연결 글 — 매칭 카드는 버튼 없음, 무태그 승격 글은 status.linked 로 버튼 대신 연결 안내, 서버도 409 이중 방어
4. 철회 후 카운트 감소 / 일 10건 초과 429
5. 글상세 SSR 무수정 — 응답시간 회귀 없음
