### PR TITLE
feat(hello): 가입인사 환영 라운지 — 채팅형 댓글 + 원터치 환영 스탬프

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -757,6 +757,7 @@ export type CommentLayout =
     | 'compact'
     | 'discussion'
     | 'feed'
+    | 'chat'
     | (string & {});
 
 // 게시판 표시 설정

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -155,6 +155,10 @@
         return comments.find((item) => String(item.id) === commentId) ?? null;
     }
 
+    // hello 환영 라운지: 가입인사 + chat 레이아웃 조합에서만 발동하는 표시 특화.
+    // ⛔ chat 분기 밖(다른 레이아웃·다른 게시판) 렌더에는 절대 영향을 주면 안 된다.
+    const isHelloLounge = $derived(boardId === 'hello' && commentLayout === 'chat');
+
     // 플러그인 활성화 여부
     let memoPluginActive = $derived(pluginStore.isPluginActive('member-memo'));
     let reactionPluginActive = $derived(pluginStore.isPluginActive('da-reaction'));
@@ -1218,9 +1222,12 @@
                             />
                             <LevelBadge level={memberLevelStore.getLevel(comment.author_id)} />
                             {#if !postDeleted && postAuthorId && comment.author_id === postAuthorId}
+                                <!-- hello 환영 라운지: 원글 작성자 = 새로 온 앙님 (chat 이름 라벨 안이라 chat 전용) -->
                                 <span
-                                    class="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
-                                    >작성자</span
+                                    class="rounded px-1.5 py-0.5 text-[10px] font-semibold {isHelloLounge
+                                        ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+                                        : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'}"
+                                    >{isHelloLounge ? '새 앙님 🎈' : '작성자'}</span
                                 >
                             {/if}
                             {#if authStore.isAuthenticated && memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
@@ -1262,7 +1269,12 @@
                                 ? 'bg-muted/50 rounded-xl px-3.5 py-2.5'
                                 : isAuthor
                                   ? 'bg-primary/10 rounded-xl rounded-br-sm px-3.5 py-2.5'
-                                  : 'bg-muted rounded-xl rounded-bl-sm px-3.5 py-2.5'
+                                  : isHelloLounge &&
+                                      !postDeleted &&
+                                      postAuthorId &&
+                                      comment.author_id === postAuthorId
+                                    ? 'rounded-xl rounded-bl-sm border border-amber-300/70 bg-amber-100/70 px-3.5 py-2.5 dark:border-amber-600/40 dark:bg-amber-900/25'
+                                    : 'bg-muted rounded-xl rounded-bl-sm px-3.5 py-2.5'
                             : ''}
                     >
                         <div

--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -22,6 +22,10 @@
         boardId
     }: Props = $props();
 
+    // hello 가입인사: 이모티콘 피커 기본 탭 = 환영(welcome) 팩 — 온보딩 겸용.
+    // 두 호출처(comment-form·comment-list 수정 툴바) 모두 boardId 를 이미 넘기므로 여기서 유도.
+    const initialPack = $derived(boardId === 'hello' ? 'welcome' : undefined);
+
     let showEmoticonPicker = $state(false);
     let showGifPicker = $state(false);
 
@@ -105,6 +109,7 @@
                 <LazyEmoticonPicker
                     onInsertEmoticon={handleInsertEmoticon}
                     onClose={() => (showEmoticonPicker = false)}
+                    {initialPack}
                 />
             </div>
         {/if}

--- a/apps/web/src/lib/components/features/board/emoticon-picker.svelte
+++ b/apps/web/src/lib/components/features/board/emoticon-picker.svelte
@@ -4,9 +4,11 @@
     interface Props {
         onInsertEmoticon: (text: string) => void;
         onClose: () => void;
+        /** 열릴 때 기본 선택할 팩의 prefix (예: 'welcome'). 없거나 못 찾으면 첫 팩 */
+        initialPack?: string;
     }
 
-    let { onInsertEmoticon, onClose }: Props = $props();
+    let { onInsertEmoticon, onClose, initialPack }: Props = $props();
 
     // 이모지 (유니코드) - 기존 리액션 설정에서 가져옴
     const emojis = REACTION_EMOTICONS.filter((e) => e.category === 'emoji');
@@ -47,6 +49,14 @@
         })
         .then((data: { packs: EmoticonPack[] }) => {
             packs = data.packs;
+            if (initialPack) {
+                const idx = packs.findIndex((p) => p.prefix === initialPack);
+                if (idx >= 0) {
+                    activeTab = `pack-${idx}`;
+                    // 접힌 목록 밖의 팩이면 펼쳐야 탭이 보인다
+                    if (idx >= DEFAULT_VISIBLE) expanded = true;
+                }
+            }
             loading = false;
         })
         .catch(() => {

--- a/apps/web/src/lib/components/features/board/welcome-stamp-bar.svelte
+++ b/apps/web/src/lib/components/features/board/welcome-stamp-bar.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { canUseCertifiedAction } from '$lib/utils/certification-gate.js';
+    import {
+        WELCOME_PACK_PREFIX,
+        hasStampedWelcome,
+        welcomeStampContent
+    } from '$lib/utils/welcome-stamp.js';
+    import type { BoardPermissions, FreeComment } from '$lib/api/types.js';
+    import { toast } from 'svelte-sonner';
+    import Check from '@lucide/svelte/icons/check';
+    import Loader2 from '@lucide/svelte/icons/loader-2';
+
+    interface Props {
+        boardId: string;
+        comments: FreeComment[];
+        // ⛔ 반드시 부모의 기존 댓글 작성 핸들러(handleCreateComment)를 받아야 한다.
+        //    여기서 apiClient 를 직접 부르면 optimistic 반영·refetch·가시성 지연 보정(#12548)을
+        //    전부 다시 구현해야 한다.
+        onSend: (content: string) => Promise<void>;
+        permissions?: BoardPermissions;
+        requiredCommentLevel?: number;
+        isRestricted?: boolean;
+        disabled?: boolean;
+    }
+
+    let {
+        boardId,
+        comments,
+        onSend,
+        permissions,
+        requiredCommentLevel = 3,
+        isRestricted = false,
+        disabled = false
+    }: Props = $props();
+
+    interface EmoticonItem {
+        file: string;
+        thumb: string | null;
+    }
+
+    let stamps = $state<EmoticonItem[]>([]);
+    let sendingFile = $state<string | null>(null);
+
+    // 비로그인·이용제한·실명인증 미비·댓글 권한 미달 = 미노출.
+    // comment-form 의 canComment 판정과 같은 기준을 유지할 것 — 여기만 느슨하면
+    // 스탬프 탭이 서버 403 으로 튕기는 반쪽 UI 가 된다.
+    const canStamp = $derived.by(() => {
+        if (!authStore.isAuthenticated || isRestricted) return false;
+        if (!canUseCertifiedAction(authStore.user, boardId)) return false;
+        if (permissions) return permissions.can_comment;
+        return (authStore.user?.mb_level ?? 1) >= requiredCommentLevel;
+    });
+
+    // 글당 1회는 클라 판정만 — 우회해도 일반 댓글과 동일 취급이라 서버 강제 불요
+    const stamped = $derived(hasStampedWelcome(comments, authStore.user?.mb_id));
+
+    // welcome 팩이 없거나 API 실패면 조용히 미노출 (스탬프는 부가 기능)
+    fetch('/api/emoticons/list')
+        .then((res) => (res.ok ? res.json() : Promise.reject(new Error('API error'))))
+        .then((data: { packs: Array<{ prefix: string; items: EmoticonItem[] }> }) => {
+            stamps = data.packs.find((p) => p.prefix === WELCOME_PACK_PREFIX)?.items ?? [];
+        })
+        .catch(() => {
+            stamps = [];
+        });
+
+    async function sendStamp(file: string): Promise<void> {
+        if (stamped || sendingFile || disabled) return;
+        sendingFile = file;
+        try {
+            await onSend(welcomeStampContent(file));
+        } catch (err) {
+            console.error('환영 스탬프 등록 실패:', err);
+            toast.error(err instanceof Error ? err.message : '환영 스탬프를 남기지 못했습니다.');
+        } finally {
+            sendingFile = null;
+        }
+    }
+</script>
+
+{#if canStamp && stamps.length > 0}
+    <div
+        class="flex items-center gap-2.5 rounded-lg border border-amber-200/70 bg-amber-50/60 px-3 py-2 dark:border-amber-800/40 dark:bg-amber-950/20"
+    >
+        <span class="text-muted-foreground shrink-0 text-xs font-medium">
+            {#if stamped}
+                <span class="flex items-center gap-1">
+                    <Check class="size-3.5 text-green-600 dark:text-green-400" />
+                    환영 완료 ✓
+                </span>
+            {:else}
+                앙티콘으로 환영하기
+            {/if}
+        </span>
+        <div class="flex min-w-0 gap-1 overflow-x-auto">
+            {#each stamps as item (item.file)}
+                <button
+                    type="button"
+                    onclick={() => sendStamp(item.file)}
+                    disabled={stamped || !!sendingFile || disabled}
+                    class="relative shrink-0 rounded-md p-1 transition-colors hover:bg-amber-100/80 disabled:cursor-default disabled:hover:bg-transparent dark:hover:bg-amber-900/30"
+                    title={stamped
+                        ? '이미 환영 스탬프를 남겼어요'
+                        : '탭 한 번으로 환영 댓글 남기기'}
+                >
+                    <img
+                        src="/emoticons/{item.thumb || item.file}"
+                        alt="환영 앙티콘"
+                        class="size-9 object-contain {stamped ? 'opacity-40 grayscale' : ''}"
+                        loading="lazy"
+                    />
+                    {#if sendingFile === item.file}
+                        <span
+                            class="bg-background/60 absolute inset-0 flex items-center justify-center rounded-md"
+                        >
+                            <Loader2 class="size-4 animate-spin" />
+                        </span>
+                    {/if}
+                </button>
+            {/each}
+        </div>
+    </div>
+{/if}

--- a/apps/web/src/lib/utils/welcome-stamp.test.ts
+++ b/apps/web/src/lib/utils/welcome-stamp.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isWelcomeStampContent,
+    hasStampedWelcome,
+    welcomeStampContent,
+    WELCOME_PACK_PREFIX
+} from './welcome-stamp';
+
+describe('welcomeStampContent', () => {
+    it('파일명을 {emo:} 토큰으로 감싼다', () => {
+        expect(welcomeStampContent('welcome-001.jpg')).toBe('{emo:welcome-001.jpg}');
+    });
+
+    it('prefix 상수는 라이브 팩 prefix(welcome)와 일치한다', () => {
+        expect(WELCOME_PACK_PREFIX).toBe('welcome');
+    });
+});
+
+describe('isWelcomeStampContent', () => {
+    it('welcome 팩 단일 토큰이면 true', () => {
+        expect(isWelcomeStampContent('{emo:welcome-001.jpg}')).toBe(true);
+        expect(isWelcomeStampContent('{emo:welcome-004.jpg}')).toBe(true);
+    });
+
+    it('에디터가 <p>로 감싼 저장분도 true', () => {
+        expect(isWelcomeStampContent('<p>{emo:welcome-002.jpg}</p>')).toBe(true);
+        expect(isWelcomeStampContent('<p>&nbsp;{emo:welcome-002.jpg}&nbsp;</p>')).toBe(true);
+    });
+
+    it('앞뒤 공백은 무시한다', () => {
+        expect(isWelcomeStampContent('  {emo:welcome-003.jpg}  ')).toBe(true);
+    });
+
+    it('다른 팩 앙티콘은 false', () => {
+        expect(isWelcomeStampContent('{emo:damoang-emo-001.gif}')).toBe(false);
+        expect(isWelcomeStampContent('{emo:onion-012.gif}')).toBe(false);
+    });
+
+    it('토큰 + 다른 텍스트가 섞이면 일반 댓글로 본다 (false)', () => {
+        expect(isWelcomeStampContent('환영해요 {emo:welcome-001.jpg}')).toBe(false);
+        expect(isWelcomeStampContent('{emo:welcome-001.jpg} 반가워요')).toBe(false);
+        expect(isWelcomeStampContent('{emo:welcome-001.jpg}{emo:welcome-002.jpg}')).toBe(false);
+    });
+
+    it('일반 텍스트·빈 값은 false', () => {
+        expect(isWelcomeStampContent('환영합니다!')).toBe(false);
+        expect(isWelcomeStampContent('')).toBe(false);
+        expect(isWelcomeStampContent(null)).toBe(false);
+        expect(isWelcomeStampContent(undefined)).toBe(false);
+    });
+});
+
+describe('hasStampedWelcome', () => {
+    const stamp = { author_id: 'me', content: '{emo:welcome-001.jpg}', deleted_at: null };
+    const normal = { author_id: 'me', content: '어서오세요!', deleted_at: null };
+    const others = { author_id: 'other', content: '{emo:welcome-002.jpg}', deleted_at: null };
+
+    it('내 welcome 스탬프 댓글이 있으면 true', () => {
+        expect(hasStampedWelcome([normal, stamp, others], 'me')).toBe(true);
+    });
+
+    it('내 스탬프가 없으면 false (남의 스탬프는 무관)', () => {
+        expect(hasStampedWelcome([normal, others], 'me')).toBe(false);
+    });
+
+    it('삭제된 스탬프는 제외 — 다시 환영할 수 있다', () => {
+        const deleted = { ...stamp, deleted_at: '2026-07-22T00:00:00Z' };
+        expect(hasStampedWelcome([deleted], 'me')).toBe(false);
+    });
+
+    it('비로그인(myId 없음)·빈 목록은 false', () => {
+        expect(hasStampedWelcome([stamp], null)).toBe(false);
+        expect(hasStampedWelcome([stamp], undefined)).toBe(false);
+        expect(hasStampedWelcome([], 'me')).toBe(false);
+        expect(hasStampedWelcome(null, 'me')).toBe(false);
+    });
+});

--- a/apps/web/src/lib/utils/welcome-stamp.ts
+++ b/apps/web/src/lib/utils/welcome-stamp.ts
@@ -1,0 +1,52 @@
+/**
+ * hello 환영 라운지 — 원터치 환영 스탬프 판정 로직 (순수 함수).
+ *
+ * 스탬프 = welcome 팩 앙티콘 하나만 담긴 실제 댓글(`{emo:welcome-XXX.jpg}`).
+ * "글당 1회" 는 클라이언트 판정만 한다 — 우회해도 일반 댓글과 동일 취급이라 서버 강제 불요.
+ */
+
+/** welcome(환영) 팩 파일명 prefix — /api/emoticons/list 의 pack.prefix 와 일치해야 한다 */
+export const WELCOME_PACK_PREFIX = 'welcome';
+
+/** 스탬프 댓글 판정용 단일 토큰 패턴: `{emo:welcome-….ext}` 하나만 */
+const WELCOME_TOKEN_RE = /^\{emo:welcome-[^{}\s]+\}$/i;
+
+/** 파일명 → 댓글 본문 토큰 (`transformEmoticons()` 가 렌더 시 이미지로 치환) */
+export function welcomeStampContent(filename: string): string {
+    return `{emo:${filename}}`;
+}
+
+/**
+ * 댓글 본문이 "welcome 팩 앙티콘 단일 토큰"인지 판정.
+ * 에디터 경유 저장분이 `<p>…</p>` 로 감싸일 수 있어 태그·공백(&nbsp; 포함)은 벗겨내고 비교한다.
+ * 토큰 외 다른 텍스트가 섞여 있으면 스탬프가 아니라 일반 댓글로 본다.
+ */
+export function isWelcomeStampContent(content: string | null | undefined): boolean {
+    if (!content) return false;
+    const stripped = content
+        .replace(/<[^>]*>/g, '')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/[\u00a0\u2800]/g, ' ')
+        .trim();
+    return WELCOME_TOKEN_RE.test(stripped);
+}
+
+/** hasStampedWelcome 판정에 필요한 최소 댓글 형태 */
+export interface WelcomeStampComment {
+    author_id?: string;
+    content?: string;
+    deleted_at?: string | null;
+}
+
+/**
+ * 내(myId)가 이 글에 환영 스탬프를 이미 남겼는지 — 삭제된 댓글은 제외(다시 환영 가능).
+ */
+export function hasStampedWelcome(
+    comments: readonly WelcomeStampComment[] | null | undefined,
+    myId: string | null | undefined
+): boolean {
+    if (!myId || !comments?.length) return false;
+    return comments.some(
+        (c) => c.author_id === myId && !c.deleted_at && isWelcomeStampContent(c.content)
+    );
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -40,6 +40,7 @@
     import DeleteConfirmDialog from '$lib/components/features/board/delete-confirm-dialog.svelte';
     import CommentForm from '$lib/components/features/board/comment-form.svelte';
     import CommentList from '$lib/components/features/board/comment-list.svelte';
+    import WelcomeStampBar from '$lib/components/features/board/welcome-stamp-bar.svelte';
     import AuthorActivityPanel from '$lib/components/features/board/author-activity-panel.svelte';
     import RecentPosts from '$lib/components/features/board/recent-posts.svelte';
     import AngttConnectCard from '$lib/components/features/board/angtt-connect-card.svelte';
@@ -2403,6 +2404,18 @@
                         postId={data.post.id}
                     />
                     {#if !data.post.is_comments_disabled}
+                        <!-- hello 환영 라운지: 원터치 환영 스탬프 (가입인사 전용 — 폭죽 하드코딩과 같은 결) -->
+                        {#if boardId === 'hello'}
+                            <WelcomeStampBar
+                                {boardId}
+                                {comments}
+                                onSend={(content) => handleCreateComment(content)}
+                                permissions={data.board?.permissions}
+                                requiredCommentLevel={data.board?.comment_level ?? 3}
+                                isRestricted={data.isRestricted}
+                                disabled={isCreatingComment}
+                            />
+                        {/if}
                         <CommentList
                             {comments}
                             onUpdate={handleUpdateComment}

--- a/apps/web/src/routes/admin/boards/[boardId]/+page.svelte
+++ b/apps/web/src/routes/admin/boards/[boardId]/+page.svelte
@@ -41,7 +41,8 @@
         Image,
         Newspaper,
         TableProperties,
-        LayoutDashboard
+        LayoutDashboard,
+        MessagesSquare
     } from '@lucide/svelte/icons';
     import type { Board, BoardGroup } from '$lib/api/types';
     import {
@@ -1048,7 +1049,7 @@
                                 </Card.Description>
                             </Card.Header>
                             <Card.Content class="space-y-3">
-                                {#each [{ id: 'flat', icon: AlignJustify, label: '기본', description: '구분선 없이 평면적으로 나열' }, { id: 'bordered', icon: LayoutGrid, label: '카드형', description: '각 댓글을 테두리가 있는 카드로 표시' }, { id: 'divided', icon: List, label: '구분선형', description: '댓글 사이에 구분선으로 분리' }, { id: 'bubble', icon: MessageCircle, label: '말풍선형', description: '채팅 앱처럼 말풍선 스타일로 표시' }, { id: 'compact', icon: AlignJustify, label: '컴팩트', description: '간격을 줄여 밀집된 레이아웃' }, { id: 'discussion', icon: LayoutDashboard, label: '토론형', description: '차분한 구분선과 여백으로 토론 흐름을 강조' }, { id: 'feed', icon: List, label: '피드형', description: '더 촘촘한 간격으로 빠르게 훑는 흐름' }, { id: 'card', icon: LayoutGrid, label: '카드(뮤지아)', description: '깔끔한 카드형 댓글 (뮤지아 스타일)' }] as layout (layout.id)}
+                                {#each [{ id: 'flat', icon: AlignJustify, label: '기본', description: '구분선 없이 평면적으로 나열' }, { id: 'bordered', icon: LayoutGrid, label: '카드형', description: '각 댓글을 테두리가 있는 카드로 표시' }, { id: 'divided', icon: List, label: '구분선형', description: '댓글 사이에 구분선으로 분리' }, { id: 'bubble', icon: MessageCircle, label: '말풍선형', description: '채팅 앱처럼 말풍선 스타일로 표시' }, { id: 'compact', icon: AlignJustify, label: '컴팩트', description: '간격을 줄여 밀집된 레이아웃' }, { id: 'discussion', icon: LayoutDashboard, label: '토론형', description: '차분한 구분선과 여백으로 토론 흐름을 강조' }, { id: 'feed', icon: List, label: '피드형', description: '더 촘촘한 간격으로 빠르게 훑는 흐름' }, { id: 'card', icon: LayoutGrid, label: '카드(뮤지아)', description: '깔끔한 카드형 댓글 (뮤지아 스타일)' }, { id: 'chat', icon: MessagesSquare, label: '채팅형', description: '카톡처럼 내 댓글은 오른쪽, 상대 댓글은 왼쪽에 표시' }] as layout (layout.id)}
                                     {@const Icon = layout.icon}
                                     <button
                                         type="button"


### PR DESCRIPTION
## 개요

hello(가입인사)를 **환영 라운지**로: 댓글을 카톡형 채팅으로 보여주고(내 댓글=오른쪽, 타인=왼쪽), welcome 팩 앙티콘 **원터치 환영 스탬프**로 이모티콘 온보딩까지 겸한다. 사용자 확정안: hello 전용(A안), 원터치=실제 댓글(글당 1회), 기존 댓글 기능 전부 유지.

`comment-list.svelte`에 이미 구현돼 있던 `commentLayout === 'chat'` 렌더(뷰어 본인 우측 정렬·`→ 대상` 표시·아바타)는 무변경 — **활성화 경로만 개방**한다.

## 변경 사항

| 파일 | 내용 |
|---|---|
| `lib/api/types.ts` | `CommentLayout` 유니온에 `'chat'` 추가 |
| `routes/admin/boards/[boardId]/+page.svelte` | 댓글 레이아웃 피커에 "채팅형" 추가 (MessagesSquare 아이콘) |
| `lib/components/features/board/comment-list.svelte` | `boardId==='hello' && commentLayout==='chat'` 한정: 원글 작성자 배지 "새 앙님 🎈" 리라벨 + 왼쪽 버블 웜톤(amber) 강조. chat 분기 밖 무접촉, `requiredReplyLevel` 전달 경로(#hello-reply) 무접촉 |
| `lib/components/features/board/welcome-stamp-bar.svelte` | 신규. welcome 팩 앙티콘 원터치 → 부모의 기존 `handleCreateComment` 로 실제 댓글(`{emo:welcome-XXX.jpg}`) 등록. 글당 1회(내 스탬프 존재 시 "환영 완료 ✓" 비활성), 비로그인·이용제한·실명인증 미비·댓글권한 미달 시 미노출. 팩 로드는 `onMount`(SSR 상대 URL fetch 방지) |
| `lib/utils/welcome-stamp.ts` (+`.test.ts`) | 스탬프 판정 순수 로직 분리: 단일 토큰 판정(`<p>`/`&nbsp;` 래핑 허용, 토큰+텍스트 혼합=일반 댓글), 내 스탬프 존재 판정(삭제분 제외). vitest 14케이스 |
| `routes/[boardId]/[postId]/+page.svelte` | `boardId==='hello'` 한정 CommentList 위에 스탬프 바 장착 (폭죽 하드코딩 선례와 같은 결) |
| `lib/components/features/board/emoticon-picker.svelte` | `initialPack` prop 신설 — 해당 팩 기본 탭 선택(접힌 범위 밖이면 자동 펼침) |
| `lib/components/features/board/comment-toolbar.svelte` | hello 면 `initialPack='welcome'` 유도해 피커에 전달 (두 호출처 모두 커버) |

welcome 팩 파일명은 라이브 `/api/emoticons/list` 실측: `welcome-001.jpg` ~ `welcome-004.jpg` (prefix `welcome`, 팩명 "환영").

## 범위 밖

- 다른 레이아웃·다른 게시판 변경 없음 (chat/hello 조건 밖 diff 0 — 배지·버블 클래스는 비 hello 경로에서 기존 문자열과 동일)
- Go 백엔드 무수정, DDL 없음
- hello `display_settings.comment_layout='chat'` 설정은 **머지·카나리 검증 후 admin 화면에서** (이 PR 에 DB 변경 없음)

## 검증 방법 (Evaluator)

1. admin > 게시판 설정 > 댓글 레이아웃에서 "채팅형" 선택·저장 동작
2. hello 글상세(chat 설정 후): 내 댓글 우측·타인 좌측, 원글 작성자 버블 amber 강조 + "새 앙님 🎈" 배지, ↪ 대상 표시
3. 스탬프 탭 → 앙티콘 댓글 실제 등록(댓글수 증가, 새로고침 후 렌더 유지), 같은 글 재진입/재탭 시 "환영 완료 ✓" 비활성
4. free 등 chat 미설정 게시판 댓글 렌더 회귀 0 (기존 8개 레이아웃)
5. hello 대댓글 권한(#hello-reply, requiredReplyLevel) 회귀 없음 — 등급2 대댓글 가능 유지
6. chat 버블에서 수정·삭제·신고·추천 메뉴 전부 접근 가능 (기존 chat 렌더 무변경이므로 구조 동일)
7. 비로그인: 스탬프 바 미노출, 댓글 열람 정상
8. `pnpm test:unit -- --run src/lib/utils/welcome-stamp.test.ts` 14케이스 통과 (CI)
