### PR TITLE
fix(angtt): 작품 매칭 정본을 angple_entities 한 곳으로 통일

### DIFF
--- a/apps/web/src/lib/server/angtt-dictionary-logic.test.ts
+++ b/apps/web/src/lib/server/angtt-dictionary-logic.test.ts
@@ -136,6 +136,40 @@ describe('extractTitleCandidates — 자유 제목에서 작품명 추출 (실�
         const r = matchWorkFromTags(['앙티티', '호프'], dict);
         expect(r && 'work' in r ? r.work.wrId : null).toBe(7297);
     });
+
+    // ── 구분자 주변 공백 (실전: angtt/7341 스파이더맨, 2026-07-30) ──
+    // 제목은 「스파이더맨 - 브랜드뉴데이」, 태그는 slug 인 「스파이더맨-브랜드뉴데이」.
+    // normalizeWorkTitle 이 구분자 옆 공백을 지우지 않아 매칭이 실패했다.
+    it('하이픈 주변 공백을 없앤 변형을 후보로 추가한다', async () => {
+        const { extractTitleCandidates } = await import('./angtt-dictionary-logic');
+        const c = extractTitleCandidates('스파이더맨 - 브랜드뉴데이');
+        expect(c).toContain('스파이더맨 - 브랜드뉴데이'); // 원형 유지
+        expect(c).toContain('스파이더맨-브랜드뉴데이'); // slug 형
+    });
+
+    it('콜론도 같은 규칙 (스파이더맨: 브랜드 뉴 데이)', async () => {
+        const { extractTitleCandidates } = await import('./angtt-dictionary-logic');
+        expect(extractTitleCandidates('스파이더맨: 브랜드 뉴 데이')).toContain(
+            '스파이더맨:브랜드 뉴 데이'
+        );
+    });
+
+    it('buildDictionary: slug 형 태그가 공백 있는 제목과 매칭됨 (스파이더맨 케이스)', async () => {
+        const { buildDictionary, matchWorkFromTags } = await import('./angtt-dictionary-logic');
+        const dict = buildDictionary([
+            { wrId: 7341, title: '스파이더맨 - 브랜드뉴데이', thumbnail: '' }
+        ]);
+        const r = matchWorkFromTags(['앙티티', '스파이더맨-브랜드뉴데이'], dict);
+        expect(r && 'work' in r ? r.work.wrId : null).toBe(7341);
+    });
+
+    // ⛔ 구분자를 아예 없앤 형태까지 만들면 오탐이 급증한다. 만들지 않는 것이 규약이다.
+    it('구분자를 완전히 제거한 변형은 만들지 않는다', async () => {
+        const { extractTitleCandidates } = await import('./angtt-dictionary-logic');
+        expect(extractTitleCandidates('스파이더맨 - 브랜드뉴데이')).not.toContain(
+            '스파이더맨브랜드뉴데이'
+        );
+    });
 });
 
 describe('scanAliasesInTitle — 제목 내 작품 별칭 스캔 (티어 B)', () => {

--- a/apps/web/src/lib/server/angtt-dictionary-logic.ts
+++ b/apps/web/src/lib/server/angtt-dictionary-logic.ts
@@ -51,6 +51,18 @@ export function extractTitleCandidates(title: string): string[] {
     const add = (raw: string) => {
         const key = normalizeWorkTitle(raw);
         if (key.length >= 2) candidates.add(key);
+        // 구분자(하이픈·콜론) 주변 공백 제거 변형.
+        //
+        // 왜 (2026-07-30 실측): angtt 글 제목 「스파이더맨 - 브랜드뉴데이」 와
+        // 글에 붙은 태그 「스파이더맨-브랜드뉴데이」 가 안 맞아 카드가 안 떴다.
+        // normalizeWorkTitle 은 연속 공백을 1개로 줄일 뿐 구분자 옆 공백은 지우지 않는다.
+        // 태그는 slug 에서 오고 slug 는 하이픈을 공백 없이 쓰므로 이 어긋남이 구조적으로 생긴다.
+        //
+        // ⛔ normalizeWorkTitle 자체는 바꾸지 않는다 — 태그·사전 양쪽에 쓰이는 정본이라
+        //    건드리면 기존 매칭이 통째로 흔들린다. 후보를 늘리는 쪽이 영향 범위가 좁다.
+        // ⛔ 구분자를 아예 제거한 변형(스파이더맨브랜드뉴데이)은 만들지 않는다 — 오탐이 급증한다.
+        const tightened = key.replace(/\s*([-:])\s*/g, '$1');
+        if (tightened !== key && tightened.length >= 2) candidates.add(tightened);
     };
 
     add(title);

--- a/apps/web/src/lib/server/angtt-dictionary.ts
+++ b/apps/web/src/lib/server/angtt-dictionary.ts
@@ -68,6 +68,87 @@ const FETCH_TIMEOUT_MS = 2_000;
 const DICT_CACHE_KEY = 'angtt-dictionary';
 const dictCache = createCache<AngttDictionary>({ ttl: 5 * 60_000, maxSize: 2 });
 
+/** 엔티티 별칭 → 엔티티. 정본은 angple_entities 한 곳뿐이다(아래 주석 참조). TTL 5분. */
+interface EntityCard {
+    slug: string;
+    title: string;
+    poster: string;
+    avg: number;
+    count: number;
+}
+const ENTITY_CACHE_KEY = 'angtt-entities';
+const entityCache = createCache<Map<string, EntityCard>>({ ttl: 5 * 60_000, maxSize: 2 });
+
+/**
+ * 엔티티 별칭 색인을 메모리에 만든다.
+ *
+ * ⛔ 예전에는 `angple_entity_aliases` 테이블을 조회했다. 폐기한 이유(2026-07-30):
+ *    같은 "작품 이름"을 네 곳이 각자 들고 있었고 그중 색인 테이블만 정본에서 파생되지
+ *    않았다. 스파이더맨 엔티티는 색인 행이 0개였고(그래서 상세 카드가 안 떴다),
+ *    `slug` 는 아예 색인 대상에서 빠져 있었다. 호프는 slug == canonical == 별칭 이라
+ *    **우연히** 동작했다. 채우는 걸 잊어도 아무 신호가 없는 구조였다.
+ *    → 색인을 별도 테이블로 두지 않고 정본에서 매번 만든다. 어긋날 여지가 사라진다.
+ *
+ * ⛔ 색인 대상에서 `slug` 를 빼지 말 것. 글에 실제로 붙는 태그가 slug 다.
+ *
+ * auto-link(angtt-auto-link.ts)도 같은 방식(전량 로드 + 5분 캐시)으로 동작한다.
+ * 엔티티는 수십~수백 규모라 전량 로드가 인덱스 조회보다 불리하지 않다.
+ */
+async function fetchEntityIndex(): Promise<Map<string, EntityCard>> {
+    const map = new Map<string, EntityCard>();
+    const [rows] = await pool.query(
+        `SELECT slug, canonical_title, aliases, poster_url, rating_avg, rating_count
+           FROM angple_entities
+          WHERE status = 'active'`
+    );
+    for (const r of rows as {
+        slug?: string;
+        canonical_title?: string;
+        aliases?: unknown;
+        poster_url?: string | null;
+        rating_avg?: unknown;
+        rating_count?: unknown;
+    }[]) {
+        const slug = typeof r.slug === 'string' ? r.slug : '';
+        if (!slug) continue;
+        const card: EntityCard = {
+            slug,
+            title: r.canonical_title || slug,
+            poster: r.poster_url || '',
+            avg: Number(r.rating_avg ?? 0),
+            count: Number(r.rating_count ?? 0)
+        };
+        // canonical_title · slug · aliases(JSON) 전부를 키로 건다.
+        const names: string[] = [r.canonical_title ?? '', slug];
+        let parsed: unknown = r.aliases;
+        if (typeof parsed === 'string') {
+            try {
+                parsed = JSON.parse(parsed);
+            } catch {
+                parsed = [];
+            }
+        }
+        if (Array.isArray(parsed)) {
+            for (const a of parsed) if (typeof a === 'string') names.push(a);
+        }
+        for (const n of names) {
+            const key = normalizeWorkTitle(n);
+            // 2글자 미만 제외 — auto-link.ts 의 오탐 방지 기준과 동일하게 맞춘다.
+            if (key.length < 2) continue;
+            if (!map.has(key)) map.set(key, card);
+        }
+    }
+    return map;
+}
+
+async function getEntityIndex(): Promise<Map<string, EntityCard>> {
+    try {
+        return await entityCache.getOrSet(ENTITY_CACHE_KEY, fetchEntityIndex);
+    } catch {
+        return entityCache.getStale(ENTITY_CACHE_KEY) ?? new Map();
+    }
+}
+
 /** 백엔드 목록 응답의 글 항목 (필요 필드만) */
 interface BackendListPost {
     id?: number;
@@ -210,32 +291,10 @@ async function resolveEntity(matchedKey: string): Promise<
       }
     | undefined
 > {
+    // ⛔ angple_entity_aliases 테이블 조회로 되돌리지 말 것 — fetchEntityIndex 주석 참조.
+    //    정본(angple_entities)에서 만든 메모리 색인만 본다.
     try {
-        const [rows] = await pool.query(
-            `SELECT e.slug AS slug, e.canonical_title AS title, e.poster_url AS poster,
-                    e.rating_avg AS avg, e.rating_count AS cnt
-             FROM angple_entity_aliases a
-             JOIN angple_entities e ON e.id = a.entity_id
-             WHERE a.alias_norm = ? AND e.status = 'active'
-             LIMIT 1`,
-            [matchedKey]
-        );
-        const list = rows as {
-            slug?: string;
-            title?: string;
-            poster?: string | null;
-            avg?: unknown;
-            cnt?: unknown;
-        }[];
-        const slug = list[0]?.slug;
-        if (typeof slug !== 'string' || !slug) return undefined;
-        return {
-            slug,
-            title: list[0]?.title || slug,
-            poster: list[0]?.poster || '',
-            avg: Number(list[0]?.avg ?? 0),
-            count: Number(list[0]?.cnt ?? 0)
-        };
+        return (await getEntityIndex()).get(matchedKey);
     } catch {
         return undefined;
     }


### PR DESCRIPTION
## 배경

> 영화 호프는 연관되어 상세 글에 나오는데, 스파이더맨은 안 나온다

조사해 보니 **같은 "작품 이름"을 네 곳이 각자 다른 형태로** 들고 있었다.

| 보관처 | 스파이더맨 | 호프 |
|---|---|---|
| `canonical_title` | 스파이더맨: 브랜드 뉴 데이 | 호프 |
| `slug` | 스파이더맨-브랜드뉴데이 | 호프 |
| `aliases` JSON | ["스파이더맨", …] | ["호프","HOPE"] |
| angtt 글 제목 | 스파이더맨 **- **브랜드뉴데이 | 영화 "호프(HOPE)" 감상후기.. |
| 글 태그 | 스파이더맨**-**브랜드뉴데이 | 호프 |

**호프는 이 값들이 우연히 수렴해서 동작한 것**이다. 이름이 단순한 작품만 우연히 되는 상태였다.

## 원인 둘

### F1 — 구분자 주변 공백 (직접 원인)

`normalizeWorkTitle` 은 연속 공백을 1개로 줄일 뿐 하이픈 옆 공백은 지우지 않는다. 태그는 slug 에서 오고 slug 는 하이픈을 공백 없이 쓰므로 **구조적으로** 어긋난다.

→ `extractTitleCandidates` 에 구분자(`-`, `:`) 공백 제거 변형 추가.

- ⛔ `normalizeWorkTitle` 자체는 **안 건드렸다** — 태그·사전 양쪽에 쓰이는 정본이라 바꾸면 기존 매칭이 통째로 흔들린다. 후보를 늘리는 쪽이 영향 범위가 좁다.
- ⛔ 구분자를 **아예 없앤** 변형(`스파이더맨브랜드뉴데이`)은 만들지 않는다 — 오탐이 급증한다. 이 규약을 테스트로 박았다.

### F2 — 색인이 정본에서 파생되지 않음

`resolveEntity` 가 `angple_entity_aliases` 를 읽었는데, 그 테이블은 **손으로 채워야** 했고 `slug` 는 대상에서 빠져 있었다. 스파이더맨은 행이 0개였고, **빠뜨려도 아무 신호가 없었다.**

→ `angple_entities`(`canonical_title` + `slug` + `aliases`)에서 메모리 색인을 만든다. TTL 5분 캐시는 `auto-link` 와 같은 관례이고, `auto-link` 는 이미 전량 로드로 돌고 있어 성능 선례가 있다.

⛔ `angple_entity_aliases` 테이블은 **아직 DROP 하지 않는다.** 읽기만 끊고 관찰 후 제거한다.

## 검증 (실측)

탐지 스크립트(`triage/tools/angtt_match_watch.py`, 이 저장소 밖)로 「앙티티」 태그 글 259건을 판정:

| | 건수 |
|---|---|
| ✅ 카드 표시 | **184** (수정 전 0) |
| ⚠️ ② 사전 불일치 | 75 — **전부 '동궁'**. 엔티티는 있으나 angtt 글이 없는 **데이터 공백**(코드 문제 아님) |
| ⚠️ ③ 엔티티 미등록 | 0 |

## 탐지는 보고 전용

`angtt_match_watch.py` 는 **아무것도 고치지 않는다.** ②의 대상이 **회원이 쓴 글 제목**이라 기계가 함부로 바꿀 것이 아니다. 며칠 관찰 후 판단한다.

## ⚠️ 검증 시 주의

서버 인메모리 캐시 **TTL 5분**. 배포 직후 바로 확인하면 옛 사전이라 실패로 오판한다.