### PR TITLE
fix(markdown): 번호목록 start·표 셀병합 속성 유실 (#13086)

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -223,7 +223,16 @@
             'open',
             'data-original',
             'data-affiliate',
-            'data-original-url'
+            'data-original-url',
+            // 목록·표 구조 속성 (#13086) — 백엔드(sanitize.go)·서버(server/sanitize.ts)는 이미 허용하는데
+            // 렌더러에만 빠져 있어 SSR 단계에서 깎였다. 목록 중간에 문단을 넣어 <ol> 이 둘로 쪼개지면
+            // 두 번째 목록이 start="2" 를 잃고 1 부터 다시 시작했고(1.1.2.), 표는 셀 병합이 풀렸다.
+            // 표현 속성이라 XSS 표면 증가 없음. 데이터는 온전하므로 과거 글도 함께 정상화된다.
+            'start',
+            'reversed',
+            'value',
+            'colspan',
+            'rowspan'
         ]
     };
 


### PR DESCRIPTION
## 제보
버그 #13086 — "편집창에서는 1. 2. 3. 인데 게시하면 **1. 1. 2.** 로 표기됩니다"

## 원인 (3중 검증)
본문 렌더러 `markdown.svelte` 의 DOMPurify `ALLOWED_ATTR` 에 **`start` 누락** → SSR 단계에서 `<ol start="2">` → `<ol>` 로 깎임.

목록 중간에 문단을 넣으면 TipTap 이 `<ol>` 을 둘로 쪼개고 두 번째에 `start="2"` 를 붙이는데, 그 속성이 사라져 **1 부터 재시작**.

**검증**
1. DB 실측: `free/6797842` 의 `wr_content` 에 `start="2"` **정상 저장됨**
2. 운영/카나리 HTML: 둘 다 `start` **소실** (최근 배포 회귀 아님 — 오래된 잠복 버그)
3. 격리 재현: marked 는 보존 → **dompurify 통과 시 유실**, `'start'` 추가만으로 해결

## 부수 발견
같은 누락으로 **표 셀 병합(`colspan`/`rowspan`)도 깨지고 있어** 함께 추가.

## 변경
`ALLOWED_ATTR` 에 `start`, `reversed`, `value`, `colspan`, `rowspan` 추가.

## 근본 원인 (구조)
허용목록이 **3벌로 갈라져 드리프트** 중이었다:
| 위치 | start | colspan/rowspan |
|---|---|---|
| 백엔드 `sanitize.go` | ✅ | ✅ |
| 웹서버 `server/sanitize.ts` | ✅ | ✅ |
| **렌더러 `markdown.svelte`** | **❌** | **❌** |

이번 PR 은 렌더러를 나머지 둘에 맞춘다. (단일화·불변식 테스트는 후속 과제)

## 안전
- 표현 속성이라 **XSS 표면 증가 없음**
- **DB 무변경** — 데이터가 온전해서 렌더러 수정만으로 **과거 글도 함께 정상화**. 백필 불필요.

## 검증 관점
- 카나리 `https://canary.damoang.net/free/6797842` 에서 `<ol start="2">` 노출 → 번호가 2,3 으로 이어지는지
- 표 셀 병합 글에서 colspan 유지
- 기존 본문(이미지·임베드·코드블록) 무회귀