### PR TITLE
feat(angtt): 작품 항목별 평점(aspect rating) — 옵트인 세부 별점·채점표 템플릿

### DIFF
--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -25,6 +25,10 @@
     import DraftList from './draft-list.svelte';
     import TagInput from './tag-input.svelte';
     import { TiptapEditor } from '$lib/components/features/editor/index.js';
+    import {
+        DEFAULT_ASPECTS,
+        buildScorecardTableHtml
+    } from '$plugins/angtt-review/lib/aspect-presets';
     import { FileUploader } from '$lib/components/features/uploader/index.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { apiClient } from '$lib/api/index.js';
@@ -140,6 +144,17 @@
         if (!angttSuggestion) return;
         angttDismissed.add(angttSuggestion.slug);
         angttSuggestion = null;
+    }
+
+    // ── 앙티티 채점표 템플릿(옵트인) ─────────────────────────────────────
+    // 앙티티 연결 상태(제안 칩 [연결] 후 또는 앙티티 태그 존재)에서만 버튼 노출.
+    // 삽입된 표는 자유 편집 — 구조화 저장이 아니라 문화 형성용. 작성폼에서는
+    // 작품 type 을 모르므로 default 프리셋(스토리/완성도/몰입)을 쓴다.
+    let editorRef: TiptapEditor | undefined = $state();
+    const showScorecardButton = $derived(tags.includes(ANGTT_TAG_NAME));
+
+    function insertScorecard(): void {
+        editorRef?.insertContent(buildScorecardTableHtml(DEFAULT_ASPECTS));
     }
 
     // 파일 업로드 상태 (이미지 + 파일 통합)
@@ -775,7 +790,22 @@
             <!-- 내용 입력 (WYSIWYG 에디터) -->
             <div class="space-y-2">
                 <Label for="content">내용 <span class="text-destructive">*</span></Label>
+                {#if showScorecardButton}
+                    <!-- 앙티티 연결 상태에서만 — 미연결 시 DOM 무변화(옵트인 보장) -->
+                    <div class="flex justify-end">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onclick={insertScorecard}
+                            disabled={isLoading}
+                        >
+                            채점표 넣기
+                        </Button>
+                    </div>
+                {/if}
                 <TiptapEditor
+                    bind:this={editorRef}
                     {content}
                     {contentFormat}
                     placeholder={`/ 를 눌러 이미지와 앙티콘을 추가하세요\n\n경어체 사용은 필수이며, 초성 비속어도 이용제한 대상입니다.${board?.insert_content ? `\n\n${board.insert_content}` : ''}`}

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -1233,6 +1233,19 @@
             rawContent = html;
         }
     }
+
+    // 커서 위치에 HTML 콘텐츠 삽입 (외부에서 호출용 — 앙티티 채점표 템플릿 등)
+    export function insertContent(html: string): void {
+        if (editorMode === 'wysiwyg') {
+            editor?.chain().focus().insertContent(html).run();
+        } else if (editorMode === 'markdown') {
+            rawContent = `${rawContent}\n${turndown.turndown(html)}`;
+            void handleRawContentChange();
+        } else {
+            rawContent = `${rawContent}\n${html}`;
+            void handleRawContentChange();
+        }
+    }
 </script>
 
 <div class="tiptap-editor border-input relative rounded-md border {className}">

--- a/apps/web/src/routes/angtt/[slug=entityslug]/+page.server.ts
+++ b/apps/web/src/routes/angtt/[slug=entityslug]/+page.server.ts
@@ -10,6 +10,7 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 import {
+    getEntityAspects,
     getEntityBySlug,
     getEntityConnectedPosts,
     getEntityRating
@@ -23,10 +24,12 @@ export const load: PageServerLoad = async ({ params, locals }) => {
         throw error(404, '작품을 찾을 수 없습니다.');
     }
 
-    const [posts, rating] = await Promise.all([
+    const [posts, rating, aspects] = await Promise.all([
         getEntityConnectedPosts(entity.id, { sort: 'best', limit: 20 }),
-        getEntityRating(entity.id, locals.user?.id)
+        getEntityRating(entity.id, locals.user?.id),
+        // 항목별 평점(옵트인) — idx_target 시크 1쿼리 편승, 0건이면 빈 배열
+        getEntityAspects(entity.id, locals.user?.id)
     ]);
 
-    return { entity, posts, rating };
+    return { entity, posts, rating, aspects };
 };

--- a/apps/web/src/routes/angtt/[slug=entityslug]/+page.svelte
+++ b/apps/web/src/routes/angtt/[slug=entityslug]/+page.svelte
@@ -19,6 +19,7 @@
         RATING_MIN_LEVEL,
         applyOptimisticRating
     } from '$lib/components/features/board/post-rating-logic.js';
+    import { getAspectPreset } from '$plugins/angtt-review/lib/aspect-presets';
 
     const { data }: { data: PageData } = $props();
 
@@ -48,6 +49,7 @@
                 count: data.rating.count,
                 my: data.rating.my ?? 0
             };
+            liveAspects = data.aspects;
         }
     });
 
@@ -150,6 +152,62 @@
             rateError = err instanceof Error ? err.message : '별점 등록에 실패했어요.';
         } finally {
             submitting = false;
+        }
+    }
+
+    // ── 항목별 평점(옵트인) — 총점의 부가 시각, 헤드라인 별점과 완전 병렬 ──
+    /** entity.type → 항목 프리셋 (모르는 type 은 default) */
+    const aspectPreset = $derived(getAspectPreset(entity.type));
+    /** 항목별 집계+본인 값의 클라이언트 소유 상태 — 저장 응답으로 통째 교체 */
+    // svelte-ignore state_referenced_locally
+    let liveAspects = $state(data.aspects);
+    /** 히어로 항목 바 — 집계가 1건이라도 있는 항목만, 프리셋 순서로 */
+    const aspectBars = $derived.by(() => {
+        const byKey = new Map(liveAspects.map((a) => [a.aspect, a]));
+        return aspectPreset.flatMap((def) => {
+            const agg = byKey.get(def.key);
+            return agg && agg.count > 0
+                ? [{ key: def.key, label: def.label, avg: agg.avg, count: agg.count }]
+                : [];
+        });
+    });
+
+    let showAspectRater = $state(false);
+    /** 저장 중인 aspect 키(행별 독립 저장 — 한 번에 한 행) */
+    let aspectSubmitting = $state<string | null>(null);
+    let aspectError = $state('');
+    let aspectHover = $state<{ key: string; star: number } | null>(null);
+
+    /** 본인이 해당 항목에 남긴 별점(없으면 0) */
+    function myAspect(key: string): number {
+        return liveAspects.find((a) => a.aspect === key)?.my ?? 0;
+    }
+    /** 항목 행의 입력 위젯 채움 기준: 호버 중이면 호버 값, 아니면 내 기존 값 */
+    function aspectRowValue(key: string): number {
+        return aspectHover?.key === key ? aspectHover.star : myAspect(key);
+    }
+
+    async function submitAspect(key: string, star: number): Promise<void> {
+        if (aspectSubmitting) return;
+        aspectError = '';
+        aspectSubmitting = key;
+        try {
+            const res = await fetch(`/api/angtt/${entity.slug}/rating/aspects`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({ aspects: { [key]: star } })
+            });
+            const body = (await res.json().catch(() => null)) as {
+                aspects?: { aspect: string; avg: number; count: number; my: number | null }[];
+                error?: string;
+            } | null;
+            if (!res.ok) throw new Error(body?.error || '항목별 평가 저장에 실패했어요.');
+            if (Array.isArray(body?.aspects)) liveAspects = body.aspects;
+        } catch (err) {
+            aspectError = err instanceof Error ? err.message : '항목별 평가 저장에 실패했어요.';
+        } finally {
+            aspectSubmitting = null;
         }
     }
 
@@ -265,6 +323,34 @@
                         </div>
                     {/if}
                 </div>
+                {#if aspectBars.length > 0}
+                    <!-- 항목별 평균(옵트인 세부) — 집계가 1건이라도 있을 때만 표시 -->
+                    <div class="flex w-full flex-col gap-1.5" aria-label="항목별 평균 별점">
+                        {#each aspectBars as bar (bar.key)}
+                            <div class="flex items-center gap-2 text-xs">
+                                <span class="text-muted-foreground w-12 shrink-0 font-semibold"
+                                    >{bar.label}</span
+                                >
+                                <div
+                                    class="h-1.5 flex-1 overflow-hidden rounded-full bg-amber-200/60 dark:bg-amber-900/40"
+                                    aria-hidden="true"
+                                >
+                                    <div
+                                        class="h-full rounded-full bg-amber-500"
+                                        style="width: {(bar.avg / 5) * 100}%"
+                                    ></div>
+                                </div>
+                                <span
+                                    class="text-foreground w-7 shrink-0 text-right font-bold tabular-nums"
+                                    >{bar.avg.toFixed(1)}</span
+                                >
+                                <span class="text-muted-foreground shrink-0 tabular-nums"
+                                    >({bar.count})</span
+                                >
+                            </div>
+                        {/each}
+                    </div>
+                {/if}
             </div>
 
             <div class="mt-4 flex flex-wrap gap-2.5">
@@ -335,6 +421,88 @@
                                 >
                             {/if}
                         </div>
+                        {#if liveRating.my > 0}
+                            <!-- 항목별 평가(옵트인) — 본인 총점이 있을 때만 접힘 버튼 노출 -->
+                            <div class="mt-3 border-t pt-3">
+                                <button
+                                    type="button"
+                                    onclick={() => (showAspectRater = !showAspectRater)}
+                                    aria-expanded={showAspectRater}
+                                    class="text-muted-foreground hover:text-foreground text-sm font-semibold"
+                                >
+                                    {showAspectRater ? '−' : '+'} 항목별로 자세히 평가
+                                </button>
+                                {#if showAspectRater}
+                                    <div class="mt-2.5 flex flex-col gap-1.5">
+                                        {#each aspectPreset as def (def.key)}
+                                            <div class="flex items-center gap-2">
+                                                <span class="w-14 shrink-0 text-sm font-semibold"
+                                                    >{def.label}</span
+                                                >
+                                                <div
+                                                    class="flex items-center"
+                                                    role="radiogroup"
+                                                    aria-label="{def.label} 별점 선택 (1~5점)"
+                                                >
+                                                    {#each RATE_STARS as star (star)}
+                                                        <button
+                                                            type="button"
+                                                            class="p-0.5 text-xl leading-none transition-transform hover:scale-110 disabled:opacity-50"
+                                                            disabled={aspectSubmitting != null}
+                                                            role="radio"
+                                                            aria-checked={myAspect(def.key) ===
+                                                                star}
+                                                            aria-label="{def.label} {star}점"
+                                                            onclick={() =>
+                                                                submitAspect(def.key, star)}
+                                                            onmouseenter={() =>
+                                                                (aspectHover = {
+                                                                    key: def.key,
+                                                                    star
+                                                                })}
+                                                            onmouseleave={() =>
+                                                                (aspectHover = null)}
+                                                            onfocus={() =>
+                                                                (aspectHover = {
+                                                                    key: def.key,
+                                                                    star
+                                                                })}
+                                                            onblur={() => (aspectHover = null)}
+                                                        >
+                                                            <span
+                                                                class={star <=
+                                                                aspectRowValue(def.key)
+                                                                    ? 'text-amber-500'
+                                                                    : 'text-muted-foreground/40'}
+                                                                >★</span
+                                                            >
+                                                        </button>
+                                                    {/each}
+                                                </div>
+                                                {#if myAspect(def.key) > 0}
+                                                    <span
+                                                        class="text-muted-foreground text-xs tabular-nums"
+                                                        >★{myAspect(def.key)}</span
+                                                    >
+                                                {/if}
+                                            </div>
+                                        {/each}
+                                        <p class="text-muted-foreground text-xs">
+                                            별을 누르면 항목마다 바로 저장돼요. 원하는 항목만 남겨도
+                                            됩니다.
+                                        </p>
+                                    </div>
+                                    {#if aspectError}
+                                        <p
+                                            class="mt-2 text-sm text-red-600 dark:text-red-400"
+                                            role="alert"
+                                        >
+                                            {aspectError}
+                                        </p>
+                                    {/if}
+                                {/if}
+                            </div>
+                        {/if}
                     {/if}
                     {#if rateError}
                         <p class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">

--- a/apps/web/src/routes/api/angtt/[slug]/rating/aspects/+server.ts
+++ b/apps/web/src/routes/api/angtt/[slug]/rating/aspects/+server.ts
@@ -1,0 +1,80 @@
+/**
+ * 앙티티 작품 항목별 평점 API — PUT(행별 등록·수정, 부분 입력 허용).
+ *
+ * 총점 별점(../+server.ts)의 부가 경로: 항목별 평가는 "총점의 세부"라는 규약이라
+ * **본인 총점(getEntityRating().my)이 있는 회원만** 허용한다. 저장 규약은
+ * angple_rating_aspects(bo_table='@entity', wr_id=entity_id) — PK 로
+ * 회원당 작품당 항목당 1표 보장. 프리셋(aspect-presets.ts) 화이트리스트 밖
+ * aspect 키·1~5 범위 밖 값은 저장 자체를 거부한다.
+ *
+ * 권한 게이트는 총점과 동일: 로그인 + 앙님💛(mb_level 3) 이상
+ * (RATING_MIN_LEVEL·buildGradeDeniedMessage 재사용, 단일 소스 유지).
+ * 조회는 별도 GET 없이 작품 페이지 SSR(getEntityAspects 편승)이 담당한다.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+    getEntityBySlug,
+    getEntityRating,
+    putEntityAspects
+} from '$plugins/angtt-review/lib/entities.server';
+import { validateAspects } from '$plugins/angtt-review/lib/aspect-presets';
+import { RATING_MIN_LEVEL } from '$lib/components/features/board/post-rating-logic.js';
+import { buildGradeDeniedMessage } from '$lib/utils/board-permissions.js';
+
+/**
+ * PUT /api/angtt/:slug/rating/aspects  body: { aspects: { story: 4, ... } }
+ * 로그인 + 앙님💛(mb_level 3) 이상 + 본인 총점 별점 보유 필요.
+ * 갱신된 { aspects: [{aspect, avg, count, my}] } 반환.
+ */
+export const PUT: RequestHandler = async ({ params, locals, request, setHeaders }) => {
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    // 인증 필수
+    const mbId = locals.user?.id;
+    if (!mbId) {
+        return json({ error: '항목별 평가를 남기려면 로그인이 필요해요.' }, { status: 401 });
+    }
+
+    // 등급 게이트(총점 별점과 동일: 로그인 + mb_level >= RATING_MIN_LEVEL)
+    const level = locals.user?.level ?? 1;
+    if (level < RATING_MIN_LEVEL) {
+        return json(
+            { error: buildGradeDeniedMessage('항목별 평가', RATING_MIN_LEVEL, level) },
+            { status: 403 }
+        );
+    }
+
+    // 본문 파싱
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return json({ error: '요청 본문을 해석할 수 없어요.' }, { status: 400 });
+    }
+    const raw = (body as { aspects?: unknown } | null)?.aspects;
+
+    // 작품 조회
+    const entity = await getEntityBySlug(params.slug);
+    if (!entity || entity.status !== 'active') {
+        return json({ error: '작품을 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    // 프리셋 화이트리스트 + 1~5 범위 검증 (밖이면 전체 거부)
+    const validated = validateAspects(entity.type, raw);
+    if (!validated.ok) {
+        return json({ error: validated.error }, { status: 400 });
+    }
+
+    // 본인 총점 게이트 — 항목별 평가는 총점의 부가라는 규약
+    const rating = await getEntityRating(entity.id, mbId);
+    if (rating.my == null) {
+        return json(
+            { error: '먼저 작품 별점(총점)을 남긴 뒤 항목별 평가를 남길 수 있어요.' },
+            { status: 403 }
+        );
+    }
+
+    const aspects = await putEntityAspects(entity.id, entity.type, mbId, validated.aspects);
+    return json({ aspects });
+};

--- a/plugins/angtt-review/lib/aspect-presets.ts
+++ b/plugins/angtt-review/lib/aspect-presets.ts
@@ -1,0 +1,119 @@
+/**
+ * 앙티티 항목별 평점(aspect rating) — type별 고정 프리셋 (단일 소스)
+ *
+ * 순수 로직만 담는다(DB·SvelteKit 의존 없음) — 서버 라우트·작품 페이지·작성폼이
+ * 모두 이 모듈을 읽어 프리셋/라벨/검증을 공유한다.
+ *
+ * 저장 규약: angple_rating_aspects (bo_table='@entity', wr_id=entity_id,
+ * PK 에 aspect 포함 → 회원당 작품당 항목당 1표). 프리셋 화이트리스트 밖 aspect 는
+ * 저장 자체를 거부해 자유텍스트 오염을 원천 차단한다.
+ *
+ * (angple_entities.meta.aspects 오버라이드는 코드만 열어둔 상태 — 운영 UI 후순위.)
+ */
+
+/** 프리셋 항목 1개: DB 저장 키(영문) + 표시 라벨(한글) */
+export interface AspectDef {
+    key: string;
+    label: string;
+}
+
+const STORY: AspectDef = { key: 'story', label: '스토리' };
+const IMMERSION: AspectDef = { key: 'immersion', label: '몰입' };
+
+/** 영화·드라마·애니메이션: 스토리/연출/연기/영상/음악 */
+const PRESET_SCREEN: AspectDef[] = [
+    STORY,
+    { key: 'directing', label: '연출' },
+    { key: 'acting', label: '연기' },
+    { key: 'visual', label: '영상' },
+    { key: 'music', label: '음악' }
+];
+
+/** 책: 스토리/문장/몰입 */
+const PRESET_BOOK: AspectDef[] = [STORY, { key: 'writing', label: '문장' }, IMMERSION];
+
+/** 웹툰: 스토리/작화/몰입 (책과 같은 구성, 문장 대신 작화) */
+const PRESET_WEBTOON: AspectDef[] = [STORY, { key: 'writing', label: '작화' }, IMMERSION];
+
+/** 게임: 스토리/게임성/그래픽/사운드 */
+const PRESET_GAME: AspectDef[] = [
+    STORY,
+    { key: 'gameplay', label: '게임성' },
+    { key: 'graphics', label: '그래픽' },
+    { key: 'sound', label: '사운드' }
+];
+
+/** 그 외 type(공연·전시 등): 스토리/완성도/몰입 */
+export const DEFAULT_ASPECTS: AspectDef[] = [
+    STORY,
+    { key: 'completeness', label: '완성도' },
+    IMMERSION
+];
+
+/** entity.type → 프리셋 매핑 (여기 없는 type 은 DEFAULT_ASPECTS) */
+const PRESETS_BY_TYPE: Record<string, AspectDef[]> = {
+    movie: PRESET_SCREEN,
+    drama: PRESET_SCREEN,
+    animation: PRESET_SCREEN,
+    book: PRESET_BOOK,
+    webtoon: PRESET_WEBTOON,
+    game: PRESET_GAME
+};
+
+/** entity.type(영문 소문자) → 항목 프리셋. 모르는 type 은 default 프리셋. */
+export function getAspectPreset(type: string): AspectDef[] {
+    return PRESETS_BY_TYPE[type] ?? DEFAULT_ASPECTS;
+}
+
+/** aspect 키 → 해당 type 프리셋의 한글 라벨. 프리셋에 없으면 null. */
+export function getAspectLabel(type: string, key: string): string | null {
+    const def = getAspectPreset(type).find((a) => a.key === key);
+    return def ? def.label : null;
+}
+
+/** 검증 결과: ok=false 면 error 에 사용자 안내 문구 */
+export type AspectValidation =
+    | { ok: true; aspects: Record<string, number> }
+    | { ok: false; error: string };
+
+/**
+ * aspects 입력({story: 4, ...})을 프리셋 화이트리스트로 검증한다.
+ *
+ *  - 프리셋에 있는 키만 수용 — 밖의 키가 하나라도 있으면 전체 거부
+ *  - 값은 숫자만, 반올림 후 1~5 범위 밖이면 거부 (4.4 → 4 수용, 5.6 → 거부)
+ *  - 부분 입력 허용(프리셋 일부 항목만 보내도 됨), 빈 입력은 거부
+ */
+export function validateAspects(type: string, input: unknown): AspectValidation {
+    if (input == null || typeof input !== 'object' || Array.isArray(input)) {
+        return { ok: false, error: '항목별 평가 형식이 올바르지 않아요.' };
+    }
+    const allowed = new Set(getAspectPreset(type).map((a) => a.key));
+    const aspects: Record<string, number> = {};
+    for (const [key, raw] of Object.entries(input as Record<string, unknown>)) {
+        if (!allowed.has(key)) {
+            return { ok: false, error: `평가할 수 없는 항목이에요: ${key}` };
+        }
+        const value = typeof raw === 'number' ? raw : Number(raw);
+        const rounded = Math.round(value);
+        if (!Number.isFinite(value) || rounded < 1 || rounded > 5) {
+            return { ok: false, error: '항목별 별점은 1~5 사이여야 해요.' };
+        }
+        aspects[key] = rounded;
+    }
+    if (Object.keys(aspects).length === 0) {
+        return { ok: false, error: '평가할 항목이 없어요.' };
+    }
+    return { ok: true, aspects };
+}
+
+/**
+ * 본문 채점표 템플릿(자유 편집용) HTML.
+ *
+ * 작성폼의 [채점표 넣기] 버튼이 tiptap 에디터에 삽입한다. 구조화 저장이 아니라
+ * 문화 형성용 — 항목 | 점수(10점 만점) | 한줄평 표를 손으로 채우는 스타일
+ * (free/6780927 KalqTrapZ님 리뷰 형식).
+ */
+export function buildScorecardTableHtml(aspects: AspectDef[]): string {
+    const rows = aspects.map((a) => `<tr><td>${a.label}</td><td> /10</td><td></td></tr>`).join('');
+    return `<table><tbody><tr><th>항목</th><th>점수</th><th>한줄평</th></tr>${rows}</tbody></table>`;
+}

--- a/plugins/angtt-review/lib/entities.server.ts
+++ b/plugins/angtt-review/lib/entities.server.ts
@@ -17,6 +17,7 @@
  */
 import pool from '$lib/server/db';
 import { hasAngttTag, normalizeWorkTitle } from './normalize';
+import { validateAspects } from './aspect-presets';
 
 /** 작품 단위 회원 1표 별점의 저장 규약: 작품 페이지 별점은 bo_table 을 이 상수로 둔다. */
 export const ENTITY_RATING_BO_TABLE = '@entity';
@@ -462,4 +463,89 @@ export async function putEntityRating(
     );
 
     return getEntityRating(entityId, mbId);
+}
+
+/** 항목별 평점 집계 행(+요청자 본인 값) */
+export interface AngttAspectRating {
+    aspect: string;
+    avg: number;
+    count: number;
+    /** 로그인 사용자 본인이 이 항목에 남긴 별점(없으면 null) */
+    my: number | null;
+}
+
+interface AspectAggRow {
+    aspect: string;
+    cnt: number;
+    avg: number | string | null;
+    my: number | null;
+}
+
+/**
+ * 작품 단위 항목별 평점 집계 — aspect별 {avg, count} + 요청자 본인 값.
+ *
+ * angple_rating_aspects 는 (bo_table='@entity', wr_id=entity_id) 규약으로
+ * idx_target/PK 프리픽스 시크 1쿼리. 세부 평가가 0건이면 빈 배열(= UI 미표시,
+ * 옵트인 보장). 총점(angple_post_ratings)과는 완전 병렬 — 여기 값은 헤드라인
+ * 별점에 어떤 영향도 주지 않는다.
+ */
+export async function getEntityAspects(
+    entityId: number,
+    mbId?: string
+): Promise<AngttAspectRating[]> {
+    const [result] = await pool.query(
+        `SELECT aspect, COUNT(*) AS cnt, AVG(rating) AS avg,
+                MAX(CASE WHEN mb_id = ? THEN rating END) AS my
+           FROM angple_rating_aspects
+          WHERE bo_table = ? AND wr_id = ?
+          GROUP BY aspect`,
+        [mbId ?? '', ENTITY_RATING_BO_TABLE, entityId]
+    );
+    return (result as AspectAggRow[]).map((r) => ({
+        aspect: String(r.aspect),
+        avg: Number(r.avg ?? 0),
+        count: Number(r.cnt ?? 0),
+        my: r.my == null ? null : Number(r.my)
+    }));
+}
+
+/**
+ * 작품 단위 항목별 평점 등록/수정 — 행별 UPSERT(회원당 작품당 항목당 1표).
+ *
+ * entity.type 프리셋 화이트리스트 밖 aspect 는 저장 자체를 거부한다(자유텍스트
+ * 오염 원천 차단). 부분 입력 허용 — 프리셋 중 일부 항목만 보내도 된다.
+ * 총점(angple_post_ratings)·비정규화 집계(rating_count/avg)는 건드리지 않는다.
+ *
+ * @throws 검증 실패 시 에러(호출부에서 400 으로 매핑 — putEntityRating 관례).
+ * @returns 갱신된 항목별 집계 — getEntityAspects 재사용.
+ */
+export async function putEntityAspects(
+    entityId: number,
+    entityType: string,
+    mbId: string,
+    input: unknown
+): Promise<AngttAspectRating[]> {
+    const validated = validateAspects(entityType, input);
+    if (!validated.ok) {
+        throw new Error(validated.error);
+    }
+
+    const entries = Object.entries(validated.aspects);
+    const placeholders = entries.map(() => '(?, ?, ?, ?, ?, NOW(3), NOW(3))').join(', ');
+    const params = entries.flatMap(([aspect, rating]) => [
+        ENTITY_RATING_BO_TABLE,
+        entityId,
+        mbId,
+        aspect,
+        rating
+    ]);
+    await pool.query(
+        `INSERT INTO angple_rating_aspects
+            (bo_table, wr_id, mb_id, aspect, rating, created_at, updated_at)
+         VALUES ${placeholders}
+         ON DUPLICATE KEY UPDATE rating = VALUES(rating), updated_at = NOW(3)`,
+        params
+    );
+
+    return getEntityAspects(entityId, mbId);
 }

--- a/plugins/angtt-review/tests/aspect-presets.test.ts
+++ b/plugins/angtt-review/tests/aspect-presets.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+    DEFAULT_ASPECTS,
+    getAspectPreset,
+    getAspectLabel,
+    validateAspects,
+    buildScorecardTableHtml
+} from '../lib/aspect-presets';
+
+/**
+ * 앙티티 항목별 평점 프리셋 — 화이트리스트 검증이 핵심 안전장치.
+ * 프리셋 밖 aspect 가 저장되면 자유텍스트 오염(집계 불능 키 난립)이 시작되므로,
+ * validateAspects 의 "전체 거부" 동작이 무너지면 이 테스트가 깨져야 한다.
+ */
+describe('getAspectPreset — type별 고정 프리셋', () => {
+    it('영화·드라마·애니메이션은 스토리/연출/연기/영상/음악 5항목', () => {
+        for (const type of ['movie', 'drama', 'animation']) {
+            expect(getAspectPreset(type).map((a) => a.key)).toEqual([
+                'story',
+                'directing',
+                'acting',
+                'visual',
+                'music'
+            ]);
+        }
+    });
+
+    it('책·웹툰은 스토리/문장(작화)/몰입 3항목', () => {
+        expect(getAspectPreset('book').map((a) => a.label)).toEqual(['스토리', '문장', '몰입']);
+        expect(getAspectPreset('webtoon').map((a) => a.label)).toEqual(['스토리', '작화', '몰입']);
+        // 키는 공유(writing) — 라벨만 type별로 다르다
+        expect(getAspectPreset('book').map((a) => a.key)).toEqual(
+            getAspectPreset('webtoon').map((a) => a.key)
+        );
+    });
+
+    it('게임은 스토리/게임성/그래픽/사운드 4항목', () => {
+        expect(getAspectPreset('game').map((a) => a.key)).toEqual([
+            'story',
+            'gameplay',
+            'graphics',
+            'sound'
+        ]);
+    });
+
+    it('모르는 type 은 default 프리셋(스토리/완성도/몰입)', () => {
+        for (const type of ['show', 'exhibition', 'netflix', 'documentary', '']) {
+            expect(getAspectPreset(type)).toEqual(DEFAULT_ASPECTS);
+        }
+        expect(DEFAULT_ASPECTS.map((a) => a.key)).toEqual(['story', 'completeness', 'immersion']);
+    });
+});
+
+describe('getAspectLabel — 키 ↔ 라벨', () => {
+    it('type 프리셋 안의 키는 한글 라벨을 돌려준다', () => {
+        expect(getAspectLabel('movie', 'directing')).toBe('연출');
+        expect(getAspectLabel('game', 'gameplay')).toBe('게임성');
+    });
+
+    it('프리셋 밖 키는 null', () => {
+        expect(getAspectLabel('movie', 'gameplay')).toBeNull();
+        expect(getAspectLabel('book', 'directing')).toBeNull();
+    });
+});
+
+describe('validateAspects — 프리셋 화이트리스트 + 1~5 범위', () => {
+    it('부분 입력을 수용한다(프리셋 일부 항목만)', () => {
+        const r = validateAspects('movie', { story: 4 });
+        expect(r).toEqual({ ok: true, aspects: { story: 4 } });
+    });
+
+    it('복수 항목 입력을 수용하고 반올림한다(4.4 → 4)', () => {
+        const r = validateAspects('movie', { story: 4.4, music: 5 });
+        expect(r).toEqual({ ok: true, aspects: { story: 4, music: 5 } });
+    });
+
+    it('프리셋 밖 키가 하나라도 있으면 전체 거부 — 자유텍스트 오염 원천 차단', () => {
+        expect(validateAspects('movie', { story: 4, gameplay: 5 }).ok).toBe(false);
+        expect(validateAspects('book', { hacked: 3 }).ok).toBe(false);
+    });
+
+    it('범위 밖 값 거부(반올림 후 1~5 밖)', () => {
+        expect(validateAspects('movie', { story: 0 }).ok).toBe(false);
+        expect(validateAspects('movie', { story: 6 }).ok).toBe(false);
+        expect(validateAspects('movie', { story: 5.6 }).ok).toBe(false); // round → 6
+        expect(validateAspects('movie', { story: 0.4 }).ok).toBe(false); // round → 0
+        expect(validateAspects('movie', { story: NaN }).ok).toBe(false);
+        expect(validateAspects('movie', { story: '별로' }).ok).toBe(false);
+    });
+
+    it('객체가 아니거나 빈 입력은 거부', () => {
+        expect(validateAspects('movie', null).ok).toBe(false);
+        expect(validateAspects('movie', [4, 5]).ok).toBe(false);
+        expect(validateAspects('movie', 'story=4').ok).toBe(false);
+        expect(validateAspects('movie', {}).ok).toBe(false);
+    });
+});
+
+describe('buildScorecardTableHtml — 본문 채점표 템플릿', () => {
+    it('항목|점수|한줄평 헤더와 항목별 /10 행을 만든다', () => {
+        const html = buildScorecardTableHtml(DEFAULT_ASPECTS);
+        expect(html).toContain('<th>항목</th><th>점수</th><th>한줄평</th>');
+        for (const a of DEFAULT_ASPECTS) {
+            expect(html).toContain(`<tr><td>${a.label}</td><td> /10</td><td></td></tr>`);
+        }
+        // tiptap insertContent 가 그대로 받는 단일 테이블
+        expect(html.startsWith('<table>')).toBe(true);
+        expect(html.endsWith('</table>')).toBe(true);
+    });
+});


### PR DESCRIPTION
## 요약

앙티티 작품에 **항목별 평점(aspect rating)** 을 완전 옵트인으로 추가합니다. free/6780927 (KalqTrapZ님 호프 리뷰)의 손 채점표가 계기 — 정성 리뷰어의 표현 수단으로 포지셔닝하고, 관심 없는 회원에게는 마찰 0을 보장합니다.

총점 별점(`angple_post_ratings`·`UNIFIED_RATING_ROWS`·Go 경로)은 **무수정** — 항목별은 병렬 테이블 `angple_rating_aspects`(DDL 적용 완료, `bo_table='@entity'`, `wr_id=entity_id`, PK로 회원당 작품당 항목당 1표)로 분리했습니다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `plugins/angtt-review/lib/aspect-presets.ts` (신규) | type별 고정 프리셋(영화·드라마·애니=스토리/연출/연기/영상/음악, 책=스토리/문장/몰입, 웹툰=스토리/작화/몰입, 게임=스토리/게임성/그래픽/사운드, 기본=스토리/완성도/몰입), 키↔라벨, `validateAspects`(화이트리스트 밖 키·1~5 범위 밖 값 전체 거부), 채점표 HTML 빌더 — 순수 로직 |
| `plugins/angtt-review/tests/aspect-presets.test.ts` (신규) | 프리셋 해석·라벨·검증·채점표 vitest |
| `plugins/angtt-review/lib/entities.server.ts` | `getEntityAspects`(aspect별 avg·count+본인 값, 1쿼리) / `putEntityAspects`(행별 UPSERT, 부분 입력 허용) |
| `apps/web/src/routes/api/angtt/[slug]/rating/aspects/+server.ts` (신규) | PUT — 로그인 + 앙님💛(mb_level 3) + **본인 총점 별점 보유** 게이트(세부는 총점의 부가 규약) |
| `.../angtt/[slug=entityslug]/+page.server.ts` | SSR 편승 1쿼리(`getEntityAspects`) |
| `.../angtt/[slug=entityslug]/+page.svelte` | 히어로 항목 바(집계 1건 이상일 때만) + rater `[+ 항목별로 자세히 평가]` 접힘(본인 총점 있을 때만, 행별 즉시 저장) |
| `.../editor/tiptap-editor.svelte` | `insertContent(html)` export 신규(wysiwyg/markdown/html 모드별 처리) |
| `.../board/post-form.svelte` | 앙티티 연결 상태(태그 존재)에서만 `[채점표 넣기]` → 항목\|점수(/10)\|한줄평 표 삽입(자유 편집, 구조화 저장 아님) |

## 옵트인 보장

- 세부 평가 0건 → 히어로에 아무것도 추가 렌더되지 않음
- 본인 총점 없음 → 접힘 버튼 자체가 미노출
- 앙티티 미연결 글 → 채점표 버튼 미노출
- 위 상태에서 기존 화면과 DOM 변화 없음 (조건부 블록만 사용)

## 검증 실측

- 순수 로직: `node --experimental-strip-types` 스크립트 전 항목 통과 (프리셋 해석·화이트리스트 거부·범위 거부·반올림·채점표 HTML)
- DB (운영 RDS, 테스트 행 즉시 DELETE 완료 — 잔존 0 확인):
  - 행별 UPSERT → 집계 쿼리 결과 정합 (story avg 3.0(n=2)·my=4, music avg 5.0(n=1))
  - 재-UPSERT 시 rating 갱신 + `updated_at` 변경 확인
  - EXPLAIN: `type=ref, key=PRIMARY, ref=const,const, rows=3` — (bo_table, wr_id) 프리픽스 시크 (idx_target도 possible_keys에 있으며 옵티마이저가 클러스터드 PK 선택)
- 기존 rating 파일(post-rating.svelte, rating/+server.ts, post-rating-logic.ts, UNIFIED_RATING_ROWS) diff 무접촉

## 배포

Evaluator 검증 → 카나리 확인 → prod 다음 묶음 (이 PR은 web-only, DDL은 이미 적용됨)
