### PR TITLE
feat(report): 일간 리포트 보강 — 반응 카드·전날 대비·시간대 글/댓글 스택

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/report-charts.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report-charts.svelte
@@ -29,7 +29,9 @@
         boardStats?: BoardStatEntry[];
         periodDays?: number;
         // ── 일간 리포트 전용 ──
-        hourlyStats?: number[]; // 시간대별 활동(0~23시, 24칸)
+        hourlyStats?: number[]; // 시간대별 활동(0~23시, 24칸, 글+댓글 합)
+        hourlyPosts?: number[]; // 시간대별 글 (있으면 글/댓글 스택으로 렌더)
+        hourlyComments?: number[]; // 시간대별 댓글
         groupStats?: BoardStatEntry[]; // 소모임별 활동
         daily?: boolean; // 일간 모드(제목·부제 문구 분기)
     }
@@ -42,6 +44,8 @@
         boardStats,
         periodDays = 1,
         hourlyStats,
+        hourlyPosts,
+        hourlyComments,
         groupStats,
         daily = false
     }: Props = $props();
@@ -286,29 +290,57 @@
                 );
             }
 
-            // 시간대별 활동 (bar) — 일간 리포트 전용
-            if (hourlyCanvas && hourlyStats && hourlyStats.length > 0) {
+            // 시간대별 활동 (bar) — 일간 리포트 전용.
+            // 글/댓글 분리 데이터가 있으면 스택으로 비율까지, 없으면 합계 단일 막대.
+            const hourlySplit =
+                hourlyPosts &&
+                hourlyComments &&
+                hourlyPosts.length === 24 &&
+                hourlyComments.length === 24;
+            const hourlyBase = hourlySplit ? hourlyPosts : hourlyStats;
+            if (hourlyCanvas && hourlyBase && hourlyBase.length > 0) {
                 charts.push(
                     new Chart(hourlyCanvas, {
                         type: 'bar',
                         data: {
-                            labels: hourlyStats.map((_, h) => `${h}시`),
-                            datasets: [
-                                {
-                                    label: '글·댓글',
-                                    data: hourlyStats,
-                                    backgroundColor: '#3b82f6'
-                                }
-                            ]
+                            labels: hourlyBase.map((_, h) => `${h}시`),
+                            datasets: hourlySplit
+                                ? [
+                                      {
+                                          label: '글',
+                                          data: hourlyPosts,
+                                          backgroundColor: '#3b82f6'
+                                      },
+                                      {
+                                          label: '댓글',
+                                          data: hourlyComments,
+                                          backgroundColor: '#10b981'
+                                      }
+                                  ]
+                                : [
+                                      {
+                                          label: '글·댓글',
+                                          data: hourlyStats ?? [],
+                                          backgroundColor: '#3b82f6'
+                                      }
+                                  ]
                         },
                         options: {
                             responsive: true,
                             maintainAspectRatio: false,
                             scales: {
-                                x: { grid: { display: false }, ticks: { maxTicksLimit: 12 } },
-                                y: { beginAtZero: true, grid: { color: gridColor } }
+                                x: {
+                                    stacked: hourlySplit,
+                                    grid: { display: false },
+                                    ticks: { maxTicksLimit: 12 }
+                                },
+                                y: {
+                                    stacked: hourlySplit,
+                                    beginAtZero: true,
+                                    grid: { color: gridColor }
+                                }
                             },
-                            plugins: { legend: { display: false } }
+                            plugins: { legend: { display: hourlySplit } }
                         }
                     })
                 );
@@ -393,11 +425,11 @@
         </div>
     {/if}
 
-    {#if hourlyStats && hourlyStats.length > 0}
+    {#if (hourlyStats && hourlyStats.length > 0) || (hourlyPosts && hourlyPosts.length > 0)}
         <div class="rounded-xl border p-5">
             <div class="mb-3">
                 <h3 class="text-foreground text-sm font-medium">시간대별 활동</h3>
-                <p class="text-muted-foreground text-xs">0시~23시 글·댓글 작성량</p>
+                <p class="text-muted-foreground text-xs">0시~23시 글/댓글 작성량 (스택)</p>
             </div>
             <div class="relative h-56">
                 <canvas bind:this={hourlyCanvas}></canvas>

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -42,6 +42,8 @@
     import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
     import Scale from '@lucide/svelte/icons/scale';
     import CalendarDays from '@lucide/svelte/icons/calendar-days';
+    import Eye from '@lucide/svelte/icons/eye';
+    import TrendingUp from '@lucide/svelte/icons/trending-up';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { DisciplinedContent } from '$lib/components/ui/discipline-related';
     import { AdultBlur } from '$lib/components/features/adult/index.js';
@@ -170,9 +172,20 @@
         good_users?: number; // 공감 누른 회원 수
         active_writers?: number; // 글·댓글 쓴 회원 수
         avg_comments?: number; // 글당 평균 댓글
-        hourly_stats?: number[]; // 시간대별 활동(0~23시, 24칸)
+        hourly_stats?: number[]; // 시간대별 활동(0~23시, 24칸, 글+댓글 합)
+        hourly_posts?: number[]; // 시간대별 글(24칸)
+        hourly_comments?: number[]; // 시간대별 댓글(24칸)
+        // 반응이 많았던 글 (일간 카드)
+        reaction_stats?: {
+            max_views?: number;
+            max_comments?: number;
+            over50_comments?: number;
+            over3k_views?: number;
+        };
         group_stats?: BoardStatEntry[]; // 소모임별 활동
         prev_day?: {
+            posts?: number;
+            comments?: number;
             total_reports?: number;
             report_count?: number;
             report_month?: number;
@@ -215,6 +228,7 @@
                   {
                       label: '글',
                       value: stats.total_cases ?? 0,
+                      prev: stats.prev_day?.posts,
                       icon: FileText,
                       color: 'text-blue-600 dark:text-blue-400',
                       bg: 'bg-blue-50 dark:bg-blue-950/30'
@@ -222,6 +236,7 @@
                   {
                       label: '댓글',
                       value: stats.total_month_cases ?? 0,
+                      prev: stats.prev_day?.comments,
                       icon: MessageCircle,
                       color: 'text-green-600 dark:text-green-400',
                       bg: 'bg-green-50 dark:bg-green-950/30'
@@ -386,6 +401,42 @@
 
     const secondaryMetrics = $derived(isDaily ? dailySecondaryMetrics : weeklySecondaryMetrics);
 
+    // 반응이 많았던 글 (일간 전용 카드 4장)
+    const reactionMetrics = $derived(
+        isDaily && stats.reaction_stats
+            ? [
+                  {
+                      label: '최다 조회',
+                      value: stats.reaction_stats.max_views ?? 0,
+                      icon: Eye,
+                      color: 'text-cyan-600 dark:text-cyan-400',
+                      bg: 'bg-cyan-50 dark:bg-cyan-950/30'
+                  },
+                  {
+                      label: '최다 댓글',
+                      value: stats.reaction_stats.max_comments ?? 0,
+                      icon: MessageCircle,
+                      color: 'text-lime-600 dark:text-lime-400',
+                      bg: 'bg-lime-50 dark:bg-lime-950/30'
+                  },
+                  {
+                      label: '댓글 50개 이상',
+                      value: stats.reaction_stats.over50_comments ?? 0,
+                      icon: Flag,
+                      color: 'text-fuchsia-600 dark:text-fuchsia-400',
+                      bg: 'bg-fuchsia-50 dark:bg-fuchsia-950/30'
+                  },
+                  {
+                      label: '조회 3천 이상',
+                      value: stats.reaction_stats.over3k_views ?? 0,
+                      icon: TrendingUp,
+                      color: 'text-violet-600 dark:text-violet-400',
+                      bg: 'bg-violet-50 dark:bg-violet-950/30'
+                  }
+              ]
+            : []
+    );
+
     // 차트 데이터 유무
     const hasChartData = $derived(
         (stats.daily_stats && Object.keys(stats.daily_stats).length > 0) ||
@@ -544,6 +595,21 @@
                                 <p class="text-foreground text-2xl font-bold">
                                     {metric.value.toLocaleString()}
                                 </p>
+                                {#if 'prev' in metric}
+                                    {@const pd = deltaPct(metric.value, metric.prev)}
+                                    {#if pd != null}
+                                        <p
+                                            class="text-xs font-medium {pd > 0
+                                                ? 'text-red-500'
+                                                : pd < 0
+                                                  ? 'text-blue-500'
+                                                  : 'text-muted-foreground'}"
+                                            title="전날 대비"
+                                        >
+                                            {pd > 0 ? '▲' : pd < 0 ? '▼' : '—'}{Math.abs(pd)}%
+                                        </p>
+                                    {/if}
+                                {/if}
                             </div>
                         </div>
                     </div>
@@ -581,6 +647,22 @@
                 {/each}
             </div>
 
+            <!-- 반응이 많았던 글 (일간 전용) -->
+            {#if reactionMetrics.length > 0}
+                <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                    {#each reactionMetrics as metric (metric.label)}
+                        {@const Icon = metric.icon}
+                        <div class="rounded-lg border p-3 text-center {metric.bg}">
+                            <Icon class="mx-auto mb-1.5 h-5 w-5 {metric.color}" />
+                            <p class="text-foreground text-lg font-bold">
+                                {metric.value.toLocaleString()}
+                            </p>
+                            <p class="text-muted-foreground text-xs">{metric.label}</p>
+                        </div>
+                    {/each}
+                </div>
+            {/if}
+
             <!-- 차트 영역 -->
             {#if hasChartData}
                 <ReportCharts
@@ -590,6 +672,8 @@
                     reportTypes={stats.report_types}
                     boardStats={stats.board_stats}
                     hourlyStats={stats.hourly_stats}
+                    hourlyPosts={stats.hourly_posts}
+                    hourlyComments={stats.hourly_comments}
                     groupStats={stats.group_stats}
                     daily={isDaily}
                     periodDays={stats.period_days ?? 1}


### PR DESCRIPTION
#1903 후속. HTML 초안 대비 누락분 보강:

- **반응이 많았던 글** 카드 4장 (최다 조회/최다 댓글/댓글 50+/조회 3천+, `reaction_stats`)
- 주요 카드 글·댓글에 **전날 대비 증감** (`prev_day.posts/comments`)
- **시간대별 글/댓글 스택 막대** (`hourly_posts/hourly_comments`, 미제공 시 합계 단일 폴백)

전 키 optional — 주간·기존 일간 데이터 무영향. 309 wr_9 는 이미 새 키로 갱신되어 머지·배포 즉시 반영. prettier 통과.