### PR TITLE
feat(home): 공감글↔모아보기 교차 중복 제거

### DIFF
--- a/apps/web/src/lib/components/features/explore/explore-preview.svelte
+++ b/apps/web/src/lib/components/features/explore/explore-preview.svelte
@@ -17,9 +17,12 @@
 
     interface Props {
         prefetchData?: { data: ExploreData } | unknown;
+        // 공감글(RecommendedPosts)에 이미 뜬 글 id — 모아보기에서 제외해 홈 중복 노출 방지.
+        // 공감글 우선 규칙: 같은 글이 양쪽에 걸리면 공감글에만 남기고 여기선 뺀다.
+        excludeIds?: Set<number>;
     }
 
-    const { prefetchData }: Props = $props();
+    const { prefetchData, excludeIds }: Props = $props();
 
     const ssrData = prefetchData as { data: ExploreData } | undefined;
     let exploreData = $state<ExploreData | null>(ssrData?.data ?? null);
@@ -53,7 +56,12 @@
         } else {
             posts = modeData.posts ?? [];
         }
-        return posts.filter((p) => !blockedUsersStore.isBlocked(p.author)).slice(0, PREVIEW_COUNT);
+        // 차단 사용자 제외 + 공감글 중복 제외 후 PREVIEW_COUNT 로 채운다
+        // (제외를 slice 앞에 둬야 빠진 만큼 다른 글로 채워져 목록이 빈약해지지 않음).
+        return posts
+            .filter((p) => !blockedUsersStore.isBlocked(p.author))
+            .filter((p) => !excludeIds || !excludeIds.has(p.id))
+            .slice(0, PREVIEW_COUNT);
     });
 
     async function loadExploreData(): Promise<void> {

--- a/widgets/empathy-explore-row/index.svelte
+++ b/widgets/empathy-explore-row/index.svelte
@@ -4,6 +4,7 @@
      * PC(lg+): 나란히 배치, 모바일: 세로 스택
      */
     import type { WidgetProps } from '$lib/types/widget-props';
+    import type { RecommendedData } from '$lib/api/types.js';
     import { RecommendedPosts } from '$lib/components/features/recommended';
     import ExplorePreview from '$lib/components/features/explore/explore-preview.svelte';
 
@@ -12,14 +13,28 @@
     const typedData = $derived(
         prefetchData as
             | {
-                  recommended?: { data: unknown; period: unknown };
+                  recommended?: { data: RecommendedData; period: unknown };
                   explore?: { data: unknown };
               }
             | undefined
     );
+
+    // 공감글(왼쪽)에 이미 노출된 글 id 집합 → 모아보기(오른쪽)에서 제외.
+    // 공감글 우선: 같은 글이 양쪽에 걸리면 공감글에만 남긴다(중복 노출 방지).
+    // SSR prefetch 기준(초기 렌더=사용자가 실제로 보는 화면). 공감글 탭을 바꾸면
+    // 집합은 그대로지만, 첫 화면 중복 제거가 목적이라 무해.
+    const recommendedIds = $derived.by(() => {
+        const sections = typedData?.recommended?.data?.sections;
+        if (!sections) return undefined;
+        const ids = new Set<number>();
+        for (const section of Object.values(sections)) {
+            for (const post of section?.posts ?? []) ids.add(post.id);
+        }
+        return ids;
+    });
 </script>
 
 <div class="grid grid-cols-1 gap-2 lg:grid-cols-2">
     <RecommendedPosts prefetchData={typedData?.recommended} />
-    <ExplorePreview prefetchData={typedData?.explore} />
+    <ExplorePreview prefetchData={typedData?.explore} excludeIds={recommendedIds} />
 </div>


### PR DESCRIPTION
홈에서 같은 글이 공감글 위젯과 모아보기 위젯에 **동시에 떠서 두 번 보이던** 문제(예: free/6779536) 수정.

## 무엇
- 결합 위젯 `empathy-explore-row`가 공감글(RecommendedPosts) 노출 글 id 집합을 모아보기(ExplorePreview)에 `excludeIds`로 전달 → 모아보기에서 중복 제거
- **공감글 우선**: 같은 글이 양쪽에 걸리면 공감글에만 남기고 모아보기에서 뺌
- 제외를 `slice(PREVIEW_COUNT=17)` **앞**에 둬 빠진 만큼 다른 글로 채워짐(목록 빈약화 없음)

## 안전
- `excludeIds` 미전달 시 기존 동작 그대로(회귀 0). SSR prefetch 기준이라 첫 화면(사용자가 실제 보는) 중복 제거
- ⚠️ 어제 홈 크래시(each_key_duplicate)와는 별개 — 그건 리스트 내부 중복(크래시), 이건 위젯 간 중복(표시). 둘 다 정리됨