### PR TITLE
fix(auth): mb_id 접미사 절단으로 소셜 로그인이 영구 불가해지는 문제

### DIFF
--- a/apps/web/src/lib/server/auth/register.test.ts
+++ b/apps/web/src/lib/server/auth/register.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 import { describe, expect, it } from 'vitest';
 
-import { adler32, generateSocialMbId } from './register';
+import { adler32, appendMbIdSuffix, generateSocialMbId, MB_ID_MAX_LENGTH } from './register';
 
 describe('generateSocialMbId', () => {
     it('keeps the provider prefix and never emits a negative hash marker', () => {
@@ -20,5 +20,50 @@ describe('generateSocialMbId', () => {
         expect(generateSocialMbId('google', identifier)).toBe(
             `google_${(signedValue >>> 0).toString(16).padStart(8, '0')}`
         );
+    });
+});
+
+/**
+ * mb_id 길이 회귀 방지.
+ *
+ * g5_member.mb_id는 varchar(20)인데 g5_member_social_profiles.mb_id는 varchar(255)다.
+ * 접미사가 20자를 넘기면 회원 테이블에만 절단 저장되어 두 테이블의 mb_id가 어긋나고,
+ * findSocialProfile이 존재하지 않는 회원을 가리켜 그 계정은 소셜 로그인이 영구 불가해진다.
+ * (2026-07-23 실측: 그렇게 갇힌 계정 62건, 최근 두 달에만 46건)
+ */
+describe('appendMbIdSuffix', () => {
+    const providers = ['google', 'naver', 'kakao', 'apple', 'facebook', 'twitter', 'payco'];
+
+    it('어떤 provider의 base에 붙여도 mb_id 최대 길이를 넘지 않는다', () => {
+        for (const provider of providers) {
+            const base = generateSocialMbId(provider, `identifier-${provider}`);
+            expect(appendMbIdSuffix(base).length).toBeLessThanOrEqual(MB_ID_MAX_LENGTH);
+        }
+    });
+
+    it('base가 이미 최대 길이를 넘겨도 결과는 넘지 않는다', () => {
+        const overlong = 'a'.repeat(MB_ID_MAX_LENGTH + 10);
+        expect(appendMbIdSuffix(overlong).length).toBeLessThanOrEqual(MB_ID_MAX_LENGTH);
+    });
+
+    it('base 뒤에 밑줄과 16진수 접미사를 붙인다', () => {
+        const base = generateSocialMbId('google', 'someone');
+        const result = appendMbIdSuffix(base);
+
+        expect(result.startsWith(`${base}_`)).toBe(true);
+        expect(result.slice(base.length + 1)).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('반복 호출하면 서로 다른 값이 나온다(충돌 회피 목적)', () => {
+        const base = generateSocialMbId('naver', 'someone');
+        const results = new Set(Array.from({ length: 20 }, () => appendMbIdSuffix(base)));
+
+        expect(results.size).toBeGreaterThan(1);
+    });
+
+    it('base 자체도 mb_id 최대 길이를 넘지 않는다', () => {
+        for (const provider of providers) {
+            expect(generateSocialMbId(provider, 'x').length).toBeLessThanOrEqual(MB_ID_MAX_LENGTH);
+        }
     });
 });

--- a/apps/web/src/lib/server/auth/register.ts
+++ b/apps/web/src/lib/server/auth/register.ts
@@ -34,6 +34,30 @@ export function generateSocialMbId(provider: string, identifier: string): string
     return `${provider.toLowerCase()}_${adlerValue.toString(16).padStart(8, '0')}`;
 }
 
+/** g5_member.mb_id 컬럼 길이. 이 값을 넘기면 DB가 조용히 절단한다. */
+export const MB_ID_MAX_LENGTH = 20;
+
+/**
+ * mb_id가 이미 점유됐을 때 붙이는 충돌 회피 접미사.
+ *
+ * ⚠️ 접미사를 길게 잡으면 안 된다. g5_member.mb_id는 varchar(20)이라 넘치는 부분이
+ * 조용히 잘려 저장되는데, g5_member_social_profiles.mb_id는 varchar(255)라
+ * 잘리지 않는다. 두 테이블의 mb_id가 어긋나면 findSocialProfile이 존재하지 않는
+ * 회원을 가리켜 **그 계정은 소셜 로그인이 영구히 불가능해진다**.
+ * (2026-07-23 실측: 그렇게 갇힌 계정 62건, 최근 두 달에만 46건)
+ *
+ * base는 `provider_adler32` 형태로 최대 15자(google_)이므로 4자 접미사까지 안전하다.
+ */
+export function appendMbIdSuffix(baseMbId: string): string {
+    const suffix = randomBytes(2).toString('hex'); // 4자
+    const candidate = `${baseMbId}_${suffix}`;
+    if (candidate.length > MB_ID_MAX_LENGTH) {
+        // base 자체가 이미 길면 접미사 자리를 확보하기 위해 base를 줄인다.
+        return `${baseMbId.slice(0, MB_ID_MAX_LENGTH - suffix.length - 1)}_${suffix}`;
+    }
+    return candidate;
+}
+
 /** g5_config에서 가입 레벨 조회 */
 export async function getRegisterLevel(): Promise<number> {
     const [rows] = await pool.query<RowDataPacket[]>(
@@ -180,6 +204,14 @@ export async function createMember(params: {
     mb_ip: string;
     skipNickLock?: boolean;
 }): Promise<void> {
+    // 모든 소셜 가입 경로가 이 함수를 지난다. 여기서 막으면 어느 경로로 오든
+    // 절단된 mb_id로 계정이 만들어지지 않는다(조용한 절단 → 시끄러운 실패).
+    if (params.mb_id.length > MB_ID_MAX_LENGTH) {
+        throw new Error(
+            `mb_id 길이 초과(${params.mb_id.length}자 > ${MB_ID_MAX_LENGTH}자): ${params.mb_id}`
+        );
+    }
+
     const registerLevel = await getRegisterLevel();
 
     // mb_password는 소셜 로그인이므로 랜덤 해시 (직접 로그인 불가)

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -36,6 +36,7 @@ import { getCertConfig } from '$lib/server/auth/cert-inicis.js';
 import { runSocialLoginPostProcess } from '$lib/server/auth/social-login-postprocess.js';
 import {
     generateSocialMbId,
+    appendMbIdSuffix,
     isMbIdTaken,
     isNicknameTaken,
     createMember,
@@ -252,7 +253,7 @@ async function handleCallback(
                     const nickname = await generateInviteTempNickname(providerName);
                     mbId = baseMbId;
                     if (await isMbIdTaken(mbId)) {
-                        mbId = `${mbId}_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+                        mbId = appendMbIdSuffix(mbId);
                     }
 
                     await createMember({
@@ -315,7 +316,7 @@ async function handleCallback(
                     const nickname = await generateInviteTempNickname(providerName);
                     mbId = baseMbId;
                     if (await isMbIdTaken(mbId)) {
-                        mbId = `${mbId}_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+                        mbId = appendMbIdSuffix(mbId);
                     }
                     await createMember({
                         mb_id: mbId,

--- a/apps/web/src/routes/auth/native/apple/+server.ts
+++ b/apps/web/src/routes/auth/native/apple/+server.ts
@@ -17,6 +17,7 @@ import { findSocialProfile, upsertSocialProfile } from '$lib/server/auth/oauth/s
 import { getMemberById, findMemberByEmail, isMemberActive } from '$lib/server/auth/oauth/member.js';
 import {
     generateSocialMbId,
+    appendMbIdSuffix,
     isMbIdTaken,
     isNicknameTaken,
     createMember,
@@ -136,7 +137,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
                 const nickname = await generateUniqueTempNickname();
                 mbId = baseMbId;
                 if (await isMbIdTaken(mbId)) {
-                    mbId = `${mbId}_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+                    mbId = appendMbIdSuffix(mbId);
                 }
                 await createMember({
                     mb_id: mbId,

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -8,6 +8,7 @@ import { dev } from '$app/environment';
 import { randomBytes } from 'crypto';
 import {
     generateSocialMbId,
+    appendMbIdSuffix,
     validateNickname,
     isNicknameTaken,
     isMbIdTaken,
@@ -179,7 +180,7 @@ export const actions: Actions = {
             nickname = await generateInviteTempNickname(socialProfile.provider);
             mbId = generateSocialMbId(socialProfile.provider, socialProfile.identifier);
             if (await isMbIdTaken(mbId)) {
-                mbId = mbId + '_' + randomBytes(4).toString('hex');
+                mbId = appendMbIdSuffix(mbId);
             }
         } else {
             // 약관 동의 확인
@@ -201,7 +202,7 @@ export const actions: Actions = {
 
             mbId = generateSocialMbId(socialProfile.provider, socialProfile.identifier);
             if (await isMbIdTaken(mbId)) {
-                mbId = mbId + '_' + randomBytes(4).toString('hex');
+                mbId = appendMbIdSuffix(mbId);
             }
         }
 


### PR DESCRIPTION
## 문제

`g5_member.mb_id` 는 **varchar(20)** 인데 `g5_member_social_profiles.mb_id` 는 **varchar(255)** 다.

탈퇴자 재가입 등으로 mb_id 가 점유되면 접미사(hex 8자)가 붙어 23~24자가 되는데,
회원 테이블에만 **절단** 저장되고 소셜 매핑에는 전체 길이로 남는다.

```
g5_member                   google_921f08b3_b97f       (20자, 절단됨)
g5_member_social_profiles   google_921f08b3_b97fc85a   (24자, 그대로)
```

두 값이 어긋나면 로그인 시 이렇게 된다:

```
findSocialProfile 히트 → mb_id = 24자 → getMemberById → 그런 회원 없음
  → account_inactive("탈퇴했거나 이용이 제한된 계정입니다")
```

`findSocialProfile` 이 히트한 시점에 mbId 가 정해지므로 **이메일 폴백에도 도달하지 못한다**
(`auth/callback/[provider]/+server.ts:184-195`). 즉 그 계정은 **소셜 로그인이 영구히 불가능**해진다.

## 실측 (2026-07-23)

| | |
|---|---|
| 절단으로 갇힌 계정 | **62건** |
| 20자 접미사 계정 중 가입 후 재로그인 못 한 비율 | **43/54 (80%)** |
| 2026-06 신규 | 26건 |
| 2026-07 신규 | 20건 |

진행 중인 장애였다. 실제로 재가입 문의를 주신 회원이 안내대로 로그인했는데도
계속 실패해 원인을 추적하다 발견했다. DB 측 고아 매핑 62건은 별도 교정 완료.

## 변경

- **`appendMbIdSuffix()` 신설** — 접미사를 hex 4자로 줄여 20자를 넘기지 않는다.
  base 가 이미 길면 base 를 줄여서라도 상한을 지킨다.
  base 는 `provider_adler32` 형태로 최대 15자(`google_`)이므로 4자까지 안전하다.
- **접미사 생성 5개 경로를 헬퍼 하나로 통일** — register 2곳, oauth callback 2곳,
  native apple 1곳에 같은 코드가 흩어져 있었다.
- **`createMember()` 에 길이 가드** — 모든 소셜 가입 경로가 지나는 지점이라
  어느 경로로 들어와도 절단된 mb_id 로 계정이 만들어지지 않는다.
  조용한 절단 대신 시끄러운 실패로 바꾼다.
- 회귀 방지 테스트 추가.

## 검증

- [ ] CI (빌드 / 타입체크 / 테스트 / prettier)
- [ ] 카나리에서 소셜 가입·로그인 정상 동작
- [ ] 접미사가 붙는 케이스에서 mb_id 가 20자 이내인지 확인