### PR TITLE
fix(comment): 대댓글 폼 Tab 이 답글작성에 먼저 닿도록 (#13172)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -396,12 +396,9 @@
                     />
 
                     <div class="ml-auto flex items-center gap-2">
-                        {#if isReplyMode}
-                            <Button type="button" variant="ghost" size="sm" onclick={handleCancel}>
-                                <X class="mr-1 h-4 w-4" />
-                                취소
-                            </Button>
-                        {/if}
+                        <!-- DOM 은 [작성, 취소] 순 — Tab 이 주 액션(작성)에 먼저 닿는다 (bug#13172).
+                             시각 배치는 order-first 로 기존 그대로 [취소][작성] 을 유지한다.
+                             ⛔ tabindex 양수로 풀지 말 것 — 전역 탭 순서를 오염시킨다. -->
                         <Button
                             type="submit"
                             size="sm"
@@ -415,6 +412,18 @@
                                 {isReplyMode ? '답글 작성' : '댓글 작성'}
                             {/if}
                         </Button>
+                        {#if isReplyMode}
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                class="order-first"
+                                onclick={handleCancel}
+                            >
+                                <X class="mr-1 h-4 w-4" />
+                                취소
+                            </Button>
+                        {/if}
                         {#if onRefresh}
                             <button
                                 type="button"


### PR DESCRIPTION
## 문제 (bug/13172)

대댓글 작성 중 Tab 키로 이동하면 '취소'가 먼저 잡힌다. 버튼 DOM 순서가 [취소, 답글작성]이고 탭 순서는 DOM을 따르기 때문. 취소는 답글 모드에서만 렌더되므로 대댓글에서만 체감된다.

## 변경

- DOM을 [답글작성, 취소]로 변경 → Tab이 주 액션에 먼저 닿음
- 취소에 `order-first` → **시각 배치는 기존 그대로** [취소][답글작성][새로고침]
- ⛔ `tabindex` 양수 미사용 (전역 탭 순서 오염 방지)

일반 댓글 모드(취소 없음)는 렌더 결과 동일.