### PR TITLE
fix(content): 밈 이모티콘 기본 표시 폭을 200px로 (#13145)

### DIFF
--- a/apps/web/src/lib/utils/content-transform.test.ts
+++ b/apps/web/src/lib/utils/content-transform.test.ts
@@ -343,6 +343,40 @@ describe('transformEmoticons - 기존 동작 유지', () => {
     });
 });
 
+describe('transformEmoticons - 팩별 기본 폭 (bug#13145)', () => {
+    it('밈 팩은 크기를 안 쓰면 200px', () => {
+        const result = transformEmoticons('{emo:damoang-meme-051.gif}');
+        expect(result).toContain('width="200"');
+    });
+
+    it('밈 외 팩은 기존대로 50px', () => {
+        expect(transformEmoticons('{emo:damoang-emo-042.gif}')).toContain('width="50"');
+        expect(transformEmoticons('{emo:onion-133.gif}')).toContain('width="50"');
+        expect(transformEmoticons('{emo:smile.gif}')).toContain('width="50"');
+    });
+
+    it('밈이라도 회원이 지정한 크기가 팩 기본값을 이긴다', () => {
+        expect(transformEmoticons('{emo:damoang-meme-051.gif:80}')).toContain('width="80"');
+    });
+
+    // 밈 기본값(200)이 MAX_WIDTH(200)와 같으므로 상한 자체가 무력화되지 않았는지 확인.
+    it('밈도 상한 200을 넘길 수 없다', () => {
+        expect(transformEmoticons('{emo:damoang-meme-051.gif:9999}')).toContain('width="200"');
+    });
+
+    // 접두사 매칭이라 'damoang-meme' 로 시작만 하면 걸린다. 대소문자 무시.
+    it('대문자 파일명도 밈으로 인식', () => {
+        expect(transformEmoticons('{emo:DAMOANG-MEME-051.GIF}')).toContain('width="200"');
+    });
+
+    // ⛔ 팩 기본값을 파일명 검증보다 먼저 적용하면 경로 탐색이 뚫린다.
+    it('밈 접두사를 흉내낸 경로 탐색도 차단', () => {
+        const result = transformEmoticons('{emo:damoang-meme-../../etc/passwd.gif}');
+        expect(result).not.toContain('passwd');
+        expect(result).toBe('😀');
+    });
+});
+
 describe('transformInlineMarkdown', () => {
     it('**bold** 변환', () => {
         expect(transformInlineMarkdown('마크다운 **테스트**!')).toBe(

--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -18,6 +18,44 @@ const DEFAULT_WIDTH = 50;
 const ALLOWED_EXTENSIONS = ['.gif', '.png', '.jpg', '.jpeg', '.webp'];
 
 /**
+ * 팩별 기본 표시 폭(px). 접두사가 일치하면 DEFAULT_WIDTH 대신 이 값을 쓴다.
+ *
+ * 왜 필요한가 (bug#13145, 2026-07-29 실측):
+ *   기본 50px 은 정사각형 인라인 이모지에 맞춘 값인데 '밈' 팩은 성격이 다르다.
+ *
+ *     팩              개수  원본폭 중앙  세로비(h/w)   폭200 렌더높이
+ *     damoang-emo      54       60      0.68~1.22   중앙 200 / 최대 245
+ *     damoang-meme     49      282      0.12~1.79   중앙 175 / 최대 358
+ *     onion           264       50      0.98~1.11   중앙 200 / 최대 222
+ *
+ *   밈은 원본 중앙값이 282px 인 '그림'이다. 최대 damoang-meme-051.gif 은
+ *   2668x1740 인데 폭 50 으로 찍으면 50x33px 이 되어 내용을 알아볼 수 없다.
+ *   제보자가 지목한 파일들이 정확히 이 팩이었다.
+ *
+ * ⛔ 이 값은 MAX_WIDTH(200)와 같다. 즉 밈은 기본이 곧 상한이라 회원은
+ *    {emo:파일:80} 처럼 줄일 수만 있고 키울 수는 없다. 의도한 것이다 —
+ *    댓글 목록이 밈 하나로 밀려나는 것을 막는다. 더 키워야 한다는 요구가
+ *    실제로 나오면 MAX_WIDTH 를 팩별로 나누는 게 다음 수순이다.
+ *
+ * ⛔ 기존 글에 소급 적용된다. 저장된 본문은 {emo:...} 숏코드 그대로이고
+ *    폭은 렌더 시점에 정해지기 때문이다. 데이터 마이그레이션은 없지만
+ *    이미 올라간 글의 밈 크기가 한꺼번에 바뀐다(2026-07 자유게시판 기준
+ *    이모티콘 사용 글 3,547건 중 크기를 직접 지정한 글은 4건뿐이었다).
+ */
+const PACK_DEFAULT_WIDTH: ReadonlyArray<readonly [string, number]> = [['damoang-meme-', 200]];
+
+/**
+ * 파일명이 속한 팩의 기본 표시 폭을 반환. 일치하는 팩이 없으면 DEFAULT_WIDTH.
+ */
+function defaultWidthFor(filename: string): number {
+    const lower = filename.toLowerCase();
+    for (const [prefix, width] of PACK_DEFAULT_WIDTH) {
+        if (lower.startsWith(prefix)) return width;
+    }
+    return DEFAULT_WIDTH;
+}
+
+/**
  * 파일명이 허용된 이미지 확장자를 가지는지 확인
  */
 function isValidFilename(filename: string): boolean {
@@ -46,8 +84,9 @@ export function transformEmoticons(text: string): string {
             return '😀'; // fallback 이모지
         }
 
+        // 팩별 기본값은 파일명 검증을 통과한 뒤에 구한다.
         if (isNaN(width) || width <= 0) {
-            width = DEFAULT_WIDTH;
+            width = defaultWidthFor(filename);
         }
         if (width > MAX_WIDTH) {
             width = MAX_WIDTH;


### PR DESCRIPTION
## 배경

회원 제보(bug/13145) — 일부 이모티콘이 작아서 알아보기 힘들다. 제보자가 파일명을 올려준 덕에 원인을 특정했다.

기본 폭 50px은 정사각형 인라인 이모지 기준값인데, '밈' 팩은 성격이 다르다.

| 팩 | 개수 | 원본폭 중앙 | 세로비(h/w) | 폭200 렌더높이 |
|---|---|---|---|---|
| damoang-emo | 54 | 60 | 0.68~1.22 | 중앙 200 / 최대 245 |
| **damoang-meme** | 49 | **282** | 0.12~1.79 | 중앙 175 / 최대 358 |
| onion | 264 | 50 | 0.98~1.11 | 중앙 200 / 최대 222 |

밈은 원본 중앙값이 282px인 '그림'이다. 최대인 `damoang-meme-051.gif`은 2668×1740이라 폭 50으로 찍으면 **50×33px**이 된다.

## 변경

파일명 접두사로 팩을 판별해 기본 폭을 다르게 준다. `damoang-meme-*`만 200px, 나머지는 기존 50px 그대로.

- 회원이 `{emo:파일:80}`으로 지정한 크기가 팩 기본값보다 우선한다 (이 기능은 이전부터 있었다)
- 상한 200px은 유지 — 밈은 줄일 수만 있고 키울 수는 없다. 댓글 목록이 밈 하나로 밀려나는 걸 막는다

## 소급 적용됨

저장된 본문은 `{emo:...}` 숏코드 그대로이고 폭은 렌더 시점에 정해진다. 데이터 마이그레이션은 없지만 **이미 올라간 글의 밈 크기가 한꺼번에 바뀐다.**

2026-07 자유게시판 기준 이모티콘 사용 글 3,547건 중 크기를 직접 지정한 글은 4건뿐이라, 사실상 전부가 영향받는다.

## 테스트

`content-transform.test.ts`에 팩별 기본 폭 6건 추가 — 밈 200 / 그 외 50 / 회원 지정 우선 / 상한 유지 / 대소문자 / 접두사를 흉내낸 경로 탐색 차단.