### PR TITLE
fix(angmap): 좌표 센티널 방어 + 초기 뷰가 지구 전체로 벌어지는 문제

### DIFF
--- a/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
+++ b/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
@@ -56,6 +56,37 @@
         return leafletPromise;
     }
 
+    function median(values: number[]): number {
+        const s = [...values].sort((a, b) => a - b);
+        const mid = s.length >> 1;
+        return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+    }
+
+    /**
+     * 초기 뷰용 bounds. **모든 핀은 지도에 그대로 그려지고**, 여기서 정하는 건
+     * "처음 어디를 비춰줄지"뿐이다. 줌아웃하면 제외된 핀도 전부 보인다.
+     *
+     * 대륙 단위로 멀리 떨어진 소수의 핀이 있으면 전체 fitBounds 가 지구 전체로 벌어져
+     * 정작 대부분의 핀이 점으로 뭉개진다(2026-07-23 실측: 해외 핀 12개 때문에 발생).
+     *
+     * ⛔ 특정 국가 범위를 하드코딩하지 말 것 — 다모앙은 글로벌이다.
+     * 중앙값에서의 거리가 MAD(중앙값 절대편차)의 6배를 넘는 핀만 초기 뷰에서 뺀다.
+     * 데이터가 스스로 중심을 정하므로, 핀이 어느 대륙에 몰리든 그곳이 초기 뷰가 된다.
+     */
+    function initialBounds(L: typeof import('leaflet'), pinData: AngmapPin[]) {
+        const pts = pinData.map((p) => [p.lat, p.lng] as [number, number]);
+        if (pts.length < 8) return L.latLngBounds(pts);
+
+        const cLat = median(pts.map((p) => p[0]));
+        const cLng = median(pts.map((p) => p[1]));
+        const dist = pts.map((p) => Math.abs(p[0] - cLat) + Math.abs(p[1] - cLng));
+        // MAD 가 0(핀이 한 점에 몰림)이면 최소 1도는 허용해 bounds 가 무너지지 않게 한다.
+        const threshold = Math.max(median(dist) * 6, 1);
+        const core = pts.filter((_, i) => dist[i] <= threshold);
+
+        return L.latLngBounds(core.length >= 3 ? core : pts);
+    }
+
     async function loadPins(): Promise<AngmapPin[]> {
         if (pins) return pins;
         const res = await fetch('/api/angmap/pins');
@@ -110,8 +141,7 @@
                 .addTo(map);
         }
 
-        const bounds = L.latLngBounds(pinData.map((p) => [p.lat, p.lng] as [number, number]));
-        map.fitBounds(bounds.pad(0.15), { maxZoom: 15 });
+        map.fitBounds(initialBounds(L, pinData).pad(0.15), { maxZoom: 15 });
     }
 
     async function expand(): Promise<void> {

--- a/apps/web/src/routes/api/angmap/pins/+server.ts
+++ b/apps/web/src/routes/api/angmap/pins/+server.ts
@@ -33,6 +33,31 @@ interface PinRow extends RowDataPacket {
 
 const pinsCache = createCache<AngmapPin[]>({ ttl: 60_000, maxSize: 4 });
 
+/**
+ * 지도에 찍을 수 있는 좌표인지. **지리적 가정이 아니라 센티널/범위 방어**다.
+ *
+ * 2026-07-23: 백필 배치가 네이버 URL 의 줌 파라미터를 좌표로 오독해
+ * `lat=0 / lng=15` 인 핀 20개를 'ok' 로 내보냈고, 지도의 fitBounds 가 이를 포함해
+ * 초기 뷰가 지구 전체로 벌어졌다. 근본 원인은 배치에서 고쳤지만,
+ * 배치가 다시 깨져도 지도는 무너지지 않도록 표시 직전에 한 겹 더 막는다.
+ *
+ * ⛔ 특정 국가/대륙 범위로 거르지 말 것 — 다모앙은 글로벌이고 해외 장소 핀이 실제로 있다.
+ * 축이 정확히 0 인 경우만 배제한다: 좌표 정밀도가 소수점 7자리(적도에서 약 1cm)라
+ * 실제 장소가 정확히 0.0000000 으로 저장될 일은 사실상 없고, 해소 실패의 흔적일 뿐이다.
+ */
+function isPlottable(p: AngmapPin): boolean {
+    return (
+        Number.isFinite(p.lat) &&
+        Number.isFinite(p.lng) &&
+        p.lat >= -90 &&
+        p.lat <= 90 &&
+        p.lng >= -180 &&
+        p.lng <= 180 &&
+        p.lat !== 0 &&
+        p.lng !== 0
+    );
+}
+
 async function loadPins(): Promise<AngmapPin[]> {
     const [rows] = await readPool.query<PinRow[]>(
         `SELECT p.wr_id, p.name, p.lat, p.lng, p.provider, w.wr_subject
@@ -51,7 +76,7 @@ async function loadPins(): Promise<AngmapPin[]> {
             lng: Number(r.lng),
             provider: r.provider
         }))
-        .filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lng));
+        .filter(isPlottable);
 }
 
 export const GET: RequestHandler = async () => {


### PR DESCRIPTION
## 발단

"no_coords 57곳 개선" 조사 중, 어제 배포된 핀맵이 **정상 동작하지 않는 상태**임을 발견.

## 근본 원인

네이버 지도 URL 의 `c=` 파라미터가 두 포맷인데 파서가 하나만 알았다.

| 포맷 | 예시 | 의미 |
|---|---|---|
| 구 v5 (7토막) | `c=127.148,37.332,15,0,0,0,dh` | `lng,lat,zoom,…` |
| 신 포맷 (5토막) | `c=15.00,0,0,0,dh` | **`zoom,…` — 좌표 없음** |

신 포맷을 구 포맷으로 읽어 **줌값 15가 경도, 0이 위도**로 저장됐고, `_valid_coords` 가 `(0,0)` 만 거부해서 `lat=0 / lng=15` 가 `'ok'` 로 통과했다. → 20건이 좌표·상호 없이 "성공" 처리되어 **재시도 대상에서도 제외**됨.

## 조치

**서버 배치** (`/home/angple/scripts/angmap-resolver`, git 미관리라 별도 반영 완료)
- `parse_naver_map_url`: 좌표는 6토막 이상일 때만 읽음 (구조 판별)
- 회귀 테스트 3종 추가 — 총 29개 통과
- 오염 20건 재해소 → **좌표·상호·주소 전부 복구**

**이 PR (웹 2겹)**
1. `isPlottable` — 범위 밖·NaN·축이 정확히 0 인 좌표 제외. 배치가 다시 깨져도 지도는 안 무너짐
2. `initialBounds` — 중앙값에서 MAD 6배를 넘는 핀만 **초기 뷰에서** 제외

## ⛔ 글로벌 원칙

두 곳 모두 **특정 국가 범위를 하드코딩하지 않는다.** 다모앙은 글로벌이고 해외 장소 핀이 실제로 있다.

- 값 기반 휴리스틱(`|위도|>1` 등)도 쓰지 않음 — 키토(-0.18)·상투메(0.33) 같은 적도 부근 실제 장소를 잃는다. 회귀 테스트로 고정
- 데이터가 스스로 중심을 정하므로, 핀이 어느 대륙에 몰리든 그곳이 초기 뷰가 된다
- **모든 핀은 지도에 그대로 그려지며, 줌아웃하면 전부 보인다**

## 실측 결과

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| `lat=0` 오염 행 | 20건 | **0건** |
| 좌표 유효 핀 | 182 | **202** |
| 커버리지 | 70.0% | **77.7%** |
| `ok` 총계 | 202 | **202** (삭제 0) |

초기 뷰 검산(핀 202개): **190개 포함 / 해외 12개만 제외**, 범위 `lat 33.23~38.45` → 제주~강원 전 국토 포함, **국내 핀 잘림 0개**.

해외 12건(Pink's Hot Dogs, Harbour House/케이프타운, 노스이스트/방콕, Bonto/두브로브니크, 柚子花花/타이베이 등)은 **무변조 확인**.