### PR TITLE
refactor(member): 닉네임 변경 이력 전체 공개 + 권한 차등 화면 제거

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -269,9 +269,6 @@ export const GET: RequestHandler = async ({ params, locals }) => {
             // 테이블 없으면 무시
         }
 
-        // 뷰어가 관리자(level>=10)인지 — 닉 이력 전체 타임라인(new_nick) 노출 게이트.
-        const viewerIsAdmin = (locals.user?.level ?? 0) >= 10;
-
         // 이미지 URL: 원본 값 그대로 전달 (프론트에서 getAvatarUrl로 CDN URL 변환)
         const imageUrl = member.mb_image_url || '';
 
@@ -318,12 +315,14 @@ export const GET: RequestHandler = async ({ params, locals }) => {
                 // 팔로우
                 follower_count: followerRows[0]?.count ?? 0,
                 following_count: followingRows[0]?.count ?? 0,
-                // 닉네임 변경 이력 (과거 별명, 최근순) — #13026.
-                // 회원 공개는 old_nick+시각만. 관리자 뷰어(level>=10)에겐 new_nick 까지(전체 타임라인).
+                // 닉네임 변경 이력 (전체 공개, 최근순) — #13026.
+                // old→new 전 체인을 모든 회원에게 동일하게 전송한다. 권한별 차등 응답을 두지
+                // 않는다: 클라이언트 {#if}로 숨기는 방식은 토큰 위조·스토어 조작 시 노출되므로,
+                // 공개 정책이면 서버가 애초에 누구에게나 같은 데이터를 보낸다(펼치기로 노출).
                 nick_history: nickHistory.map((h) => ({
                     old_nick: h.old_nick,
-                    changed_at: h.changed_at,
-                    ...(viewerIsAdmin ? { new_nick: h.new_nick } : {})
+                    new_nick: h.new_nick,
+                    changed_at: h.changed_at
                 }))
             }
         });

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -14,6 +14,7 @@
     import { onMount } from 'svelte';
     import DamoangLogo from '$lib/assets/logo.svg';
     import User from '@lucide/svelte/icons/user';
+    import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import Calendar from '@lucide/svelte/icons/calendar';
     import Clock from '@lucide/svelte/icons/clock';
     import FileText from '@lucide/svelte/icons/file-text';
@@ -586,30 +587,23 @@
                                 </div>
                             {/if}
                             {#if p.nick_history && p.nick_history.length > 0}
-                                <!-- 과거 별명(닉네임) 이력 — 공개(#13026). old_nick = 그 시점 변경 전 별명. -->
-                                <div class="flex items-start gap-2">
-                                    <User class="mt-0.5 h-4 w-4 shrink-0" />
-                                    <span>
-                                        이전 별명:
-                                        {#each p.nick_history as h, i (i)}<span
-                                                title={`${formatDate(h.changed_at)} 변경`}
-                                                >{h.old_nick}</span
-                                            >{i < p.nick_history.length - 1 ? ', ' : ''}{/each}
-                                    </span>
-                                </div>
-                            {/if}
-                            {#if (authStore.user?.mb_level ?? 0) >= 10 && p.nick_history && p.nick_history.length > 0}
-                                <!-- 관리자 전용 전체 타임라인 (날짜·old→new) — 모더레이션(평판 세탁·다중이·사칭). -->
-                                <div
-                                    class="border-border/60 mt-1 rounded-md border border-dashed p-2"
-                                >
-                                    <div
-                                        class="text-muted-foreground mb-1 flex items-center gap-1.5 text-xs font-medium"
+                                <!-- 닉네임 변경 이력 — 전체 공개(#13026 → 완전 투명). 권한별 차등 화면을
+                                     두지 않는다: 서버가 old→new 전 체인을 모든 회원에게 동일하게 보내고,
+                                     여기서 펼쳐 보여준다. 클라 조건부 렌더(mb_level 체크)로 숨기는 방식은
+                                     토큰 위조·스토어 조작 시 노출되므로 쓰지 않는다(공개 = 서버가 동일 전송). -->
+                                <details class="group">
+                                    <summary
+                                        class="text-muted-foreground hover:text-foreground flex cursor-pointer list-none items-center gap-1.5 [&::-webkit-details-marker]:hidden"
                                     >
-                                        <User class="h-3.5 w-3.5 shrink-0" />
-                                        닉네임 변경 이력 (관리자)
-                                    </div>
-                                    <ul class="space-y-0.5 text-xs">
+                                        <User class="h-4 w-4 shrink-0" />
+                                        <span>닉네임 변경 이력 {p.nick_history.length}회</span>
+                                        <ChevronDown
+                                            class="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180"
+                                        />
+                                    </summary>
+                                    <ul
+                                        class="border-border/60 mt-1 space-y-0.5 rounded-md border border-dashed p-2 text-xs"
+                                    >
                                         {#each p.nick_history as h, i (i)}
                                             <li class="flex flex-wrap items-center gap-1">
                                                 <span class="text-muted-foreground tabular-nums"
@@ -623,7 +617,7 @@
                                             </li>
                                         {/each}
                                     </ul>
-                                </div>
+                                </details>
                             {/if}
                             {#if p.mb_level < 10}
                                 <div class="flex items-center gap-2">


### PR DESCRIPTION
## 배경
회원 프로필의 "닉네임 변경 이력 (관리자)" 패널이 실제로는 관리자가 아니라 **회원 본인의 셀프
닉 변경**을 보여주는데, "(관리자)" 라벨 + 권한별 차등 렌더 때문에 오해를 부르고 있었다.

기존 구조:
- `old_nick` + 시각 → 전체 공개
- `new_nick`(전체 old→new 체인) → 클라 `{#if mb_level>=10}` 로 **관리자에게만**

클라이언트 조건부 렌더는 데이터를 이미 응답에 실어 보낸 뒤 시각적으로만 숨기는 것이라,
토큰 위조·클라 스토어 조작 시 노출될 수 있는 안티패턴이다. (이 케이스는 서버가 new_nick 을
비관리자 응답에서 실제로 제외하고 있어 leak 은 없었으나, "권한별로 다르게 보이는 화면" 자체를
없애는 방향으로 정리.)

## 변경
- **서버**(`api/members/[id]/profile/+server.ts`): `viewerIsAdmin` 게이트 제거 →
  `new_nick` 을 **모든 요청자에게 동일 전송**. 권한별 차등 응답 없음.
- **UI**(`member/[id]/+page.svelte`): 갈라진 두 블록(공개 요약 "이전 별명" / 관리자 전용
  타임라인)을 **단일 공개 펼치기(`<details>`) 패널**로 통합. old→new 전체 이력을 누구나
  펼쳐 열람. 네이티브 `<details>` 라 SSR 안전·무JS·접근성 OK.

## 근거 (관례)
공개 닉 변경 이력은 포럼 소프트웨어 표준 — vBulletin 은 공개 프로필에 표시, XenForo 는 전용
"Username History" 탭 제공. 사칭·평판세탁 억제 효과. 다만 성숙한 플랫폼은 **개별 항목 비공개
옵션**(괴롭힘·신상 등 예외)을 함께 두므로, 그건 후속 과제로 남긴다.

## 안전
- 데이터는 이미 공개 방향이던 것(#13026)을 완전 공개로 확장. 새 노출 필드 = 과거 닉(new_nick).
- 서버·클라 논리 일치(둘 다 전체 공개). 권한 분기 소멸.
- 되돌리기: 이전 릴리스 승격. 데이터 무변경.

## 검증 관점 (Evaluator)
- 비로그인/일반회원/관리자 **모두 동일**하게 전체 old→new 타임라인 열람
- 네트워크 응답에 new_nick 이 모든 뷰어에게 포함(차등 없음)
- 펼치기 접힘/펼침 SSR·CSR 정상, 이력 0건이면 패널 미표시
