### PR TITLE
fix(profile): 소명 회수 제재를 프로필 이력에서 제외

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -227,7 +227,10 @@ export const GET: RequestHandler = async ({ params, locals }) => {
             );
             for (const row of logRows) {
                 const entry = parseDisciplineLogContent(row);
-                if (entry) {
+                // 소명 인용 등으로 회수(revoke)된 제재는 프로필 이력에서 제외 —
+                // 처분이 취소된 건을 유효한 제재처럼 노출하지 않는다.
+                // 전체 기록(회수 표시 포함)은 /disciplinelog 에서 확인 가능.
+                if (entry && !entry.revoked) {
                     disciplineHistory.push(entry);
                 }
             }

--- a/apps/web/src/routes/api/members/[id]/profile/_parse-discipline.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/_parse-discipline.ts
@@ -9,6 +9,8 @@ export interface DisciplineEntry {
     penalty_date_from: string;
     sg_types?: string[];
     wr_id?: number;
+    /** 소명 인용 등으로 회수(revoke)된 제재 — 프로필 이력에서는 제외한다 */
+    revoked?: boolean;
 }
 
 /**
@@ -34,6 +36,9 @@ export function parseDisciplineLogContent(row: {
         };
         if (Array.isArray(parsed.sg_types)) {
             entry.sg_types = parsed.sg_types.map((t: unknown) => String(t));
+        }
+        if (typeof parsed.revoked_at === 'string' && parsed.revoked_at !== '') {
+            entry.revoked = true;
         }
         return entry;
     } catch {

--- a/apps/web/src/routes/api/members/[id]/profile/parse-discipline.test.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/parse-discipline.test.ts
@@ -21,6 +21,37 @@ describe('parseDisciplineLogContent', () => {
         });
     });
 
+    it('revoked_at 있으면 revoked=true (프로필 이력 제외용)', () => {
+        const row = {
+            wr_id: 4022,
+            wr_content: JSON.stringify({
+                penalty_period: 5,
+                penalty_date_from: '2026-07-24 23:41:55',
+                revoked_at: '2026-07-25 01:01:47',
+                revoked_by: 'appeal'
+            }),
+            wr_datetime: '2026-07-24 23:41:55'
+        };
+        const result = parseDisciplineLogContent(row);
+        expect(result?.revoked).toBe(true);
+        expect(result?.penalty_period).toBe(5);
+    });
+
+    it('revoked_at 없거나 빈 문자열이면 revoked 미설정', () => {
+        const noField = parseDisciplineLogContent({
+            wr_id: 1,
+            wr_content: JSON.stringify({ penalty_period: 3 }),
+            wr_datetime: '2026-07-01 00:00:00'
+        });
+        expect(noField?.revoked).toBeUndefined();
+        const emptyField = parseDisciplineLogContent({
+            wr_id: 2,
+            wr_content: JSON.stringify({ penalty_period: 3, revoked_at: '' }),
+            wr_datetime: '2026-07-01 00:00:00'
+        });
+        expect(emptyField?.revoked).toBeUndefined();
+    });
+
     it('penalty_date_from 누락 시 wr_datetime fallback', () => {
         const row = {
             wr_id: 1041,


### PR DESCRIPTION
## 목적
소명 인용으로 회수(revoke)된 제재가 회원 프로필 "이용제한 내역"에 **유효한 제재처럼 계속 표시**되던 문제. Java(disciplinelog 4022) 건에서 확인 — 소명 인용·해제됐는데 프로필엔 "5일 이용제한"이 그대로.

## 방침 (A안)
- **회수된 제재는 프로필 요약(이력·현재제재)에서 제외** — 처분 취소 = 이력 요약에서도 제거
- 전체 공적 기록은 /disciplinelog 에 그대로 (해제 배너·"소명해제" 배지 포함, #1873·#1874)

## 변경
- `_parse-discipline.ts`: wr_content JSON 의 `revoked_at` → `entry.revoked` 플래그
- `profile/+server.ts`: `revoked` 항목을 `discipline`/`discipline_history` 에서 필터
- 테스트 2건 추가 (revoked_at 존재 시 플래그 설정 / 부재·빈값 시 미설정)

## 안전성
- revoked_at 없는 기존 데이터는 동작 불변 (플래그 미설정 → 필터 통과)
- 프록시 1파일 + 파서 + 테스트, DB 스키마 무관