### PR TITLE
feat(angtt): 엔티티만 있어도 작품 카드가 뜨도록

### DIFF
--- a/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
+++ b/apps/web/src/lib/components/features/board/angtt-connect-card.svelte
@@ -23,7 +23,8 @@
     /** 서버 AngttMatch(lib/server/angtt-dictionary.ts)와 구조 동일 — $lib/server 는 클라 import 불가라 별도 선언 */
     type AngttCardMatch =
         | {
-              wrId: number;
+              /** angtt 글이 아직 없는 작품은 wrId 가 없다 — entitySlug 로만 링크한다. */
+              wrId?: number;
               title: string;
               thumbnail: string;
               rating: { avg: number; count: number } | null;
@@ -193,7 +194,9 @@
             ? ''
             : match.entitySlug
               ? `/angtt/${encodeURIComponent(match.entitySlug)}`
-              : `/angtt/${match.wrId}`
+              : match.wrId
+                ? `/angtt/${match.wrId}`
+                : ''
     );
 
     onMount(() => {
@@ -201,7 +204,7 @@
             board_id: boardId,
             post_id: String(postId),
             matched: matched ? 'yes' : 'no',
-            work_id: 'notFound' in match ? '' : String(match.wrId)
+            work_id: 'notFound' in match ? '' : String(match.wrId ?? match.entitySlug ?? '')
         });
         // 미연결 카드만 제안 현황을 지연 조회한다 (SSR 무접촉)
         if ('notFound' in match) void loadSuggestStatus();
@@ -212,7 +215,7 @@
             board_id: boardId,
             post_id: String(postId),
             cta,
-            work_id: 'notFound' in match ? '' : String(match.wrId)
+            work_id: 'notFound' in match ? '' : String(match.wrId ?? match.entitySlug ?? '')
         });
     }
 </script>
@@ -380,13 +383,17 @@
                         </p>
                     {/if}
                 </div>
-                <a
-                    href={rateHref}
-                    class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
-                    onclick={() => onCtaClick('rate')}
-                >
-                    ⭐ 별점 주러 가기
-                </a>
+                <!-- ⛔ rateHref 가 비면 <a href=""> 가 되어 현재 페이지로 가는 깨진 CTA 가 된다.
+                     (entitySlug·wrId 가 둘 다 없는 경우 — 정상 흐름에선 안 생기지만 방어한다) -->
+                {#if rateHref}
+                    <a
+                        href={rateHref}
+                        class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium"
+                        onclick={() => onCtaClick('rate')}
+                    >
+                        ⭐ 별점 주러 가기
+                    </a>
+                {/if}
             </div>
         {/if}
     </div>

--- a/apps/web/src/lib/server/angtt-dictionary.ts
+++ b/apps/web/src/lib/server/angtt-dictionary.ts
@@ -33,8 +33,15 @@ export type { AngttWork, AngttDictionary } from './angtt-dictionary-logic.js';
 /** 글 상세 SSR 에 내려가는 카드 데이터 (일치 / 미등록 유도) */
 export type AngttMatch =
     | {
-          /** angtt 작품 글 번호 — /angtt/{wrId} 링크 대상 */
-          wrId: number;
+          /**
+           * angtt 작품 글 번호 — /angtt/{wrId} 링크 대상.
+           *
+           * ⛔ 선택 필드다. 엔티티만 등록되고 angtt 글이 아직 없는 작품이 있다(실측: 동궁 75건,
+           * 오디세이). 그 경우 wrId 가 없고 entitySlug 로만 링크한다.
+           * 소비처는 entitySlug 를 먼저 보므로 링크는 문제없다 — 다만 wrId 를 그대로
+           * String() 하면 "undefined" 가 되니 반드시 널 가드를 둘 것.
+           */
+          wrId?: number;
           title: string;
           thumbnail: string;
           /** 별점 집계 — 조회 실패 시 null (카드는 별점 줄만 생략) */
@@ -336,6 +343,35 @@ export async function resolveAngttMatch(
         const dict = await getAngttDictionary();
         const match = matchWorkFromTags(strTags, dict);
         if (!match) return undefined;
+
+        // 사전(angtt 글 제목)에 없어도 **엔티티에 있으면** 그것으로 카드를 만든다.
+        //
+        // 왜 (2026-07-30): 정본은 angple_entities 인데 매칭 자격을 angtt 글이 쥐고 있었다.
+        // 그래서 엔티티가 멀쩡히 등록돼 있어도 angtt 글이 없으면 "등록 유도 카드"가 떴다.
+        // 실측: 「앙티티」 태그 글 259건 중 75건이 여기서 막혔고 전부 '동궁'이었다.
+        // 새로 등록한 '오디세이'도 같은 처지였다. 앞뒤가 바뀐 구조라 바로잡는다.
+        //
+        // ⛔ 「앙티티」 태그 제약은 그대로 둔다(위 hasAngttTag). 태그 없는 글까지 훑으면
+        //    '오디세이' 같은 일반명사성 제목에서 오탐이 터진다.
+        if ('notFound' in match) {
+            const index = await getEntityIndex();
+            for (const t of strTags) {
+                const key = normalizeWorkTitle(t);
+                if (key === normalizeWorkTitle(ANGTT_TAG)) continue;
+                const entity = index.get(key);
+                if (!entity) continue;
+                return {
+                    // wrId 없음 — angtt 글이 아직 없는 작품이다. entitySlug 로 링크한다.
+                    title: entity.title,
+                    thumbnail: entity.poster,
+                    rating: { avg: entity.avg, count: entity.count },
+                    entitySlug: entity.slug,
+                    ...(ctx && (await isAutoLinked(ctx.boardId, ctx.wrId))
+                        ? { autoLinked: true }
+                        : {})
+                };
+            }
+        }
 
         if ('work' in match) {
             // 매칭 작품에 활성 엔티티가 있으면 작품 페이지 슬러그 부착(없으면 기존 wrId 폴백).


### PR DESCRIPTION
## 배경

정본은 `angple_entities` 인데 **매칭 자격은 angtt 게시판 글이 쥐고** 있었다. 엔티티가 멀쩡히 등록돼 있어도 angtt 글이 없으면 "등록 유도 카드"로 빠진다. 앞뒤가 바뀐 구조다.

```
① 「앙티티」 태그
② angtt 글 제목 사전과 일치      ← 여기서 막힘
③ 엔티티 조회                    ← #1906 에서 정본 통일
```

## 실측

`triage/tools/angtt_match_watch.py` 로 「앙티티」 태그 글 259건 판정:

| | 건수 |
|---|---|
| ✅ 카드 표시 | 184 |
| ⚠️ **② 사전 불일치** | **75 — 전부 '동궁'** |
| ⚠️ ③ 엔티티 미등록 | 0 |

'동궁'은 엔티티(id=2)가 등록돼 있는데 angtt 글이 없어서 막혔다. 오늘 등록한 **'오디세이'**(id=5, 자유게시판 7월 언급 10건+)도 같은 처지였다.

## 변경

- `notFound` 로 빠지기 전에 **엔티티 색인을 한 번 더** 본다
- `AngttMatch.wrId` 를 **선택 필드**로 — angtt 글이 없는 작품은 `entitySlug` 로만 링크
- 카드 널 가드 2건:
  - `String(match.wrId)` → `'undefined'` 문자열이 분석 이벤트로 새던 것 차단
  - `rateHref` 가 비면 `<a href="">` (현재 페이지로 가는 깨진 CTA) 가 되므로 **버튼 자체를 숨김**

## ⛔ 넓히지 않은 것

**「앙티티」 태그 제약은 그대로 둔다.** 태그 없는 글까지 훑으면 '오디세이' 같은 일반명사성 제목에서 오탐이 터진다.

넓힌 것은 **"무엇과 대조하는가"**(angtt 글 제목 → + 엔티티)뿐이고, **"어떤 글을 보는가"**(「앙티티」 태그 글만)는 그대로다.

## 검증

- 배포 후 `angtt_match_watch.py` 재실행 → ② 불일치 **75 → 0** 기대
- '동궁' 태그 글에 카드가 뜨는지
- 스파이더맨·호프 회귀 없는지
- ⚠️ 서버 캐시 **TTL 5분** — 배포 직후 바로 보면 오판한다