### PR TITLE
fix(activity): 삭제·빈 콘텐츠 표기 통일 (#13095, #13097)

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -7,6 +7,11 @@
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronUp from '@lucide/svelte/icons/chevron-up';
     import { formatDate } from '$lib/utils/format-date.js';
+    import {
+        getPostLabel,
+        getCommentLabel,
+        type ContentKind
+    } from '$lib/utils/content-label.js';
     import { slide } from 'svelte/transition';
 
     interface RecentPost {
@@ -29,6 +34,8 @@
         href: string;
         deleted_at?: string | null;
         post_deleted_at?: string | null;
+        /** 백엔드가 내려주는 콘텐츠 종류 — 미배포 시 undefined 라 유틸이 폴백한다 */
+        content_kind?: ContentKind | null;
     }
 
     interface Props {
@@ -94,14 +101,16 @@
         import.meta.env.VITE_ADSENSE_ACTIVITY_CLIENT || 'ca-pub-2456249131797827';
     const ADSENSE_ACTIVITY_SLOT = import.meta.env.VITE_ADSENSE_ACTIVITY_SLOT || '1893595467';
 
+    // 표기는 content-label 유틸이 단일 판정한다(#13095, #13097).
+    // 이전엔 화면마다 문구가 갈라졌고, 텍스트 없는 댓글이 이모티콘·이미지·빈댓글 구분 없이
+    // 전부 '(내용 없음)' 으로 뭉개졌다.
     function getRecentPostLabel(post: RecentPost): string {
-        return post.deleted_at ? '삭제된 글입니다.' : post.wr_subject || '(제목 없음)';
+        return getPostLabel(post).text;
     }
 
     function getRecentCommentLabel(comment: RecentComment): string {
-        if (comment.deleted_at) return '삭제된 댓글입니다.';
-        if (comment.post_deleted_at) return `[삭제된 글] ${comment.preview || '(내용 없음)'}`;
-        return comment.preview || '(내용 없음)';
+        const label = getCommentLabel(comment);
+        return label.badge ? `${label.badge} ${label.text}` : label.text;
     }
 
     function getTargetHeight(): number {

--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -7,11 +7,7 @@
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronUp from '@lucide/svelte/icons/chevron-up';
     import { formatDate } from '$lib/utils/format-date.js';
-    import {
-        getPostLabel,
-        getCommentLabel,
-        type ContentKind
-    } from '$lib/utils/content-label.js';
+    import { getPostLabel, getCommentLabel, type ContentKind } from '$lib/utils/content-label.js';
     import { slide } from 'svelte/transition';
 
     interface RecentPost {

--- a/apps/web/src/lib/utils/content-label.test.ts
+++ b/apps/web/src/lib/utils/content-label.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getPostLabel,
+    getCommentLabel,
+    LABEL_DELETED_POST,
+    LABEL_DELETED_COMMENT,
+    LABEL_NO_TITLE
+} from './content-label';
+
+describe('getPostLabel — 글 제목 표기', () => {
+    it('삭제된 글은 제목을 노출하지 않고 링크도 걸지 않는다', () => {
+        const r = getPostLabel({ deleted_at: '2026-07-25T10:00:00Z', wr_subject: '원래 제목' });
+        expect(r.text).toBe(LABEL_DELETED_POST);
+        expect(r.linkable).toBe(false);
+        expect(r.muted).toBe(true);
+        // soft delete 라 제목이 남아 있어도 절대 새어나가면 안 된다
+        expect(r.text).not.toContain('원래 제목');
+    });
+
+    it('제목이 비면 (제목 없음), 링크는 유지', () => {
+        const r = getPostLabel({ deleted_at: null, wr_subject: '' });
+        expect(r.text).toBe(LABEL_NO_TITLE);
+        expect(r.linkable).toBe(true);
+    });
+
+    it('정상 글은 제목 그대로', () => {
+        const r = getPostLabel({ deleted_at: null, wr_subject: '안녕하세요' });
+        expect(r.text).toBe('안녕하세요');
+        expect(r.muted).toBe(false);
+    });
+});
+
+describe('getCommentLabel — 댓글 미리보기 표기', () => {
+    it('삭제된 댓글은 내용을 노출하지 않는다', () => {
+        const r = getCommentLabel({ deleted_at: '2026-07-25T10:00:00Z', preview: '남아있는 원문' });
+        expect(r.text).toBe(LABEL_DELETED_COMMENT);
+        expect(r.linkable).toBe(false);
+        expect(r.text).not.toContain('남아있는 원문');
+    });
+
+    it('원글만 삭제되면 댓글 내용은 유지하고 배지만 붙인다 (#12965 정책)', () => {
+        const r = getCommentLabel({
+            deleted_at: null,
+            post_deleted_at: '2026-07-25T10:00:00Z',
+            preview: '살아있는 댓글'
+        });
+        expect(r.text).toBe('살아있는 댓글');
+        expect(r.badge).toBe(LABEL_DELETED_POST);
+        expect(r.linkable).toBe(true); // 댓글은 살아있어 이동 가능
+    });
+
+    it('이모티콘 댓글은 (이모티콘)', () => {
+        expect(getCommentLabel({ preview: '', content_kind: 'emoticon' }).text).toBe('(이모티콘)');
+    });
+
+    it('이미지 댓글은 (이미지)', () => {
+        expect(getCommentLabel({ preview: '', content_kind: 'image' }).text).toBe('(이미지)');
+    });
+
+    it('동영상·링크도 각각 표기', () => {
+        expect(getCommentLabel({ preview: '', content_kind: 'video' }).text).toBe('(동영상)');
+        expect(getCommentLabel({ preview: '', content_kind: 'link' }).text).toBe('(링크)');
+    });
+
+    it('빈 댓글은 (빈 댓글)', () => {
+        expect(getCommentLabel({ preview: '', content_kind: 'empty' }).text).toBe('(빈 댓글)');
+    });
+
+    it('점자공백(U+2800)만 있어도 빈 댓글로 본다 — 실측 1,791건', () => {
+        const r = getCommentLabel({ preview: '⠀', content_kind: 'empty' });
+        expect(r.text).toBe('(빈 댓글)');
+    });
+
+    it('백엔드 미배포(content_kind 없음)여도 폴백으로 깨지지 않는다', () => {
+        const r = getCommentLabel({ preview: '' });
+        expect(r.text).toBe('(빈 댓글)');
+        expect(r.muted).toBe(true);
+    });
+
+    it('텍스트가 있으면 content_kind 와 무관하게 내용 우선', () => {
+        const r = getCommentLabel({ preview: '실제 댓글', content_kind: 'text' });
+        expect(r.text).toBe('실제 댓글');
+        expect(r.muted).toBe(false);
+    });
+
+    it('댓글·원글 둘 다 삭제면 댓글 삭제가 우선', () => {
+        const r = getCommentLabel({
+            deleted_at: '2026-07-25T10:00:00Z',
+            post_deleted_at: '2026-07-25T09:00:00Z',
+            preview: '원문'
+        });
+        expect(r.text).toBe(LABEL_DELETED_COMMENT);
+        expect(r.linkable).toBe(false);
+    });
+});

--- a/apps/web/src/lib/utils/content-label.ts
+++ b/apps/web/src/lib/utils/content-label.ts
@@ -1,0 +1,108 @@
+/**
+ * 삭제·빈 콘텐츠 표기 통일 (#13095, #13097)
+ *
+ * 같은 상태가 화면마다 다른 문구로 보이던 문제를 한 곳에서 판정한다.
+ * 이전에는 목록 8종 / 댓글 목록 / 활동 패널 / 프로필 / 임시저장이 각자 문구를 갖고 있었고,
+ * 텍스트 없는 댓글은 이모티콘·이미지·빈댓글 구분 없이 전부 "(내용 없음)" 으로 뭉개졌다.
+ *
+ * 표기 원칙 — 대괄호 [ ] = 상태 / 소괄호 ( ) = 내용의 종류
+ *
+ * ⚠️ 부모글이 삭제돼도 댓글은 살아있다(자진삭제 시 댓글 스레드 유지 정책 #12965).
+ *    실측: free 30일 기준 2,925건. 이 경우 댓글 내용을 가리지 않고 배지로 맥락만 덧붙인다.
+ */
+
+/** 백엔드(mypage_handler.classifyContent)가 내려주는 콘텐츠 종류. */
+export type ContentKind = 'text' | 'emoticon' | 'image' | 'video' | 'link' | 'empty';
+
+export const LABEL_DELETED_POST = '[삭제된 게시물]';
+export const LABEL_DELETED_COMMENT = '[삭제된 댓글]';
+export const LABEL_NO_TITLE = '(제목 없음)';
+
+const KIND_LABEL: Record<Exclude<ContentKind, 'text'>, string> = {
+    emoticon: '(이모티콘)',
+    image: '(이미지)',
+    video: '(동영상)',
+    link: '(링크)',
+    empty: '(빈 댓글)'
+};
+
+export interface ContentLabel {
+    /** 화면에 표시할 문구 */
+    text: string;
+    /** 회색 처리 여부 (삭제·빈 콘텐츠) */
+    muted: boolean;
+    /** 링크를 걸어도 되는지 — 삭제된 항목은 눌러도 갈 수 없다 */
+    linkable: boolean;
+    /** 부모글이 삭제된 댓글에 붙이는 맥락 배지 (댓글 자체는 살아있음) */
+    badge?: string;
+}
+
+interface PostLike {
+    deleted_at?: string | null;
+    wr_subject?: string | null;
+}
+
+interface CommentLike {
+    deleted_at?: string | null;
+    post_deleted_at?: string | null;
+    preview?: string | null;
+    /** 백엔드 미배포 시 undefined — preview 기반으로 폴백한다 */
+    content_kind?: ContentKind | null;
+}
+
+/** 점자공백(U+2800)은 빈댓글 기능이 쓰는 문자라 공백으로 취급한다. */
+function isBlank(s: string | null | undefined): boolean {
+    return !s || s.replace(/⠀/g, '').trim() === '';
+}
+
+/**
+ * 글 제목 라벨.
+ *
+ * 삭제된 글은 제목을 노출하지 않는다 — soft delete 라 DB 에는 원문이 남지만,
+ * 삭제한 사람의 의사를 존중해 화면에는 상태만 표시한다(#13097).
+ */
+export function getPostLabel(post: PostLike): ContentLabel {
+    if (post.deleted_at) {
+        return { text: LABEL_DELETED_POST, muted: true, linkable: false };
+    }
+    if (isBlank(post.wr_subject)) {
+        return { text: LABEL_NO_TITLE, muted: true, linkable: true };
+    }
+    return { text: post.wr_subject as string, muted: false, linkable: true };
+}
+
+/**
+ * 댓글 미리보기 라벨.
+ *
+ * 판정 순서(전수 실측 기반, 첫 매치 확정):
+ *   댓글삭제 → 텍스트 있음 → content_kind → 빈 값(최종 폴백)
+ * 마지막이 폴백이라 미분류가 남지 않는다.
+ */
+export function getCommentLabel(comment: CommentLike): ContentLabel {
+    // 1. 댓글 자체가 삭제됨 — 내용 절대 노출 금지
+    if (comment.deleted_at) {
+        return { text: LABEL_DELETED_COMMENT, muted: true, linkable: false };
+    }
+
+    // 부모글만 삭제된 경우: 댓글은 살아있으므로 내용을 그대로 보여주고 배지만 붙인다
+    const badge = comment.post_deleted_at ? LABEL_DELETED_POST : undefined;
+
+    // 2. 텍스트가 남아 있으면 그대로
+    if (!isBlank(comment.preview)) {
+        return { text: comment.preview as string, muted: false, linkable: true, badge };
+    }
+
+    // 3. 백엔드가 알려준 종류로 표기 (미배포 시 undefined → 4번 폴백)
+    const kind = comment.content_kind;
+    if (kind && kind !== 'text' && kind in KIND_LABEL) {
+        return {
+            text: KIND_LABEL[kind as Exclude<ContentKind, 'text'>],
+            muted: true,
+            linkable: true,
+            badge
+        };
+    }
+
+    // 4. 최종 폴백 — 빈 댓글
+    return { text: KIND_LABEL.empty, muted: true, linkable: true, badge };
+}

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -37,6 +37,11 @@
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
+    import {
+        getPostLabel,
+        getCommentLabel,
+        type ContentKind
+    } from '$lib/utils/content-label.js';
     import FollowListDialog from '$lib/components/features/member/follow-list-dialog.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
 
@@ -153,6 +158,8 @@
         href: string;
         deleted_at?: string | null;
         post_deleted_at?: string | null;
+        /** 백엔드가 내려주는 콘텐츠 종류 — 미배포 시 undefined 라 유틸이 폴백한다 */
+        content_kind?: ContentKind | null;
     }
     interface LikedPost {
         bo_table: string;
@@ -182,14 +189,14 @@
     let commentsLoaded = $state(false);
     let likedLoaded = $state(false);
 
+    // 표기는 content-label 유틸이 단일 판정한다(#13095, #13097).
     function getRecentPostTitle(post: RecentPost): string {
-        return post.deleted_at ? '삭제된 글입니다.' : post.wr_subject;
+        return getPostLabel(post).text;
     }
 
     function getRecentCommentPreview(comment: RecentComment): string {
-        if (comment.deleted_at) return '삭제된 댓글입니다.';
-        if (comment.post_deleted_at) return `[삭제된 글] ${comment.preview || '(내용 없음)'}`;
-        return comment.preview || '(내용 없음)';
+        const label = getCommentLabel(comment);
+        return label.badge ? `${label.badge} ${label.text}` : label.text;
     }
 
     onMount(async () => {

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -37,11 +37,7 @@
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { formatDate } from '$lib/utils/format-date.js';
-    import {
-        getPostLabel,
-        getCommentLabel,
-        type ContentKind
-    } from '$lib/utils/content-label.js';
+    import { getPostLabel, getCommentLabel, type ContentKind } from '$lib/utils/content-label.js';
     import FollowListDialog from '$lib/components/features/member/follow-list-dialog.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
 


### PR DESCRIPTION
설계: `triage/improvements/deleted-empty-content-display-design.md` · 백엔드 짝 PR: angple-backend#590

## 제보 (취미생활자님)
- **#13095** 작성자 최근 활동: "유독 (제목 없음)과 (내용 없음)이 많이 보인다"
- **#13097** 프로필 최근 글: 삭제된 글인데 제목·게시판·날짜가 남고 링크도 살아있다

## 문제 — 표기가 5갈래로 드리프트
| 위치 | 삭제된 글 | 삭제된 댓글 |
|---|---|---|
| 게시판 목록 8종 | `[삭제된 게시물입니다]` | — |
| 댓글 목록 | — | `삭제된 댓글입니다.` |
| 활동 패널 / 프로필 | `삭제된 글입니다.` | 〃 |

여기에 텍스트 없는 댓글이 전부 `(내용 없음)` 으로 뭉개졌다.

## 표기 규칙 (대괄호=상태 / 소괄호=내용 종류)
| 상황 | 표기 | 링크 |
|---|---|---|
| 글/댓글 삭제 | `[삭제된 게시물]` `[삭제된 댓글]` | ❌ |
| **원글만 삭제, 댓글 생존** | `[삭제된 게시물]` **배지 + 댓글 내용 그대로** | ✅ |
| 이모티콘/이미지/동영상/링크 | `(이모티콘)` `(이미지)` `(동영상)` `(링크)` | ✅ |
| 빈 댓글 | `(빈 댓글)` | ✅ |
| 제목 없는 글 | `(제목 없음)` | ✅ |

⚠️ **부모글이 삭제돼도 댓글은 살아있다** — 자진삭제 시 댓글 스레드 유지 정책(#12965). 실측 **2,925건**. 댓글 내용을 가리면 댓글 작성자의 글을 부당하게 지우는 것이므로 **배지로 맥락만** 덧붙인다.

⚠️ 삭제는 **soft delete** 라 DB 에 원문이 남지만(실측 1,581건) **화면에는 절대 노출하지 않는다**.

## 변경
- `lib/utils/content-label.ts` 신규 — `getPostLabel` / `getCommentLabel` 이 단일 판정. `text`·`muted`·`linkable`·`badge` 반환.
- 적용: `author-activity-panel.svelte`(호출 4곳), `member/[id]/+page.svelte`
- 단위테스트 12케이스

## 안전
- `content_kind` 없으면(백엔드 미배포) **폴백** → 배포 순서 무관
- 제보자는 `[삭제된 게시물입니다]` **또는** `[삭제된 게시물]` 둘 다 수용한다고 명시 — 목록 항목이므로 명사형 채택

## 왜 유틸로 묶었나
#13086(번호목록 깨짐)이 **허용목록 3벌 드리프트**에서 났다. 이 표기도 5벌로 갈라진 같은 종류 문제라 단일 소스로 만들어 재발을 막는다.

## 검증 관점
- 이모티콘/이미지/빈댓글이 각각 다르게 표시되는지
- 삭제된 글: 제목·날짜 미노출, 링크 없음
- 원글만 삭제된 댓글: 내용 유지 + 배지, 링크 유지
- 정상 글·댓글 무회귀
- 백엔드 미배포 상태에서 폴백 동작