### PR TITLE
fix(ads): curation 광고 단위 코드 교정 — 수익 0의 원인

### DIFF
--- a/apps/web/src/lib/config/ad-config.ts
+++ b/apps/web/src/lib/config/ad-config.ts
@@ -62,7 +62,12 @@ export const ADFIT_FALLBACK_MAP: Record<string, AdfitFallback> = {
 // 광고 단위 경로 (환경변수로 커스터마이징 가능)
 const unitMain = import.meta.env.VITE_GAM_UNIT_MAIN || 'banner-responsive_main';
 const unitSub = import.meta.env.VITE_GAM_UNIT_SUB || 'banner-responsive_sub';
-const unitCuration = import.meta.env.VITE_GAM_UNIT_CURATION || 'banner-responsive_curation';
+// ⛔ 이 값은 GAM 의 '표시 이름'이 아니라 **광고 단위 코드(ad_unit_code)** 여야 한다.
+//    다른 단위들은 표시 이름과 코드가 같아 우연히 맞았지만, curation 만 다르다:
+//      display_name = banner-responsive_curation / ad_unit_code = curation
+//    표시 이름으로 요청하면 존재하지 않는 경로가 되어 GAM 이 광고를 주지 않는다.
+//    실제로 이 단위는 수집 시작(2026-04-30) 이후 노출·수익이 한 건도 잡히지 않았다.
+const unitCuration = import.meta.env.VITE_GAM_UNIT_CURATION || 'curation';
 const unitArticle = import.meta.env.VITE_GAM_UNIT_ARTICLE || 'banner-responsive_article';
 const unitWing = import.meta.env.VITE_GAM_UNIT_WING || 'banner-responsive_wing';
 


### PR DESCRIPTION
## 원인

GAM 광고 요청 경로는 **표시 이름이 아니라 광고 단위 코드(`ad_unit_code`)** 로 만들어야 한다. 다른 단위는 둘이 같아 우연히 맞았지만 **curation 만 다르다.**

| 단위 | display_name | **ad_unit_code** | 코드가 쓰던 값 | |
|---|---|---|---|---|
| main | banner-responsive_main | `banner-responsive_main` | 동일 | ✅ |
| sub | banner-responsive_sub | `banner-responsive_sub` | 동일 | ✅ |
| article | banner-responsive_article | `banner-responsive_article` | 동일 | ✅ |
| wing | banner-responsive_wing | `banner-responsive_wing` | 동일 | ✅ |
| **curation** | banner-responsive_curation | **`curation`** | `banner-responsive_curation` | ❌ |

부모 경로는 동일(`ca-pub-5124617752473025` → `damoang`). **leaf 코드만 틀렸다.**

→ 요청 경로가 `/23338387889/damoang/banner-responsive_curation` (존재하지 않음)
→ 실제는 `/23338387889/damoang/curation`

## 근거 (실측)

`ad_metrics.gam_ad_unit` · `gam_viewability` 에 **`curation` 단위가 역대 한 번도 없다.** 수집 시작 2026-04-30 이후 노출·수익 **0**.

같은 기간 다른 단위는 정상 (최근 30일):

| 단위 | 노출 | 수익 |
|---|---:|---:|
| sub | 1,047만 | 1,548,936원 |
| article | 731만 | 685,657원 |
| damoang | 506만 | 448,440원 |
| wing | 70만 | 230,471원 |
| main | 73만 | 117,406원 |
| **curation** | **0** | **0** |

⚠️ 수익은 `as_revenue`(GAM 직판)가 아니라 **`adsense_revenue`** 컬럼에 적재된다.

## 영향 위치

`AD_UNIT_PATHS.curation` → `infeed-compact` → 두 곳:
- **목록 인피드** (7·17번째 글 뒤) — 한 페이지 30개 중 7번째는 **상위 23%**, 노출이 많은 자리
- **댓글 인피드**

## 왜 지금 발견됐나

"인피드 광고를 빼면 손실이 클까" 를 실측하다 **수익이 0** 인 것을 발견했고, "안 팔리는 자리" 가 아니라 **설정 오타로 못 팔던 자리** 였음이 드러났다.

## 남은 것

같은 형태(코드≠표시이름)인 `creator`(banner-responsive_creator) · `tv`(banner-responsive_tv) 는 **아직 코드에서 쓰지 않는다.** 앞으로 쓰게 되면 같은 함정에 빠지므로 주의.

## 검증

- [ ] 배포 후 GAM 에서 `curation` 단위 노출이 잡히기 시작
- [ ] 목록 7·17 자리에 광고가 실제로 채워짐
- [ ] 다른 단위 수익 회귀 없음
- [ ] 며칠 뒤 `gam_ad_unit` 에서 curation 행 확인