### PR TITLE
fix(disciplinelog): 소명 회수 시 제재기간 조기 해제 표기

### DIFF
--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -184,7 +184,23 @@
                             <Badge variant="secondary" class="text-xs">해제</Badge>
                         {/if}
                         <span class="text-muted-foreground text-sm">
-                            ({formatPeriodRange(log)})
+                            {#if log.revoked_at}
+                                <!-- 회수된 제재: 원래 종료일에 취소선 + 조기 해제 표기.
+                                     (기간이 만료된 게 아니라 소명 인용으로 중간에 풀렸음을 명확히) -->
+                                ({log.penalty_date_from} 시작 ·
+                                {#if log.penalty_period !== 0}
+                                    <s class="opacity-60"
+                                        >{log.penalty_period === -1
+                                            ? '영구'
+                                            : log.penalty_date_to || ''}</s
+                                    > ·
+                                {/if}
+                                <span class="text-emerald-700 dark:text-emerald-400"
+                                    >{log.revoked_at} 소명 인용으로 해제</span
+                                >)
+                            {:else}
+                                ({formatPeriodRange(log)})
+                            {/if}
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
## 목적
disciplinelog 상세에서 소명 회수(revoked) 시, 제재기간이 원래 창(시작~원래 종료일) 그대로 표시돼 **"종료일까지 여전히 제한"으로 오해**되던 것을 바로잡음. Java(4022) 건에서 확인 — 실제 mb_intercept_date는 비워졌는데 화면엔 07-29까지로 보임.

## 변경
- `[id]/+page.svelte` 제재기간 표시에 `revoked_at` 분기 추가
- 회수 시: `시작일 · ~~원래 종료일(취소선)~~ · {해제일} 소명 인용으로 해제`
- 기간 만료(released)가 아니라 **소명 인용으로 조기 해제**임을 시각적으로 구분
- warning(0)·영구(-1) 케이스도 처리 (영구는 "영구"에 취소선)

## 안전성
- revoked_at 없으면 기존 `formatPeriodRange` 그대로 (하위호환)
- 순수 표시 변경, 데이터·권한 무관