### PR TITLE
fix(board): 목록 행의 중첩 <a> 제거 — 하이드레이션 실패 근본 원인

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,34 @@ jobs:
       - name: Check HTML comments
         run: node scripts/check-html-comments.mjs
 
+  # 중첩 <a> 검사 — 하이드레이션을 통째로 깨뜨린다.
+  # 2026-07-28: 게시판 목록 행 <a> 안에 댓글수 <a> 가 있어 시간당 회원 약 1,700명이
+  # 하이드레이션 실패를 겪고 있었다(#1040 도입, 관측 부재로 못 보고 있었음).
+  # svelte/compiler AST 로 검사하므로 pnpm install 이 필요하다.
+  nested-anchors:
+    name: Nested Anchor Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: |
+          pnpm fetch --frozen-lockfile
+          pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Check nested anchors
+        run: node scripts/check-nested-anchors.mjs
+
   # 전체 lint는 수동 실행만 허용한다.
   # PR에서는 eslint-review/prettier-suggester가 이미 같은 역할을 맡고,
   # main push에서는 빌드/테스트/배포 경로를 막지 않도록 분리한다.

--- a/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/archive.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { goto } from '$app/navigation';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
@@ -111,12 +112,19 @@
                         {/if}
                     </span>
 
+                    <!-- ⛔ <a> 금지 — 행 전체가 <a class="archive-row"> 안이라 중첩되면
+                         파서가 트리를 재구성해 하이드레이션이 깨진다.
+                         상세 근거는 classic.svelte 의 같은 위치 주석 참조. -->
                     {#if post.comments_count > 0 && !post.is_comments_disabled}
-                        <a
-                            href="{href}#comments"
+                        <button
+                            type="button"
                             class="comment-count shrink-0"
-                            onclick={(e) => e.stopPropagation()}
-                            >{formatCommentCountBadge(post.comments_count)}</a
+                            aria-label="댓글 {post.comments_count}개 보기"
+                            onclick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                void goto(`${href}#comments`);
+                            }}>{formatCommentCountBadge(post.comments_count)}</button
                         >
                     {/if}
                 </div>
@@ -242,6 +250,13 @@
         font-size: 0.85em;
         font-weight: 600;
         color: var(--color-liked, orangered);
+        /* <a> → <button> 교체(2026-07-28) 후 기존 모양 유지용 리셋 */
+        background: none;
+        border: 0;
+        padding: 0;
+        font-family: inherit;
+        line-height: inherit;
+        cursor: pointer;
     }
 
     .mobile-meta {

--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { goto } from '$app/navigation';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import {
         RestrictedBadge,
@@ -249,12 +250,33 @@
                         {:else if hasImage}
                             <ImageIcon class="text-muted-foreground h-3.5 w-3.5 shrink-0" />
                         {/if}
+                        <!--
+                            ⛔ 여기에 <a> 를 쓰지 말 것 (#1040 에서 <a> 였다가 2026-07-28 교체).
+
+                            이 행 전체가 <a class="post-row"> 안이다. <a> 안에 <a> 가 오면
+                            HTML5 파서의 adoption agency algorithm 이 발동해 바깥 <a> 를 복제하고
+                            가장 가까운 블록(제목 줄 div)의 자식을 통째로 그 복제본으로 옮긴다.
+                            그러면 SSR 이 찍은 하이드레이션 마커가 클라이언트가 기대하는 부모와
+                            다른 곳에 놓이고, 하이드레이션이 통째로 실패한다.
+
+                            실측(2026-07-28): 시간당 로그인 회원 약 1,700명이 이 실패를 겪고 있었다.
+                            증상은 화면 깜빡임, 글쓰기 버튼 안 보임, 로그인 상태 잘못 표시.
+                            엔진별로 에러 문구만 다를 뿐(Blink: appendChild HierarchyRequestError,
+                            WebKit: incorrect node tree / null is not an object) 같은 단일 결함이다.
+
+                            button 은 포맷팅 요소가 아니라 adoption agency 대상이 아니다.
+                            (콘텐츠 모델상 여전히 이상적이진 않으나 파서가 트리를 바꾸지 않는다.)
+                        -->
                         {#if post.comments_count > 0 && !post.is_comments_disabled}
-                            <a
-                                href="{href}#comments"
+                            <button
+                                type="button"
                                 class="comment-count shrink-0"
-                                onclick={(e) => e.stopPropagation()}
-                                >{formatCommentCountBadge(post.comments_count)}</a
+                                aria-label="댓글 {post.comments_count}개 보기"
+                                onclick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    void goto(`${href}#comments`);
+                                }}>{formatCommentCountBadge(post.comments_count)}</button
                             >
                         {/if}
                     </span>
@@ -416,6 +438,14 @@
         font-size: 0.85em;
         font-weight: 600;
         color: var(--color-liked, orangered);
+        /* <a> → <button> 교체(2026-07-28) 후에도 기존 모양을 그대로 유지하기 위한 리셋.
+           button 기본 배경·테두리·패딩·폰트상속을 없앤다. */
+        background: none;
+        border: 0;
+        padding: 0;
+        font-family: inherit;
+        line-height: inherit;
+        cursor: pointer;
     }
 
     /* ===== 모바일 전용 요소 (scoped → SSR 청크와 동시 로드, 플래시 방지) ===== */

--- a/scripts/check-nested-anchors.mjs
+++ b/scripts/check-nested-anchors.mjs
@@ -24,7 +24,23 @@
  * 종료코드: 위반 1건 이상이면 1
  */
 import { readFileSync, globSync } from 'node:fs';
-import { parse } from 'svelte/compiler';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+// pnpm 워크스페이스라 svelte 는 저장소 루트가 아니라 apps/web/node_modules 에 있다.
+// 루트에서 `import 'svelte/compiler'` 하면 ERR_MODULE_NOT_FOUND 로 죽는다(실제로 CI 에서 겪음).
+// apps/web 기준으로 해석한 뒤 그 경로를 직접 import 한다.
+const req = createRequire(new URL('../apps/web/package.json', import.meta.url));
+const mod = await import(pathToFileURL(req.resolve('svelte/compiler')).href);
+// svelte/compiler 는 CJS 로 해석되어 default 아래에 실린다. 둘 다 대비한다.
+const parse = mod.parse ?? mod.default?.parse;
+
+// ⛔ 여기서 조용히 넘어가면 안 된다. parse 를 못 얻은 채 통과시키면 "검사했는데 0건"
+//    처럼 보여서, 실제 결함이 있어도 CI 가 초록으로 지나간다. 실제로 초안이 그랬다.
+if (typeof parse !== 'function') {
+    console.error('❌ svelte/compiler 의 parse 를 얻지 못했습니다 — 검사를 수행할 수 없습니다.');
+    process.exit(2);
+}
 
 // 인자로 파일/글롭을 주면 그것만 검사한다(테스트·부분검사용). 없으면 기본 범위.
 const patterns =
@@ -37,6 +53,7 @@ const files = patterns.flatMap((p) =>
 
 let violations = 0;
 let scanned = 0;
+let parseFailed = 0;
 
 /** AST 를 훑으며 <a> 조상 아래의 <a> 를 찾는다. */
 function walk(node, file, src, insideAnchor) {
@@ -73,14 +90,25 @@ for (const file of files) {
     let ast;
     try {
         ast = parse(src, { modern: true });
-    } catch {
-        // 파싱 실패는 이 검사의 관심사가 아니다(svelte-check 가 잡는다). 건너뛴다.
+    } catch (e) {
+        // 파싱 실패를 조용히 넘기지 않는다. 못 본 파일은 "검사한 것"이 아니다.
+        console.error(`⚠️  ${file}: 파싱 실패 — ${String(e).slice(0, 120)}`);
+        parseFailed++;
         continue;
     }
     scanned++;
     walk(ast.fragment, file, src, false);
 }
 
+// 검사 대상이 하나도 없으면 글롭이 어긋났다는 뜻이다. 통과로 위장하면 안 된다.
+if (scanned === 0) {
+    console.error(`❌ 검사한 파일이 0개입니다 (대상 ${files.length}개). 경로·글롭을 확인하세요.`);
+    process.exit(2);
+}
+if (parseFailed > 0) {
+    console.error(`❌ 파싱 실패 ${parseFailed}건 — 그 파일들은 검사되지 않았습니다.`);
+    process.exit(2);
+}
 if (violations > 0) {
     console.error(`\n❌ 중첩 <a> ${violations}건. 배포되면 하이드레이션이 실패합니다.`);
     process.exit(1);

--- a/scripts/check-nested-anchors.mjs
+++ b/scripts/check-nested-anchors.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * 중첩 <a> 검사 — 하이드레이션을 통째로 깨뜨리는 결함을 막는다.
+ *
+ * 왜 필요한가 (2026-07-28 실측):
+ *   게시판 목록 행이 <a class="post-row"> 로 감싸여 있는데, 그 안에 댓글수 링크가
+ *   또 <a> 로 들어 있었다(#1040 도입). HTML5 파서는 <a> 안의 <a> 를 만나면 adoption
+ *   agency algorithm 을 실행해 바깥 <a> 를 복제하고 가장 가까운 블록의 자식들을 그
+ *   복제본으로 옮긴다. SSR 이 찍은 하이드레이션 마커가 클라이언트가 기대하는 부모와
+ *   달라지고, 하이드레이션이 실패한다.
+ *
+ *   피해: 시간당 로그인 회원 약 1,700명. 화면 깜빡임, 글쓰기 버튼 안 보임, 로그인 상태
+ *   잘못 표시. 엔진별로 에러 문구만 다를 뿐 같은 결함이었다.
+ *   무엇보다 **관측되지 않았다** — 후킹 채널이 틀려 14일간 0건으로 보였고 제보로만 알았다.
+ *
+ * ⛔ 정규식으로 세지 않는다. Svelte 의 {#if}/{#each} 분기를 넘나드는 태그를 선형
+ *    스캔으로 세면 depth 가 어긋나 오탐이 쏟아진다(초안이 실제로 61건 오탐).
+ *    svelte/compiler 의 parse() AST 를 쓴다 — 분기 구조를 정확히 이해한다.
+ *
+ * 한계 (정직하게):
+ *   컴포넌트 경계를 넘는 중첩(부모가 <a> 로 감싸고 자식 컴포넌트가 <a> 를 렌더)은
+ *   못 잡는다. 그건 SSR 산출물 검사로만 가능하고 별도 과제다.
+ *
+ * 종료코드: 위반 1건 이상이면 1
+ */
+import { readFileSync, globSync } from 'node:fs';
+import { parse } from 'svelte/compiler';
+
+// 인자로 파일/글롭을 주면 그것만 검사한다(테스트·부분검사용). 없으면 기본 범위.
+const patterns =
+    process.argv.length > 2
+        ? process.argv.slice(2)
+        : ['apps/web/src/**/*.svelte', 'themes/**/*.svelte', 'widgets/**/*.svelte'];
+const files = patterns.flatMap((p) =>
+    p.includes('*') ? globSync(p, { exclude: (x) => x.includes('node_modules') }) : [p]
+);
+
+let violations = 0;
+let scanned = 0;
+
+/** AST 를 훑으며 <a> 조상 아래의 <a> 를 찾는다. */
+function walk(node, file, src, insideAnchor) {
+    if (!node || typeof node !== 'object') return;
+
+    const isAnchor = node.type === 'RegularElement' && node.name === 'a';
+
+    if (isAnchor && insideAnchor) {
+        const line = src.slice(0, node.start).split('\n').length;
+        const ctx = src.slice(node.start, node.start + 70).replace(/\s+/g, ' ').trim();
+        console.error(
+            `${file}:${line}  <a> 안에 <a> 가 중첩되어 있습니다.\n` +
+                `    ${ctx}...\n` +
+                `    → 파서가 트리를 재구성해 하이드레이션이 깨집니다.\n` +
+                `    → 안쪽을 <button type="button"> + goto() 로 바꾸세요.`
+        );
+        violations++;
+    }
+
+    const nowInside = insideAnchor || isAnchor;
+    for (const key of Object.keys(node)) {
+        if (key === 'parent') continue;
+        const v = node[key];
+        if (Array.isArray(v)) {
+            for (const c of v) walk(c, file, src, nowInside);
+        } else if (v && typeof v === 'object' && 'type' in v) {
+            walk(v, file, src, nowInside);
+        }
+    }
+}
+
+for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    let ast;
+    try {
+        ast = parse(src, { modern: true });
+    } catch {
+        // 파싱 실패는 이 검사의 관심사가 아니다(svelte-check 가 잡는다). 건너뛴다.
+        continue;
+    }
+    scanned++;
+    walk(ast.fragment, file, src, false);
+}
+
+if (violations > 0) {
+    console.error(`\n❌ 중첩 <a> ${violations}건. 배포되면 하이드레이션이 실패합니다.`);
+    process.exit(1);
+}
+console.log(`✅ 중첩 <a> 검사 통과 (${scanned}개 파일)`);


### PR DESCRIPTION
## 규모

**시간당 로그인 회원 약 1,700명**이 하이드레이션 실패를 겪고 있었습니다. 오늘 관측 채널을 고치기 전까지 14일간 **0건**으로 보였고, 회원 제보로만 알 수 있었습니다.

## 원인 — 중첩 `<a>`

행 전체가 `<a class="post-row">`인데 그 안에 댓글수 링크가 또 `<a>`였습니다(#1040 도입).

HTML5 파서는 `<a>` 안의 `<a>`를 만나면 **adoption agency algorithm**을 실행해 바깥 `<a>`를 복제하고 **가장 가까운 블록의 자식을 통째로 복제본으로 옮깁니다.** SSR이 찍은 하이드레이션 마커가 클라이언트가 기대하는 부모와 달라지고, 하이드레이션이 통째로 실패합니다.

운영 `/free` HTML 실측에서 중첩 `<a>` **13건** 확인, 전부 댓글수 배지였습니다.

## 엔진별로 문구만 다른 단일 결함

| 엔진 | 에러 | 영향 회원 |
|---|---|---:|
| Blink | `appendChild HierarchyRequestError` | 2,032 |
| WebKit | `incorrect node tree` / `null is not an object` | 2,294 |

**Safari가 1위인 것은 인과가 아닙니다** — damoang의 1위 브라우저이기 때문입니다(iOS는 엔진이 WebKit뿐이고 인앱 웹뷰도 이 버킷). 실패율에 브라우저 편중은 없습니다.

## 사용자 체감 — 오늘 아침 제보와 일치

실패하면 `clear_text_content(target)`로 SSR DOM을 통째로 버리고 CSR 재마운트합니다.

- 화면이 한 번 비었다 다시 그려짐 → **"깜빡임"**
- `syncAuth`가 `onMount`에서만 호출되므로 재마운트 순간 로그아웃 상태 → **"글쓰기 버튼이 안 보임", "로그아웃 버튼이 없음"**
- 스크롤 위치 소실
- **SSR 이득 0** (서버 비용만 지출)

## 수정

댓글수를 `<button type="button">` + `goto`로 교체. **button은 포맷팅 요소가 아니라 adoption agency 대상이 아닙니다.**

`.comment-count` 스타일은 클래스 기준이라 button 기본 스타일만 리셋하면 **모양이 동일**합니다. `aria-label`도 추가했습니다.

## 재발 방지 — CI 가드

`scripts/check-nested-anchors.mjs` + CI 잡 `Nested Anchor Guard`.

⛔ **정규식으로 세지 않습니다.** Svelte의 `{#if}`/`{#each}`를 넘나드는 태그를 선형 스캔하면 depth가 어긋나 오탐이 쏟아집니다 — **초안이 실제로 61건 오탐**을 냈습니다. `svelte/compiler` AST로 검사합니다.

**검증**
- 수정 전 파일 → 검출 ✓
- 수정 후 → 통과 ✓
- 전체 스캔(`apps/web/src/**`) → 오탐 **0**, 검출은 이 2개 파일뿐 ✓

## 한계 (정직하게)

- 컴포넌트 경계를 넘는 중첩(부모가 `<a>`로 감싸고 자식 컴포넌트가 `<a>` 렌더)은 못 잡습니다. SSR 산출물 검사 영역이고 별건입니다
- `<button>` in `<a>`도 콘텐츠 모델상 이상적이진 않으나, **파서가 트리를 바꾸지 않아** 이 결함은 해소됩니다
- ⌘+클릭 새 탭 기능은 잃습니다(같은 글의 fragment 링크라 SEO 영향 없음)

## 2차 원인 (이 PR 범위 밖)

`localStorage` 기반 `angple_ui_settings`가 하이드레이션 **전에** 적용되어 SSR과 다른 `{#each}` 길이·`{#if}` 분기를 만듭니다(`isMuted`, `hideReadNotices`, `listView`, `hideMyProfile`). Svelte가 우아하게 복구하지만 실패 확률을 올립니다. 쿠키 미러링으로 옮기는 것이 근본이며 별도 PR로 다루겠습니다.