### PR TITLE
feat(disciplinelog): 소명 인용 해제 배너·배지 표시

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -76,6 +76,7 @@ export interface DisciplineLogListItem {
     violation_types: number[];
     violation_titles: string[];
     memo?: string;
+    revoked?: boolean; // 소명 인용 등으로 회수된 제재 (목록 배지용)
 }
 
 export interface DisciplineLogDetail {

--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -95,6 +95,7 @@ export interface DisciplineLogDetail {
     created_at: string;
     status: 'pending' | 'approved' | 'rejected';
     claim_post_id?: number;
+    revoked_at?: string; // 소명 인용 등으로 회수된 경우 해제일 (revoked_by·admin_memo는 미노출)
 }
 
 export interface DisciplineLogListResponse {

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -179,7 +179,13 @@
                                             >
                                                 {penalty.text}
                                             </Badge>
-                                            {#if penalty.released}
+                                            {#if log.revoked}
+                                                <Badge
+                                                    variant="secondary"
+                                                    class="border-emerald-300 bg-emerald-100 text-xs text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                                                    >소명해제</Badge
+                                                >
+                                            {:else if penalty.released}
                                                 <Badge variant="secondary" class="text-xs"
                                                     >해제</Badge
                                                 >
@@ -232,7 +238,13 @@
                                         >
                                             {penalty.text}
                                         </Badge>
-                                        {#if penalty.released}
+                                        {#if log.revoked}
+                                            <Badge
+                                                variant="secondary"
+                                                class="border-emerald-300 bg-emerald-100 text-xs text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                                                >소명해제</Badge
+                                            >
+                                        {:else if penalty.released}
                                             <Badge variant="secondary" class="text-xs">해제</Badge>
                                         {/if}
                                     </div>

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -14,6 +14,7 @@
     import Megaphone from '@lucide/svelte/icons/megaphone';
     import ExternalLink from '@lucide/svelte/icons/external-link';
     import History from '@lucide/svelte/icons/history';
+    import ShieldCheck from '@lucide/svelte/icons/shield-check';
     import {
         getPenaltyDisplay,
         type DisciplineLogDetail,
@@ -124,6 +125,27 @@
     {:else}
         {@const penalty = getPenaltyDisplay(log.penalty_period, log.penalty_date_to)}
 
+        <!-- 소명 인용 해제 배너: revoked_at 있을 때만. 회수 사실만 공개(회수자·사유 비공개). -->
+        {#if log.revoked_at}
+            <Card.Root
+                class="mb-4 border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/40"
+            >
+                <Card.Content class="flex items-start gap-3 py-4">
+                    <ShieldCheck
+                        class="mt-0.5 h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400"
+                    />
+                    <div class="text-sm">
+                        <div class="font-semibold text-emerald-800 dark:text-emerald-300">
+                            이 이용제한은 소명 인용으로 해제되었습니다
+                        </div>
+                        <div class="mt-0.5 text-emerald-700/80 dark:text-emerald-400/80">
+                            해제일 {log.revoked_at.slice(0, 10)}
+                        </div>
+                    </div>
+                </Card.Content>
+            </Card.Root>
+        {/if}
+
         <!-- Basic Info -->
         <Card.Root class="mb-4">
             <Card.Header>
@@ -151,7 +173,14 @@
                         >
                             {penalty.text}
                         </Badge>
-                        {#if penalty.released}
+                        {#if log.revoked_at}
+                            <Badge
+                                variant="secondary"
+                                class="border-emerald-300 bg-emerald-100 text-xs text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                            >
+                                소명 해제
+                            </Badge>
+                        {:else if penalty.released}
                             <Badge variant="secondary" class="text-xs">해제</Badge>
                         {/if}
                         <span class="text-muted-foreground text-sm">


### PR DESCRIPTION
## 목적
disciplinelog 상세·목록에 "소명 인용으로 해제됨"을 표시. angple-backend#586(읽기 A단계)과 세트.

## 변경
- 상세 화면 상단에 **소명 해제 배너**(ShieldCheck + "이 이용제한은 소명 인용으로 해제되었습니다 · 해제일")
- 제재기간 옆 **"소명 해제" 배지** (emerald 톤)
- 목록(테이블·모바일)에 **"소명해제" 배지**
- `DisciplineLogDetail.revoked_at?` / `DisciplineLogListItem.revoked?` 타입 추가

## 기존 "해제"와 구분
- 기존 `해제`(회색) = **기간만료**(released)
- 신규 `소명해제`(emerald) = **소명 인용 회수**(revoked)
- revoke면 배너+소명해제 배지, 기간만료는 기존 그대로

## 공개 범위
- `revoked_at`(해제일)만 노출. 회수자(revoked_by)·회수사유(admin_memo)는 백엔드에서 drop되어 프론트에 안 옴

## 의존
- angple-backend#586 (revoked_at 응답 필드) 선배포 필요. 없으면 배너 미표시(무해)