### PR TITLE
feat(report): 일간 리포트에 자유게시판 구성비 표시

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -172,6 +172,14 @@
         good_users?: number; // 공감 누른 회원 수
         active_writers?: number; // 글·댓글 쓴 회원 수
         avg_comments?: number; // 글당 평균 댓글
+        // 자유게시판 쏠림(구성비) — 합계만 보면 나머지 게시판이 묻힌다
+        free_share?: {
+            total?: number;
+            free?: number;
+            free_pct?: number;
+            other?: number;
+            other_boards?: number;
+        };
         hourly_stats?: number[]; // 시간대별 활동(0~23시, 24칸, 글+댓글 합)
         hourly_posts?: number[]; // 시간대별 글(24칸)
         hourly_comments?: number[]; // 시간대별 댓글(24칸)
@@ -646,6 +654,40 @@
                     </div>
                 {/each}
             </div>
+
+            <!-- 자유게시판 쏠림: 합계는 전 게시판인데 90%가 자유게시판이라 구성을 함께 밝힌다 -->
+            {#if isDaily && stats.free_share?.total}
+                {@const fs = stats.free_share}
+                <div class="bg-muted/40 rounded-lg border px-4 py-3">
+                    <div class="mb-1.5 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
+                        <span class="text-muted-foreground">글·댓글 구성</span>
+                        <span class="text-foreground font-semibold">
+                            자유게시판 {(fs.free ?? 0).toLocaleString()}건
+                        </span>
+                        <span class="text-muted-foreground">({fs.free_pct}%)</span>
+                        <span class="text-muted-foreground/50">·</span>
+                        <span class="text-foreground font-semibold">
+                            그 외 {(fs.other ?? 0).toLocaleString()}건
+                        </span>
+                        <span class="text-muted-foreground">
+                            ({fs.other_boards}곳, {Math.round((100 - (fs.free_pct ?? 0)) * 10) /
+                                10}%)
+                        </span>
+                    </div>
+                    <div class="bg-muted flex h-2 overflow-hidden rounded-full">
+                        <div
+                            class="bg-amber-500"
+                            style="width: {fs.free_pct}%"
+                            title="자유게시판 {(fs.free ?? 0).toLocaleString()}건"
+                        ></div>
+                        <div
+                            class="bg-emerald-500"
+                            style="width: {100 - (fs.free_pct ?? 0)}%"
+                            title="그 외 {fs.other_boards}곳 {(fs.other ?? 0).toLocaleString()}건"
+                        ></div>
+                    </div>
+                </div>
+            {/if}
 
             <!-- 반응이 많았던 글 (일간 전용) -->
             {#if reactionMetrics.length > 0}


### PR DESCRIPTION
## 배경
일간 리포트 카드가 **자유게시판만** 세고 7일추이 차트는 **전 게시판**을 그려서, 두 숫자를 대조하면 어긋났습니다(글 1,212 vs 1,349). 크론에서 집계를 **전 게시판으로 통일**했는데, 활동의 **90.6%가 자유게시판**이라 합계만 키우면 나머지 43곳이 묻힙니다.

## 변경
`wr_9.free_share` 를 받아 일간 리포트에 한 줄 + 2색 비율 막대:
```
글·댓글 구성   자유게시판 11,025건 (90.6%) · 그 외 1,147건 (43곳, 9.4%)
[■■■■■■■■■□]
```
게시판별 차트는 이미 자유게시판을 제외해 그리므로, free 물량이 이 줄에서 드러나 **정보 손실 없이** 나머지 게시판이 제 크기로 보입니다.

크론(daily_report_gen.py·report_publish.py)은 별도 배포 불필요 — 내일 00:35부터 새 기준. prettier 통과.