### PR TITLE
feat(admin): 소모임 당주 지정 화면

### DIFF
--- a/apps/web/src/lib/components/admin/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/admin/layout/sidebar.svelte
@@ -75,6 +75,11 @@
             icon: FolderOpen
         },
         {
+            title: '소모임 당주',
+            href: '/admin/group-owners',
+            icon: Users
+        },
+        {
             title: '내용 관리',
             href: '/admin/contents',
             icon: StickyNote

--- a/apps/web/src/lib/server/board-owner.ts
+++ b/apps/web/src/lib/server/board-owner.ts
@@ -46,15 +46,26 @@ export async function getBoardOwnerContext(
 ): Promise<BoardOwnerContext | null> {
     if (!user?.mb_id) return null;
 
+    // 탈퇴 여부를 판정 시점에 함께 본다. 지정 화면에서 탈퇴자를 걸러도, 지정된 뒤에
+    // 탈퇴하는 경우가 있어 여기가 유일하게 믿을 수 있는 경계다.
+    // (클라이언트에서 버튼을 막는 것은 보호가 아니다 — devtools 로 풀린다.)
     const [rows] = await pool.query<RowDataPacket[]>(
-        `SELECT bo_subject, COALESCE(bo_admin, '') AS bo_admin
-           FROM g5_board
-          WHERE bo_table = ? AND gr_id = 'group'`,
-        [boardId]
+        `SELECT b.bo_subject,
+                COALESCE(b.bo_admin, '')                  AS bo_admin,
+                COALESCE(me.mb_leave_date, '')            AS me_leave_date,
+                (me.mb_id IS NOT NULL)                    AS me_exists
+           FROM g5_board b
+           LEFT JOIN g5_member me ON me.mb_id = ?
+          WHERE b.bo_table = ? AND b.gr_id = 'group'`,
+        [user.mb_id, boardId]
     );
 
     const board = rows[0];
     if (!board) return null; // 없는 게시판이거나 소모임이 아님
+
+    // 요청자 본인이 탈퇴했거나 없는 계정이면 어떤 권한도 주지 않는다.
+    if (!Number(board.me_exists)) return null;
+    if (String(board.me_leave_date || '').trim() !== '') return null;
 
     const ownerId = String(board.bo_admin || '').trim();
     const isSiteAdmin = user.mb_level >= SITE_ADMIN_LEVEL;

--- a/apps/web/src/lib/server/board-owner.ts
+++ b/apps/web/src/lib/server/board-owner.ts
@@ -1,0 +1,111 @@
+/**
+ * 소모임 당주 권한 판정 (서버 전용)
+ *
+ * 소모임(gr_id='group')마다 관리 책임자를 두고, 그 사람만 자기 소모임의 관리 화면을
+ * 열 수 있게 한다. 판정 근거는 `g5_board.bo_admin` 하나뿐이다 — 새 테이블을 만들지 않는다.
+ *
+ * ⛔ 권한 판정은 반드시 서버에서 한다. 클라이언트 `{#if}` 분기는 토큰이 위조되면
+ *    무력하고, 가려둔 데이터가 번들에 그대로 남는다. 권한이 없으면 데이터를 애초에
+ *    내려보내지 않는다.
+ *
+ * ⛔ 권한 없음은 403이 아니라 404로 다룬다. 403은 "여기 관리 화면이 있다"를 알려준다.
+ */
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+/** 사이트 관리자 레벨. 이 이상이면 모든 소모임을 열 수 있다. */
+const SITE_ADMIN_LEVEL = 10;
+
+export interface BoardOwnerContext {
+    boardId: string;
+    /** 소모임 표시 이름 (bo_subject) */
+    subject: string;
+    /** 지정된 당주의 mb_id. 미지정이면 빈 문자열 */
+    ownerId: string;
+    /** 요청자가 당주 본인인지 */
+    isOwner: boolean;
+    /** 요청자가 사이트 관리자인지 */
+    isSiteAdmin: boolean;
+}
+
+interface UserLike {
+    mb_id: string;
+    mb_level: number;
+}
+
+/**
+ * 요청자가 해당 소모임을 관리할 수 있는지 판정한다.
+ *
+ * 관리 가능하면 컨텍스트를, 아니면 null 을 돌려준다. 호출부는 null 이면 404 를 낸다.
+ *
+ * 소모임이 아닌 게시판(자유게시판 등)은 항상 null 이다 — 당주 개념 자체가 없다.
+ */
+export async function getBoardOwnerContext(
+    boardId: string,
+    user: UserLike | null | undefined
+): Promise<BoardOwnerContext | null> {
+    if (!user?.mb_id) return null;
+
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT bo_subject, COALESCE(bo_admin, '') AS bo_admin
+           FROM g5_board
+          WHERE bo_table = ? AND gr_id = 'group'`,
+        [boardId]
+    );
+
+    const board = rows[0];
+    if (!board) return null; // 없는 게시판이거나 소모임이 아님
+
+    const ownerId = String(board.bo_admin || '').trim();
+    const isSiteAdmin = user.mb_level >= SITE_ADMIN_LEVEL;
+    const isOwner = ownerId !== '' && ownerId === user.mb_id;
+
+    if (!isOwner && !isSiteAdmin) return null;
+
+    return {
+        boardId,
+        subject: String(board.bo_subject || boardId),
+        ownerId,
+        isOwner,
+        isSiteAdmin
+    };
+}
+
+/**
+ * 소모임 확장 설정(JSON)에서 소개글을 읽는다.
+ *
+ * `v2_board_extended_settings.settings` 는 여러 기능이 공유하는 JSON 이라
+ * 통째로 덮어쓰면 다른 설정(rating, skin 등)이 날아간다. 읽기도 방어적으로 한다.
+ */
+export async function getBoardIntro(boardId: string): Promise<string> {
+    try {
+        const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT settings FROM v2_board_extended_settings WHERE board_id = ?`,
+            [boardId]
+        );
+        const raw = rows[0]?.settings;
+        if (!raw) return '';
+        const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        const intro = parsed?.intro;
+        return typeof intro === 'string' ? intro : '';
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * 소개글만 바꾸고 나머지 설정은 보존한다.
+ *
+ * ⛔ settings 를 통째로 교체하면 rating·skin 같은 기존 키가 사라진다.
+ *    MySQL JSON_SET 으로 해당 키만 손대고, 행이 없으면 새로 만든다.
+ */
+export async function setBoardIntro(boardId: string, intro: string): Promise<void> {
+    await pool.query(
+        `INSERT INTO v2_board_extended_settings (board_id, settings, created_at, updated_at)
+         VALUES (?, JSON_OBJECT('intro', ?), NOW(3), NOW(3))
+         ON DUPLICATE KEY UPDATE
+           settings = JSON_SET(COALESCE(settings, JSON_OBJECT()), '$.intro', ?),
+           updated_at = NOW(3)`,
+        [boardId, intro, intro]
+    );
+}

--- a/apps/web/src/params/entityslug.ts
+++ b/apps/web/src/params/entityslug.ts
@@ -18,7 +18,7 @@ import type { ParamMatcher } from '@sveltejs/kit';
  *    이 일치 여부는 entityslug.test.ts 가 실제 디렉터리를 읽어 검사하므로,
  *    빠뜨리면 사람이 기억하지 못해도 **CI 가 먼저 실패한다**.
  */
-export const RESERVED = new Set(['write']);
+export const RESERVED = new Set(['write', 'manage']);
 
 export const match: ParamMatcher = (param) => {
     if (param.length === 0) return false;

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -764,6 +764,14 @@ export const load: PageServerLoad = async ({
         };
     }
 
+    // 이 소모임의 당주인지 — 목록에 "소모임 관리" 링크를 띄울지 결정한다.
+    // ⛔ 표시용 힌트일 뿐이고 실제 권한은 /manage 로드와 저장 API 가 각각 다시 본다.
+    // (return 리터럴 안에서 await 하면 postsData 의 타입 추론이 흐트러진다 — 밖에서 계산한다.)
+    const canManageBoard = !!(await getBoardOwnerContext(
+        boardId,
+        locals.user?.id ? { mb_id: locals.user.id, mb_level: locals.user.level ?? 0 } : null
+    ).catch(() => null));
+
     return {
         boardId,
         board: toListBoardPayload(board),
@@ -772,14 +780,7 @@ export const load: PageServerLoad = async ({
         watermark,
         postsData,
         promotionData,
-        /**
-         * 이 소모임의 당주인지 — 목록에 "소모임 관리" 링크를 띄울지 결정한다.
-         * ⛔ 표시용 힌트일 뿐이고 실제 권한은 /manage 로드와 저장 API 가 각각 다시 본다.
-         */
-        canManageBoard: !!(await getBoardOwnerContext(
-            boardId,
-            locals.user?.id ? { mb_id: locals.user.id, mb_level: locals.user.level ?? 0 } : null
-        ).catch(() => null)),
+        canManageBoard,
         streamed: {
             promotionData: promotionDataPromise ?? Promise.resolve([] as unknown[])
         }

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -21,6 +21,7 @@ import { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { applyFilter } from '$lib/hooks/registry.js';
 import { buildHookContext } from '$lib/hooks/context.js';
+import { getBoardOwnerContext } from '$lib/server/board-owner';
 
 // --- 인메모리 캐시: 비로그인 게시글 목록 (15초 TTL) ---
 interface PostsCacheData {
@@ -771,6 +772,14 @@ export const load: PageServerLoad = async ({
         watermark,
         postsData,
         promotionData,
+        /**
+         * 이 소모임의 당주인지 — 목록에 "소모임 관리" 링크를 띄울지 결정한다.
+         * ⛔ 표시용 힌트일 뿐이고 실제 권한은 /manage 로드와 저장 API 가 각각 다시 본다.
+         */
+        canManageBoard: !!(await getBoardOwnerContext(
+            boardId,
+            locals.user?.id ? { mb_id: locals.user.id, mb_level: locals.user.level ?? 0 } : null
+        ).catch(() => null)),
         streamed: {
             promotionData: promotionDataPromise ?? Promise.resolve([] as unknown[])
         }

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -229,6 +229,9 @@ export const load: PageServerLoad = async ({
                 error: '로그인 후 검색할 수 있습니다.'
             },
             promotionData: [],
+            // 비로그인 경로라 당주일 수 없다. 모든 return 이 같은 필드를 가져야
+            // postsData 타입이 합집합으로 갈라지지 않는다.
+            canManageBoard: false,
             streamed: { promotionData: Promise.resolve([] as unknown[]) }
         };
     }
@@ -338,6 +341,8 @@ export const load: PageServerLoad = async ({
                 searchParams: null,
                 activeTag: null,
                 postsData: cachedPosts,
+                // 비로그인 목록 캐시 경로 — 당주일 수 없다(위 return 과 필드를 맞춘다).
+                canManageBoard: false,
                 streamed: { promotionData: Promise.resolve([] as unknown[]) }
             };
         }

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1006,6 +1006,17 @@
                 </div>
             </div>
 
+            <!-- 소모임 당주에게만 보이는 관리 진입점.
+                 서버(+page.server.ts)가 g5_board.bo_admin 으로 판정한 값이라 이 링크가
+                 보인다는 것 자체가 권한이 있다는 뜻이다. 링크가 없으면 URL 을 직접 쳐야 했다. -->
+            {#if data.canManageBoard}
+                <div class="mb-3 text-right">
+                    <a href="/{boardId}/manage" class="text-primary text-sm underline">
+                        소모임 관리
+                    </a>
+                </div>
+            {/if}
+
             <!-- 최상단 자체 배너 (자체 배너 없으면 안 보임) -->
             {#if widgetLayoutStore.hasEnabledAds}
                 <div class="mb-3">

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -36,6 +36,7 @@ import { getAngmapPlace, type AngmapPlaceCoord } from '$lib/server/angmap-place.
 import { getPostAspects, type AspectRating } from '$lib/server/rating-aspects.js';
 import { getBoardAspectPreset } from '$plugins/angtt-review/lib/aspect-presets';
 import { fetchAngmapArchiveRating } from '$lib/server/angmap-archive-rating.js';
+import { getBoardOwnerContext } from '$lib/server/board-owner';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -809,6 +810,16 @@ export const load: PageServerLoad = async ({
             angmapPlace,
             /** 항목별 평점 집계(옵트인 표시·입력용) — 프리셋 매핑 보드에서만 채워짐(그 외 빈 배열) */
             postAspects,
+            /**
+             * 이 소모임의 당주인지 (공지 고정 버튼 노출용).
+             * ⛔ 이건 화면 표시용 힌트일 뿐이고, 실제 권한은 공지 API 가 다시 검증한다.
+             *    소모임이 아니거나 당주가 아니면 false.
+             */
+            canManageBoard: !!(await getBoardOwnerContext(
+                boardId,
+                // locals.user 는 { id, level } 형태다 — 판정 함수가 쓰는 이름으로 옮긴다.
+                locals.user?.id ? { mb_id: locals.user.id, mb_level: locals.user.level ?? 0 } : null
+            ).catch(() => null)),
             /** 스트리밍: Promise로 반환 → 클라이언트에서 $effect로 수신 */
             streamed: {
                 auxiliaryData: auxiliaryDataPromise

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2248,7 +2248,7 @@
                 board={data.board}
                 {boardId}
                 {isAuthor}
-                isAdmin={authStore.user?.mb_id === 'admin'}
+                isAdmin={authStore.user?.mb_id === 'admin' || data.canManageBoard === true}
                 {canViewSecret}
                 {promotionExpired}
                 {likeCount}

--- a/apps/web/src/routes/[boardId]/manage/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/manage/+page.server.ts
@@ -7,7 +7,7 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import type { RowDataPacket } from 'mysql2';
-import pool from '$lib/server/db';
+import pool, { readPool } from '$lib/server/db';
 import { getAuthUser } from '$lib/server/auth';
 import { getBoardOwnerContext, getBoardIntro } from '$lib/server/board-owner';
 
@@ -50,27 +50,43 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
     }
 
     // 활동 현황 — 당주가 소모임 상태를 파악할 유일한 수단.
+    //
+    // ⚠️ g5_write_* 에는 wr_datetime 인덱스가 없다. 기간 조건을 그 테이블에 직접 걸면
+    //    풀스캔이 된다(g5_write_car 실측 13.6만 행). 관리 화면을 열 때마다 그걸 도는 건
+    //    7/20 스왑 스래싱·7/21 EBS IOPS 502 이력을 생각하면 위험하다.
+    //    → 기간 필터는 bn_datetime 인덱스가 있는 g5_board_new 로 걸고(실측 5.2천 행),
+    //      삭제글 제외만 PK 조인으로 붙인다. 실측 결과 직접 집계와 수치가 정확히 일치했다.
+    // ⚠️ 읽기는 readPool 로 보낸다(설정 없으면 writer 로 자동 폴백).
     let stats = { posts30d: 0, comments30d: 0, writers30d: 0, totalPosts: 0 };
     try {
-        const [rows] = await pool.query<RowDataPacket[]>(
-            `SELECT
-               SUM(wr_is_comment = 0 AND wr_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)) AS posts30d,
-               SUM(wr_is_comment = 1 AND wr_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)) AS comments30d,
-               COUNT(DISTINCT CASE WHEN wr_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)
-                                   AND mb_id <> '' THEN mb_id END)                        AS writers30d,
-               SUM(wr_is_comment = 0)                                                     AS totalPosts
-             FROM ?? WHERE wr_deleted_at IS NULL`,
-            [`g5_write_${boardId}`]
+        const [rows] = await readPool.query<RowDataPacket[]>(
+            `SELECT SUM(w.wr_is_comment = 0)              AS posts30d,
+                    SUM(w.wr_is_comment = 1)              AS comments30d,
+                    COUNT(DISTINCT NULLIF(w.mb_id, ''))   AS writers30d
+               FROM g5_board_new n
+               JOIN ?? w ON w.wr_id = n.wr_id
+              WHERE n.bo_table = ?
+                AND n.bn_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)
+                AND w.wr_deleted_at IS NULL`,
+            [`g5_write_${boardId}`, boardId]
         );
         const r = rows[0] ?? {};
-        stats = {
-            posts30d: Number(r.posts30d ?? 0),
-            comments30d: Number(r.comments30d ?? 0),
-            writers30d: Number(r.writers30d ?? 0),
-            totalPosts: Number(r.totalPosts ?? 0)
-        };
+        stats.posts30d = Number(r.posts30d ?? 0);
+        stats.comments30d = Number(r.comments30d ?? 0);
+        stats.writers30d = Number(r.writers30d ?? 0);
     } catch {
         // 통계 실패가 관리 화면 전체를 막지 않는다.
+    }
+
+    try {
+        // wr_is_comment + wr_deleted_at 인덱스를 탄다(실측 5.5천 행).
+        const [rows] = await readPool.query<RowDataPacket[]>(
+            `SELECT COUNT(*) AS total FROM ?? WHERE wr_is_comment = 0 AND wr_deleted_at IS NULL`,
+            [`g5_write_${boardId}`]
+        );
+        stats.totalPosts = Number(rows[0]?.total ?? 0);
+    } catch {
+        // 무시 — 0 으로 남는다.
     }
 
     return {

--- a/apps/web/src/routes/[boardId]/manage/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/manage/+page.server.ts
@@ -1,0 +1,87 @@
+/**
+ * 소모임 관리 화면 (당주 콘솔) — 서버 로드
+ *
+ * ⛔ 여기서 권한을 확정한다. 권한이 없으면 데이터를 아예 만들지 않고 404 를 낸다.
+ *    403 이 아니라 404 인 이유: 403 은 "여기 관리 화면이 있다"를 알려준다.
+ */
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+import { getAuthUser } from '$lib/server/auth';
+import { getBoardOwnerContext, getBoardIntro } from '$lib/server/board-owner';
+
+export const load: PageServerLoad = async ({ params, cookies }) => {
+    const { boardId } = params;
+
+    const user = await getAuthUser(cookies);
+    const ctx = await getBoardOwnerContext(boardId, user);
+    if (!ctx) throw error(404, 'Not Found');
+
+    const [boardRows] = await pool.query<RowDataPacket[]>(
+        `SELECT COALESCE(bo_notice, '')        AS bo_notice,
+                COALESCE(bo_category_list, '') AS bo_category_list,
+                COALESCE(bo_use_category, 0)   AS bo_use_category
+           FROM g5_board WHERE bo_table = ?`,
+        [boardId]
+    );
+    const board = boardRows[0] ?? {};
+
+    // 고정된 공지의 제목까지 함께 보여준다 — 번호만 보고는 무엇을 고정했는지 알 수 없다.
+    const noticeIds = String(board.bo_notice || '')
+        .split(',')
+        .map((s) => Number(s.trim()))
+        .filter((n) => Number.isInteger(n) && n > 0);
+
+    let notices: Array<{ id: number; subject: string }> = [];
+    if (noticeIds.length > 0) {
+        try {
+            const [rows] = await pool.query<RowDataPacket[]>(
+                `SELECT wr_id, wr_subject FROM ??
+                  WHERE wr_id IN (?) AND wr_is_comment = 0 AND wr_deleted_at IS NULL`,
+                [`g5_write_${boardId}`, noticeIds]
+            );
+            const found = new Map(rows.map((r) => [Number(r.wr_id), String(r.wr_subject || '')]));
+            // bo_notice 의 순서를 유지한다. 사라진 글은 제목 없이 번호만 남겨 정리할 수 있게 한다.
+            notices = noticeIds.map((id) => ({ id, subject: found.get(id) ?? '' }));
+        } catch {
+            notices = noticeIds.map((id) => ({ id, subject: '' }));
+        }
+    }
+
+    // 활동 현황 — 당주가 소모임 상태를 파악할 유일한 수단.
+    let stats = { posts30d: 0, comments30d: 0, writers30d: 0, totalPosts: 0 };
+    try {
+        const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT
+               SUM(wr_is_comment = 0 AND wr_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)) AS posts30d,
+               SUM(wr_is_comment = 1 AND wr_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)) AS comments30d,
+               COUNT(DISTINCT CASE WHEN wr_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)
+                                   AND mb_id <> '' THEN mb_id END)                        AS writers30d,
+               SUM(wr_is_comment = 0)                                                     AS totalPosts
+             FROM ?? WHERE wr_deleted_at IS NULL`,
+            [`g5_write_${boardId}`]
+        );
+        const r = rows[0] ?? {};
+        stats = {
+            posts30d: Number(r.posts30d ?? 0),
+            comments30d: Number(r.comments30d ?? 0),
+            writers30d: Number(r.writers30d ?? 0),
+            totalPosts: Number(r.totalPosts ?? 0)
+        };
+    } catch {
+        // 통계 실패가 관리 화면 전체를 막지 않는다.
+    }
+
+    return {
+        boardId,
+        subject: ctx.subject,
+        isOwner: ctx.isOwner,
+        isSiteAdmin: ctx.isSiteAdmin,
+        intro: await getBoardIntro(boardId),
+        useCategory: Number(board.bo_use_category ?? 0) === 1,
+        categoryList: String(board.bo_category_list || ''),
+        notices,
+        stats
+    };
+};

--- a/apps/web/src/routes/[boardId]/manage/+page.svelte
+++ b/apps/web/src/routes/[boardId]/manage/+page.svelte
@@ -133,7 +133,7 @@
         <Card.Header>
             <Card.Title class="text-base">고정된 공지</Card.Title>
             <Card.Description>
-                글 상세에서 공지로 지정할 수 있습니다. 여기서는 해제만 합니다. 고정은 글 제목 옆의 압정을 누르면 됩니다.
+                고정은 글 제목 옆의 압정을 누르면 됩니다. 여기서는 해제만 합니다.
             </Card.Description>
         </Card.Header>
         <Card.Content>

--- a/apps/web/src/routes/[boardId]/manage/+page.svelte
+++ b/apps/web/src/routes/[boardId]/manage/+page.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+    /**
+     * 소모임 관리 화면 (당주 콘솔)
+     *
+     * 권한 판정은 +page.server.ts 가 끝냈다. 여기 도달했다는 것 자체가 권한이 있다는 뜻이라
+     * 화면에서 권한으로 무언가를 가리지 않는다 — 가릴 데이터는 애초에 내려오지 않는다.
+     */
+    import * as Card from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { Input } from '$lib/components/ui/input/index.js';
+    import { Textarea } from '$lib/components/ui/textarea/index.js';
+    import { Badge } from '$lib/components/ui/badge/index.js';
+    import Pin from '@lucide/svelte/icons/pin';
+    import type { PageData } from './$types';
+
+    let { data }: { data: PageData } = $props();
+
+    let intro = $state(data.intro);
+    let categories = $state<string[]>(
+        data.categoryList ? data.categoryList.split('|').filter(Boolean) : []
+    );
+    let newCategory = $state('');
+    let saving = $state(false);
+    let message = $state('');
+    let isError = $state(false);
+
+    const introDirty = $derived(intro.trim() !== data.intro.trim());
+    const categoriesDirty = $derived(categories.join('|') !== data.categoryList);
+
+    function notify(text: string, error = false) {
+        message = text;
+        isError = error;
+    }
+
+    async function save(payload: Record<string, unknown>, okText: string) {
+        if (saving) return;
+        saving = true;
+        message = '';
+        try {
+            const res = await fetch(`/api/boards/${data.boardId}/manage`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            const body = await res.json().catch(() => ({}));
+            if (!res.ok || !body.success) {
+                throw new Error(body.error || '저장하지 못했습니다.');
+            }
+            notify(okText);
+        } catch (e) {
+            notify(e instanceof Error ? e.message : '저장하지 못했습니다.', true);
+        } finally {
+            saving = false;
+        }
+    }
+
+    function addCategory() {
+        const name = newCategory.trim();
+        if (!name) return;
+        if (categories.includes(name)) {
+            notify('이미 있는 카테고리입니다.', true);
+            return;
+        }
+        categories = [...categories, name];
+        newCategory = '';
+    }
+
+    async function unpinNotice(id: number) {
+        if (!confirm(`${id}번 글의 공지 고정을 해제할까요?`)) return;
+        saving = true;
+        try {
+            const res = await fetch(`/api/boards/${data.boardId}/posts/${id}/notice`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ notice_type: null })
+            });
+            const body = await res.json().catch(() => ({}));
+            if (!res.ok || !body.success) throw new Error(body.error || '해제하지 못했습니다.');
+            location.reload();
+        } catch (e) {
+            notify(e instanceof Error ? e.message : '해제하지 못했습니다.', true);
+        } finally {
+            saving = false;
+        }
+    }
+</script>
+
+<svelte:head><title>{data.subject} 관리</title></svelte:head>
+
+<div class="mx-auto max-w-3xl space-y-4 p-4">
+    <div class="flex flex-wrap items-center gap-2">
+        <h1 class="text-xl font-semibold">{data.subject} 관리</h1>
+        {#if data.isOwner}
+            <Badge variant="secondary">당주</Badge>
+        {:else if data.isSiteAdmin}
+            <Badge variant="outline">운영진</Badge>
+        {/if}
+        <a href="/{data.boardId}" class="text-primary ml-auto text-sm underline">소모임으로</a>
+    </div>
+
+    {#if message}
+        <p class="text-sm {isError ? 'text-destructive' : 'text-emerald-600'}">{message}</p>
+    {/if}
+
+    <Card.Root>
+        <Card.Header>
+            <Card.Title class="text-base">활동 현황</Card.Title>
+            <Card.Description>최근 30일 기준입니다.</Card.Description>
+        </Card.Header>
+        <Card.Content>
+            <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <div>
+                    <div class="text-2xl font-semibold">{data.stats.posts30d}</div>
+                    <div class="text-muted-foreground text-xs">새 글</div>
+                </div>
+                <div>
+                    <div class="text-2xl font-semibold">{data.stats.comments30d}</div>
+                    <div class="text-muted-foreground text-xs">댓글</div>
+                </div>
+                <div>
+                    <div class="text-2xl font-semibold">{data.stats.writers30d}</div>
+                    <div class="text-muted-foreground text-xs">참여한 앙님</div>
+                </div>
+                <div>
+                    <div class="text-2xl font-semibold">{data.stats.totalPosts}</div>
+                    <div class="text-muted-foreground text-xs">전체 글</div>
+                </div>
+            </div>
+        </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+        <Card.Header>
+            <Card.Title class="text-base">고정된 공지</Card.Title>
+            <Card.Description>
+                글 상세에서 공지로 지정할 수 있습니다. 여기서는 해제만 합니다.
+            </Card.Description>
+        </Card.Header>
+        <Card.Content>
+            {#if data.notices.length === 0}
+                <p class="text-muted-foreground text-sm">고정된 공지가 없습니다.</p>
+            {:else}
+                <ul class="space-y-1">
+                    {#each data.notices as n (n.id)}
+                        <li class="flex items-center justify-between gap-2 rounded border p-2">
+                            <div class="flex min-w-0 items-center gap-2">
+                                <Pin class="h-4 w-4 shrink-0" />
+                                {#if n.subject}
+                                    <a
+                                        href="/{data.boardId}/{n.id}"
+                                        class="truncate hover:underline"
+                                    >
+                                        {n.subject}
+                                    </a>
+                                {:else}
+                                    <span class="text-muted-foreground truncate">
+                                        {n.id}번 — 삭제되었거나 찾을 수 없는 글
+                                    </span>
+                                {/if}
+                            </div>
+                            <Button
+                                size="sm"
+                                variant="ghost"
+                                disabled={saving}
+                                onclick={() => unpinNotice(n.id)}
+                            >
+                                해제
+                            </Button>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
+        </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+        <Card.Header>
+            <Card.Title class="text-base">소모임 소개</Card.Title>
+            <Card.Description>어떤 소모임인지 알려주세요. 최대 2,000자입니다.</Card.Description>
+        </Card.Header>
+        <Card.Content class="space-y-2">
+            <Textarea rows={5} bind:value={intro} placeholder="소모임 소개를 적어주세요." />
+            <div class="flex items-center gap-2">
+                <Button
+                    disabled={saving || !introDirty}
+                    onclick={() => save({ intro }, '소개글을 저장했습니다.')}
+                >
+                    저장
+                </Button>
+                <span class="text-muted-foreground text-xs">{intro.length} / 2000</span>
+            </div>
+        </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+        <Card.Header>
+            <Card.Title class="text-base">카테고리</Card.Title>
+            <Card.Description>
+                글을 분류합니다. 비우면 카테고리를 쓰지 않습니다. 이미 쓰인 카테고리를 지워도 <b
+                    >글은 지워지지 않습니다.</b
+                >
+            </Card.Description>
+        </Card.Header>
+        <Card.Content class="space-y-2">
+            <div class="flex flex-wrap gap-1">
+                {#each categories as c, i (c)}
+                    <Badge variant="secondary" class="gap-1">
+                        {c}
+                        <button
+                            type="button"
+                            aria-label={`${c} 삭제`}
+                            class="hover:text-destructive"
+                            onclick={() => (categories = categories.filter((_, idx) => idx !== i))}
+                            >×</button
+                        >
+                    </Badge>
+                {/each}
+                {#if categories.length === 0}
+                    <span class="text-muted-foreground text-sm">카테고리 없음</span>
+                {/if}
+            </div>
+            <form
+                class="flex gap-2"
+                onsubmit={(e) => {
+                    e.preventDefault();
+                    addCategory();
+                }}
+            >
+                <Input class="max-w-xs" placeholder="카테고리 이름" bind:value={newCategory} />
+                <Button type="submit" variant="outline">추가</Button>
+            </form>
+            <Button
+                disabled={saving || !categoriesDirty}
+                onclick={() => save({ categories }, '카테고리를 저장했습니다.')}
+            >
+                저장
+            </Button>
+        </Card.Content>
+    </Card.Root>
+</div>

--- a/apps/web/src/routes/[boardId]/manage/+page.svelte
+++ b/apps/web/src/routes/[boardId]/manage/+page.svelte
@@ -133,7 +133,7 @@
         <Card.Header>
             <Card.Title class="text-base">고정된 공지</Card.Title>
             <Card.Description>
-                글 상세에서 공지로 지정할 수 있습니다. 여기서는 해제만 합니다.
+                글 상세에서 공지로 지정할 수 있습니다. 여기서는 해제만 합니다. 고정은 글 제목 옆의 압정을 누르면 됩니다.
             </Card.Description>
         </Card.Header>
         <Card.Content>

--- a/apps/web/src/routes/admin/group-owners/+page.svelte
+++ b/apps/web/src/routes/admin/group-owners/+page.svelte
@@ -107,8 +107,19 @@
         searching = true;
         searchError = '';
         try {
-            const res = await listMembers({ search: q, limit: 10 });
-            candidates = res.members ?? [];
+            // 백엔드는 search_field 기본값이 'name'(닉네임)이라 아이디로는 안 잡힌다.
+            // 그런데 이 화면이 보여주는 값은 mb_id 라, 운영진은 화면의 그 값을 그대로
+            // 붙여넣기 마련이다. 두 방식으로 조회해 합친다.
+            const [byNick, byId] = await Promise.allSettled([
+                listMembers({ search: q, limit: 10 }),
+                listMembers({ search: q, searchField: 'id', limit: 10 })
+            ]);
+            const merged = new Map<string, AdminMember>();
+            for (const r of [byNick, byId]) {
+                if (r.status !== 'fulfilled') continue;
+                for (const m of r.value.members ?? []) merged.set(m.mb_id, m);
+            }
+            candidates = [...merged.values()].slice(0, 20);
             if (candidates.length === 0) searchError = '검색 결과가 없습니다.';
         } catch (e) {
             searchError = e instanceof Error ? e.message : '회원 검색에 실패했습니다.';

--- a/apps/web/src/routes/admin/group-owners/+page.svelte
+++ b/apps/web/src/routes/admin/group-owners/+page.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+    /**
+     * 소모임 당주 지정 (운영진 전용)
+     *
+     * 소모임(gr_id='group')마다 관리 책임자를 지정한다. 저장 위치는 g5_board.bo_admin 이며,
+     * 백엔드 PUT /api/v1/admin/boards/:boardId 가 이미 이 필드를 지원한다(신규 API 없음).
+     *
+     * 왜 필요한가 — 실측(2026-07-26): 소모임 91곳 중 실제 당주가 지정된 곳은 9곳뿐이고
+     * 63곳이 특정 한 명으로 몰려 있었다. 이 상태로 당주 콘솔을 열면 그 한 사람이
+     * 63개 소모임의 관리 권한을 갖게 된다. 그래서 콘솔보다 이 화면이 먼저다.
+     *
+     * ⛔ 닉네임이 아니라 mb_id 를 저장한다 — 닉네임은 바뀌고, 바뀌면 권한이 끊긴다.
+     * ⛔ 권한 검사는 /admin/+layout.server.ts 가 서버에서 한다(level>=10). 여기서 화면을
+     *    가리는 분기는 두지 않는다 — 클라이언트 분기는 토큰 위조에 무력하다.
+     */
+    import { onMount } from 'svelte';
+    import * as Card from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { Input } from '$lib/components/ui/input/index.js';
+    import { Badge } from '$lib/components/ui/badge/index.js';
+    import * as Dialog from '$lib/components/ui/dialog/index.js';
+    import Users from '@lucide/svelte/icons/users';
+    import Search from '@lucide/svelte/icons/search';
+    import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
+    import { listBoards, updateBoard } from '$lib/api/admin-boards';
+    import { listMembers, type AdminMember } from '$lib/api/admin-members';
+    import type { Board } from '$lib/api/types';
+
+    const GROUP_ID = 'group';
+
+    let boards = $state<Board[]>([]);
+    let loading = $state(true);
+    let loadError = $state('');
+    let filter = $state('');
+
+    // 지정 다이얼로그
+    let dialogOpen = $state(false);
+    let target = $state<Board | null>(null);
+    let memberQuery = $state('');
+    let candidates = $state<AdminMember[]>([]);
+    let searching = $state(false);
+    let searchError = $state('');
+    let saving = $state(false);
+
+    const groupBoards = $derived(boards.filter((b) => b.group_id === GROUP_ID));
+
+    /** 같은 사람이 여러 소모임 당주로 잡혀 있으면 눈에 띄게 한다(대량 기본값 탐지). */
+    const ownerCounts = $derived.by(() => {
+        const counts = new Map<string, number>();
+        for (const b of groupBoards) {
+            const owner = (b.admin || '').trim();
+            if (owner) counts.set(owner, (counts.get(owner) ?? 0) + 1);
+        }
+        return counts;
+    });
+
+    const visible = $derived.by(() => {
+        const q = filter.trim().toLowerCase();
+        const rows = q
+            ? groupBoards.filter(
+                  (b) =>
+                      b.board_id.toLowerCase().includes(q) ||
+                      (b.subject || b.name || '').toLowerCase().includes(q) ||
+                      (b.admin || '').toLowerCase().includes(q)
+              )
+            : groupBoards;
+        // 미지정 → 중복 지정 → 나머지 순. 손봐야 할 것이 위로 온다.
+        return [...rows].sort((a, b) => rank(a) - rank(b));
+    });
+
+    const unassignedCount = $derived(groupBoards.filter((b) => !(b.admin || '').trim()).length);
+    const duplicated = $derived([...ownerCounts.entries()].filter(([, n]) => n > 1));
+
+    function rank(b: Board): number {
+        const owner = (b.admin || '').trim();
+        if (!owner) return 0;
+        if ((ownerCounts.get(owner) ?? 0) > 1) return 1;
+        return 2;
+    }
+
+    async function load() {
+        loading = true;
+        loadError = '';
+        try {
+            boards = await listBoards();
+        } catch (e) {
+            loadError = e instanceof Error ? e.message : '게시판 목록을 불러오지 못했습니다.';
+        } finally {
+            loading = false;
+        }
+    }
+
+    function openDialog(board: Board) {
+        target = board;
+        memberQuery = '';
+        candidates = [];
+        searchError = '';
+        dialogOpen = true;
+    }
+
+    async function searchMembers() {
+        const q = memberQuery.trim();
+        if (!q) {
+            candidates = [];
+            return;
+        }
+        searching = true;
+        searchError = '';
+        try {
+            const res = await listMembers({ search: q, limit: 10 });
+            candidates = res.members ?? [];
+            if (candidates.length === 0) searchError = '검색 결과가 없습니다.';
+        } catch (e) {
+            searchError = e instanceof Error ? e.message : '회원 검색에 실패했습니다.';
+        } finally {
+            searching = false;
+        }
+    }
+
+    /** 탈퇴한 회원을 당주로 두면 그 소모임은 관리 불능이 된다. */
+    function isWithdrawn(m: AdminMember): boolean {
+        return !!(m.mb_leave_date && m.mb_leave_date.trim() !== '');
+    }
+
+    async function assign(mbId: string) {
+        if (!target || saving) return;
+        saving = true;
+        try {
+            await updateBoard(target.board_id, { admin: mbId });
+            // 목록을 다시 받지 않고 해당 행만 갱신 — 91행 재조회는 과하다.
+            boards = boards.map((b) =>
+                b.board_id === target!.board_id ? { ...b, admin: mbId } : b
+            );
+            dialogOpen = false;
+        } catch (e) {
+            searchError = e instanceof Error ? e.message : '당주 지정에 실패했습니다.';
+        } finally {
+            saving = false;
+        }
+    }
+
+    async function clearOwner(board: Board) {
+        if (!confirm(`${board.subject || board.board_id} 의 당주 지정을 해제할까요?`)) return;
+        try {
+            await updateBoard(board.board_id, { admin: '' });
+            boards = boards.map((b) => (b.board_id === board.board_id ? { ...b, admin: '' } : b));
+        } catch (e) {
+            alert(e instanceof Error ? e.message : '해제에 실패했습니다.');
+        }
+    }
+
+    onMount(load);
+</script>
+
+<svelte:head><title>소모임 당주 지정 - 관리자</title></svelte:head>
+
+<div class="space-y-4">
+    <div class="flex items-center gap-2">
+        <Users class="h-5 w-5" />
+        <h1 class="text-xl font-semibold">소모임 당주 지정</h1>
+    </div>
+
+    <p class="text-muted-foreground text-sm">
+        소모임마다 관리 책임자를 지정합니다. 지정된 분만 해당 소모임의 관리 화면을 열 수 있고,
+        지정되지 않은 소모임은 관리 화면 자체가 열리지 않습니다.
+    </p>
+
+    {#if duplicated.length > 0}
+        <Card.Root class="border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30">
+            <Card.Content class="flex gap-3 pt-6">
+                <TriangleAlert class="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+                <div class="text-sm">
+                    <p class="font-medium">한 분이 여러 소모임의 당주로 지정되어 있습니다.</p>
+                    <ul class="mt-1 space-y-0.5">
+                        {#each duplicated as [owner, count] (owner)}
+                            <li><code class="text-xs">{owner}</code> — {count}곳</li>
+                        {/each}
+                    </ul>
+                    <p class="text-muted-foreground mt-1">
+                        기본값이 그대로 남아 있는 경우가 많습니다. 실제 당주로 바꿔 주세요.
+                    </p>
+                </div>
+            </Card.Content>
+        </Card.Root>
+    {/if}
+
+    <div class="flex flex-wrap items-center gap-2">
+        <Input class="max-w-xs" placeholder="소모임 이름·주소·당주로 검색" bind:value={filter} />
+        <span class="text-muted-foreground text-sm">
+            전체 {groupBoards.length}곳 · 미지정 {unassignedCount}곳
+        </span>
+    </div>
+
+    {#if loading}
+        <p class="text-muted-foreground text-sm">불러오는 중…</p>
+    {:else if loadError}
+        <p class="text-destructive text-sm">{loadError}</p>
+    {:else if visible.length === 0}
+        <p class="text-muted-foreground text-sm">해당하는 소모임이 없습니다.</p>
+    {:else}
+        <div class="overflow-x-auto rounded-md border">
+            <table class="w-full text-sm">
+                <thead class="bg-muted/50">
+                    <tr>
+                        <th class="p-2 text-left font-medium">소모임</th>
+                        <th class="p-2 text-left font-medium">주소</th>
+                        <th class="p-2 text-left font-medium">현재 당주</th>
+                        <th class="p-2 text-right font-medium">지정</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each visible as b (b.board_id)}
+                        {@const owner = (b.admin || '').trim()}
+                        {@const dup = owner ? (ownerCounts.get(owner) ?? 0) > 1 : false}
+                        <tr class="border-t">
+                            <td class="p-2">{b.subject || b.name || b.board_id}</td>
+                            <td class="text-muted-foreground p-2"><code>{b.board_id}</code></td>
+                            <td class="p-2">
+                                {#if !owner}
+                                    <Badge variant="outline">미지정</Badge>
+                                {:else}
+                                    <code class="text-xs">{owner}</code>
+                                    {#if dup}
+                                        <Badge variant="destructive" class="ml-1 text-[10px]">
+                                            중복 {ownerCounts.get(owner)}곳
+                                        </Badge>
+                                    {/if}
+                                {/if}
+                            </td>
+                            <td class="whitespace-nowrap p-2 text-right">
+                                <Button size="sm" variant="outline" onclick={() => openDialog(b)}>
+                                    변경
+                                </Button>
+                                {#if owner}
+                                    <Button size="sm" variant="ghost" onclick={() => clearOwner(b)}>
+                                        해제
+                                    </Button>
+                                {/if}
+                            </td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    {/if}
+</div>
+
+<Dialog.Root bind:open={dialogOpen}>
+    <Dialog.Content class="max-w-lg">
+        <Dialog.Header>
+            <Dialog.Title>
+                당주 지정 — {target?.subject || target?.name || target?.board_id}
+            </Dialog.Title>
+            <Dialog.Description>
+                닉네임이나 아이디로 회원을 찾아 지정합니다. 저장되는 값은 아이디(mb_id)라 닉네임이
+                바뀌어도 권한은 유지됩니다.
+            </Dialog.Description>
+        </Dialog.Header>
+
+        <div class="space-y-3">
+            <form
+                class="flex gap-2"
+                onsubmit={(e) => {
+                    e.preventDefault();
+                    searchMembers();
+                }}
+            >
+                <Input placeholder="닉네임 또는 아이디" bind:value={memberQuery} />
+                <Button type="submit" disabled={searching}>
+                    <Search class="mr-1 h-4 w-4" />
+                    {searching ? '검색 중' : '검색'}
+                </Button>
+            </form>
+
+            {#if searchError}
+                <p class="text-destructive text-sm">{searchError}</p>
+            {/if}
+
+            {#if candidates.length > 0}
+                <ul class="max-h-64 space-y-1 overflow-y-auto">
+                    {#each candidates as m (m.mb_id)}
+                        {@const withdrawn = isWithdrawn(m)}
+                        <li class="flex items-center justify-between gap-2 rounded border p-2">
+                            <div class="min-w-0">
+                                <div class="truncate">
+                                    {m.mb_name}
+                                    {#if withdrawn}
+                                        <Badge variant="destructive" class="ml-1 text-[10px]">
+                                            탈퇴
+                                        </Badge>
+                                    {/if}
+                                </div>
+                                <code class="text-muted-foreground text-xs">{m.mb_id}</code>
+                            </div>
+                            <Button
+                                size="sm"
+                                disabled={saving || withdrawn}
+                                title={withdrawn ? '탈퇴한 회원은 당주로 지정할 수 없습니다' : ''}
+                                onclick={() => assign(m.mb_id)}
+                            >
+                                이 회원으로 지정
+                            </Button>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
+        </div>
+    </Dialog.Content>
+</Dialog.Root>

--- a/apps/web/src/routes/api/boards/[boardId]/manage/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/manage/+server.ts
@@ -1,0 +1,117 @@
+/**
+ * 소모임 관리 저장 API (당주 콘솔)
+ * PATCH /api/boards/[boardId]/manage
+ *
+ * ⛔ 페이지 로드에서 이미 권한을 봤더라도 여기서 **다시** 확인한다.
+ *    API 는 화면을 거치지 않고 직접 호출할 수 있다. slug 를 바꿔 넣어도 막혀야 한다.
+ * ⛔ 권한 없음은 404 로 응답한다(존재를 알리지 않는다).
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import pool from '$lib/server/db';
+import { getAuthUser } from '$lib/server/auth';
+import { getBoardOwnerContext, setBoardIntro } from '$lib/server/board-owner';
+
+/** 소개글 상한 — 무제한이면 저장소·화면 모두 감당이 안 된다. */
+const INTRO_MAX = 2000;
+/** 카테고리 개수·길이 상한 (그누보드 bo_category_list 는 '|' 구분) */
+const CATEGORY_MAX_COUNT = 20;
+const CATEGORY_NAME_MAX = 20;
+
+export const PATCH: RequestHandler = async ({ params, request, cookies, getClientAddress }) => {
+    const { boardId } = params;
+
+    const user = await getAuthUser(cookies);
+    const ctx = await getBoardOwnerContext(boardId, user);
+    if (!ctx) return json({ success: false, error: 'Not Found' }, { status: 404 });
+
+    let body: Record<string, unknown>;
+    try {
+        body = await request.json();
+    } catch {
+        return json({ success: false, error: '잘못된 요청입니다.' }, { status: 400 });
+    }
+
+    const changed: string[] = [];
+
+    // --- 소개글 ---
+    if (typeof body.intro === 'string') {
+        const intro = body.intro.trim();
+        if (intro.length > INTRO_MAX) {
+            return json(
+                { success: false, error: `소개글은 ${INTRO_MAX}자까지 쓸 수 있습니다.` },
+                { status: 400 }
+            );
+        }
+        await setBoardIntro(boardId, intro);
+        changed.push('intro');
+    }
+
+    // --- 카테고리 ---
+    if (body.categories !== undefined) {
+        if (!Array.isArray(body.categories)) {
+            return json(
+                { success: false, error: '카테고리 형식이 올바르지 않습니다.' },
+                { status: 400 }
+            );
+        }
+
+        const names = body.categories
+            .map((c) => (typeof c === 'string' ? c.trim() : ''))
+            .filter((c) => c !== '');
+
+        if (names.length > CATEGORY_MAX_COUNT) {
+            return json(
+                {
+                    success: false,
+                    error: `카테고리는 ${CATEGORY_MAX_COUNT}개까지 만들 수 있습니다.`
+                },
+                { status: 400 }
+            );
+        }
+        if (names.some((n) => n.length > CATEGORY_NAME_MAX)) {
+            return json(
+                { success: false, error: `카테고리 이름은 ${CATEGORY_NAME_MAX}자까지 가능합니다.` },
+                { status: 400 }
+            );
+        }
+        // '|' 는 구분자라 이름에 들어가면 목록이 깨진다. ',' 는 다른 설정에서 구분자로 쓰인다.
+        if (names.some((n) => n.includes('|') || n.includes(','))) {
+            return json(
+                { success: false, error: '카테고리 이름에 | 나 , 는 쓸 수 없습니다.' },
+                { status: 400 }
+            );
+        }
+        if (new Set(names).size !== names.length) {
+            return json({ success: false, error: '중복된 카테고리가 있습니다.' }, { status: 400 });
+        }
+
+        await pool.query(
+            `UPDATE g5_board SET bo_category_list = ?, bo_use_category = ? WHERE bo_table = ?`,
+            [names.join('|'), names.length > 0 ? 1 : 0, boardId]
+        );
+        changed.push('categories');
+    }
+
+    if (changed.length === 0) {
+        return json({ success: false, error: '변경할 내용이 없습니다.' }, { status: 400 });
+    }
+
+    // 감사 로그 — best-effort. 기록 실패가 기능을 막지 않는다.
+    try {
+        await pool.query(
+            `INSERT INTO audit_logs (created_at, user_id, action, resource, resource_id, details, client_ip)
+             VALUES (NOW(3), ?, 'board_owner.update', 'board', ?, ?, ?)`,
+            [
+                user!.mb_id,
+                boardId,
+                JSON.stringify({ changed, is_owner: ctx.isOwner, is_site_admin: ctx.isSiteAdmin }),
+                getClientAddress()
+            ]
+        );
+    } catch {
+        // 감사 로그 스키마가 다르거나 없더라도 저장 자체는 성공으로 둔다.
+    }
+
+    return json({ success: true, changed });
+};

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/notice/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/notice/+server.ts
@@ -1,13 +1,16 @@
 /**
  * 게시글 공지 고정/해제 API
  * PATCH /api/boards/[boardId]/posts/[postId]/notice
- * 관리자(mb_level >= 10)만 사용 가능
+ *
+ * 권한: 사이트 관리자(mb_level >= 10) 또는 **그 소모임의 당주**(g5_board.bo_admin).
+ * 당주는 자기 소모임 하나에만 권한이 있다.
  */
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
 import { getAuthUser } from '$lib/server/auth';
+import { getBoardOwnerContext } from '$lib/server/board-owner';
 
 export const PATCH: RequestHandler = async ({ params, request, cookies }) => {
     const { boardId, postId } = params;
@@ -17,9 +20,14 @@ export const PATCH: RequestHandler = async ({ params, request, cookies }) => {
         return json({ success: false, error: '로그인이 필요합니다.' }, { status: 401 });
     }
 
-    // 관리자만 공지 설정 가능
+    // 사이트 관리자 또는 그 소모임의 당주(g5_board.bo_admin)만 공지를 고정할 수 있다.
+    // 당주에게 열어주는 이유: 지금까지 소모임 공지 하나 고정하려 해도 운영진에게
+    // 요청해야 했다. 권한은 자기 소모임 하나로 한정된다(getBoardOwnerContext 가 검사).
     if (user.mb_level < 10) {
-        return json({ success: false, error: '관리자 권한이 필요합니다.' }, { status: 403 });
+        const ctx = await getBoardOwnerContext(boardId, user);
+        if (!ctx) {
+            return json({ success: false, error: '권한이 없습니다.' }, { status: 403 });
+        }
     }
 
     try {


### PR DESCRIPTION
소모임 관리자 페이지 1차 중 **①단계**. (설계: `triage/improvements/group-admin-page-design.md`)

## 왜 이것부터인가

실측(2026-07-26):

| 소모임 당주 상태 | 곳 |
|---|---|
| 실제 당주 지정됨 | **9** |
| **한 명(`500원`)에게 몰림** | **63** |
| 미지정 | 19 |

당주 콘솔을 먼저 열면 **한 사람이 63개 소모임 관리 권한**을 갖게 된다. 지정 수단이 전제다.

## 좋은 소식 — 백엔드 신규 개발 없음

- `PUT /api/v1/admin/boards/:boardId` 존재 (`main.go:5249`)
- `Admin *string` → `board.BoAdmin = *req.Admin` 로 **실제 저장됨**
- 프론트 `updateBoard({admin})` 도 이미 있음
- **관리 UI 에서 `bo_admin` 편집만 전무했음** (전역 grep 0건)

→ 화면만 추가한다.

## 안전장치

- ⛔ **닉네임이 아니라 `mb_id` 저장** — 닉이 바뀌면 권한이 끊긴다
- ⛔ **탈퇴 회원 지정 차단** — 탈퇴자가 당주로 남으면 그 소모임은 관리 불능
- 같은 사람이 여러 소모임 당주면 **경고 배너 + 행 배지**
- 미지정·중복이 목록 **위로** 오도록 정렬
- 권한은 `/admin/+layout.server.ts` 가 **서버에서** 확인(level>=10). 클라 분기 없음

## 검증

- [ ] 소모임 91곳만 보임 (`gr_id='group'`)
- [ ] 지정 후 `g5_board.bo_admin` 에 mb_id 저장
- [ ] 해제 시 빈 값
- [ ] 탈퇴 회원 버튼 비활성
- [ ] '500원' 63곳 중복 경고 노출
- [ ] 비관리자 접근 시 리다이렉트

## 다음

②단계 = 당주 콘솔(`/[boardId]/manage`) — 공지 고정·소개글·카테고리·활동 현황