### PR TITLE
feat(board): 작성자 최근 활동 — 모바일 펼침 상태 기억 (#13077)

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -53,6 +53,20 @@
     let adContainer = $state<HTMLElement | null>(null);
     let clipWrapper = $state<HTMLElement | null>(null);
     let panelEl = $state<HTMLElement | null>(null);
+    /**
+     * 모바일 펼침 상태 저장 키 (#13077).
+     *
+     * ⛔ 모바일에만 적용한다. 데스크톱은 접어도 공간이 줄지 않기 때문이다 —
+     * 광고 열이 DESKTOP_AD_MAX_HEIGHT(190px) 로 !important 고정돼 있어,
+     * 활동 카드를 접으면 헤더만 남아도 그 190px 이 그리드 행 높이를 지배한다.
+     * 반면 모바일 블록(sm:hidden)은 광고 그리드와 분리돼 있어 접으면 실제로 줄어든다.
+     *
+     * 서버 동기화(ui-settings)가 아니라 localStorage 를 쓰는 이유:
+     * 화면 크기에 종속된 표시 취향이라 기기 간 공유가 오히려 부자연스럽다.
+     * 같은 디렉터리의 angmap-pin-map.svelte 가 같은 방식을 쓴다.
+     */
+    const MOBILE_EXPANDED_KEY = 'author_activity_mobile_expanded';
+
     let mobileExpanded = $state(false);
     let shouldLoad = $state(false);
     let desktopExpanded = $state(hasInitial);
@@ -191,12 +205,28 @@
         if (mobileExpanded) {
             shouldLoad = true;
         }
+        try {
+            localStorage.setItem(MOBILE_EXPANDED_KEY, mobileExpanded ? '1' : '0');
+        } catch {
+            // 프라이빗 모드 등 — 상태 기억만 포기하고 동작은 유지
+        }
     }
 
     onMount(() => {
         let mutationObserver: MutationObserver | undefined;
         let resizeObserver: ResizeObserver | undefined;
         const handleResize = () => enforceClipHeight();
+
+        // 지난번에 모바일에서 펼쳐뒀다면 복원 (#13077).
+        // 기본값은 접힘 그대로라, 한 번도 펼친 적 없는 사용자에겐 변화가 없다.
+        try {
+            if (localStorage.getItem(MOBILE_EXPANDED_KEY) === '1') {
+                mobileExpanded = true;
+                shouldLoad = true;
+            }
+        } catch {
+            // 프라이빗 모드 등 — 기본값(접힘) 유지
+        }
 
         loadAdSense();
 


### PR DESCRIPTION
제보 [#13077](https://damoang.net/bug/13077) (풀레드님) 수용.

## 제보 내용
> '작성자 최근 활동' 목록이 항상 펼쳐져 있어서 접었는데 다른 게시물을 들어가면 다시 펼쳐져 있습니다.
> 설정에서 옵션으로 제공하거나 마지막 값을 계속 기억했으면 좋겠습니다.

## 원인
컴포넌트 로컬 `$state` 라 글을 옮길 때마다 초기화된다.

```js
let mobileExpanded = $state(false);
let desktopExpanded = $state(hasInitial);
```

## ⛔ 모바일에만 적용한 이유

데스크톱은 **접어도 공간이 줄지 않는다.**

```js
const DESKTOP_AD_MAX_HEIGHT = 190;
clipWrapper.style.setProperty('height', target, 'important');   // min/max 도 동일
```

패널은 `sm:grid-cols-3` 이고 1열이 애드센스, 2~3열이 활동 카드(`sm:col-span-2`)다.
광고 높이가 **190px 로 !important 고정**이라, 활동 카드를 접어 헤더만 남아도
그 190px 이 그리드 행 높이를 지배한다. 기억해봐야 얻는 게 없다.

반면 모바일 블록은 `sm:hidden` 으로 **광고 그리드와 분리**돼 있어 접으면 실제로 줄어든다.

## localStorage 를 쓴 이유

`ui-settings`(서버 동기화)가 아니라 `localStorage` 다. 화면 크기에 종속된 표시 취향이라
기기 간 공유가 오히려 부자연스럽다. 같은 디렉터리 `angmap-pin-map.svelte` 의 기존 패턴을 따랐다.

## 영향

- **기본값은 접힘 그대로** — 한 번도 펼친 적 없는 사용자에겐 변화 없음
- 프라이빗 모드 등 `localStorage` 실패 시 기억만 포기하고 동작은 유지
- 데스크톱 동작 무변경

`+30 / -0` (순수 추가), 1개 파일.