### PR TITLE
fix(seo): 깊은 페이지네이션 크롤 차단 — 힙 폭증 장애 완화

### DIFF
--- a/apps/web/src/routes/robots.txt/+server.ts
+++ b/apps/web/src/routes/robots.txt/+server.ts
@@ -41,6 +41,25 @@ Disallow: /link/
 Disallow: /bbs/link.php
 Disallow: /plugin/
 
+# ⛔ 깊은 페이지네이션 — 2026-07-30 장애 원인
+#
+#    구글봇(66.249.92.x)이 CloudFront 를 거쳐 ?page=17000~21000 대를 계속 긁고 있었다.
+#    실측: 전체 요청 165,252 중 page>=1000 이 31,871건(**19%**), 그중 502/504 가 62건.
+#
+#    ?page=17510 은 오프셋 약 52만이다. MySQL 이 52만 행을 읽고 버리는 동안 결과 처리에서
+#    힙이 순간 폭증해 V8 상한(--max-old-space-size=520)을 넘고 죽었다:
+#      FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
+#    평상시 heapUsed 는 181~229MB 로 멀쩡해서 60초 간격 heap_metrics 에는 안 잡혔다.
+#    → 느린 누수가 아니라 **버스트 할당**이다. 7/25·7/28 OOM 도 같은 원인 의심.
+#
+#    색인 손실은 없다 — 글은 sitemap.xml 로 이미 노출하고 있고, 깊은 목록 페이지는
+#    검색 가치가 없다. 오히려 크롤 예산을 본문으로 돌리는 효과가 있다.
+#
+# ⛔ 이것만으로는 반쪽이다. robots.txt 는 **협조 요청**이라 무시하는 크롤러엔 안 통한다.
+#    앱에서 페이지 상한을 걸어 오프셋 쿼리 자체를 막는 것이 근본이다(별건 PR).
+Disallow: /*?page=
+Disallow: /*&page=
+
 # AI 크롤러 차단 (콘텐츠 학습 방지)
 User-agent: GPTBot
 Disallow: /


### PR DESCRIPTION
## 장애

2026-07-30 20:02 부터 `angple-web` 파드가 재시작 루프. 21:45 기준 누적 재시작 **34회**(13파드).

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
Mark-Compact 543.6 -> 543.6 MB  (current mu = 0.099)   ← GC 가 시간의 90% 소모
```

## 원인 — 구글봇의 초깊은 페이지네이션

| | 건수 |
|---|---|
| 전체 요청 | 165,252 |
| **`page>=1000`** | **31,871 (19%)** |
| 그중 502/504 | 62 |

요청자는 `66.249.92.x`(구글봇)가 CloudFront 경유.

`?page=17510` 은 오프셋 **약 52만**이다. MySQL 이 52만 행을 읽고 버리는 동안 결과 처리에서 힙이 순간 폭증해 V8 상한(`--max-old-space-size=520`)을 넘겼다.

**평상시 heapUsed 는 181~229MB 로 멀쩡**해서 60초 간격 `heap_metrics` 에는 안 잡혔다 — 느린 누수가 아니라 **버스트 할당**이다.

회원들이 겪던 `TimeoutError: signal timed out`(시간당 800건, 12시간 7,481건)의 실체이기도 하다.

## ⛔ 오해를 막기 위해

- **오늘 배포 탓이 아니다.** 19:10 배포는 `ASSET_BASE_URL` 한 줄만 바뀌었고 이미지·힙 설정은 이전 RS 와 동일하다. **롤백해도 안 고쳐진다.**
- **힙 상한을 올리는 것도 답이 아니다.** 매니페스트 불변식 `limit ≥ heap × 1.45 + 120` 상 520 이 이미 천장(`520×1.45+120 = 874 ≤ 896`). 올리려면 memory limit 도 올려야 하는데 노드 여유가 10.6GB 뿐이다.
- 7/25·7/28 OOM 도 같은 원인일 가능성이 크다.

## 변경

```
Disallow: /*?page=
Disallow: /*&page=
```

**색인 손실 없음** — 글은 `sitemap.xml`(84만) 로 이미 노출하고 있고, 깊은 목록 페이지는 검색 가치가 없다. 오히려 크롤 예산이 본문으로 돌아간다.

⚠️ **트레이드오프**: robots.txt 는 숫자 범위를 표현할 수 없어 `page=2` 같은 얕은 페이지도 함께 막힌다. 목록 경유 발견 경로가 줄지만 사이트맵이 대체한다. 되돌리기 쉬운 한 줄이다.

## ⛔ 이건 반쪽이다

robots.txt 는 **협조 요청**이라 무시하는 크롤러엔 안 통한다. **앱에서 페이지 상한을 걸어 오프셋 쿼리 자체를 막는 것이 근본**이고, 별건 PR 로 올린다.

## 배포 후 필수

**CDN 캐시 퍼지.** `robots.txt` 는 `max-age=86400` 이라 지금 라이브에 24시간 전 응답이 굳어 있다(실측: 앱은 긴 버전 반환, CDN 은 5줄 옛 버전).

```bash
/home/angple/web/scripts/cloudflare-purge.sh 'https://damoang.net/robots.txt'
```