### PR TITLE
fix(observability): 하이드레이션 실패를 실제로 수집하도록 후킹 채널 교정

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -314,6 +314,34 @@
     </head>
     <body>
         <div style="display: contents">%sveltekit.body%</div>
+        <!--
+            하이드레이션 앵커 캡처 — 로그가 아예 없는 실패 경로를 잡기 위한 것.
+
+            Svelte 는 하이드레이션 타깃 안에서 HYDRATION_START 주석(<!--[-->)을 못 찾으면 throw
+        HYDRATION_ERROR 하는데, render.js:134 의 `error !== HYDRATION_ERROR` 가 false 라 **console
+        출력이 0** 이다. 그대로 clear_text_content(target) 후 조용히 CSR 재마운트된다. 즉
+        console.warn 후킹으로도 이 경로는 못 잡는다. 번역 확장이 SSR 마커를 건드리는 경우가 여기
+        해당한다. 앵커 노드를 붙잡아 두고 마운트 후 isConnected 를 보면 폐기 여부를 확정할 수 있다.
+        비용은 노드 참조 1개 + boolean 1회. -->
+        <script>
+            (function () {
+                try {
+                    var target = document.body.firstElementChild;
+                    if (!target) return;
+                    for (var n = target.firstChild; n; n = n.nextSibling) {
+                        // Comment 노드이면서 data 가 '[' 이면 HYDRATION_START
+                        if (n.nodeType === 8 && n.data === '[') {
+                            window.__angpleHydrationAnchor = n;
+                            return;
+                        }
+                    }
+                    // 여기 도달 = 앵커가 처음부터 없음
+                    window.__angpleHydrationAnchor = null;
+                } catch (e) {
+                    /* 관측용이라 실패해도 무시 */
+                }
+            })();
+        </script>
         <!-- Safari bfcache 복원 시 stale 상태 방지 (#303) + 스크롤 위치 보존 (#13022) -->
         <script>
             (function () {

--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -432,30 +432,82 @@ if (typeof window !== 'undefined') {
     // 골라 보내고, 기존 guardedSend 의 중복 스로틀·레이트리밋을 그대로 탄다.
     // bug/12981: '[upload-fail]' prefix 도 함께 수집 — 업로드/스왑 실패가 전부 무음 catch 로
     // console.error 에만 남아 js_errors 가 30일간 0건이던 관측 공백을 메운다.
-    const originalConsoleError = console.error;
-    console.error = function (...args: unknown[]) {
-        try {
-            const first = String(args[0] ?? '');
-            const isHydration = first.includes('hydrat');
-            const isUploadFail = first.startsWith('[upload-fail]');
-            if (isHydration || isUploadFail) {
-                const detail = args
-                    .slice(1)
-                    .map((a) => (a instanceof Error ? `${a.name}: ${a.message}` : String(a)))
-                    .join(' ')
-                    .slice(0, 300);
-                const err = args.find((a): a is Error => a instanceof Error);
-                guardedSend({
-                    type: isHydration ? 'hydration_error' : 'upload_fail',
-                    message: `${first} ${detail}`.trim().slice(0, 400),
-                    stack: err?.stack?.slice(0, 1500) || '(no stack)',
-                    url: window.location.href,
-                    userAgent: navigator.userAgent
-                });
-            }
-        } catch {
-            // 수집 실패가 원래 로그를 막으면 안 된다
+    // ⛔ 채널이 둘이다. Svelte 5 는 하이드레이션 실패를 **console.warn** 으로 낸다:
+    //      svelte/src/internal/client/render.js:135
+    //      console.warn('Failed to hydrate: ', error);   // DEV 가드 없음 = 프로덕션에도 있음
+    //    그래서 console.error 만 감싸던 동안 hydration_error 는 14일 0건이었다.
+    //    "안 일어난다"가 아니라 **후킹 채널이 틀렸던 것**이다. 관측된 이중 공백
+    //    ("Failed to hydrate:  HierarchyRequestError")이 위 소스 문자열과 정확히 일치한다.
+    //    같은 래퍼의 upload_fail 이 정상 수집되던 것은 앱 코드가 진짜 console.error 를
+    //    부르기 때문이고, 두 타입의 차이를 이걸로 전부 설명할 수 있다.
+    //
+    // ⛔ shouldIgnore() 를 태우지 않는다. IGNORED_PATTERNS 의 'querySelectorAll',
+    //    'getAttribute', 'parentNode.parentNode' 가 하이드레이션 스택을 삼킨다.
+    type ConsoleCapture = { type: string; reason: string };
+
+    function classifyConsoleMessage(first: string): ConsoleCapture | null {
+        // prod 빌드에서는 축약형 'https://svelte.dev/e/hydration_mismatch' 로 나온다.
+        // 둘 다 'hydrat' 를 포함하므로 한 조건으로 잡되 reason 으로 구분한다.
+        if (first.includes('hydrat')) {
+            return {
+                type: 'hydration_error',
+                reason: first.includes('mismatch') ? 'hydration_mismatch' : 'failed_to_hydrate'
+            };
         }
-        originalConsoleError.apply(console, args as []);
-    };
+        if (first.startsWith('[upload-fail]')) {
+            return { type: 'upload_fail', reason: 'upload_fail' };
+        }
+        return null;
+    }
+
+    function captureFromConsole(args: unknown[], channel: 'error' | 'warn') {
+        const first = String(args[0] ?? '');
+        const hit = classifyConsoleMessage(first);
+        if (!hit) return;
+
+        const detail = args
+            .slice(1)
+            .map((a) => (a instanceof Error ? `${a.name}: ${a.message}` : String(a)))
+            .join(' ')
+            .slice(0, 300);
+        const err = args.find((a): a is Error => a instanceof Error);
+        guardedSend({
+            type: hit.type,
+            reason: hit.reason,
+            channel,
+            message: `${first} ${detail}`.trim().slice(0, 400),
+            stack: err?.stack?.slice(0, 1500) || '(no stack)',
+            url: window.location.href,
+            userAgent: navigator.userAgent
+        });
+    }
+
+    // 재래핑 가드. 이게 없으면 HMR·모듈 재평가 때 래퍼가 중첩되어 콘솔 로그가 N 배로 찍힌다.
+    const patchFlag = '__angpleConsolePatched';
+    const w = window as unknown as Record<string, unknown>;
+    if (!w[patchFlag]) {
+        w[patchFlag] = true;
+
+        const originalConsoleError = console.error;
+        console.error = function (...args: unknown[]) {
+            try {
+                captureFromConsole(args, 'error');
+            } catch {
+                // 수집 실패가 원래 로그를 막으면 안 된다
+            }
+            originalConsoleError.apply(console, args as []);
+        };
+
+        // console.warn 은 하이드레이션 전용이다. 앱 내 console.warn 40 곳 중
+        // 'hydrat' 를 포함하는 것은 0 건이라 전송량 순증이 없다(2026-07-28 실측).
+        const originalConsoleWarn = console.warn;
+        console.warn = function (...args: unknown[]) {
+            try {
+                captureFromConsole(args, 'warn');
+            } catch {
+                // 위와 동일
+            }
+            originalConsoleWarn.apply(console, args as []);
+        };
+    }
 }

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -552,6 +552,46 @@
     });
 
     onMount(() => {
+        // 하이드레이션 앵커 판정 — 로그 없는 실패 경로 포착 (app.html 의 앵커 캡처와 한 쌍)
+        //
+        // Svelte 가 HYDRATION_START 주석을 못 찾으면 throw HYDRATION_ERROR 로 빠지는데,
+        // 그 경로는 console 출력이 아예 없어서(render.js:134) warn 후킹으로도 안 잡힌다.
+        // 하이드레이션이 폐기되면 clear_text_content(target) 가 자식 노드를 전부 떼어내므로,
+        // 붙잡아 둔 앵커의 isConnected 로 확정 판정할 수 있다.
+        // 마운트 1회만 검사하고 참조는 즉시 버린다(노드 누수 방지).
+        try {
+            const w = window as unknown as Record<string, unknown>;
+            if ('__angpleHydrationAnchor' in w) {
+                const anchor = w.__angpleHydrationAnchor as Comment | null;
+                const reason =
+                    anchor === null
+                        ? 'anchor_missing' // SSR 마커가 처음부터 없음 (확장이 제거한 경우 등)
+                        : !anchor.isConnected
+                          ? 'anchor_detached' // 하이드레이션 폐기 후 CSR 재마운트됨
+                          : null;
+                if (reason) {
+                    fetch('https://aplog.damoang.net/api/v1/dantry', {
+                        mode: 'cors',
+                        credentials: 'include',
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            type: 'hydration_error',
+                            reason,
+                            channel: 'anchor',
+                            message: `hydration anchor ${reason}`,
+                            stack: '(no stack)',
+                            url: window.location.href,
+                            userAgent: navigator.userAgent
+                        })
+                    }).catch(() => {});
+                }
+                delete w.__angpleHydrationAnchor;
+            }
+        } catch {
+            // 관측용이라 실패해도 무시
+        }
+
         // 디바이스 핑거프린트 수집은 상단 $effect(로그인 확정 후 발화)로 이관.
         // (onMount 는 auth 하이드레이션 전이라 isAuthenticated=false → 스킵되던 문제)
 


### PR DESCRIPTION
## 문제

`hydration_error` 가 **14일 0건**입니다. 그런데 운영자 브라우저 콘솔에는 분명히 찍혔습니다.

```
Failed to hydrate:  HierarchyRequestError: Failed to execute 'appendChild' on 'Node'...
```

**"안 일어난다"가 아니라 관측이 안 되고 있었습니다.**

이틀간 "화면이 깨진다" 제보가 3건 있었고 전부 번역 확장(DeepL) 원인으로 확인됐는데, 그 사고들이 우리 관측에 **한 건도 안 잡혔습니다.** 오늘 제보자(`google_8e1f087d`)는 아예 에러 기록이 0건입니다.

## 원인 — 후킹 채널이 틀렸습니다

Svelte 5 는 하이드레이션 실패를 **`console.warn`** 으로 냅니다.

```js
// svelte@5.53.6/src/internal/client/render.js:135  ← DEV 가드 없음 = 프로덕션에도 있음
console.warn('Failed to hydrate: ', error);
```

그런데 우리는 `console.error` 만 감쌌습니다 (`hooks.client.ts:435`). `includes('hydrat')` 조건에 **영원히 도달하지 못합니다.**

**교차 검증 3건 전부 일치**

| 근거 | 내용 |
|---|---|
| 이중 공백 | 관측된 `Failed to hydrate:  Hierarchy...` = `'Failed to hydrate: '` 트레일링 스페이스 + 인자 구분 스페이스. 소스 문자열 그대로 |
| `upload_fail` 대조 | 같은 래퍼인데 7일 65건 정상 수집 — 앱 코드가 **진짜 `console.error`** 를 부르기 때문. 두 타입의 차이를 완전히 설명 |
| 런타임 스캔 | Svelte 클라이언트의 `console.error` 는 2곳뿐이고 둘 다 하이드레이션과 무관 |

## 수정

**① `console.warn` 후킹 추가** — 분류 로직을 `classifyConsoleMessage` 로 추출해 두 래퍼가 공유

- ⛔ `console.error` 래퍼는 **유지**합니다 (교체 아님). `upload_fail` 65건이 그 경로입니다
- prod 축약형 `https://svelte.dev/e/hydration_mismatch` 도 같은 조건에 걸리므로 `reason` 으로 전면 실패/부분 불일치 구분
- **재래핑 가드**(`__angpleConsolePatched`) 추가 — 없으면 모듈 재평가 시 래퍼가 중첩돼 콘솔 로그가 N배가 됩니다. 기존 error 래퍼에도 소급 적용
- ⛔ console 래퍼 경로는 `shouldIgnore()` 를 태우지 않습니다 — `querySelectorAll`·`getAttribute`·`parentNode.parentNode` 패턴이 하이드레이션 스택을 삼킵니다

**② 로그가 아예 없는 경로 포착**

타깃에서 `<!--[-->`(HYDRATION_START)를 못 찾으면 `throw HYDRATION_ERROR` 인데, `render.js:134` 의 `error !== HYDRATION_ERROR` 가 false라 **console 출력이 0**입니다. 조용히 CSR 재마운트됩니다. **확장이 SSR 마커를 건드리는 케이스가 여기 해당**해서 warn 후킹으로도 못 잡습니다.

→ `app.html` 에서 앵커 노드를 붙잡고 `onMount` 에서 `isConnected` 로 판정 (`anchor_missing` / `anchor_detached`). 비용은 노드 참조 1개 + boolean 1회, 검사 후 참조 즉시 해제.

## 전송량 영향

앱 내 `console.warn` **40곳 중 `'hydrat'` 포함 0건** (실측) → 순증 없음. 하이드레이션 실패는 페이지당 1회라 기존 스로틀(동일 5건)·레이트리밋(20/min)에 여유가 충분합니다.

## 회귀 확인 포인트

- `upload_fail` 이 **여전히** 수집되는지 (이게 깨지면 안 됨)
- 재래핑 가드로 콘솔 로그가 중복 출력되지 않는지
- 화면 회귀 0 (관측 코드만 추가, 렌더 경로 미접촉)

## 배포 후 24시간 판정

```sql
SELECT toStartOfHour(timestamp) h, message, count()
FROM error_logs.js_errors WHERE type='hydration_error' AND timestamp>=now()-INTERVAL 1 DAY
GROUP BY h, message ORDER BY h DESC;
```

건수가 잡히면 `url` 별 분포로 어느 라우트·광고 슬롯이 원인인지 즉시 좁혀집니다. 여전히 0건이면 dantry 수신측 드롭 가설로 넘어갑니다(web 레포에서 확인 불가 = 미확인).

## 후속 (별도)

`DANTRY_URL` 이 광고 로깅과 같은 호스트(`aplog.damoang.net`)라 차단 사용자는 전 텔레메트리가 통째로 죽습니다. 더 심각한 건 `ad_blocked` 이벤트조차 그 채널로 보낸다는 것 — **차단당한 사실을 차단당한 채널로 보고**합니다. 퍼스트파티 릴레이는 다음 PR로 분리합니다.