### PR TITLE
feat(notice): 소모임 전역 공지 링크 + 댓글 유입 소모임 배지

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -60,6 +60,10 @@ export interface FreePost {
     is_comments_disabled?: boolean; // 댓글 비활성화 (읽기 전용 공지)
     is_notice?: boolean; // 공지사항 여부
     notice_type?: 'normal' | 'important'; // 공지 타입 (일반/필수)
+    /** 소모임 전 게시판 공통 공지 — 원본 글 1개를 91개 소모임이 공유한다. */
+    global_notice?: boolean;
+    /** 전역 공지의 원본이 실제로 있는 게시판 slug (링크는 이쪽으로 걸어야 한다). */
+    source_board?: string;
     is_adult?: boolean; // 19금 콘텐츠 여부
     suppress_ads?: boolean; // 작가 기반 광고 억제
     thumbnail?: string; // 썸네일 URL (Lambda 리사이즈)
@@ -117,6 +121,10 @@ export interface FreeComment {
     is_blocked?: boolean;
     /** 작성자 탈퇴 여부 — 닉네임 취소선 표시용. */
     is_left?: boolean;
+    /** 전역 공지에 달린 댓글이 어느 소모임에서 작성됐는지 (slug). 서버가 검증한 값만 내려온다. */
+    from_board?: string;
+    /** 위 소모임의 표시 이름 (bo_subject). */
+    from_board_name?: string;
     /** 리뷰 별점(리뷰=댓글+별점): 작성자가 이 댓글에 남긴 리뷰 점수(1~5). 별점 게시판만. */
     review_rating?: number;
     link1?: string;
@@ -655,6 +663,11 @@ export interface CreateCommentRequest {
     parent_id?: number | string; // 대댓글인 경우 부모 댓글 ID
     is_secret?: boolean; // 선택 (비밀댓글)
     images?: string[]; // 첨부 이미지 URL 배열
+    /**
+     * 전역 공지에 댓글을 달 때, 어느 소모임을 통해 들어왔는지 (URL 의 ?from= 값).
+     * 서버가 소모임 화이트리스트로 검증하므로 위조해도 저장되지 않는다.
+     */
+    from_board?: string;
 }
 
 // 댓글 수정 요청

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1272,6 +1272,15 @@
                                     blur={uiSettingsStore.blurMemo}
                                 />
                             {/if}
+                            <!-- 소모임 전역 공지: 이 의견이 어느 소모임에서 올라왔는지.
+                                 글이 1개를 91개 소모임이 공유하므로 이 배지가 유일한 구분점이다. -->
+                            {#if comment.from_board_name}
+                                <span
+                                    class="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                                    title="{comment.from_board_name} 소모임에서 작성"
+                                    >{comment.from_board_name}</span
+                                >
+                            {/if}
                             {#if comment.author_ip}
                                 <span class="text-muted-foreground font-normal"
                                     >· {comment.author_ip}</span

--- a/apps/web/src/lib/utils/notice-link.test.ts
+++ b/apps/web/src/lib/utils/notice-link.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getNoticeHref, sanitizeFromBoard } from './notice-link';
+
+describe('getNoticeHref', () => {
+    it('일반 공지는 지금 보고 있는 게시판으로 링크한다', () => {
+        expect(getNoticeHref({ id: 123 }, 'car')).toBe('/car/123');
+    });
+
+    it('전역 공지는 원본 게시판으로 가되 유입 소모임을 붙인다', () => {
+        const href = getNoticeHref(
+            { id: 18300, global_notice: true, source_board: 'notice' },
+            'car'
+        );
+        expect(href).toBe('/notice/18300?from=car');
+    });
+
+    it('source_board 가 없으면 전역 공지라도 현재 게시판으로 폴백한다 (백엔드 미배포 안전)', () => {
+        expect(getNoticeHref({ id: 5, global_notice: true }, 'stock')).toBe('/stock/5');
+    });
+
+    it('소모임 slug 를 URL 인코딩한다', () => {
+        const href = getNoticeHref({ id: 1, global_notice: true, source_board: 'notice' }, 'a b');
+        expect(href).toBe('/notice/1?from=a%20b');
+    });
+});
+
+describe('sanitizeFromBoard', () => {
+    it('정상 slug 는 통과', () => {
+        expect(sanitizeFromBoard('car')).toBe('car');
+        expect(sanitizeFromBoard('reading_books')).toBe('reading_books');
+        expect(sanitizeFromBoard('plastic-model')).toBe('plastic-model');
+    });
+
+    it('빈 값은 undefined', () => {
+        expect(sanitizeFromBoard(null)).toBeUndefined();
+        expect(sanitizeFromBoard(undefined)).toBeUndefined();
+        expect(sanitizeFromBoard('')).toBeUndefined();
+    });
+
+    it('경로 조작·특수문자는 버린다', () => {
+        expect(sanitizeFromBoard('../admin')).toBeUndefined();
+        expect(sanitizeFromBoard('car/../free')).toBeUndefined();
+        expect(sanitizeFromBoard('<script>')).toBeUndefined();
+        expect(sanitizeFromBoard('a'.repeat(41))).toBeUndefined();
+    });
+});

--- a/apps/web/src/lib/utils/notice-link.ts
+++ b/apps/web/src/lib/utils/notice-link.ts
@@ -1,0 +1,45 @@
+/**
+ * 소모임 전역 공지 링크 (소모임 관리자 페이지 안내)
+ *
+ * 소모임 91곳에 같은 글을 복제하지 않고 원본 글 하나를 모든 소모임 목록 상단에 노출한다.
+ * 복제하지 않는 이유는 댓글 때문이다 — 글이 91개로 갈라지면 의견도 91곳에 흩어진다.
+ *
+ * 대신 글이 하나뿐이라 "어느 소모임 분의 의견인지"를 알 수 없으므로,
+ * 링크에 `?from={소모임}` 을 붙여 **유입 경로**를 넘긴다.
+ * (회원 다수가 여러 소모임에 가입해 있어 '소속'으로는 특정되지 않는다.)
+ *
+ * ⚠️ from 은 클라이언트가 만드는 값이라 위조 가능하다. 서버가 소모임 화이트리스트로
+ *    검증한 뒤에만 저장하므로, 여기서는 표기 편의만 담당한다.
+ */
+
+interface NoticeLike {
+    id: number | string;
+    /** 소모임 전 게시판 공통 공지인지 */
+    global_notice?: boolean;
+    /** 원본 글이 실제로 있는 게시판 slug */
+    source_board?: string;
+}
+
+/**
+ * 공지 항목의 링크 주소를 만든다.
+ *
+ * 일반 공지는 지금 보고 있는 게시판 그대로,
+ * 전역 공지는 원본 게시판으로 보내되 어느 소모임에서 눌렀는지 함께 넘긴다.
+ */
+export function getNoticeHref(notice: NoticeLike, currentBoardId: string): string {
+    if (notice.global_notice && notice.source_board) {
+        return `/${notice.source_board}/${notice.id}?from=${encodeURIComponent(currentBoardId)}`;
+    }
+    return `/${currentBoardId}/${notice.id}`;
+}
+
+/**
+ * 글 상세에서 넘겨받은 `?from=` 값을 정리한다.
+ *
+ * 게시판 slug 는 영문/숫자/밑줄/하이픈만 쓰므로 그 외 문자가 섞이면 버린다.
+ * 서버가 다시 검증하지만, 이상한 값을 굳이 실어 보낼 이유가 없다.
+ */
+export function sanitizeFromBoard(raw: string | null | undefined): string | undefined {
+    if (!raw) return undefined;
+    return /^[A-Za-z0-9_-]{1,40}$/.test(raw) ? raw : undefined;
+}

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -91,7 +91,11 @@ function trimFreeListPayload(post: FreePost): FreePost {
         has_video: post.has_video ?? !!post.extra_9,
         has_image: post.has_image ?? !!(post.has_file || post.extra_10),
         deleted_at: post.deleted_at,
-        thumbnail: post.thumbnail
+        thumbnail: post.thumbnail,
+        // 소모임 전역 공지는 원본이 다른 게시판에 있어, 이 두 필드가 없으면 링크가
+        // 현재 소모임의 같은 번호 글로 잘못 걸린다(소모임 91곳 전부 이 trim 대상).
+        global_notice: post.global_notice,
+        source_board: post.source_board
     } as FreePost;
 }
 

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -59,6 +59,7 @@
     import { Card, CardContent } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import { Badge } from '$lib/components/ui/badge/index.js';
+    import { getNoticeHref } from '$lib/utils/notice-link';
     import type { PageData } from './$types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import {
@@ -1346,7 +1347,7 @@
                     {#if listLayoutId === 'classic'}
                         {#each importantNotices as notice (notice.id)}
                             <a
-                                href="/{boardId}/{notice.id}"
+                                href={getNoticeHref(notice, boardId)}
                                 class="hover:bg-destructive/10 block px-4 py-1.5 no-underline transition-colors"
                                 style="background: rgba(239, 68, 68, 0.04);"
                             >
@@ -1387,7 +1388,7 @@
                         {/each}
                         {#each normalNotices as notice (notice.id)}
                             <a
-                                href="/{boardId}/{notice.id}"
+                                href={getNoticeHref(notice, boardId)}
                                 class="hover:bg-accent block px-4 py-1.5 no-underline transition-colors"
                                 style="background: rgba(255, 255, 255, 0.03);"
                             >
@@ -1427,7 +1428,7 @@
                     {:else}
                         {#each importantNotices as notice (notice.id)}
                             <a
-                                href="/{boardId}/{notice.id}"
+                                href={getNoticeHref(notice, boardId)}
                                 class="bg-destructive/5 border-destructive/20 hover:bg-destructive/10 block rounded-lg border px-4 py-3 no-underline transition-colors"
                             >
                                 <div class="flex items-center gap-3">
@@ -1448,7 +1449,7 @@
                         {/each}
                         {#each normalNotices as notice (notice.id)}
                             <a
-                                href="/{boardId}/{notice.id}"
+                                href={getNoticeHref(notice, boardId)}
                                 class="bg-muted/50 border-border hover:bg-muted block rounded-lg border px-4 py-3 no-underline transition-colors"
                             >
                                 <div class="flex items-center gap-3">

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1345,7 +1345,7 @@
                 <!-- 공지사항 (목록 내부) -->
                 {#if hasNotices && !isSearching}
                     {#if listLayoutId === 'classic'}
-                        {#each importantNotices as notice (notice.id)}
+                        {#each importantNotices as notice (`${notice.source_board ?? boardId}:${notice.id}`)}
                             <a
                                 href={getNoticeHref(notice, boardId)}
                                 class="hover:bg-destructive/10 block px-4 py-1.5 no-underline transition-colors"
@@ -1386,7 +1386,7 @@
                                 </div>
                             </a>
                         {/each}
-                        {#each normalNotices as notice (notice.id)}
+                        {#each normalNotices as notice (`${notice.source_board ?? boardId}:${notice.id}`)}
                             <a
                                 href={getNoticeHref(notice, boardId)}
                                 class="hover:bg-accent block px-4 py-1.5 no-underline transition-colors"
@@ -1426,7 +1426,7 @@
                             </a>
                         {/each}
                     {:else}
-                        {#each importantNotices as notice (notice.id)}
+                        {#each importantNotices as notice (`${notice.source_board ?? boardId}:${notice.id}`)}
                             <a
                                 href={getNoticeHref(notice, boardId)}
                                 class="bg-destructive/5 border-destructive/20 hover:bg-destructive/10 block rounded-lg border px-4 py-3 no-underline transition-colors"
@@ -1447,7 +1447,7 @@
                                 </div>
                             </a>
                         {/each}
-                        {#each normalNotices as notice (notice.id)}
+                        {#each normalNotices as notice (`${notice.source_board ?? boardId}:${notice.id}`)}
                             <a
                                 href={getNoticeHref(notice, boardId)}
                                 class="bg-muted/50 border-border hover:bg-muted block rounded-lg border px-4 py-3 no-underline transition-colors"

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -18,7 +18,6 @@
     import { browser } from '$app/environment';
     import { env as publicEnv } from '$env/dynamic/public';
     import { afterNavigate, goto } from '$app/navigation';
-    import { page } from '$app/stores';
     import { sanitizeFromBoard } from '$lib/utils/notice-link';
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -18,6 +18,8 @@
     import { browser } from '$app/environment';
     import { env as publicEnv } from '$env/dynamic/public';
     import { afterNavigate, goto } from '$app/navigation';
+    import { page } from '$app/stores';
+    import { sanitizeFromBoard } from '$lib/utils/notice-link';
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import * as Dialog from '$lib/components/ui/dialog/index.js';
@@ -297,6 +299,9 @@
 
     // 게시판 정보
     const boardId = $derived(data.boardId);
+    // 소모임 전역 공지에서 넘어왔다면 어느 소모임에서 눌렀는지 (?from=).
+    // 글이 1개뿐이라 이 값이 없으면 어느 소모임의 의견인지 알 수 없다.
+    const fromBoard = $derived(sanitizeFromBoard($page.url.searchParams.get('from')));
     const boardTitle = $derived(data.board?.subject || data.board?.name || boardId);
 
     // #12920: 이용제한 근거 콘텐츠 공개 워터마크용 열람자 정보를 스토어에 동기화.
@@ -1562,7 +1567,8 @@
                 author: authStore.user.mb_name,
                 parent_id: parentId,
                 is_secret: isSecret,
-                images
+                images,
+                from_board: fromBoard
             });
 
             // 리뷰 별점(리뷰=댓글+별점): 댓글 저장 후 그 댓글 wr_id 에 작성자 본인 별점 기록.
@@ -1645,7 +1651,8 @@
                 author: authStore.user.mb_name,
                 parent_id: parentId,
                 is_secret: isSecret,
-                images
+                images,
+                from_board: fromBoard
             });
 
             // Optimistic update: 대댓글도 즉시 목록에 추가 (#11946, #12228)

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -41,6 +41,8 @@ interface CommentRow extends RowDataPacket {
     wr_deleted_at: string | null;
     wr_deleted_by: string | null;
     wr_7: string | null;
+    /** 소모임 전역 공지의 댓글이 어느 소모임에서 작성됐는지 (백엔드가 검증해 저장). */
+    wr_1: string | null;
 }
 
 interface CountRow extends RowDataPacket {
@@ -77,6 +79,10 @@ interface CommentResponseItem {
     is_blocked?: boolean;
     /** 작성자가 탈퇴 회원인지 — 닉네임 취소선 표시용. */
     is_left?: boolean;
+    /** 소모임 전역 공지 댓글의 유입 소모임 slug. */
+    from_board?: string;
+    /** 위 소모임의 표시 이름 (bo_subject). */
+    from_board_name?: string;
     /** 리뷰 별점(리뷰=댓글+별점): 작성자가 이 댓글에 남긴 리뷰 점수(1~5). 별점 게시판만. */
     review_rating?: number;
 }
@@ -209,7 +215,7 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             `SELECT wr_id, wr_parent, wr_comment, wr_comment_reply, wr_content, wr_link1, wr_link2, wr_option,
 			        wr_good, wr_nogood, mb_id, wr_name, wr_ip, wr_datetime,
 			        wr_edit_count, wr_last_edited_at,
-			        wr_deleted_at, wr_deleted_by, wr_7
+			        wr_deleted_at, wr_deleted_by, wr_7, wr_1
 			 FROM ??
 			 WHERE wr_parent = ? AND wr_is_comment = 1
 			 ORDER BY wr_comment, wr_comment_reply, wr_id
@@ -303,6 +309,27 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
             () => new Set<string>()
         );
 
+        // 유입 소모임 이름 — 소모임 전역 공지(원본 1건을 91개 소모임이 공유)의 댓글에만 붙는다.
+        // wr_1 에 이미 없어진 게시판 slug 가 남아 있을 수 있어 현재 소모임만 인정한다.
+        const fromSlugs = Array.from(
+            new Set(rows.map((r) => (r.wr_1 || '').trim()).filter(Boolean))
+        );
+        const fromBoardNameMap = new Map<string, string>();
+        if (fromSlugs.length > 0) {
+            try {
+                const [boardRows] = await pool.query<RowDataPacket[]>(
+                    `SELECT bo_table, bo_subject FROM g5_board WHERE bo_table IN (?) AND gr_id = 'group'`,
+                    [fromSlugs]
+                );
+                for (const b of boardRows) {
+                    fromBoardNameMap.set(String(b.bo_table), String(b.bo_subject));
+                }
+            } catch (e) {
+                // 표기용 부가 정보라 실패해도 댓글 목록은 그대로 내려보낸다.
+                console.warn('[comments] from_board enrich failed:', e);
+            }
+        }
+
         const comments: CommentResponseItem[] = rows.map((row) => {
             // 비밀댓글은 열람 권한이 없으면 본문·링크를 서버에서 비운다.
             // is_secret 플래그는 그대로 내려 화면이 "비밀댓글입니다" 안내를 유지한다.
@@ -367,6 +394,12 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
                 edit_count: row.wr_edit_count || 0,
                 ...(row.mb_id && blockedSet.has(String(row.mb_id)) ? { is_blocked: true } : {}),
                 ...(row.mb_id && withdrawnSet.has(String(row.mb_id)) ? { is_left: true } : {}),
+                ...(row.wr_1 && fromBoardNameMap.has(row.wr_1.trim())
+                    ? {
+                          from_board: row.wr_1.trim(),
+                          from_board_name: fromBoardNameMap.get(row.wr_1.trim())
+                      }
+                    : {}),
                 ...(disciplineSet.has(row.wr_id) ? { is_discipline_related: true } : {}),
                 ...(reviewRatingMap.has(row.wr_id)
                     ? { review_rating: reviewRatingMap.get(row.wr_id) }


### PR DESCRIPTION
백엔드 PR(angple-backend `feat/group-global-notice`)과 **함께 배포**해야 한다.

## 변경

- `getNoticeHref`: 전역 공지는 **원본 게시판 + `?from={소모임}`**, 일반 공지는 기존 그대로
  - `source_board` 가 없으면 현재 게시판으로 폴백 → **백엔드 미배포 상태에서도 안 깨진다**
- `sanitizeFromBoard`: slug 형식(`[A-Za-z0-9_-]{1,40}`) 아닌 값은 버림. 서버가 다시 검증
- 댓글에 소모임 배지 (`from_board_name` 있을 때만)
- 목록 4곳의 공지 링크를 헬퍼로 통일

## 왜 '소속'이 아니라 '유입 경로'인가

글이 1개라 소모임을 알 방법이 링크 파라미터뿐이다. 또한 회원 다수가 **여러 소모임에 가입**해 있어 '소속'으로는 어차피 특정되지 않는다.

## 검증

- [ ] `/car` 공지 클릭 → `/notice/NNNN?from=car`
- [ ] 댓글 작성 → 배지 `차한잔`
- [ ] 일반 게시판 공지 링크 회귀 없음
- [ ] `notice-link.test.ts` 통과