### PR TITLE
fix(search): 검색 결과에 썸네일이 안 나오는 문제 (bug/13130)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -13,6 +13,10 @@ import { fetchMemberImagesWithTimestamp } from '$lib/server/member-images.js';
 import { fetchWithdrawnMemberIds } from '$lib/server/withdrawn-members.js';
 import { fetchScheduledDeletes } from '$lib/server/scheduled-deletes.js';
 import { createCache } from '$lib/server/cache.js';
+// 검색 결과 썸네일 파생용 (bug/13130). Go 의 TransformToV1Post 와 같은 규칙을 재현한다.
+import { normalizeMediaUrl } from '$lib/utils/media-url.js';
+import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
+import { extractFirstImage } from '$lib/components/features/adult/thumbnail-utils.js';
 import { getCachedBoard, resolveCanonicalBoardId } from '$lib/server/board-cache.js';
 import { resolveGivingMeta } from '$lib/features/giving/model.js';
 import { searchByBoard } from '$lib/server/sphinx-search.js';
@@ -510,7 +514,8 @@ export const load: PageServerLoad = async ({
                                 wr_option,
                                 (wr_deleted_at IS NOT NULL AND wr_deleted_at <> '0000-00-00 00:00:00') AS is_deleted_parent,
                                 wr_1 AS extra_1, wr_2 AS extra_2, wr_3 AS extra_3,
-                                wr_4 AS extra_4, wr_5 AS extra_5, wr_6 AS extra_6, wr_7 AS extra_7
+                                wr_4 AS extra_4, wr_5 AS extra_5, wr_6 AS extra_6, wr_7 AS extra_7,
+                                wr_9 AS extra_9, wr_10 AS extra_10, wr_file
                          FROM ${tableName}
                          WHERE wr_id IN (${ph}) AND wr_is_comment = 0
                            ${
@@ -543,6 +548,25 @@ export const load: PageServerLoad = async ({
                     rows.map((r) => {
                         const deleted = Number(r.is_deleted_parent) === 1;
                         const disciplined = disciplinedIds.has(Number(r.id));
+                        const masked = deleted || disciplined;
+
+                        // 썸네일 파생 — Go 의 TransformToV1Post(transform.go:203-243) 와 같은 규칙.
+                        //
+                        // 검색은 Go 백엔드를 타지 않고 여기서 DB 를 직접 읽는데, 그동안 이 계산이
+                        // 없어서 썸네일을 쓰는 게시판(앙지도 등)은 검색 결과에서 이미지가 통째로
+                        // 사라졌다(bug/13130). 레이아웃은 평소와 같은 컴포넌트를 쓰므로
+                        // 필드만 채우면 된다.
+                        //
+                        // 우선순위: wr_10(지정 썸네일) > 본문 첫 <img>
+                        // ⛔ 마스킹된 글은 썸네일도 비운다. 제목·본문만 가리고 이미지를 남기면
+                        //    삭제·이용제한 마스킹이 그림으로 우회된다.
+                        const rawThumb = masked
+                            ? ''
+                            : String(r.extra_10 || '') ||
+                              extractFirstImage(String(r.content || '')) ||
+                              '';
+                        const normalizedThumb = rawThumb ? normalizeMediaUrl(rawThumb) : '';
+
                         return [
                             r.id,
                             {
@@ -552,8 +576,15 @@ export const load: PageServerLoad = async ({
                                     : disciplined
                                       ? DISCIPLINED_TITLE
                                       : r.title,
-                                content: deleted || disciplined ? '' : r.content,
-                                is_notice: noticeIds.has(Number(r.id))
+                                content: masked ? '' : r.content,
+                                is_notice: noticeIds.has(Number(r.id)),
+                                thumbnail_raw: normalizedThumb,
+                                thumbnail: normalizedThumb
+                                    ? toThumbnailUrl(normalizedThumb, '400x225')
+                                    : '',
+                                has_file: Number(r.wr_file) > 0,
+                                has_image: !masked && (Number(r.wr_file) > 0 || !!r.extra_10),
+                                has_video: !masked && !!r.extra_9
                             }
                         ];
                     })


### PR DESCRIPTION
## 제보

**bug/13130** (마음은청춘) — "앙지도에 등록된 속초 맛집을 검색하니 검색 결과에 썸네일이 안 나옵니다."

## 원인 — 검색은 Go 백엔드를 타지 않습니다

| | 평소 목록 | 검색 |
|---|---|---|
| 경로 | Go `/api/v1/boards/{id}/posts` | Sphinx(ID만) → SvelteKit이 DB 직조회 |
| 썸네일 | `TransformToV1Post`가 파생 | **컬럼도 없고 로직도 없음** |

Go의 `transform.go:203-243`은 **`wr_10` 우선, 없으면 본문 첫 `<img>` 파싱**으로 `thumbnail`/`thumbnail_raw`를 만듭니다. 그런데 검색 경로(`fetchPostsViaSphinx`)의 SELECT에는 `wr_10`이 아예 없습니다.

레이아웃은 **평소와 같은 컴포넌트**를 씁니다(`post.thumbnail_raw || post.thumbnail || post.images?.[0]`). 세 필드가 전부 undefined → `showThumbnail === false` → 이미지 영역이 안 그려집니다.

## 앙지도 고유 문제가 아닙니다

썸네일을 쓰는 게시판(`detailed`/`webzine`/`card`/`gallery`/`message`/`giving`/`trade`/`poster-gallery`) **전부** 같은 증상입니다. `classic` 계열(free 등)은 원래 썸네일이 없어 드러나지 않았을 뿐입니다.

## 수정

SELECT에 `wr_9`·`wr_10`·`wr_file` 추가 + Go와 동일한 파생 로직:

```
thumbnail_raw / thumbnail / has_file / has_image / has_video
```

**기존 유틸을 재사용**했습니다 — `normalizeMediaUrl`, `toThumbnailUrl`, `extractFirstImage`. 새로 만들지 않았습니다.

## ⛔ 보안 — 마스킹 우회 차단

삭제글·이용제한글은 제목과 본문을 가리는데, **이미지를 남기면 마스킹이 그림으로 우회**됩니다. `masked` 플래그로 썸네일·`has_image`·`has_video`를 함께 비웁니다.

이게 이 수정의 유일한 실질 리스크 지점이라 명시적으로 처리했습니다.

## 회귀 위험

- 변경은 **`isSearching` 분기 안쪽뿐** — 평소 목록 경로(트래픽 대부분)는 1바이트도 안 바뀝니다
- `fetchPostsViaGoBackend()` 폴백 경로 무변경
- `trimFreeListPayload`는 `thumbnail`을 이미 보존하고, 트림 대상은 classic 계열(썸네일 미표시)이라 무해
- **Go 백엔드 수정 불필요** — 검색은 Go를 호출조차 하지 않습니다

## 확인 방법

앙지도에서 검색 후 결과에 썸네일이 나오는지, 그리고 free 등 classic 게시판 검색 결과가 그대로인지.