### PR TITLE
feat(hello): 환영 라운지 후속 4종 — ↪ 실표시·새 앙님 오른쪽·하늘색·폭죽 강화

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1081,6 +1081,11 @@
             : null}
         {@const isDiscussion = commentLayout === 'discussion'}
         {@const isFeed = commentLayout === 'feed'}
+        {@const chatRight =
+            commentLayout === 'chat' &&
+            (isHelloLounge
+                ? !postDeleted && !!postAuthorId && comment.author_id === postAuthorId
+                : isAuthor)}
         {@const iconUrl = isDeleted
             ? null
             : getAvatarUrl(
@@ -1134,7 +1139,7 @@
                     ? ''
                     : 'overflow-hidden'} transition-colors duration-200
                 {commentLayout === 'chat'
-                    ? 'flex items-start gap-2.5' + (isAuthor ? ' flex-row-reverse' : '')
+                    ? 'flex items-start gap-2.5' + (chatRight ? ' flex-row-reverse' : '')
                     : isDiscussion
                       ? 'border-border/70 border-b py-4 last:border-b-0'
                       : isFeed
@@ -1210,7 +1215,7 @@
 
                 <div class={commentLayout === 'chat' ? 'min-w-0 max-w-[80%]' : 'min-w-0'}>
                     <!-- Chat: 이름 라벨 + 메모 + IP (타인 댓글만) -->
-                    {#if commentLayout === 'chat' && !isAuthor && !isDeleted}
+                    {#if commentLayout === 'chat' && !chatRight && !isDeleted}
                         <p
                             class="text-foreground mb-1 ml-1 flex items-center gap-1 text-xs font-semibold"
                         >
@@ -1231,7 +1236,7 @@
                                 <!-- hello 환영 라운지: 원글 작성자 = 새로 온 앙님 (chat 이름 라벨 안이라 chat 전용) -->
                                 <span
                                     class="rounded px-1.5 py-0.5 text-[10px] font-semibold {isHelloLounge
-                                        ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+                                        ? 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300'
                                         : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'}"
                                     >{isHelloLounge ? '새 앙님 🎈' : '작성자'}</span
                                 >
@@ -1273,14 +1278,11 @@
                         class={commentLayout === 'chat'
                             ? isDeleted
                                 ? 'bg-muted/50 rounded-xl px-3.5 py-2.5'
-                                : isAuthor
-                                  ? 'bg-primary/10 rounded-xl rounded-br-sm px-3.5 py-2.5'
-                                  : isHelloLounge &&
-                                      !postDeleted &&
-                                      postAuthorId &&
-                                      comment.author_id === postAuthorId
-                                    ? 'rounded-xl rounded-bl-sm border border-amber-300/70 bg-amber-100/70 px-3.5 py-2.5 dark:border-amber-600/40 dark:bg-amber-900/25'
-                                    : 'bg-muted rounded-xl rounded-bl-sm px-3.5 py-2.5'
+                                : chatRight
+                                  ? isHelloLounge
+                                      ? 'rounded-xl rounded-br-sm border border-sky-300/70 bg-sky-100/70 px-3.5 py-2.5 dark:border-sky-600/40 dark:bg-sky-900/25'
+                                      : 'bg-primary/10 rounded-xl rounded-br-sm px-3.5 py-2.5'
+                                  : 'bg-muted rounded-xl rounded-bl-sm px-3.5 py-2.5'
                             : ''}
                     >
                         <div

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1221,6 +1221,12 @@
                                 expandTouchArea
                             />
                             <LevelBadge level={memberLevelStore.getLevel(comment.author_id)} />
+                            {#if replyToAuthor}
+                                <!-- 대댓글 대상 — 기존에는 chat 모드에서 숨겨지는 구 헤더에만 있어 실제로 보이지 않았다 -->
+                                <span class="text-muted-foreground text-xs font-normal"
+                                    >↪ {replyToAuthor}</span
+                                >
+                            {/if}
                             {#if !postDeleted && postAuthorId && comment.author_id === postAuthorId}
                                 <!-- hello 환영 라운지: 원글 작성자 = 새로 온 앙님 (chat 이름 라벨 안이라 chat 전용) -->
                                 <span

--- a/apps/web/src/lib/components/features/board/welcome-stamp-bar.svelte
+++ b/apps/web/src/lib/components/features/board/welcome-stamp-bar.svelte
@@ -7,6 +7,7 @@
         welcomeStampContent
     } from '$lib/utils/welcome-stamp.js';
     import type { BoardPermissions, FreeComment } from '$lib/api/types.js';
+    import { onMount } from 'svelte';
     import { toast } from 'svelte-sonner';
     import Check from '@lucide/svelte/icons/check';
     import Loader2 from '@lucide/svelte/icons/loader-2';
@@ -55,15 +56,19 @@
     // 글당 1회는 클라 판정만 — 우회해도 일반 댓글과 동일 취급이라 서버 강제 불요
     const stamped = $derived(hasStampedWelcome(comments, authStore.user?.mb_id));
 
-    // welcome 팩이 없거나 API 실패면 조용히 미노출 (스탬프는 부가 기능)
-    fetch('/api/emoticons/list')
-        .then((res) => (res.ok ? res.json() : Promise.reject(new Error('API error'))))
-        .then((data: { packs: Array<{ prefix: string; items: EmoticonItem[] }> }) => {
-            stamps = data.packs.find((p) => p.prefix === WELCOME_PACK_PREFIX)?.items ?? [];
-        })
-        .catch(() => {
-            stamps = [];
-        });
+    // welcome 팩이 없거나 API 실패면 조용히 미노출 (스탬프는 부가 기능).
+    // ⛔ onMount 필수 — 이 컴포넌트는 글상세에 정적 import 되므로 스크립트 최상위 fetch 는
+    //    SSR 에서도 실행되고, 상대 URL fetch 가 서버에서 터진다(emoticon-picker 는 lazy 라 무관).
+    onMount(() => {
+        fetch('/api/emoticons/list')
+            .then((res) => (res.ok ? res.json() : Promise.reject(new Error('API error'))))
+            .then((data: { packs: Array<{ prefix: string; items: EmoticonItem[] }> }) => {
+                stamps = data.packs.find((p) => p.prefix === WELCOME_PACK_PREFIX)?.items ?? [];
+            })
+            .catch(() => {
+                stamps = [];
+            });
+    });
 
     async function sendStamp(file: string): Promise<void> {
         if (stamped || sendingFile || disabled) return;

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -199,7 +199,7 @@
     let reactionPluginActive = $derived(pluginStore.isPluginActive('da-reaction'));
 
     import TagNav from '$lib/components/ui/tag-nav/tag-nav.svelte';
-    import { launchCelebrationConfetti } from '$lib/utils/confetti.js';
+    import { launchCelebrationConfetti, launchSidesConfetti } from '$lib/utils/confetti.js';
 
     // 동적 import: member-memo 플러그인 컴포넌트
     import type { Component } from 'svelte';
@@ -938,6 +938,9 @@
         };
     });
 
+    // 가입인사 환영 타이틀 오버레이 표시 여부 (아래 onMount 폭죽과 한 쌍)
+    let showWelcomeTitle = $state(false);
+
     // 가입인사 환영 폭죽 — 신입이 자기 인사글을 처음 열 때 한 번만.
     //
     // 왜 "작성자 + 최초 1회" 인가:
@@ -959,11 +962,18 @@
             // localStorage 불가(시크릿 모드 등)면 중복 방지를 포기하고 그냥 띄운다
         }
 
-        // 페이지가 자리를 잡은 뒤 터뜨린다
+        // 페이지가 자리를 잡은 뒤 폭죽 + 영화 타이틀식 환영 문구를 함께 띄운다
         const t = setTimeout(() => {
             void launchCelebrationConfetti();
+            showWelcomeTitle = true;
         }, 600);
-        return () => clearTimeout(t);
+        const t2 = setTimeout(() => {
+            showWelcomeTitle = false;
+        }, 5000);
+        return () => {
+            clearTimeout(t);
+            clearTimeout(t2);
+        };
     });
 
     // 날짜 포맷 헬퍼
@@ -1564,6 +1574,14 @@
                     comments = [...comments, optimisticComment];
                     commentsTotal = commentsTotal + 1;
                 }
+            }
+
+            // hello 환영 라운지: 환영 댓글을 단 순간 작은 폭죽 — 환영하는 쪽도 즐겁게
+            if (
+                boardId === 'hello' &&
+                !window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+            ) {
+                void launchSidesConfetti();
             }
 
             // 서버에서 정렬된 댓글 목록 다시 가져오기 (중복 제거 포함)
@@ -2745,3 +2763,48 @@
         </a>
     {/if}
 </div>
+
+{#if showWelcomeTitle}
+    <!-- 가입인사 환영 타이틀 — 신입 본인 최초 1회, 폭죽과 함께 (pointer-events 없음 = 조작 방해 0) -->
+    <div
+        class="pointer-events-none fixed inset-0 z-[90] flex flex-col items-center justify-center px-6 text-center"
+    >
+        <p
+            class="dm-welcome-line text-3xl font-extrabold text-sky-500 drop-shadow-lg sm:text-5xl dark:text-sky-300"
+        >
+            환영해요, {data.post.author} 앙님! 🎈
+        </p>
+        <p
+            class="dm-welcome-line dm-welcome-sub text-foreground/80 mt-3 text-base font-medium sm:text-xl"
+        >
+            다모앙 라이프의 시작을 축하해요
+        </p>
+    </div>
+{/if}
+
+<style>
+    .dm-welcome-line {
+        animation: dm-welcome-pop 4.2s ease forwards;
+    }
+    .dm-welcome-sub {
+        animation-delay: 0.25s;
+        opacity: 0;
+    }
+    @keyframes dm-welcome-pop {
+        0% {
+            opacity: 0;
+            transform: translateY(14px) scale(0.92);
+        }
+        12% {
+            opacity: 1;
+            transform: translateY(0) scale(1);
+        }
+        80% {
+            opacity: 1;
+        }
+        100% {
+            opacity: 0;
+            transform: translateY(-8px);
+        }
+    }
+</style>


### PR DESCRIPTION
hello 환영 라운지 후속 — `→ 누구에게`가 chat 모드에서 숨겨지는 구 헤더에만 렌더돼 실제로 보이지 않던 문제. 보이는 이름 라벨에 ↪ 칩 추가 (타 레이아웃 무접촉).