### PR TITLE
feat(giving): 나눔 게임 프론트 배선 복구 + 5종 방식 UI (Phase 0, 동반배포)

### DIFF
--- a/apps/web/src/lib/features/giving/api.ts
+++ b/apps/web/src/lib/features/giving/api.ts
@@ -1,0 +1,126 @@
+/**
+ * 나눔 게임 API 클라이언트. SvelteKit 프록시(/api/plugins/giving/*)를 경유하며,
+ * 프록시가 세션 쿠키 → 백엔드 인증 헤더 주입을 처리한다(별도 토큰 첨부 불필요).
+ */
+
+import type { GivingMethod } from './methods.js';
+import type { LadderData } from './pure/ladder.js';
+
+const BASE = '/api/plugins/giving';
+
+export interface GivingDrawResult {
+    method: string;
+    winner_mb_id: string | null;
+    winning_number: number | null;
+    seed: string | null;
+    seed_hash: string | null;
+    drawn_by: string | null;
+    drawn_at: string | null;
+    result: {
+        method: string;
+        participants?: string[];
+        winners?: string[];
+        winning_number?: number;
+        no_winner?: boolean;
+        input_hash?: string;
+        seed?: string;
+        seed_hash?: string;
+        capacity?: number;
+        ladder?: LadderData;
+        reason?: string;
+        designated?: boolean;
+        drawn_by?: string;
+    } | null;
+}
+
+export interface GivingDetail {
+    wr_id: number;
+    title: string;
+    host_mb_id: string;
+    method: GivingMethod;
+    capacity: number | null;
+    number_max: number | null;
+    seed_hash: string | null;
+    config_status: string;
+    unit_price: number;
+    status: 'active' | 'waiting' | 'paused' | 'ended' | 'no_giving';
+    is_paused: boolean;
+    is_urgent: boolean;
+    giving_start: string | null;
+    giving_end: string | null;
+    participant_count: number;
+    participants: string[];
+    total_numbers: number;
+    total_bids: number;
+    is_host: boolean;
+    my_participation: {
+        joined: boolean;
+        numbers: string;
+        count: number;
+        points: number;
+    };
+    draw?: GivingDrawResult;
+    reveal_bids?: Array<{ mb_id: string; numbers: string }>;
+}
+
+interface Envelope<T> {
+    success: boolean;
+    data?: T;
+    error?: string;
+}
+
+async function call<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(`${BASE}${path}`, {
+        credentials: 'same-origin',
+        headers: init?.body ? { 'Content-Type': 'application/json' } : undefined,
+        ...init
+    });
+    let body: Envelope<T>;
+    try {
+        body = (await res.json()) as Envelope<T>;
+    } catch {
+        throw new Error(`서버 응답 오류 (${res.status})`);
+    }
+    if (!res.ok || !body.success) {
+        throw new Error(body.error || `요청 실패 (${res.status})`);
+    }
+    return body.data as T;
+}
+
+export const givingApi = {
+    detail(id: number | string): Promise<GivingDetail> {
+        return call<GivingDetail>(`/detail/${id}`);
+    },
+
+    config(
+        id: number | string,
+        payload: { method: GivingMethod; capacity?: number | null; number_max?: number | null }
+    ): Promise<{ wr_id: number; method: string; seed_hash: string }> {
+        return call(`/config/${id}`, { method: 'POST', body: JSON.stringify(payload) });
+    },
+
+    /** lowest_unique: numbers 필요. 무료형: numbers 생략. */
+    bid(id: number | string, numbers?: string): Promise<Record<string, unknown>> {
+        return call(`/bid/${id}`, {
+            method: 'POST',
+            body: JSON.stringify(numbers != null ? { numbers } : {})
+        });
+    },
+
+    draw(
+        id: number | string,
+        payload?: { winner_mb_id?: string; reason?: string }
+    ): Promise<Record<string, unknown>> {
+        return call(`/draw/${id}`, {
+            method: 'POST',
+            body: JSON.stringify(payload ?? {})
+        });
+    },
+
+    admin(
+        id: number | string,
+        action: 'pause' | 'resume' | 'force-stop'
+    ): Promise<{ status: string }> {
+        return call(`/admin/${id}/${action}`, { method: 'POST', body: '{}' });
+    }
+};

--- a/apps/web/src/lib/features/giving/draw-result.svelte
+++ b/apps/web/src/lib/features/giving/draw-result.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+    import type { GivingDrawResult } from './api.js';
+    import { methodLabel } from './methods.js';
+    import { simulateLadder } from './pure/ladder.js';
+
+    let { draw }: { draw: GivingDrawResult } = $props();
+
+    const result = $derived(draw.result);
+    const winners: string[] = $derived(
+        result?.winners ?? (draw.winner_mb_id ? [draw.winner_mb_id] : [])
+    );
+
+    // Commit-reveal 검증: SeedHash(seed) === seed_hash 인지 브라우저에서 재계산.
+    let seedVerified = $state<null | boolean>(null);
+    $effect(() => {
+        const seed = draw.seed;
+        const hash = draw.seed_hash;
+        if (!seed || !hash || !globalThis.crypto?.subtle) {
+            seedVerified = null;
+            return;
+        }
+        (async () => {
+            try {
+                const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed));
+                const hex = [...new Uint8Array(buf)]
+                    .map((b) => b.toString(16).padStart(2, '0'))
+                    .join('');
+                seedVerified = hex === hash;
+            } catch {
+                seedVerified = null;
+            }
+        })();
+    });
+
+    const ladder = $derived(result?.ladder ?? null);
+    const ladderEnd = $derived(ladder ? (ladder.end_col ?? simulateLadder(ladder)) : []);
+</script>
+
+<div class="border-border bg-muted/30 rounded-lg border p-4">
+    <div class="mb-2 flex items-center gap-2">
+        <span class="text-lg">🎉</span>
+        <h3 class="text-foreground font-semibold">
+            나눔 결과 · {methodLabel(draw.method)}
+        </h3>
+    </div>
+
+    {#if result?.no_winner}
+        <p class="text-muted-foreground text-sm">
+            모든 번호가 중복되어 <strong>당첨자가 없습니다.</strong>
+        </p>
+    {:else if winners.length > 0}
+        {#if draw.method === 'lowest_unique' && draw.winning_number != null}
+            <p class="text-foreground text-sm">
+                당첨 번호 <strong class="text-primary">{draw.winning_number}</strong> —
+                <strong>{winners[0]}</strong>
+            </p>
+        {:else}
+            <p class="text-foreground mb-1 text-sm">당첨자</p>
+            <ul class="flex flex-wrap gap-2">
+                {#each winners as w (w)}
+                    <li
+                        class="rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
+                    >
+                        {w}
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+
+        {#if result?.designated && result?.reason}
+            <div class="border-border mt-3 rounded-md border bg-white/60 p-3 dark:bg-black/20">
+                <p class="text-muted-foreground text-xs font-medium">선정 사유</p>
+                <p class="text-foreground mt-1 whitespace-pre-wrap text-sm">{result.reason}</p>
+            </div>
+        {:else if result?.designated}
+            <p class="text-muted-foreground mt-2 text-xs">주최자가 직접 지명했습니다.</p>
+        {/if}
+    {/if}
+
+    <!-- 사다리 시각화 -->
+    {#if ladder && ladder.columns > 0}
+        <div class="mt-4 overflow-x-auto">
+            <svg
+                width={ladder.columns * 44}
+                height={ladder.levels * 22 + 40}
+                class="min-w-full"
+                role="img"
+                aria-label="사다리 결과"
+            >
+                {#each Array(ladder.columns) as _, c (c)}
+                    <line
+                        x1={c * 44 + 22}
+                        y1="16"
+                        x2={c * 44 + 22}
+                        y2={ladder.levels * 22 + 16}
+                        stroke="currentColor"
+                        stroke-width="2"
+                        class="text-border"
+                    />
+                    <text
+                        x={c * 44 + 22}
+                        y="12"
+                        text-anchor="middle"
+                        class="fill-muted-foreground text-[10px]">{c + 1}</text
+                    >
+                    <text
+                        x={c * 44 + 22}
+                        y={ladder.levels * 22 + 32}
+                        text-anchor="middle"
+                        class="text-[10px] {c < ladder.win_slots
+                            ? 'fill-emerald-600 font-bold'
+                            : 'fill-muted-foreground'}">{c < ladder.win_slots ? '당첨' : '—'}</text
+                    >
+                {/each}
+                {#each ladder.rungs as row, l (l)}
+                    {#each row as on, gap (gap)}
+                        {#if on}
+                            <line
+                                x1={gap * 44 + 22}
+                                y1={l * 22 + 27}
+                                x2={gap * 44 + 66}
+                                y2={l * 22 + 27}
+                                stroke="currentColor"
+                                stroke-width="2"
+                                class="text-primary"
+                            />
+                        {/if}
+                    {/each}
+                {/each}
+            </svg>
+            <p class="text-muted-foreground mt-1 text-xs">
+                각 열 → 도착 열: {ladderEnd.map((e, i) => `${i + 1}→${e + 1}`).join(', ')}
+            </p>
+        </div>
+    {/if}
+
+    <!-- Commit-Reveal 재현 데이터 -->
+    {#if draw.seed_hash}
+        <details class="mt-3">
+            <summary class="text-muted-foreground cursor-pointer text-xs"
+                >공정성 검증 데이터</summary
+            >
+            <div class="text-muted-foreground mt-2 space-y-1 break-all text-xs">
+                <p>seed_hash: <code>{draw.seed_hash}</code></p>
+                {#if draw.seed}
+                    <p>seed(공개): <code>{draw.seed}</code></p>
+                {/if}
+                {#if result?.input_hash}
+                    <p>input_hash: <code>{result.input_hash}</code></p>
+                {/if}
+                {#if seedVerified === true}
+                    <p class="font-medium text-emerald-600">✓ SHA-256(seed) = seed_hash 검증됨</p>
+                {:else if seedVerified === false}
+                    <p class="text-red-600">✗ 시드 해시 불일치</p>
+                {/if}
+            </div>
+        </details>
+    {/if}
+</div>

--- a/apps/web/src/lib/features/giving/giving-participation.svelte
+++ b/apps/web/src/lib/features/giving/giving-participation.svelte
@@ -1,0 +1,385 @@
+<script lang="ts">
+    import { untrack } from 'svelte';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { givingApi, type GivingDetail } from './api.js';
+    import { METHOD_INFO, methodLabel, isNumberMethod, type GivingMethod } from './methods.js';
+    import { parseBidNumbers } from './pure/lowest-unique.js';
+    import MethodSelect from './method-select.svelte';
+    import DrawResult from './draw-result.svelte';
+
+    let { post, boardId }: { post: { id: number | string }; boardId?: string } = $props();
+
+    let detail = $state<GivingDetail | null>(null);
+    let loadError = $state<string | null>(null);
+    let busy = $state(false);
+    let actionMsg = $state<string | null>(null);
+    let actionErr = $state<string | null>(null);
+
+    // lowest_unique 응모 입력
+    let numbersInput = $state('');
+    // 주최자 지명 입력
+    let designateWinner = $state('');
+    let designateReason = $state('');
+    // 주최자 설정
+    let showSetup = $state(false);
+    let cfgMethod = $state<GivingMethod>('lowest_unique');
+    let cfgCapacity = $state(1);
+    let cfgNumberMax = $state(100);
+    let cfgUnit = $state(100);
+
+    async function load() {
+        loadError = null;
+        try {
+            const d = await givingApi.detail(post.id);
+            detail = d;
+            cfgMethod = d.method;
+            cfgCapacity = d.capacity ?? 1;
+            cfgNumberMax = d.number_max ?? 100;
+            cfgUnit = d.unit_price || 100;
+        } catch (e) {
+            loadError = e instanceof Error ? e.message : '나눔 정보를 불러오지 못했습니다.';
+        }
+    }
+
+    $effect(() => {
+        // post.id 변경 시 재로딩
+        void post.id;
+        untrack(() => load());
+    });
+
+    const method: GivingMethod = $derived(detail?.method ?? 'lowest_unique');
+    const isEnded = $derived(detail?.status === 'ended');
+    const isActive = $derived(detail?.status === 'active');
+    const drawn = $derived(!!detail?.draw);
+    const parsedPreview = $derived(numbersInput ? parseBidNumbers(numbersInput) : []);
+    const estCost = $derived(parsedPreview.length * (detail?.unit_price ?? 0));
+
+    function flash(msg: string, isErr = false) {
+        if (isErr) {
+            actionErr = msg;
+            actionMsg = null;
+        } else {
+            actionMsg = msg;
+            actionErr = null;
+        }
+    }
+
+    async function guard<T>(fn: () => Promise<T>): Promise<T | undefined> {
+        if (busy) return;
+        busy = true;
+        actionErr = null;
+        actionMsg = null;
+        try {
+            const r = await fn();
+            await load();
+            return r;
+        } catch (e) {
+            flash(e instanceof Error ? e.message : '처리에 실패했습니다.', true);
+        } finally {
+            busy = false;
+        }
+    }
+
+    async function submitBid() {
+        if (parsedPreview.length === 0) {
+            flash('올바른 응모 번호를 입력해주세요.', true);
+            return;
+        }
+        await guard(async () => {
+            await givingApi.bid(post.id, numbersInput);
+            numbersInput = '';
+            flash('응모가 완료되었습니다.');
+        });
+    }
+
+    async function joinFree() {
+        await guard(async () => {
+            await givingApi.bid(post.id);
+            flash('참가가 완료되었습니다.');
+        });
+    }
+
+    async function saveConfig() {
+        await guard(async () => {
+            await givingApi.config(post.id, {
+                method: cfgMethod,
+                capacity: cfgCapacity,
+                number_max: cfgNumberMax
+            });
+            showSetup = false;
+            flash('나눔 방식을 저장했습니다.');
+        });
+    }
+
+    async function runDraw() {
+        const designated = METHOD_INFO[method].hostDesignated;
+        if (designated && !designateWinner) {
+            flash('당첨자를 지정해주세요.', true);
+            return;
+        }
+        if (method === 'curation' && !designateReason) {
+            flash('선정 사유를 입력해주세요.', true);
+            return;
+        }
+        await guard(async () => {
+            await givingApi.draw(
+                post.id,
+                designated ? { winner_mb_id: designateWinner, reason: designateReason } : undefined
+            );
+            flash('개표가 완료되었습니다.');
+        });
+    }
+
+    async function admin(action: 'pause' | 'resume' | 'force-stop') {
+        await guard(async () => {
+            await givingApi.admin(post.id, action);
+            flash(
+                action === 'pause'
+                    ? '일시정지했습니다.'
+                    : action === 'resume'
+                      ? '재개했습니다.'
+                      : '강제종료했습니다.'
+            );
+        });
+    }
+
+    const statusLabel = $derived(
+        {
+            active: '진행 중',
+            waiting: '대기 중',
+            paused: '일시정지',
+            ended: '종료',
+            no_giving: '일정 미정'
+        }[detail?.status ?? 'no_giving']
+    );
+</script>
+
+{#if detail}
+    <section class="border-border my-6 rounded-xl border p-4 sm:p-5">
+        <header class="mb-3 flex flex-wrap items-center gap-2">
+            <span class="text-base font-bold">🎁 나눔</span>
+            <span
+                class="bg-primary/10 text-primary rounded-full px-2.5 py-0.5 text-xs font-semibold"
+                >{methodLabel(method)}</span
+            >
+            <span
+                class="rounded-full px-2.5 py-0.5 text-xs font-medium {isActive
+                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200'
+                    : 'bg-muted text-muted-foreground'}">{statusLabel}</span
+            >
+            {#if detail.is_urgent}
+                <span class="rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700"
+                    >마감 임박</span
+                >
+            {/if}
+        </header>
+
+        <div class="text-muted-foreground mb-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+            <span>참가자 <strong class="text-foreground">{detail.participant_count}</strong>명</span
+            >
+            {#if isNumberMethod(method)}
+                <span
+                    >응모 번호 <strong class="text-foreground">{detail.total_numbers}</strong
+                    >개</span
+                >
+                <span>단가 <strong class="text-foreground">{detail.unit_price}</strong>pt</span>
+            {:else if detail.capacity}
+                <span>당첨 <strong class="text-foreground">{detail.capacity}</strong>명</span>
+            {/if}
+            {#if detail.giving_end}
+                <span>마감 {detail.giving_end}</span>
+            {/if}
+        </div>
+
+        {#if actionMsg}
+            <p
+                class="mb-2 rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:bg-emerald-950/30"
+            >
+                {actionMsg}
+            </p>
+        {/if}
+        {#if actionErr}
+            <p class="mb-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/30">
+                {actionErr}
+            </p>
+        {/if}
+
+        <!-- 당첨 결과 -->
+        {#if drawn && detail.draw}
+            <DrawResult draw={detail.draw} />
+        {/if}
+
+        <!-- 참가 UI (비주최자, 진행 중, 미개표) -->
+        {#if !detail.is_host && isActive && !drawn}
+            {#if !authStore.isAuthenticated}
+                <p class="text-muted-foreground text-sm">참가하려면 로그인이 필요합니다.</p>
+            {:else if method === 'lowest_unique'}
+                <div class="space-y-2">
+                    <label for="giving-bid-input" class="text-foreground block text-sm font-medium"
+                        >응모 번호 (예: 1,3,5-10,15~20)</label
+                    >
+                    <input
+                        id="giving-bid-input"
+                        type="text"
+                        bind:value={numbersInput}
+                        placeholder="번호 또는 범위 입력"
+                        class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+                    />
+                    {#if parsedPreview.length > 0}
+                        <p class="text-muted-foreground text-xs">
+                            {parsedPreview.length}개 번호 · 예상 {estCost}pt 소모
+                        </p>
+                    {/if}
+                    <button
+                        type="button"
+                        onclick={submitBid}
+                        disabled={busy || parsedPreview.length === 0}
+                        class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50"
+                        >응모하기</button
+                    >
+                </div>
+            {:else if method === 'curation' || method === 'host_pick'}
+                <div class="space-y-2">
+                    <p class="text-muted-foreground text-sm">
+                        {method === 'curation'
+                            ? '아래 댓글로 사연을 남겨 참여하세요. 주최자가 읽고 선정합니다.'
+                            : '참가 버튼을 누르거나 댓글을 남겨 참여하세요. 주최자가 지정합니다.'}
+                    </p>
+                    <button
+                        type="button"
+                        onclick={joinFree}
+                        disabled={busy || detail.my_participation.joined}
+                        class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50"
+                        >{detail.my_participation.joined ? '참가 완료' : '참가하기'}</button
+                    >
+                </div>
+            {:else}
+                <!-- random / ladder -->
+                <button
+                    type="button"
+                    onclick={joinFree}
+                    disabled={busy || detail.my_participation.joined}
+                    class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50"
+                    >{detail.my_participation.joined ? '참가 완료' : '무료 응모하기'}</button
+                >
+            {/if}
+
+            {#if detail.my_participation.joined && method === 'lowest_unique'}
+                <p class="text-muted-foreground mt-2 text-xs">
+                    내 응모: {detail.my_participation.numbers} ({detail.my_participation.count}개, {detail
+                        .my_participation.points}pt)
+                </p>
+            {/if}
+        {/if}
+
+        <!-- 주최자 컨트롤 -->
+        {#if detail.is_host && !drawn}
+            <div class="border-border mt-3 space-y-3 border-t pt-3">
+                <div class="flex items-center justify-between">
+                    <span class="text-sm font-semibold">주최자 관리</span>
+                    <button
+                        type="button"
+                        class="text-primary text-xs underline"
+                        onclick={() => (showSetup = !showSetup)}>나눔 방식 설정</button
+                    >
+                </div>
+
+                {#if showSetup}
+                    <div class="border-border rounded-md border p-3">
+                        <MethodSelect
+                            bind:method={cfgMethod}
+                            bind:capacity={cfgCapacity}
+                            bind:numberMax={cfgNumberMax}
+                            bind:unitPrice={cfgUnit}
+                        />
+                        <p class="text-muted-foreground mt-2 text-xs">
+                            ※ 단가는 글 본문(번호 단가)에서 관리됩니다. 방식·정원·최대번호가
+                            저장됩니다.
+                        </p>
+                        <button
+                            type="button"
+                            onclick={saveConfig}
+                            disabled={busy}
+                            class="bg-primary text-primary-foreground mt-2 rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+                            >설정 저장</button
+                        >
+                    </div>
+                {/if}
+
+                <!-- 개표 -->
+                {#if METHOD_INFO[method].hostDesignated}
+                    <div class="space-y-2">
+                        <label for="giving-winner" class="text-foreground block text-sm font-medium"
+                            >당첨자 지정</label
+                        >
+                        <input
+                            id="giving-winner"
+                            list="giving-participant-list"
+                            bind:value={designateWinner}
+                            placeholder="참가자 또는 댓글 작성자 mb_id"
+                            class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+                        />
+                        <datalist id="giving-participant-list">
+                            {#each detail.participants as p (p)}
+                                <option value={p}></option>
+                            {/each}
+                        </datalist>
+                        {#if method === 'curation'}
+                            <textarea
+                                bind:value={designateReason}
+                                placeholder="선정 사유 (공개됩니다)"
+                                rows="2"
+                                class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+                            ></textarea>
+                        {/if}
+                    </div>
+                {/if}
+
+                <div class="flex flex-wrap gap-2">
+                    {#if detail.status === 'paused'}
+                        <button
+                            type="button"
+                            onclick={() => admin('resume')}
+                            disabled={busy}
+                            class="border-border rounded-md border px-3 py-1.5 text-sm disabled:opacity-50"
+                            >재개</button
+                        >
+                    {:else if isActive}
+                        <button
+                            type="button"
+                            onclick={() => admin('pause')}
+                            disabled={busy}
+                            class="border-border rounded-md border px-3 py-1.5 text-sm disabled:opacity-50"
+                            >일시정지</button
+                        >
+                    {/if}
+                    <button
+                        type="button"
+                        onclick={runDraw}
+                        disabled={busy}
+                        class="bg-primary text-primary-foreground rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+                        >{METHOD_INFO[method].hostDesignated ? '당첨자 확정' : '개표하기'}</button
+                    >
+                    {#if !METHOD_INFO[method].hostDesignated}
+                        <button
+                            type="button"
+                            onclick={() => admin('force-stop')}
+                            disabled={busy}
+                            class="rounded-md border border-red-300 px-3 py-1.5 text-sm text-red-600 disabled:opacity-50"
+                            >강제종료(즉시 개표)</button
+                        >
+                    {/if}
+                </div>
+            </div>
+        {/if}
+
+        <!-- 종료·미개표 안내 -->
+        {#if isEnded && !drawn && !detail.is_host}
+            <p class="text-muted-foreground text-sm">
+                종료된 나눔입니다. 개표를 기다리고 있습니다.
+            </p>
+        {/if}
+    </section>
+{:else if loadError}
+    <p class="text-muted-foreground my-4 text-sm">{loadError}</p>
+{/if}

--- a/apps/web/src/lib/features/giving/giving-write-form.svelte
+++ b/apps/web/src/lib/features/giving/giving-write-form.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+    import { goto } from '$app/navigation';
+    import { apiClient } from '$lib/api/index.js';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import PostForm from '$lib/components/features/board/post-form.svelte';
+    import type { CreatePostRequest, UpdatePostRequest, Board } from '$lib/api/types.js';
+    import MethodSelect from './method-select.svelte';
+    import { type GivingMethod } from './methods.js';
+    import { givingApi } from './api.js';
+
+    let {
+        boardId = 'giving',
+        board,
+        categories = [],
+        contentFormat = 'html',
+        onCancel
+    }: {
+        boardId?: string;
+        board?: Board;
+        categories?: string[];
+        contentFormat?: 'html' | 'markdown';
+        onSubmit?: (data: CreatePostRequest | UpdatePostRequest) => Promise<void>;
+        onCancel: () => void;
+        isLoading?: boolean;
+    } = $props();
+
+    let method = $state<GivingMethod>('lowest_unique');
+    let capacity = $state(1);
+    let numberMax = $state(100);
+    let unitPrice = $state(100);
+    let startAt = $state('');
+    let endAt = $state('');
+
+    let busy = $state(false);
+    let error = $state<string | null>(null);
+
+    async function handleSubmit(formData: CreatePostRequest | UpdatePostRequest): Promise<void> {
+        if (busy) return;
+        if (!authStore.user) {
+            error = '로그인이 필요합니다.';
+            return;
+        }
+        busy = true;
+        error = null;
+        try {
+            const req: CreatePostRequest = {
+                ...(formData as CreatePostRequest),
+                author: authStore.user.mb_name,
+                extra_2: method === 'lowest_unique' ? String(unitPrice) : '0',
+                extra_4: startAt || '',
+                extra_5: endAt || ''
+            };
+            const post = await apiClient.createPost(boardId, req);
+            if (!post?.id) throw new Error('게시글 작성에 실패했습니다.');
+
+            // 방식 설정 저장 (실패해도 글은 생성됨 — 상세 페이지에서 재설정 가능)
+            try {
+                await givingApi.config(post.id, { method, capacity, number_max: numberMax });
+            } catch {
+                /* 상세에서 주최자가 다시 설정할 수 있음 */
+            }
+            goto(`/${boardId}/${post.id}`);
+        } catch (e) {
+            error = e instanceof Error ? e.message : '게시글 작성에 실패했습니다.';
+        } finally {
+            busy = false;
+        }
+    }
+</script>
+
+<div class="space-y-4">
+    {#if error}
+        <div class="bg-destructive/10 text-destructive rounded-md p-3 text-sm">{error}</div>
+    {/if}
+
+    <div class="border-border rounded-lg border p-4">
+        <h2 class="mb-3 text-sm font-semibold">나눔 설정</h2>
+        <MethodSelect bind:method bind:capacity bind:numberMax bind:unitPrice />
+
+        <div class="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+                <label for="giving-start" class="text-foreground mb-1 block text-sm font-medium"
+                    >시작 일시</label
+                >
+                <input
+                    id="giving-start"
+                    type="datetime-local"
+                    bind:value={startAt}
+                    class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+                />
+            </div>
+            <div>
+                <label for="giving-end" class="text-foreground mb-1 block text-sm font-medium"
+                    >종료 일시</label
+                >
+                <input
+                    id="giving-end"
+                    type="datetime-local"
+                    bind:value={endAt}
+                    class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+                />
+            </div>
+        </div>
+    </div>
+
+    <PostForm
+        mode="create"
+        {board}
+        {categories}
+        {boardId}
+        {contentFormat}
+        onSubmit={handleSubmit}
+        {onCancel}
+        isLoading={busy}
+    />
+</div>

--- a/apps/web/src/lib/features/giving/method-select.svelte
+++ b/apps/web/src/lib/features/giving/method-select.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+    import {
+        GIVING_METHODS,
+        METHOD_INFO,
+        isNumberMethod,
+        usesCapacity,
+        type GivingMethod
+    } from './methods.js';
+
+    let {
+        method = $bindable('lowest_unique'),
+        capacity = $bindable(1),
+        numberMax = $bindable(100),
+        unitPrice = $bindable(100)
+    }: {
+        method?: GivingMethod;
+        capacity?: number;
+        numberMax?: number;
+        unitPrice?: number;
+    } = $props();
+</script>
+
+<div class="space-y-3">
+    <div>
+        <label for="giving-method" class="text-foreground mb-1 block text-sm font-medium"
+            >나눔 방식</label
+        >
+        <select
+            id="giving-method"
+            bind:value={method}
+            class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+        >
+            {#each GIVING_METHODS as m (m)}
+                <option value={m}>{METHOD_INFO[m].label}</option>
+            {/each}
+        </select>
+        <p class="text-muted-foreground mt-1 text-xs">{METHOD_INFO[method].desc}</p>
+    </div>
+
+    {#if isNumberMethod(method)}
+        <div class="grid grid-cols-2 gap-3">
+            <div>
+                <label for="giving-unit" class="text-foreground mb-1 block text-sm font-medium"
+                    >번호 단가 (pt)</label
+                >
+                <input
+                    id="giving-unit"
+                    type="number"
+                    min="0"
+                    bind:value={unitPrice}
+                    class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+                />
+            </div>
+            <div>
+                <label for="giving-max" class="text-foreground mb-1 block text-sm font-medium"
+                    >최대 번호</label
+                >
+                <input
+                    id="giving-max"
+                    type="number"
+                    min="1"
+                    bind:value={numberMax}
+                    class="border-border bg-background text-foreground w-full rounded-md border px-3 py-2 text-sm"
+                />
+            </div>
+        </div>
+        <p class="text-muted-foreground text-xs">
+            비용 = 응모 번호 수 × 단가. 아무도 안 고른 번호 중 최저 번호 보유자가 당첨됩니다.
+        </p>
+    {:else if usesCapacity(method)}
+        <div>
+            <label for="giving-cap" class="text-foreground mb-1 block text-sm font-medium"
+                >당첨 인원 (N)</label
+            >
+            <input
+                id="giving-cap"
+                type="number"
+                min="1"
+                bind:value={capacity}
+                class="border-border bg-background text-foreground w-32 rounded-md border px-3 py-2 text-sm"
+            />
+        </div>
+    {:else}
+        <p class="text-muted-foreground text-xs">
+            {method === 'curation'
+                ? '참가자는 댓글로 사연을 남기고, 주최자가 사유를 밝혀 선정합니다.'
+                : '참가자 중에서 주최자가 직접 당첨자를 지정합니다.'}
+        </p>
+    {/if}
+</div>

--- a/apps/web/src/lib/features/giving/methods.ts
+++ b/apps/web/src/lib/features/giving/methods.ts
@@ -1,0 +1,83 @@
+/**
+ * 나눔 게임 방식 정의 — 백엔드 domain/giving/method.go 와 값 일치 필수.
+ */
+
+export type GivingMethod = 'lowest_unique' | 'random' | 'ladder' | 'curation' | 'host_pick';
+
+export const GIVING_METHODS: GivingMethod[] = [
+    'lowest_unique',
+    'random',
+    'ladder',
+    'curation',
+    'host_pick'
+];
+
+export const DEFAULT_METHOD: GivingMethod = 'lowest_unique';
+
+interface MethodInfo {
+    label: string;
+    /** 개설 폼 설명 */
+    desc: string;
+    /** 참가 시 포인트 소모 여부 */
+    paid: boolean;
+    /** 당첨자를 주최자가 직접 지명 */
+    hostDesignated: boolean;
+    /** 지명 시 사유 필수 */
+    requiresReason: boolean;
+}
+
+export const METHOD_INFO: Record<GivingMethod, MethodInfo> = {
+    lowest_unique: {
+        label: '최저 유일 번호',
+        desc: '포인트로 번호를 구매하고, 아무도 안 고른 번호 중 가장 낮은 번호 보유자가 당첨됩니다.',
+        paid: true,
+        hostDesignated: false,
+        requiresReason: false
+    },
+    random: {
+        label: '랜덤 추첨',
+        desc: '무료로 응모하면 서버가 공개 시드로 무작위 당첨자를 뽑습니다. (검증 가능)',
+        paid: false,
+        hostDesignated: false,
+        requiresReason: false
+    },
+    ladder: {
+        label: '사다리타기',
+        desc: '무료 참가. 서버가 시드로 사다리 결과를 확정하고, 애니메이션으로 재생합니다.',
+        paid: false,
+        hostDesignated: false,
+        requiresReason: false
+    },
+    curation: {
+        label: '댓글 큐레이션',
+        desc: '무료. 댓글로 사연을 남기면 주최자가 읽고 선정합니다. (선정 사유 공개 필수)',
+        paid: false,
+        hostDesignated: true,
+        requiresReason: true
+    },
+    host_pick: {
+        label: '주최자 직접 지명',
+        desc: '무료. 주최자가 참가자 중에서 재량으로 당첨자를 지정합니다. (사유 선택)',
+        paid: false,
+        hostDesignated: true,
+        requiresReason: false
+    }
+};
+
+export function methodLabel(m: string): string {
+    return (METHOD_INFO as Record<string, MethodInfo>)[m]?.label ?? m;
+}
+
+export function isValidMethod(m: string): m is GivingMethod {
+    return GIVING_METHODS.includes(m as GivingMethod);
+}
+
+/** 번호형(단가·최대번호 입력 필요) 방식 여부 */
+export function isNumberMethod(m: string): boolean {
+    return m === 'lowest_unique';
+}
+
+/** 정원(N) 입력이 의미있는 방식 여부 */
+export function usesCapacity(m: string): boolean {
+    return m === 'random' || m === 'ladder';
+}

--- a/apps/web/src/lib/features/giving/pure/ladder.test.ts
+++ b/apps/web/src/lib/features/giving/pure/ladder.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { simulateLadder, ladderWinners, ladderPath, type LadderData } from './ladder.js';
+
+// 4열, 2레벨 사다리. gap 인덱스는 열 사이 간격(0=열0-열1).
+// level0: gap0 rung → 열0↔1 스왑. level1: gap2 rung → 열2↔3 스왑.
+const data: LadderData = {
+    columns: 4,
+    levels: 2,
+    rungs: [
+        [true, false, false],
+        [false, false, true]
+    ],
+    win_slots: 2
+};
+
+describe('simulateLadder', () => {
+    it('produces a bijection (permutation of columns)', () => {
+        const end = simulateLadder(data);
+        expect(end.length).toBe(4);
+        expect([...end].sort()).toEqual([0, 1, 2, 3]);
+    });
+
+    it('applies rungs deterministically', () => {
+        // start0 -> gap0 right -> col1 ; then no rung at level1 for col1 -> stays 1
+        // start1 -> gap0 left -> col0 ; stays 0
+        // start2 -> level0 none -> col2 ; level1 gap2 right -> col3
+        // start3 -> level1 gap2 left -> col2
+        expect(simulateLadder(data)).toEqual([1, 0, 3, 2]);
+    });
+});
+
+describe('ladderWinners', () => {
+    it('marks participants landing in the first win_slots columns', () => {
+        const parts = ['p0', 'p1', 'p2', 'p3'];
+        // end = [1,0,3,2] → cols <2 are winners: p0(→1), p1(→0)
+        expect(ladderWinners(data, parts)).toEqual(['p0', 'p1']);
+    });
+
+    it('prefers server-provided end_col when present', () => {
+        const withEnd = { ...data, end_col: [0, 1, 2, 3] };
+        // identity end → winners are first 2 participants
+        expect(ladderWinners(withEnd, ['a', 'b', 'c', 'd'])).toEqual(['a', 'b']);
+    });
+});
+
+describe('ladderPath', () => {
+    it('returns the column at each level including the start', () => {
+        expect(ladderPath(data, 2)).toEqual([2, 2, 3]);
+    });
+});

--- a/apps/web/src/lib/features/giving/pure/ladder.ts
+++ b/apps/web/src/lib/features/giving/pure/ladder.ts
@@ -1,0 +1,63 @@
+/**
+ * 사다리 순수 재생 로직 — 서버가 result_json 으로 내려준 rungs 를 그대로 시뮬레이션해
+ * 각 참가자의 도착 열을 계산한다. 서버(domain/giving/method.go BuildLadder)와 동일한
+ * 시뮬레이션이므로 클라이언트가 결과를 검증할 수 있다. 애니메이션은 이 경로의 시각화일 뿐.
+ */
+
+export interface LadderData {
+    columns: number;
+    levels: number;
+    rungs: boolean[][]; // rungs[level][gap]
+    win_slots: number;
+    winners?: string[];
+    end_col?: number[];
+}
+
+/**
+ * rungs 로부터 시작 열별 도착 열을 재계산. 표준 사다리 규칙:
+ * 각 레벨에서 현재 열의 오른쪽 가로줄이 있으면 오른쪽, 아니면 왼쪽 가로줄이 있으면 왼쪽.
+ */
+export function simulateLadder(data: LadderData): number[] {
+    const { columns, levels, rungs } = data;
+    const out: number[] = [];
+    for (let start = 0; start < columns; start++) {
+        let c = start;
+        for (let l = 0; l < levels; l++) {
+            const row = rungs[l] || [];
+            if (c < columns - 1 && row[c]) c++;
+            else if (c > 0 && row[c - 1]) c--;
+        }
+        out.push(c);
+    }
+    return out;
+}
+
+/**
+ * 참가자 목록 순서 기준으로, 도착 열이 win_slots 미만인 참가자를 당첨자로 반환.
+ * 서버 winners 와 일치해야 한다(검증용).
+ */
+export function ladderWinners(data: LadderData, participants: string[]): string[] {
+    const end =
+        data.end_col && data.end_col.length === data.columns ? data.end_col : simulateLadder(data);
+    const winners: string[] = [];
+    for (let i = 0; i < participants.length && i < end.length; i++) {
+        if (end[i] < data.win_slots) winners.push(participants[i]);
+    }
+    return winners.sort();
+}
+
+/**
+ * 애니메이션용 경로 좌표: 한 시작 열이 레벨을 내려가며 거치는 열 인덱스 시퀀스.
+ */
+export function ladderPath(data: LadderData, start: number): number[] {
+    const { columns, levels, rungs } = data;
+    const path: number[] = [start];
+    let c = start;
+    for (let l = 0; l < levels; l++) {
+        const row = rungs[l] || [];
+        if (c < columns - 1 && row[c]) c++;
+        else if (c > 0 && row[c - 1]) c--;
+        path.push(c);
+    }
+    return path;
+}

--- a/apps/web/src/lib/features/giving/pure/lowest-unique.test.ts
+++ b/apps/web/src/lib/features/giving/pure/lowest-unique.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { parseBidNumbers, lowestUniqueWinner, buildBidsByNumber } from './lowest-unique.js';
+
+describe('parseBidNumbers', () => {
+    it('parses single numbers, ranges (- and ~), dedups and sorts', () => {
+        expect(parseBidNumbers('1,3,5')).toEqual([1, 3, 5]);
+        expect(parseBidNumbers('5-8')).toEqual([5, 6, 7, 8]);
+        expect(parseBidNumbers('15~17')).toEqual([15, 16, 17]);
+        expect(parseBidNumbers('1,3,5-7,3')).toEqual([1, 3, 5, 6, 7]);
+        expect(parseBidNumbers(' 4 , 2 ')).toEqual([2, 4]);
+    });
+
+    it('ignores all-zero and decimal tokens and reversed ranges', () => {
+        expect(parseBidNumbers('0,00,2.5,3')).toEqual([3]);
+        expect(parseBidNumbers('10-5')).toEqual([]);
+        expect(parseBidNumbers('')).toEqual([]);
+    });
+});
+
+describe('lowestUniqueWinner', () => {
+    it('picks the bidder of the smallest number chosen by exactly one person', () => {
+        const map = buildBidsByNumber([
+            { mb_id: 'A', numbers: '1,2' },
+            { mb_id: 'B', numbers: '1,3' }, // 1 duplicated
+            { mb_id: 'C', numbers: '4' }
+        ]);
+        // 2 (A), 3 (B), 4 (C) are unique → smallest is 2 → A
+        const r = lowestUniqueWinner(map);
+        expect(r.hasWinner).toBe(true);
+        expect(r.winningNumber).toBe(2);
+        expect(r.winnerMbId).toBe('A');
+    });
+
+    it('returns no winner when every number is duplicated', () => {
+        const map = buildBidsByNumber([
+            { mb_id: 'A', numbers: '1,2' },
+            { mb_id: 'B', numbers: '1,2' }
+        ]);
+        expect(lowestUniqueWinner(map).hasWinner).toBe(false);
+    });
+
+    it('handles empty board', () => {
+        expect(lowestUniqueWinner(new Map()).hasWinner).toBe(false);
+    });
+});

--- a/apps/web/src/lib/features/giving/pure/lowest-unique.ts
+++ b/apps/web/src/lib/features/giving/pure/lowest-unique.ts
@@ -1,0 +1,81 @@
+/**
+ * 최저 유일 번호 순수 로직 — 백엔드 domain/giving/method.go 와 동작 일치.
+ * 서버가 권위이나, 종료 후 전량 공개 시 클라이언트가 당첨을 재계산·검증할 수 있게 한다.
+ */
+
+/**
+ * "1,3,5-10,15~20" 형식을 정렬·중복제거된 양의 정수 배열로 파싱.
+ * 0으로만 된 토큰·소숫점 토큰은 무시. 레거시 parseAndValidateBidNumbers 이식.
+ */
+export function parseBidNumbers(input: string): number[] {
+    const seen = new Set<number>();
+    for (const rawPart of input.split(',')) {
+        const part = rawPart.trim();
+        if (!part) continue;
+        if (part.includes('.') || /^0+$/.test(part)) continue;
+        if (part.includes('-') || part.includes('~')) {
+            const m = part.split(/[-~]/);
+            if (m.length === 2) {
+                const start = parseIntSafe(m[0]);
+                const end = parseIntSafe(m[1]);
+                if (start > 0 && end > 0 && start <= end) {
+                    for (let i = start; i <= end; i++) {
+                        seen.add(i);
+                        if (seen.size >= 100000) break;
+                    }
+                }
+            }
+            continue;
+        }
+        const n = parseIntSafe(part);
+        if (n > 0) seen.add(n);
+    }
+    return [...seen].sort((a, b) => a - b);
+}
+
+function parseIntSafe(s: string): number {
+    const n = parseInt(s.trim(), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+export interface LowestUniqueResult {
+    hasWinner: boolean;
+    winningNumber: number | null;
+    winnerMbId: string | null;
+}
+
+/**
+ * bidsByNumber: 번호 → 그 번호를 고른 mb_id 목록.
+ * 정확히 1명이 고른 번호가 "유일 번호"이며, 그 중 최저 번호 보유자가 당첨.
+ */
+export function lowestUniqueWinner(bidsByNumber: Map<number, string[]>): LowestUniqueResult {
+    const uniques: number[] = [];
+    for (const [num, bidders] of bidsByNumber) {
+        if (bidders.length === 1) uniques.push(num);
+    }
+    if (uniques.length === 0) {
+        return { hasWinner: false, winningNumber: null, winnerMbId: null };
+    }
+    uniques.sort((a, b) => a - b);
+    const win = uniques[0];
+    return {
+        hasWinner: true,
+        winningNumber: win,
+        winnerMbId: bidsByNumber.get(win)![0]
+    };
+}
+
+/** 응모 스냅샷 목록에서 번호별 응모자 맵을 구성. */
+export function buildBidsByNumber(
+    bids: Array<{ mb_id: string; numbers: string }>
+): Map<number, string[]> {
+    const map = new Map<number, string[]>();
+    for (const b of bids) {
+        for (const n of parseBidNumbers(b.numbers)) {
+            const arr = map.get(n);
+            if (arr) arr.push(b.mb_id);
+            else map.set(n, [b.mb_id]);
+        }
+    }
+    return map;
+}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -157,12 +157,6 @@
                       ? 'economy'
                       : 'standard')
     );
-    $effect(() => {
-        if (boardType !== 'giving') return;
-        const p = '../../../../../plugins/giving/hooks/register-layouts.js';
-        // @ts-ignore
-        import(p).then((m: { default: () => void }) => m.default()).catch(() => {});
-    });
     const isAngmapBoard = $derived(boardType === 'angmap');
     const isEconomyBoard = $derived(boardType === 'economy');
     const isMessageBoard = $derived(boardId === 'message');

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -94,6 +94,19 @@
     } from '$lib/components/features/board/layouts/index.js';
     import ScrapButton from '$lib/components/post/scrap-button.svelte';
     import { Watermark } from '$lib/components/ui/watermark/index.js';
+    import GivingParticipation from '$lib/features/giving/giving-participation.svelte';
+
+    // 나눔 게시판 슬롯 등록 (참가/개표/결과 패널 — 본문 직후, 댓글 직전)
+    postSlotRegistry.register('post.before_comments', {
+        id: 'core:giving-participation',
+        component: GivingParticipation,
+        condition: (boardType: string) => boardType === 'giving',
+        priority: 5,
+        propsMapper: (pageData: { post: FreePost; boardId: string }) => ({
+            post: pageData.post,
+            boardId: pageData.boardId
+        })
+    });
 
     // Q&A 게시판 슬롯 등록
     postSlotRegistry.register('post.before_content', {
@@ -307,11 +320,6 @@
                       ? 'economy'
                       : 'standard')
     );
-    $effect(() => {
-        if (boardType !== 'giving') return;
-        const p = '../../../../../../plugins/giving/hooks/register-layouts.js';
-        import(p).then((m: { default: () => void }) => m.default()).catch(() => {});
-    });
     const isUsedMarket = $derived(boardType === 'used-market');
 
     // 플러그인 슬롯

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -5,6 +5,10 @@
     import PostForm from '$lib/components/features/board/post-form.svelte';
     import { writeFormRegistry } from '$lib/components/features/board/write-form-registry.js';
     import { contentFormatRegistry } from '$lib/components/features/board/content-format-registry.js';
+    import GivingWriteForm from '$lib/features/giving/giving-write-form.svelte';
+
+    // 나눔 게시판: 방식 선택이 포함된 커스텀 글쓰기 폼 등록
+    writeFormRegistry.register('giving', GivingWriteForm, 'core');
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { apiClient } from '$lib/api/index.js';
     import type { PageData } from './$types.js';


### PR DESCRIPTION
## 나눔(giving) 게임 플랫폼 — 웹 (Phase 0 배선 복구 + 5종 방식 UI)

⚠️ **동반 배포 필수** — 백엔드 PR(damoang/angple-backend#577)과 반드시 함께 배포.
프론트만 살리면 응모가 백엔드 404로 실패해 더 나빠집니다.

### Phase 0 — 배선 복구 (재유실 방지)
`[boardId]/+page.svelte`·`[boardId]/[postId]/+page.svelte`의 **변수 경로 `import()`+`.catch(()=>{})`**(Vite 번들 실패를 조용히 삼키던 이중 단절)를 제거.
존재하지 않는 `plugins/giving/hooks/register-layouts.js` 대신, **`post.before_comments` 슬롯에 정적 등록**으로 대체(리터럴 import → 회귀 안전). 나눔 목록 카드 레이아웃은 이미 core 등록되어 있어 무관.

### 5종 방식 UI (`$lib/features/giving/`)
- **개설**(`giving-write-form.svelte`, `writeFormRegistry`): 방식 `<select>` 5종 + 조건부 필드(번호형=단가·최대번호 / 랜덤·사다리=정원 / 큐레이션·지명=안내) + 시작·종료 일시. 글 생성 후 `POST /config/:id`로 방식 저장.
- **참가**(`giving-participation.svelte`, 상세 슬롯): lowest_unique 번호 응모(파싱·예상 포인트 표시), random/ladder 무료 응모, curation/host_pick 참가+댓글 안내.
- **주최자**: 방식 설정(재설정)·일시정지/재개/강제종료·개표(auto 또는 참가자 목록에서 당첨자 지명; curation은 사유 필수).
- **발표**(`draw-result.svelte`): 방식별 결과 + 사다리 SVG 시각화 + **commit-reveal 시드 브라우저 재계산 검증**(SHA-256(seed)==seed_hash).

### 순수 로직 + 테스트
`pure/lowest-unique.ts`(번호파싱·최저유일)·`pure/ladder.ts`(사다리 재생) + vitest(`*.test.ts`). 서버가 권위이며 클라는 재계산·검증만.

### 아키텍처
기존 프록시 `/api/plugins/giving/[...path]`(세션→백엔드 인증 주입) 재사용. `postSlotRegistry`·`writeFormRegistry` 등 기존 확장점 사용, 코어 침습 최소.

### 자가검증
순수 로직을 standalone node로 실측(파싱 `1,3,5-7,3`→`[1,3,5,6,7]`, `0,00,2.5,3`→`[3]`, 최저유일 winner, 사다리 `[1,0,3,2]`) — vitest 기대값과 일치 확인. (CI에서 `pnpm test:unit` 실행)

### 후속/미완
- host 지명 UI는 응모자 datalist + mb_id 직접입력(댓글작성자 지정 가능하나 목록엔 응모자만 노출).
- 커스텀 write form은 자체 create+config 흐름이라 표준 write의 @멘션/트래킹은 미적용.
- 카운트다운·당첨 알림 토스트 등 부가 UX 후속.
