### PR TITLE
fix(giving): 설정 실패를 조용히 삼키지 않기 + 일정 필수화

### DIFF
--- a/apps/web/src/lib/features/giving/api.ts
+++ b/apps/web/src/lib/features/giving/api.ts
@@ -37,6 +37,15 @@ export interface GivingDetail {
     wr_id: number;
     title: string;
     host_mb_id: string;
+    /**
+     * 나눔 설정(g5_giving_meta)이 저장돼 있는지.
+     *
+     * false 면 백엔드가 참가·개표를 모두 거부하는 '준비 중' 상태다.
+     * 글 작성이 ①글 생성 → ②설정 저장 두 단계라 ②가 실패하면 이렇게 된다.
+     * 예전에는 백엔드가 기본값(유료)으로 폴백해 주최자가 알아챌 수 없었다.
+     */
+    configured: boolean;
+    /** 미설정(configured=false)이면 빈 문자열 */
     method: GivingMethod;
     capacity: number | null;
     number_max: number | null;

--- a/apps/web/src/lib/features/giving/giving-participation.svelte
+++ b/apps/web/src/lib/features/giving/giving-participation.svelte
@@ -51,6 +51,22 @@
     const isEnded = $derived(detail?.status === 'ended');
     const isActive = $derived(detail?.status === 'active');
     const drawn = $derived(!!detail?.draw);
+
+    // 참가를 받을 수 없는 두 가지 미완성 상태.
+    //   ① configured=false : 설정(방식·인원) 자체가 저장되지 않음 → 백엔드가 참가를 거부
+    //   ② no_giving        : 시작·마감 일시가 비어 상태 판정이 안 됨 → 참가 UI가 안 그려짐
+    // 둘 다 주최자는 정상 게시했다고 믿기 쉬운 상태라 명시적으로 알린다.
+    const missingConfig = $derived(detail ? detail.configured === false : false);
+    const missingSchedule = $derived(detail?.status === 'no_giving');
+    const needsSetup = $derived(!drawn && (missingConfig || missingSchedule));
+    const setupReason = $derived(
+        missingConfig && missingSchedule
+            ? '나눔 방식과 일정이 저장되지 않았어요.'
+            : missingConfig
+              ? '나눔 방식이 저장되지 않았어요.'
+              : '시작·마감 일시가 비어 있어요.'
+    );
+
     const parsedPreview = $derived(numbersInput ? parseBidNumbers(numbersInput) : []);
     const estCost = $derived(parsedPreview.length * (detail?.unit_price ?? 0));
 
@@ -173,6 +189,23 @@
                 >
             {/if}
         </header>
+
+        <!-- 설정이 없거나 일정이 비면 아무도 참가할 수 없다. 조용히 두지 않고 알린다.
+             (2026-07-23 첫 나눔이 일정 누락으로 참가 버튼 없이 게시됐다) -->
+        {#if needsSetup}
+            <div
+                class="mb-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100"
+            >
+                {#if detail.is_host}
+                    <p class="font-semibold">아직 참가를 받을 수 없어요</p>
+                    <p class="mt-1">
+                        {setupReason} 아래 설정을 완료하면 회원들이 참가할 수 있어요.
+                    </p>
+                {:else}
+                    <p>주최자가 나눔을 준비하고 있어요. 잠시 후 다시 확인해주세요.</p>
+                {/if}
+            </div>
+        {/if}
 
         <div class="text-muted-foreground mb-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">
             <span>참가자 <strong class="text-foreground">{detail.participant_count}</strong>명</span

--- a/apps/web/src/lib/features/giving/giving-write-form.svelte
+++ b/apps/web/src/lib/features/giving/giving-write-form.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
+    import { toast } from 'svelte-sonner';
     import { apiClient } from '$lib/api/index.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import PostForm from '$lib/components/features/board/post-form.svelte';
@@ -24,12 +25,29 @@
         isLoading?: boolean;
     } = $props();
 
+    /**
+     * datetime-local 입력용 'YYYY-MM-DDTHH:mm' (로컬 시각 기준).
+     * toISOString() 은 UTC 로 바꿔버려 9시간이 어긋나므로 쓰지 않는다.
+     */
+    function toLocalInput(d: Date): string {
+        const p = (n: number) => String(n).padStart(2, '0');
+        return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
+    }
+
+    const now = new Date();
+    const weekLater = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
     let method = $state<GivingMethod>('lowest_unique');
     let capacity = $state(1);
     let numberMax = $state(100);
     let unitPrice = $state(100);
-    let startAt = $state('');
-    let endAt = $state('');
+    // ⛔ 일정을 빈 값으로 두지 않는다.
+    // 백엔드 Normalize 는 시작·마감이 모두 있어야 active 로 판정하고, 하나라도 비면
+    // no_giving 이 된다. 프론트는 status==='active' 일 때만 참가 UI를 그리므로
+    // **참가 버튼이 아예 안 뜨는 글**이 아무 경고 없이 게시된다.
+    // 2026-07-23 첫 나눔(#2397)이 정확히 이 상태로 올라갔다 — 주최자도 회원도 몰랐다.
+    let startAt = $state(toLocalInput(now));
+    let endAt = $state(toLocalInput(weekLater));
 
     let busy = $state(false);
     let error = $state<string | null>(null);
@@ -40,6 +58,16 @@
             error = '로그인이 필요합니다.';
             return;
         }
+        // 일정이 비면 참가 버튼이 안 뜨는 글이 된다(no_giving) — 등록 자체를 막는다.
+        if (!startAt || !endAt) {
+            error = '나눔 시작일시와 마감일시를 모두 입력해주세요.';
+            return;
+        }
+        if (new Date(endAt) <= new Date(startAt)) {
+            error = '마감일시는 시작일시보다 뒤여야 합니다.';
+            return;
+        }
+
         busy = true;
         error = null;
         try {
@@ -47,17 +75,28 @@
                 ...(formData as CreatePostRequest),
                 author: authStore.user.mb_name,
                 extra_2: method === 'lowest_unique' ? String(unitPrice) : '0',
-                extra_4: startAt || '',
-                extra_5: endAt || ''
+                extra_4: startAt,
+                extra_5: endAt
             };
             const post = await apiClient.createPost(boardId, req);
             if (!post?.id) throw new Error('게시글 작성에 실패했습니다.');
 
-            // 방식 설정 저장 (실패해도 글은 생성됨 — 상세 페이지에서 재설정 가능)
+            // 방식 설정 저장.
+            //
+            // ⛔ 실패를 조용히 삼키지 않는다. 설정이 없으면 백엔드가 '준비 중'으로 두어
+            // 아무도 참가할 수 없는데, 주최자가 그 사실을 모르면 글만 덩그러니 남는다.
+            // 글은 이미 생성됐으므로 폼에 머물지 않고(재제출 시 중복 등록) 상세로 보내되,
+            // 무엇을 해야 하는지 분명히 알린다.
             try {
                 await givingApi.config(post.id, { method, capacity, number_max: numberMax });
-            } catch {
-                /* 상세에서 주최자가 다시 설정할 수 있음 */
+            } catch (configErr) {
+                console.error('나눔 설정 저장 실패:', configErr);
+                toast.error(
+                    '나눔 방식이 저장되지 않았어요. 글에서 설정을 완료해야 참가를 받을 수 있어요.',
+                    {
+                        duration: 10000
+                    }
+                );
             }
             goto(`/${boardId}/${post.id}`);
         } catch (e) {


### PR DESCRIPTION
**be#580(fail-closed) 동반 프론트 변경.** 두 PR은 함께 배포해야 합니다 — 백엔드만 나가면 UI가 `configured` 를 몰라 안내를 못 합니다.

## 배경 — 첫 나눔에서 실제로 터진 결함

2026-07-23 첫 실사용(#2397):

| 항목 | 결과 |
|---|---|
| `method=random` 저장 | ✅ 정상 |
| `seed_hash` 커밋 | ✅ 정상 |
| **시작·마감 일시** | ❌ **빈 값으로 게시** |

일정이 비면 백엔드 `Normalize` 가 `status=no_giving` 을 내고, 프론트는 `status==='active'` 일 때만
참가 UI를 그립니다 → **참가 버튼이 아예 렌더되지 않았습니다.** 주최자는 정상 게시했다고 믿고,
회원은 버튼을 못 찾습니다. **아무 경고도 없었습니다.**

## 변경 3가지

### 1. 일정 기본값 + 검증
- 기본값 자동 채움 (시작 = 현재, 마감 = +7일)
- 빈 값이거나 마감이 시작보다 앞이면 **등록 차단**
- `toISOString()` 은 UTC 로 바꿔 9시간이 어긋나므로 로컬 포맷 헬퍼 사용

### 2. `config` 실패 노출
```js
// 기존
} catch {
    /* 상세에서 주최자가 다시 설정할 수 있음 */
}
```
설정이 없으면 백엔드가 참가를 거부하는데, 주최자가 모르면 글만 덩그러니 남습니다.
글은 이미 생성됐으므로 폼에 머물지 않고(재제출 시 **중복 등록**) 상세로 보내되, 토스트로 분명히 알립니다.

### 3. 상세페이지 미설정 배너
- `configured=false`(설정 없음) 또는 `no_giving`(일정 없음) 감지
- **주최자**: 사유 + "설정을 완료하면 회원들이 참가할 수 있어요"
- **회원**: "주최자가 준비하고 있어요"

## 동반 배포

- 백엔드: damoang/angple-backend#580
- 순서: 양쪽 CI → 각각 카나리 → **함께 prod 승격**

`+88 / -7`, 3개 파일.