### PR TITLE
fix(hello): 이모티콘 피커 기본 탭을 다른 게시판과 동일하게

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -390,7 +390,6 @@
                             editorRef?.insertImage(`/emoticons/${filename}`, filename);
                         }}
                         disabled={isLoading || isUploading}
-                        {boardId}
                     />
 
                     <div class="ml-auto flex items-center gap-2">

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1681,7 +1681,6 @@
                                             );
                                         }}
                                         disabled={isUpdating}
-                                        {boardId}
                                     />
 
                                     <div class="ml-auto flex items-center gap-2">

--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -11,20 +11,9 @@
         onSelectImage: () => void;
         onInsertEmoticon?: (filename: string) => void;
         disabled?: boolean;
-        boardId?: string;
     }
 
-    let {
-        onInsertText,
-        onSelectImage,
-        onInsertEmoticon,
-        disabled = false,
-        boardId
-    }: Props = $props();
-
-    // hello 가입인사: 이모티콘 피커 기본 탭 = 환영(welcome) 팩 — 온보딩 겸용.
-    // 두 호출처(comment-form·comment-list 수정 툴바) 모두 boardId 를 이미 넘기므로 여기서 유도.
-    const initialPack = $derived(boardId === 'hello' ? 'welcome' : undefined);
+    let { onInsertText, onSelectImage, onInsertEmoticon, disabled = false }: Props = $props();
 
     let showEmoticonPicker = $state(false);
     let showGifPicker = $state(false);
@@ -109,7 +98,6 @@
                 <LazyEmoticonPicker
                     onInsertEmoticon={handleInsertEmoticon}
                     onClose={() => (showEmoticonPicker = false)}
-                    {initialPack}
                 />
             </div>
         {/if}


### PR DESCRIPTION
## 배경

가입인사(`hello`) 게시판에서만 이모티콘 버튼을 누르면 피커가 **'환영(welcome)' 팩 탭**으로 열려, 다른 게시판과 동작이 달랐습니다. 어제 배포된 #1850 (환영 라운지)에서 온보딩 보조 목적으로 들어갔으나, 일관성을 우선해 되돌립니다.

## 변경

```js
// 제거된 코드 (comment-toolbar.svelte)
const initialPack = $derived(boardId === 'hello' ? 'welcome' : undefined);
```

- `comment-toolbar`: `boardId` 기반 `initialPack` 유도 제거
- 이에 따라 미사용이 된 `boardId` prop 및 두 호출처(`comment-form`·`comment-list`)의 전달 제거
- `emoticon-picker`의 `initialPack` 기능 자체는 **유지** (향후 재사용 대비, 현재는 아무도 전달하지 않음)

## 영향

- 환영 팩은 피커 안에 **그대로 존재**하며, 기본 선택만 첫 팩으로 돌아갑니다
- 가입인사 외 게시판은 변화 없음
- 어제 배포된 환영 라운지의 나머지 기능(채팅형 댓글, 환영 스탬프, 새 앙님 배지)은 **영향 없음**

`-15 / +1`