### PR TITLE
docs(point): 포인트 유효기간 안내 추가

### DIFF
--- a/apps/web/src/routes/point/+page.svelte
+++ b/apps/web/src/routes/point/+page.svelte
@@ -121,6 +121,26 @@
                         </p>
                     </div>
                 </div>
+                <!--
+                    유효기간 안내 (2026-07-29).
+                    포인트 만료는 원래부터 '적립일로부터 1년' 정책이고 DB 에도 그렇게 기록된다
+                    (g5_point.po_expire_date = 적립일 + 364일, 1,245만 건).
+                    그런데 안내 페이지에 이 내용이 한 줄도 없었다 — 리뉴얼 과정에서 빠진 것으로 보인다.
+
+                    ⛔ "소멸됩니다" 라고 쓰지 않는다.
+                       소멸 배치(point-expiry)는 현재 의도적으로 꺼져 있고(POINT_EXPIRY_ENABLED 미설정),
+                       켤 계획도 정해지지 않았다. 소멸을 단언하면 곧 집행할 것처럼 읽혀
+                       회원 문의를 부른다. 유효기간이라는 사실만 알린다.
+                -->
+                <div class="flex items-start gap-3">
+                    <Info class="mt-0.5 h-5 w-5 shrink-0 text-blue-500" />
+                    <div>
+                        <p class="text-foreground text-sm font-medium">포인트 유효기간</p>
+                        <p class="text-muted-foreground text-sm">
+                            포인트의 유효기간은 적립일로부터 <b>1년</b>입니다.
+                        </p>
+                    </div>
+                </div>
             </CardContent>
         </Card>
     </section>


### PR DESCRIPTION
## 문제

포인트 만료는 **원래부터 '적립일로부터 1년' 정책**이고 DB 에도 그렇게 기록됩니다.

```
g5_point.po_expire_date = 적립일 + 364일   →   12,454,604건 (대다수)
```

그런데 `/point` 안내 페이지에 **"소멸·만료·유효기간" 이라는 단어가 한 줄도 없습니다.** 리뉴얼 과정에서 안내가 빠진 것으로 보입니다.

정책은 있는데 고지가 없는 상태가 가장 위험합니다.

## 변경

「포인트 사용」 섹션에 항목 하나를 추가합니다. 기존 카드 구조를 그대로 따릅니다.

> **포인트 유효기간**
> 포인트의 유효기간은 적립일로부터 **1년**입니다.

## ⛔ "소멸됩니다" 를 쓰지 않은 이유

소멸 배치(`point-expiry`)는 **현재 의도적으로 꺼져 있습니다.**

```go
if os.Getenv("POINT_EXPIRY_ENABLED") != "true" {
    log.Printf("[point] ExpireBatch skipped: ... (대량 만료 방지 가드)")
    return 0, nil
}
```

켤 계획도 정해지지 않았습니다. 이 상태에서 "소멸됩니다" 라고 단언하면 **곧 집행할 것처럼 읽혀** 문의를 부릅니다. 유효기간이라는 사실만 알립니다.

## 참고 — 이번 PR 범위 밖이지만 기록해 둡니다

2026-07-29 실측:

| | |
|---|---|
| 만료일이 지난 미처리 포인트 | **836,148,837 P** |
| 영향 회원 | **40,365명** (1인당 평균 20,715P) |
| 회원 보유 총액 대비 | **52%** |

⛔ **`ExpireBatch` 는 한 번 호출에 전량을 처리합니다.**

```go
for {
    ... LIMIT 1000 FOR UPDATE ... 트랜잭션 ...
    if len(expired) < batchSize { break }   // 빌 때까지 계속
}
```

지금 켜면 **600만 행 ÷ 1000 = 약 6,022회 트랜잭션이 한 요청 안에서** 연달아 돕니다. 켜기 전에 **회당 상한**을 넣어야 합니다. 오늘 아침 엔진 크래시로 8분 중단됐던 그 DB입니다.

또한 `po_expired=1` 로 표시만 하고 **행을 지우지 않으므로** 테이블 공간(4.7GB)은 줄지 않습니다.