### PR TITLE
fix(app): HTML 주석 조기 종료로 노출된 텍스트 제거 + CI 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # HTML 주석 조기 종료 검사.
+  # 주석 본문에 닫는 시퀀스가 들어가면 거기서 주석이 끊겨 나머지가 화면에 노출된다.
+  # 2026-07-28 실제로 배포까지 나가 회원 제보로 알았다(bug/13122). 사람 눈에 잘 안 걸리는
+  # 종류라 기계가 막는다. 의존성 설치가 필요 없어 수십 초면 끝난다.
+  html-comments:
+    name: HTML Comment Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Check HTML comments
+        run: node scripts/check-html-comments.mjs
+
   # 전체 lint는 수동 실행만 허용한다.
   # PR에서는 eslint-review/prettier-suggester가 이미 같은 역할을 맡고,
   # main push에서는 빌드/테스트/배포 경로를 막지 않도록 분리한다.

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -314,16 +314,21 @@
     </head>
     <body>
         <div style="display: contents">%sveltekit.body%</div>
-        <!--
-            하이드레이션 앵커 캡처 — 로그가 아예 없는 실패 경로를 잡기 위한 것.
-
-            Svelte 는 하이드레이션 타깃 안에서 HYDRATION_START 주석(<!--[-->)을 못 찾으면 throw
-        HYDRATION_ERROR 하는데, render.js:134 의 `error !== HYDRATION_ERROR` 가 false 라 **console
-        출력이 0** 이다. 그대로 clear_text_content(target) 후 조용히 CSR 재마운트된다. 즉
-        console.warn 후킹으로도 이 경로는 못 잡는다. 번역 확장이 SSR 마커를 건드리는 경우가 여기
-        해당한다. 앵커 노드를 붙잡아 두고 마운트 후 isConnected 를 보면 폐기 여부를 확정할 수 있다.
-        비용은 노드 참조 1개 + boolean 1회. -->
         <script>
+            // 하이드레이션 앵커 캡처 — 로그가 아예 없는 실패 경로를 잡기 위한 것.
+            //
+            // ⛔ 이 설명을 HTML 주석으로 쓰지 말 것. HTML 주석은 중첩되지 않아서, 본문에
+            //    닫는 시퀀스가 들어가면 거기서 주석이 끊기고 나머지가 화면에 노출된다.
+            //    실제로 그렇게 유출된 사고가 있었다(bug/13122, 2026-07-28).
+            //    Svelte 마커를 예시로 적어야 할 때는 반드시 JS 주석 안에서만 쓴다.
+            //
+            // Svelte 는 하이드레이션 타깃 안에서 HYDRATION_START 마커(여는 주석 + "[")를
+            // 못 찾으면 throw HYDRATION_ERROR 한다. 그런데 render.js:134 의
+            // `error !== HYDRATION_ERROR` 가 false 라 console 출력이 0 이고, 그대로
+            // clear_text_content(target) 후 조용히 CSR 재마운트된다. 즉 console.warn
+            // 후킹으로도 이 경로는 못 잡는다. 번역 확장이 SSR 마커를 건드리는 경우가
+            // 여기 해당한다. 앵커 노드를 붙잡아 두고 마운트 후 isConnected 를 보면
+            // 폐기 여부를 확정할 수 있다. 비용은 노드 참조 1개 + boolean 1회.
             (function () {
                 try {
                     var target = document.body.firstElementChild;

--- a/scripts/check-html-comments.mjs
+++ b/scripts/check-html-comments.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * HTML 주석 조기 종료 검사.
+ *
+ * HTML 주석은 중첩되지 않는다. 파서는 여는 시퀀스를 만나면 **처음 나오는 닫는 시퀀스**까지를
+ * 주석으로 보고 끊는다. 그래서 주석 본문에 닫는 시퀀스가 들어가면 거기서 주석이 끝나고,
+ * 뒤에 이어지던 설명이 그대로 화면에 렌더된다.
+ *
+ * 실제 사고: 2026-07-28, app.html 의 하이드레이션 앵커 설명 주석에 Svelte 마커를 예시로
+ * 적었다가 모바일 메인 하단에 한글 설명이 통째로 노출됐다(bug/13122). 배포까지 나갔고
+ * 회원 제보로 알았다. 사람 눈으로는 잘 안 걸리는 종류라 기계가 막는다.
+ *
+ * 검사 대상: .html (Svelte 파일의 {# ... } 주석은 이 규칙과 무관)
+ * 종료코드: 위반 1건 이상이면 1
+ */
+import { readFileSync } from 'node:fs';
+import { globSync } from 'node:fs';
+
+const OPEN = '<' + '!--';
+const CLOSE = '--' + '>';
+
+const files = globSync('apps/web/src/**/*.html', { exclude: (p) => p.includes('node_modules') });
+
+let violations = 0;
+
+for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    let i = 0;
+    while (true) {
+        const start = src.indexOf(OPEN, i);
+        if (start === -1) break;
+        const end = src.indexOf(CLOSE, start + OPEN.length);
+        if (end === -1) break;
+
+        const body = src.slice(start + OPEN.length, end);
+        // 주석 본문에 여는 시퀀스가 또 있으면, 이 주석은 의도한 범위보다 일찍 끊긴 것이다.
+        if (body.includes(OPEN)) {
+            const line = src.slice(0, start).split('\n').length;
+            const preview = body.replace(/\s+/g, ' ').trim().slice(0, 70);
+            console.error(
+                `${file}:${line}  주석이 조기 종료됩니다 — 본문에 여는 시퀀스가 중첩되어 있습니다.\n` +
+                    `    ${preview}...\n` +
+                    `    → 설명이 필요하면 <script> 안의 JS 주석으로 옮기세요.`
+            );
+            violations++;
+        }
+        i = end + CLOSE.length;
+    }
+}
+
+if (violations > 0) {
+    console.error(`\n❌ HTML 주석 조기 종료 ${violations}건. 배포되면 화면에 텍스트가 노출됩니다.`);
+    process.exit(1);
+}
+console.log(`✅ HTML 주석 검사 통과 (${files.length}개 파일)`);


### PR DESCRIPTION
## 사고

모바일 메인화면 하단에 한글 설명이 그대로 노출됐습니다. 회원 제보로 알았습니다 — **bug/13122** (같이놀아요님, 10:03).

라이브 확인:
```
)을 못 찾으면 throw HYDRATION_ERROR 하는데, render.js:134 의 error !== HYDRATION_ERROR 가
false 라 **console 출력이 0** 이다. 그대로 clear_text_content(target) 후 조용히 CSR 재마운트된다...
```

## 원인 — HTML 주석은 중첩되지 않습니다

파서는 여는 시퀀스를 만나면 **처음 나오는 닫는 시퀀스**까지를 주석으로 보고 끊습니다.

#1887에서 하이드레이션 앵커 설명을 HTML 주석으로 달면서 Svelte의 HYDRATION_START 마커를 예시로 적었는데, **그 마커 안에 닫는 시퀀스가 들어 있습니다.** 주석이 거기서 종료됐고, 뒤에 이어지던 설명 전체가 본문 텍스트가 됐습니다.

## 수정

**설명을 `<script>` 안의 JS 주석으로 이동.** JS 주석에는 이 제약이 없습니다. 앵커 캡처 로직 자체는 한 글자도 안 바꿨습니다 — **동작 변경 없음**, 순수 주석 이동입니다.

## 재발 방지 — CI 가드

`scripts/check-html-comments.mjs` + CI 잡 `HTML Comment Guard` 추가.

**왜 필요한가**: 이 실수는 리뷰·CI·카나리 SSR 실측을 **전부 통과**해서 운영까지 나갔습니다. 사람 눈으로 `-->`가 문자열 안에 있는지 세는 건 신뢰할 수 없습니다. 기계가 막아야 합니다.

**양방향 검증 완료**
- 수정본 → ✅ 통과
- 사고 커밋(`70a2a272`) → ❌ `app.html:317` 정확히 1건 검출

의존성 설치가 없어 수십 초면 끝나고, 기존 lint 잡과 독립적으로 돕니다.

## 점검 범위

`apps/web/src/**/*.html` 전수 스캔 결과 위험 지점은 **이 한 곳뿐**이었습니다. 다른 파일·테마·위젯은 깨끗합니다.

배포 후 `body` 영역 잔여 텍스트가 `%sveltekit.body%` 플레이스홀더 외에 없음을 확인했습니다.