### PR TITLE
fix(comment): 댓글 입력 후 Tab 이 이모티콘 대신 '댓글 작성'으로

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -54,7 +54,10 @@
     let {
         onSubmit,
         onCancel,
-        placeholder = '댓글을 입력하세요. 경어체 사용은 필수이며, 초성 비속어도 이용제한 대상입니다.',
+        // 끝의 단축키 안내 — Ctrl+Enter 제출은 오래전부터 있었으나 아무도 몰라
+        // "마우스로 눌러야 해서 불편하다"는 제보가 반복됐다. 노출로 해소한다.
+        // ⚠️ TipTap Placeholder 는 CSS ::before content 로 그려서 개행(\n)이 무시된다 — 한 줄 유지.
+        placeholder = '댓글을 입력하세요. 경어체 사용은 필수이며, 초성 비속어도 이용제한 대상입니다. (Ctrl+Enter 로 바로 작성)',
         isLoading = false,
         parentId,
         parentAuthor,

--- a/apps/web/src/lib/components/features/board/comment-toolbar.svelte
+++ b/apps/web/src/lib/components/features/board/comment-toolbar.svelte
@@ -70,6 +70,11 @@
     }
 </script>
 
+<!--
+    툴바 버튼은 모두 tabindex="-1" — 댓글 입력 후 Tab 을 누르면 이모티콘이 아니라
+    '댓글 작성' 버튼으로 바로 가야 한다(#13092 회원 제보). 삽입 도구는 마우스·클릭
+    전용이라 키보드 순회에서 빼도 기능 손실이 없고, 오히려 작성 흐름이 자연스러워진다.
+-->
 <div class="flex items-center gap-1">
     <!-- 이모티콘 버튼 -->
     <div class="relative">
@@ -79,6 +84,7 @@
             size="sm"
             onclick={toggleEmoticonPicker}
             {disabled}
+            tabindex={-1}
             class="h-8 px-2"
             title="이모티콘"
         >
@@ -110,6 +116,7 @@
         size="sm"
         onclick={openGifPicker}
         {disabled}
+        tabindex={-1}
         class="h-8 px-2"
         title="GIF"
     >
@@ -124,6 +131,7 @@
         size="sm"
         onclick={onSelectImage}
         {disabled}
+        tabindex={-1}
         class="h-8 px-2"
         title="사진"
     >
@@ -138,6 +146,7 @@
         size="sm"
         onclick={insertBlankComment}
         {disabled}
+        tabindex={-1}
         class="h-8 px-2"
         title="빈댓글"
     >


### PR DESCRIPTION
## 배경
회원 제보 — "댓글 달고 마우스로 '댓글작성'을 눌러야 하는 건 불편합니다. 탭키 누르면 바로 '댓글작성' 버튼으로 이동해야 하는데 이모티콘으로 갑니다."

댓글 폼 DOM 순서가 **[에디터 → 툴바(이모티콘·GIF·사진·빈댓글) → 작성 버튼]** 이라 Tab 이 자연스럽게 툴바로 갔다.

## 변경
툴바 삽입 도구 4개에 `tabindex={-1}` — 키보드 순회에서 제외.
- **Tab: 에디터 → '댓글 작성' 버튼 직행**
- 마우스·클릭 동작, 시각적 배치는 완전히 동일

## 무변경
- 단축키 **Alt/Ctrl+Enter 제출은 이미 구현돼 있음**(comment-editor handleKeyDown → onSubmitShortcut), 버튼 title 힌트도 기존 존재. 이번 PR 은 Tab 순서만 수정.
- 다른 폼·게시판 영향 없음.

## 검증 관점
- 댓글 입력 → Tab → 포커스가 '댓글 작성' 버튼인지
- 이모티콘·GIF·사진·빈댓글 클릭 정상 동작
- 답글 모드에서도 동일(취소 버튼은 순회 유지)
- Alt/Ctrl+Enter 제출 무회귀