### PR TITLE
Revert curation 단위 교정 — 광고 제거 관측 기간 보호

### DIFF
--- a/apps/web/src/lib/config/ad-config.ts
+++ b/apps/web/src/lib/config/ad-config.ts
@@ -62,12 +62,7 @@ export const ADFIT_FALLBACK_MAP: Record<string, AdfitFallback> = {
 // 광고 단위 경로 (환경변수로 커스터마이징 가능)
 const unitMain = import.meta.env.VITE_GAM_UNIT_MAIN || 'banner-responsive_main';
 const unitSub = import.meta.env.VITE_GAM_UNIT_SUB || 'banner-responsive_sub';
-// ⛔ 이 값은 GAM 의 '표시 이름'이 아니라 **광고 단위 코드(ad_unit_code)** 여야 한다.
-//    다른 단위들은 표시 이름과 코드가 같아 우연히 맞았지만, curation 만 다르다:
-//      display_name = banner-responsive_curation / ad_unit_code = curation
-//    표시 이름으로 요청하면 존재하지 않는 경로가 되어 GAM 이 광고를 주지 않는다.
-//    실제로 이 단위는 수집 시작(2026-04-30) 이후 노출·수익이 한 건도 잡히지 않았다.
-const unitCuration = import.meta.env.VITE_GAM_UNIT_CURATION || 'curation';
+const unitCuration = import.meta.env.VITE_GAM_UNIT_CURATION || 'banner-responsive_curation';
 const unitArticle = import.meta.env.VITE_GAM_UNIT_ARTICLE || 'banner-responsive_article';
 const unitWing = import.meta.env.VITE_GAM_UNIT_WING || 'banner-responsive_wing';
 


### PR DESCRIPTION
## 왜 되돌리나

**#1883 의 수정 자체는 옳다.** 다만 지금 운영에 올라가면 관측이 오염된다.

| | 변경 | 지면 영향 |
|---|---|---|
| 7/26 배포 (#1882) | 마음메시지 아래 광고 **제거** | 목록·상세 각 1자리 **감소** |
| #1883 (되돌림 대상) | curation 단위 교정 | 목록 인피드 7·17 + 댓글 인피드 **증가** |

둘이 함께 배포되면 **"뺀 효과"와 "살린 효과"가 상쇄되어** 어느 쪽 영향인지 판별할 수 없다.

## 관측 대상 (기준선 기록됨)

`triage/improvements/ad-removal-baseline-20260726.md`

제거한 두 자리는 **서로 다른 단위**다:

| 자리 | position | 단위 | 30일 수익 |
|---|---|---|---:|
| 목록 마음메시지 아래 | `board-list-head` | **sub** | 1,548,936원 |
| 상세 마음메시지 아래 | `board-content` | **article** | 685,657원 |

평일 총 수익 기준선 **약 12만원/일**, 주말 7.5~9.3만원. 요일 편차가 ±30% 라 **같은 요일끼리 최소 7일** 비교해야 한다.

## 다시 올릴 때

이 revert 를 다시 revert 하면 된다. 되살릴 내용:

```ts
const unitCuration = import.meta.env.VITE_GAM_UNIT_CURATION || 'curation';
```

GAM 요청 경로는 **표시 이름이 아니라 `ad_unit_code`** 로 만들어야 한다. 다른 단위는 둘이 같아 우연히 맞았지만 curation 만 `display_name=banner-responsive_curation` / `ad_unit_code=curation` 로 다르다. 이 단위는 수집 시작(2026-04-30) 이후 노출·수익이 **0** 이다.

## 검증

- [ ] 목록 인피드(7·17)에 광고가 나오지 않는 상태 유지(현행과 동일)
- [ ] 다른 광고 자리 회귀 없음