### PR TITLE
fix(footer): 맞붙은 분기 블록 제거 — 하이드레이션 연쇄 붕괴 근본 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,20 @@ jobs:
       - name: Check HTML comments
         run: node scripts/check-html-comments.mjs
 
-  # 중첩 <a> 검사 — 하이드레이션을 통째로 깨뜨린다.
-  # 2026-07-28: 게시판 목록 행 <a> 안에 댓글수 <a> 가 있어 시간당 회원 약 1,700명이
-  # 하이드레이션 실패를 겪고 있었다(#1040 도입, 관측 부재로 못 보고 있었음).
-  # svelte/compiler AST 로 검사하므로 pnpm install 이 필요하다.
+  # 하이드레이션 AST 가드 — 두 검사가 pnpm install 을 공유한다.
+  #
+  #  1) 중첩 <a>  (2026-07-28)
+  #     게시판 목록 행 <a> 안에 댓글수 <a> 가 있어 시간당 회원 약 1,700명이
+  #     하이드레이션 실패를 겪고 있었다(#1040 도입, 관측 부재로 못 보고 있었음).
+  #
+  #  2) 맞붙은 분기 블록  (2026-07-29)
+  #     푸터에 {/if}{#if …} 로 맞붙은 분기가 5쌍 있었다. SSR 마커가 맞닿아
+  #     번역이 텍스트 노드를 감싸는 순간 뒤따르는 분기가 연쇄로 밀렸다.
+  #     푸터는 모든 페이지에 있어 12시간당 약 2,000명이 영향을 받았다.
+  #
+  # 둘 다 svelte/compiler AST 로 검사하므로 pnpm install 이 필요하다.
+  # ⚠️ 표시 이름(name)은 브랜치 보호의 필수 체크명이라 바꾸지 않았다.
+  #    이름을 넓히려면 저장소 설정의 required check 도 함께 바꿔야 한다.
   nested-anchors:
     name: Nested Anchor Guard
     runs-on: ubuntu-latest
@@ -60,6 +70,9 @@ jobs:
 
       - name: Check nested anchors
         run: node scripts/check-nested-anchors.mjs
+
+      - name: Check adjacent hydration blocks
+        run: node scripts/check-adjacent-blocks.mjs
 
   # 전체 lint는 수동 실행만 허용한다.
   # PR에서는 eslint-review/prettier-suggester가 이미 같은 역할을 맡고,

--- a/apps/web/src/lib/components/layout/footer.svelte
+++ b/apps/web/src/lib/components/layout/footer.svelte
@@ -22,6 +22,46 @@
     // site 자체가 없거나(기본 다모앙) business 키가 없으면 DEFAULT 사용.
     const biz = $derived(page.data.site?.business ?? (page.data.site ? null : DEFAULT_BUSINESS));
 
+    /**
+     * 사업자·연락처 줄은 마크업의 {#if} 가 아니라 여기서 문자열로 조립한다.
+     *
+     * ⛔ 인접한 {#if} 로 되돌리지 말 것. 하이드레이션이 통째로 깨진다.
+     *
+     *    {#if} 는 SSR HTML 에 <!--[--> … <!--]--> 마커를 남긴다. 조건을 나란히
+     *    이어 쓰면 마커가 맨텍스트만 사이에 두고 <!--]--><!--[--> 로 맞붙는다.
+     *    번역 확장이나 브라우저 내장 번역이 그 텍스트 노드를 감싸는 순간
+     *    앵커가 이웃 마커를 읽어 분기 판정이 어긋나고, 뒤따르는 마커가 연쇄로
+     *    한 칸씩 밀린다. 종착점이 Svelte skip_nodes() 의 null 참조이고,
+     *    거기서 화면이 통째로 다시 그려진다("되다 안 되다 한다"의 정체).
+     *
+     *    푸터는 모든 페이지에 있어서 피해가 사이트 전체로 퍼진다.
+     *    2026-07-29 실측: 하이드레이션 실패 스택이 이 지점 한 곳으로 수렴했고,
+     *    12시간당 약 2,000명이 영향을 받았다. 회사명·주소는 번역기가 가장 먼저
+     *    건드리는 텍스트라 하필 이곳이 제일 취약했다.
+     *
+     *    같은 원리의 선행 조치: 목록 레이아웃 grid → flex 전환(#1885).
+     */
+    const bizLine = $derived(
+        biz
+            ? [
+                  biz.company,
+                  biz.ceo && `대표: ${biz.ceo}`,
+                  biz.business_no && `사업자등록번호: ${biz.business_no}`,
+                  biz.ecommerce_no && `통신판매업신고: ${biz.ecommerce_no}`
+              ]
+                  .filter(Boolean)
+                  .join(' | ')
+            : ''
+    );
+
+    const contactLine = $derived(
+        biz
+            ? [biz.address, biz.email, biz.report_email && `제보: ${biz.report_email}`]
+                  .filter(Boolean)
+                  .join(' | ')
+            : ''
+    );
+
     type FooterLink = { name: string; href: string; external?: boolean };
 
     // 서비스
@@ -194,43 +234,47 @@
                 </li>
             </ul>
 
-            {#if biz}
+            <!--
+                조건 분기의 내용은 반드시 요소로 감싼다. 마커가 <p> 에 붙어 있으면
+                안쪽 텍스트가 번역기에 감싸여도 앵커가 흔들리지 않는다.
+            -->
+            {#if bizLine || contactLine}
                 <div class="text-muted-foreground mt-3 text-xs leading-relaxed">
-                    <p>
-                        {#if biz.company}{biz.company}{/if}{#if biz.ceo}
-                            | 대표: {biz.ceo}{/if}{#if biz.business_no}
-                            | 사업자등록번호: {biz.business_no}{/if}{#if biz.ecommerce_no}
-                            | 통신판매업신고: {biz.ecommerce_no}{/if}
-                    </p>
-                    {#if biz.address || biz.email || biz.report_email}
-                        <p>
-                            {#if biz.address}{biz.address}{/if}{#if biz.email}
-                                | {biz.email}{/if}{#if biz.report_email}
-                                | 제보: {biz.report_email}{/if}
-                        </p>
-                    {/if}
+                    {#if bizLine}<p>{bizLine}</p>{/if}
+                    {#if contactLine}<p>{contactLine}</p>{/if}
                 </div>
             {/if}
 
             <p class="text-muted-foreground mt-2 text-xs">
-                {#if biz?.copyright}
-                    © {#if biz.copyright_url}<a
+                <!--
+                    중첩 {#if} 를 {:else if} 사슬로 폈다. 중첩이면 마커가 겹쳐 쌓여
+                    바깥쪽이 밀릴 때 안쪽까지 함께 어긋난다. 각 분기는 <span> 안에 둔다.
+                -->
+                {#if biz?.copyright && biz.copyright_url}
+                    <span
+                        >© <a
                             href={biz.copyright_url}
                             target="_blank"
                             rel="noopener noreferrer"
                             class="hover:text-primary transition-colors">{biz.copyright}</a
-                        >{:else}{biz.copyright}{/if}
+                        ></span
+                    >
+                {:else if biz?.copyright}
+                    <span>© {biz.copyright}</span>
                 {:else}
-                    © {new Date().getFullYear()}
-                    {page.data.site?.title?.split(' - ')[0] ?? 'Angple'}
+                    <span
+                        >© {new Date().getFullYear()}
+                        {page.data.site?.title?.split(' - ')[0] ?? 'Angple'}</span
+                    >
                 {/if}
                 {#if biz?.powered_by !== false}
-                    · Powered by
-                    <a
-                        href="https://angple.com"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="hover:text-primary transition-colors">angple.com</a
+                    <span
+                        >· Powered by <a
+                            href="https://angple.com"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="hover:text-primary transition-colors">angple.com</a
+                        ></span
                     >
                 {/if}
             </p>

--- a/scripts/check-adjacent-blocks.mjs
+++ b/scripts/check-adjacent-blocks.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * 맞붙은 분기 블록 검사 — 하이드레이션 연쇄 붕괴를 막는다.
+ *
+ * 무엇을 잡는가:
+ *   {#if a}…{/if}{#if b}…{/if}   ← 사이에 아무 노드도 없이 맞붙은 분기 블록
+ *
+ * 왜 위험한가 (2026-07-29 실측):
+ *   {#if} 는 SSR HTML 에 <!--[--> … <!--]--> 마커를 남긴다. 분기를 나란히 이어 쓰면
+ *   마커가 <!--]--><!--[--> 로 맞닿는다. 하이드레이션은 이 마커를 읽어 "SSR 이 어느
+ *   분기를 골랐는지"를 판정하는데, 앞쪽 노드가 하나라도 바뀌면 앵커가 이웃 마커를
+ *   읽어 판정이 어긋난다. 그러면 skip_nodes() 가 종료 마커를 찾아 형제 노드를 지우며
+ *   전진하는데, 이미 어긋난 뒤라 목록 끝을 넘어가 null 을 참조하고 죽는다.
+ *   맞붙은 분기가 N개면 하나가 밀리는 순간 N개가 연쇄로 밀린다.
+ *
+ *   노드를 바꾸는 주체는 대개 번역이다 — 확장(DeepL 등)이든 브라우저 내장 번역이든
+ *   텍스트 노드를 감싸는 순간 같은 일이 벌어진다. 회사 정보·주소처럼 번역기가 가장
+ *   먼저 건드리는 텍스트일수록 취약하다.
+ *
+ *   실제 피해: 푸터(모든 페이지에 있다)에 맞붙은 분기가 5쌍 있었고, 하이드레이션
+ *   실패 스택이 그 한 지점으로 수렴했다. 12시간당 약 2,000명이 영향을 받았다.
+ *
+ * 어떻게 고치나:
+ *   - 여러 조건을 이어 붙이는 텍스트라면 스크립트에서 문자열로 조립한다
+ *     (filter(Boolean).join(' | ')). 분기가 아예 사라진다. ← 대개 이게 정답이다
+ *   - 분기가 꼭 필요하면 각 분기의 내용을 <span> 등 요소로 감싼다. 마커가 요소에
+ *     붙어 있으면 안쪽 텍스트가 감싸여도 앵커가 흔들리지 않는다.
+ *   - 중첩 {#if} 는 {:else if} 사슬로 편다. 중첩은 마커를 겹쳐 쌓아 더 나쁘다.
+ *
+ * ⛔ 정규식으로 세지 않는다. 분기 구조는 선형 스캔으로 못 센다(선행 가드에서 오탐 61건).
+ *    svelte/compiler 의 parse() AST 를 쓴다.
+ *
+ * 한계 (정직하게):
+ *   맞붙지 않았더라도 공백 텍스트 하나만 사이에 둔 분기는 여전히 취약할 수 있다.
+ *   여기서는 "사이에 노드가 전혀 없는" 확실한 경우만 잡는다. 오탐 0을 우선한다.
+ *
+ * 종료코드: 위반 1건 이상이면 1, 검사 자체가 성립하지 않으면 2
+ */
+import { readFileSync, globSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+// pnpm 워크스페이스라 svelte 는 저장소 루트가 아니라 apps/web/node_modules 에 있다.
+const req = createRequire(new URL('../apps/web/package.json', import.meta.url));
+const mod = await import(pathToFileURL(req.resolve('svelte/compiler')).href);
+const parse = mod.parse ?? mod.default?.parse;
+
+// ⛔ 조용히 넘어가면 안 된다. parse 없이 통과시키면 "검사했는데 0건"으로 위장된다.
+if (typeof parse !== 'function') {
+    console.error('❌ svelte/compiler 의 parse 를 얻지 못했습니다 — 검사를 수행할 수 없습니다.');
+    process.exit(2);
+}
+
+const patterns =
+    process.argv.length > 2
+        ? process.argv.slice(2)
+        : ['apps/web/src/**/*.svelte', 'themes/**/*.svelte', 'widgets/**/*.svelte'];
+const files = patterns.flatMap((p) =>
+    p.includes('*') ? globSync(p, { exclude: (x) => x.includes('node_modules') }) : [p]
+);
+
+/** SSR 에 하이드레이션 마커를 남기는 블록들 */
+const BLOCK = new Set(['IfBlock', 'EachBlock', 'AwaitBlock', 'KeyBlock']);
+
+let violations = 0;
+let scanned = 0;
+let parseFailed = 0;
+
+function walk(node, file, src) {
+    if (!node || typeof node !== 'object') return;
+
+    const kids = node.nodes ?? node.children;
+    if (Array.isArray(kids)) {
+        for (let i = 0; i + 1 < kids.length; i++) {
+            const a = kids[i];
+            const b = kids[i + 1];
+            if (!BLOCK.has(a?.type) || !BLOCK.has(b?.type)) continue;
+
+            const line = src.slice(0, a.start).split('\n').length;
+            const ctx = src
+                .slice(a.start, b.end)
+                .replace(/\s+/g, ' ')
+                .trim()
+                .slice(0, 90);
+            console.error(
+                `${file}:${line}  분기 블록이 사이에 아무것도 없이 맞붙어 있습니다.\n` +
+                    `    ${ctx}...\n` +
+                    `    → SSR 마커가 <!--]--><!--[--> 로 맞닿아, 앞이 한 번 흔들리면 뒤가 연쇄로 밀립니다.\n` +
+                    `    → 문자열로 조립하거나(filter(Boolean).join), 각 분기를 요소로 감싸세요.`
+            );
+            violations++;
+        }
+    }
+
+    for (const key of Object.keys(node)) {
+        if (key === 'parent') continue;
+        const v = node[key];
+        if (Array.isArray(v)) {
+            for (const c of v) walk(c, file, src);
+        } else if (v && typeof v === 'object' && 'type' in v) {
+            walk(v, file, src);
+        }
+    }
+}
+
+for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    let ast;
+    try {
+        ast = parse(src, { modern: true });
+    } catch (e) {
+        console.error(`⚠️  ${file}: 파싱 실패 — ${String(e).slice(0, 120)}`);
+        parseFailed++;
+        continue;
+    }
+    scanned++;
+    walk(ast.fragment, file, src);
+}
+
+// 검사 대상이 0개면 글롭이 어긋난 것이다. 통과로 위장하지 않는다.
+if (scanned === 0) {
+    console.error(`❌ 검사한 파일이 0개입니다 (대상 ${files.length}개). 경로·글롭을 확인하세요.`);
+    process.exit(2);
+}
+if (parseFailed > 0) {
+    console.error(`❌ 파싱 실패 ${parseFailed}건 — 그 파일들은 검사되지 않았습니다.`);
+    process.exit(2);
+}
+if (violations > 0) {
+    console.error(`\n❌ 맞붙은 분기 블록 ${violations}건. 배포되면 하이드레이션이 연쇄로 깨집니다.`);
+    process.exit(1);
+}
+console.log(`✅ 맞붙은 분기 블록 검사 통과 (${scanned}개 파일)`);


### PR DESCRIPTION
## 무엇이었나

하이드레이션 실패 스택이 **세 릴리스에서 한 지점으로 수렴**했다. 그 지점이 푸터였다.

```
Vh(skip_nodes) → s(if_block) → @148:50174 → 푸터
```

SSR 산출물:

```html
<p><!--[-->주식회사 에스디케이(SDK)<!--]--><!--[-->| 대표: 김선도<!--]--><!--[-->| 사업자등록번호: …<!--]--><!--[-->| 통신판매업신고: …<!--]--></p>
```

`{#if}` 네 개가 **사이에 아무 노드도 없이** 맞붙어 마커가 `<!--]--><!--[-->` 로 맞닿아 있었다.

## 왜 죽었나

`skip_nodes()` 는 분기 판정이 어긋났을 때만 호출된다. 데이터는 서버·클라이언트가 동일한데도 어긋난 이유:

1. 번역(확장이든 브라우저 내장이든)이 사이의 **텍스트 노드를 감싼다**
2. 앵커가 이웃 마커를 읽어 `l !== m` 성립 → `skip_nodes()` 호출
3. 이미 어긋난 상태라 종료 마커를 못 찾고 형제 목록 끝을 넘어감 → `r.nodeType` of null
4. 맞붙은 분기가 5쌍이라 **하나가 밀리면 전부 밀린다**

## 실측

| 항목 | 값 |
|---|---|
| 영향 회원 | 12시간당 약 2,000명 |
| 라우트 분포 | 트래픽에 정확히 비례 (푸터는 모든 페이지) |
| Safari 94% vs Blink 24% | 회사정보·주소 = 번역기의 1순위 표적 |
| 전체 트리 동일 패턴 | **푸터에만 5건** (523개 svelte 파일 중) |

## 수정

- 사업자·연락처 줄을 스크립트에서 문자열로 조립 → **분기 자체를 제거**
- 남는 분기는 내용을 `<p>`/`<span>` 으로 감싸 마커를 요소에 고정
- 저작권의 중첩 `{#if}` 를 `{:else if}` 사슬로 평탄화

원리는 어제 `#1885`(목록 grid→flex)와 같다. 푸터가 그 조치에서 빠져 있었다.

### 표시 변화

구분자 앞에 공백이 생긴다: `…(SDK)| 대표` → `…(SDK) | 대표`. 원래 의도한 모양으로 보인다.

## 재발 방지

`scripts/check-adjacent-blocks.mjs` 신설, 기존 AST 가드 잡에 배선(`pnpm install` 공유).

**양방향 검증**
- 수정 전 푸터 → **5건 검출, exit 1** ✅
- 수정 후 전체 트리 518개 파일 → **통과** ✅
- `parse` 미획득 / 검사 0건 / 파싱 실패는 전부 exit 2 (조용한 통과 차단)

기존 위반이 0건이라 가드를 붙여도 아무것도 막히지 않는다.

> ⚠️ 체크 표시 이름(`Nested Anchor Guard`)은 브랜치 보호의 필수 체크명이라 바꾸지 않았다. 이름을 넓히려면 저장소 설정도 함께 바꿔야 한다.

## 검증 계획

배포 후 24시간, `error_logs.js_errors` 의 `hydration_error` 에서 `null is not an object` 계열이 줄어드는지 확인. 현재 12시간당 uniq 1,997명.