### PR TITLE
feat(cert): DI 충돌 시 계정 복구 경로 — 활성 계정 durable 기록 + 안내

### DIFF
--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -190,8 +190,25 @@ export async function flagDupinfoCollision(
     );
 
     if (blockingRows.length === 0) {
-        // 정상(활성) 계정 매칭: 추가 차단 없이 감사 로그만.
-        console.warn('[Cert][DI-guard] DI collision with active account(s) — logged only', {
+        // 정상(활성) 계정 매칭: 차단하지 않되, "이전 계정을 잊고 새로 가입"한 회원의
+        // 계정 복구 안내를 위해 매칭 계정을 durable 하게 기록한다.
+        // ⚠️다중이/징계회피가 아니므로 중립 문구를 쓴다. mb_id 만 남기며 DI·이메일은
+        // 저장하지 않는다(개인정보방침 제2조3항 '중복가입 방지 및 계정 복구' 목적 범위).
+        const activeIds = rows.map((r) => r.mb_id).join(', ');
+        const memo =
+            `${formatLeaveDate()} [기존계정확인] 동일 본인확인정보의 기존 활성 계정 ` +
+            `${activeIds} 존재 — 계정 복구 안내 대상`;
+        try {
+            await pool.query(
+                `UPDATE g5_member
+                    SET mb_memo = CONCAT(?, IF(mb_memo IS NULL OR mb_memo = '', '', CONCAT('\n', mb_memo)))
+                  WHERE mb_id = ?`,
+                [memo, mbId]
+            );
+        } catch (e) {
+            console.error('[Cert][DI-guard] active-collision memo write failed:', e);
+        }
+        console.warn('[Cert][DI-guard] DI collision with active account(s) — recovery candidate', {
             mbId,
             dupinfoPrefix: dupinfo.slice(0, 16),
             collisions: rows.map((r) => r.mb_id)

--- a/apps/web/src/routes/cert/inicis/result/+server.ts
+++ b/apps/web/src/routes/cert/inicis/result/+server.ts
@@ -142,7 +142,11 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
         await flagDupinfoCollision(mbId, mbDupinfo).catch((e) => {
             console.error('[Cert] DI 충돌 플래그 기록 실패:', e);
         });
-        return certResultPage(false, '입력하신 본인확인 정보로 이미 가입된 내역이 존재합니다.');
+        return certResultPage(
+            false,
+            '이전에 가입하신 계정이 있어 본인인증이 제한되었습니다. ' +
+                '기존 계정으로 로그인하시거나, 계정 복구가 필요하시면 고객센터로 문의해 주세요.'
+        );
     }
 
     // DB 업데이트


### PR DESCRIPTION
## 배경

실명인증이 기존 DI와 충돌해 거부될 때:
- **탈퇴/제재 계정** 충돌 → 신규 계정 `mb_memo`에 매칭 mb_id 기록 (durable) ✅
- **활성 계정** 충돌 → `console.warn`만 (휘발) ❌

"이전 계정을 잊고 새로 가입"한 회원의 **계정 복구 문의가 잦은데**, 활성 계정 충돌은 사후에 매칭 계정을 특정할 수 없어 수동 대응에 의존했습니다. (2026-07-22 실제 문의 건에서 로그 롤오버로 특정 실패)

## 변경

**1. `flagDupinfoCollision` — 활성 계정 충돌도 durable 기록**
- 매칭 mb_id를 신규 계정 `mb_memo`에 기록
- ⚠️ 다중이/징계회피가 아니므로 **중립 문구**: `[기존계정확인] … 계정 복구 안내 대상`
- **mb_id만** 저장, DI·이메일은 저장 안 함

**2. 거부 안내 UX**
- 막다른 `"이미 가입된 내역이 존재합니다"` → `"기존 계정으로 로그인하시거나, 계정 복구가 필요하시면 고객센터로 문의해 주세요"`

## 개인정보

- 신규 저장은 **내부 식별자(mb_id)뿐** — 개인정보방침 **제2조3항('중복가입 방지 및 계정 복구')** 목적 범위
- ⛔ email↔DI 매핑 등 PII 축적은 하지 않음 (방침이 약속한 'DI만 보관' 유지)

## 효과

- 활성 계정 충돌 문의 → 관리자 회원관리 화면(`mb_memo`)에서 **매칭 계정 즉시 확인** → "그 계정으로 로그인" 안내
- 탈퇴 충돌은 기존대로 (복원 판정)

## 검증

- [ ] CI 빌드
- [ ] 활성 계정 DI 충돌 재현 → 신규 계정 mb_memo에 중립 문구 기록
- [ ] 거부 화면에 복구 안내 문구 노출
- [ ] 탈퇴/제재 충돌은 기존 문구 유지(회귀 없음)