### PR TITLE
fix(board): 목록 전면 로딩 실패 시 200 대신 503 반환

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -633,7 +633,9 @@ export const load: PageServerLoad = async ({
         // 게시글
         let posts: FreePost[] = [];
         let pagination: PostsCacheData['pagination'] = { page, limit, total: 0, totalPages: 0 };
-        let error: string | null = null;
+        // 전면 실패는 아래에서 503 으로 throw 하므로 여기까지 오면 항상 null 이다.
+        // 반환 형태(PostsCacheData)를 유지하려고 남겨둔다.
+        const error: string | null = null;
 
         if (postsResult.status === 'fulfilled') {
             const postsData = postsResult.value;
@@ -665,7 +667,22 @@ export const load: PageServerLoad = async ({
             if (stale) {
                 return { ...stale, error: null };
             }
-            error = '게시글을 불러오는데 실패했습니다.';
+
+            // ⛔ 여기서 200 + 빈 목록을 돌려주면 안 된다.
+            //
+            // 2026-07-29 실측: CDN 캐시 규칙이 이 경로들(/ · /free · /qa 등 76개)의
+            // 200 응답을 edge_ttl override_origin 으로 1,200초 붙잡는다. DB 가 8분 만에
+            // 스스로 복구된 뒤에도 "글이 없습니다" 화면이 비로그인 사용자와 검색 크롤러에게
+            // 20분간 그대로 나갔다. 로그인 사용자는 쿠키 때문에 캐시를 타지 않아 무사했지만,
+            // 구글이 빈 게시판을 수집하는 것은 그대로 손해다.
+            //
+            // 상태 코드를 5xx 로 바꾸면 "성공한 빈 페이지"가 아니게 되어 캐시 대상에서
+            // 빠진다. 사용자에게도 "글이 없다"가 아니라 "지금 문제가 있다"로 정직해진다.
+            // ⚠️ CDN 규칙에 5xx → TTL 0 을 명시하는 작업이 짝이다. 한쪽만 하면 반쪽이다.
+            //
+            // ⛔ stale 이 있으면 위에서 이미 반환했다. 여기는 보여줄 것이 정말 아무것도
+            //    없는 경우뿐이다. 부분 실패(공지·프로필 등)는 여기로 오지 않는다.
+            throw svelteError(503, '게시글을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
         }
 
         const notices = noticesResult.status === 'fulfilled' ? noticesResult.value : [];


### PR DESCRIPTION
## 문제

DB 장애로 게시글을 못 불러오면 `'글이 없습니다'` 화면을 **200 OK** 로 돌려줍니다.

CDN 캐시 규칙이 이 응답을 붙잡습니다.

```
Cache anonymous public HTML high-traffic lists  (규칙 23)
  edge_ttl.mode = override_origin   default = 1200
    status 200 → 1200초 (20분)
    status 404 → 0
    status 5xx → 항목 없음
  expr: damoang.net and path in {"/" "/free" "/qa" "/hello" "/new" ...}   ← 76개 경로
```

**2026-07-29 실측**: RDS 가 엔진 assertion(`grover_space_exist`)으로 09:52~10:01 사이 9회 재시작했습니다. DB 는 8분 21초 만에 스스로 복구했지만, 그 사이 캐시에 굳은 빈 화면이 계속 나갔습니다.

## 영향 범위 — 정확히

```
익명            200  글=26  cf=HIT      age=477
로그인 쿠키 있음  200  글=26  cf=DYNAMIC  age=-
```

**로그인 사용자는 캐시를 타지 않아 무사했습니다.** 영향은 **비로그인 사용자와 검색 크롤러** 입니다. 구글이 빈 게시판을 수집하는 손해가 실질 피해입니다.

## 수정

전면 실패 시 `throw svelteError(503, ...)`.

5xx 는 "성공한 빈 페이지"가 아니므로 캐시 대상에서 빠집니다. 사용자에게도 "글이 없다"가 아니라 "지금 문제가 있다"로 정직해집니다. `+error.svelte` 가 `status >= 500` 을 이미 처리합니다(ServerCrash 화면).

### 건드리지 않은 것

- **stale 반환 경로는 그대로** — 만료된 캐시라도 에러보다 낫습니다. 503 은 보여줄 것이 정말 아무것도 없을 때뿐입니다
- **부분 실패**(공지·프로필 enrichment 등)는 이 경로로 오지 않습니다. 종전처럼 무시하고 진행합니다
- 게시판에 글이 0건인 정상 상태는 API 가 200 을 주므로 `fulfilled` 입니다 → 영향 없음

## ⚠️ 짝이 되는 작업 (별건)

CDN 규칙 23·13·10 에 `status_code_ttl: 5xx → 0` 을 명시해야 합니다.
**한쪽만 하면 반쪽입니다.** `override_origin` 상태에서 5xx 기본 동작을 실측으로 확인하지 못했기 때문에(관련 경로가 외부에서 403 차단), 규칙에 명시해 모호함을 제거하는 것이 설계 의도입니다.

## 검증 계획

1. 정상 상태에서 `/free` 200 + `cf-cache-status: HIT` 유지
2. DB 실패 상황에서 503 반환
3. 그 503 이 `HIT` 로 굳지 않음
4. stale 반환 경로 회귀 없음
5. `__data.json` 경로도 동일 동작

## 기각한 대안

- ⛔ **TTL 1200 → 60초 축소** — 오리진 요청이 크게 늘어납니다. DB 가 불안정한 지금 반대 방향입니다
- ⛔ **`Cache-Control: no-store`** — `override_origin` 이 무시하는지 **검증하지 못했습니다**. 검증 못 한 것에 기대면 배포하고도 효과가 0일 수 있습니다
- ⛔ **404 반환** — SEO 위험