### PR TITLE
feat(editor): 첫 글자 입력 시 작성 매너 풍선 (하루 1회)

### DIFF
--- a/apps/web/src/lib/components/features/editor/manner-tip.svelte
+++ b/apps/web/src/lib/components/features/editor/manner-tip.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+    /**
+     * 작성 매너 안내 풍선.
+     *
+     * placeholder 가 사라지는 순간 — 즉 회원이 첫 글자를 입력한 순간 — 에디터 위에
+     * 잠깐 떠올랐다 사라진다.
+     *
+     * 왜 이 타이밍인가:
+     *   - placeholder 는 항상 거기 있어서 배경이 된다. 읽히지 않는다.
+     *   - 에디터 클릭 진입 시 띄우면 쓰려는 사람을 막는다. 모바일은 키보드가
+     *     올라오는 순간과 겹쳐 더 나쁘다.
+     *   - 첫 글자를 친 순간은 "쓰기 시작했다"는 확실한 신호이면서, 아직 문장을
+     *     짓기 전이라 방해가 가장 적다.
+     *
+     * ⛔ 규제가 아니라 안내다. 막지 않고, 검사하지 않고, 되돌리지 않는다.
+     *    비속어 판단은 회원 스스로 한다(2026-07-28 방침).
+     *
+     * 표시 규칙:
+     *   - 하루 1회. 매번 뜨면 사흘이면 아무도 안 본다.
+     *   - 문구는 번갈아 하나씩. 둘을 동시에 띄우면 둘 다 안 읽힌다.
+     *   - 3초 후 자동 소멸. 나타남 0.3초 / 사라짐 0.5초로 놀라지 않게.
+     */
+    import { onMount } from 'svelte';
+    import { browser } from '$app/environment';
+
+    const STORAGE_KEY = 'angple_manner_tip';
+    const SHOW_MS = 3000;
+
+    const TIPS = ['경어체 사용해 주세앙 🙏', '초성 포함 욕설 안돼앙 🙅'] as const;
+
+    let { show = false }: { show?: boolean } = $props();
+
+    let visible = $state(false);
+    let message = $state('');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    /** 오늘 이미 보여줬는지 + 다음에 보여줄 문구 index */
+    function readState(): { date: string; next: number } {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) {
+                const p = JSON.parse(raw);
+                if (typeof p?.date === 'string' && typeof p?.next === 'number') return p;
+            }
+        } catch {
+            // 파싱 실패는 "처음 보는 것"으로 취급한다
+        }
+        return { date: '', next: 0 };
+    }
+
+    function todayKST(): string {
+        // 한국 기준 날짜. UTC 로 계산하면 오전 9시에 날짜가 바뀐다.
+        return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    }
+
+    function maybeShow() {
+        if (!browser || visible) return;
+
+        const today = todayKST();
+        const st = readState();
+        if (st.date === today) return; // 오늘 이미 봤다
+
+        message = TIPS[st.next % TIPS.length];
+        visible = true;
+
+        try {
+            localStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify({ date: today, next: (st.next + 1) % TIPS.length })
+            );
+        } catch {
+            // 저장 실패해도 이번 한 번은 보여준다. 다음에 또 뜰 뿐 해가 없다.
+        }
+
+        clearTimeout(timer);
+        timer = setTimeout(() => (visible = false), SHOW_MS);
+    }
+
+    // show 가 false → true 로 바뀌는 순간에만 발화한다.
+    let prevShow = false;
+    $effect(() => {
+        if (show && !prevShow) maybeShow();
+        prevShow = show;
+    });
+
+    onMount(() => () => clearTimeout(timer));
+</script>
+
+{#if visible}
+    <!--
+        aria-live=polite: 스크린리더에게 현재 작업(입력)을 끊지 말고 알리게 한다.
+        pointer-events-none: 풍선이 클릭을 가로채지 않는다. 글쓰기를 절대 방해하지 않는다.
+    -->
+    <div
+        class="manner-tip pointer-events-none absolute left-1/2 top-2 z-20 -translate-x-1/2"
+        role="status"
+        aria-live="polite"
+    >
+        <div
+            class="bg-primary text-primary-foreground whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium shadow-lg"
+        >
+            {message}
+        </div>
+        <div class="manner-tip-tail" aria-hidden="true"></div>
+    </div>
+{/if}
+
+<style>
+    .manner-tip {
+        animation:
+            manner-tip-in 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+            manner-tip-out 0.5s ease-in forwards;
+        /* 3초 뒤부터 사라지기 시작 — SHOW_MS 와 맞춘다 */
+        animation-delay: 0s, 2.5s;
+    }
+
+    /* 말풍선 꼬리 */
+    .manner-tip-tail {
+        width: 0;
+        height: 0;
+        margin: -1px auto 0;
+        border-left: 6px solid transparent;
+        border-right: 6px solid transparent;
+        border-top: 7px solid var(--color-primary, #f59e0b);
+    }
+
+    @keyframes manner-tip-in {
+        from {
+            opacity: 0;
+            transform: translate(-50%, 8px) scale(0.92);
+        }
+        to {
+            opacity: 1;
+            transform: translate(-50%, 0) scale(1);
+        }
+    }
+
+    @keyframes manner-tip-out {
+        to {
+            opacity: 0;
+            transform: translate(-50%, -6px);
+        }
+    }
+
+    /* 움직임을 줄이도록 설정한 사용자에게는 애니메이션 없이 보여준다 */
+    @media (prefers-reduced-motion: reduce) {
+        .manner-tip {
+            animation: none;
+        }
+    }
+</style>

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -75,6 +75,7 @@
     import HashIcon from '@lucide/svelte/icons/hash';
     import SmileIcon from '@lucide/svelte/icons/smile';
     import type { Component } from 'svelte';
+    import MannerTip from './manner-tip.svelte';
 
     interface Props {
         content?: string;
@@ -147,6 +148,8 @@
     let rawContent = $state(''); // 마크다운/HTML 직접 편집용
 
     let editorElement: HTMLDivElement;
+    /** 이 에디터에서 첫 글자를 입력했는가 — 작성 매너 풍선 발화 신호 */
+    let hasTyped = $state(false);
     let editor: Editor | null = $state(null);
 
     // 툴바 상태 (reactive하게 추적)
@@ -355,10 +358,15 @@
             },
             onUpdate: ({ editor: ed }) => {
                 onUpdate?.(ed.getHTML());
+                // 첫 글자가 들어온 순간 = placeholder 가 사라지는 순간.
+                // 이때 작성 매너 풍선을 띄운다(하루 1회). manner-tip.svelte 주석 참조.
+                // 트랜잭션 밖에서 바꿔야 state_unsafe_mutation 이 안 난다 — 아래 setTimeout 안에서 처리.
                 // Svelte $state 변경은 Tiptap 트랜잭션 밖에서 실행 (state_unsafe_mutation 방지)
                 setTimeout(() => {
                     updateActiveState();
                     updateCounts(ed);
+                    // 빈 문서 → 내용 있음으로 처음 바뀌는 순간에만 true 가 된다.
+                    if (!hasTyped && !ed.isEmpty) hasTyped = true;
                 }, 0);
             },
             onSelectionUpdate: () => {
@@ -1707,15 +1715,24 @@
 
     <!-- 에디터 영역 -->
     <!-- WYSIWYG: hidden 속성으로 표시/숨김 (DOM 유지 — TipTap 에디터가 참조하는 요소 파괴 방지) -->
-    <div
-        class="tiptap-content min-h-[300px] p-4"
-        class:uploading={isUploading}
-        hidden={editorMode !== 'wysiwyg'}
-        bind:this={editorElement}
-        ondrop={handleDrop}
-        ondragover={(e) => e.preventDefault()}
-        onpaste={handlePaste}
-    ></div>
+    <!--
+        relative 래퍼: 작성 매너 풍선의 기준점. 에디터 본문 상단에 뜨게 하려면
+        .tiptap-editor(툴바 포함) 가 아니라 본문 영역이 기준이어야 한다.
+        ⛔ 에디터 CSS 는 전부 `.tiptap-content .tiptap` 하위 선택자라 이 래퍼는 영향 없다.
+        ⛔ TipTap 이 참조하는 것은 editorElement 자신이지 부모가 아니다.
+    -->
+    <div class="relative">
+        <MannerTip show={hasTyped} />
+        <div
+            class="tiptap-content min-h-[300px] p-4"
+            class:uploading={isUploading}
+            hidden={editorMode !== 'wysiwyg'}
+            bind:this={editorElement}
+            ondrop={handleDrop}
+            ondragover={(e) => e.preventDefault()}
+            onpaste={handlePaste}
+        ></div>
+    </div>
     {#if editorMode !== 'wysiwyg'}
         <!-- 마크다운/HTML 텍스트 에디터 -->
         <textarea


### PR DESCRIPTION
## 왜

에디터 placeholder에 이미 안내가 있지만 **항상 거기 있어서 배경이 됩니다.** 읽히지 않습니다.

그렇다고 클릭 진입 시 오버레이를 띄우면 쓰려는 사람을 막고, 모바일은 **키보드가 올라오는 순간과 겹쳐** 더 나쁩니다.

## 무엇을

**첫 글자가 들어온 순간** — placeholder가 사라지는 그 순간 — 에디터 본문 상단에 말풍선이 잠깐 떠올랐다 사라집니다.

```
      ╭─────────────────────────╮
      │ 경어체 사용해 주세앙 🙏  │
      ╰──────────▽──────────────╯
     ┌───────────────────────────┐
     │ 안녕하▏                    │  ← 방금 첫 글자를 침
```

"쓰기 시작했다"는 확실한 신호이면서, **아직 문장을 짓기 전이라 방해가 가장 적은** 타이밍입니다.

## ⛔ 규제가 아니라 안내입니다

**막지 않고, 검사하지 않고, 되돌리지 않습니다.** 비속어 판단은 회원 스스로 합니다. 필터를 붙이는 게 아니라 분위기만 만듭니다.

## 표시 규칙

| | |
|---|---|
| 빈도 | **하루 1회** (KST 기준) — 매번 뜨면 사흘이면 아무도 안 봄 |
| 문구 | **번갈아 하나씩** — 둘을 동시에 띄우면 둘 다 안 읽힘 |
| 시간 | 3초 후 자동 소멸 (나타남 0.3s / 사라짐 0.5s 페이드) |
| 접근성 | `prefers-reduced-motion` 이면 애니메이션 없이 표시, `aria-live=polite` |

## 방해하지 않기 위한 장치

- **`pointer-events-none`** — 클릭을 가로채지 않습니다. 툴바 버튼도 그대로 눌립니다
- **`absolute`** — 레이아웃을 밀지 않습니다. 글쓰기 영역이 움직이지 않습니다
- **하루 1회** — 같은 세션에서 여러 글을 써도 한 번만

## 구현 메모

**`.tiptap-content`를 `relative` 래퍼로 감쌌습니다.** 풍선 기준점이 툴바 포함 전체가 아니라 본문 영역이어야 하기 때문입니다.

안전 근거:
- 에디터 CSS는 전부 `.tiptap-content .tiptap` **하위 선택자** — 부모 래퍼 무영향
- TipTap이 참조하는 건 `editorElement` **자신**이지 부모가 아님

**`hasTyped`는 `onUpdate`의 `setTimeout` 안에서 변경**합니다 — 기존 `updateActiveState`와 같은 규약이고 `state_unsafe_mutation`을 피합니다.

`localStorage` 파싱·저장 실패는 조용히 넘깁니다. 최악이 "다음에 또 뜸"이라 무해합니다.

## 확인 방법

1. 글쓰기 진입 → 첫 글자 입력 → 풍선이 뜨는지
2. 3초 후 사라지는지, 글쓰기가 안 밀리는지
3. 같은 날 다시 글쓰기 → **안 떠야 함**
4. `localStorage.removeItem('angple_manner_tip')` 후 재시도 → 다른 문구가 떠야 함