### PR TITLE
fix(ads): 마음메시지와 목록/본문 사이 구글 광고 제거

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1031,13 +1031,6 @@
                 </div>
             {/if}
 
-            <!-- 마음메시지 아래 구글 광고 -->
-            {#if widgetLayoutStore.hasEnabledAds}
-                <div class="mb-3">
-                    <AdSlot position="board-list-head" height="90px" slotKey="board-list-head" />
-                </div>
-            {/if}
-
             <!-- 플러그인 슬롯: 필터 영역 직전 — Slot Catalog Sprint 2c -->
             <PluginSlot name="board-list-filter-before" {boardId} />
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2167,13 +2167,6 @@
         <PluginSlot name="board-view-rolling" />
     </div>
 
-    <!-- 마음메시지 아래 구글 광고 -->
-    {#if widgetLayoutStore.hasEnabledAds && !data.post.deleted_at}
-        <div class="mb-3">
-            <AdSlot position="board-content" height="90px" slotKey="board-view-head-ad" />
-        </div>
-    {/if}
-
     <!-- 읽기 권한 체크 -->
     {#if !canRead}
         <div class="bg-muted/50 mx-auto mt-12 max-w-md rounded-lg p-8 text-center">


### PR DESCRIPTION
## 무엇을

마음메시지(축하 롤링) 바로 아래 붙은 구글 광고를 **목록·상세 두 곳** 모두 제거한다.

"마음메시지가 없습니다" 와 목록 사이가 광고로 채워져 있었다.

| 위치 | 슬롯 | 파일 |
|---|---|---|
| 목록 | `board-list-head` | `[boardId]/+page.svelte` |
| 상세 | `board-view-head-ad` | `[boardId]/[postId]/+page.svelte` |

## 남는 광고

| 위치 | 종류 | 유지 |
|---|---|---|
| 목록·상세 최상단 | 자체 배너 (`board-list-banner`/`board-view-banner`) | ✅ |
| 사이드바 | 자체 배너 | ✅ |
| 목록 중간 · 본문 하단 | `AdSlot` | ✅ |

즉 **마음메시지 바로 아래 한 자리만** 비운다. `AdSlot` import 는 다른 위치에서 계속 쓰여 유지한다.

## 수익 영향

⛔ **이 자리 수익은 측정하지 못했다.** `aplog.ad_events` 에는 자체 배너(`damoang-banner:*`)와 사이드 배너만 기록되고, 이 슬롯은 **구글 광고라 AdSense 쪽 수치**가 따로 필요하다. 목록·상세는 트래픽이 가장 높은 화면이라 체감 감소가 있을 수 있다.

## 검증

- [ ] 목록에서 마음메시지 아래 광고 없음
- [ ] 상세에서 마음메시지 아래 광고 없음
- [ ] 상단 자체 배너·사이드바·본문 하단 광고는 그대로
- [ ] 레이아웃 여백 어색하지 않음