### PR TITLE
fix(post-form): 수정 페이로드에 is_secret 포함 (#13161)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -647,6 +647,7 @@ export interface UpdatePostRequest {
     title?: string; // 선택, 1-200자
     content?: string; // 선택, 1자 이상
     category?: string; // 선택
+    is_secret?: boolean; // 선택 (비밀글 설정/해제 — 생략 시 변경 없음) (#13161)
     tags?: string[]; // 선택 (태그 목록)
     link1?: string; // 선택 (링크1)
     link2?: string; // 선택 (링크2)

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -628,6 +628,9 @@
                       title: sanitizedTitle,
                       content: finalContent,
                       category: category || undefined,
+                      // 작성처럼 수정에서도 비밀글 상태를 보낸다 — 빠뜨리면 백엔드가
+                      // '변경 없음'으로 처리해 체크박스를 바꿔도 저장되지 않는다. (#13161)
+                      is_secret: isSecret,
                       tags: tags.length > 0 ? tags : undefined,
                       // 수정 시엔 빈 문자열('')을 보내야 백엔드가 링크를 삭제한다.
                       // undefined(생략)면 백엔드가 '변경 없음'(nil)으로 처리해 기존 링크가 남는다. (#13043)


### PR DESCRIPTION
## 문제

bug/13161 — 비밀글 체크박스가 수정 화면에도 렌더되지만(`board?.use_secret`), 수정 페이로드에 `is_secret` 이 없어 바꿔도 저장되지 않는다. link1 이 겪은 #13043 과 같은 계열(작성에만 있고 수정에 없음).

## 변경

- `UpdatePostRequest` 에 `is_secret?: boolean` 추가
- 수정 페이로드에 `is_secret: isSecret` 포함

체크박스가 없는 보드(`use_secret` falsy)에서는 초기값(`post?.is_secret`) 그대로 전송 = 무변화라 안전.

## 호환

구백엔드는 미지 필드 무시. 배포 순서 무관.

백엔드 짝: damoang/angple-backend#601