### PR TITLE
feat(web): 지금 뜨는 소모임 발견 위젯

### DIFF
--- a/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
+++ b/apps/web/src/lib/components/widget-renderer/widget-renderer.svelte
@@ -26,6 +26,7 @@
     import RecommendedWidget from '../../../../../../widgets/recommended/index.svelte';
     import ExploreWidget from '../../../../../../widgets/explore/index.svelte';
     import GivingWidget from '../../../../../../widgets/giving/index.svelte';
+    import TrendingGroupsWidget from '../../../../../../widgets/trending-groups/index.svelte';
 
     interface Props {
         /** 렌더링할 위젯 존 */
@@ -54,7 +55,8 @@
         'emoji-awards': EmojiAwardsWidget,
         recommended: RecommendedWidget,
         explore: ExploreWidget,
-        giving: GivingWidget
+        giving: GivingWidget,
+        'trending-groups': TrendingGroupsWidget
     };
 
     // 존별 위젯 목록

--- a/apps/web/src/lib/constants/default-widgets.ts
+++ b/apps/web/src/lib/constants/default-widgets.ts
@@ -80,11 +80,13 @@ export const DEFAULT_SIDEBAR_WIDGETS: WidgetConfig[] = [
     { id: 'notice', type: 'notice', position: 0, enabled: true },
     { id: 'emoji-awards', type: 'emoji-awards', position: 1, enabled: true },
     { id: 'hidden-gems', type: 'hidden-gems', position: 2, enabled: true },
-    { id: 'celebration', type: 'celebration', position: 3, enabled: true },
+    // 발견 엔진 — 롱테일 소모임 노출 레버(자체 fetch, 활동 0이면 미표시).
+    { id: 'trending-groups', type: 'trending-groups', position: 3, enabled: true },
+    { id: 'celebration', type: 'celebration', position: 4, enabled: true },
     {
         id: 'sidebar-ad-2',
         type: 'ad-slot',
-        position: 4,
+        position: 5,
         enabled: true,
         settings: { position: 'sidebar-2', type: 'image-text', format: 'grid' }
     }

--- a/apps/web/src/routes/api/groups/trending/+server.ts
+++ b/apps/web/src/routes/api/groups/trending/+server.ts
@@ -1,0 +1,23 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { loadTrendingGroups, clampLimit } from '../../../groups/trending-groups-data.js';
+
+/**
+ * GET /api/groups/trending?limit=5
+ * 활동순 상위 소모임(3~5개)을 반환한다. "지금 뜨는 소모임" 사이드바 위젯 전용.
+ * 60초 인메모리/Redis 캐시 + 60초 HTTP 캐시(swr 120)로 read 부하를 억제한다.
+ */
+export const GET: RequestHandler = async ({ url }) => {
+    const limit = clampLimit(url.searchParams.get('limit'));
+
+    try {
+        const items = await loadTrendingGroups(limit);
+        return json(
+            { items },
+            { headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=120' } }
+        );
+    } catch (err) {
+        console.error('[api/groups/trending] error:', err);
+        return json({ items: [] }, { status: 500 });
+    }
+};

--- a/apps/web/src/routes/groups/trending-groups-data.ts
+++ b/apps/web/src/routes/groups/trending-groups-data.ts
@@ -41,10 +41,13 @@ const trendingCache = new TieredCache<TrendingGroup[]>('group-trending', 60_000,
  */
 export async function loadTrendingGroups(limit = MAX_LIMIT): Promise<TrendingGroup[]> {
     const n = clampLimit(limit);
-    const cacheKey = `top:${n}`;
-    const cached = await trendingCache.get(cacheKey);
-    if (cached) return cached;
+    // getOrFetch = singleflight. 60초 만료 순간 홈 최고 트래픽에서 동시 미스가
+    // 몰려도 factory 는 1회만 실행된다(thundering herd 방지). 홈/사이드바에 곱해지는
+    // 위치라 수동 get/set 대신 반드시 이걸 쓴다(2026-07-22 IOPS 민감도 교훈).
+    return trendingCache.getOrFetch(`top:${n}`, () => computeTrendingGroups(n));
+}
 
+async function computeTrendingGroups(n: number): Promise<TrendingGroup[]> {
     // 1) 소모임별 주간/오늘 글수 집계 (subscriber 조인 제외 — 경량).
     //    groups 페이지와 동일한 인덱스 시크 경로(bn_datetime range + bo_table group by).
     const [aggRows] = await readPool.query<RowDataPacket[]>(
@@ -78,12 +81,14 @@ export async function loadTrendingGroups(limit = MAX_LIMIT): Promise<TrendingGro
     );
 
     if (ranked.length === 0) {
-        await trendingCache.set(cacheKey, []);
         return [];
     }
 
     // 2) 상위 N 소모임의 최신 루트글 1건씩 조회 (제목 표시용).
-    //    g5_board_new 는 board_new 인덱스로 bo_table IN + wr_parent=wr_id 시크.
+    //    board_new 인덱스로 bo_table IN + wr_parent=wr_id range 시크 후 최신순.
+    //    N=3~5개 소량이라 boundedness 문제 없음. (상관 서브쿼리 MAX 로 바꾸면
+    //    g5_board_new 대형 테이블에서 보드별 스캔이 돌아 오히려 2분+ — 2026-07-23
+    //    EXPLAIN 실측으로 폐기. 앱측 첫 등장 방식 유지.)
     const topTables = ranked.map((r) => r.bo_table);
     const latestByTable = new Map<string, { wr_id: number; bn_datetime: string }>();
     try {
@@ -143,6 +148,5 @@ export async function loadTrendingGroups(limit = MAX_LIMIT): Promise<TrendingGro
         };
     });
 
-    await trendingCache.set(cacheKey, result);
     return result;
 }

--- a/apps/web/src/routes/groups/trending-groups-data.ts
+++ b/apps/web/src/routes/groups/trending-groups-data.ts
@@ -1,0 +1,148 @@
+/**
+ * "지금 뜨는 소모임" 발견 위젯 데이터 모듈
+ *
+ * 소모임(g5_board.gr_id='group') 중 최근 활동이 활발한 상위 N개를 집계한다.
+ * groups/+page.server.ts 의 집계와 동일 소스(g5_board + g5_board_new)를 재사용하되,
+ * 무거운 subscriber(g5_board_subscribe) 조인은 제외해 read 경로 부하를 최소화한다.
+ *
+ * 순수 랭킹 로직은 trending-groups-rank.ts 로 분리(vitest 단독 검증).
+ */
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+import { TieredCache } from '$lib/server/cache.js';
+import { fetchPostDetails } from './groups-data.js';
+import {
+    rankTrendingGroups,
+    clampLimit,
+    MAX_LIMIT,
+    type TrendingGroupRow
+} from './trending-groups-rank.js';
+
+export { clampLimit } from './trending-groups-rank.js';
+
+export interface TrendingGroup {
+    bo_table: string;
+    /** 소문자 정규화 링크 경로 (라우트에서 canonical redirect 처리) */
+    board_path: string;
+    bo_subject: string;
+    weekly_count: number;
+    today_count: number;
+    /** 최신 루트글 (없으면 null → 위젯에서 제목 줄 생략) */
+    latest_wr_id: number | null;
+    latest_subject: string | null;
+}
+
+/** 위젯 캐시: L1 60초, L2(Redis) 120초 */
+const trendingCache = new TieredCache<TrendingGroup[]>('group-trending', 60_000, 120, 1);
+
+/**
+ * 활동순 상위 N개 소모임을 최신글 제목과 함께 반환한다.
+ * 실패/빈 결과는 [] 로 graceful — 위젯은 활동 0이면 렌더하지 않는다.
+ */
+export async function loadTrendingGroups(limit = MAX_LIMIT): Promise<TrendingGroup[]> {
+    const n = clampLimit(limit);
+    const cacheKey = `top:${n}`;
+    const cached = await trendingCache.get(cacheKey);
+    if (cached) return cached;
+
+    // 1) 소모임별 주간/오늘 글수 집계 (subscriber 조인 제외 — 경량).
+    //    groups 페이지와 동일한 인덱스 시크 경로(bn_datetime range + bo_table group by).
+    const [aggRows] = await readPool.query<RowDataPacket[]>(
+        `SELECT b.bo_table, b.bo_subject,
+                IFNULL(w.cnt, 0) AS weekly_count,
+                IFNULL(t.cnt, 0) AS today_count
+         FROM g5_board b
+         LEFT JOIN (
+             SELECT bo_table, COUNT(*) AS cnt
+             FROM g5_board_new
+             WHERE bn_datetime >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+             GROUP BY bo_table
+         ) w ON w.bo_table = b.bo_table
+         LEFT JOIN (
+             SELECT bo_table, COUNT(*) AS cnt
+             FROM g5_board_new
+             WHERE bn_datetime >= CURDATE()
+             GROUP BY bo_table
+         ) t ON t.bo_table = b.bo_table
+         WHERE b.gr_id = 'group'`
+    );
+
+    const ranked = rankTrendingGroups(
+        (aggRows as RowDataPacket[]).map<TrendingGroupRow>((r) => ({
+            bo_table: r.bo_table as string,
+            bo_subject: r.bo_subject as string,
+            weekly_count: Number(r.weekly_count) || 0,
+            today_count: Number(r.today_count) || 0
+        })),
+        n
+    );
+
+    if (ranked.length === 0) {
+        await trendingCache.set(cacheKey, []);
+        return [];
+    }
+
+    // 2) 상위 N 소모임의 최신 루트글 1건씩 조회 (제목 표시용).
+    //    g5_board_new 는 board_new 인덱스로 bo_table IN + wr_parent=wr_id 시크.
+    const topTables = ranked.map((r) => r.bo_table);
+    const latestByTable = new Map<string, { wr_id: number; bn_datetime: string }>();
+    try {
+        const [refRows] = await readPool.query<RowDataPacket[]>(
+            `SELECT n.bo_table, n.wr_id, n.bn_datetime
+             FROM g5_board_new n
+             JOIN g5_board b ON b.bo_table = n.bo_table AND b.gr_id = 'group'
+             WHERE n.bo_table IN (?) AND n.wr_parent = n.wr_id
+             ORDER BY n.bn_datetime DESC`,
+            [topTables]
+        );
+        for (const row of refRows as RowDataPacket[]) {
+            const table = row.bo_table as string;
+            // ORDER BY 최신순 → 각 게시판의 첫 등장이 최신글.
+            if (!latestByTable.has(table)) {
+                latestByTable.set(table, {
+                    wr_id: row.wr_id as number,
+                    bn_datetime: row.bn_datetime as string
+                });
+            }
+        }
+    } catch (err) {
+        console.error('[groups/trending] latest ref 조회 에러:', err);
+    }
+
+    // 최신글 제목 조회 (동적 g5_write_ 테이블 + 이용제한 마스킹 재사용).
+    const refs = ranked
+        .map((r) => {
+            const latest = latestByTable.get(r.bo_table);
+            if (!latest) return null;
+            return {
+                bo_table: r.bo_table,
+                bo_subject: r.bo_subject,
+                wr_id: latest.wr_id,
+                mb_id: '',
+                bn_datetime: latest.bn_datetime
+            };
+        })
+        .filter((x): x is NonNullable<typeof x> => x !== null);
+
+    const details = await fetchPostDetails(refs);
+    const subjectByTable = new Map<string, { wr_id: number; wr_subject: string }>();
+    for (const d of details) {
+        subjectByTable.set(d.bo_table, { wr_id: d.wr_id, wr_subject: d.wr_subject });
+    }
+
+    const result: TrendingGroup[] = ranked.map((r) => {
+        const latest = subjectByTable.get(r.bo_table);
+        return {
+            bo_table: r.bo_table,
+            board_path: r.bo_table.toLowerCase(),
+            bo_subject: r.bo_subject,
+            weekly_count: r.weekly_count,
+            today_count: r.today_count,
+            latest_wr_id: latest?.wr_id ?? null,
+            latest_subject: latest?.wr_subject ?? null
+        };
+    });
+
+    await trendingCache.set(cacheKey, result);
+    return result;
+}

--- a/apps/web/src/routes/groups/trending-groups-rank.test.ts
+++ b/apps/web/src/routes/groups/trending-groups-rank.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { rankTrendingGroups, clampLimit, type TrendingGroupRow } from './trending-groups-rank';
+
+function row(bo_table: string, weekly: number, today = 0, subject = bo_table): TrendingGroupRow {
+    return { bo_table, bo_subject: subject, weekly_count: weekly, today_count: today };
+}
+
+describe('clampLimit', () => {
+    it('3~5 범위 안의 값은 그대로 통과', () => {
+        expect(clampLimit(3)).toBe(3);
+        expect(clampLimit(4)).toBe(4);
+        expect(clampLimit(5)).toBe(5);
+    });
+
+    it('하한 미만은 3으로, 상한 초과는 5로 수렴', () => {
+        expect(clampLimit(1)).toBe(3);
+        expect(clampLimit(0)).toBe(3);
+        expect(clampLimit(-10)).toBe(3);
+        expect(clampLimit(99)).toBe(5);
+    });
+
+    it('숫자 문자열은 파싱, 잘못된 값은 상한(5)으로 안전 수렴', () => {
+        expect(clampLimit('4')).toBe(4);
+        expect(clampLimit('abc')).toBe(5);
+        expect(clampLimit(null)).toBe(5);
+        expect(clampLimit(undefined)).toBe(5);
+        expect(clampLimit(NaN)).toBe(5);
+    });
+});
+
+describe('rankTrendingGroups', () => {
+    it('주간 글수 내림차순으로 정렬한다', () => {
+        const result = rankTrendingGroups([row('a', 3), row('b', 10), row('c', 7)], 5);
+        expect(result.map((r) => r.bo_table)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('주간 글수 0(활동 없음) 소모임은 제외한다', () => {
+        const result = rankTrendingGroups([row('a', 0), row('b', 5), row('c', 0)], 5);
+        expect(result.map((r) => r.bo_table)).toEqual(['b']);
+    });
+
+    it('모두 활동 0이면 빈 배열 → 위젯 미표시(폴백)', () => {
+        expect(rankTrendingGroups([row('a', 0), row('b', 0)], 5)).toEqual([]);
+    });
+
+    it('주간 동점이면 오늘 글수 내림차순으로 우선한다', () => {
+        const result = rankTrendingGroups([row('a', 5, 1), row('b', 5, 4), row('c', 5, 2)], 5);
+        expect(result.map((r) => r.bo_table)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('주간·오늘 모두 동점이면 이름 오름차순으로 안정 정렬한다', () => {
+        const result = rankTrendingGroups(
+            [row('z', 5, 2, '지읒'), row('a', 5, 2, '가나'), row('m', 5, 2, '마바')],
+            5
+        );
+        expect(result.map((r) => r.bo_subject)).toEqual(['가나', '마바', '지읒']);
+    });
+
+    it('limit 을 3~5 범위로 제한해 상위 N개만 반환한다', () => {
+        const rows = [row('a', 9), row('b', 8), row('c', 7), row('d', 6), row('e', 5), row('f', 4)];
+        expect(rankTrendingGroups(rows, 3)).toHaveLength(3);
+        expect(rankTrendingGroups(rows, 5)).toHaveLength(5);
+        // 상한 초과 요청은 5로 수렴
+        expect(rankTrendingGroups(rows, 99)).toHaveLength(5);
+        // 하한 미만 요청은 3으로 수렴
+        expect(rankTrendingGroups(rows, 1)).toHaveLength(3);
+    });
+
+    it('입력 배열을 변형하지 않는다(순수 함수)', () => {
+        const rows = [row('a', 3), row('b', 10)];
+        const snapshot = rows.map((r) => r.bo_table);
+        rankTrendingGroups(rows, 5);
+        expect(rows.map((r) => r.bo_table)).toEqual(snapshot);
+    });
+});

--- a/apps/web/src/routes/groups/trending-groups-rank.ts
+++ b/apps/web/src/routes/groups/trending-groups-rank.ts
@@ -1,0 +1,51 @@
+/**
+ * "지금 뜨는 소모임" 순수 랭킹 로직
+ *
+ * DB / 서버 모듈을 import 하지 않는 순수 함수만 모아 vitest 단독 검증이 가능하도록 분리한다.
+ * (trending-groups-data.ts 가 이 모듈을 재사용한다.)
+ */
+
+export interface TrendingGroupRow {
+    bo_table: string;
+    bo_subject: string;
+    weekly_count: number;
+    today_count: number;
+}
+
+/** 위젯 표시 개수 하한/상한 (요구: 3~5개) */
+export const MIN_LIMIT = 3;
+export const MAX_LIMIT = 5;
+
+/**
+ * limit 값을 3~5 범위로 정규화한다.
+ *
+ * - 값이 없거나(null·undefined·빈 문자열) 파싱 불가(NaN)면 기본값 상한(5)으로 수렴
+ *   → API 에서 `?limit=` 미지정 시 기본 5개.
+ * - 숫자면 3~5 범위로 클램프(0·1·2 → 3, 6+ → 5, 음수 → 3).
+ */
+export function clampLimit(raw: number | string | null | undefined): number {
+    if (raw === null || raw === undefined || raw === '') return MAX_LIMIT;
+    const v = Math.floor(Number(raw));
+    if (!Number.isFinite(v)) return MAX_LIMIT;
+    return Math.min(MAX_LIMIT, Math.max(MIN_LIMIT, v));
+}
+
+/**
+ * 소모임을 활동순으로 정렬하고 상위 N개를 고른다.
+ *
+ * - 활동 0(주간 글 0건) 소모임은 제외 → 위젯이 죽은 소모임을 노출하지 않는다.
+ * - 정렬: 주간 글수 desc → 오늘 글수 desc → 이름 asc(동점 안정 정렬).
+ */
+export function rankTrendingGroups(rows: TrendingGroupRow[], limit: number): TrendingGroupRow[] {
+    const n = clampLimit(limit);
+    return rows
+        .filter((r) => (r.weekly_count ?? 0) > 0)
+        .slice()
+        .sort(
+            (a, b) =>
+                (b.weekly_count ?? 0) - (a.weekly_count ?? 0) ||
+                (b.today_count ?? 0) - (a.today_count ?? 0) ||
+                a.bo_subject.localeCompare(b.bo_subject)
+        )
+        .slice(0, n);
+}

--- a/widgets/trending-groups/index.svelte
+++ b/widgets/trending-groups/index.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+    /**
+     * 지금 뜨는 소모임 — 최근 활동이 활발한 소모임을 소개하는 발견 위젯.
+     * 소수 인기 소모임에 쏠린 활동을 롱테일 소모임으로 분산시키기 위한 노출 레버.
+     *
+     * 자체 fetch(/api/groups/trending) — SSR prefetch 불필요 → 홈 SSR 경로 무변경(회귀 0).
+     * 활동 0(빈 결과)이면 아무것도 렌더하지 않는다(hidden-gems·emoji-awards 와 동일 패턴).
+     */
+    import type { WidgetProps } from '$lib/types/widget-props';
+    import { onMount } from 'svelte';
+    import Flame from '@lucide/svelte/icons/flame';
+    import { timedFetch } from '$lib/utils/timed-fetch';
+    import { trackEvent } from '$lib/services/ga4.js';
+
+    let { config }: WidgetProps = $props();
+
+    interface TrendingGroupItem {
+        bo_table: string;
+        board_path: string;
+        bo_subject: string;
+        weekly_count: number;
+        today_count: number;
+        latest_wr_id: number | null;
+        latest_subject: string | null;
+    }
+
+    const itemCount = $derived(
+        Math.min(
+            5,
+            Math.max(
+                3,
+                Number((config?.settings as Record<string, unknown> | undefined)?.item_count ?? 5)
+            )
+        )
+    );
+
+    let items = $state<TrendingGroupItem[]>([]);
+
+    onMount(async () => {
+        try {
+            const res = await timedFetch(`/api/groups/trending?limit=${itemCount}`);
+            if (res.ok) {
+                const data = await res.json();
+                items = ((data.items ?? []) as TrendingGroupItem[]).slice(0, itemCount);
+            }
+        } catch {
+            // 무해 실패 — 위젯 미표시
+        }
+    });
+
+    function handleGroupClick(item: TrendingGroupItem): void {
+        trackEvent('trending_group_click', { board: item.bo_table, target: 'group' });
+    }
+
+    function handlePostClick(item: TrendingGroupItem): void {
+        trackEvent('trending_group_click', { board: item.bo_table, target: 'post' });
+    }
+</script>
+
+{#if items.length > 0}
+    <div class="bg-card rounded-lg border p-4">
+        <div class="mb-3 flex items-center justify-between">
+            <h3 class="flex items-center gap-1.5 text-sm font-semibold">
+                <Flame class="h-4 w-4 text-orange-500" />
+                지금 뜨는 소모임
+            </h3>
+            <a href="/groups" class="text-muted-foreground hover:text-primary text-xs">전체보기</a>
+        </div>
+        <ul class="space-y-2.5">
+            {#each items as item (item.bo_table)}
+                <li class="min-w-0">
+                    <div class="flex items-center gap-2">
+                        <a
+                            href={`/${item.board_path}`}
+                            class="hover:text-primary truncate text-sm font-medium"
+                            onclick={() => handleGroupClick(item)}
+                        >
+                            {item.bo_subject}
+                        </a>
+                        <span class="text-muted-foreground shrink-0 text-xs">
+                            주 {item.weekly_count}
+                        </span>
+                    </div>
+                    {#if item.latest_subject && item.latest_wr_id}
+                        <a
+                            href={`/${item.board_path}/${item.latest_wr_id}`}
+                            class="text-muted-foreground hover:text-primary block truncate text-xs"
+                            onclick={() => handlePostClick(item)}
+                        >
+                            {item.latest_subject}
+                        </a>
+                    {/if}
+                </li>
+            {/each}
+        </ul>
+    </div>
+{/if}

--- a/widgets/trending-groups/widget.json
+++ b/widgets/trending-groups/widget.json
@@ -1,0 +1,21 @@
+{
+    "id": "trending-groups",
+    "name": "지금 뜨는 소모임",
+    "version": "1.0.0",
+    "description": "최근 활동이 활발한 소모임을 소개해 롱테일 소모임의 발견을 돕는 위젯",
+    "author": { "name": "Angple" },
+    "category": "content",
+    "slots": ["sidebar", "main"],
+    "icon": "Flame",
+    "allowMultiple": false,
+    "main": "index.svelte",
+    "settings": {
+        "item_count": {
+            "type": "number",
+            "label": "표시 개수",
+            "default": 5,
+            "min": 3,
+            "max": 5
+        }
+    }
+}


### PR DESCRIPTION
## 배경

소모임(gnuboard 게시판 그룹, `g5_board.gr_id='group'`)은 90개 중 63개가 활성이지만 car/stock/ai 등 소수에 활동이 쏠려 있고 ~80개 롱테일이 방치돼 있다. 소모임엔 별도 가입 기능이 없어 **발견성**만 높이면 롱테일이 노출을 회복할 수 있다.

이 PR은 "지금 뜨는 소모임" 사이드바 발견 위젯을 추가해, 최근 활동이 활발한 소모임 3~5개를 홈 사이드바에 상시 노출한다. hidden-gems("이런 게시판도 있어요")·emoji-awards("오늘의 앙모지")와 같은 발견 엔진 계열에 합류한다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `widgets/trending-groups/{widget.json,index.svelte}` | 사이드바 위젯. `/api/groups/trending` 자체 fetch. 활동 0(빈 결과)이면 `{#if}` 가드로 렌더하지 않음 |
| `routes/api/groups/trending/+server.ts` | `GET ?limit=5` → 활동순 상위 N개. HTTP 캐시 `max-age=60, swr=120` |
| `routes/groups/trending-groups-data.ts` | 집계 로직. `g5_board + g5_board_new` 재사용(subscriber 조인 제외로 경량). 상위 N개 최신글 제목 1건. L1 60초 / L2(Redis) 120초 캐시 |
| `routes/groups/trending-groups-rank.ts` | 순수 랭킹/클램프 로직(서버 import 없음 → vitest 단독 검증) |
| `routes/groups/trending-groups-rank.test.ts` | 정렬·활동0 제외·동점 tiebreak·limit 클램프 단위 테스트 |
| `constants/default-widgets.ts` | `DEFAULT_SIDEBAR_WIDGETS` 에 등록(hidden-gems 아래) |
| `components/widget-renderer/widget-renderer.svelte` | STATIC 매핑 등록(SSR 폴백) |

## 설계 근거

- **위치 = 사이드바(자체 fetch)**: 홈 `+page.server.ts` SSR 경로를 건드리지 않아 홈 회귀 0. `panel.svelte` 는 사이드바 위젯에 prefetchDataMap 을 넘기지 않으므로(giving·notice 선례) 위젯이 자체 fetch 하는 것이 정합적이다. `WidgetProps` 도 "자체 fetch 또는 SSR prefetch" 를 명시.
- **활동순 = 주간 글수 desc → 오늘 글수 desc → 이름 asc**. 주간 글수 0(죽은 소모임)은 제외.
- **read 부하**: 집계 쿼리는 groups 페이지의 검증된 쿼리와 동일 구조(subscriber 조인만 제외). `bn_datetime` range → `bo_table` group by. 최신글 제목은 상위 N개(3~5) 게시판만 `IN` 시크. 다층 캐시로 원본 쿼리는 분당 1회 수준.
- **무해/폴백**: 모든 실패·빈 결과는 `[]` → 위젯 미표시. 기존 홈 레이아웃 회귀 0.

## 클릭 이동

- 소모임 이름 → `/{board_path}` (소문자 정규화, 라우트 canonical redirect)
- 최신글 제목 → `/{board_path}/{wr_id}`
- 전체보기 → `/groups`

## 검증

- `trending-groups-rank.test.ts`: 순수 로직 8종(정렬/필터/동점/클램프/불변성). CI(vitest server 프로젝트)에서 실행.
- 랭킹·클램프 로직은 독립 스크립트로 기대 출력 일치 확인.
