### PR TITLE
fix(level): XP 레벨 계산을 백엔드와 같은 곡선으로 통일 (bug/13149)

### DIFF
--- a/apps/web/src/lib/components/features/member/follow-list-dialog.svelte
+++ b/apps/web/src/lib/components/features/member/follow-list-dialog.svelte
@@ -9,7 +9,10 @@
         mb_nick: string;
         mb_image: string;
         mb_image_updated_at?: string;
+        /** 등급(1~10). ⛔ LevelBadge 에 넘기지 말 것 — 그건 XP 레벨용이다. */
         mb_level: number;
+        /** XP 레벨(1~109). API 가 as_exp 로부터 계산해 내려준다. */
+        as_level?: number;
         followed_at: string;
     }
 
@@ -107,7 +110,15 @@
 
                                 <div class="min-w-0 flex-1">
                                     <div class="flex items-center gap-1">
-                                        <LevelBadge level={member.mb_level} size="sm" />
+                                        <!--
+                                            ⛔ mb_level(등급 1~10)을 넘기지 말 것.
+                                            2026-07-29 까지 여기가 mb_level 이어서 팔로워 목록의
+                                            모든 회원이 Lv.1~10 으로 보였다(bug/13149).
+                                            LevelBadge 는 XP 레벨(as_level) 전용이다.
+                                        -->
+                                        {#if member.as_level}
+                                            <LevelBadge level={member.as_level} size="sm" />
+                                        {/if}
                                         <a
                                             href="/member/{member.mb_id}"
                                             class="text-foreground hover:text-primary truncate text-sm font-medium"

--- a/apps/web/src/lib/server/auth/xp-grant.ts
+++ b/apps/web/src/lib/server/auth/xp-grant.ts
@@ -10,16 +10,9 @@
  */
 import pool, { readPool } from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
+import { calculateLevelFromExp } from '$lib/utils/level-thresholds';
 
 const LOGIN_XP = 500;
-
-// Level thresholds (cumulative exp required for each level) — nariya compatible
-// Formula: 1000 * (n-1)² where n = level
-// Level 1: 0, Level 2: 1000, Level 3: 4000, Level 10: 81000, Level 40: 1521000
-const levelThresholds: number[] = [];
-for (let n = 1; n <= 110; n++) {
-    levelThresholds.push(1000 * (n - 1) * (n - 1));
-}
 
 interface ExistingRow extends RowDataPacket {
     cnt: number;
@@ -31,17 +24,18 @@ interface MemberRow extends RowDataPacket {
     mb_level: number;
 }
 
-function calculateLevel(totalExp: number): number {
-    let level = 1;
-    for (let i = 0; i < levelThresholds.length; i++) {
-        if (totalExp >= levelThresholds[i]) {
-            level = i + 1;
-        } else {
-            break;
-        }
-    }
-    return level;
-}
+/**
+ * ⛔ 여기에 임계값 표를 다시 만들지 말 것 — 정본은 $lib/utils/level-thresholds 다.
+ *
+ * 원래 이 파일이 `1000·(n−1)²` 를 자체 생성해 썼다. 공식 자체는 백엔드와 같아
+ * 저장값은 옳았지만, 웹의 다른 계산부는 109개짜리 계단식 표를 쓰고 있어
+ * 같은 회원이 화면마다 다른 레벨로 보였다(bug/13149, 2026-07-29).
+ * 지금은 정본이 같은 2차식이므로 그대로 위임한다.
+ *
+ * 상한만 달랐다(옛 110 vs 정본 5000). 실측상 as_exp 최대가 8,991,485(Lv.95)로
+ * 110 경계(11,881,000)를 넘는 회원이 0명이라 저장값 변화는 없다.
+ */
+const calculateLevel = calculateLevelFromExp;
 
 /**
  * 로그인 XP 적립

--- a/apps/web/src/lib/server/member-levels.ts
+++ b/apps/web/src/lib/server/member-levels.ts
@@ -5,8 +5,12 @@
  * +page.server.ts에서 SSR 스트리밍으로 직접 호출하여 CDN 요청 제거.
  *
  * #12046 — DB 의 as_level 컬럼이 as_exp 변동을 따라가지 못해 stale 한 케이스가 다수
- * 존재(시스템 광역). 단일 source of truth 인 as_exp + LEVEL_THRESHOLDS 로 항상
- * 동적 계산해 LevelBadge / 프로필 등 모든 표시 위치가 일관된 값을 보도록 함.
+ * 존재(시스템 광역). 단일 source of truth 인 as_exp 로 항상 동적 계산해
+ * LevelBadge / 프로필 등 모든 표시 위치가 일관된 값을 보도록 함.
+ *
+ * bug/13149 (2026-07-29) — 그 "동적 계산"이 백엔드와 다른 곡선이었다는 것이 드러나
+ * 계산 함수를 백엔드와 같은 2차식으로 교체했다($lib/utils/level-thresholds).
+ * 동시에 여기 있던 Math.max(계산값, 저장값) 래칫도 제거했다 — 아래 참조.
  */
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
@@ -53,10 +57,12 @@ async function queryMemberLevels(ids: string[]): Promise<Record<string, number>>
     const levels: Record<string, number> = {};
     for (const row of rows) {
         const exp = Number(row.as_exp) || 0;
-        const calculated = calculateLevelFromExp(exp);
-        // 저장된 as_level 보다 계산값이 더 크면 계산값(최신) 우선.
-        // 두 값 중 큰 쪽을 채택해 backward compat 유지하고 drift 만 보정.
-        levels[row.mb_id] = Math.max(calculated, Number(row.as_level) || 1);
+        // ⛔ 예전에는 Math.max(계산값, 저장값) 이었다. 계산 곡선이 백엔드와 달랐을 때
+        //    저장값을 보정해주려던 장치인데, 그 자체가 **제5의 규칙**이 되어
+        //    "내 프로필의 레벨"과 "내 댓글 옆 배지"가 서로 다르게 굳는 원인이었다.
+        //    2026-07-29 부터 계산 곡선이 백엔드와 동일해졌으므로(bug/13149) 불필요하다.
+        //    남겨두면 옛 부풀려진 저장값이 배지에 영구 고착된다.
+        levels[row.mb_id] = calculateLevelFromExp(exp);
     }
 
     const expiresAt = Date.now() + CACHE_TTL_MS;

--- a/apps/web/src/lib/utils/level-thresholds.test.ts
+++ b/apps/web/src/lib/utils/level-thresholds.test.ts
@@ -102,10 +102,16 @@ describe('백엔드와 완전 일치 (level + progress)', () => {
 
 describe('calculateLevelInfo — 진행도', () => {
     it('레벨 시작점은 0%', () => expect(calculateLevelInfo(1000).progress).toBe(0));
-    it('다음 레벨 직전은 100% 미만', () => {
-        const info = calculateLevelInfo(3999);
-        expect(info.progress).toBeLessThan(100);
+    it('다음 레벨 직전에도 레벨은 오르지 않고 expToNext 만 1 남는다', () => {
+        const info = calculateLevelInfo(3999); // Lv.2 구간의 마지막 XP
+        expect(info.level).toBe(2);
         expect(info.expToNext).toBe(1);
+        // ⚠️ 여기서 progress 는 100 이 된다. 백엔드의 정수 반올림
+        //    ((x × 200 / range) + 1) / 2 가 레벨업 직전을 100 으로 올리기 때문이다.
+        //    (3999-1000)×200/3000 = 199 → (199+1)/2 = 100
+        //    "100% 인데 아직 레벨업 전"은 의도된 동작이 아니라 공식의 성질이다.
+        //    백엔드와 같게 두는 것이 이 파일의 목적이므로 그대로 단언한다.
+        expect(info.progress).toBe(100);
     });
     it('expToNext 는 음수가 되지 않는다', () => {
         expect(calculateLevelInfo(0).expToNext).toBeGreaterThanOrEqual(0);

--- a/apps/web/src/lib/utils/level-thresholds.test.ts
+++ b/apps/web/src/lib/utils/level-thresholds.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+    levelExp,
+    calculateLevelFromExp,
+    calculateLevelInfo,
+    MAX_XP_LEVEL
+} from './level-thresholds';
+
+/**
+ * 이 테스트의 목적은 "웹 계산이 백엔드와 같은가" 하나다.
+ *
+ * 정본: backend internal/repository/v2/exp_repo.go
+ *   levelExp(n) = 1000 × (n-1)²,  maxLevel 5000,  이진탐색
+ *   progress    = ((x × 200 / range) + 1) / 2   (정수 나눗셈)
+ *
+ * 2026-07-29 bug/13149 — 웹이 109개짜리 계단식 표를 쓰고 백엔드는 2차식을 써서
+ * 같은 회원이 화면마다 다른 레벨로 보였다. 두 곡선이 다시 갈라지면 이 테스트가 깨진다.
+ */
+
+/** 백엔드 Go 를 그대로 옮긴 참조 구현 (정수 나눗셈 포함). */
+function goCalculateLevelInfo(totalExp: number): { level: number; progress: number } {
+    const lvlExp = (l: number) => (l <= 1 ? 0 : 1000 * (l - 1) * (l - 1));
+    let lo = 1;
+    let hi = 5000;
+    while (lo < hi) {
+        const mid = Math.trunc((lo + hi + 1) / 2);
+        if (lvlExp(mid) <= totalExp) lo = mid;
+        else hi = mid - 1;
+    }
+    const level = lo;
+    if (level >= 5000) return { level, progress: 100 };
+    const next = lvlExp(level + 1);
+    const prev = lvlExp(level);
+    const range = next - prev;
+    const progress =
+        range > 0 ? Math.trunc((Math.trunc(((totalExp - prev) * 200) / range) + 1) / 2) : 0;
+    return { level, progress };
+}
+
+describe('levelExp — 백엔드 공식', () => {
+    it('레벨 1은 0', () => expect(levelExp(1)).toBe(0));
+    it('0 이하도 0', () => expect(levelExp(0)).toBe(0));
+    it('알려진 값', () => {
+        expect(levelExp(2)).toBe(1000);
+        expect(levelExp(3)).toBe(4000);
+        expect(levelExp(10)).toBe(81000);
+        expect(levelExp(40)).toBe(1521000);
+    });
+});
+
+describe('calculateLevelFromExp — 경계값', () => {
+    it.each([
+        [0, 1],
+        [1, 1],
+        [999, 1],
+        [1000, 2], // 딱 경계
+        [3999, 2],
+        [4000, 3], // 딱 경계
+        [81000, 10],
+        // bug/13149 제보 회원. 예전 109표로는 34 가 나왔다.
+        [592363, 25]
+    ])('exp %i → Lv.%i', (exp, expected) => {
+        expect(calculateLevelFromExp(exp)).toBe(expected);
+    });
+
+    it('음수는 레벨 1', () => expect(calculateLevelFromExp(-1)).toBe(1));
+
+    it('상한을 넘지 않는다', () => {
+        expect(calculateLevelFromExp(Number.MAX_SAFE_INTEGER)).toBe(MAX_XP_LEVEL);
+    });
+});
+
+describe('백엔드와 완전 일치 (level + progress)', () => {
+    const samples = [
+        0, 1, 999, 1000, 3000, 4000, 50000, 81000, 300000, 592363, 1000000, 1521000, 3116632,
+        9000000, 11664000, 20000000
+    ];
+
+    it.each(samples)('exp %i', (exp) => {
+        const web = calculateLevelInfo(exp);
+        const go = goCalculateLevelInfo(exp);
+        expect(web.level).toBe(go.level);
+        expect(web.progress).toBe(go.progress);
+    });
+
+    it('무작위 20,000건에서도 일치', () => {
+        // 시드 없는 난수 대신 결정적 시퀀스 — 실패 재현이 가능해야 한다.
+        let seed = 12345;
+        const next = () => {
+            seed = (seed * 1103515245 + 12345) % 2147483648;
+            return seed;
+        };
+        for (let i = 0; i < 20000; i++) {
+            const exp = next() % 20000000;
+            const web = calculateLevelInfo(exp);
+            const go = goCalculateLevelInfo(exp);
+            expect(web.level, `exp=${exp}`).toBe(go.level);
+            expect(web.progress, `exp=${exp}`).toBe(go.progress);
+        }
+    });
+});
+
+describe('calculateLevelInfo — 진행도', () => {
+    it('레벨 시작점은 0%', () => expect(calculateLevelInfo(1000).progress).toBe(0));
+    it('다음 레벨 직전은 100% 미만', () => {
+        const info = calculateLevelInfo(3999);
+        expect(info.progress).toBeLessThan(100);
+        expect(info.expToNext).toBe(1);
+    });
+    it('expToNext 는 음수가 되지 않는다', () => {
+        expect(calculateLevelInfo(0).expToNext).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/apps/web/src/lib/utils/level-thresholds.ts
+++ b/apps/web/src/lib/utils/level-thresholds.ts
@@ -1,32 +1,64 @@
 /**
- * XP 레벨 임계값 + 레벨 계산 유틸 (server·client 공통)
+ * XP 레벨 계산 유틸 (server·client 공통) — 단일 source of truth.
  *
- * 단일 source of truth. 기존 다음 위치들에서 중복 정의돼 있던 것을 모음:
+ * 기존 다음 위치들에서 중복 정의돼 있던 것을 모음:
  * - apps/web/src/routes/api/members/[id]/profile/+server.ts (계산 사용)
  * - apps/web/src/lib/server/member-levels.ts (저장값 그대로 반환 — drift 발생)
  * - angple-backend / damoang-backend 의 별도 구현
  *
  * #12046 — 헤더의 LevelBadge 가 stale 한 DB as_level 을 보여 프로필 동적 계산값과
  * 불일치하던 문제를 fix 하기 위해 동일 임계값으로 항상 계산하도록 통일.
+ *
+ * ---------------------------------------------------------------------------
+ * 2026-07-29 (bug/13149) — 곡선을 백엔드와 같은 것으로 교체.
+ *
+ * 그동안 이 파일은 109개짜리 계단식 임계값 표를 들고 있었는데, **백엔드가 쓰는
+ * 곡선과 다른 곡선이었다.** 백엔드는 `1000·(n−1)²` 로 as_level 을 저장하고 조회도
+ * 같은 공식으로 하는데(exp_repo.go:111), 웹만 이 표로 계산하고 있었다.
+ *
+ *   as_exp 592,363  →  이 표: Lv.34   /   백엔드: Lv.25
+ *
+ * 두 곡선은 3번째 항목부터 갈라진다(표 3,000 vs 공식 4,000). 중간 구간은 공식이
+ * 낮게 나오고, 표가 109 에서 잘리는 초고 XP 구간은 공식이 높게 나온다 — 그래서
+ * 차이가 한 방향이 아니라 양쪽으로 갈렸다.
+ *
+ * 실측: as_exp 상위 3,000명 중 2,996명(99.9%)이 웹 표시값 ≠ 저장값. 최대 14레벨 차이.
+ * 회원 눈에는 "프로필 들어가는 길에 따라 레벨이 다르게 보인다"로 나타났다.
+ *
+ * ⛔ 왜 표가 아니라 공식을 정본으로 골랐는가:
+ *    표를 정본으로 삼으면 DB 의 as_level 을 전 회원 일괄 보정해야 하는데, 레벨이
+ *    오르는 순간 xp-levelup-toast 가 발화해 **수천 명에게 동시에 축하 모달**이 뜬다
+ *    (전환쌍 중복방지 키가 새 값이라 막지 못한다). 게다가 중고거래 글쓰기 권한이
+ *    as_level >= 30 이라 경계가 대량 이동한다.
+ *    공식을 백엔드에 맞추면 **DB 를 한 줄도 건드리지 않고** 표시만 일치한다.
+ *
+ * ⛔ 이 파일의 계산을 백엔드와 다르게 바꾸지 말 것.
+ *    정본은 backend `internal/repository/v2/exp_repo.go` 의 levelExp / calculateLevelInfo 다.
+ *    한쪽만 바꾸면 이 버그가 그대로 재발한다.
  */
 
+/** 나리야 호환 XP 기준값 — 백엔드 exp_repo.go 의 xp_base. */
+const XP_BASE = 1000;
+
 /**
- * 누적 XP 임계값 — index 0 부터 시작하며 currentLevel = (조건 만족하는 최대 index) + 1.
- * 예: as_exp=3,116,632 → idx 63 (3,003,000) 통과, idx 64 (3,146,000) 미통과 → level 64
+ * 도달 가능한 최대 레벨 (나리야 xp_max). 백엔드 exp_repo.go:106 과 같은 값.
+ *
+ * ⚠️ 배지 이미지는 109 까지만 있고(level-badge.svelte 의 MAX_LEVEL) 그 위는 클램프된다.
+ *    레벨 109 = 1000 × 108² = 11,664,000 XP.
  */
-export const LEVEL_THRESHOLDS: readonly number[] = [
-    0, 1000, 3000, 6000, 10000, 15000, 21000, 28000, 36000, 45000, 55000, 66000, 78000, 91000,
-    105000, 120000, 136000, 153000, 171000, 190000, 210000, 231000, 253000, 276000, 300000, 325000,
-    351000, 378000, 406000, 435000, 466000, 499000, 534000, 571000, 610000, 651000, 694000, 739000,
-    786000, 835000, 887000, 941000, 998000, 1058000, 1121000, 1187000, 1256000, 1328000, 1403000,
-    1481000, 1563000, 1649000, 1739000, 1833000, 1931000, 2033000, 2139000, 2249000, 2363000,
-    2481000, 2604000, 2732000, 2865000, 3003000, 3146000, 3294000, 3447000, 3605000, 3768000,
-    3936000, 4110000, 4290000, 4476000, 4668000, 4866000, 5070000, 5280000, 5496000, 5718000,
-    5946000, 6181000, 6423000, 6672000, 6928000, 7191000, 7461000, 7738000, 8022000, 8313000,
-    8611000, 8917000, 9231000, 9553000, 9883000, 10221000, 10567000, 10921000, 11283000, 11653000,
-    12031000, 12418000, 12814000, 13219000, 13633000, 14056000, 14488000, 14929000, 15379000,
-    15838000
-];
+export const MAX_XP_LEVEL = 5000;
+
+/**
+ * 해당 레벨에 도달하는 데 필요한 누적 XP.
+ * 백엔드 `levelExp()` 와 동일: `XP_BASE × (level−1)²`
+ *
+ *   Lv.1 → 0 / Lv.2 → 1,000 / Lv.3 → 4,000 / Lv.10 → 81,000 / Lv.40 → 1,521,000
+ */
+export function levelExp(level: number): number {
+    if (level <= 1) return 0;
+    const n = level - 1;
+    return XP_BASE * n * n;
+}
 
 export interface LevelInfo {
     level: number;
@@ -41,37 +73,45 @@ export interface LevelInfo {
  * @returns currentLevel (1 부터 시작)
  */
 export function calculateLevelFromExp(totalExp: number): number {
-    let currentLevel = 1;
-    for (let i = 0; i < LEVEL_THRESHOLDS.length; i++) {
-        if (totalExp >= LEVEL_THRESHOLDS[i]) {
-            currentLevel = i + 1;
+    // 백엔드와 같은 이진탐색. levelExp(level) <= totalExp 를 만족하는 가장 높은 level.
+    let lo = 1;
+    let hi = MAX_XP_LEVEL;
+    while (lo < hi) {
+        const mid = Math.floor((lo + hi + 1) / 2);
+        if (levelExp(mid) <= totalExp) {
+            lo = mid;
         } else {
-            break;
+            hi = mid - 1;
         }
     }
-    return currentLevel;
+    return lo;
 }
 
 /**
- * 누적 XP 로부터 레벨 + 진행도 정보 반환
+ * 누적 XP 로부터 레벨 + 진행도 정보 반환.
+ * progress 반올림까지 백엔드 calculateLevelInfo 와 같은 값이 나오도록 맞췄다.
  */
 export function calculateLevelInfo(totalExp: number): LevelInfo {
     const level = calculateLevelFromExp(totalExp);
 
-    if (level >= LEVEL_THRESHOLDS.length) {
+    if (level >= MAX_XP_LEVEL) {
         return {
             level,
-            nextLevelExp: LEVEL_THRESHOLDS[LEVEL_THRESHOLDS.length - 1],
+            nextLevelExp: levelExp(level),
             expToNext: 0,
             progress: 100
         };
     }
 
-    const nextLevelExp = LEVEL_THRESHOLDS[level];
-    const prevLevelExp = level > 1 ? LEVEL_THRESHOLDS[level - 1] : 0;
+    const nextLevelExp = levelExp(level + 1);
+    const prevLevelExp = levelExp(level);
     const expToNext = Math.max(0, nextLevelExp - totalExp);
-    const range = nextLevelExp - prevLevelExp;
-    const progress = range > 0 ? Math.round(((totalExp - prevLevelExp) * 100) / range) : 0;
+    const levelRange = nextLevelExp - prevLevelExp;
+    // 백엔드와 동일한 정수 반올림 트릭: ((x * 200 / range) + 1) / 2
+    const progress =
+        levelRange > 0
+            ? Math.floor((Math.floor(((totalExp - prevLevelExp) * 200) / levelRange) + 1) / 2)
+            : 0;
 
     return { level, nextLevelExp, expToNext, progress };
 }

--- a/apps/web/src/routes/admin/xp/+page.svelte
+++ b/apps/web/src/routes/admin/xp/+page.svelte
@@ -38,12 +38,15 @@
     } from '$lib/api/admin-xp';
     import Clock from '@lucide/svelte/icons/clock';
     import Coins from '@lucide/svelte/icons/coins';
+    import { levelExp } from '$lib/utils/level-thresholds';
 
-    // 레벨 구간 데이터
-    const levelThresholds = [
-        0, 1000, 3000, 6000, 10000, 15000, 21000, 28000, 36000, 45000, 55000, 66000, 78000, 91000,
-        105000
-    ];
+    // 레벨 구간 표 — 정본 공식에서 유도한다.
+    //
+    // ⛔ 여기에 숫자를 하드코딩하지 말 것. 원래 15개짜리 표가 박혀 있었는데
+    //    실제 곡선과 달라 관리자 화면이 잘못된 구간을 보여주고 있었다
+    //    (bug/13149, 2026-07-29). 정본은 $lib/utils/level-thresholds 다.
+    const LEVEL_ROWS = 15;
+    const levelThresholds = Array.from({ length: LEVEL_ROWS }, (_, i) => levelExp(i + 1));
 
     // 설정 상태
     let config = $state<XPConfig>({

--- a/apps/web/src/routes/api/admin/backfill-xp/+server.ts
+++ b/apps/web/src/routes/api/admin/backfill-xp/+server.ts
@@ -11,6 +11,7 @@ import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool, { readPool } from '$lib/server/db.js';
 import { grantLoginXPForDate } from '$lib/server/auth/xp-grant.js';
+import { calculateLevelFromExp as calculateLevel } from '$lib/utils/level-thresholds';
 
 interface MissingRow extends RowDataPacket {
     mb_id: string;
@@ -29,32 +30,15 @@ interface MemberExpRow extends RowDataPacket {
     mb_level: number;
 }
 
-// Level thresholds — same as xp-grant.ts
-const levelThresholds = [
-    0, 1000, 3000, 6000, 10000, 15000, 21000, 28000, 36000, 45000, 55000, 66000, 78000, 91000,
-    105000, 120000, 136000, 153000, 171000, 190000, 210000, 231000, 253000, 276000, 300000, 325000,
-    351000, 378000, 406000, 435000, 466000, 499000, 534000, 571000, 610000, 651000, 694000, 739000,
-    786000, 835000, 887000, 941000, 998000, 1058000, 1121000, 1187000, 1256000, 1328000, 1403000,
-    1481000, 1563000, 1649000, 1739000, 1833000, 1931000, 2033000, 2139000, 2249000, 2363000,
-    2481000, 2604000, 2732000, 2865000, 3003000, 3146000, 3294000, 3447000, 3605000, 3768000,
-    3936000, 4110000, 4290000, 4476000, 4668000, 4866000, 5070000, 5280000, 5496000, 5718000,
-    5946000, 6181000, 6423000, 6672000, 6928000, 7191000, 7461000, 7738000, 8022000, 8313000,
-    8611000, 8917000, 9231000, 9553000, 9883000, 10221000, 10567000, 10921000, 11283000, 11653000,
-    12031000, 12418000, 12814000, 13219000, 13633000, 14056000, 14488000, 14929000, 15379000,
-    15838000
-];
-
-function calculateLevel(totalExp: number): number {
-    let level = 1;
-    for (let i = 0; i < levelThresholds.length; i++) {
-        if (totalExp >= levelThresholds[i]) {
-            level = i + 1;
-        } else {
-            break;
-        }
-    }
-    return level;
-}
+// 레벨 계산은 정본($lib/utils/level-thresholds)에 위임한다 — 위 import 참조.
+//
+// ⛔ 여기에 임계값 표를 다시 만들지 말 것. 원래 109개짜리 사본이 있었고,
+//    그것이 백엔드와 다른 곡선이라 같은 회원이 화면마다 다른 레벨로 보이는
+//    원인 중 하나였다(bug/13149, 2026-07-29).
+//
+// ⚠️ 이 엔드포인트의 POST 는 MISSING_QUERY 에 LIMIT 이 없어 **전 회원 as_level 을
+//    일괄 UPDATE** 한다. 레벨이 오르는 회원에게는 xp-levelup-toast 가 발화하므로
+//    수천 명에게 동시에 축하 모달이 뜰 수 있다. 함부로 실행하지 말 것.
 
 const MISSING_QUERY = `
 SELECT DISTINCT s.mb_id, DATE(s.created_at) as login_date

--- a/apps/web/src/routes/api/members/[id]/followers/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/followers/+server.ts
@@ -7,6 +7,7 @@ import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import { readPool } from '$lib/server/db.js';
 import { isWithdrawnMember } from '../_withdrawn';
+import { calculateLevelFromExp } from '$lib/utils/level-thresholds';
 
 interface FollowerRow extends RowDataPacket {
     mb_id: string;
@@ -14,6 +15,9 @@ interface FollowerRow extends RowDataPacket {
     mb_image_url: string;
     mb_image_updated_at: string;
     mb_level: number;
+    // XP 배지용. ⛔ 저장된 as_level 이 아니라 as_exp 를 읽어 계산한다 —
+    //    다른 화면과 같은 규칙을 쓰기 위해서다(bug/13149).
+    as_exp: number;
     followed_at: string;
 }
 
@@ -41,7 +45,7 @@ export const GET: RequestHandler = async ({ params }) => {
         const total = countRows[0]?.count ?? 0;
 
         const [rows] = await readPool.query<FollowerRow[]>(
-            `SELECT f.mb_id, m.mb_nick, m.mb_image_url, m.mb_image_updated_at, m.mb_level, f.created_at as followed_at
+            `SELECT f.mb_id, m.mb_nick, m.mb_image_url, m.mb_image_updated_at, m.mb_level, m.as_exp, f.created_at as followed_at
 			 FROM g5_member_follow f
 			 JOIN g5_member m ON f.mb_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
 			 WHERE f.target_id = ?
@@ -60,6 +64,7 @@ export const GET: RequestHandler = async ({ params }) => {
                     mb_image: r.mb_image_url || '',
                     mb_image_updated_at: r.mb_image_updated_at || '',
                     mb_level: r.mb_level,
+                    as_level: calculateLevelFromExp(Number(r.as_exp) || 0),
                     followed_at: r.followed_at
                 }))
             }

--- a/apps/web/src/routes/api/members/[id]/following/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/following/+server.ts
@@ -7,6 +7,7 @@ import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import { readPool } from '$lib/server/db.js';
 import { isWithdrawnMember } from '../_withdrawn';
+import { calculateLevelFromExp } from '$lib/utils/level-thresholds';
 
 interface FollowingRow extends RowDataPacket {
     mb_id: string;
@@ -14,6 +15,9 @@ interface FollowingRow extends RowDataPacket {
     mb_image_url: string;
     mb_image_updated_at: string;
     mb_level: number;
+    // XP 배지용. ⛔ 저장된 as_level 이 아니라 as_exp 를 읽어 계산한다 —
+    //    다른 화면과 같은 규칙을 쓰기 위해서다(bug/13149).
+    as_exp: number;
     followed_at: string;
 }
 
@@ -41,7 +45,7 @@ export const GET: RequestHandler = async ({ params }) => {
         const total = countRows[0]?.count ?? 0;
 
         const [rows] = await readPool.query<FollowingRow[]>(
-            `SELECT f.target_id as mb_id, m.mb_nick, m.mb_image_url, m.mb_image_updated_at, m.mb_level, f.created_at as followed_at
+            `SELECT f.target_id as mb_id, m.mb_nick, m.mb_image_url, m.mb_image_updated_at, m.mb_level, m.as_exp, f.created_at as followed_at
 			 FROM g5_member_follow f
 			 JOIN g5_member m ON f.target_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
 			 WHERE f.mb_id = ?
@@ -60,6 +64,7 @@ export const GET: RequestHandler = async ({ params }) => {
                     mb_image: r.mb_image_url || '',
                     mb_image_updated_at: r.mb_image_updated_at || '',
                     mb_level: r.mb_level,
+                    as_level: calculateLevelFromExp(Number(r.as_exp) || 0),
                     followed_at: r.followed_at
                 }))
             }

--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -49,6 +49,7 @@ interface DisciplineLogRow extends RowDataPacket {
 
 import { parseDisciplineLogContent, type DisciplineEntry } from './_parse-discipline';
 import { calculateDeletePostCount } from './_recompute-counts';
+import { calculateLevelInfo as calcLevelInfo } from '$lib/utils/level-thresholds';
 
 interface CountRow extends RowDataPacket {
     count: number;
@@ -61,48 +62,24 @@ interface NickHistoryRow extends RowDataPacket {
     changed_at: string;
 }
 
-// Level thresholds (cumulative exp required for each level) — synced with backend
-const levelThresholds = [
-    0, 1000, 3000, 6000, 10000, 15000, 21000, 28000, 36000, 45000, 55000, 66000, 78000, 91000,
-    105000, 120000, 136000, 153000, 171000, 190000, 210000, 231000, 253000, 276000, 300000, 325000,
-    351000, 378000, 406000, 435000, 466000, 499000, 534000, 571000, 610000, 651000, 694000, 739000,
-    786000, 835000, 887000, 941000, 998000, 1058000, 1121000, 1187000, 1256000, 1328000, 1403000,
-    1481000, 1563000, 1649000, 1739000, 1833000, 1931000, 2033000, 2139000, 2249000, 2363000,
-    2481000, 2604000, 2732000, 2865000, 3003000, 3146000, 3294000, 3447000, 3605000, 3768000,
-    3936000, 4110000, 4290000, 4476000, 4668000, 4866000, 5070000, 5280000, 5496000, 5718000,
-    5946000, 6181000, 6423000, 6672000, 6928000, 7191000, 7461000, 7738000, 8022000, 8313000,
-    8611000, 8917000, 9231000, 9553000, 9883000, 10221000, 10567000, 10921000, 11283000, 11653000,
-    12031000, 12418000, 12814000, 13219000, 13633000, 14056000, 14488000, 14929000, 15379000,
-    15838000
-];
-
+/**
+ * 레벨 계산은 정본($lib/utils/level-thresholds)에 위임한다.
+ *
+ * ⛔ 여기에 임계값 표를 다시 만들지 말 것. 원래 109개짜리 사본이 있었는데,
+ *    그 사본이 백엔드와 다른 곡선이라 같은 회원이 이 API 로는 Lv.34,
+ *    백엔드 /my 로는 Lv.25 로 보였다(bug/13149, 2026-07-29).
+ *    정본은 backend internal/repository/v2/exp_repo.go 의 levelExp 다.
+ *
+ * 반환 필드명(currentLevel)은 기존 호출부 호환을 위해 유지한다.
+ */
 function calculateLevelInfo(totalExp: number) {
-    let currentLevel = 1;
-    for (let i = 0; i < levelThresholds.length; i++) {
-        if (totalExp >= levelThresholds[i]) {
-            currentLevel = i + 1;
-        } else {
-            break;
-        }
-    }
-
-    if (currentLevel >= levelThresholds.length) {
-        return {
-            currentLevel,
-            nextLevelExp: levelThresholds[levelThresholds.length - 1],
-            expToNext: 0,
-            progress: 100
-        };
-    }
-
-    const nextLevelExp = levelThresholds[currentLevel];
-    const prevLevelExp = currentLevel > 1 ? levelThresholds[currentLevel - 1] : 0;
-    const expToNext = nextLevelExp - totalExp;
-    const levelRange = nextLevelExp - prevLevelExp;
-    const progress =
-        levelRange > 0 ? Math.round(((totalExp - prevLevelExp) * 100) / levelRange) : 0;
-
-    return { currentLevel, nextLevelExp, expToNext, progress };
+    const info = calcLevelInfo(totalExp);
+    return {
+        currentLevel: info.level,
+        nextLevelExp: info.nextLevelExp,
+        expToNext: info.expToNext,
+        progress: info.progress
+    };
 }
 
 export const GET: RequestHandler = async ({ params, locals }) => {


### PR DESCRIPTION
## 제보

`bug/13149` — 같은 회원인데 프로필 진입 경로에 따라 레벨이 다르게 보인다.

실측 (`google_85c7079f`, `as_exp = 592,363`):

| 화면 | 표시 | 계산 주체 |
|---|---|---|
| `/member/[id]` | **Lv.34** | 웹 109개 계단식 표 |
| `/my` | **Lv.25** | 백엔드 `expSummary` |
| DB `g5_member.as_level` | **25** | 백엔드가 저장 |

**`as_exp` 상위 3,000명 중 2,996명(99.9%)** 이 웹 표시값과 저장값이 달랐다. 최대 14레벨 차이이고 **차이 방향이 양쪽으로 갈렸다**.

## 원인 — 곡선이 두 개였다

| | 공식 | 쓰는 곳 |
|---|---|---|
| **A** | `1000 × (n−1)²` | 백엔드 `exp_repo.go` (저장·조회 모두), 웹 `xp-grant.ts` |
| **B** | 109개 계단식 표 | 웹 `level-thresholds.ts` + 사본 3곳 |

3번째 항목부터 갈라진다(A는 4,000 / B는 3,000). 중간 구간은 A가 낮고, **B가 109에서 잘리는** 초고 XP 구간은 A가 높다 — 편차가 한 방향이 아니었던 이유다.

백엔드는 저장·조회에 같은 공식을 써서 **자기 일관적**이었고, **웹만 다른 곡선**이었다.

## 정본 = A (2차식)

**DB 를 한 줄도 건드리지 않는다.**

표를 정본으로 삼는 선택지도 있었으나 기각했다 — 전 회원 `as_level` 일괄 보정이 필요하고, 레벨이 오르는 순간 `xp-levelup-toast` 가 발화해 **수천 명에게 동시에 축하 모달**이 뜬다(전환쌍 중복방지 키가 새 값이라 막지 못한다). 중고거래 글쓰기 권한(`as_level >= 30`) 경계도 대량 이동한다.

## 변경

| 파일 | 내용 |
|---|---|
| `lib/utils/level-thresholds.ts` | 109개 표 → **백엔드와 같은 2차식 + 이진탐색**. export 시그니처 유지 |
| `api/members/[id]/profile` | 사본 제거 → 정본 위임 |
| `api/admin/backfill-xp` | 사본 제거 → 정본 import |
| `routes/admin/xp` | **15개짜리 낡은 표** 제거 → 정본에서 유도 |
| `lib/server/auth/xp-grant.ts` | 자체 생성 배열 제거 → 정본 위임 |
| `lib/server/member-levels.ts` | `Math.max(계산값, 저장값)` **래칫 제거** |
| `follow-list-dialog.svelte` | `LevelBadge` 에 `mb_level`(등급) 넘기던 것 → `as_level` |
| `followers`/`following` API | `as_exp` 읽어 `as_level` 계산해 반환 |

**하드코딩 임계값 배열이 전멸**했고 7곳이 전부 정본을 import 한다.

### 래칫을 없앤 이유

```js
levels[row.mb_id] = Math.max(calculated, Number(row.as_level) || 1);
```

곡선이 달랐을 때 저장값을 보정해주려던 장치인데, 그 자체가 **제5의 규칙**이 되어 "내 프로필 레벨"과 "내 댓글 옆 배지"가 서로 다르게 굳는 원인이었다.

### 팔로워 배지

`LevelBadge level={member.mb_level}` — 등급(1~10)을 XP 배지에 넘기고 있어 **팔로워 목록의 모든 회원이 Lv.1~10** 으로 보였다. PR #717 과 같은 계열이다.

## 검증

**단위 테스트 신설** (`level-thresholds.test.ts`) — 백엔드 Go 를 그대로 옮긴 참조 구현과 대조:

- 경계값 (`0/999/1000/3999/4000/81000/592363`)
- **결정적 난수 20,000건에서 `level`·`progress` 완전 일치**
- 제보 케이스 592,363 → **25** (진행도 33%까지 화면 B와 동일)

**상한 차이 무해 확인** — `xp-grant` 는 110, 정본은 5000. `as_exp` 최대가 **8,991,485(Lv.95)** 로 110 경계(11,881,000)를 넘는 회원이 **0명**이라 저장값 변화 없음.

하이드레이션 가드 2종 통과.

## ⚠️ 사용자 체감

웹에서 보이던 레벨이 **내려간다**(34 → 25). 배지 숫자 하락이라 안내가 필요하다. "레벨이 깎였다"가 아니라 **"화면마다 다르게 계산되던 것을 하나로 맞췄다"** 로 설명해야 한다.

레벨업 토스트는 **하향에서 발화하지 않는다**(`xp-levelup-detect.svelte.ts:53-56` 저장만) — 배포 후 실측 확인 필요.

## 이번 범위 밖 (별도 티켓 권장)

- ⛔ `/api/admin/backfill-xp` POST 는 여전히 **LIMIT 없이 전량 UPDATE**. 누르면 대량 레벨업 모달이 터진다
- ⛔ 중고거래 글쓰기 권한이 `as_level` 을 쓰는 **규약 위반** (서버 `main.go:3188` + 클라 양쪽)
- 백엔드 `XPConfig`(xp_base/xp_rate/max_level) 설정값이 코드에서 참조되지 않아 **관리자가 바꿔도 무효**