### PR TITLE
feat(register): 탈퇴자 재가입 시 접미사 계정 대신 이전 계정 복원 안내

### DIFF
--- a/apps/web/src/lib/server/auth/register.ts
+++ b/apps/web/src/lib/server/auth/register.ts
@@ -58,6 +58,84 @@ export function appendMbIdSuffix(baseMbId: string): string {
     return candidate;
 }
 
+/**
+ * 소셜 재가입 시 이미 그 소셜 계정으로 만들어진 계정이 있는지 판정한다.
+ *
+ * `generateSocialMbId`는 결정적이라 mb_id가 충돌한다는 것은 **같은 소셜 계정**이라는 뜻이다.
+ * 즉 점유 계정은 동일인의 것이 확실하므로, 새 계정을 만들 게 아니라 복구를 안내해야 한다.
+ * (2026-07-23 실측: 같은 base를 공유하는 198계정 90묶음 중 둘 이상이 활동한 묶음 0개
+ *  — 다중이가 아니라 재가입이 막혀 쌓인 빈 계정이었다)
+ *
+ * - `none`        점유 없음 → 정상 가입
+ * - `blocked`     이용제한 중 → 계정 생성 금지. 제재 회피 재가입 통로를 막는다
+ * - `recoverable` 그 외(탈퇴/활성) → 복구 안내 대상
+ */
+export type OccupantKind = 'none' | 'blocked' | 'recoverable';
+
+export interface OccupantInfo {
+    kind: OccupantKind;
+    mbId: string;
+    nick: string;
+    joinedAt: string;
+    postCount: number;
+    withdrawn: boolean;
+}
+
+export async function inspectSocialMbIdOccupant(
+    provider: string,
+    identifier: string
+): Promise<OccupantInfo> {
+    const mbId = generateSocialMbId(provider, identifier);
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT mb_id, mb_nick, mb_datetime, mb_leave_date, mb_intercept_date
+		   FROM g5_member WHERE mb_id = ? LIMIT 1`,
+        [mbId]
+    );
+    const row = rows[0];
+    if (!row) {
+        return { kind: 'none', mbId, nick: '', joinedAt: '', postCount: 0, withdrawn: false };
+    }
+
+    // mb_intercept_date는 YYYYMMDD 문자열. 99991231 = 영구.
+    // 만료된 제재는 차단 대상이 아니다.
+    const intercept = String(row.mb_intercept_date || '');
+    const today = new Date();
+    const todayStr =
+        `${today.getFullYear()}` +
+        `${String(today.getMonth() + 1).padStart(2, '0')}` +
+        `${String(today.getDate()).padStart(2, '0')}`;
+    const blocked = intercept.length === 8 && intercept >= todayStr;
+
+    const [cnt] = await pool.query<RowDataPacket[]>(
+        'SELECT COUNT(*) AS cnt FROM g5_board_new WHERE mb_id = ?',
+        [mbId]
+    );
+
+    return {
+        kind: blocked ? 'blocked' : 'recoverable',
+        mbId,
+        nick: row.mb_nick || '',
+        joinedAt: row.mb_datetime ? String(row.mb_datetime) : '',
+        postCount: Number(cnt[0]?.cnt || 0),
+        withdrawn: Boolean(row.mb_leave_date)
+    };
+}
+
+/**
+ * 탈퇴 상태인 옛 계정을 되살린다. 소셜 로그인 자기증명이 본인 확인을 대신한다
+ * (같은 소셜 sub이어야만 이 경로에 도달하므로 DI보다 강한 근거다).
+ */
+export async function reactivateMember(mbId: string, reason: string): Promise<void> {
+    await pool.query(
+        `UPDATE g5_member
+		    SET mb_leave_date = '',
+		        mb_leave_reason = '',
+		        mb_memo = CONCAT(IFNULL(mb_memo,''), '\\n', DATE_FORMAT(NOW(),'%Y%m%d'), ' ', ?)
+		  WHERE mb_id = ?`,
+        [reason, mbId]
+    );
+}
+
 /** g5_config에서 가입 레벨 조회 */
 export async function getRegisterLevel(): Promise<number> {
     const [rows] = await pool.query<RowDataPacket[]>(

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -12,7 +12,9 @@ import {
     validateNickname,
     isNicknameTaken,
     isMbIdTaken,
-    createMember
+    createMember,
+    inspectSocialMbIdOccupant,
+    reactivateMember
 } from '$lib/server/auth/register.js';
 import { upsertSocialProfile } from '$lib/server/auth/oauth/social-profile.js';
 import {
@@ -85,6 +87,21 @@ export const load: PageServerLoad = async ({ url, cookies }) => {
 
     const isInviteFlow = redirectUrl.includes('ads.damoang.net/invite/');
 
+    // 같은 소셜 계정으로 만들어진 계정이 이미 있으면 재가입이 아니라 복원 대상이다.
+    // 개인정보처리방침상 DI 를 반영구 보관하며 중복 가입을 막고 있으므로, 탈퇴자의
+    // 재가입은 애초에 성립하지 않는다. 그동안 운영에서 수동으로 복원해 주던 것을
+    // 이 경로로 자동화한다.
+    // 초대 플로우는 광고 계정용 임시 계정 발급이라 대상이 아니다.
+    if (!isInviteFlow && socialProfile.identifier) {
+        const occupant = await inspectSocialMbIdOccupant(
+            socialProfile.provider,
+            socialProfile.identifier
+        );
+        if (occupant.kind !== 'none') {
+            redirect(302, '/register/recover');
+        }
+    }
+
     // 약관/개인정보처리방침/이용제한사유 + 광고주 약관(초대 시) 로드
     const [termsContent, privacyContent, policyContent, siteTitle, contractContent] =
         await Promise.all([
@@ -126,6 +143,8 @@ export const actions: Actions = {
         let nickname = (formData.get('nickname') as string)?.trim() || '';
         const agreeTerms = formData.get('agree_terms') === 'on';
         const agreePrivacy = formData.get('agree_privacy') === 'on';
+        // 이전 계정 복구 요청. 새 계정을 만들지 않고 옛 계정으로 로그인시킨다.
+        const isRecovery = formData.get('intent') === 'recover';
 
         // Rate limit 체크 (5회/시간)
         const rateCheck = checkRateLimit(clientIp, 'register', 5, 60 * 60 * 1000);
@@ -137,8 +156,8 @@ export const actions: Actions = {
         }
         recordAttempt(clientIp, 'register');
 
-        // Turnstile CAPTCHA 검증 (초대 플로우는 소셜 인증 완료 상태이므로 스킵)
-        if (!isInviteFlow) {
+        // Turnstile CAPTCHA 검증 (초대·복구 플로우는 소셜 인증 완료 상태이므로 스킵)
+        if (!isInviteFlow && !isRecovery) {
             const turnstileToken = (formData.get('cf-turnstile-response') as string) || '';
             const captchaValid = await verifyTurnstile(turnstileToken, clientIp);
             if (!captchaValid) {
@@ -176,7 +195,33 @@ export const actions: Actions = {
         }
 
         let mbId: string;
-        if (isInviteFlow) {
+        if (isRecovery) {
+            // 복구 경로: 닉네임·약관 절차 없이 옛 계정으로 이어붙인다.
+            // 이 경로에 도달했다는 것 자체가 같은 소셜 sub 으로 로그인했다는 뜻이므로
+            // 본인 확인은 소셜 로그인 자기증명으로 충족된다(DI 보다 강한 근거).
+            const occupant = await inspectSocialMbIdOccupant(
+                socialProfile.provider,
+                socialProfile.identifier
+            );
+            if (occupant.kind !== 'recoverable') {
+                cookies.delete('pending_social_register', { path: '/' });
+                return fail(400, {
+                    error:
+                        occupant.kind === 'blocked'
+                            ? '이용이 제한된 계정입니다. 자세한 내용은 고객센터로 문의해주세요.'
+                            : '복구할 이전 계정을 찾지 못했습니다. 다시 시도해주세요.',
+                    nickname
+                });
+            }
+            mbId = occupant.mbId;
+            nickname = occupant.nick;
+            if (occupant.withdrawn) {
+                await reactivateMember(
+                    mbId,
+                    '[계정복구] 동일 소셜 계정 재로그인으로 본인 확인 후 재활성(F3)'
+                );
+            }
+        } else if (isInviteFlow) {
             nickname = await generateInviteTempNickname(socialProfile.provider);
             mbId = generateSocialMbId(socialProfile.provider, socialProfile.identifier);
             if (await isMbIdTaken(mbId)) {
@@ -200,14 +245,33 @@ export const actions: Actions = {
                 });
             }
 
-            mbId = generateSocialMbId(socialProfile.provider, socialProfile.identifier);
-            if (await isMbIdTaken(mbId)) {
-                mbId = appendMbIdSuffix(mbId);
+            // 같은 소셜 계정으로 만들어진 계정이 이미 있으면 새로 만들지 않는다.
+            // mb_id는 소셜 sub에서 결정적으로 나오므로 충돌 = 동일인이 확실하다.
+            const occupant = await inspectSocialMbIdOccupant(
+                socialProfile.provider,
+                socialProfile.identifier
+            );
+            if (occupant.kind === 'blocked') {
+                cookies.delete('pending_social_register', { path: '/' });
+                return fail(400, {
+                    error: '이용이 제한된 계정입니다. 자세한 내용은 고객센터로 문의해주세요.',
+                    nickname
+                });
             }
+            if (occupant.kind === 'recoverable') {
+                return fail(409, {
+                    error: '이전에 사용하시던 계정이 있습니다. 그 계정으로 이어서 이용하실 수 있습니다.',
+                    nickname,
+                    needsRecovery: true
+                });
+            }
+
+            mbId = occupant.mbId;
         }
 
-        // 이메일 중복 체크: 같은 이메일로 가입된 계정이 있으면 가입 차단
-        if (socialProfile.email) {
+        // 이메일 중복 체크: 같은 이메일로 가입된 계정이 있으면 가입 차단.
+        // 복구 경로는 옛 계정 자신이 걸리므로 건너뛴다.
+        if (!isRecovery && socialProfile.email) {
             const existingByEmail = await findMemberByEmail(socialProfile.email);
             if (existingByEmail) {
                 cookies.delete('pending_social_register', { path: '/' });
@@ -219,14 +283,16 @@ export const actions: Actions = {
         }
 
         try {
-            // g5_member INSERT
-            await createMember({
-                mb_id: mbId,
-                mb_nick: nickname,
-                mb_email: socialProfile.email,
-                mb_name: nickname,
-                mb_ip: clientIp
-            });
+            // g5_member INSERT (복구 경로는 이미 존재하는 계정이므로 생성하지 않는다)
+            if (!isRecovery) {
+                await createMember({
+                    mb_id: mbId,
+                    mb_nick: nickname,
+                    mb_email: socialProfile.email,
+                    mb_name: nickname,
+                    mb_ip: clientIp
+                });
+            }
 
             // 소셜 프로필 연결
             const oauthProfile: OAuthUserProfile = {

--- a/apps/web/src/routes/register/recover/+page.server.ts
+++ b/apps/web/src/routes/register/recover/+page.server.ts
@@ -1,0 +1,54 @@
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+import { inspectSocialMbIdOccupant } from '$lib/server/auth/register.js';
+
+/**
+ * 이전 계정 안내 화면.
+ *
+ * 탈퇴한 회원이 같은 소셜 계정으로 다시 가입하려 할 때, 새 계정을 만들어 주는 대신
+ * 이 화면으로 보낸다. mb_id 는 소셜 sub 에서 결정적으로 나오므로(generateSocialMbId)
+ * 충돌한다는 것은 **같은 소셜 계정**, 즉 동일인이라는 뜻이다.
+ *
+ * 복구 폼은 /register 의 액션으로 보낸다(intent=recover). 세션 생성·SSO 쿠키 등
+ * 로그인 마무리 로직을 그대로 재사용하기 위해서다.
+ */
+export const load: PageServerLoad = async ({ cookies }) => {
+    const pendingData = cookies.get('pending_social_register');
+    if (!pendingData) {
+        redirect(302, '/login');
+    }
+
+    let socialProfile: { provider: string; identifier: string; email?: string };
+    try {
+        socialProfile = JSON.parse(pendingData);
+    } catch {
+        redirect(302, '/login');
+    }
+
+    if (!socialProfile.identifier) {
+        redirect(302, '/register');
+    }
+
+    const occupant = await inspectSocialMbIdOccupant(
+        socialProfile.provider,
+        socialProfile.identifier
+    );
+
+    // 점유 계정이 없으면 평범한 가입 건이다. 원래 흐름으로 돌려보낸다.
+    if (occupant.kind === 'none') {
+        redirect(302, '/register');
+    }
+
+    return {
+        provider: socialProfile.provider,
+        email: socialProfile.email || '',
+        // mb_id 는 내려보내지 않는다. 화면에 필요한 최소 정보만.
+        account: {
+            kind: occupant.kind,
+            nick: occupant.nick,
+            joinedAt: occupant.joinedAt ? String(occupant.joinedAt).slice(0, 10) : '',
+            postCount: occupant.postCount,
+            withdrawn: occupant.withdrawn
+        }
+    };
+};

--- a/apps/web/src/routes/register/recover/+page.svelte
+++ b/apps/web/src/routes/register/recover/+page.svelte
@@ -9,9 +9,11 @@
     } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import Loader2 from '@lucide/svelte/icons/loader-2';
-    import type { PageData, ActionData } from './$types.js';
+    import type { PageData } from './$types.js';
 
-    let { data, form }: { data: PageData; form: ActionData } = $props();
+    // 복원 폼은 /register 액션으로 보낸다(세션 생성 로직 재사용). 실패 시 그쪽에서
+    // 에러를 표시하므로 이 페이지에는 form prop 이 없다.
+    let { data }: { data: PageData } = $props();
 
     let isSubmitting = $state(false);
 
@@ -88,12 +90,6 @@
                             </div>
                         </dl>
                     </div>
-
-                    {#if form?.error}
-                        <div class="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
-                            {form.error}
-                        </div>
-                    {/if}
 
                     <form
                         method="POST"

--- a/apps/web/src/routes/register/recover/+page.svelte
+++ b/apps/web/src/routes/register/recover/+page.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+    import { enhance } from '$app/forms';
+    import {
+        Card,
+        CardContent,
+        CardHeader,
+        CardTitle,
+        CardDescription
+    } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import Loader2 from '@lucide/svelte/icons/loader-2';
+    import type { PageData, ActionData } from './$types.js';
+
+    let { data, form }: { data: PageData; form: ActionData } = $props();
+
+    let isSubmitting = $state(false);
+
+    const providerNames: Record<string, string> = {
+        google: 'Google',
+        kakao: '카카오',
+        naver: '네이버',
+        apple: 'Apple',
+        facebook: 'Facebook',
+        twitter: 'X (Twitter)',
+        payco: 'PAYCO'
+    };
+
+    const providerLabel = $derived(providerNames[data.provider] || data.provider);
+    const blocked = $derived(data.account.kind === 'blocked');
+</script>
+
+<svelte:head>
+    <title>이전 계정 안내 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<div class="flex min-h-[calc(100vh-200px)] items-center justify-center px-4 py-12">
+    <Card class="w-full max-w-lg">
+        <CardHeader class="text-center">
+            <CardTitle class="text-2xl font-bold">
+                {blocked ? '가입할 수 없습니다' : '이전 계정이 있습니다'}
+            </CardTitle>
+            <CardDescription>
+                {#if blocked}
+                    이 {providerLabel} 계정으로 만든 계정이 이용 제한 상태입니다
+                {:else}
+                    같은 {providerLabel} 계정으로 만드신 계정입니다
+                {/if}
+            </CardDescription>
+        </CardHeader>
+
+        <CardContent>
+            {#if blocked}
+                <div class="space-y-5">
+                    <div
+                        class="bg-destructive/10 text-destructive rounded-md p-4 text-sm leading-6"
+                    >
+                        <p>
+                            이 소셜 계정으로 만들어진 계정이 현재 이용 제한 상태입니다. 새로
+                            가입하실 수 없습니다.
+                        </p>
+                    </div>
+                    <p class="text-muted-foreground text-sm leading-6">
+                        문의가 필요하시면 고객센터로 연락해 주세요.
+                    </p>
+                    <Button href="/" variant="outline" class="w-full">돌아가기</Button>
+                </div>
+            {:else}
+                <div class="space-y-5">
+                    <div class="border-border bg-muted/40 rounded-lg border p-4 text-sm leading-6">
+                        <p class="text-muted-foreground">
+                            새로 가입하지 않으셔도 됩니다. 아래 계정으로 이어서 이용하실 수
+                            있습니다.
+                        </p>
+                        <dl class="mt-4 space-y-1.5">
+                            <div class="flex gap-3">
+                                <dt class="text-muted-foreground w-20 shrink-0">닉네임</dt>
+                                <dd class="font-medium">{data.account.nick}</dd>
+                            </div>
+                            {#if data.account.joinedAt}
+                                <div class="flex gap-3">
+                                    <dt class="text-muted-foreground w-20 shrink-0">가입일</dt>
+                                    <dd>{data.account.joinedAt}</dd>
+                                </div>
+                            {/if}
+                            <div class="flex gap-3">
+                                <dt class="text-muted-foreground w-20 shrink-0">글·댓글</dt>
+                                <dd>{data.account.postCount.toLocaleString()}건</dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    {#if form?.error}
+                        <div class="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
+                            {form.error}
+                        </div>
+                    {/if}
+
+                    <form
+                        method="POST"
+                        action="/register"
+                        use:enhance={() => {
+                            isSubmitting = true;
+                            return async ({ result, update }) => {
+                                if (result.type !== 'redirect') {
+                                    isSubmitting = false;
+                                }
+                                await update();
+                            };
+                        }}
+                    >
+                        <input type="hidden" name="intent" value="recover" />
+                        <input type="hidden" name="redirect" value="/" />
+                        <Button type="submit" class="w-full" disabled={isSubmitting}>
+                            {#if isSubmitting}
+                                <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+                                처리 중...
+                            {:else}
+                                이 계정으로 계속 이용하기
+                            {/if}
+                        </Button>
+                    </form>
+
+                    <p class="text-muted-foreground text-center text-xs leading-5">
+                        본인 확인은 방금 로그인하신 {providerLabel} 계정으로 대신합니다.
+                    </p>
+                </div>
+            {/if}
+        </CardContent>
+    </Card>
+</div>


### PR DESCRIPTION
## 배경

개인정보처리방침상 **DI 를 반영구 보관하며 중복 가입을 막고** 있으므로 탈퇴자의 재가입은
애초에 성립하지 않는다. 그동안 운영에서 **수동으로 복원**해 주던 것을 자동화한다.

그런데 코드는 그 정책을 뚫고 있었다. mb_id 가 점유돼 있으면 접미사를 붙여
`google_923b0918_3c34` 같은 계정을 조용히 만들어 줬다. 회원이 만든 것도 아닌 아이디이고,
원래 계정은 그대로 잠긴 채 남는다.

## 실측 (2026-07-23)

| | |
|---|---|
| 접미사 계정 | 107건 |
| 그중 base 가 탈퇴 상태 | **71명** |
| 같은 base 공유 계정 | 198개 / 90묶음 |
| **둘 이상이 활동한 묶음** | **0개** |
| 옛 계정에 글이 있는 회원 | 13명 · **3,986건** 잠김 |

**둘 이상 활동한 묶음이 하나도 없다** — 다중이가 아니라 재가입이 막혀 쌓인 빈 계정이다.
어떤 회원은 **6번**까지 재시도했다(메서악 6, 쿠마s 5). 커뮤니티가 체감하는 "다중이 증가"의
일부가 여기서 나왔다.

## 변경

- **`inspectSocialMbIdOccupant()`** — mb_id 는 소셜 sub 에서 결정적으로 나오므로
  **충돌 = 동일인이 확실하다**. 점유 계정을 `none` / `blocked` / `recoverable` 로 판정한다.
  - `blocked`(이용제한 중)이면 계정을 만들지 않는다 → **제재 회피 재가입 통로 차단**
  - `mb_intercept_date` 는 `YYYYMMDD` 문자열이라 **만료 건을 오판하지 않도록** 오늘과 비교
- **`/register/recover` 신설** — 이전 계정의 닉네임·가입일·글 수를 보여주고 복원을 안내.
  `mb_id` 는 화면에 내려보내지 않는다.
- `/register` load 에서 점유가 확인되면 이 화면으로 보낸다.
- **복원 실행은 `/register` 액션에 `intent=recover` 로 합류** — 세션 생성·SSO 쿠키 등
  로그인 마무리 로직을 그대로 재사용하고 계정 생성만 건너뛴다.
- **본인 확인은 소셜 로그인 자기증명**으로 충족. 같은 소셜 sub 으로 로그인해야만 이 경로에
  도달하므로 DI 보다 강한 근거다(DI 는 명의를 나눠 쓰면 갈린다).
- 일반 가입 경로의 접미사 생성 제거. 초대 플로우(광고 계정 임시 발급)는 별개 트랙이라 유지.

## 선행 작업

#1862 (mb_id 절단 차단) 이 먼저 들어갔다. 접미사가 20자를 넘어 회원 테이블에만 절단
저장되면서 **소셜 로그인이 영구 불가**해지던 문제였고, 그 계정이 벽돌이 되니 회원이 또
재가입을 시도하는 악순환이 있었다.

## 검증

- [ ] CI (빌드 / 타입체크 / 테스트 / prettier)
- [ ] 카나리: 탈퇴 계정 보유 소셜로 가입 시도 → 복원 안내 노출
- [ ] 카나리: 복원 실행 → 옛 계정으로 로그인, 글 수 보존
- [ ] 카나리: 이용제한 계정 → 차단, 신규 계정 미생성
- [ ] 카나리: 초대 플로우 회귀 없음