### PR TITLE
fix(angmap): 핀 증가로 초기 뷰에서 국내 핀이 잘리던 문제

### DIFF
--- a/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
+++ b/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
@@ -63,6 +63,20 @@
     }
 
     /**
+     * 초기 뷰 이상치 판정 배수 (MAD 의 몇 배까지 포함할지).
+     *
+     * ⚠️ 핀 밀도가 올라가면 MAD 가 **작아져** 임계도 같이 줄어든다. 배수가 낮으면
+     * 밀집 지역만 남고 변두리 핀이 잘린다.
+     *   2026-07-23 (핀 239개): MAD 1.19 → ×6 = 7.15  → 국내 잘림 0
+     *   2026-07-24 (핀 1493개): MAD 0.63 → ×6 = 3.76 → **국내 161개 잘림**
+     *   백필 완료로 핀이 6배가 되자 제주·부산·강원이 초기 화면에서 사라졌다.
+     *
+     * ×8 부터 국내 잘림이 0 이 되고, ×20 까지 올려도 해외 핀은 계속 배제된다
+     * (포함 1462 → 1463, 1개 차이). 여유를 두되 대륙 밖은 거르도록 ×10 으로 둔다.
+     */
+    const MAD_MULTIPLIER = 10;
+
+    /**
      * 초기 뷰용 bounds. **모든 핀은 지도에 그대로 그려지고**, 여기서 정하는 건
      * "처음 어디를 비춰줄지"뿐이다. 줌아웃하면 제외된 핀도 전부 보인다.
      *
@@ -70,7 +84,7 @@
      * 정작 대부분의 핀이 점으로 뭉개진다(2026-07-23 실측: 해외 핀 12개 때문에 발생).
      *
      * ⛔ 특정 국가 범위를 하드코딩하지 말 것 — 다모앙은 글로벌이다.
-     * 중앙값에서의 거리가 MAD(중앙값 절대편차)의 6배를 넘는 핀만 초기 뷰에서 뺀다.
+     * 중앙값에서의 거리가 MAD(중앙값 절대편차)의 일정 배수를 넘는 핀만 초기 뷰에서 뺀다.
      * 데이터가 스스로 중심을 정하므로, 핀이 어느 대륙에 몰리든 그곳이 초기 뷰가 된다.
      */
     function initialBounds(L: typeof import('leaflet'), pinData: AngmapPin[]) {
@@ -81,7 +95,7 @@
         const cLng = median(pts.map((p) => p[1]));
         const dist = pts.map((p) => Math.abs(p[0] - cLat) + Math.abs(p[1] - cLng));
         // MAD 가 0(핀이 한 점에 몰림)이면 최소 1도는 허용해 bounds 가 무너지지 않게 한다.
-        const threshold = Math.max(median(dist) * 6, 1);
+        const threshold = Math.max(median(dist) * MAD_MULTIPLIER, 1);
         const core = pts.filter((_, i) => dist[i] <= threshold);
 
         return L.latLngBounds(core.length >= 3 ? core : pts);


### PR DESCRIPTION
야간 백필 완료로 핀이 **239 → 1,493개**(커버리지 92.0%)가 되자, 초기 화면에서 **제주·부산·강원 등 국내 핀 161개가 잘렸습니다.**

## 원인

핀 밀도가 올라가면 MAD(중앙값 절대편차)가 **작아져** 임계도 같이 줄어듭니다.

| 시점 | 핀 | MAD | ×6 임계 | 국내 잘림 |
|---|---|---|---|---|
| 07-23 | 239 | 1.19 | 7.15 | **0** |
| 07-24 | 1,493 | 0.63 | 3.76 | **161** |

수도권에 핀이 조밀해지면서 변두리가 이상치로 판정된 것입니다.

## 배수 선택 (실데이터 1,493핀 시뮬레이션)

| 배수 | 임계 | 국내잘림 | 포함 |
|---|---|---|---|
| ×6 (기존) | 3.76 | **161** | 1301 |
| ×8 | 5.01 | 0 | 1462 |
| **×10 (채택)** | **6.26** | **0** | **1462** |
| ×20 | 12.52 | 0 | 1463 |

`×8` 부터 잘림이 사라지고, `×20` 까지 올려도 **해외 핀은 계속 배제**됩니다(1462 → 1463, 1개 차이). 여유를 두되 대륙 밖은 거르도록 **×10** 으로 했습니다.

## 검산

| | 기존 ×6 | 수정 ×10 |
|---|---|---|
| 국내 잘림 | 161개 ❌ | **0개** ✅ |
| 해외 배제 | 31개 | 31개 (유지) |
| 초기 범위 | lat 34.18~38.54 | **lat 33.22~38.54** (제주 포함) |

⛔ 국가 범위 하드코딩은 여전히 하지 않습니다. 배수만 조정했고, 상수에 재발 방지용 근거를 주석으로 남겼습니다.