### PR TITLE
fix(nav): 목록 2페이지 이상에서 탭을 눌러도 1페이지로 안 가던 문제

### DIFF
--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -15,7 +15,19 @@
     const menus = $derived(menusProp ?? widgetLayoutStore.tagNavMenus ?? DEFAULT_TAG_NAV_MENUS);
 
     const visibleMenus = $derived(menus.filter((m) => m.show));
+
+    // 하이라이트 판정용 — 경로만 본다.
+    // /free?page=5 도, 글 상세 /free/123 도 '자유게시판' 탭이 활성으로 보여야 한다.
     const currentPath = $derived($page.url.pathname);
+
+    // 클릭 가드용 — 쿼리스트링까지 본다.
+    //
+    // 페이지네이션이 /free?page=5 형태라, 경로만 비교하면 5페이지에서도
+    // currentPath === '/free' 가 되어 navigation 이 취소된다. 그러면 탭을 눌러도
+    // 5페이지가 새로고침될 뿐 1페이지로 가지 않아 "눌러도 아무 일이 없다"로 보인다.
+    // (free/6793410 제보: "하나만 1페이지로 가고 다른 두 개는 더미 같은 느낌")
+    // ?search=·?filter= 등 다른 쿼리에서도 같은 문제라 전체 URL 로 비교한다.
+    const currentUrl = $derived($page.url.pathname + $page.url.search);
 
     function isActive(url: string): boolean {
         if (url === '/') return currentPath === '/';
@@ -33,7 +45,10 @@
                     // 로 새로고침(#12027). 하위 경로(글 상세 /free/123 등)에서는 isActive 가
                     // true(탭 하이라이트용)여도 정상적으로 목록으로 이동해야 한다 — 안 그러면
                     // 글 상세에서 해당 탭 클릭 시 목록이 안 뜨고 무반응처럼 보임.
-                    if (currentPath === menu.url) {
+                    //
+                    // ⛔ currentPath(경로만)가 아니라 currentUrl(쿼리 포함)로 비교할 것.
+                    // /free?page=5 에서 경로만 비교하면 여기 걸려 1페이지로 못 간다.
+                    if (currentUrl === menu.url) {
                         e.preventDefault();
                         invalidateAll();
                         window.scrollTo(0, 0);


### PR DESCRIPTION
제보 [free/6793410](https://damoang.net/free/6793410) (갤러리김님)

> 자유게시판을 누르면 내가 보던 페이지가 아닌 자유게시판 1페이지가 나오길 기대하는데
> 저 중에 **하나만 1페이지로 가고 다른 두 개는 더미 같은 느낌**이에요
> 매번 할 때마다 어떤 거였지 하며 한 번씩 다 눌러보게 되네요

## 조사

글 상세 페이지의 '자유게시판' 링크는 **3개**이고 href 는 **전부 `/free` 로 동일**합니다.

| 위치 | 정체 |
|---|---|
| 브레드크럼 | `홈 / 자유게시판 / 제목` |
| **탭 바** | `공감글 · 소모임 · [자유게시판] · Q&A` |
| 하단 목록 헤더 | 글 아래 목록의 제목 |

브레드크럼과 하단 헤더는 평범한 `<a>` 라 항상 정상 이동합니다.
**탭 바만** `onclick` 가드가 있습니다.

## 원인

```js
const currentPath = $derived($page.url.pathname);   // ← 쿼리 제외
...
if (currentPath === menu.url) {
    e.preventDefault();   // 이동 취소
    invalidateAll();      // 현재 페이지 새로고침만
}
```

페이지네이션이 `/free?page=5` 형태인데 `pathname` 만 보면 `/free` 라 **가드에 걸립니다.**
탭을 눌러도 1페이지로 가지 않고 5페이지가 새로고침될 뿐이라 무반응처럼 보입니다.

#12027 에서 '글 상세에서는 이동해야 한다' 는 고쳤으나, **'목록 N페이지에서는 1페이지로 가야 한다'** 가 빠져 있었습니다.

## 조치

하이라이트 판정(`currentPath`)은 경로만 그대로 두고 — `/free?page=5` 도 글 상세도 탭이 활성으로 보여야 하므로 — **클릭 가드만 쿼리를 포함**해 비교합니다.

| 현재 위치 | 기존 | 수정 후 |
|---|---|---|
| `/free` | 새로고침 | 새로고침 (유지) |
| `/free?page=5` | 새로고침 | **이동** ✅ |
| `/free?search=1` | 새로고침 | **이동** ✅ |
| `/free/6793410` | 이동 | 이동 (유지) |

의도한 두 케이스만 바뀌고 나머지는 그대로입니다.