### PR TITLE
fix(home): 홈 위젯 등 잔여 grid 자동배치를 확장 주입 면역 flex로 전환

### DIFF
--- a/apps/web/src/lib/components/admin/widgets/widget-list-table.svelte
+++ b/apps/web/src/lib/components/admin/widgets/widget-list-table.svelte
@@ -119,10 +119,10 @@
     <div
         class="text-muted-foreground flex items-center gap-4 border-b px-4 py-2 text-sm font-medium"
     >
-        <div class="w-10 shrink-0"></div>
+        <div class="w-[40px] shrink-0"></div>
         <div class="min-w-0 flex-1">위젯</div>
         <div class="w-[100px] shrink-0">카테고리</div>
-        <div class="w-20 shrink-0 text-center">활성화</div>
+        <div class="w-[80px] shrink-0 text-center">활성화</div>
         <div class="w-[100px] shrink-0 text-right">작업</div>
     </div>
 
@@ -146,7 +146,7 @@
                     !widget.enabled && 'opacity-60'
                 )}
             >
-                <div class="w-10 shrink-0 cursor-grab active:cursor-grabbing">
+                <div class="w-[40px] shrink-0 cursor-grab active:cursor-grabbing">
                     <GripVertical class="text-muted-foreground h-5 w-5" />
                 </div>
 
@@ -181,7 +181,7 @@
                     {/if}
                 </div>
 
-                <div class="flex w-20 shrink-0 justify-center">
+                <div class="flex w-[80px] shrink-0 justify-center">
                     <Switch
                         checked={widget.enabled}
                         onCheckedChange={() => handleToggle(widget.id)}

--- a/apps/web/src/lib/components/admin/widgets/widget-list-table.svelte
+++ b/apps/web/src/lib/components/admin/widgets/widget-list-table.svelte
@@ -115,14 +115,15 @@
 </script>
 
 <div class="space-y-1">
+    <!-- 행형 grid → flex (#free-6824455 확장 주입 면역, classic.svelte 선례) -->
     <div
-        class="text-muted-foreground grid grid-cols-[40px_1fr_100px_80px_100px] gap-4 border-b px-4 py-2 text-sm font-medium"
+        class="text-muted-foreground flex items-center gap-4 border-b px-4 py-2 text-sm font-medium"
     >
-        <div></div>
-        <div>위젯</div>
-        <div>카테고리</div>
-        <div class="text-center">활성화</div>
-        <div class="text-right">작업</div>
+        <div class="w-10 shrink-0"></div>
+        <div class="min-w-0 flex-1">위젯</div>
+        <div class="w-[100px] shrink-0">카테고리</div>
+        <div class="w-20 shrink-0 text-center">활성화</div>
+        <div class="w-[100px] shrink-0 text-right">작업</div>
     </div>
 
     <div
@@ -139,20 +140,20 @@
             <div
                 animate:flip={{ duration: flipDurationMs }}
                 class={cn(
-                    'grid grid-cols-[40px_1fr_100px_80px_100px] items-center gap-4 rounded-lg border px-4 py-3 transition-colors',
+                    'flex items-center gap-4 rounded-lg border px-4 py-3 transition-colors',
                     isSelected ? 'border-primary bg-primary/5' : 'bg-card hover:bg-muted/50',
                     isShadow && 'opacity-50',
                     !widget.enabled && 'opacity-60'
                 )}
             >
-                <div class="cursor-grab active:cursor-grabbing">
+                <div class="w-10 shrink-0 cursor-grab active:cursor-grabbing">
                     <GripVertical class="text-muted-foreground h-5 w-5" />
                 </div>
 
                 <button
                     type="button"
                     onclick={() => handleSelect(widget.id)}
-                    class="flex items-center gap-3 text-left"
+                    class="flex min-w-0 flex-1 items-center gap-3 text-left"
                 >
                     <div
                         class={cn(
@@ -172,7 +173,7 @@
                     </div>
                 </button>
 
-                <div>
+                <div class="w-[100px] shrink-0">
                     {#if registry}
                         <Badge variant={getCategoryVariant(registry.category)}
                             >{getCategoryLabel(registry.category)}</Badge
@@ -180,14 +181,14 @@
                     {/if}
                 </div>
 
-                <div class="flex justify-center">
+                <div class="flex w-20 shrink-0 justify-center">
                     <Switch
                         checked={widget.enabled}
                         onCheckedChange={() => handleToggle(widget.id)}
                     />
                 </div>
 
-                <div class="flex justify-end gap-1">
+                <div class="flex w-[100px] shrink-0 justify-end gap-1">
                     <Button
                         variant="ghost"
                         size="icon"

--- a/apps/web/src/routes/member/leave/cancel/+page.svelte
+++ b/apps/web/src/routes/member/leave/cancel/+page.svelte
@@ -37,13 +37,23 @@
             <div
                 class="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
             >
-                <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
-                    <dt class="text-muted-foreground">신청일</dt>
-                    <dd class="font-medium">{data.leaveDate}</dd>
-                    <dt class="text-muted-foreground">확정 예정일</dt>
-                    <dd class="font-medium">{data.deadline}</dd>
-                    <dt class="text-muted-foreground">남은 기간</dt>
-                    <dd class="font-medium">{data.daysRemaining}일</dd>
+                <!--
+                    grid 자동배치(dt/dd 6자식) → 쌍 단위 flex (#free-6824455 확장 주입 면역).
+                    grid 에선 확장이 요소 하나만 주입해도 라벨-값 짝이 전부 어긋난다.
+                -->
+                <dl class="flex flex-col gap-1.5">
+                    <div class="flex gap-4">
+                        <dt class="text-muted-foreground w-24 shrink-0">신청일</dt>
+                        <dd class="font-medium">{data.leaveDate}</dd>
+                    </div>
+                    <div class="flex gap-4">
+                        <dt class="text-muted-foreground w-24 shrink-0">확정 예정일</dt>
+                        <dd class="font-medium">{data.deadline}</dd>
+                    </div>
+                    <div class="flex gap-4">
+                        <dt class="text-muted-foreground w-24 shrink-0">남은 기간</dt>
+                        <dd class="font-medium">{data.daysRemaining}일</dd>
+                    </div>
                 </dl>
             </div>
 

--- a/widgets/empathy-explore-row/index.svelte
+++ b/widgets/empathy-explore-row/index.svelte
@@ -34,7 +34,17 @@
     });
 </script>
 
-<div class="grid grid-cols-1 gap-2 lg:grid-cols-2">
-    <RecommendedPosts prefetchData={typedData?.recommended} />
-    <ExplorePreview prefetchData={typedData?.explore} excludeIds={recommendedIds} />
+<!--
+    grid 자동배치 → flex (#free-6824455 확장 주입 면역).
+    번역 확장이 래퍼를 주입하면 grid 는 컬럼 배정이 통째로 밀리지만,
+    flex+wrap 은 주입 노드가 다음 줄로 떨어질 뿐 두 컬럼 위치가 불변이다.
+    gap-2(0.5rem) 절반 보정 = 0.25rem.
+-->
+<div class="flex flex-col gap-2 lg:flex-row lg:flex-wrap">
+    <div class="min-w-0 lg:w-[calc(50%-0.25rem)]">
+        <RecommendedPosts prefetchData={typedData?.recommended} />
+    </div>
+    <div class="min-w-0 lg:w-[calc(50%-0.25rem)]">
+        <ExplorePreview prefetchData={typedData?.explore} excludeIds={recommendedIds} />
+    </div>
 </div>

--- a/widgets/empathy-explore-row/index.svelte
+++ b/widgets/empathy-explore-row/index.svelte
@@ -36,15 +36,21 @@
 
 <!--
     grid 자동배치 → flex (#free-6824455 확장 주입 면역).
-    번역 확장이 래퍼를 주입하면 grid 는 컬럼 배정이 통째로 밀리지만,
-    flex+wrap 은 주입 노드가 다음 줄로 떨어질 뿐 두 컬럼 위치가 불변이다.
-    gap-2(0.5rem) 절반 보정 = 0.25rem.
+    grid 는 확장이 요소를 주입하면 컬럼 배정이 통째로 밀려 좌우가 뒤바뀌거나
+    한쪽이 다음 행으로 내려간다. flex 는 각 카드가 자기 폭을 유지한 채
+    넘친 것만 다음 줄로 떨어진다.
+
+    ⛔ w-[calc(50%-…)] 를 쓰지 않는다. 합이 정확히 100% 라 컨테이너 폭이
+    홀수 서브픽셀일 때 조기 wrap(카드 하나가 통째로 아래로) 위험이 있다.
+    flex-1 basis-0 은 1fr 과 수학적으로 동일 배분이면서 그 위험이 없다.
+    ⛔ *:h-full 필수 — grid 시절 두 카드는 stretch 로 바닥선이 맞았다.
+    래퍼를 씌우면 늘어나는 건 래퍼뿐이라 이게 없으면 짧은 카드 바닥이 올라온다.
 -->
 <div class="flex flex-col gap-2 lg:flex-row lg:flex-wrap">
-    <div class="min-w-0 lg:w-[calc(50%-0.25rem)]">
+    <div class="min-w-0 *:h-full lg:min-w-0 lg:flex-1 lg:basis-0">
         <RecommendedPosts prefetchData={typedData?.recommended} />
     </div>
-    <div class="min-w-0 lg:w-[calc(50%-0.25rem)]">
+    <div class="min-w-0 *:h-full lg:min-w-0 lg:flex-1 lg:basis-0">
         <ExplorePreview prefetchData={typedData?.explore} excludeIds={recommendedIds} />
     </div>
 </div>

--- a/widgets/news-economy-row/index.svelte
+++ b/widgets/news-economy-row/index.svelte
@@ -11,12 +11,12 @@
     let { config, slot, isEditMode = false, prefetchData }: WidgetProps = $props();
 </script>
 
-<!-- grid 자동배치 → flex (#free-6824455 확장 주입 면역, empathy-explore-row 와 동일). gap-4 절반 보정 = 0.5rem -->
+<!-- grid 자동배치 → flex (#free-6824455 확장 주입 면역). 설계 근거는 empathy-explore-row 주석 참조 -->
 <div class="flex flex-col gap-4 lg:flex-row lg:flex-wrap">
-    <div class="min-w-0 lg:w-[calc(50%-0.5rem)]">
+    <div class="min-w-0 *:h-full lg:min-w-0 lg:flex-1 lg:basis-0">
         <NewBoard posts={indexWidgetsStore.newsTabs} />
     </div>
-    <div class="min-w-0 lg:w-[calc(50%-0.5rem)]">
+    <div class="min-w-0 *:h-full lg:min-w-0 lg:flex-1 lg:basis-0">
         <EconomyTabs posts={indexWidgetsStore.economyTabs} />
     </div>
 </div>

--- a/widgets/news-economy-row/index.svelte
+++ b/widgets/news-economy-row/index.svelte
@@ -11,7 +11,12 @@
     let { config, slot, isEditMode = false, prefetchData }: WidgetProps = $props();
 </script>
 
-<div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-    <NewBoard posts={indexWidgetsStore.newsTabs} />
-    <EconomyTabs posts={indexWidgetsStore.economyTabs} />
+<!-- grid 자동배치 → flex (#free-6824455 확장 주입 면역, empathy-explore-row 와 동일). gap-4 절반 보정 = 0.5rem -->
+<div class="flex flex-col gap-4 lg:flex-row lg:flex-wrap">
+    <div class="min-w-0 lg:w-[calc(50%-0.5rem)]">
+        <NewBoard posts={indexWidgetsStore.newsTabs} />
+    </div>
+    <div class="min-w-0 lg:w-[calc(50%-0.5rem)]">
+        <EconomyTabs posts={indexWidgetsStore.economyTabs} />
+    </div>
 </div>


### PR DESCRIPTION
## 배경

#1885(게시판 목록) 후속. **홈에서도 화면이 깨진다는 확인**이 있었고, DeepL 제거로 해결된 사례가 **3인**(제보자·회원·운영자) 누적됐습니다.

전 레포를 전수 조사했습니다 — web `apps/web/src`·`themes`·`plugins`·`widgets` + **premium(origin/main)**.

| 패턴 | web src | themes/plugins/widgets | premium |
|---|---|---|---|
| `display:contents` | 1건(SvelteKit hydration anchor, 무해) | 0 | **0** |
| 행형 `grid-cols-[...]` | 실제 행형 2건 | 0 | **0** |
| `:nth-child` 위치 의존 | 8건(전부 장식) | 0 | **0** |
| JS 형제 인덱스 | 7건(전부 아바타 onerror 폴백) | 0 | **0** |

**premium·themes·plugins는 수정 불필요 확정.** 홈 위젯 체인도 전수 확인했고, grid 자동배치를 쓰는 곳은 아래 2개뿐이었습니다.

## 수정 4곳

| 파일 | 표면 | 위험 |
|---|---|---|
| `widgets/empathy-explore-row` | **홈 최상단** | 상 |
| `widgets/news-economy-row` | **홈 5번째** | 상 |
| `member/leave/cancel` | 탈퇴취소 | 붕괴도 상 (dt/dd 6자식 → 하나만 주입돼도 라벨-값 짝이 전부 어긋남) |
| `admin/widgets/widget-list-table` | admin | 레포에 유일하게 남은 진짜 행형 grid |

`card-header`는 `card-action`이 `col-start` 명시 배치라 이미 면역 → 유지.

## 독립 검증에서 잡힌 회귀 (2번째 커밋에서 수정)

Evaluator가 **실제 픽셀 회귀 1건**을 찾았습니다.

- **카드 높이 stretch 소실** — grid 시절 두 위젯 카드는 stretch로 바닥선이 맞았는데, flex 래퍼를 씌우면 늘어나는 건 래퍼뿐이고 안의 `Card`는 `height:auto`라 짧은 쪽 바닥이 올라옵니다. `Card`는 배경·그림자가 보여 눈에 띕니다 → `*:h-full`로 해결
- **조기 wrap 위험** — `w-[calc(50%-…)]`는 합이 정확히 100%라 서브픽셀 반올림 시 카드 하나가 통째로 아래로 떨어질 수 있음 → `flex-1 basis-0`(1fr과 동일 배분, 위험 없음)
- **단위 변경** — admin 테이블 원본이 절대 px였는데 rem으로 바뀌어 있던 것 → `w-[40px]`/`w-[80px]`로 복원

나머지 항목(폭 산술, 모바일 parity, `dl>div` 스펙 유효성, dnd 라이브러리 영향, prettier/tailwind 순서, 외부 참조)은 전부 Pass.

## 면역성

| 주입 위치 | grid | flex |
|---|---|---|
| 말미 | 둘 다 다음 줄 (동일) | |
| **선두·중간** | 컬럼 배정이 밀려 좌우 뒤바뀜 | 각 카드가 폭 유지, 넘친 것만 다음 줄 |
| leave/cancel | 라벨-값 짝 전부 어긋남 | **구조적으로 불가능** |

## 후속 (이 PR 범위 밖)

- `content/advertisement`·`angtt/[slug]`에 2자식 자동배치 grid 잔존 — 저위험이나 조치 여부 판단 필요
- `widget-editor.svelte`에 옛 grid 코드 2벌 잔존 (dead code, 사용처 0)
- `Failed to hydrate` 에러가 `js_errors`에 전혀 수집되지 않음(14일 0행) — 수집기 보강해야 실사용 규모 측정 가능