### PR TITLE
feat(report): 게시판·소모임 순위를 글/댓글 스택 막대로

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/report-charts.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report-charts.svelte
@@ -18,6 +18,10 @@
     interface BoardStatEntry {
         name: string;
         count: number;
+        // 글/댓글 분리. 발행기가 내려주면 스택 막대로, 없으면 count 단일 막대로 폴백한다.
+        // (과거 발행분에는 없으므로 optional 이어야 한다 — 필수로 바꾸면 옛 리포트가 빈 차트가 된다)
+        posts?: number;
+        comments?: number;
     }
 
     interface Props {
@@ -63,6 +67,55 @@
         import('chart.js').then(({ Chart, registerables }) => {
             Chart.register(...registerables);
             const gridColor = 'rgba(156, 163, 175, 0.2)';
+
+            /**
+             * 순위형 가로 막대 설정. 게시판별·소모임별이 같은 모양이라 공통화한다.
+             *
+             * 정렬은 발행기가 내려준 순서를 그대로 쓴다(활동 많은 곳이 앞). Chart.js 는
+             * indexAxis:'y' 에서 labels[0] 을 **맨 위**에 그리므로 1위가 위에 온다.
+             * 반대로 두려면 entries 를 slice().reverse() 하면 된다.
+             *
+             * 글/댓글이 있으면 스택, 없으면 count 단일 막대 — 시간대별 차트와 같은 폴백 규칙.
+             */
+            const rankedBar = (entries: BoardStatEntry[], fallbackName: string) => {
+                const split = entries.some((e) => e.posts != null || e.comments != null);
+                return {
+                    type: 'bar' as const,
+                    data: {
+                        labels: entries.map((e) => e.name || fallbackName),
+                        datasets: split
+                            ? [
+                                  {
+                                      label: '글',
+                                      data: entries.map((e) => e.posts ?? 0),
+                                      backgroundColor: '#3b82f6'
+                                  },
+                                  {
+                                      label: '댓글',
+                                      data: entries.map((e) => e.comments ?? 0),
+                                      backgroundColor: '#10b981'
+                                  }
+                              ]
+                            : [
+                                  {
+                                      label: '글·댓글',
+                                      data: entries.map((e) => e.count || 0),
+                                      backgroundColor: '#3b82f6'
+                                  }
+                              ]
+                    },
+                    options: {
+                        indexAxis: 'y' as const,
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            x: { stacked: split, beginAtZero: true, grid: { color: gridColor } },
+                            y: { stacked: split, grid: { display: false } }
+                        },
+                        plugins: { legend: { display: split, position: 'top' as const } }
+                    }
+                };
+            };
 
             // 일별 활동 트렌드 (line)
             if (dailyCanvas && dailyStats && Object.keys(dailyStats).length > 0) {
@@ -261,33 +314,11 @@
                 );
             }
 
-            // 게시판별 현황 (horizontal bar)
+            // 게시판별 활동 (horizontal bar)
+            // ⛔ 이 차트는 예전에 '신고 건수'(빨강)로 라벨돼 있었으나 실제 데이터는
+            //    g5_board_new 기반 **활동(글+댓글) 건수**였다. 라벨이 틀린 것이라 바로잡았다.
             if (boardCanvas && boardStats && boardStats.length > 0) {
-                charts.push(
-                    new Chart(boardCanvas, {
-                        type: 'bar',
-                        data: {
-                            labels: boardStats.map((b) => b.name || '게시판'),
-                            datasets: [
-                                {
-                                    label: '신고 건수',
-                                    data: boardStats.map((b) => b.count || 0),
-                                    backgroundColor: '#ef4444'
-                                }
-                            ]
-                        },
-                        options: {
-                            indexAxis: 'y',
-                            responsive: true,
-                            maintainAspectRatio: false,
-                            scales: {
-                                x: { beginAtZero: true, grid: { color: gridColor } },
-                                y: { grid: { display: false } }
-                            },
-                            plugins: { legend: { display: false } }
-                        }
-                    })
-                );
+                charts.push(new Chart(boardCanvas, rankedBar(boardStats, '게시판')));
             }
 
             // 시간대별 활동 (bar) — 일간 리포트 전용.
@@ -348,31 +379,7 @@
 
             // 소모임별 활동 (horizontal bar) — 일간 리포트 전용
             if (groupCanvas && groupStats && groupStats.length > 0) {
-                charts.push(
-                    new Chart(groupCanvas, {
-                        type: 'bar',
-                        data: {
-                            labels: groupStats.map((g) => g.name || '소모임'),
-                            datasets: [
-                                {
-                                    label: '글·댓글',
-                                    data: groupStats.map((g) => g.count || 0),
-                                    backgroundColor: '#10b981'
-                                }
-                            ]
-                        },
-                        options: {
-                            indexAxis: 'y',
-                            responsive: true,
-                            maintainAspectRatio: false,
-                            scales: {
-                                x: { beginAtZero: true, grid: { color: gridColor } },
-                                y: { grid: { display: false } }
-                            },
-                            plugins: { legend: { display: false } }
-                        }
-                    })
-                );
+                charts.push(new Chart(groupCanvas, rankedBar(groupStats, '소모임')));
             }
         });
 
@@ -453,8 +460,13 @@
         <div class="rounded-xl border p-5">
             <div class="mb-3">
                 <h3 class="text-foreground text-sm font-medium">게시판별 현황</h3>
+                <!--
+                    ⛔ 비일간 부제가 '게시판별 신고 건수' 였으나 board_stats 를 만드는 곳은
+                       report_publish.py 하나이고 거기서 넣는 값은 항상 g5_board_new 기반
+                       **활동(글+댓글) 건수**다. 신고 건수를 넣는 생산자는 없다 → 문구 정정.
+                -->
                 <p class="text-muted-foreground text-xs">
-                    {daily ? '게시판별 글·댓글 활동' : '게시판별 신고 건수'}
+                    {daily ? '게시판별 글·댓글 (자유게시판 제외)' : '게시판별 활동'}
                 </p>
             </div>
             <div class="relative h-56">


### PR DESCRIPTION
## 배경

일간 리포트의 게시판별·소모임별 차트가 **합계 한 줄**이라 "글이 많은 곳"과 "댓글만 많은 곳"을 구분할 수 없었다. 실제로 차이가 크다.

| 소모임 | 글 | 댓글 |
|---|---|---|
| 주식한당 | 30 | **226** |
| 굴러간당 | 9 | **150** |
| 경로당 | **16** | 73 |

## 변경 (이 저장소)

- `BoardStatEntry` 에 `posts`/`comments` 추가 — **optional**. 발행기가 주면 스택, 없으면 기존 `count` 단일 막대로 폴백해서 **과거 발행분이 빈 차트가 되지 않는다.**
- 게시판별·소모임별이 같은 모양이라 `rankedBar()` 로 공통화. #1904 의 시간대별 차트가 쓰는 폴백 규칙과 색(글 `#3b82f6` / 댓글 `#10b981`)을 그대로 따른다.
- 1위가 맨 위에 온다(`indexAxis:'y'` 는 `labels[0]` 을 위에 그림). 뒤집으려면 `entries.slice().reverse()` 한 줄.

### ⛔ 라벨 오류 정정

이 차트 부제가 `게시판별 신고 건수`(빨강 `#ef4444`, dataset label `'신고 건수'`)였다. 그런데 `board_stats` 를 만드는 곳은 `report_publish.py` **하나**이고, 거기서 넣는 값은 항상 `g5_board_new` 기반 **활동(글+댓글) 건수**다. 신고 건수를 넣는 생산자는 존재하지 않는다 → 문구·색 정정.

## 발행기 변경 (이 저장소 밖 — `/home/angple/triage/tools`)

`daily_report_gen.py` · `report_publish.py`:

1. **자유게시판 제외** — 활동의 약 90%를 혼자 차지해서 같이 넣으면 나머지가 눈금 하나로 붙어 순위가 안 읽힌다. free 수치는 리포트 헤드라인(`▣ 활동`)이 이미 말한다. 역할 분리: **헤드라인=자유게시판 / 이 표=그 외 분해**.
2. **게시판명을 `g5_board.bo_subject` 정본에서 읽음.** 하드코딩 `BOARD_NAMES`(21개)가 실제 이름을 날조하고 있었다:

   | slug | 하드코딩 | 실제 |
   |---|---|---|
   | `hello` | 안녕하세요 | **가입인사** |
   | `stock` | 주식 | **주식한당** |
   | `car` | 자동차 | **굴러간당** |
   | `referral` | 추천인 | **수익링크** |
   | `angtt`·`giving`·`lecture`·`angmap` | (없음 → 영문 slug 노출) | 앙티티·나눔·강좌/팁·앙지도 |

3. 요약 문장 정정 — `{1위}이 전체 활동의 N%` 는 free 를 빼면서 분모·1위가 둘 다 바뀌어 틀린 말이 됐다. 백분율을 억지로 살리지 않고 실제 수치로 적는다.
4. LIMIT 8→12(게시판) / 6→10(소모임)

## 검증 (실측)

발행기를 dry-run 해서 확인했다.

```
▣ 게시판 (자유게시판 제외)
• 게시판 1위 가입인사 — 글 18개 · 댓글 215개
• 소모임 1위 주식한당 — 글 30개 · 댓글 226개
• 최근 7일간 글이 올라온 소모임 50곳
```

이름이 정본으로 나오고, 자유게시판이 빠진 것을 확인했다. 다음 `00:35` 실행에 데이터가 들어가고, 화면은 이 PR 배포 후 스택으로 보인다.