### PR TITLE
fix(emoticon): 이모티콘 크기 지정 복구 — CSS 캡을 크기 미지정에만 적용

### DIFF
--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -325,6 +325,18 @@ pre:hover .hljs-copy-btn {
 img[src*='/emoticons/'] {
     display: inline;
     vertical-align: middle;
+}
+
+/* 크기 명시(width 속성)가 없는 이모티콘만 기본 캡 — 레거시 앙티콘·리액션 등.
+ *
+ * ⛔ 이 캡을 width 속성이 있는 img 에 다시 넓히지 말 것 (bug#13145·13159·13165).
+ *    `width: auto` 는 CSS 명세상 HTML width 속성보다 우선하므로, 파서(코어
+ *    content-transform / premium emoticon 플러그인)가 옳게 계산해 넣는
+ *    width="N"(회원 지정 크기·팩별 기본폭, 20~200 클램프)을 전부 지워버린다.
+ *    2026-03-19(#727)부터 이 규칙이 전체에 걸려 있어 크기 지정이 5개월간
+ *    조용히 죽어 있었고, 코드만 봐서는 파서가 멀쩡해 두 번 오판했다. */
+.emoticon-inline:not([width]),
+img[src*='/emoticons/']:not([width]) {
     max-height: 2.5em;
     width: auto;
 }


### PR DESCRIPTION
## 문제 (bug/13145 · 13159 · 13165)

이모티콘 숏코드의 크기 인수(`{emo:파일:150}`)가 무시된다. 파서(코어·premium)는 모두 `width="N"` 속성을 옳게 내보내는데, `components.css`의 아래 규칙이 전부 지운다:

```css
.emoticon-inline, img[src*='/emoticons/'] { ... max-height: 2.5em; width: auto; }
```

CSS `width:auto`는 명세상 HTML width 속성(presentational attribute)보다 우선한다. 2026-03-19 #727부터라 **크기 지정이 5개월간 죽어 있었고**, #1901(밈 기본폭 200)도 이 CSS에 지워져 체감이 없었다.

## 변경

인라인 배치(display/vertical-align)는 전체 유지, 캡(max-height/width:auto)은 **`:not([width])`로 좁힘** — width 속성 없는 레거시(앙티콘·리액션)만 캡.

## 소급 효과 (전 게시글)

| 대상 | 지금 | 후 |
|---|---|---|
| 크기 미지정 (대다수) | 높이 40px 캡 | 폭 50px (파서 기본) |
| 밈 팩 미지정 | 폭 ~61px | **폭 200px** (#13145 승인 의도) |
| 크기 지정 (드묾) | 무시 | 반영 (20~200 클램프) |
| 레거시 width 무속성 | 캡 | 캡 유지