### PR TITLE
소모임 게시판 구독 CTA 강화 (구독=사실상 멤버십)

### DIFF
--- a/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
+++ b/apps/web/src/lib/components/features/board/board-subscribe-button.svelte
@@ -11,15 +11,25 @@
     import Bell from '@lucide/svelte/icons/bell';
     import BellOff from '@lucide/svelte/icons/bell-off';
     import Check from '@lucide/svelte/icons/check';
+    import Users from '@lucide/svelte/icons/users';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { toast } from 'svelte-sonner';
+    import { formatMemberCount, subscribeCtaLabel, subscribeCtaTitle } from './subscribe-cta.js';
 
     interface Props {
         boardId: string;
         boardTitle: string;
+        /**
+         * 'icon'(기본) = 기존 벨 아이콘. 모든 일반 게시판에서 그대로 동작(회귀 0).
+         * 'prominent' = 소모임(gr_id='group') 전용 강화 CTA. 라벨 + 구독자수("멤버 N명")를
+         *               항상 노출하고, 마운트 시 구독 상태를 미리 로드한다.
+         */
+        variant?: 'icon' | 'prominent';
     }
 
-    let { boardId, boardTitle }: Props = $props();
+    let { boardId, boardTitle, variant = 'icon' }: Props = $props();
+
+    const isProminent = $derived(variant === 'prominent');
 
     let isSubscribed = $state(false);
     let level = $state<1 | 2 | 3 | null>(null);
@@ -42,6 +52,16 @@
         level = null;
         subscriberCount = 0;
         busy = false;
+    });
+
+    // 소모임(prominent) CTA 는 구독자수·"멤버" 표기를 즉시 보여줘야 하므로, hover 를 기다리지 않고
+    // 마운트/보드 전환 시 상태를 미리 로드한다. 위 리셋 $effect 뒤에 선언해 리셋 후 실행되도록 한다.
+    // 일반 게시판(variant='icon')은 이 경로를 타지 않아 기존 동작 그대로(회귀 0).
+    $effect(() => {
+        void boardId; // 보드 전환 시 재프라임
+        if (isProminent) {
+            primeSubscribeState();
+        }
     });
 
     async function loadSubscribeState(): Promise<void> {
@@ -149,28 +169,58 @@
 <DropdownMenu.Root {onOpenChange}>
     <DropdownMenu.Trigger>
         {#snippet child({ props })}
-            <Button
-                {...props}
-                variant="ghost"
-                size="icon"
-                onmouseenter={primeSubscribeState}
-                onfocus={primeSubscribeState}
-                disabled={loading}
-                aria-label={isSubscribed ? '구독 설정' : '새 글 알림 구독'}
-                title={isSubscribed
-                    ? `'${boardTitle}' 구독 중 (${subscriberCount}명) — 클릭하여 설정`
-                    : `'${boardTitle}' 구독하기 — 새 글 알림 받기${subscriberCount > 0 ? ` (${subscriberCount}명 구독 중)` : ''}`}
-                class="relative h-8 w-8 {isSubscribed
-                    ? 'text-primary hover:text-primary/80'
-                    : 'text-muted-foreground hover:text-primary'}"
-            >
-                <span class="absolute -inset-2"></span>
-                {#if isSubscribed}
-                    <Bell class="h-4 w-4" fill="currentColor" />
-                {:else}
-                    <BellOff class="h-4 w-4" />
-                {/if}
-            </Button>
+            {#if isProminent}
+                <!-- 소모임 전용 강화 CTA: 라벨 + "멤버 N명" 노출로 구독을 멤버십처럼 -->
+                <Button
+                    {...props}
+                    variant={isSubscribed ? 'secondary' : 'default'}
+                    size="sm"
+                    onmouseenter={primeSubscribeState}
+                    onfocus={primeSubscribeState}
+                    disabled={loading}
+                    aria-label={isSubscribed ? '소모임 멤버 · 알림 설정' : '소모임 구독하기'}
+                    title={subscribeCtaTitle(boardTitle, isSubscribed, subscriberCount)}
+                    class="h-8 gap-1.5 px-3"
+                >
+                    {#if isSubscribed}
+                        <Bell class="h-4 w-4" fill="currentColor" />
+                    {:else}
+                        <Users class="h-4 w-4" />
+                    {/if}
+                    <span class="text-sm font-medium">{subscribeCtaLabel(isSubscribed)}</span>
+                    {#if subscriberCount > 0}
+                        <span
+                            class="ml-0.5 border-l pl-1.5 text-xs font-normal opacity-80"
+                            class:border-primary-foreground={!isSubscribed}
+                        >
+                            {formatMemberCount(subscriberCount)}
+                        </span>
+                    {/if}
+                </Button>
+            {:else}
+                <Button
+                    {...props}
+                    variant="ghost"
+                    size="icon"
+                    onmouseenter={primeSubscribeState}
+                    onfocus={primeSubscribeState}
+                    disabled={loading}
+                    aria-label={isSubscribed ? '구독 설정' : '새 글 알림 구독'}
+                    title={isSubscribed
+                        ? `'${boardTitle}' 구독 중 (${subscriberCount}명) — 클릭하여 설정`
+                        : `'${boardTitle}' 구독하기 — 새 글 알림 받기${subscriberCount > 0 ? ` (${subscriberCount}명 구독 중)` : ''}`}
+                    class="relative h-8 w-8 {isSubscribed
+                        ? 'text-primary hover:text-primary/80'
+                        : 'text-muted-foreground hover:text-primary'}"
+                >
+                    <span class="absolute -inset-2"></span>
+                    {#if isSubscribed}
+                        <Bell class="h-4 w-4" fill="currentColor" />
+                    {:else}
+                        <BellOff class="h-4 w-4" />
+                    {/if}
+                </Button>
+            {/if}
         {/snippet}
     </DropdownMenu.Trigger>
     <DropdownMenu.Content align="end" class="w-56">

--- a/apps/web/src/lib/components/features/board/subscribe-cta.test.ts
+++ b/apps/web/src/lib/components/features/board/subscribe-cta.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isGroupBoard,
+    formatMemberCount,
+    subscribeCtaLabel,
+    subscribeCtaTitle
+} from './subscribe-cta.js';
+
+describe('isGroupBoard', () => {
+    it('group_id 가 group 이면 true', () => {
+        expect(isGroupBoard('group')).toBe(true);
+    });
+    it('다른 group_id 는 false — 소모임 아닌 게시판 무영향', () => {
+        expect(isGroupBoard('community')).toBe(false);
+        expect(isGroupBoard('')).toBe(false);
+        expect(isGroupBoard(null)).toBe(false);
+        expect(isGroupBoard(undefined)).toBe(false);
+    });
+});
+
+describe('formatMemberCount', () => {
+    it('양수는 천단위 구분 + "명"', () => {
+        expect(formatMemberCount(0)).toBe('멤버 0명');
+        expect(formatMemberCount(3)).toBe('멤버 3명');
+        expect(formatMemberCount(1234)).toBe('멤버 1,234명');
+    });
+    it('음수/비유한수는 0 으로 방어', () => {
+        expect(formatMemberCount(-5)).toBe('멤버 0명');
+        expect(formatMemberCount(Number.NaN)).toBe('멤버 0명');
+        expect(formatMemberCount(Number.POSITIVE_INFINITY)).toBe('멤버 0명');
+    });
+    it('소수는 내림', () => {
+        expect(formatMemberCount(2.9)).toBe('멤버 2명');
+    });
+});
+
+describe('subscribeCtaLabel', () => {
+    it('구독 여부에 따라 라벨 분기', () => {
+        expect(subscribeCtaLabel(true)).toBe('멤버');
+        expect(subscribeCtaLabel(false)).toBe('소모임 구독');
+    });
+});
+
+describe('subscribeCtaTitle', () => {
+    it('구독 중이면 멤버 상태 문구', () => {
+        expect(subscribeCtaTitle('낚시', true, 12)).toContain('멤버');
+        expect(subscribeCtaTitle('낚시', true, 12)).toContain('낚시');
+        expect(subscribeCtaTitle('낚시', true, 12)).toContain('멤버 12명');
+    });
+    it('미구독이면 가입 유도 문구', () => {
+        expect(subscribeCtaTitle('낚시', false, 0)).toContain('멤버가 되어');
+        expect(subscribeCtaTitle('낚시', false, 0)).toContain('멤버 0명');
+    });
+});

--- a/apps/web/src/lib/components/features/board/subscribe-cta.ts
+++ b/apps/web/src/lib/components/features/board/subscribe-cta.ts
@@ -1,0 +1,38 @@
+/**
+ * 소모임 구독 CTA 문구 유틸 (순수 로직)
+ *
+ * board-subscribe-button.svelte 의 prominent(소모임) 변형에서 사용.
+ * 구독을 "멤버십"처럼 보이게 하는 라벨/구독자수 표기를 순수 함수로 분리해 테스트한다.
+ */
+
+/** 소모임 게시판 여부 — group_id 가 'group' 인 게시판만 CTA 강화 대상 */
+export function isGroupBoard(groupId: string | null | undefined): boolean {
+    return groupId === 'group';
+}
+
+/** 구독자수를 "멤버 N명" 형태로 표기. 음수/비유한수는 0으로 방어. */
+export function formatMemberCount(count: number): string {
+    const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+    return `멤버 ${n.toLocaleString('ko-KR')}명`;
+}
+
+/** 구독 여부에 따른 CTA 라벨 */
+export function subscribeCtaLabel(isSubscribed: boolean): string {
+    return isSubscribed ? '멤버' : '소모임 구독';
+}
+
+/**
+ * prominent 버튼 title(툴팁) 문구.
+ * 구독 중이면 멤버로서 상태를, 아니면 가입 유도를 보여준다.
+ */
+export function subscribeCtaTitle(
+    boardTitle: string,
+    isSubscribed: boolean,
+    subscriberCount: number
+): string {
+    const memberText = formatMemberCount(subscriberCount);
+    if (isSubscribed) {
+        return `'${boardTitle}' 멤버 (${memberText}) — 클릭하여 알림 설정`;
+    }
+    return `'${boardTitle}' 소모임 멤버가 되어 새 글을 받아보세요 (${memberText})`;
+}

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -42,6 +42,7 @@ interface PostsCacheData {
 type ListBoardPayload = Pick<
     Board,
     | 'board_id'
+    | 'group_id'
     | 'subject'
     | 'name'
     | 'list_level'
@@ -119,6 +120,7 @@ function toListBoardPayload(board: Board | null): ListBoardPayload | null {
 
     return {
         board_id: board.board_id,
+        group_id: board.group_id,
         subject: board.subject,
         name: board.name,
         list_level: board.list_level,

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -141,6 +141,9 @@
     // subject(프론트엔드 타입) 또는 name(백엔드 API 응답) 사용
     const boardTitle = $derived(data.board?.subject || data.board?.name || boardId);
 
+    // 소모임(gr_id='group') 게시판이면 구독 버튼을 강화 CTA로 노출한다.
+    const isGroupBoard = $derived(data.board?.group_id === 'group');
+
     // 특수 게시판 타입 감지 (board_type 또는 boardId로 판단)
     const boardType = $derived(
         data.board?.board_type ||
@@ -868,7 +871,11 @@
                         </a>
                     </h1>
                     <BoardFavoriteButton {boardId} {boardTitle} />
-                    <BoardSubscribeButton {boardId} {boardTitle} />
+                    <BoardSubscribeButton
+                        {boardId}
+                        {boardTitle}
+                        variant={isGroupBoard ? 'prominent' : 'icon'}
+                    />
                 </div>
 
                 <div class="flex items-center gap-2">


### PR DESCRIPTION
## 배경
소모임 멤버십 기능은 미구현(`g5_group_member` 폐기, 0행)이고, 유일한 소속 지표는 게시판 **구독**(`g5_board_subscribe`)이다. 구독 토글 인프라(API·버튼·목록·알림설정)는 이미 존재하지만, 소모임 게시판에서 구독 버튼이 **벨 아이콘 하나**라 눈에 띄지 않아 가입 유도가 약하다.

이 PR은 **없는 기능을 새로 짓지 않고**, 기존 구독을 소모임에서 "사실상 멤버십"처럼 보이도록 **CTA만 강화**한다.

## 변경
- **`board-subscribe-button.svelte`**: `variant('icon'|'prominent')` prop 추가.
  - `prominent`(소모임 전용): 벨 아이콘 대신 **라벨("소모임 구독"/"멤버") + 구독자수("멤버 N명")** 를 노출하고, hover 를 기다리지 않고 마운트·보드 전환 시 구독 상태를 미리 로드.
  - `icon`(기본): 기존 벨 드롭다운 그대로 → **일반 게시판 회귀 0**.
  - 구독/해제/단계 변경은 기존 API `/api/boards/[boardId]/subscribe` 그대로 재사용(**신규 API·스키마 없음**).
- **`[boardId]/+page.svelte`**: `data.board.group_id === 'group'` 로 소모임 판별 후 variant 전달.
- **`[boardId]/+page.server.ts`**: `toListBoardPayload` 에 `group_id` 추가 노출(추가 필드 1개, 기존 동작 무영향).
- **`subscribe-cta.ts` + `.test.ts`**: 라벨/멤버수 포맷 순수 함수 + vitest.

## 무해성
- 구독 0이면 라벨만 표시(멤버수 숨김) — 자연스러운 기본 상태.
- 소모임 아닌 게시판은 `variant='icon'` 경로라 완전 무영향.
- 소모임 페이지에서만 마운트 시 구독상태 GET 1회(구독자수 COUNT, 게스트도 count 조회 가능).

## 범위 밖 (후속 작업으로 미룸)
- **구독 피드**("내가 구독한 소모임 새글" 모음) — 제외.
- **구독 소모임 새글 알림** — 제외.
