### PR TITLE
feat(admin): 회원 수동 실명인증 화면

### DIFF
--- a/apps/web/src/lib/api/admin-members.ts
+++ b/apps/web/src/lib/api/admin-members.ts
@@ -19,6 +19,10 @@ export interface AdminMember {
     mb_intercept_date?: string;
     post_count?: number;
     comment_count?: number;
+    /** 실명인증 상태. 빈 문자열이면 미인증. (simple=간편인증, abroad=해외/수동, ipin, hp) */
+    mb_certify?: string;
+    /** 명의 중복 검사(DI) 보유 여부. 수동 인증은 DI 를 만들지 않아 인증돼도 false 일 수 있다. */
+    has_dupinfo?: boolean;
 }
 
 export interface AnonymizeMemberInput {
@@ -195,6 +199,36 @@ export async function unbanMember(memberId: string): Promise<void> {
         }
     } catch (error) {
         console.error('❌ 회원 차단 해제 실패:', error);
+        throw error;
+    }
+}
+
+/**
+ * 회원 수동 실명인증 / 해제
+ *
+ * 해외 앙님처럼 국내 휴대폰 인증이 불가능한 회원을 관리자가 직접 처리한다.
+ *
+ * ⛔ 수동 인증은 DI(명의 중복 검사)를 만들지 않는다. 인증 회원 권한(인증필수 게시판·
+ *    쪽지 발송·자동 등급 승급)이 열리므로 사유가 반드시 남아야 한다(서버가 10자 이상 강제).
+ */
+export async function certifyMember(
+    memberId: string,
+    certify: boolean,
+    reason: string
+): Promise<void> {
+    try {
+        const response = await fetch(`${API_BASE}/${memberId}/certify`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ certify, reason })
+        });
+        if (!response.ok) {
+            const errorResult = await safeJson(response);
+            throw new Error(errorResult.error?.message || `HTTP ${response.status}`);
+        }
+    } catch (error) {
+        console.error('❌ 회원 인증 처리 실패:', error);
         throw error;
     }
 }

--- a/apps/web/src/routes/admin/members/+page.svelte
+++ b/apps/web/src/routes/admin/members/+page.svelte
@@ -180,8 +180,14 @@
     // --- 수동 실명인증 ---------------------------------------------------------
     // 해외 앙님처럼 국내 휴대폰 인증이 불가능한 회원을 관리자가 직접 처리한다.
     // ⛔ 권한 판정·검증은 전부 서버가 한다. 여기 분기는 화면 안내일 뿐이다.
-    /** 실제 본인확인을 거친 값 — 관리자가 덮어쓸 수 없다(서버도 거부한다). */
-    const VERIFIED_CERTIFY = new Set(['simple', 'ipin', 'hp']);
+    /**
+     * 이 화면이 다룰 수 있는 상태는 "미인증"과 "수동 인증(abroad)" 둘뿐이다.
+     * ⛔ 차단 목록(simple/ipin/hp)으로 두면 admin·email 같은 그 밖의 값이 뚫린다.
+     *    서버와 같은 규칙(허용 목록)으로 맞춰야 화면 문구와 실제 동작이 어긋나지 않는다.
+     */
+    function isManageableCertify(v: string): boolean {
+        return v === '' || v === 'abroad';
+    }
 
     let certifyDialogOpen = $state(false);
     let certifyTarget = $state<AdminMember | null>(null);
@@ -190,7 +196,7 @@
     let certifyError = $state('');
 
     const certifyTargetIsVerified = $derived(
-        VERIFIED_CERTIFY.has((certifyTarget?.mb_certify || '').trim())
+        !isManageableCertify((certifyTarget?.mb_certify || '').trim())
     );
     /** 이미 인증돼 있으면 해제, 아니면 부여 */
     const certifyWillGrant = $derived(!(certifyTarget?.mb_certify || '').trim());
@@ -897,6 +903,14 @@
                             인증하면 <b>인증필수 게시판 글쓰기·쪽지 발송·자동 등급 승급</b> 자격이 열립니다.
                             왜 인증했는지 남겨 주세요.
                         </p>
+                    </div>
+                {:else}
+                    <div class="text-muted-foreground rounded border p-3 text-sm">
+                        해제하면 앞으로의 인증 권한만 닫힙니다.
+                        <b
+                            >이미 오른 등급, 인증필수 게시판에 쓴 글, 보낸 쪽지는 되돌아가지
+                            않습니다.</b
+                        >
                     </div>
                 {/if}
 

--- a/apps/web/src/routes/admin/members/+page.svelte
+++ b/apps/web/src/routes/admin/members/+page.svelte
@@ -17,6 +17,7 @@
     import Pencil from '@lucide/svelte/icons/pencil';
     import Ban from '@lucide/svelte/icons/ban';
     import ShieldCheck from '@lucide/svelte/icons/shield-check';
+    import BadgeCheck from '@lucide/svelte/icons/badge-check';
     import ChevronLeft from '@lucide/svelte/icons/chevron-left';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
@@ -30,6 +31,7 @@
         unbanMember,
         anonymizeMemberByUsername,
         bulkUpdateLevel,
+        certifyMember,
         type AdminMember,
         type MemberListParams,
         type AnonymizeMemberResult
@@ -172,6 +174,56 @@
             alert(err instanceof Error ? err.message : '저장에 실패했습니다.');
         } finally {
             saving = false;
+        }
+    }
+
+    // --- 수동 실명인증 ---------------------------------------------------------
+    // 해외 앙님처럼 국내 휴대폰 인증이 불가능한 회원을 관리자가 직접 처리한다.
+    // ⛔ 권한 판정·검증은 전부 서버가 한다. 여기 분기는 화면 안내일 뿐이다.
+    /** 실제 본인확인을 거친 값 — 관리자가 덮어쓸 수 없다(서버도 거부한다). */
+    const VERIFIED_CERTIFY = new Set(['simple', 'ipin', 'hp']);
+
+    let certifyDialogOpen = $state(false);
+    let certifyTarget = $state<AdminMember | null>(null);
+    let certifyReason = $state('');
+    let certifySaving = $state(false);
+    let certifyError = $state('');
+
+    const certifyTargetIsVerified = $derived(
+        VERIFIED_CERTIFY.has((certifyTarget?.mb_certify || '').trim())
+    );
+    /** 이미 인증돼 있으면 해제, 아니면 부여 */
+    const certifyWillGrant = $derived(!(certifyTarget?.mb_certify || '').trim());
+
+    function certifyLabel(member: AdminMember): string {
+        const v = (member.mb_certify || '').trim();
+        if (!v) return '수동 인증';
+        if (v === 'abroad') return '해외/수동 인증됨 — 해제';
+        return `본인확인 완료(${v}) — 변경 불가`;
+    }
+
+    function openCertifyDialog(member: AdminMember) {
+        certifyTarget = member;
+        certifyReason = '';
+        certifyError = '';
+        certifyDialogOpen = true;
+    }
+
+    async function submitCertify() {
+        if (!certifyTarget || certifySaving) return;
+        certifySaving = true;
+        certifyError = '';
+        try {
+            await certifyMember(certifyTarget.mb_id, certifyWillGrant, certifyReason.trim());
+            const next = certifyWillGrant ? 'abroad' : '';
+            members = members.map((m) =>
+                m.mb_id === certifyTarget!.mb_id ? { ...m, mb_certify: next } : m
+            );
+            certifyDialogOpen = false;
+        } catch (e) {
+            certifyError = e instanceof Error ? e.message : '처리하지 못했습니다.';
+        } finally {
+            certifySaving = false;
         }
     }
 
@@ -564,6 +616,18 @@
                                         <Button
                                             variant="ghost"
                                             size="icon"
+                                            onclick={() => openCertifyDialog(member)}
+                                            title={certifyLabel(member)}
+                                        >
+                                            <BadgeCheck
+                                                class="h-4 w-4 {member.mb_certify
+                                                    ? 'text-emerald-600'
+                                                    : 'text-muted-foreground/50'}"
+                                            />
+                                        </Button>
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
                                             onclick={() => openAnonymizeDialog(member)}
                                             title="익명화"
                                         >
@@ -801,5 +865,68 @@
                 </Button>
             </Dialog.Footer>
         </form>
+    </Dialog.Content>
+</Dialog.Root>
+
+<!-- 수동 실명인증 다이얼로그 -->
+<Dialog.Root bind:open={certifyDialogOpen}>
+    <Dialog.Content class="max-w-lg">
+        <Dialog.Header>
+            <Dialog.Title>
+                {certifyWillGrant ? '수동 실명인증' : '인증 해제'}
+            </Dialog.Title>
+            <Dialog.Description>
+                {certifyTarget?.mb_name}
+                <code class="text-xs">({certifyTarget?.mb_id})</code>
+            </Dialog.Description>
+        </Dialog.Header>
+
+        {#if certifyTargetIsVerified}
+            <p class="text-destructive text-sm">
+                이 회원은 <b>{certifyTarget?.mb_certify}</b> 로 본인확인을 마쳤습니다. 실제 확인을 거친
+                값이라 이 화면에서는 변경할 수 없습니다.
+            </p>
+        {:else}
+            <div class="space-y-3">
+                {#if certifyWillGrant}
+                    <div
+                        class="rounded border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950/30"
+                    >
+                        <p class="font-medium">수동 인증은 명의 중복 검사(DI)를 거치지 않습니다.</p>
+                        <p class="text-muted-foreground mt-1">
+                            인증하면 <b>인증필수 게시판 글쓰기·쪽지 발송·자동 등급 승급</b> 자격이 열립니다.
+                            왜 인증했는지 남겨 주세요.
+                        </p>
+                    </div>
+                {/if}
+
+                <div class="space-y-1">
+                    <Label for="certify-reason">사유 (10자 이상)</Label>
+                    <Textarea
+                        id="certify-reason"
+                        rows={3}
+                        bind:value={certifyReason}
+                        placeholder="예) verification/1234 신청 건, 해외 거주 확인"
+                    />
+                    <p class="text-muted-foreground text-xs">
+                        {certifyReason.trim().length} / 최소 10자 — 기록에 남습니다.
+                    </p>
+                </div>
+
+                {#if certifyError}
+                    <p class="text-destructive text-sm">{certifyError}</p>
+                {/if}
+            </div>
+
+            <Dialog.Footer>
+                <Button variant="outline" onclick={() => (certifyDialogOpen = false)}>취소</Button>
+                <Button
+                    disabled={certifySaving || certifyReason.trim().length < 10}
+                    onclick={submitCertify}
+                >
+                    {certifySaving ? '처리 중…' : certifyWillGrant ? '인증 처리' : '인증 해제'}
+                </Button>
+            </Dialog.Footer>
+        {/if}
     </Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
백엔드 **angple-backend#592** 와 함께 배포해야 한다. (설계: `triage/improvements/admin-manual-certify-design.md`)

## 변경

- 회원 목록 행에 **인증 아이콘** (인증됨 초록 / 미인증 회색)
- 다이얼로그에서 **사유 10자 이상** 입력 후 인증/해제
- `simple`·`ipin`·`hp` 는 **변경 불가 안내만** — 실제 본인확인을 거친 값이라 덮어쓰면 안 됨(서버도 409)
- 인증 부여 시 경고 노출: **수동 인증은 명의 중복 검사(DI)를 거치지 않으며**, 인증필수 게시판·쪽지·자동승급 자격이 열림

## 원칙

화면 분기는 **안내일 뿐**이고 검증(사유 길이·본인확인 값·탈퇴 여부)은 전부 서버가 한다. DI 원본은 응답에 없고 `has_dupinfo` 존재 여부만 내려온다.

## 검증

- [ ] 미인증 회원 인증 → 아이콘 초록으로 전환
- [ ] 사유 10자 미만이면 버튼 비활성 + 서버도 거부
- [ ] `simple` 회원은 안내만 뜨고 버튼 없음
- [ ] 해제 동작
- [ ] 비관리자 접근 차단(기존 admin 레이아웃)