### PR TITLE
fix(editor): 모바일에서 이미지 삽입 버튼이 화면 밖에 있던 문제

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -1365,6 +1365,52 @@
             >
                 <UnderlineIcon class="h-4 w-4" />
             </Button>
+            <!--
+                이미지 삽입 — 자주 쓰는 버튼이라 앞쪽에 둔다.
+                ⛔ 뒤로 옮기지 말 것. 모바일 툴바는 1줄 가로 스크롤(flex-nowrap + overflow-x-auto,
+                   #1809 안드로이드 가림 해소)이라 뒤에 있으면 화면 밖으로 나간다.
+                   특히 iOS 는 스크롤바를 숨겨 "옆으로 밀린다"는 단서가 전혀 없다.
+                   2026-07-29 제보: 아이폰에서 "사진 삽입 메뉴가 없어졌다" — 25개 중 20번째라
+                   375~430px 화면에서 보이지 않았다. 버튼은 그대로 있었고 도달만 못 했다.
+            -->
+            <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onclick={openImageDialog}
+                {disabled}
+                class="h-8 w-8 p-0"
+                title="이미지 삽입"
+            >
+                <ImageIcon class="h-4 w-4" />
+            </Button>
+            {#if isActive.image}
+                <!-- 이미지 선택 시에만: 크기 컨트롤 (저장된 의도만 존중, 렌더 추측 없음) -->
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onclick={toggleImageFitWidth}
+                    {disabled}
+                    class="h-8 whitespace-nowrap px-2 text-xs {getButtonClass(
+                        isActive.imageFitWidth
+                    )}"
+                    title="이미지를 본문 폭에 맞춰 채웁니다"
+                >
+                    ↔ 본문 폭
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onclick={resetImageSize}
+                    {disabled}
+                    class="h-8 whitespace-nowrap px-2 text-xs"
+                    title="이미지를 원본 크기로 되돌립니다"
+                >
+                    원본
+                </Button>
+            {/if}
             <!-- 문단 정렬 (TextAlign extension) -->
             <Button
                 type="button"
@@ -1513,44 +1559,6 @@
             >
                 <LinkIcon class="h-4 w-4" />
             </Button>
-            <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onclick={openImageDialog}
-                {disabled}
-                class="h-8 w-8 p-0"
-                title="이미지 삽입"
-            >
-                <ImageIcon class="h-4 w-4" />
-            </Button>
-            {#if isActive.image}
-                <!-- 이미지 선택 시에만: 크기 컨트롤 (저장된 의도만 존중, 렌더 추측 없음) -->
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onclick={toggleImageFitWidth}
-                    {disabled}
-                    class="h-8 whitespace-nowrap px-2 text-xs {getButtonClass(
-                        isActive.imageFitWidth
-                    )}"
-                    title="이미지를 본문 폭에 맞춰 채웁니다"
-                >
-                    ↔ 본문 폭
-                </Button>
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onclick={resetImageSize}
-                    {disabled}
-                    class="h-8 whitespace-nowrap px-2 text-xs"
-                    title="이미지를 원본 크기로 되돌립니다"
-                >
-                    원본
-                </Button>
-            {/if}
             <Button
                 type="button"
                 variant="ghost"


### PR DESCRIPTION
## 제보

`free/6840527` 댓글 — **"모바일(아이폰)에서 사진 삽입하는 메뉴가 없어졌더군요"**

하필 딴지 유입 회원을 위한 **사용법 안내 글**에 달린 댓글이라, 신규 유입자가 바로 겪는 자리입니다.

## 확인 — 버튼은 있었고 도달만 못 했습니다

`#1809` 에서 안드로이드 툴바가 글쓰기 영역을 가리는 문제(`#13037`)를 고치며 모바일 툴바를 **1줄 가로 스크롤**로 바꿨습니다.

```
flex-nowrap overflow-x-auto          ← 640px 미만
sm:flex-wrap sm:overflow-x-visible
```

그런데 **이미지 삽입이 25개 중 20번째**였습니다.

```
 1.실행취소 2.다시실행 3~5.제목 6.굵게 7.기울임 8.밑줄
 9~12.정렬 13.취소선 14~15.목록 16.인용문 17.코드블록
18.가로줄 19.링크 → 20.이미지 삽입 ← 21~22.크기 23.YouTube 24.앙티콘 25.테이블
```

버튼 하나가 약 32px 이니 20번째까지 **640px 이상**입니다. 아이폰 화면 폭은 375~430px 입니다.

결정적으로 **iOS 는 스크롤바를 숨깁니다.** 안드로이드는 스크롤 힌트가 잠깐이라도 보이는데 아이폰은 옆으로 밀린다는 단서가 전혀 없어, 사용자에겐 "없어진 것"과 같습니다.

## 수정

이미지 삽입 버튼(+선택 시 나타나는 크기 컨트롤)을 **밑줄 뒤 9번째**로 이동.

```
… 6.굵게 7.기울임 8.밑줄 → 9.이미지 삽입 ← 10~11.크기 12~15.정렬 …
```

**줄 수는 그대로 1줄**이라 `#1809` 가 고친 안드로이드 문제는 되돌아가지 않습니다.

되돌리지 말라는 이유를 주석으로 남겼습니다.

## 서드파티 앱 아닙니다 (확인함)

| 확인 | 결과 |
|---|---|
| 제보자 UA | `iPhone … Mobile/… Safari` — 모바일 사파리 웹, **1,432건** |
| 작성 글 마크업 | `<p style="text-align: left;">` — 우리 TipTap TextAlign 확장 |
| AngPilot(서드파티) 쓰기 API | **0건** — 읽기 전용 |

## 검증

- 맞붙은 분기 가드 통과 ✅
- 중첩 `<a>` 가드 통과 ✅
- `title="이미지 삽입"` 중복 0 (이동 후 1개)
- 이동 후 `{#if isActive.image}` 는 앞뒤가 모두 요소라 마커 인접 없음

## 남은 개선 여지

근본적으로는 **모바일에서 스크롤 가능하다는 시각 단서**(오른쪽 끝 페이드 등)가 있어야 합니다. 이번엔 위험이 가장 낮은 순서 재배치만 했습니다.