### PR TITLE
fix(seo): 리뷰 스니펫 GSC 오류 해소 — CreativeWork에 별점 미부착

### DIFF
--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -211,9 +211,35 @@ export function ratingSchemaTypeForCategory(category?: string): JsonLdRatedItem[
 }
 
 /**
+ * 구글 리뷰 스니펫이 aggregateRating 을 실제 리치결과(★)로 띄우는 schema.org 타입.
+ * 이 집합 밖의 타입에 aggregateRating 을 붙이면 리치결과가 안 뜰 뿐 아니라
+ * GSC 가 "'<parent_node>' 입력란의 개체 유형이 잘못되었습니다" 심각 오류로 잡는다
+ * (2026-07-31 GSC 실측 오류의 원인 = **CreativeWork**(미지정 카테고리) 매핑).
+ * 그래서 미지원 타입은 별점 블록 자체를 생략한다 — 잘못된 구조화 데이터를 내보내지 않는다.
+ *
+ * 지원 근거(developers.google.com/search/docs/appearance/structured-data/review-snippet):
+ * 1차 목록 = Book/Course/Event/LocalBusiness/Movie/Product/Recipe/SoftwareApplication,
+ * "and their subtypes" = Game 등. VideoGame 은 Game ∧ SoftwareApplication 의 서브타입이라
+ * 이중 자격으로 지원된다(제외하면 정당한 게임 별점을 죽이므로 포함).
+ * CreativeWork 는 이 목록에 없다(CreativeWorkSeason/Series 만 있음) → 유일한 제외 대상.
+ */
+const REVIEW_SNIPPET_SUPPORTED_TYPES: ReadonlySet<string> = new Set([
+    'Movie',
+    'Book',
+    'Event',
+    'VideoGame',
+    'Product',
+    'SoftwareApplication',
+    'Recipe',
+    'Course',
+    'LocalBusiness'
+]);
+
+/**
  * 평점 대상(작품) + AggregateRating JSON-LD 생성.
  * 앙티티(리뷰) 게시판 글에 별점 집계가 있을 때 구글 검색결과에 ★ 노출.
  * 참여 0(count<1)·평점 0·이름 없으면 null → buildJsonLd 가 블록 생략.
+ * 리뷰 스니펫 미지원 타입(게임·미지정 등)도 null → GSC 오류 방지.
  */
 export function createRatedItemJsonLd(options: {
     name: string;
@@ -228,8 +254,11 @@ export function createRatedItemJsonLd(options: {
     if (!options.ratingCount || options.ratingCount < 1) return null;
     if (!(options.ratingValue > 0)) return null;
 
+    const type = ratingSchemaTypeForCategory(options.category);
+    if (!REVIEW_SNIPPET_SUPPORTED_TYPES.has(type)) return null;
+
     const item: JsonLdRatedItem = {
-        '@type': ratingSchemaTypeForCategory(options.category),
+        '@type': type,
         name,
         aggregateRating: {
             '@type': 'AggregateRating',

--- a/apps/web/src/lib/seo/rated-item.test.ts
+++ b/apps/web/src/lib/seo/rated-item.test.ts
@@ -24,6 +24,30 @@ describe('ratingSchemaTypeForCategory — 앙티티 카테고리 → schema.org 
     });
 });
 
+describe('createRatedItemJsonLd — 리뷰 스니펫 미지원 타입은 블록 생략 (GSC parent_node 오류 방지)', () => {
+    const base = { ratingValue: 4, ratingCount: 5, url: 'https://damoang.net/angtt/1' };
+
+    it('CreativeWork(미지정 카테고리)는 null — 리뷰 스니펫 미지원 타입에 aggregateRating 을 붙이지 않는다', () => {
+        expect(createRatedItemJsonLd({ ...base, name: '무제', category: '음악' })).toBeNull();
+        expect(createRatedItemJsonLd({ ...base, name: '무제' })).toBeNull();
+    });
+
+    it('지원 타입은 정상 생성 — 게임(VideoGame)은 Game∧SoftwareApplication 서브타입이라 지원', () => {
+        expect(createRatedItemJsonLd({ ...base, name: '듄', category: '영화' })?.['@type']).toBe(
+            'Movie'
+        );
+        expect(
+            createRatedItemJsonLd({ ...base, name: '살인자의 기억법', category: '소설' })?.['@type']
+        ).toBe('Book');
+        expect(
+            createRatedItemJsonLd({ ...base, name: '오페라의 유령', category: '공연' })?.['@type']
+        ).toBe('Event');
+        expect(
+            createRatedItemJsonLd({ ...base, name: '발더스 게이트 3', category: '게임' })?.['@type']
+        ).toBe('VideoGame');
+    });
+});
+
 describe('createRatedItemJsonLd — 작품 + AggregateRating', () => {
     it('평점 있으면 Movie + aggregateRating 생성', () => {
         const r = createRatedItemJsonLd({


### PR DESCRIPTION
## 제보
GSC: "리뷰 스니펫 — '<parent_node>' 입력란의 개체 유형이 잘못되었습니다"(심각).

## 원인 (실측)
앙티티(리뷰) 글 별점 구조화데이터(`createRatedItemJsonLd`)가 카테고리를 schema.org 타입으로 매핑하는데, **미지정 카테고리 → `CreativeWork`** 로 두고 거기에 `aggregateRating` 을 붙였다. CreativeWork 는 구글 리뷰 스니펫 지원 타입이 아니라(지원 목록엔 CreativeWorkSeason/Series 만) GSC 가 심각 오류로 잡는다.

## 변경
- `REVIEW_SNIPPET_SUPPORTED_TYPES` 화이트리스트 도입. 미지원 타입이면 `createRatedItemJsonLd` 가 `null` → `buildJsonLd` 의 filter 가 블록 생략. 잘못된 구조화데이터를 아예 안 내보낸다
- **게임(VideoGame)은 유지** — 구글 문서상 `Game` + 서브타입 지원이고 VideoGame 은 Game ∧ SoftwareApplication 서브타입이라 이중 자격. 제외 대상은 **CreativeWork(미지정 카테고리) 하나**

## 근거
developers.google.com/search/docs/appearance/structured-data/review-snippet — 1차 지원 Book/Course/Event/LocalBusiness/Movie/Product/Recipe/SoftwareApplication + "and their subtypes"(Game 등). CreativeWork 는 목록에 없음.

## 검증
- Evaluator 독립 검증(구글 공식 문서 대조): 1차 판정에서 VideoGame 제외가 부당(정당한 게임 별점 죽임)함을 잡아내 VideoGame 을 화이트리스트에 복원
- 단위 테스트 11 passed (영화→Movie·소설→Book·공연→Event·게임→VideoGame 정상 / 미지정→null)
- 라이브 angtt/7297(영화, Movie+aggregateRating) 유지 확인
- 타입체크/prettier 는 CI (로컬 svelte-check 금지 규칙 준수)

## 배포 후
GSC 재크롤되며 오류 해소. 배포 후 "수정 확인 요청" 클릭 대상.