### PR TITLE
feat(angmap): 앙지도 레거시 평점 아카이브 표시

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -84,6 +84,8 @@ export interface FreePost {
     report_count?: number | string; // wr_7 값: 숫자(신고수) 또는 "lock"(잠김)
     // 별점 집계 (features.rating 보드에서만 백엔드가 동봉 — 없으면 위젯 미표시)
     rating?: PostRating;
+    // 레거시 평점 아카이브 (앙지도 전용, SSR enrichment, 읽기전용 — 신규 rating 과 별개로 나란히 표시)
+    archiveRating?: ArchiveRating;
     // 확장 필드 (PHP wr_1~wr_10 매핑)
     extra_1?: string; // wr_1 - 회원전용 등
     extra_2?: string; // wr_2 - 나눔: 포인트/숫자
@@ -666,6 +668,13 @@ export interface PostRating {
     avg: number; // 평균 별점 (0~5)
     count: number; // 참여 인원
     my: number; // 내 별점 (1~5, 비로그인/미투표 0)
+}
+
+// 레거시 평점 아카이브 (앙지도 — gnuboard 10점 시절 동결 집계).
+// 신규 5점 rating 과 개인식별 매핑이 없어 합칠 수 없어(합치면 날조) 별도로 "과거 평점"만 표시한다.
+export interface ArchiveRating {
+    avg5: number; // 10점 레거시를 5점으로 환산한 평균 (0~5)
+    count: number; // 과거 참여 인원
 }
 
 // 추천/비추천 응답

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -339,7 +339,12 @@
         <!-- 별점 위젯 (앙티티 Phase 0): features.rating 보드에서만 백엔드가
              post.rating 을 동봉 → 없으면 렌더 0 (전 게시판 회귀 0) -->
         {#if post.rating}
-            <PostRatingWidget {boardId} postId={post.id} initial={post.rating} />
+            <PostRatingWidget
+                {boardId}
+                postId={post.id}
+                initial={post.rating}
+                archive={post.archiveRating}
+            />
         {/if}
     </CardHeader>
     <CardContent class="space-y-6">

--- a/apps/web/src/lib/components/features/board/post-rating.svelte
+++ b/apps/web/src/lib/components/features/board/post-rating.svelte
@@ -17,7 +17,7 @@
     import { apiClient } from '$lib/api/client.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { buildGradeDeniedMessage } from '$lib/utils/board-permissions.js';
-    import type { PostRating } from '$lib/api/types.js';
+    import type { PostRating, ArchiveRating } from '$lib/api/types.js';
     import {
         RATING_MIN_LEVEL,
         applyOptimisticRating,
@@ -27,11 +27,14 @@
     let {
         boardId,
         postId,
-        initial
+        initial,
+        archive
     }: {
         boardId: string;
         postId: number | string;
         initial: PostRating;
+        // 레거시 평점 아카이브 (앙지도 — gnuboard 10점 동결 집계, 신규와 별개로 표시만)
+        archive?: ArchiveRating;
     } = $props();
 
     const STARS = [1, 2, 3, 4, 5];
@@ -82,53 +85,72 @@
     }
 </script>
 
-<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-    <div class="flex items-center" role="radiogroup" aria-label="별점 선택 (1~5점)">
-        {#each STARS as star (star)}
-            <button
-                type="button"
-                class="p-0.5 transition-transform {canVote
-                    ? 'cursor-pointer hover:scale-110'
-                    : 'cursor-default'}"
-                disabled={submitting}
-                role="radio"
-                aria-checked={rating.my === star}
-                aria-label="별점 {star}점"
-                onclick={() => vote(star)}
-                onmouseenter={() => {
-                    if (canVote) hoverValue = star;
-                }}
-                onmouseleave={() => (hoverValue = 0)}
-                onfocus={() => {
-                    if (canVote) hoverValue = star;
-                }}
-                onblur={() => (hoverValue = 0)}
-            >
-                <span class="relative block h-5 w-5">
-                    <Star class="text-muted-foreground/40 h-5 w-5" />
-                    <span
-                        class="absolute inset-y-0 left-0 overflow-hidden"
-                        style="width: {starFillPercent(displayValue, star)}%"
-                    >
-                        <Star
-                            class="h-5 w-5 {isMyFill(star)
-                                ? 'fill-primary text-primary'
-                                : 'fill-amber-400 text-amber-400'}"
-                        />
+<div class="space-y-1">
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <div class="flex items-center" role="radiogroup" aria-label="별점 선택 (1~5점)">
+            {#each STARS as star (star)}
+                <button
+                    type="button"
+                    class="p-0.5 transition-transform {canVote
+                        ? 'cursor-pointer hover:scale-110'
+                        : 'cursor-default'}"
+                    disabled={submitting}
+                    role="radio"
+                    aria-checked={rating.my === star}
+                    aria-label="별점 {star}점"
+                    onclick={() => vote(star)}
+                    onmouseenter={() => {
+                        if (canVote) hoverValue = star;
+                    }}
+                    onmouseleave={() => (hoverValue = 0)}
+                    onfocus={() => {
+                        if (canVote) hoverValue = star;
+                    }}
+                    onblur={() => (hoverValue = 0)}
+                >
+                    <span class="relative block h-5 w-5">
+                        <Star class="text-muted-foreground/40 h-5 w-5" />
+                        <span
+                            class="absolute inset-y-0 left-0 overflow-hidden"
+                            style="width: {starFillPercent(displayValue, star)}%"
+                        >
+                            <Star
+                                class="h-5 w-5 {isMyFill(star)
+                                    ? 'fill-primary text-primary'
+                                    : 'fill-amber-400 text-amber-400'}"
+                            />
+                        </span>
                     </span>
-                </span>
-            </button>
-        {/each}
+                </button>
+            {/each}
+        </div>
+        <span class="text-muted-foreground text-sm">
+            {#if rating.count > 0}
+                <span class="text-foreground font-medium">★{rating.avg.toFixed(1)}</span>
+                · 앙님 {rating.count.toLocaleString()}명
+            {:else}
+                첫 별점을 남겨주세요
+            {/if}
+            {#if rating.my > 0}
+                <span class="text-primary ml-1">내 별점 ★{rating.my}</span>
+            {/if}
+        </span>
     </div>
-    <span class="text-muted-foreground text-sm">
-        {#if rating.count > 0}
-            <span class="text-foreground font-medium">★{rating.avg.toFixed(1)}</span>
-            · 앙님 {rating.count.toLocaleString()}명
-        {:else}
-            첫 별점을 남겨주세요
-        {/if}
-        {#if rating.my > 0}
-            <span class="text-primary ml-1">내 별점 ★{rating.my}</span>
-        {/if}
-    </span>
+    {#if archive}
+        <!-- 레거시 아카이브: gnuboard 10점 시절 동결 집계. 신규 별점과 별개로 "과거 평점"만 표시.
+             n<3 은 평균 대신 인원만(작은 표본 착시 방지 — 설계 §4). -->
+        <div class="text-muted-foreground mt-0.5 flex flex-wrap items-center gap-1 text-xs">
+            <span aria-hidden="true">📜</span>
+            {#if archive.count >= 3}
+                <span>
+                    과거 평점
+                    <span class="text-foreground font-medium">★{archive.avg5.toFixed(1)}</span>
+                    · 앙님 {archive.count.toLocaleString()}명
+                </span>
+            {:else}
+                <span>과거 앙님 {archive.count.toLocaleString()}명 평가</span>
+            {/if}
+            <span class="opacity-70">(아카이브)</span>
+        </div>
+    {/if}
 </div>

--- a/apps/web/src/lib/server/angmap-archive-rating.ts
+++ b/apps/web/src/lib/server/angmap-archive-rating.ts
@@ -1,0 +1,44 @@
+/**
+ * 앙지도(angmap) 레거시 평점 아카이브 조회 — 읽기 전용.
+ *
+ * gnuboard 시절 `g5_board_rate_average`(10점 척도)에 쌓인 과거 집계다. 신규 5점
+ * `angple_post_ratings` 와는 **개인식별 매핑이 없어 합칠 수 없다**(합치려면 가짜 투표자를
+ * 지어내야 하고 그건 날조). 이 테이블은 현재 코드베이스에서 쓰기가 완전히 죽은 동결 상태라,
+ * 신규 평점 재계산(COUNT/AVG over 개인행)에 절대 덮이지 않는다. 그래서 "과거 평점"으로
+ * **별도 표시만** 한다 — 10점을 2로 나눠 5점 척도로 환산.
+ *
+ * ⛔ 쓰기 금지. ⛔ 신규 rating(post.rating)과 합치지 말 것 — 나란히 두 숫자로만 보여준다.
+ */
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+import type { ArchiveRating } from '$lib/api/types.js';
+
+interface RateRow extends RowDataPacket {
+    rate_average: number | string;
+    rate_count: number | string;
+}
+
+/**
+ * 주어진 앙지도 글의 레거시 평점을 반환. 과거 평가가 없으면(또는 조회 실패) undefined.
+ * 아카이브는 부가정보이므로 조회 실패가 페이지 렌더를 깨선 안 된다 → 항상 undefined 로 흡수.
+ */
+export async function fetchAngmapArchiveRating(wrId: number): Promise<ArchiveRating | undefined> {
+    if (!Number.isFinite(wrId) || wrId <= 0) return undefined;
+    try {
+        const [rows] = await readPool.query<RateRow[]>(
+            `SELECT rate_average, rate_count
+             FROM g5_board_rate_average
+             WHERE bo_table = 'angmap' AND wr_id = ?
+             LIMIT 1`,
+            [wrId]
+        );
+        const row = rows[0];
+        const count = Number(row?.rate_count ?? 0);
+        if (!row || count < 1) return undefined;
+        // 10점 → 5점 환산, 소수 1자리
+        const avg5 = Math.round((Number(row.rate_average) / 2) * 10) / 10;
+        return { avg5, count };
+    } catch {
+        return undefined;
+    }
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -32,6 +32,7 @@ import { applyFilter } from '$lib/hooks/registry.js';
 import { buildHookContext } from '$lib/hooks/context.js';
 import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 import { resolveAngttMatch, type AngttMatch } from '$lib/server/angtt-dictionary.js';
+import { fetchAngmapArchiveRating } from '$lib/server/angmap-archive-rating.js';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -168,6 +169,13 @@ export const load: PageServerLoad = async ({
                 post.comments_count = 0;
             }
             setHeaders({ 'X-Robots-Tag': 'noindex, noarchive' });
+        }
+
+        // 앙지도 레거시 평점(아카이브): gnuboard 10점 시절 동결 집계를 읽기전용으로 별도 표시.
+        // 신규 5점(post.rating)과 합치지 않는다 — 개인식별 매핑이 없어 합치면 날조가 된다.
+        // 조회 실패는 헬퍼가 undefined 로 흡수 → 페이지 렌더에 영향 0.
+        if (boardId === 'angmap' && !post.deleted_at) {
+            post.archiveRating = await fetchAngmapArchiveRating(Number(postId));
         }
 
         let board = null;


### PR DESCRIPTION
## 요약
앙지도(angmap) 상세에 **레거시 평점 아카이브**를 표시합니다. gnuboard 10점 시절
`g5_board_rate_average`(현재 코드에서 쓰기 死한 동결 테이블, angmap 1,035건)의 과거 집계를
읽어 "📜 과거 평점"으로 노출합니다.

**신규 5점 `angple_post_ratings`와 합치지 않습니다.** 레거시는 히스토그램만 남아 개인식별
매핑이 없어, 라이브 숫자에 합치려면 가짜 투표자 생성(날조)이 불가피합니다. 그래서 나란히
두 숫자(⭐ 앵님 평점 / 📜 과거 평점)로만 보여줍니다. 신규 집계는 개인행 재계산식이라
아카이브를 별도 분리 소스로 두어야 재계산에 덮이지 않습니다.

## 변경
- `angmap-archive-rating.ts` (신규): `readPool` 읽기전용 조회, 10→5 환산, 실패는 undefined 흡수(페이지 영향 0)
- `[boardId]/[postId]/+page.server.ts`: angmap 글에 `post.archiveRating` 부착(비삭제 글만)
- `post-rating.svelte`: `archive` prop 추가, 별도 줄로 렌더. **n<3 은 평균 대신 인원만**(작은 표본 착시 방지, 설계 §4)
- `basic.svelte`: 위젯에 `archive` 전달
- `types.ts`: `ArchiveRating` 인터페이스 + `FreePost.archiveRating`

## 무변경 / 안전
- `g5_board_rate_average` **읽기만**(보존). 쓰기·마이그레이션·DDL 0.
- angmap 외 보드·삭제글·좌표없는 글 영향 0. 아카이브 없으면 줄 미표시.
- 별점 기능 자체(features.rating)는 별도 config 토글(P0)로 켬 — 본 PR과 독립.

## 검증 관점 (Evaluator)
- 레거시 있는 글: 과거 평점 = rate_average/2, 신규와 분리 표시
- 신규 별점 1개 달아도 아카이브 불변(분리 소스)
- 해외 장소 글에서도 정상(국가 가정 0)
- n<3 글에서 평균 숫자 미노출
