### PR TITLE
fix(comments): 자동링크로 깨진 GIF 이미지 렌더 복구

### DIFF
--- a/apps/web/src/lib/utils/content-transform.test.ts
+++ b/apps/web/src/lib/utils/content-transform.test.ts
@@ -402,4 +402,28 @@ describe('transformBracketImages - 기존 동작 유지', () => {
         const result = transformBracketImages('[https://example.com/page.html]');
         expect(result).toBe('[https://example.com/page.html]');
     });
+
+    // #12439(댓글 자동 링크 시각 표시 강제) 이후, GIF 피커가 넣은 `[url]` 의 URL 을
+    // tiptap Link 확장이 <a> 로 먼저 감싸면서 대괄호 패턴이 매칭되지 않아
+    // 이미지가 뜨지 않는 회귀가 생겼다. 실제 저장된 hello/29516 형태로 고정한다.
+    it('자동링크로 감싸진 대괄호 GIF 도 img 로 변환', () => {
+        const stored =
+            '<p>[<a target="_blank" rel="noopener noreferrer nofollow" ' +
+            'class="text-primary underline" data-comment-autolink="true" ' +
+            'href="https://static.klipy.com/ii/abc/3a/81/9FtST6op.gif">' +
+            'https://static.klipy.com/ii/abc/3a/81/9FtST6op.gif</a>]</p>';
+        const result = transformBracketImages(stored);
+        expect(result).toContain('<img src="https://static.klipy.com/ii/abc/3a/81/9FtST6op.gif"');
+        expect(result).not.toContain('<a ');
+    });
+
+    it('자동링크라도 이미지 확장자가 아니면 변환 안 함', () => {
+        const stored = '<p>[<a href="https://example.com/page.html">page</a>]</p>';
+        expect(transformBracketImages(stored)).toBe(stored);
+    });
+
+    it('대괄호 없는 자동링크는 건드리지 않음 (일반 링크 보존)', () => {
+        const stored = '<p><a href="https://example.com/image.jpg">사진</a></p>';
+        expect(transformBracketImages(stored)).toBe(stored);
+    });
 });

--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -67,14 +67,30 @@ export function transformEmoticons(text: string): string {
  * 그누보드/나리야 PHP 호환
  */
 export function transformBracketImages(text: string): string {
-    if (!text || !text.includes('[http')) return text;
+    if (!text || !text.includes('[')) return text;
 
-    return text.replace(
+    const imgTag = (url: string) =>
+        `<img src="${url}" alt="이미지" loading="lazy" class="bracket-image" style="max-width:100%;height:auto;">`;
+
+    // ① 순수 대괄호: [https://…/x.gif]
+    let out = text.replace(
         /\[(https?:\/\/[^\]]+\.(?:jpg|jpeg|png|gif|webp|bmp|svg)(?:\?[^\]]*)?)\]/gi,
-        (_match, url: string) => {
-            return `<img src="${url}" alt="이미지" loading="lazy" class="bracket-image" style="max-width:100%;height:auto;">`;
-        }
+        (_match, url: string) => imgTag(url)
     );
+
+    // ② 자동링크로 감싸진 대괄호: [<a href="https://…/x.gif" …>…</a>]
+    //
+    // GIF 피커는 `[${url}]` 로 넣는데(tenor-gif-picker.svelte), #12439 에서 댓글
+    // 자동 링크 시각 표시를 강제하면서 tiptap Link 확장이 URL 을 먼저 <a> 로 감싼다.
+    // 그러면 ①의 정규식이 매칭되지 않아 대괄호만 남고 이미지가 뜨지 않는다.
+    //   저장 형태: <p>[<a href="…gif" data-comment-autolink="true">https://…</a>]</p>
+    // 삽입 쪽을 바꾸지 않고 여기서 흡수하면, 이미 저장된 댓글도 함께 살아난다.
+    out = out.replace(
+        /\[\s*<a\b[^>]*\shref="(https?:\/\/[^"]+\.(?:jpg|jpeg|png|gif|webp|bmp|svg)(?:\?[^"]*)?)"[^>]*>.*?<\/a>\s*\]/gi,
+        (_match, url: string) => imgTag(url)
+    );
+
+    return out;
 }
 
 /**


### PR DESCRIPTION
댓글 GIF 피커로 넣은 이미지가 **뜨지 않고 링크 텍스트로만** 보입니다.
사례: [hello/29514](https://damoang.net/hello/29514) 댓글

## 원인 — #12439 의 부작용

GIF 피커는 `[${url}]` 형태로 삽입합니다 (`tenor-gif-picker.svelte:90`).
렌더 단계의 `transformBracketImages` 가 이 대괄호를 `<img>` 로 바꾸는 구조입니다.

그런데 **#12439(댓글 자동 링크 시각 표시 강제)** 로 tiptap `Link` 확장이 URL 을 먼저 `<a>` 로 감싸면서, 정규식 `\[(https?://…)\]` 이 더 이상 매칭되지 않습니다.

```html
<p>[<a href="…gif" data-comment-autolink="true">https://…</a>]</p>
   ↑ 대괄호는 남았는데 안쪽이 순수 URL 이 아님
```

함수 첫 줄 `if (!text.includes('[http')) return text` 에서 즉시 반환됩니다.

## 조치 — 삽입이 아니라 **렌더**를 고침

자동링크로 감싸진 형태도 흡수하는 두 번째 치환을 추가했습니다.

**삽입 쪽(피커·툴바)을 바꾸지 않은 이유:**

1. **이미 저장된 댓글도 함께 살아납니다** — `free` 댓글만 **28,799건**이 대괄호 형식입니다
2. `<img>` 를 직접 저장하는 방식은 **외부 도메인 img 저장 선례가 0건**이라 sanitizer 통과 여부가 불확실합니다. 기존 렌더 경로를 그대로 쓰는 편이 안전합니다

## 검증 — 실제 저장 데이터로

| 대상 | 결과 |
|---|---|
| `hello/29516` (깨진 새 댓글) | `<img>` 생성 ✅ |
| 기존 대괄호 댓글 | `<img>` 생성 ✅ (하위호환) |

테스트 4종 추가 — 자동링크 GIF 변환 / 비이미지 확장자 무시 / **대괄호 없는 일반 링크 보존**(회귀 방지).