### PR TITLE
앙지도 평점 P2 — 항목별 평점 범용화·n<3 착시 보정·상세 미니맵

### DIFF
--- a/apps/web/src/lib/components/features/board/angmap-place-map.svelte
+++ b/apps/web/src/lib/components/features/board/angmap-place-map.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+    /**
+     * 앙지도 상세 단일 핀 미니맵.
+     *
+     * 좌표가 있는 글에만 렌더된다(부모에서 가드 — 좌표 없으면 이 컴포넌트를 아예 mount
+     * 하지 않아 빈 지도 박스가 안 뜬다). 단일 핀 + 줌 16, 클릭 시 원본 지도 링크로.
+     *
+     * SSR 안전이 핵심 함정: Leaflet 은 브라우저 전용(window 참조)이라 정적 import 금지.
+     * 뷰포트 진입 시(IntersectionObserver)에만 동적 import 하고, 지도 컨테이너도
+     * {#if} 로 클라이언트에서만 mount 한다. (angmap-pin-map.svelte 패턴과 동일.)
+     *
+     * ⛔ 글로벌 원칙: 좌표 범위·초기 뷰 어디에도 국가를 가정하지 않는다 — 좌표만 본다.
+     */
+    import { onMount, onDestroy, tick } from 'svelte';
+    import { browser } from '$app/environment';
+    import MapPin from '@lucide/svelte/icons/map-pin';
+    import ExternalLink from '@lucide/svelte/icons/external-link';
+    import type { Map as LeafletMap } from 'leaflet';
+    import { ANGMAP_TILE_PROVIDER, ANGMAP_TILE_PROVIDERS } from './angmap-map-provider.js';
+
+    let {
+        lat,
+        lng,
+        name = null,
+        mapUrl = null
+    }: {
+        lat: number;
+        lng: number;
+        name?: string | null;
+        /** 클릭 시 이동할 원본 지도 링크(글의 지도 URL). 없으면 지도 클릭 비활성. */
+        mapUrl?: string | null;
+    } = $props();
+
+    /** 상세 진입 시 뷰포트에 들어올 때까지 로드 지연할 줌 레벨(단일 핀이라 근접). */
+    const DETAIL_ZOOM = 16;
+
+    let mapContainer = $state<HTMLDivElement | null>(null);
+    let sentinel = $state<HTMLDivElement | null>(null);
+    let mounted = $state(false);
+    let loading = $state(false);
+    let failed = $state(false);
+
+    let map: LeafletMap | null = null;
+    let leafletPromise: Promise<typeof import('leaflet')> | null = null;
+    let observer: IntersectionObserver | null = null;
+
+    function loadLeaflet(): Promise<typeof import('leaflet')> {
+        if (!leafletPromise) {
+            leafletPromise = Promise.all([
+                import('leaflet'),
+                // Leaflet CSS 도 뷰포트 진입 시에만 로드 (vite 가 청크로 처리)
+                import('leaflet/dist/leaflet.css')
+            ]).then(([mod]) => mod);
+        }
+        return leafletPromise;
+    }
+
+    function initMap(leaflet: typeof import('leaflet')): void {
+        if (map || !mapContainer) return;
+        const L = leaflet;
+        const tile = ANGMAP_TILE_PROVIDERS[ANGMAP_TILE_PROVIDER];
+
+        map = L.map(mapContainer, {
+            center: [lat, lng],
+            zoom: DETAIL_ZOOM,
+            scrollWheelZoom: false,
+            // 단일 핀 미니맵 — 부가 컨트롤 최소화
+            zoomControl: true,
+            attributionControl: true
+        });
+        L.tileLayer(tile.urlTemplate, {
+            attribution: tile.attribution,
+            maxZoom: tile.maxZoom
+        }).addTo(map);
+
+        const marker = L.circleMarker([lat, lng], {
+            radius: 9,
+            weight: 2,
+            color: '#be123c',
+            fillColor: '#f43f5e',
+            fillOpacity: 0.8
+        }).addTo(map);
+        if (name) marker.bindTooltip(name, { permanent: false, direction: 'top' });
+    }
+
+    async function activate(): Promise<void> {
+        if (!browser || mounted) return;
+        mounted = true;
+        loading = true;
+        failed = false;
+        try {
+            const leaflet = await loadLeaflet();
+            await tick(); // {#if mounted} 컨테이너 mount 대기
+            if (!mapContainer) return;
+            initMap(leaflet);
+        } catch (err) {
+            console.error('[angmap place map] init failed:', err);
+            failed = true;
+        } finally {
+            loading = false;
+        }
+    }
+
+    onMount(() => {
+        if (!browser || !sentinel) return;
+        // 뷰포트 진입 시에만 Leaflet 로드 (상세 진입 즉시 로드하지 않음)
+        if (typeof IntersectionObserver === 'undefined') {
+            void activate();
+            return;
+        }
+        observer = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    if (entry.isIntersecting) {
+                        void activate();
+                        observer?.disconnect();
+                        observer = null;
+                        break;
+                    }
+                }
+            },
+            { rootMargin: '200px' }
+        );
+        observer.observe(sentinel);
+    });
+
+    onDestroy(() => {
+        observer?.disconnect();
+        observer = null;
+        map?.remove();
+        map = null;
+    });
+</script>
+
+<div class="mb-4" bind:this={sentinel}>
+    <div class="mb-1.5 flex items-center justify-between gap-2">
+        <span class="text-foreground flex items-center gap-1.5 text-sm font-semibold">
+            <MapPin class="text-primary h-4 w-4" />
+            {name || '위치'}
+        </span>
+        {#if mapUrl}
+            <a
+                href={mapUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
+            >
+                원본 지도
+                <ExternalLink class="h-3 w-3" />
+            </a>
+        {/if}
+    </div>
+
+    {#if failed}
+        <div
+            class="border-border text-muted-foreground flex h-40 items-center justify-center rounded-lg border text-sm"
+        >
+            지도를 불러오지 못했습니다.
+        </div>
+    {:else}
+        <!-- z-0 스택 컨텍스트: Leaflet 내부 z-index 가 사이트 헤더/드롭다운을 덮지 않게 -->
+        <div class="relative z-0">
+            {#if mounted}
+                <div
+                    bind:this={mapContainer}
+                    class="border-border h-48 w-full rounded-lg border sm:h-64"
+                ></div>
+            {:else}
+                <div class="border-border h-48 w-full rounded-lg border sm:h-64"></div>
+            {/if}
+            {#if loading}
+                <div
+                    class="bg-background/60 absolute inset-0 flex items-center justify-center rounded-lg"
+                >
+                    <span class="text-muted-foreground text-sm">지도 불러오는 중...</span>
+                </div>
+            {/if}
+        </div>
+        {#if mapUrl}
+            <a
+                href={mapUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-muted-foreground hover:text-foreground mt-1 block text-right text-xs transition-colors"
+            >
+                지도에서 길찾기 →
+            </a>
+        {/if}
+    {/if}
+</div>

--- a/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
+++ b/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
@@ -18,6 +18,7 @@
     import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { SUGGEST_MIN_LEVEL, buildSuggestStatusText } from './angtt-suggest-logic.js';
+    import { shouldShowAverage } from './rating-display.js';
 
     /** 서버 AngttMatch(lib/server/angtt-dictionary.ts)와 구조 동일 — $lib/server 는 클라 import 불가라 별도 선언 */
     type AngttCardMatch =
@@ -348,8 +349,13 @@
                     <p class="text-muted-foreground text-xs">
                         다모앙 추천작 — 앙티티
                         {#if match.rating && match.rating.count > 0}
+                            <!-- n<3 착시 방지: 참여 3명 미만이면 평균 숫자 미노출(rating-display 규약) -->
                             <span class="text-amber-600 dark:text-amber-400">
-                                · ★{match.rating.avg.toFixed(1)} · 앙님 {match.rating.count}명
+                                {#if shouldShowAverage(match.rating.count)}
+                                    · ★{match.rating.avg.toFixed(1)} · 앙님 {match.rating.count}명
+                                {:else}
+                                    · 앙님 {match.rating.count}명 평가
+                                {/if}
                             </span>
                         {:else if match.rating}
                             <span>· 아직 별점이 없어요</span>

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -339,7 +339,12 @@
         <!-- 별점 위젯 (앙티티 Phase 0): features.rating 보드에서만 백엔드가
              post.rating 을 동봉 → 없으면 렌더 0 (전 게시판 회귀 0) -->
         {#if post.rating}
-            <PostRatingWidget {boardId} postId={post.id} initial={post.rating} />
+            <PostRatingWidget
+                {boardId}
+                postId={post.id}
+                initial={post.rating}
+                aspects={pageData?.postAspects}
+            />
         {/if}
     </CardHeader>
     <CardContent class="space-y-6">

--- a/apps/web/src/lib/components/features/board/post-rating.svelte
+++ b/apps/web/src/lib/components/features/board/post-rating.svelte
@@ -23,17 +23,25 @@
         applyOptimisticRating,
         starFillPercent
     } from './post-rating-logic.js';
-    import { shouldShowAverage } from './rating-display.js';
+    import { shouldShowAverage, type AspectRating } from './rating-display.js';
+    import { getBoardAspectPreset } from '$plugins/angtt-review/lib/aspect-presets';
+    import RatingAspects from './rating-aspects.svelte';
 
     let {
         boardId,
         postId,
-        initial
+        initial,
+        aspects
     }: {
         boardId: string;
         postId: number | string;
         initial: PostRating;
+        /** 항목별 평점 집계(SSR 주입). 프리셋 매핑 보드(앙지도 등)에서만 전달됨. */
+        aspects?: AspectRating[];
     } = $props();
+
+    /** 이 게시판의 항목별 프리셋(맛/가성비 등). 없으면 항목별 UI 미표시. */
+    const aspectPreset = $derived(getBoardAspectPreset(boardId));
 
     const STARS = [1, 2, 3, 4, 5];
 
@@ -138,3 +146,17 @@
         {/if}
     </span>
 </div>
+
+<!--
+    항목별 평점(맛/가성비 등) — 프리셋이 매핑된 보드(앙지도)에서만. 표시(평균 바)는 공개,
+    입력 [+ 항목별로 자세히] 는 본인 총점(rating.my>0) + 투표 등급(canVote) 옵트인 게이트.
+-->
+{#if aspectPreset}
+    <RatingAspects
+        {boardId}
+        {postId}
+        preset={aspectPreset}
+        initial={aspects ?? []}
+        canEdit={canVote && rating.my > 0}
+    />
+{/if}

--- a/apps/web/src/lib/components/features/board/post-rating.svelte
+++ b/apps/web/src/lib/components/features/board/post-rating.svelte
@@ -23,6 +23,7 @@
         applyOptimisticRating,
         starFillPercent
     } from './post-rating-logic.js';
+    import { shouldShowAverage } from './rating-display.js';
 
     let {
         boardId,
@@ -122,8 +123,13 @@
     </div>
     <span class="text-muted-foreground text-sm">
         {#if rating.count > 0}
-            <span class="text-foreground font-medium">★{rating.avg.toFixed(1)}</span>
-            · 앙님 {rating.count.toLocaleString()}명
+            <!-- n<3 착시 방지: 참여 3명 미만이면 평균 숫자를 내세우지 않는다(rating-display 규약) -->
+            {#if shouldShowAverage(rating.count)}
+                <span class="text-foreground font-medium">★{rating.avg.toFixed(1)}</span>
+                · 앙님 {rating.count.toLocaleString()}명
+            {:else}
+                앙님 {rating.count.toLocaleString()}명 평가
+            {/if}
         {:else}
             첫 별점을 남겨주세요
         {/if}

--- a/apps/web/src/lib/components/features/board/rating-aspects.svelte
+++ b/apps/web/src/lib/components/features/board/rating-aspects.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+    /**
+     * 항목별 평점 — 표시(평균 바) + 옵트인 입력(별점 행). 범용 재사용 컴포넌트.
+     *
+     * 총점 위젯(post-rating.svelte)의 부가 시각이다. 총점을 남긴 회원에게만
+     * [+ 항목별로 자세히] 접힘 버튼을 노출하고, 안 펼치면 화면 변화 0(옵트인).
+     * 저장은 범용 API `PUT /api/boards/{boardId}/{postId}/rating/aspects`(공유 핸들러).
+     *
+     * n<3 착시 방지: 표본이 적은 항목은 평균 숫자를 내세우지 않고 인원만 보여준다
+     * (rating-display 규약 · shouldShowAverage).
+     *
+     * ⛔ 프리셋(맛/가성비 등)은 전적으로 prop 으로 받는다 — 국가·도메인 가정 없음.
+     */
+    import type { AspectDef } from '$plugins/angtt-review/lib/aspect-presets';
+    import { type AspectRating, shouldShowAverage } from './rating-display.js';
+
+    let {
+        boardId,
+        postId,
+        preset,
+        initial,
+        canEdit = false
+    }: {
+        boardId: string;
+        postId: number | string;
+        preset: AspectDef[];
+        initial: AspectRating[];
+        /** 본인 총점 별점 보유 + 투표 등급 충족 시에만 입력 UI 노출(옵트인 게이트) */
+        canEdit?: boolean;
+    } = $props();
+
+    const RATE_STARS = [1, 2, 3, 4, 5];
+
+    // 집계+본인 값의 클라이언트 소유 상태 — 저장 응답으로 통째 교체.
+    // svelte-ignore state_referenced_locally
+    let liveAspects = $state<AspectRating[]>(initial ?? []);
+    let showAspectRater = $state(false);
+    let aspectSubmitting = $state<string | null>(null);
+    let aspectError = $state('');
+    let aspectHover = $state<{ key: string; star: number } | null>(null);
+
+    // 글 이동(컴포넌트 재사용)으로 postId 가 바뀌면 SSR 값으로 재동기화 + 접힘 초기화.
+    // svelte-ignore state_referenced_locally
+    let trackedPostId = $state(postId);
+    $effect(() => {
+        if (postId !== trackedPostId) {
+            trackedPostId = postId;
+            liveAspects = initial ?? [];
+            showAspectRater = false;
+            aspectError = '';
+        }
+    });
+
+    /** 표시용 바 — 집계가 1건이라도 있는 항목만, 프리셋 순서로 */
+    const aspectBars = $derived.by(() => {
+        const byKey = new Map(liveAspects.map((a) => [a.aspect, a]));
+        return preset.flatMap((def) => {
+            const agg = byKey.get(def.key);
+            return agg && agg.count > 0
+                ? [{ key: def.key, label: def.label, avg: agg.avg, count: agg.count }]
+                : [];
+        });
+    });
+
+    /** 본인이 해당 항목에 남긴 별점(없으면 0) */
+    function myAspect(key: string): number {
+        return liveAspects.find((a) => a.aspect === key)?.my ?? 0;
+    }
+    /** 입력 위젯 채움 기준: 호버 중이면 호버 값, 아니면 내 기존 값 */
+    function aspectRowValue(key: string): number {
+        return aspectHover?.key === key ? aspectHover.star : myAspect(key);
+    }
+
+    async function submitAspect(key: string, star: number): Promise<void> {
+        if (aspectSubmitting) return;
+        aspectError = '';
+        aspectSubmitting = key;
+        try {
+            const res = await fetch(`/api/boards/${boardId}/${postId}/rating/aspects`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({ aspects: { [key]: star } })
+            });
+            const body = (await res.json().catch(() => null)) as {
+                aspects?: AspectRating[];
+                error?: string;
+            } | null;
+            if (!res.ok) throw new Error(body?.error || '항목별 평가 저장에 실패했어요.');
+            if (Array.isArray(body?.aspects)) liveAspects = body.aspects;
+        } catch (err) {
+            aspectError = err instanceof Error ? err.message : '항목별 평가 저장에 실패했어요.';
+        } finally {
+            aspectSubmitting = null;
+        }
+    }
+</script>
+
+{#if aspectBars.length > 0}
+    <!-- 항목별 평균(옵트인 세부) — 집계가 1건이라도 있을 때만 표시 -->
+    <div class="mt-2 flex w-full max-w-sm flex-col gap-1.5" aria-label="항목별 평균 별점">
+        {#each aspectBars as bar (bar.key)}
+            <div class="flex items-center gap-2 text-xs">
+                <span class="text-muted-foreground w-12 shrink-0 font-semibold">{bar.label}</span>
+                {#if shouldShowAverage(bar.count)}
+                    <div
+                        class="h-1.5 flex-1 overflow-hidden rounded-full bg-amber-200/60 dark:bg-amber-900/40"
+                        aria-hidden="true"
+                    >
+                        <div
+                            class="h-full rounded-full bg-amber-500"
+                            style="width: {(bar.avg / 5) * 100}%"
+                        ></div>
+                    </div>
+                    <span class="text-foreground w-7 shrink-0 text-right font-bold tabular-nums"
+                        >{bar.avg.toFixed(1)}</span
+                    >
+                    <span class="text-muted-foreground shrink-0 tabular-nums">({bar.count})</span>
+                {:else}
+                    <!-- n<3 착시 방지: 표본 적으면 평균 숨김, 인원만 -->
+                    <span class="text-muted-foreground flex-1">앙님 {bar.count}명 평가</span>
+                {/if}
+            </div>
+        {/each}
+    </div>
+{/if}
+
+{#if canEdit}
+    <!-- 항목별 평가(옵트인) — 본인 총점이 있을 때만 접힘 버튼 노출 -->
+    <div class="mt-2">
+        <button
+            type="button"
+            onclick={() => (showAspectRater = !showAspectRater)}
+            aria-expanded={showAspectRater}
+            class="text-muted-foreground hover:text-foreground text-sm font-semibold"
+        >
+            {showAspectRater ? '−' : '+'} 항목별로 자세히 평가
+        </button>
+        {#if showAspectRater}
+            <div class="mt-2.5 flex flex-col gap-1.5">
+                {#each preset as def (def.key)}
+                    <div class="flex items-center gap-2">
+                        <span class="w-14 shrink-0 text-sm font-semibold">{def.label}</span>
+                        <div
+                            class="flex items-center"
+                            role="radiogroup"
+                            aria-label="{def.label} 별점 선택 (1~5점)"
+                        >
+                            {#each RATE_STARS as star (star)}
+                                <button
+                                    type="button"
+                                    class="p-0.5 text-xl leading-none transition-transform hover:scale-110 disabled:opacity-50"
+                                    disabled={aspectSubmitting != null}
+                                    role="radio"
+                                    aria-checked={myAspect(def.key) === star}
+                                    aria-label="{def.label} {star}점"
+                                    onclick={() => submitAspect(def.key, star)}
+                                    onmouseenter={() => (aspectHover = { key: def.key, star })}
+                                    onmouseleave={() => (aspectHover = null)}
+                                    onfocus={() => (aspectHover = { key: def.key, star })}
+                                    onblur={() => (aspectHover = null)}
+                                >
+                                    <span
+                                        class={star <= aspectRowValue(def.key)
+                                            ? 'text-amber-500'
+                                            : 'text-muted-foreground/40'}>★</span
+                                    >
+                                </button>
+                            {/each}
+                        </div>
+                        {#if myAspect(def.key) > 0}
+                            <span class="text-muted-foreground text-xs tabular-nums"
+                                >★{myAspect(def.key)}</span
+                            >
+                        {/if}
+                    </div>
+                {/each}
+                <p class="text-muted-foreground text-xs">
+                    별을 누르면 항목마다 바로 저장돼요. 원하는 항목만 남겨도 됩니다.
+                </p>
+            </div>
+            {#if aspectError}
+                <p class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">
+                    {aspectError}
+                </p>
+            {/if}
+        {/if}
+    </div>
+{/if}

--- a/apps/web/src/lib/components/features/board/rating-display.test.ts
+++ b/apps/web/src/lib/components/features/board/rating-display.test.ts
@@ -22,7 +22,8 @@ describe('shouldShowAverage — 평균 노출 임계(n>=3)', () => {
 
     it('비유한 수는 노출하지 않음', () => {
         expect(shouldShowAverage(Number.NaN)).toBe(false);
-        expect(shouldShowAverage(Number.POSITIVE_INFINITY)).toBe(true);
+        // 무한대는 실제 참여수가 아니므로(비유한) 노출하지 않는다 — NaN 과 동일하게 안전측
+        expect(shouldShowAverage(Number.POSITIVE_INFINITY)).toBe(false);
     });
 });
 
@@ -59,7 +60,8 @@ describe('bayesianScore — 랭킹 보정(m=5, 전체평균으로 끌어당김)'
         const few = bayesianScore(5, 1, 4);
         const many = bayesianScore(5, 100, 4);
         expect(many).toBeGreaterThan(few);
-        expect(many).toBeCloseTo(500 / 105, 6);
+        // (100/105)*5 + (5/105)*4 = (500 + 20)/105 = 520/105 ≈ 4.952
+        expect(many).toBeCloseTo(520 / 105, 6);
     });
 
     it('n=1 5.0 보정점 < n=100 4.2 보정점 (착시 역전 방지)', () => {

--- a/apps/web/src/lib/components/features/board/rating-display.test.ts
+++ b/apps/web/src/lib/components/features/board/rating-display.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+    RATING_DISPLAY_MIN_COUNT,
+    RATING_BAYESIAN_M,
+    shouldShowAverage,
+    formatRatingSummary,
+    bayesianScore
+} from './rating-display';
+
+describe('shouldShowAverage — 평균 노출 임계(n>=3)', () => {
+    it('n<3 이면 평균 숨김', () => {
+        expect(shouldShowAverage(0)).toBe(false);
+        expect(shouldShowAverage(1)).toBe(false);
+        expect(shouldShowAverage(2)).toBe(false);
+    });
+
+    it('n>=3 이면 평균 노출', () => {
+        expect(shouldShowAverage(RATING_DISPLAY_MIN_COUNT)).toBe(true);
+        expect(shouldShowAverage(3)).toBe(true);
+        expect(shouldShowAverage(100)).toBe(true);
+    });
+
+    it('비유한 수는 노출하지 않음', () => {
+        expect(shouldShowAverage(Number.NaN)).toBe(false);
+        expect(shouldShowAverage(Number.POSITIVE_INFINITY)).toBe(true);
+    });
+});
+
+describe('formatRatingSummary — n<3 착시 방지 문구', () => {
+    it('참여 0 → 평가 없음', () => {
+        expect(formatRatingSummary(0, 0)).toBe('아직 평가 없음');
+        expect(formatRatingSummary(5, -1)).toBe('아직 평가 없음');
+    });
+
+    it('0<n<3 → 평균 숫자 미노출("앙님 N명 평가")', () => {
+        expect(formatRatingSummary(5, 1)).toBe('앙님 1명 평가');
+        expect(formatRatingSummary(4.8, 2)).toBe('앙님 2명 평가');
+        // 평균이 아무리 높아도 숫자를 내세우지 않는다(핵심 규약)
+        expect(formatRatingSummary(5, 2)).not.toContain('★');
+    });
+
+    it('n>=3 → 평균 + n 병기', () => {
+        expect(formatRatingSummary(4.25, 3)).toBe('★4.3 · 앙님 3명');
+        expect(formatRatingSummary(4.2, 100)).toBe('★4.2 · 앙님 100명');
+    });
+
+    it('큰 수는 천 단위 구분', () => {
+        expect(formatRatingSummary(4.0, 1234)).toBe('★4.0 · 앙님 1,234명');
+    });
+});
+
+describe('bayesianScore — 랭킹 보정(m=5, 전체평균으로 끌어당김)', () => {
+    it('참여 적은 고평점은 전체평균 쪽으로 강하게 끌린다', () => {
+        // v=1, avg=5, global=4, m=5 → (1/6)*5 + (5/6)*4 = 4.1666...
+        expect(bayesianScore(5, 1, 4)).toBeCloseTo(25 / 6, 6);
+    });
+
+    it('참여가 많을수록 개별 평균에 수렴한다', () => {
+        const few = bayesianScore(5, 1, 4);
+        const many = bayesianScore(5, 100, 4);
+        expect(many).toBeGreaterThan(few);
+        expect(many).toBeCloseTo(500 / 105, 6);
+    });
+
+    it('n=1 5.0 보정점 < n=100 4.2 보정점 (착시 역전 방지)', () => {
+        const lonelyFive = bayesianScore(5, 1, 4);
+        const popularFourTwo = bayesianScore(4.2, 100, 4);
+        expect(lonelyFive).toBeLessThan(popularFourTwo);
+    });
+
+    it('참여 0 이면 전체평균을 그대로 반환', () => {
+        expect(bayesianScore(0, 0, 3.7)).toBe(3.7);
+    });
+
+    it('기본 m 은 RATING_BAYESIAN_M(5)', () => {
+        expect(bayesianScore(5, 5, 3)).toBe(bayesianScore(5, 5, 3, RATING_BAYESIAN_M));
+    });
+});

--- a/apps/web/src/lib/components/features/board/rating-display.ts
+++ b/apps/web/src/lib/components/features/board/rating-display.ts
@@ -13,6 +13,15 @@
  * DB·Svelte 의존 없음 — vitest 로 규약을 단위 검증한다.
  */
 
+/** 항목별 평점 집계 행(+요청자 본인 값) — 앙지도/앙티티 공통 표시 모델. */
+export interface AspectRating {
+    aspect: string;
+    avg: number;
+    count: number;
+    /** 로그인 사용자 본인이 이 항목에 남긴 별점(없으면 null) */
+    my: number | null;
+}
+
 /** 평균 숫자를 노출하기 위한 최소 참여 수(미만이면 숫자 미노출). */
 export const RATING_DISPLAY_MIN_COUNT = 3;
 

--- a/apps/web/src/lib/components/features/board/rating-display.ts
+++ b/apps/web/src/lib/components/features/board/rating-display.ts
@@ -1,0 +1,59 @@
+/**
+ * 별점 표시·랭킹 공유 규약 — n(참여 수)이 작을 때의 착시 방지 (순수 로직).
+ *
+ * 문제: 참여 1명짜리 ★5.0 가게가 100명이 매긴 ★4.2 가게보다 위에 보인다.
+ * 초기에는 거의 모든 대상이 n=1~2 이므로 이게 기본값이 된다.
+ *
+ * 규약:
+ *   - n < RATING_DISPLAY_MIN_COUNT(3): 평균을 숫자로 내세우지 않는다("앙님 N명 평가"만).
+ *   - n >= 3: 평균 + n 병기.
+ *   - 정렬·랭킹: 단순 평균 금지 → 베이지안 보정(전체 평균으로 끌어당김, m=5).
+ *
+ * 앙지도·앙티티(작품 카드/위젯) 등 별점 요약 표면이 모두 이 모듈을 공유한다.
+ * DB·Svelte 의존 없음 — vitest 로 규약을 단위 검증한다.
+ */
+
+/** 평균 숫자를 노출하기 위한 최소 참여 수(미만이면 숫자 미노출). */
+export const RATING_DISPLAY_MIN_COUNT = 3;
+
+/** 베이지안 보정 사전값 개수(전체 평균 쪽으로 끌어당기는 세기). */
+export const RATING_BAYESIAN_M = 5;
+
+/** 평균 숫자를 내세워도 되는 참여 수인지(n >= 3). */
+export function shouldShowAverage(count: number): boolean {
+    return Number.isFinite(count) && count >= RATING_DISPLAY_MIN_COUNT;
+}
+
+/**
+ * 별점 요약 문구.
+ *   - count <= 0: '아직 평가 없음'
+ *   - 0 < count < 3: '앙님 N명 평가' (평균 숨김 — 착시 방지)
+ *   - count >= 3: '★4.3 · 앙님 21명'
+ */
+export function formatRatingSummary(avg: number, count: number): string {
+    const n = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+    if (n <= 0) return '아직 평가 없음';
+    if (!shouldShowAverage(n)) return `앙님 ${n.toLocaleString()}명 평가`;
+    const a = Number.isFinite(avg) ? avg : 0;
+    return `★${a.toFixed(1)} · 앙님 ${n.toLocaleString()}명`;
+}
+
+/**
+ * 랭킹용 베이지안 보정 점수.
+ *   보정점수 = (v/(v+m)) * 개별평균 + (m/(v+m)) * 전체평균
+ * v=참여 수, m=사전값 개수(기본 5). v가 작을수록 전체 평균 쪽으로 끌린다.
+ * 정렬/추천에만 쓰고 표시 숫자로는 쓰지 않는다(표시는 formatRatingSummary).
+ */
+export function bayesianScore(
+    avg: number,
+    count: number,
+    globalAvg: number,
+    m: number = RATING_BAYESIAN_M
+): number {
+    const v = Number.isFinite(count) ? Math.max(0, count) : 0;
+    const a = Number.isFinite(avg) ? avg : 0;
+    const g = Number.isFinite(globalAvg) ? globalAvg : 0;
+    const denom = v + m;
+    if (denom <= 0) return g;
+    return (v / denom) * a + (m / denom) * g;
+}

--- a/apps/web/src/lib/server/angmap-place.ts
+++ b/apps/web/src/lib/server/angmap-place.ts
@@ -1,0 +1,74 @@
+/**
+ * 앙지도(angmap) 글 1건의 좌표 조회 — 상세 미니맵용, 읽기 전용.
+ *
+ * angmap_places(resolve_status='ok') 에서 해당 글의 좌표·상호·provider 를 읽는다.
+ * 좌표는 별도 백필 트랙이 채운다 — 이 경로는 무접촉(읽기만). 좌표가 없거나 센티널
+ * (축이 정확히 0)인 글은 null 을 반환해 상세에서 지도를 아예 그리지 않는다(빈 박스 금지).
+ *
+ * ⛔ 글로벌 원칙: 특정 국가/대륙 범위로 거르지 말 것. 해외 장소 핀이 실재한다.
+ *    좌표 유효성(범위·축 0)만 본다 — angmap-pin-map/pins 의 isPlottable 과 동일 규약.
+ */
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+
+/** 상세 미니맵에 주입할 좌표 모델 */
+export interface AngmapPlaceCoord {
+    lat: number;
+    lng: number;
+    name: string | null;
+    provider: string;
+}
+
+interface PlaceRow extends RowDataPacket {
+    name: string | null;
+    lat: string | number;
+    lng: string | number;
+    provider: string;
+}
+
+/**
+ * 좌표가 지도에 찍을 수 있는지 — 지리적 가정이 아니라 센티널/범위 방어.
+ * 축이 정확히 0 인 경우만 배제(해소 실패의 흔적). 나머지는 좌표만 본다.
+ */
+function isPlottable(lat: number, lng: number): boolean {
+    return (
+        Number.isFinite(lat) &&
+        Number.isFinite(lng) &&
+        lat >= -90 &&
+        lat <= 90 &&
+        lng >= -180 &&
+        lng <= 180 &&
+        lat !== 0 &&
+        lng !== 0
+    );
+}
+
+/**
+ * angmap 글의 좌표를 조회한다. 좌표 없음·비밀글·해소 실패면 null.
+ * 실패는 조용히 null(미니맵은 부가 기능 — 상세 로드를 절대 막지 않는다).
+ */
+export async function getAngmapPlace(wrId: number): Promise<AngmapPlaceCoord | null> {
+    if (!Number.isFinite(wrId) || wrId <= 0) return null;
+    try {
+        const [rows] = await readPool.query<PlaceRow[]>(
+            `SELECT p.name, p.lat, p.lng, p.provider
+               FROM angmap_places p
+               INNER JOIN g5_write_angmap w
+                   ON w.wr_id = p.wr_id AND w.wr_is_comment = 0
+              WHERE p.wr_id = ?
+                AND p.resolve_status = 'ok'
+                AND w.wr_option NOT LIKE '%secret%'
+              LIMIT 1`,
+            [wrId]
+        );
+        const row = rows[0];
+        if (!row) return null;
+        const lat = Number(row.lat);
+        const lng = Number(row.lng);
+        if (!isPlottable(lat, lng)) return null;
+        return { lat, lng, name: row.name, provider: row.provider };
+    } catch (err) {
+        console.error('[angmap place] error:', err instanceof Error ? err.message : err);
+        return null;
+    }
+}

--- a/apps/web/src/lib/server/rating-aspects.ts
+++ b/apps/web/src/lib/server/rating-aspects.ts
@@ -1,0 +1,208 @@
+/**
+ * 항목별 평점(aspect rating) — 범용 서버 로직 + PUT 오케스트레이션 (공유 모듈)
+ *
+ * 앙티티 전용 라우트(api/angtt/[slug]/rating/aspects)의 핵심 흐름을 여기로 뽑아
+ * 앙지도 등 일반 게시판(api/boards/[boardId]/[postId]/rating/aspects)이 재사용한다.
+ * 앙티티 경로는 target 해석(entities.server)만 자기 것으로 넘기고 나머지(인증·등급·
+ * 검증·총점 게이트·응답)를 이 핸들러에 위임한다 — 두 경로의 규약이 한곳에서 정의된다.
+ *
+ * 저장 규약: angple_rating_aspects(bo_table, wr_id, mb_id, aspect, rating).
+ *   - 일반 게시판: bo_table=boardId, wr_id=postId
+ *   - 앙티티      : bo_table='@entity', wr_id=entity_id (entities.server 소유)
+ * PK(bo_table, wr_id, mb_id, aspect)로 회원당 대상당 항목당 1표. DDL 없음(기존 테이블 재사용).
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import pool, { readPool } from '$lib/server/db.js';
+import { RATING_MIN_LEVEL } from '$lib/components/features/board/post-rating-logic.js';
+import { buildGradeDeniedMessage } from '$lib/utils/board-permissions.js';
+import { validateAspectsAgainst, type AspectDef } from '$plugins/angtt-review/lib/aspect-presets';
+
+/** 항목별 평점 집계 행(+요청자 본인 값) — 앙티티/일반 공통 표시 모델 */
+export interface AspectRating {
+    aspect: string;
+    avg: number;
+    count: number;
+    /** 로그인 사용자 본인이 이 항목에 남긴 별점(없으면 null) */
+    my: number | null;
+}
+
+interface AspectAggRow {
+    aspect: string;
+    cnt: number;
+    avg: number | string | null;
+    my: number | null;
+}
+
+/**
+ * 항목별 평점 집계 — aspect별 {avg, count} + 요청자 본인 값(범용).
+ * 세부 평가가 0건이면 빈 배열(옵트인 보장 — UI 미표시). 총점과는 완전 병렬.
+ */
+export async function getPostAspects(
+    boTable: string,
+    wrId: number,
+    mbId?: string,
+    db = readPool
+): Promise<AspectRating[]> {
+    const [result] = await db.query(
+        `SELECT aspect, COUNT(*) AS cnt, AVG(rating) AS avg,
+                MAX(CASE WHEN mb_id = ? THEN rating END) AS my
+           FROM angple_rating_aspects
+          WHERE bo_table = ? AND wr_id = ?
+          GROUP BY aspect`,
+        [mbId ?? '', boTable, wrId]
+    );
+    return (result as AspectAggRow[]).map((r) => ({
+        aspect: String(r.aspect),
+        avg: Number(r.avg ?? 0),
+        count: Number(r.cnt ?? 0),
+        my: r.my == null ? null : Number(r.my)
+    }));
+}
+
+/** 본인 총점 별점(angple_post_ratings) 보유 여부 — 항목별 평가 옵트인 게이트. */
+export async function hasPostTotalRating(
+    boTable: string,
+    wrId: number,
+    mbId: string
+): Promise<boolean> {
+    const [rows] = await readPool.query(
+        `SELECT 1 FROM angple_post_ratings
+          WHERE bo_table = ? AND wr_id = ? AND mb_id = ? LIMIT 1`,
+        [boTable, wrId, mbId]
+    );
+    return (rows as unknown[]).length > 0;
+}
+
+/**
+ * 항목별 평점 등록/수정 — 행별 UPSERT(회원당 대상당 항목당 1표, 범용).
+ * 검증 통과한 aspects(Record)만 받는다(호출부가 프리셋으로 검증). 총점 집계는 무접촉.
+ */
+export async function putPostAspects(
+    boTable: string,
+    wrId: number,
+    mbId: string,
+    aspects: Record<string, number>
+): Promise<AspectRating[]> {
+    const entries = Object.entries(aspects);
+    const placeholders = entries.map(() => '(?, ?, ?, ?, ?, NOW(3), NOW(3))').join(', ');
+    const params = entries.flatMap(([aspect, rating]) => [boTable, wrId, mbId, aspect, rating]);
+    await pool.query(
+        `INSERT INTO angple_rating_aspects
+            (bo_table, wr_id, mb_id, aspect, rating, created_at, updated_at)
+         VALUES ${placeholders}
+         ON DUPLICATE KEY UPDATE rating = VALUES(rating), updated_at = NOW(3)`,
+        params
+    );
+    // 방금 쓴 값을 즉시 정확히 되돌려주려 writer pool 로 재조회(리플리카 지연 회피).
+    return getPostAspects(boTable, wrId, mbId, pool);
+}
+
+interface ExtendedSettingsRow {
+    settings: string | null;
+}
+
+/**
+ * 게시판이 features.rating 을 켰는지(v2_board_extended_settings) — 읽기 전용.
+ * 총점 평점 파이프라인과 동일한 토글을 항목별 평가 게이트로도 재사용한다.
+ */
+export async function boardHasRatingFeature(boardId: string): Promise<boolean> {
+    const [rows] = await readPool.query(
+        `SELECT settings FROM v2_board_extended_settings WHERE board_id = ? LIMIT 1`,
+        [boardId]
+    );
+    const row = (rows as ExtendedSettingsRow[])[0];
+    if (!row?.settings) return false;
+    try {
+        const parsed = JSON.parse(row.settings) as { features?: { rating?: boolean } };
+        return parsed.features?.rating === true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * PUT 대상 기술서 — 경로별로 다른 부분만 콜백으로 주입한다.
+ * preset 이 null 이거나 available=false 면 404(대상 없음/미지원).
+ */
+export interface AspectPutTarget {
+    /** 대상 존재 + 항목별 평가 허용 여부(글 없음·features.rating off 면 false) */
+    available: boolean;
+    /** 화이트리스트 프리셋. null 이면 항목별 평가 미지원(→404) */
+    preset: AspectDef[] | null;
+    /** available=false 일 때 404 문구 */
+    notFoundMessage?: string;
+    /** 본인 총점 별점 보유 여부 */
+    hasTotalRating: (mbId: string) => Promise<boolean>;
+    /** 총점 미보유 시 403 문구 */
+    noTotalRatingMessage?: string;
+    /** 검증 통과 aspects 를 UPSERT 하고 최신 집계 반환 */
+    upsert: (mbId: string, aspects: Record<string, number>) => Promise<AspectRating[]>;
+}
+
+const DEFAULT_NOT_FOUND = '평가할 대상을 찾을 수 없어요.';
+const DEFAULT_NO_TOTAL = '먼저 별점(총점)을 남긴 뒤 항목별 평가를 남길 수 있어요.';
+
+/**
+ * 항목별 평점 PUT 공통 처리. 규약(양 경로 동일):
+ *   1) 로그인 필수(401)
+ *   2) 앙님💛(mb_level >= RATING_MIN_LEVEL) 등급 게이트(403)
+ *   3) 본문 파싱(400)
+ *   4) 대상 해석 — 없음/미지원(404)
+ *   5) 프리셋 화이트리스트 + 1~5 검증, 밖이면 전체 거부(400)
+ *   6) 본인 총점 별점 보유 게이트(403) — 항목별은 총점의 부가
+ *   7) UPSERT → { aspects } 반환
+ */
+export async function handleAspectsPut(
+    event: Pick<RequestEvent, 'locals' | 'request' | 'setHeaders'>,
+    resolveTarget: () => Promise<AspectPutTarget>
+): Promise<Response> {
+    const { locals, request, setHeaders } = event;
+    setHeaders({ 'Cache-Control': 'private, no-store' });
+
+    // 1) 인증
+    const mbId = locals.user?.id;
+    if (!mbId) {
+        return json({ error: '항목별 평가를 남기려면 로그인이 필요해요.' }, { status: 401 });
+    }
+
+    // 2) 등급 게이트(총점 별점과 동일)
+    const level = locals.user?.level ?? 1;
+    if (level < RATING_MIN_LEVEL) {
+        return json(
+            { error: buildGradeDeniedMessage('항목별 평가', RATING_MIN_LEVEL, level) },
+            { status: 403 }
+        );
+    }
+
+    // 3) 본문 파싱
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return json({ error: '요청 본문을 해석할 수 없어요.' }, { status: 400 });
+    }
+    const raw = (body as { aspects?: unknown } | null)?.aspects;
+
+    // 4) 대상 해석
+    const target = await resolveTarget();
+    if (!target.available || !target.preset) {
+        return json({ error: target.notFoundMessage ?? DEFAULT_NOT_FOUND }, { status: 404 });
+    }
+
+    // 5) 프리셋 화이트리스트 + 범위 검증
+    const validated = validateAspectsAgainst(target.preset, raw);
+    if (!validated.ok) {
+        return json({ error: validated.error }, { status: 400 });
+    }
+
+    // 6) 본인 총점 게이트 — 항목별 평가는 총점의 부가
+    const hasTotal = await target.hasTotalRating(mbId);
+    if (!hasTotal) {
+        return json({ error: target.noTotalRatingMessage ?? DEFAULT_NO_TOTAL }, { status: 403 });
+    }
+
+    // 7) UPSERT
+    const aspects = await target.upsert(mbId, validated.aspects);
+    return json({ aspects });
+}

--- a/apps/web/src/lib/server/rating-aspects.ts
+++ b/apps/web/src/lib/server/rating-aspects.ts
@@ -17,15 +17,10 @@ import pool, { readPool } from '$lib/server/db.js';
 import { RATING_MIN_LEVEL } from '$lib/components/features/board/post-rating-logic.js';
 import { buildGradeDeniedMessage } from '$lib/utils/board-permissions.js';
 import { validateAspectsAgainst, type AspectDef } from '$plugins/angtt-review/lib/aspect-presets';
+import type { AspectRating } from '$lib/components/features/board/rating-display.js';
 
-/** 항목별 평점 집계 행(+요청자 본인 값) — 앙티티/일반 공통 표시 모델 */
-export interface AspectRating {
-    aspect: string;
-    avg: number;
-    count: number;
-    /** 로그인 사용자 본인이 이 항목에 남긴 별점(없으면 null) */
-    my: number | null;
-}
+// 표시 모델(AspectRating)은 클라이언트-세이프 모듈(rating-display)에 단일 정의 → 재노출.
+export type { AspectRating };
 
 interface AspectAggRow {
     aspect: string;

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -33,6 +33,8 @@ import { buildHookContext } from '$lib/hooks/context.js';
 import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 import { resolveAngttMatch, type AngttMatch } from '$lib/server/angtt-dictionary.js';
 import { getAngmapPlace, type AngmapPlaceCoord } from '$lib/server/angmap-place.js';
+import { getPostAspects, type AspectRating } from '$lib/server/rating-aspects.js';
+import { getBoardAspectPreset } from '$plugins/angtt-review/lib/aspect-presets';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -760,6 +762,14 @@ export const load: PageServerLoad = async ({
         const angmapPlace: AngmapPlaceCoord | null =
             boardId === 'angmap' && !post.deleted_at ? await getAngmapPlace(post.id) : null;
 
+        // 항목별 평점 집계(옵트인 표시·입력용) — 프리셋이 매핑된 보드(angmap) + features.rating
+        // (post.rating 동봉) 글에서만 조회. 총점 위젯이 이 값으로 항목별 UI 를 렌더한다.
+        // 실패는 빈 배열로 수렴(부가 기능 — 상세 로드 무영향).
+        const postAspects: AspectRating[] =
+            !post.deleted_at && post.rating && getBoardAspectPreset(boardId)
+                ? await getPostAspects(boardId, post.id, locals.user?.id).catch(() => [])
+                : [];
+
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).
         // 미설치 시 pass-through. (premium PR #43 기준 stub)
         // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달.
@@ -789,6 +799,8 @@ export const load: PageServerLoad = async ({
             angttMatch,
             /** 앙지도(angmap) 상세 미니맵 좌표 — angmap 보드 + 좌표 확보 글에서만 (없으면 null) */
             angmapPlace,
+            /** 항목별 평점 집계(옵트인 표시·입력용) — 프리셋 매핑 보드에서만 채워짐(그 외 빈 배열) */
+            postAspects,
             /** 스트리밍: Promise로 반환 → 클라이언트에서 $effect로 수신 */
             streamed: {
                 auxiliaryData: auxiliaryDataPromise

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -32,6 +32,7 @@ import { applyFilter } from '$lib/hooks/registry.js';
 import { buildHookContext } from '$lib/hooks/context.js';
 import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 import { resolveAngttMatch, type AngttMatch } from '$lib/server/angtt-dictionary.js';
+import { getAngmapPlace, type AngmapPlaceCoord } from '$lib/server/angmap-place.js';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -754,6 +755,11 @@ export const load: PageServerLoad = async ({
         // 앙티티 커넥트 카드 데이터 — 위에서 병렬 시작한 promise 를 여기서 확정 (reject 없음).
         const angttMatch = await angttMatchPromise;
 
+        // 앙지도(angmap) 상세 미니맵용 좌표 — angmap 보드 + 미삭제 글에서만 조회(읽기 전용).
+        // 좌표 없으면 null → 상세에서 지도 미표시(빈 박스 금지). 실패는 내부 catch → null.
+        const angmapPlace: AngmapPlaceCoord | null =
+            boardId === 'angmap' && !post.deleted_at ? await getAngmapPlace(post.id) : null;
+
         // Phase 1C: 플러그인 enrich filter (member-memo author_memo 등).
         // 미설치 시 pass-through. (premium PR #43 기준 stub)
         // Step A′: 서버 hook 표준 컨텍스트(site/user) 전달.
@@ -781,6 +787,8 @@ export const load: PageServerLoad = async ({
             memberActivity,
             /** 앙티티 커넥트(Phase 1): 태그 「앙티티」+작품명 → 작품 카드 (없으면 undefined) */
             angttMatch,
+            /** 앙지도(angmap) 상세 미니맵 좌표 — angmap 보드 + 좌표 확보 글에서만 (없으면 null) */
+            angmapPlace,
             /** 스트리밍: Promise로 반환 → 클라이언트에서 $effect로 수신 */
             streamed: {
                 auxiliaryData: auxiliaryDataPromise

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -44,6 +44,7 @@
     import AuthorActivityPanel from '$lib/components/features/board/author-activity-panel.svelte';
     import RecentPosts from '$lib/components/features/board/recent-posts.svelte';
     import AngttConnectCard from '$lib/components/features/board/angtt-connect-card.svelte';
+    import AngmapPlaceMap from '$lib/components/features/board/angmap-place-map.svelte';
     import { BOARD_LIST_PAGE_SIZE } from '$lib/constants/board';
     import { ReportDialog } from '$lib/components/features/report/index.js';
     import type { FreeComment, FreePost, LikerInfo, PostRevision } from '$lib/api/types.js';
@@ -2307,6 +2308,16 @@
                     {/each}
                 </div>
             </div>
+        {/if}
+
+        <!-- 앙지도 상세 단일 핀 미니맵 — 좌표 확보 글에만(서버 주입). 좌표 없으면 미표시(빈 박스 금지). -->
+        {#if boardType === 'angmap' && data.angmapPlace}
+            <AngmapPlaceMap
+                lat={data.angmapPlace.lat}
+                lng={data.angmapPlace.lng}
+                name={data.angmapPlace.name}
+                mapUrl={data.post.link1 || data.post.link2 || null}
+            />
         {/if}
 
         <!-- 앙티티 커넥트 카드 (Phase 1): 태그 「앙티티」+작품명 규약 — 서버 매칭, SSR 렌더 -->

--- a/apps/web/src/routes/api/angtt/[slug]/rating/aspects/+server.ts
+++ b/apps/web/src/routes/api/angtt/[slug]/rating/aspects/+server.ts
@@ -7,74 +7,45 @@
  * 회원당 작품당 항목당 1표 보장. 프리셋(aspect-presets.ts) 화이트리스트 밖
  * aspect 키·1~5 범위 밖 값은 저장 자체를 거부한다.
  *
- * 권한 게이트는 총점과 동일: 로그인 + 앙님💛(mb_level 3) 이상
- * (RATING_MIN_LEVEL·buildGradeDeniedMessage 재사용, 단일 소스 유지).
- * 조회는 별도 GET 없이 작품 페이지 SSR(getEntityAspects 편승)이 담당한다.
+ * 인증·등급 게이트·검증·총점 게이트·응답은 공유 핸들러(handleAspectsPut)에 위임하고,
+ * 여기서는 앙티티 고유의 대상 해석(entities.server)만 target 으로 넘긴다.
+ * 규약은 일반 게시판 경로(api/boards/[boardId]/[postId]/rating/aspects)와 단일 소스.
  */
-import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import {
     getEntityBySlug,
     getEntityRating,
     putEntityAspects
 } from '$plugins/angtt-review/lib/entities.server';
-import { validateAspects } from '$plugins/angtt-review/lib/aspect-presets';
-import { RATING_MIN_LEVEL } from '$lib/components/features/board/post-rating-logic.js';
-import { buildGradeDeniedMessage } from '$lib/utils/board-permissions.js';
+import { getAspectPreset } from '$plugins/angtt-review/lib/aspect-presets';
+import { handleAspectsPut } from '$lib/server/rating-aspects.js';
 
 /**
  * PUT /api/angtt/:slug/rating/aspects  body: { aspects: { story: 4, ... } }
  * 로그인 + 앙님💛(mb_level 3) 이상 + 본인 총점 별점 보유 필요.
  * 갱신된 { aspects: [{aspect, avg, count, my}] } 반환.
  */
-export const PUT: RequestHandler = async ({ params, locals, request, setHeaders }) => {
-    setHeaders({ 'Cache-Control': 'private, no-store' });
-
-    // 인증 필수
-    const mbId = locals.user?.id;
-    if (!mbId) {
-        return json({ error: '항목별 평가를 남기려면 로그인이 필요해요.' }, { status: 401 });
-    }
-
-    // 등급 게이트(총점 별점과 동일: 로그인 + mb_level >= RATING_MIN_LEVEL)
-    const level = locals.user?.level ?? 1;
-    if (level < RATING_MIN_LEVEL) {
-        return json(
-            { error: buildGradeDeniedMessage('항목별 평가', RATING_MIN_LEVEL, level) },
-            { status: 403 }
-        );
-    }
-
-    // 본문 파싱
-    let body: unknown;
-    try {
-        body = await request.json();
-    } catch {
-        return json({ error: '요청 본문을 해석할 수 없어요.' }, { status: 400 });
-    }
-    const raw = (body as { aspects?: unknown } | null)?.aspects;
-
-    // 작품 조회
-    const entity = await getEntityBySlug(params.slug);
-    if (!entity || entity.status !== 'active') {
-        return json({ error: '작품을 찾을 수 없습니다.' }, { status: 404 });
-    }
-
-    // 프리셋 화이트리스트 + 1~5 범위 검증 (밖이면 전체 거부)
-    const validated = validateAspects(entity.type, raw);
-    if (!validated.ok) {
-        return json({ error: validated.error }, { status: 400 });
-    }
-
-    // 본인 총점 게이트 — 항목별 평가는 총점의 부가라는 규약
-    const rating = await getEntityRating(entity.id, mbId);
-    if (rating.my == null) {
-        return json(
-            { error: '먼저 작품 별점(총점)을 남긴 뒤 항목별 평가를 남길 수 있어요.' },
-            { status: 403 }
-        );
-    }
-
-    const aspects = await putEntityAspects(entity.id, entity.type, mbId, validated.aspects);
-    return json({ aspects });
+export const PUT: RequestHandler = async (event) => {
+    const { params } = event;
+    return handleAspectsPut(event, async () => {
+        const entity = await getEntityBySlug(params.slug);
+        if (!entity || entity.status !== 'active') {
+            return {
+                available: false,
+                preset: null,
+                notFoundMessage: '작품을 찾을 수 없습니다.',
+                hasTotalRating: async () => false,
+                upsert: async () => []
+            };
+        }
+        return {
+            available: true,
+            preset: getAspectPreset(entity.type),
+            hasTotalRating: async (mbId: string) =>
+                (await getEntityRating(entity.id, mbId)).my != null,
+            noTotalRatingMessage: '먼저 작품 별점(총점)을 남긴 뒤 항목별 평가를 남길 수 있어요.',
+            upsert: (mbId: string, aspects) =>
+                putEntityAspects(entity.id, entity.type, mbId, aspects)
+        };
+    });
 };

--- a/apps/web/src/routes/api/boards/[boardId]/[postId]/rating/aspects/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/[postId]/rating/aspects/+server.ts
@@ -1,0 +1,55 @@
+/**
+ * 일반 게시판 항목별 평점 API — PUT(행별 등록·수정, 부분 입력 허용) — 범용 경로.
+ *
+ * 앙지도(angmap) 등 features.rating 을 켠 게시판에서 총점 별점의 세부(맛/가성비 등)를
+ * 남긴다. 앙티티 전용 경로(api/angtt/[slug]/rating/aspects)와 **동일한 공유 핸들러**를
+ * 쓰되, 대상 해석만 게시판/글 기준으로 바꾼다(bo_table=boardId, wr_id=postId).
+ *
+ * 규약(공유 핸들러가 강제):
+ *   (a) 본인 총점(angple_post_ratings) 없는 회원의 항목별 PUT 거부(403)
+ *   (b) 프리셋 화이트리스트 밖 aspect 키 거부(400) — 자유텍스트 오염 차단
+ *   (c) features.rating 을 켠 보드 + 프리셋이 매핑된 보드만 허용(그 외 404)
+ * 저장 테이블 angple_rating_aspects — DDL 없음.
+ */
+import type { RequestHandler } from './$types';
+import { getBoardAspectPreset } from '$plugins/angtt-review/lib/aspect-presets';
+import {
+    boardHasRatingFeature,
+    hasPostTotalRating,
+    putPostAspects,
+    handleAspectsPut
+} from '$lib/server/rating-aspects.js';
+
+/**
+ * PUT /api/boards/:boardId/:postId/rating/aspects  body: { aspects: { taste: 4, ... } }
+ * 로그인 + 앙님💛(mb_level 3) 이상 + 본인 총점 별점 보유 + features.rating 보드 필요.
+ * 갱신된 { aspects: [{aspect, avg, count, my}] } 반환.
+ */
+export const PUT: RequestHandler = async (event) => {
+    const { params } = event;
+    return handleAspectsPut(event, async () => {
+        const boardId = params.boardId;
+        const wrId = Number(params.postId);
+        const preset = getBoardAspectPreset(boardId);
+
+        // 프리셋이 없으면(항목별 미지원 보드) features.rating 조회 없이 즉시 미지원 처리.
+        if (!preset || !Number.isFinite(wrId) || wrId <= 0) {
+            return {
+                available: false,
+                preset: null,
+                notFoundMessage: '이 게시판은 항목별 평가를 지원하지 않아요.',
+                hasTotalRating: async () => false,
+                upsert: async () => []
+            };
+        }
+
+        const featureOn = await boardHasRatingFeature(boardId);
+        return {
+            available: featureOn,
+            preset,
+            notFoundMessage: '이 게시판은 항목별 평가를 지원하지 않아요.',
+            hasTotalRating: (mbId: string) => hasPostTotalRating(boardId, wrId, mbId),
+            upsert: (mbId: string, aspects) => putPostAspects(boardId, wrId, mbId, aspects)
+        };
+    });
+};

--- a/plugins/angtt-review/lib/aspect-presets.ts
+++ b/plugins/angtt-review/lib/aspect-presets.ts
@@ -50,6 +50,32 @@ export const DEFAULT_ASPECTS: AspectDef[] = [
     IMMERSION
 ];
 
+/**
+ * 맛집·장소(앙지도) 프리셋: 맛/가성비/분위기/친절.
+ *
+ * 앙티티 프리셋(작품 축)과 완전히 별개 축이다. 게시판(boardId) 단위로 매핑되며
+ * (엔티티 type 이 아님), 총점을 남긴 회원에게만 옵트인으로 노출된다.
+ */
+export const PRESET_PLACE: AspectDef[] = [
+    { key: 'taste', label: '맛' },
+    { key: 'value', label: '가성비' },
+    { key: 'mood', label: '분위기' },
+    { key: 'service', label: '친절' }
+];
+
+/** 일반 게시판 boardId → 항목 프리셋. 여기 없는 보드는 항목별 평가 미지원(null). */
+const PRESETS_BY_BOARD: Record<string, AspectDef[]> = {
+    angmap: PRESET_PLACE
+};
+
+/**
+ * 일반 게시판(boardId) → 항목 프리셋. 매핑에 없으면 null(= 항목별 평가 미지원).
+ * 엔티티 type 프리셋(getAspectPreset)과 별개 축 — 절대 섞지 않는다.
+ */
+export function getBoardAspectPreset(boardId: string): AspectDef[] | null {
+    return PRESETS_BY_BOARD[boardId] ?? null;
+}
+
 /** entity.type → 프리셋 매핑 (여기 없는 type 은 DEFAULT_ASPECTS) */
 const PRESETS_BY_TYPE: Record<string, AspectDef[]> = {
     movie: PRESET_SCREEN,
@@ -77,17 +103,19 @@ export type AspectValidation =
     | { ok: false; error: string };
 
 /**
- * aspects 입력({story: 4, ...})을 프리셋 화이트리스트로 검증한다.
+ * aspects 입력({story: 4, ...})을 **주어진 프리셋** 화이트리스트로 검증한다(축 불문).
  *
  *  - 프리셋에 있는 키만 수용 — 밖의 키가 하나라도 있으면 전체 거부
  *  - 값은 숫자만, 반올림 후 1~5 범위 밖이면 거부 (4.4 → 4 수용, 5.6 → 거부)
  *  - 부분 입력 허용(프리셋 일부 항목만 보내도 됨), 빈 입력은 거부
+ *
+ * 엔티티(type)·게시판(boardId) 양쪽 경로가 이 순수 함수를 공유한다.
  */
-export function validateAspects(type: string, input: unknown): AspectValidation {
+export function validateAspectsAgainst(preset: AspectDef[], input: unknown): AspectValidation {
     if (input == null || typeof input !== 'object' || Array.isArray(input)) {
         return { ok: false, error: '항목별 평가 형식이 올바르지 않아요.' };
     }
-    const allowed = new Set(getAspectPreset(type).map((a) => a.key));
+    const allowed = new Set(preset.map((a) => a.key));
     const aspects: Record<string, number> = {};
     for (const [key, raw] of Object.entries(input as Record<string, unknown>)) {
         if (!allowed.has(key)) {
@@ -104,6 +132,13 @@ export function validateAspects(type: string, input: unknown): AspectValidation 
         return { ok: false, error: '평가할 항목이 없어요.' };
     }
     return { ok: true, aspects };
+}
+
+/**
+ * aspects 입력을 엔티티 type 프리셋으로 검증한다(앙티티 경로 — 기존 호출부 호환).
+ */
+export function validateAspects(type: string, input: unknown): AspectValidation {
+    return validateAspectsAgainst(getAspectPreset(type), input);
 }
 
 /**


### PR DESCRIPTION
## 앙지도(angmap) 평점 — P2 (품질 확장)

Sprint Contract `angmap-rating-sprint-contract.md` 의 **P2** 4항목 구현. 설계 원문 `angmap-rating-map-design.md`.
P0(features.rating 토글)·P1(레거시 아카이브)과 독립. **DDL 없음** — 기존 테이블(`angple_rating_aspects`) 재사용.

### 변경 요약
1. **맛집 프리셋** — `PRESET_PLACE`(맛/가성비/분위기/친절) + `angmap` 보드 매핑. 엔티티 type 축과 완전 분리(`getBoardAspectPreset`).
2. **항목별 평점 범용 API** — 신규 `PUT /api/boards/[boardId]/[postId]/rating/aspects`. 앙티티 전용 경로의 핵심 흐름(인증→등급→검증→총점 게이트→UPSERT)을 공유 핸들러 `handleAspectsPut` 로 추출해 양 경로가 재사용. 규약: (a) 총점 없는 회원 거부(403), (b) 프리셋 밖 aspect 키 거부(400), (c) `features.rating` 보드만 허용(404).
3. **n<3 착시 공유 유틸** — `rating-display.ts`(참여 3명 미만이면 평균 숫자 미노출 / 랭킹용 베이지안 보정 m=5) + vitest. `post-rating` 위젯·앙티티 커넥트 카드에 소급 적용.
4. **상세 단일 핀 미니맵** — `angmap-place-map.svelte`(좌표 있는 글만, 줌16, Leaflet 지연로딩·SSR 금지). 서버 로더가 `readPool` 로 좌표 주입, 좌표 없으면 미표시(빈 박스 금지).

### 무변경/안전
- **백엔드 무접촉**, **스키마 무변경(DDL 0)**. 쓰기는 기존 `angple_rating_aspects` 재사용.
- **앙티티 경로 무회귀**: `api/angtt/[slug]/rating/aspects` 는 대상 해석(entities.server)만 넘기고 나머지를 공유 핸들러에 위임 — DB 경로·응답 형태(`{aspects}`)·문구 그대로. `getEntityAspects/putEntityAspects` 미변경.
- **글로벌 원칙 준수**: 좌표 범위·초기 뷰 어디에도 국가 하드코딩 없음. 해외 장소 글도 좌표만 보고 동작.
- 좌표·미니맵은 부가 기능 — 조회 실패는 내부 catch → null(상세 로드 무영향).

### 검증 관점 (Evaluator)
1. `bo_table='angmap'` 항목별 UPSERT/재저장 중복 없음(PK bo_table,wr_id,mb_id,aspect)
2. 총점 없는 회원 항목별 PUT 403 / 프리셋 밖 키 400
3. `features.rating` off 보드·미매핑 보드 → 404
4. 좌표 없는 글·해외 장소 글에서 미니맵·평점 정상(빈 박스 없음, 국가 가정 0)
5. n<3 글에서 평균 숫자 미노출("앙님 N명 평가")
6. 앙티티 기존 평점 흐름 무회귀 + n 보정 소급이 앙티티 표시(커넥트 카드) 안 깨는지
7. 신규 별점 1개 달아도 아카이브(P1) 숫자 불변 — 분리 소스

> 서버에서 빌드/타입체크/prettier 미실행(운영 규약). 정적 검토만 수행 — 타입·테스트 통과는 CI가 게이트.
