### PR TITLE
feat(editor): 댓글 입력창에도 작성 매너 풍선 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-editor.svelte
+++ b/apps/web/src/lib/components/features/board/comment-editor.svelte
@@ -10,6 +10,7 @@
     import Mention from '@tiptap/extension-mention';
     import { mentionSuggestion } from '$lib/components/features/editor/mention-suggestion';
     import { watchCommentInput, stopWatch } from '$lib/services/comment-input-telemetry';
+    import MannerTip from '$lib/components/features/editor/manner-tip.svelte';
     import Bold from '@lucide/svelte/icons/bold';
     import Italic from '@lucide/svelte/icons/italic';
 
@@ -34,6 +35,8 @@
     }: Props = $props();
 
     let editorElement = $state<HTMLDivElement | null>(null);
+    /** 이 에디터에서 첫 글자를 입력했는가 — 작성 매너 풍선 발화 신호 */
+    let hasTyped = $state(false);
     let editor: Editor | null = null;
     let isBold = $state(false);
     let isItalic = $state(false);
@@ -115,6 +118,12 @@
             },
             onUpdate: ({ editor: e }) => {
                 onUpdate?.(e.getHTML());
+                // 첫 글자가 들어온 순간 작성 매너 풍선을 띄운다(하루 1회, 글쓰기와 공유).
+                // ProseMirror 트랜잭션 중 $state 를 바꾸면 state_unsafe_mutation 이 나므로
+                // 아래 onTransaction 과 같은 규약으로 트랜잭션 밖에서 처리한다.
+                if (!hasTyped && !e.isEmpty) {
+                    setTimeout(() => (hasTyped = true), 0);
+                }
             },
             onFocus: () => {
                 // #12939/#13045 — 작성 중 키보드가 내려가는 현상 진단.
@@ -216,7 +225,15 @@
             <Italic class="size-3.5" />
         </button>
     </div>
-    <div bind:this={editorElement}></div>
+    <!--
+        작성 매너 풍선 — 첫 글자 입력 시 댓글 입력창 위에 잠깐 떠오른다(하루 1회).
+        relative 래퍼가 기준점. absolute + pointer-events-none 이라 레이아웃도
+        클릭도 방해하지 않는다.
+    -->
+    <div class="relative">
+        <MannerTip show={hasTyped} placement="above" />
+        <div bind:this={editorElement}></div>
+    </div>
 </div>
 
 <style>

--- a/apps/web/src/lib/components/features/editor/manner-tip.svelte
+++ b/apps/web/src/lib/components/features/editor/manner-tip.svelte
@@ -17,16 +17,20 @@
      *
      * 표시 규칙:
      *   - 하루 1회. 매번 뜨면 사흘이면 아무도 안 본다.
-     *   - 문구는 번갈아 하나씩. 둘을 동시에 띄우면 둘 다 안 읽힌다.
-     *   - 3초 후 자동 소멸. 나타남 0.3초 / 사라짐 0.5초로 놀라지 않게.
+     *   - 두 문구를 함께, 앙모지와 같이 보여준다.
+     *   - 6초 후 자동 소멸. 나타남 0.3초 / 사라짐 0.6초로 놀라지 않게.
+     *     (처음엔 3초·한 문구씩이었는데 "너무 빨리 사라진다"는 확인으로 늘렸다.
+     *      읽을 것이 두 줄로 늘었으니 그만큼 더 필요하다.)
      */
     import { onMount } from 'svelte';
     import { browser } from '$app/environment';
 
     const STORAGE_KEY = 'angple_manner_tip';
-    const SHOW_MS = 3000;
+    const SHOW_MS = 6000;
 
-    const TIPS = ['경어체 사용해 주세앙 🙏', '초성 포함 욕설 안돼앙 🙅'] as const;
+    const TIPS = ['경어체 사용해 주세앙 🙏', '초성 포함 비속어 안돼앙 🙅'] as const;
+    /** 앙모지 — 안내가 잔소리로 읽히지 않게 하는 장치 */
+    const EMOJI_SRC = '/emoticons/DINKIssTyle-3d-ang-033.webp';
 
     /**
      * placement
@@ -38,21 +42,23 @@
         $props();
 
     let visible = $state(false);
-    let message = $state('');
     let timer: ReturnType<typeof setTimeout> | undefined;
 
-    /** 오늘 이미 보여줬는지 + 다음에 보여줄 문구 index */
-    function readState(): { date: string; next: number } {
+    /** 마지막으로 보여준 날짜(KST). 값이 없거나 깨졌으면 "처음 보는 것"으로 취급한다. */
+    function lastShownDate(): string {
         try {
             const raw = localStorage.getItem(STORAGE_KEY);
-            if (raw) {
+            if (!raw) return '';
+            // 과거에는 {date, next} 객체였다. 두 문구를 함께 띄우면서 next 가 필요 없어졌지만
+            // 이미 저장된 값이 있는 사용자를 위해 두 형태를 모두 읽는다.
+            if (raw.startsWith('{')) {
                 const p = JSON.parse(raw);
-                if (typeof p?.date === 'string' && typeof p?.next === 'number') return p;
+                return typeof p?.date === 'string' ? p.date : '';
             }
+            return raw;
         } catch {
-            // 파싱 실패는 "처음 보는 것"으로 취급한다
+            return '';
         }
-        return { date: '', next: 0 };
     }
 
     function todayKST(): string {
@@ -64,17 +70,12 @@
         if (!browser || visible) return;
 
         const today = todayKST();
-        const st = readState();
-        if (st.date === today) return; // 오늘 이미 봤다
+        if (lastShownDate() === today) return; // 오늘 이미 봤다
 
-        message = TIPS[st.next % TIPS.length];
         visible = true;
 
         try {
-            localStorage.setItem(
-                STORAGE_KEY,
-                JSON.stringify({ date: today, next: (st.next + 1) % TIPS.length })
-            );
+            localStorage.setItem(STORAGE_KEY, today);
         } catch {
             // 저장 실패해도 이번 한 번은 보여준다. 다음에 또 뜰 뿐 해가 없다.
         }
@@ -101,15 +102,28 @@
     <div
         class="manner-tip pointer-events-none absolute left-1/2 z-20 -translate-x-1/2 {placement ===
         'above'
-            ? '-top-11'
+            ? '-top-20'
             : 'top-2'}"
         role="status"
         aria-live="polite"
     >
         <div
-            class="bg-primary text-primary-foreground whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium shadow-lg"
+            class="bg-primary text-primary-foreground flex items-center gap-2.5 rounded-2xl py-2 pl-2.5 pr-4 shadow-lg"
         >
-            {message}
+            <!-- width/height 를 명시해 이미지 로드 전후로 풍선 크기가 흔들리지 않게 한다 -->
+            <img
+                src={EMOJI_SRC}
+                alt=""
+                width="44"
+                height="44"
+                class="h-11 w-11 shrink-0 object-contain"
+                aria-hidden="true"
+            />
+            <div class="flex flex-col gap-0.5 whitespace-nowrap text-sm font-medium leading-snug">
+                {#each TIPS as tip (tip)}
+                    <span>{tip}</span>
+                {/each}
+            </div>
         </div>
         <div class="manner-tip-tail" aria-hidden="true"></div>
     </div>
@@ -119,9 +133,10 @@
     .manner-tip {
         animation:
             manner-tip-in 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
-            manner-tip-out 0.5s ease-in forwards;
-        /* 3초 뒤부터 사라지기 시작 — SHOW_MS 와 맞춘다 */
-        animation-delay: 0s, 2.5s;
+            manner-tip-out 0.6s ease-in forwards;
+        /* SHOW_MS(6s) 에 맞춰 5.4s 부터 사라지기 시작해 6s 에 완전히 사라진다.
+           이 값을 바꾸면 스크립트의 SHOW_MS 도 함께 바꿔야 한다. */
+        animation-delay: 0s, 5.4s;
     }
 
     /* 말풍선 꼬리 */

--- a/apps/web/src/lib/components/features/editor/manner-tip.svelte
+++ b/apps/web/src/lib/components/features/editor/manner-tip.svelte
@@ -28,7 +28,14 @@
 
     const TIPS = ['경어체 사용해 주세앙 🙏', '초성 포함 욕설 안돼앙 🙅'] as const;
 
-    let { show = false }: { show?: boolean } = $props();
+    /**
+     * placement
+     *   'inside' — 입력 영역 안쪽 상단. 글쓰기처럼 높이가 넉넉한 곳에 쓴다.
+     *   'above'  — 입력 영역 바깥 위. 댓글처럼 입력창이 낮아 안쪽에 띄우면
+     *              방금 친 글자를 가리는 곳에 쓴다.
+     */
+    let { show = false, placement = 'inside' }: { show?: boolean; placement?: 'inside' | 'above' } =
+        $props();
 
     let visible = $state(false);
     let message = $state('');
@@ -92,7 +99,10 @@
         pointer-events-none: 풍선이 클릭을 가로채지 않는다. 글쓰기를 절대 방해하지 않는다.
     -->
     <div
-        class="manner-tip pointer-events-none absolute left-1/2 top-2 z-20 -translate-x-1/2"
+        class="manner-tip pointer-events-none absolute left-1/2 z-20 -translate-x-1/2 {placement ===
+        'above'
+            ? '-top-11'
+            : 'top-2'}"
         role="status"
         aria-live="polite"
     >


### PR DESCRIPTION
## 왜

#1891에서 글쓰기 에디터에만 붙였는데, **댓글에서는 안 뜬다는 확인**이 있었습니다.

댓글이 `tiptap-editor`가 아니라 **별도 컴포넌트**(`comment-editor.svelte`)를 쓰기 때문입니다. 둘 다 TipTap 기반이지만 파일이 다릅니다.

## 위치를 나눴습니다

댓글 입력창은 높이가 낮아 **안쪽 상단에 띄우면 방금 친 글자를 가립니다.**

| 곳 | placement | 위치 |
|---|---|---|
| 글쓰기 | `inside` | 입력 영역 안쪽 상단 (높이 넉넉) |
| **댓글** | **`above`** | **입력창 바깥 위** |

```
      ╭─────────────────────────╮
      │ 경어체 사용해 주세앙 🙏  │
      ╰──────────▽──────────────╯
     ┌───────────────────────────┐
     │ 좋은 글 감▏                │  ← 댓글 입력창
     └───────────────────────────┘
```

## 하루 1회는 공유합니다

두 에디터가 **같은 `localStorage` 키**를 씁니다. 글을 쓰든 댓글을 쓰든 그날 한 번만 보이고, 문구도 번갈아 이어집니다. 글쓰기에서 "경어체"를 봤으면 다음날 댓글에서 "초성 욕설"이 나옵니다.

## ⛔ 트랜잭션 밖에서 상태 변경

`hasTyped` 변경을 `setTimeout`으로 감쌌습니다. ProseMirror 트랜잭션 중 `$state`를 바꾸면 `state_unsafe_mutation`이 납니다 — 같은 파일 `onTransaction` 주석이 남긴 교훈을 따랐습니다.

## 확인 방법

```js
localStorage.removeItem('angple_manner_tip')
```

새로고침 후 **댓글 입력창**에 첫 글자를 치면 위쪽에 풍선이 뜹니다.