### PR TITLE
fix(board): 목록 레이아웃을 확장 DOM 주입에 면역인 flex로 전환

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
@@ -53,11 +53,10 @@
         href={isReportLock ? originalLink || href : href}
         class="archive-row bg-background hover:bg-accent block px-4 no-underline transition-colors"
     >
-        <div
-            class="flex items-center gap-2 md:grid md:grid-cols-[50px_1fr_auto_auto_auto] md:items-center md:gap-0"
-        >
+        <!-- grid+contents → flex 전환 (classic.svelte 와 동일 사유, #free-6824455) -->
+        <div class="flex items-center gap-2 md:gap-0">
             <!-- col 1: 배지 (데스크톱) -->
-            <div class="hidden md:flex md:items-center md:justify-center">
+            <div class="hidden md:flex md:w-[50px] md:shrink-0 md:items-center md:justify-center">
                 {#if isReportLock}
                     <Badge
                         variant={isCommentEntry ? 'secondary' : 'default'}
@@ -77,9 +76,9 @@
             </div>
 
             <!-- col 2~5: 콘텐츠 -->
-            <div class="min-w-0 flex-1 space-y-1 md:contents md:space-y-0">
+            <div class="min-w-0 flex-1 space-y-1 md:flex md:items-center md:space-y-0">
                 <!-- 제목 줄 (col 2) -->
-                <div class="flex min-w-0 items-center gap-1">
+                <div class="flex min-w-0 items-center gap-1 md:flex-1">
                     <!-- 모바일 배지 -->
                     {#if isReportLock}
                         <Badge
@@ -124,7 +123,7 @@
 
                 <!-- 이름 (col 3, 데스크톱) -->
                 <span
-                    class="post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:pl-1"
+                    class="post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:shrink-0 md:pl-1"
                 >
                     <Avatar
                         path={post.author_image}
@@ -142,7 +141,7 @@
 
                 <!-- 날짜 (col 4, 데스크톱) -->
                 <span
-                    class="post-meta-text hidden md:inline md:w-[70px] md:pl-1 md:text-center {isToday(
+                    class="post-meta-text hidden md:inline md:w-[70px] md:shrink-0 md:pl-1 md:text-center {isToday(
                         post.created_at
                     )
                         ? 'date-today'
@@ -152,7 +151,9 @@
                 </span>
 
                 <!-- 조회수 (col 5, 데스크톱) -->
-                <span class="post-meta-text hidden md:inline md:w-[50px] md:pl-1 md:text-center">
+                <span
+                    class="post-meta-text hidden md:inline md:w-[50px] md:shrink-0 md:pl-1 md:text-center"
+                >
                     {formatCompactNumber(post.views)}
                 </span>
 

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -150,14 +150,21 @@
         class:post-promo={isPromo}
         class:post-notice={post.is_notice}
     >
-        <div
-            class={isMobileView
-                ? 'flex items-center gap-2'
-                : 'flex items-center gap-2 md:grid md:grid-cols-[60px_1fr_auto_auto_auto] md:items-center md:gap-0'}
-        >
+        <!--
+            데스크톱 레이아웃을 grid(60px_1fr_auto_auto_auto) + display:contents 에서
+            flex + 고정폭으로 전환 (#free-6824455).
+            grid 자동 배치는 "자식 수 = 트랙 수" 암묵 계약이라, 번역 확장(DeepL 등)이
+            래퍼 요소 하나만 주입해도 전 컬럼이 한 트랙씩 밀려 제목이 min-content 로
+            수축했다(제목 2~3글자 잘림·작성자/날짜 증발). flex 는 트랙 재배정 개념이
+            없어 주입에 면역이고, 작성자/날짜/조회가 이미 고정폭(120/70/50px)이라
+            컬럼 위치는 픽셀 동일하다.
+        -->
+        <div class={isMobileView ? 'flex items-center gap-2' : 'flex items-center gap-2 md:gap-0'}>
             <!-- 추천 박스 (col 1, 데스크톱만) — legacy: rcmd-box 40×20 rounded-lg -->
             <div
-                class={isMobileView ? 'hidden' : 'hidden md:flex md:items-center md:justify-center'}
+                class={isMobileView
+                    ? 'hidden'
+                    : 'hidden md:flex md:w-[60px] md:shrink-0 md:items-center md:justify-center'}
             >
                 {#if post.is_notice}
                     <div
@@ -176,14 +183,14 @@
                 {/if}
             </div>
 
-            <!-- 콘텐츠 (모바일: block, 데스크톱: contents → 그리드 col 2~5 참여) -->
+            <!-- 콘텐츠 (모바일: block, 데스크톱: flex 행 — 제목이 flex-1로 잔여 폭 차지) -->
             <div
                 class={isMobileView
                     ? 'min-w-0 flex-1 space-y-1'
-                    : 'min-w-0 flex-1 space-y-1 md:contents md:space-y-0'}
+                    : 'min-w-0 flex-1 space-y-1 md:flex md:items-center md:space-y-0'}
             >
                 <!-- 제목 줄 (col 2) -->
-                <div class="flex min-w-0 items-center gap-1">
+                <div class="flex min-w-0 items-center gap-1 md:flex-1">
                     {#if post.is_notice}
                         <span class="mobile-only" class:modern-view={isMobileView}
                             ><Pin class="text-liked h-3.5 w-3.5 shrink-0" /></span
@@ -274,7 +281,7 @@
                 <span
                     class={isMobileView
                         ? 'hidden'
-                        : 'post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:pl-1'}
+                        : 'post-meta-text hidden items-center gap-1 truncate md:inline-flex md:w-[120px] md:shrink-0 md:pl-1'}
                 >
                     <Avatar
                         path={post.author_image}
@@ -294,7 +301,7 @@
                 <span
                     class={isMobileView
                         ? 'hidden'
-                        : `post-meta-text hidden md:inline md:w-[70px] md:pl-1 md:text-center ${isToday(post.created_at) ? 'date-today' : ''}`}
+                        : `post-meta-text hidden md:inline md:w-[70px] md:shrink-0 md:pl-1 md:text-center ${isToday(post.created_at) ? 'date-today' : ''}`}
                 >
                     {formatDateCompact(post.created_at)}
                 </span>
@@ -303,7 +310,7 @@
                 <span
                     class={isMobileView
                         ? 'hidden'
-                        : 'post-meta-text hidden md:inline md:w-[50px] md:pl-1 md:text-center'}
+                        : 'post-meta-text hidden md:inline md:w-[50px] md:shrink-0 md:pl-1 md:text-center'}
                 >
                     {formatCompactNumber(post.views)}
                 </span>

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -374,21 +374,22 @@
     <div class="space-y-1">
         {#each Array(5) as _, i (i)}
             <div class="bg-background rounded-lg border px-4 py-3">
-                <div
-                    class="flex items-center gap-2 md:grid md:grid-cols-[60px_1fr_auto_auto_auto] md:items-center md:gap-0"
-                >
+                <!-- grid → flex (#free-6824455, classic.svelte 와 동일 사유) -->
+                <div class="flex items-center gap-2 md:gap-0">
+                    <div class="hidden md:flex md:w-[60px] md:shrink-0 md:justify-center">
+                        <div class="bg-muted-foreground/20 h-4 w-8 animate-pulse rounded"></div>
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <div class="bg-muted-foreground/20 h-4 w-2/3 animate-pulse rounded"></div>
+                    </div>
                     <div
-                        class="bg-muted-foreground/20 hidden h-4 w-8 animate-pulse rounded md:mx-auto md:block"
-                    ></div>
-                    <div class="bg-muted-foreground/20 h-4 w-2/3 animate-pulse rounded"></div>
-                    <div
-                        class="bg-muted-foreground/20 hidden h-3 w-[100px] animate-pulse rounded md:ml-1 md:block"
-                    ></div>
-                    <div
-                        class="bg-muted-foreground/20 hidden h-3 w-[50px] animate-pulse rounded md:ml-1 md:block"
+                        class="bg-muted-foreground/20 hidden h-3 w-[100px] shrink-0 animate-pulse rounded md:ml-1 md:block"
                     ></div>
                     <div
-                        class="bg-muted-foreground/20 hidden h-3 w-[34px] animate-pulse rounded md:ml-1 md:block"
+                        class="bg-muted-foreground/20 hidden h-3 w-[50px] shrink-0 animate-pulse rounded md:ml-1 md:block"
+                    ></div>
+                    <div
+                        class="bg-muted-foreground/20 hidden h-3 w-[34px] shrink-0 animate-pulse rounded md:ml-1 md:block"
                     ></div>
                 </div>
             </div>
@@ -423,12 +424,13 @@
                     ? ''
                     : 'md:block'}"
             >
-                <div class="grid grid-cols-[60px_1fr_auto_auto_auto] items-center gap-0">
-                    <div class="text-center">공감</div>
-                    <div>제목</div>
-                    <div class="w-[120px] pl-1">이름</div>
-                    <div class="w-[70px] pl-1 text-center">날짜</div>
-                    <div class="w-[50px] pl-1 text-center">조회</div>
+                <!-- 목록 행(classic.svelte)과 동일하게 grid → flex (#free-6824455) -->
+                <div class="flex items-center gap-0">
+                    <div class="w-[60px] shrink-0 text-center">공감</div>
+                    <div class="min-w-0 flex-1">제목</div>
+                    <div class="w-[120px] shrink-0 pl-1">이름</div>
+                    <div class="w-[70px] shrink-0 pl-1 text-center">날짜</div>
+                    <div class="w-[50px] shrink-0 pl-1 text-center">조회</div>
                 </div>
             </div>
         {/if}

--- a/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
+++ b/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
@@ -45,11 +45,10 @@
         class="dm-list-row block px-4 no-underline transition-colors hover:bg-amber-100/10 dark:hover:bg-amber-950/15"
         style="background: rgba(255, 179, 39, 0.06); border-left: 3px solid rgba(255, 179, 39, 0.4); border-bottom: 1px solid color-mix(in oklch, var(--foreground) 8%, transparent);"
     >
-        <div
-            class="flex items-center gap-2 md:grid md:grid-cols-[60px_1fr_auto_auto_auto] md:items-center md:gap-0"
-        >
+        <!-- grid → flex (#free-6824455, classic.svelte 와 동일 사유) -->
+        <div class="flex items-center gap-2 md:gap-0">
             <!-- 홍보 박스 (col 1, 데스크톱만) — legacy step-pai: rgb(255,179,39) bg -->
-            <div class="hidden md:flex md:items-center md:justify-center">
+            <div class="hidden md:flex md:w-[60px] md:shrink-0 md:items-center md:justify-center">
                 <div
                     class="flex h-5 w-10 items-center justify-center rounded-lg text-xs font-semibold leading-5"
                     style="background: rgb(255, 179, 39); color: rgb(78, 78, 78);"
@@ -58,8 +57,8 @@
                 </div>
             </div>
 
-            <!-- 제목 (col 2) -->
-            <div class="min-w-0 flex-1 md:flex-none">
+            <!-- 제목 (col 2) — flex 행에서 잔여 폭 차지 -->
+            <div class="min-w-0 flex-1">
                 <div class="flex min-w-0 items-center gap-1">
                     <span
                         class="inline-flex shrink-0 items-center rounded px-1.5 py-0 text-[10px] font-semibold md:hidden"
@@ -76,7 +75,7 @@
 
             <!-- 광고주 (col 3, 데스크톱만) -->
             <span
-                class="text-muted-foreground hidden w-[120px] truncate pl-1 md:inline-flex"
+                class="text-muted-foreground hidden w-[120px] shrink-0 truncate pl-1 md:inline-flex"
                 style="font-size: 0.9em;"
             >
                 {post.advertiserName}
@@ -84,14 +83,14 @@
 
             <!-- 날짜 (col 4, 데스크톱만) -->
             <span
-                class="text-muted-foreground hidden w-[70px] pl-1 text-center md:inline"
+                class="text-muted-foreground hidden w-[70px] shrink-0 pl-1 text-center md:inline"
                 style="font-size: 0.9em;"
             >
                 {formatDate(post.createdAt)}
             </span>
 
             <!-- 조회 (col 5, 빈칸) -->
-            <span class="hidden w-[50px] pl-1 md:inline"></span>
+            <span class="hidden w-[50px] shrink-0 pl-1 md:inline"></span>
         </div>
     </a>
 {:else}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1337,12 +1337,13 @@
                             ? ''
                             : 'md:block'}"
                     >
-                        <div class="grid grid-cols-[60px_1fr_auto_auto_auto] items-center gap-0">
-                            <div class="text-center">공감</div>
-                            <div>제목</div>
-                            <div class="w-[120px] pl-1">이름</div>
-                            <div class="w-[70px] pl-1 text-center">날짜</div>
-                            <div class="w-[50px] pl-1 text-center">조회</div>
+                        <!-- 목록 행(classic.svelte)과 동일하게 grid → flex (#free-6824455) -->
+                        <div class="flex items-center gap-0">
+                            <div class="w-[60px] shrink-0 text-center">공감</div>
+                            <div class="min-w-0 flex-1">제목</div>
+                            <div class="w-[120px] shrink-0 pl-1">이름</div>
+                            <div class="w-[70px] shrink-0 pl-1 text-center">날짜</div>
+                            <div class="w-[50px] shrink-0 pl-1 text-center">조회</div>
                         </div>
                     </div>
                 {/if}


### PR DESCRIPTION
## 제보

free/6824455 — 자유게시판 목록 제목이 2~3글자로 잘리고 작성자·날짜·조회 컬럼이 사라짐.

- 크롬 계열에서만 재현, 엣지 정상, 프라이빗 창 정상, 캐시 삭제 무효
- 재현자 2명 모두 **DeepL 번역 확장 제거/수정으로 해결** 확인

## 원인 — 확장이 방아쇠, 우리 구조가 화약고

`classic.svelte`·`archive.svelte`의 데스크톱 목록이 `grid-cols-[60px_1fr_auto_auto_auto]` + `display:contents` 조합인데, **어느 아이템에도 `grid-column` 명시 배치가 없습니다.** 트랙 배정이 "자식 수 = 트랙 수" 자동 배치 암묵 계약에 전적으로 의존합니다.

번역 확장이 래퍼 요소를 **하나만** 주입해도:

| 트랙 | 60px | 1fr | auto | auto | auto |
|---|---|---|---|---|---|
| 정상 | 추천 | **제목** | 작성자 | 날짜 | 조회 |
| 주입 후 | 추천 | 제목 | **주입노드** | 작성자 | 날짜 (조회는 2행 낙하) |

주입 노드(긴 번역 텍스트)가 auto 트랙으로 여유 폭을 전부 흡수 → `1fr` 트랙이 min-content로 수축 → 제목은 `truncate`라 기여 0, N배지·댓글수는 `shrink-0`이라 생존 → **"배지는 멀쩡한데 제목만 40~60px"** 실측과 정확히 일치. 공지는 별도 flexbox 블록이라 멀쩡했습니다.

## 수정

**flex는 트랙 재배정 개념이 없어 주입에 면역**입니다.

- 행 컨테이너: grid 제거 → flex 유지
- 추천박스: 트랙이 주던 60px를 `w-[60px] shrink-0`으로 명시
- 콘텐츠 래퍼: `md:contents` → `md:flex md:items-center`
- 제목행: `md:flex-1` (= 기존 1fr)
- 작성자(120px)·날짜(70px)·조회(50px): 기존 고정폭에 `shrink-0` 추가
- 컬럼 헤더 행도 동일 전환 (정렬 일치)

작성자·날짜·조회가 이미 고정폭이라 grid의 auto 트랙도 사실상 이 값으로 해소되고 있었으므로 **컬럼 위치는 동일**합니다. 모바일(<768px)·모던 보기(`isMobileView`)는 별도 분기라 미접촉.

## 검증

- fe#1882(오늘 광고 제거)는 diff 확인 결과 무관 — 배포 시점과의 상관은 우연
- 회귀 확인 포인트: 데스크톱 목록 컬럼 정렬(공감/제목/이름/날짜/조회), 공지 행, 메모 배지, promo/notice 배경, 모바일 2줄 레이아웃