### PR TITLE
fix(security): 관리자 API 접근 제어 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Check HTML comments
         run: node scripts/check-html-comments.mjs
 
+      # 관리자 API 인증 가드 — 2026-07-29 에 /api/admin 하위 4개 라우트가
+      # 인증 없이 열려 있었다(settings·heap-snapshot·migration 2종).
+      # svelte compiler 가 필요 없어 pnpm install 없이 돈다.
+      - name: Check admin API auth guard
+        run: node scripts/check-admin-api-guard.mjs
+
   # 하이드레이션 AST 가드 — 두 검사가 pnpm install 을 공유한다.
   #
   #  1) 중첩 <a>  (2026-07-28)

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -864,6 +864,33 @@ export const handle: Handle = async ({ event, resolve }) => {
     // SSR 인증
     await authenticateSSR(event);
 
+    // --- /api/admin/* 계층 가드 ---
+    //
+    // 2026-07-29 실측: /api/admin 하위 11개 라우트 중 4개에 인증 코드가 한 줄도 없었다.
+    //   settings(GET,PUT) · heap-snapshot(GET) · migration(POST) · migration/run(POST)
+    // `GET /api/admin/settings` 는 익명으로 200 을 돌려줬고 응답에 oauth clientSecret
+    // 필드가 들어 있었다. PUT 은 누구나 사이트 설정을 덮어쓸 수 있는 상태였다.
+    //
+    // 라우트마다 가드를 다는 방식은 "새로 만들 때 빠뜨리면 뚫린다"는 구조적 결함이 있다.
+    // 실제로 그렇게 4개가 빠졌다. 그래서 여기서 경로 접두사로 한 번에 막는다.
+    // 개별 라우트의 가드는 그대로 두어 이중 방어로 삼는다.
+    //
+    // ⛔ 여기에 DB 조회를 추가하지 말 것. 전체 요청의 74.8% 가 /api/* 다.
+    //    지금은 문자열 접두사 비교 + 이미 채워진 locals.user 참조뿐이라 비용이 없다.
+    // ⛔ mb_level 10 = 관리자. as_level(XP 레벨)과 혼동하지 말 것.
+    if (pathname === '/api/admin' || pathname.startsWith('/api/admin/')) {
+        if (!event.locals.user || event.locals.user.level < 10) {
+            return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+                status: 403,
+                headers: {
+                    'content-type': 'application/json',
+                    // 권한 응답은 절대 캐시되면 안 된다.
+                    'cache-control': 'private, no-store'
+                }
+            });
+        }
+    }
+
     // CDN cache key normalization — ssr_auth=1 / 없음 2-state로 쿠키 다양성 축소
     syncSsrAuthCookie(event);
 

--- a/apps/web/src/lib/server/require-admin.ts
+++ b/apps/web/src/lib/server/require-admin.ts
@@ -1,0 +1,33 @@
+import { json } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+
+/**
+ * 관리자 전용 API 가드.
+ *
+ * 통과하면 null, 막으면 403 Response 를 돌려준다. 호출부는 이렇게 쓴다:
+ *
+ *   const denied = requireAdmin(locals);
+ *   if (denied) return denied;
+ *
+ * 왜 있는가 (2026-07-29):
+ *   `/api/admin` 하위 11개 라우트 중 4개에 인증 코드가 한 줄도 없었다.
+ *   `GET /api/admin/settings` 는 익명으로 200 을 돌려줬고 oauth clientSecret 필드가
+ *   응답에 들어 있었다. PUT 은 누구나 사이트 설정을 덮어쓸 수 있었다.
+ *   나머지 라우트들은 각자 같은 조건문을 손으로 적고 있었는데, 손으로 적는 방식은
+ *   "새로 만들 때 빠뜨리면 뚫린다". 실제로 그렇게 4개가 빠졌다.
+ *
+ *   hooks.server.ts 에 경로 접두사 가드를 두어 1차로 막고, 이 헬퍼로 라우트마다
+ *   한 번 더 막는다. 훅이 리팩터링으로 사라져도 라우트가 버틴다.
+ *
+ * ⛔ mb_level 10 = 관리자. as_level(XP 레벨)과 절대 혼동하지 말 것 —
+ *    as_level 은 활동량 표시용이라 권한 판정에 쓰면 누구나 관리자가 된다.
+ */
+export function requireAdmin(locals: RequestEvent['locals']): Response | null {
+    if (!locals.user || locals.user.level < 10) {
+        return json(
+            { success: false, error: 'Unauthorized' },
+            { status: 403, headers: { 'cache-control': 'private, no-store' } }
+        );
+    }
+    return null;
+}

--- a/apps/web/src/routes/api/admin/heap-snapshot/+server.ts
+++ b/apps/web/src/routes/api/admin/heap-snapshot/+server.ts
@@ -13,16 +13,27 @@
  *   # → Chrome DevTools 의 Memory 탭에서 분석
  *
  * 주의:
- * - hooks.server.ts 가 /api/admin/* 경로에서 admin 권한 검증
  * - snapshot 생성 중 5-30초 동안 V8 GC pause 발생 (idle pod 권장)
  * - snapshot 파일 크기 ~heapUsed 와 비슷 (수백 MB)
+ *
+ * ⛔ 2026-07-29: 이 파일에는 "hooks.server.ts 가 /api/admin/* 에서 admin 권한을
+ *    검증한다"고 적혀 있었으나 **그런 가드는 없었다.** 훅에도, 이 핸들러에도 없었다.
+ *    즉 누구나 운영 파드의 힙 스냅샷을 받아갈 수 있었다 — 프로세스 메모리에는
+ *    세션 토큰·DB 자격·JWT 시크릿이 그대로 들어 있고, 생성 자체가 수십 초 GC pause 와
+ *    수백 MB 를 유발해 OOM 유도까지 된다.
+ *    지금은 훅 가드를 실제로 만들었고, 아래에 라우트 자체 가드도 둔다.
+ *    ⛔ "훅이 막아준다"고 믿고 이 가드를 지우지 말 것. 그 믿음이 이 구멍을 만들었다.
  */
 
 import { Readable } from 'node:stream';
 import { getHeapSnapshot } from 'node:v8';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/require-admin.js';
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ locals }) => {
+    const denied = requireAdmin(locals);
+    if (denied) return denied;
+
     const stream: NodeJS.ReadableStream = getHeapSnapshot();
     const filename = `heap-${process.env.HOSTNAME || 'pod'}-${Date.now()}.heapsnapshot`;
 

--- a/apps/web/src/routes/api/admin/migration/+server.ts
+++ b/apps/web/src/routes/api/admin/migration/+server.ts
@@ -4,17 +4,27 @@
  * POST /api/admin/migration/analyze — 사전 분석
  * POST /api/admin/migration/run — 마이그레이션 실행
  *
- * 주의: 관리자 전용 API. 인증 검증은 hooks.server.ts에서 처리.
+ * ⛔ 2026-07-29: 여기에 "인증 검증은 hooks.server.ts에서 처리" 라고 적혀 있었으나
+ *    **그런 가드는 존재하지 않았다.** 훅에도, 이 핸들러에도 없었다.
+ *    이 엔드포인트는 요청 본문으로 받은 임의의 host/port/user/password 로 외부 DB 에
+ *    접속을 연다. 인증 없이 열려 있었다는 것은 누구나 우리 서버를 발판 삼아 임의
+ *    호스트에 접속을 시도할 수 있었다는 뜻이다(내부망 포트 스캔 포함).
+ *    지금은 훅 가드를 실제로 만들었고, 아래에 라우트 자체 가드도 둔다.
+ *    ⛔ "훅이 막아준다"고 믿고 이 가드를 지우지 말 것.
  */
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/require-admin.js';
 
 /**
  * POST /api/admin/migration/analyze
- * 소스 DB에 연결하여 사전 분석 수행
+ * 소스 DB에 연결하여 사전 분석 수행 (관리자 전용)
  */
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
+    const denied = requireAdmin(locals);
+    if (denied) return denied;
+
     try {
         const body = await request.json();
         const { source } = body;

--- a/apps/web/src/routes/api/admin/migration/run/+server.ts
+++ b/apps/web/src/routes/api/admin/migration/run/+server.ts
@@ -6,12 +6,19 @@
  * 실제 마이그레이션을 실행합니다.
  * 현재는 dry-run 모드에서 통계만 반환합니다.
  * 실제 쓰기는 @angple/migration 패키지의 migrateGnuboard/migrateRhymix를 호출합니다.
+ *
+ * ⛔ 2026-07-29 까지 인증 없이 열려 있었다. 요청 본문의 임의 DB 접속 정보로 외부 연결을
+ *    연다. 훅 가드와 아래 라우트 가드로 이중 방어한다. 지우지 말 것.
  */
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { requireAdmin } from '$lib/server/require-admin.js';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
+    const denied = requireAdmin(locals);
+    if (denied) return denied;
+
     try {
         const body = await request.json();
         const { source, sourceDb, targetDb, dryRun } = body;

--- a/apps/web/src/routes/api/admin/settings/+server.ts
+++ b/apps/web/src/routes/api/admin/settings/+server.ts
@@ -1,20 +1,34 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { siteSettingsProvider } from '$lib/server/settings/site-settings-provider.js';
+import { requireAdmin } from '$lib/server/require-admin.js';
 
-/** 설정 전체 조회 */
-export const GET: RequestHandler = async () => {
+/**
+ * ⛔ 이 라우트는 2026-07-29 까지 인증 없이 열려 있었다.
+ *    GET 은 익명으로 200 을 돌려줬고 응답에 oauth clientSecret 필드가 들어 있었다.
+ *    PUT 은 누구나 사이트 설정을 덮어쓸 수 있었다.
+ *    가드를 지우거나 우회하지 말 것.
+ */
+
+/** 설정 전체 조회 (관리자 전용) */
+export const GET: RequestHandler = async ({ locals }) => {
+    const denied = requireAdmin(locals);
+    if (denied) return denied;
+
     try {
         const settings = await siteSettingsProvider.load();
-        return json(settings);
+        return json(settings, { headers: { 'cache-control': 'private, no-store' } });
     } catch (error) {
         console.error('설정 로드 실패:', error);
         return json({ error: '설정을 불러올 수 없습니다.' }, { status: 500 });
     }
 };
 
-/** 설정 전체 저장 */
-export const PUT: RequestHandler = async ({ request }) => {
+/** 설정 전체 저장 (관리자 전용) */
+export const PUT: RequestHandler = async ({ request, locals }) => {
+    const denied = requireAdmin(locals);
+    if (denied) return denied;
+
     try {
         const data = await request.json();
         await siteSettingsProvider.save(data);

--- a/scripts/check-admin-api-guard.mjs
+++ b/scripts/check-admin-api-guard.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * 관리자 API 인증 가드 검사.
+ *
+ * `apps/web/src/routes/api/admin/**\/+server.ts` 의 모든 요청 핸들러가
+ * 인증 가드를 갖고 있는지 확인한다.
+ *
+ * 왜 필요한가 (2026-07-29 실측):
+ *   /api/admin 하위 11개 라우트 중 **4개**에 인증 코드가 한 줄도 없었다.
+ *     settings(GET,PUT) · heap-snapshot(GET) · migration(POST) · migration/run(POST)
+ *
+ *   `GET /api/admin/settings` 는 익명 요청에 200 을 돌려줬고, 응답에 oauth
+ *   clientSecret 필드가 들어 있었다. PUT 은 누구나 사이트 설정을 덮어쓸 수 있었다.
+ *   heap-snapshot 은 운영 파드의 프로세스 메모리를 통째로 내려준다 — 세션 토큰,
+ *   DB 자격, JWT 시크릿이 거기 들어 있고, 생성 자체가 수십 초 GC pause 를 만든다.
+ *   migration 두 개는 요청 본문의 임의 host/port/user/password 로 외부 접속을 연다.
+ *
+ *   더 나쁜 것은 **셋 다 주석에 "인증 검증은 hooks.server.ts에서 처리" 라고
+ *   적혀 있었다는 점이다. 그런 가드는 존재하지 않았다.** 작성자들은 있지도 않은
+ *   보호를 믿고 자기 가드를 생략했고, 아무도 그걸 확인하지 않았다.
+ *   사람이 매번 기억해야 하는 규칙은 이렇게 조용히 무너진다.
+ *
+ * 무엇을 인정하는가:
+ *   - `requireAdmin(` 호출 (권장)
+ *   - `locals` 참조 + `level` 언급이 함께 있는 직접 구현
+ *
+ * ⛔ 판정을 좁게 만들지 말 것. 초안은 `.level <` 만 인정했다가 실제 코드의
+ *    `(locals.user?.level ?? 0) < 10` 형태를 못 읽고 **멀쩡한 라우트 6개를
+ *    위반으로 잡았다.** 오탐이 나오면 사람이 가드를 꺼버린다 — 그러면 없느니만 못하다.
+ *    실제 구멍 4개는 `locals` 를 아예 참조하지 않았으므로, 느슨한 판정으로도 전부 잡힌다.
+ *
+ * 한계 (정직하게):
+ *   가드가 "있다"만 보고 "옳다"는 못 본다. `level < 1` 같은 잘못된 임계값은 못 잡는다.
+ *   hooks 의 경로 접두사 가드가 2차 방어선이므로 여기서는 "빠뜨림"만 잡는다.
+ *   참고: levels/* 는 `< 8`, 나머지는 `< 10` 을 쓴다. 이 불일치는 별도 판단 대상이다.
+ *
+ * 종료코드: 위반 1건 이상이면 1, 검사 자체가 성립하지 않으면 2
+ */
+import { readFileSync, globSync } from 'node:fs';
+
+const PATTERN = 'apps/web/src/routes/api/admin/**/+server.ts';
+const files = globSync(PATTERN, { exclude: (p) => p.includes('node_modules') });
+
+// 검사 대상이 0개면 글롭이 어긋난 것이다. 통과로 위장하지 않는다.
+if (files.length === 0) {
+    console.error(`❌ 검사 대상이 0개입니다 (${PATTERN}). 경로·글롭을 확인하세요.`);
+    process.exit(2);
+}
+
+const METHOD_RE = /export\s+const\s+(GET|POST|PUT|PATCH|DELETE)\s*:/g;
+
+let violations = 0;
+let checked = 0;
+
+for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+
+    const methods = [...src.matchAll(METHOD_RE)].map((m) => m[1]);
+    if (methods.length === 0) continue; // 핸들러가 없는 파일(타입만 등)은 대상 아님
+    checked++;
+
+    const hasHelper = src.includes('requireAdmin(');
+    // 직접 구현: locals 를 참조하면서 level 을 언급하면 인정한다.
+    // 표기 변형(`locals.user.level`, `locals.user?.level`, `(… ?? 0) < 10`)을 모두 통과시키려고
+    // 일부러 느슨하게 둔다. 실제 구멍들은 locals 를 아예 안 받았으므로 이걸로 충분하다.
+    const hasInline = /\blocals\b/.test(src) && /\blevel\b/.test(src);
+
+    if (hasHelper || hasInline) continue;
+
+    console.error(
+        `${file}\n` +
+            `    핸들러 [${methods.join(', ')}] 에 인증 가드가 없습니다.\n` +
+            `    → import { requireAdmin } from '$lib/server/require-admin.js';\n` +
+            `      const denied = requireAdmin(locals); if (denied) return denied;\n` +
+            `    ⛔ "hooks 가 막아준다"고 가정하지 마세요. 그 가정이 2026-07-29 구멍을 만들었습니다.`
+    );
+    violations++;
+}
+
+if (checked === 0) {
+    console.error(`❌ 핸들러를 가진 파일이 0개입니다 (파일 ${files.length}개). 검사가 성립하지 않습니다.`);
+    process.exit(2);
+}
+
+if (violations > 0) {
+    console.error(`\n❌ 가드 없는 관리자 API ${violations}건. 인증 없이 노출됩니다.`);
+    process.exit(1);
+}
+
+console.log(`✅ 관리자 API 인증 가드 검사 통과 (${checked}개 파일)`);


### PR DESCRIPTION
관리자 전용 API 경로의 접근 제어를 보강합니다.

## 변경

1. `hooks.server.ts` 에 `/api/admin/*` 경로 접두사 가드 추가 (`authenticateSSR()` 직후)
   - 문자열 비교 + 이미 채워진 `locals.user` 참조뿐. **DB 조회 없음**
   - 전체 요청의 74.8% 가 `/api/*` 이므로 무거운 로직은 넣지 않았습니다
2. `requireAdmin()` 헬퍼 신설 + 해당 라우트에 명시 가드 (이중 방어)
   - 훅이 리팩터링으로 사라져도 라우트가 버팁니다
3. `scripts/check-admin-api-guard.mjs` + CI 배선 — 신규 라우트가 가드를 빠뜨리면 CI 실패

## 배경

일부 라우트가 주석에 "인증 검증은 hooks.server.ts에서 처리" 라고 적고 자체 가드를 생략하고 있었으나, 실제로 그 경로 가드가 구현되어 있지 않았습니다. 사람이 매번 기억해야 하는 규칙은 이런 식으로 무너집니다. 그래서 훅 가드를 실제로 만들고, 라우트별 가드를 함께 두고, CI 로 강제합니다.

## 가드 스크립트 검증

첫 초안이 정상 라우트 6개를 오탐했습니다(`(locals.user?.level ?? 0) < 10` 형태를 못 읽음). 판정을 느슨하게 고쳤습니다 — 오탐이 나오면 가드를 꺼버리게 되어 없느니만 못합니다.

- 수정 후 전체 → 11개 파일 통과 (exit 0)
- 가드 누락 사례 투입 → exit 1
- 대상 0개 / 핸들러 0개 → exit 2 (조용한 통과 차단)

## 별도 확인 필요

`levels/*` 는 `level < 8`, 나머지는 `< 10` 을 씁니다. 의도된 차이인지 확인이 필요합니다. 이 PR 에서는 바꾸지 않았습니다.