### PR TITLE
fix(deleted): 활동 피드 비링크 표시 + 검색 tombstone 서버 마스킹 (#13174)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -76,6 +76,7 @@ export interface FreePost {
     link2_affiliate?: boolean; // 링크2 제휴 변환 여부
     deleted_at?: string | null; // 소프트 삭제 시점
     deleted_by?: string | null; // 삭제한 사용자 ID
+    self_deleted?: boolean; // 자진삭제 여부 — 신 백엔드가 deleted_by 를 drop 하며 판정 결과만 전달 (#13174)
     scheduled_delete_at?: string | null; // 삭제 예약된 시점 (g5_scheduled_deletes.scheduled_at, SSR enrichment, 게시판 목록용)
     scheduled_delete?: {
         // 글 상세 응답에 백엔드가 inline 포함 (PR #430), 별도 /delete-status fetch 회피

--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -7,7 +7,12 @@
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronUp from '@lucide/svelte/icons/chevron-up';
     import { formatDate } from '$lib/utils/format-date.js';
-    import { getPostLabel, getCommentLabel, type ContentKind } from '$lib/utils/content-label.js';
+    import {
+        getPostLabel,
+        getCommentLabel,
+        type ContentKind,
+        type ContentLabel
+    } from '$lib/utils/content-label.js';
     import { slide } from 'svelte/transition';
 
     interface RecentPost {
@@ -100,12 +105,9 @@
     // 표기는 content-label 유틸이 단일 판정한다(#13095, #13097).
     // 이전엔 화면마다 문구가 갈라졌고, 텍스트 없는 댓글이 이모티콘·이미지·빈댓글 구분 없이
     // 전부 '(내용 없음)' 으로 뭉개졌다.
-    function getRecentPostLabel(post: RecentPost): string {
-        return getPostLabel(post).text;
-    }
-
-    function getRecentCommentLabel(comment: RecentComment): string {
-        const label = getCommentLabel(comment);
+    // #13174: label.linkable 을 실제로 적용한다 — 삭제 항목은 <a> 없이 <span> 으로.
+    // (7/26 수정이 문구만 통일하고 링크 제거는 미적용이었다. 렌더는 아래 snippet 두 개가 단일 정본.)
+    function commentText(label: ContentLabel): string {
         return label.badge ? `${label.badge} ${label.text}` : label.text;
     }
 
@@ -261,6 +263,54 @@
     });
 </script>
 
+<!-- 최근 글/댓글 한 줄 렌더 정본 — 삭제 항목(linkable:false)은 링크 없이 표시 (#13174) -->
+{#snippet postItem(p: RecentPost)}
+    {@const label = getPostLabel(p)}
+    {#if label.linkable}
+        <a href={p.href} class="text-foreground hover:text-primary block min-w-0 truncate text-xs">
+            {label.text}
+        </a>
+    {:else}
+        <span class="text-muted-foreground block min-w-0 truncate text-xs">{label.text}</span>
+    {/if}
+{/snippet}
+
+{#snippet commentItem(c: RecentComment)}
+    {@const label = getCommentLabel(c)}
+    {#if label.linkable}
+        <a
+            href={c.href}
+            class="text-foreground hover:text-primary block min-w-0 truncate text-xs"
+            onclick={(e) => {
+                const hash = c.href.split('#')[1];
+                if (hash && window.location.pathname === c.href.split('#')[0]) {
+                    e.preventDefault();
+                    const el = document.getElementById(hash);
+                    if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        el.style.transition = 'background-color 0.3s ease';
+                        el.style.backgroundColor = 'hsl(var(--primary) / 0.1)';
+                        el.style.borderRadius = '0.5rem';
+                        setTimeout(() => {
+                            el.style.backgroundColor = '';
+                            setTimeout(() => {
+                                el.style.transition = '';
+                                el.style.borderRadius = '';
+                            }, 300);
+                        }, 2000);
+                    }
+                }
+            }}
+        >
+            {commentText(label)}
+        </a>
+    {:else}
+        <span class="text-muted-foreground block min-w-0 truncate text-xs">
+            {commentText(label)}
+        </span>
+    {/if}
+{/snippet}
+
 {#if post.author_id && !post.deleted_at}
     <div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3" bind:this={panelEl}>
         <!-- AdSense 광고 -->
@@ -317,12 +367,7 @@
                             <ul class="divide-border divide-y">
                                 {#each recentPosts as p (`${p.bo_table}_${p.wr_id}`)}
                                     <li class="py-1">
-                                        <a
-                                            href={p.href}
-                                            class="text-foreground hover:text-primary block min-w-0 truncate text-xs"
-                                        >
-                                            {getRecentPostLabel(p)}
-                                        </a>
+                                        {@render postItem(p)}
                                     </li>
                                 {/each}
                             </ul>
@@ -340,41 +385,7 @@
                             <ul class="divide-border divide-y">
                                 {#each recentComments as c (`${c.bo_table}_${c.wr_id}`)}
                                     <li class="py-1">
-                                        <a
-                                            href={c.href}
-                                            class="text-foreground hover:text-primary block min-w-0 truncate text-xs"
-                                            onclick={(e) => {
-                                                const hash = c.href.split('#')[1];
-                                                if (
-                                                    hash &&
-                                                    window.location.pathname ===
-                                                        c.href.split('#')[0]
-                                                ) {
-                                                    e.preventDefault();
-                                                    const el = document.getElementById(hash);
-                                                    if (el) {
-                                                        el.scrollIntoView({
-                                                            behavior: 'smooth',
-                                                            block: 'start'
-                                                        });
-                                                        el.style.transition =
-                                                            'background-color 0.3s ease';
-                                                        el.style.backgroundColor =
-                                                            'hsl(var(--primary) / 0.1)';
-                                                        el.style.borderRadius = '0.5rem';
-                                                        setTimeout(() => {
-                                                            el.style.backgroundColor = '';
-                                                            setTimeout(() => {
-                                                                el.style.transition = '';
-                                                                el.style.borderRadius = '';
-                                                            }, 300);
-                                                        }, 2000);
-                                                    }
-                                                }
-                                            }}
-                                        >
-                                            {getRecentCommentLabel(c)}
-                                        </a>
+                                        {@render commentItem(c)}
                                     </li>
                                 {/each}
                             </ul>
@@ -416,12 +427,7 @@
                             <ul class="divide-border divide-y">
                                 {#each recentPosts as p (`${p.bo_table}_${p.wr_id}`)}
                                     <li class="py-1">
-                                        <a
-                                            href={p.href}
-                                            class="text-foreground hover:text-primary block min-w-0 truncate text-xs"
-                                        >
-                                            {getRecentPostLabel(p)}
-                                        </a>
+                                        {@render postItem(p)}
                                     </li>
                                 {/each}
                             </ul>
@@ -443,12 +449,7 @@
                             <ul class="divide-border divide-y">
                                 {#each recentComments as c (`${c.bo_table}_${c.wr_id}`)}
                                     <li class="py-1">
-                                        <a
-                                            href={c.href}
-                                            class="text-foreground hover:text-primary block min-w-0 truncate text-xs"
-                                        >
-                                            {getRecentCommentLabel(c)}
-                                        </a>
+                                        {@render commentItem(c)}
                                     </li>
                                 {/each}
                             </ul>

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -538,6 +538,8 @@ export const load: PageServerLoad = async ({
                                 wr_datetime AS created_at, wr_last AS updated_at, ca_name AS category,
                                 wr_option,
                                 (wr_deleted_at IS NOT NULL AND wr_deleted_at <> '0000-00-00 00:00:00') AS is_deleted_parent,
+                                CASE WHEN wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00'
+                                     THEN NULL ELSE wr_deleted_at END AS deleted_at,
                                 wr_1 AS extra_1, wr_2 AS extra_2, wr_3 AS extra_3,
                                 wr_4 AS extra_4, wr_5 AS extra_5, wr_6 AS extra_6, wr_7 AS extra_7,
                                 wr_9 AS extra_9, wr_10 AS extra_10, wr_file
@@ -567,8 +569,9 @@ export const load: PageServerLoad = async ({
                         .filter((n) => Number.isFinite(n) && n > 0)
                 );
                 // Sphinx 결과 순서 유지 (refetchIds: parentIds dedupe or ids) + is_notice 주입
-                // 댓글 검색 시 삭제된 부모 글은 제목을 가리고 본문은 비운다(#12577).
-                // 일반 검색은 위 쿼리에서 삭제글이 이미 제외되므로 영향 없음.
+                // 댓글 검색 시 삭제된 부모 글은 tombstone(deleted_at + 빈 필드)로만 내린다
+                // (#12577 포함 정책 → #13174 전면 마스킹). 일반 검색은 위 쿼리에서 삭제글이
+                // 이미 제외되므로 영향 없음.
                 const rowMap = new Map(
                     rows.map((r) => {
                         const deleted = Number(r.is_deleted_parent) === 1;
@@ -585,6 +588,30 @@ export const load: PageServerLoad = async ({
                         // 우선순위: wr_10(지정 썸네일) > 본문 첫 <img>
                         // ⛔ 마스킹된 글은 썸네일도 비운다. 제목·본문만 가리고 이미지를 남기면
                         //    삭제·이용제한 마스킹이 그림으로 우회된다.
+                        // #13174: 삭제글은 스프레드(...r) 금지 — 최소 tombstone 만 명시 구성한다.
+                        // 종전엔 title/content 만 가리고 author·views·likes·날짜가 ...r 로
+                        // 그대로 실려, 일반 목록에선 전부 마스킹되는 메타데이터가 댓글 작성자
+                        // 검색에서만 노출됐다. deleted_at 을 내려보내면 8개 리스트 레이아웃의
+                        // 기존 `isDeleted = !!post.deleted_at` 분기가 일반 목록과 동일한
+                        // placeholder 행을 렌더한다. (민감 필드는 서버가 drop — 클라 가림 금지)
+                        if (deleted) {
+                            return [
+                                r.id,
+                                {
+                                    id: r.id,
+                                    deleted_at: r.deleted_at,
+                                    is_notice: noticeIds.has(Number(r.id)),
+                                    title: '',
+                                    content: '',
+                                    thumbnail: '',
+                                    thumbnail_raw: '',
+                                    has_file: false,
+                                    has_image: false,
+                                    has_video: false
+                                }
+                            ];
+                        }
+
                         const rawThumb = masked
                             ? ''
                             : String(r.extra_10 || '') ||
@@ -596,11 +623,8 @@ export const load: PageServerLoad = async ({
                             r.id,
                             {
                                 ...r,
-                                title: deleted
-                                    ? '[삭제된 글입니다]'
-                                    : disciplined
-                                      ? DISCIPLINED_TITLE
-                                      : r.title,
+                                deleted_at: null,
+                                title: disciplined ? DISCIPLINED_TITLE : r.title,
                                 content: masked ? '' : r.content,
                                 is_notice: noticeIds.has(Number(r.id)),
                                 thumbnail_raw: normalizedThumb,

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -572,8 +572,10 @@ export const load: PageServerLoad = async ({
                 // 댓글 검색 시 삭제된 부모 글은 tombstone(deleted_at + 빈 필드)로만 내린다
                 // (#12577 포함 정책 → #13174 전면 마스킹). 일반 검색은 위 쿼리에서 삭제글이
                 // 이미 제외되므로 영향 없음.
+                // 콜백 반환을 명시 튜플로 표기 — tombstone 분기와 ...r 분기의 객체 모양이
+                // 달라 TS 가 Map 생성자 유니온 추론에 실패한다(런타임 무관, 타입 표기용).
                 const rowMap = new Map(
-                    rows.map((r) => {
+                    rows.map((r): [unknown, Record<string, unknown>] => {
                         const deleted = Number(r.is_deleted_parent) === 1;
                         const disciplined = disciplinedIds.has(Number(r.id));
                         const masked = deleted || disciplined;

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -167,7 +167,10 @@ export const load: PageServerLoad = async ({
             // 댓글 스레드는 유지한다(#12965 — 댓글은 각 댓글 작성자의 소유·책임).
             // 타인 삭제(관리자/징계 등) 또는 삭제자 미상이면 댓글도 가린다(#12711).
             // 삭제 사유(자진/징계)는 문구로 구분하지 않는다. 댓글 API 게이트와 정합.
-            const selfDeleted = !!post.deleted_by && post.deleted_by === post.author_id;
+            // #13174: 신 백엔드는 삭제글에서 deleted_by/author_id 를 서버 drop 하고
+            // 판정 결과인 self_deleted 만 내려준다. 구 백엔드 호환으로 기존 식을 폴백 유지.
+            const selfDeleted =
+                post.self_deleted ?? (!!post.deleted_by && post.deleted_by === post.author_id);
             if (!selfDeleted) {
                 // 헤더 카운트 라벨/SSR total/클라 backfill 게이트 일치를 위해 권위 카운트 0.
                 post.comments_count = 0;

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -186,14 +186,7 @@
     let likedLoaded = $state(false);
 
     // 표기는 content-label 유틸이 단일 판정한다(#13095, #13097).
-    function getRecentPostTitle(post: RecentPost): string {
-        return getPostLabel(post).text;
-    }
-
-    function getRecentCommentPreview(comment: RecentComment): string {
-        const label = getCommentLabel(comment);
-        return label.badge ? `${label.badge} ${label.text}` : label.text;
-    }
+    // #13174: 렌더에서 label.linkable 분기까지 적용하므로 템플릿이 getPostLabel/getCommentLabel 직접 호출.
 
     onMount(async () => {
         if (!p?.mb_id) return;
@@ -903,13 +896,21 @@
                     {:else}
                         <ul class="divide-border divide-y">
                             {#each recentPosts as post (post.wr_id)}
+                                {@const label = getPostLabel(post)}
                                 <li class="py-2">
-                                    <a
-                                        href={post.href}
-                                        class="text-foreground hover:text-primary block text-sm transition-colors"
-                                    >
-                                        {getRecentPostTitle(post)}
-                                    </a>
+                                    <!-- #13174: 삭제 항목(linkable:false)은 링크 없이 표시 -->
+                                    {#if label.linkable}
+                                        <a
+                                            href={post.href}
+                                            class="text-foreground hover:text-primary block text-sm transition-colors"
+                                        >
+                                            {label.text}
+                                        </a>
+                                    {:else}
+                                        <span class="text-muted-foreground block text-sm">
+                                            {label.text}
+                                        </span>
+                                    {/if}
                                     <div class="text-muted-foreground mt-0.5 flex gap-2 text-xs">
                                         <span class="text-primary/70">{post.bo_subject}</span>
                                         <span>{formatDate(post.wr_datetime)}</span>
@@ -933,13 +934,24 @@
                     {:else}
                         <ul class="divide-border divide-y">
                             {#each recentComments as comment (comment.wr_id)}
+                                {@const label = getCommentLabel(comment)}
+                                {@const text = label.badge
+                                    ? `${label.badge} ${label.text}`
+                                    : label.text}
                                 <li class="py-2">
-                                    <a
-                                        href={comment.href}
-                                        class="text-foreground hover:text-primary block text-sm transition-colors"
-                                    >
-                                        {getRecentCommentPreview(comment)}
-                                    </a>
+                                    <!-- #13174: 삭제 항목(linkable:false)은 링크 없이 표시 -->
+                                    {#if label.linkable}
+                                        <a
+                                            href={comment.href}
+                                            class="text-foreground hover:text-primary block text-sm transition-colors"
+                                        >
+                                            {text}
+                                        </a>
+                                    {:else}
+                                        <span class="text-muted-foreground block text-sm">
+                                            {text}
+                                        </span>
+                                    {/if}
                                     <div class="text-muted-foreground mt-0.5 flex gap-2 text-xs">
                                         <span class="text-primary/70">{comment.bo_subject}</span>
                                         <span>{formatDate(comment.wr_datetime)}</span>


### PR DESCRIPTION
## 문제 (bug/13174, 이전 13095·13097)

1. 프로필·작성자 최근 활동의 삭제 항목이 링크가 살아있는 채 렌더 — 7/26 #1878 이 `content-label.ts` 에 `linkable:false` 를 넣었지만 renderer 가 무시하고 `<a>` 를 무조건 감쌌다.
2. **댓글 작성자 검색의 삭제글 행에서 작성자·공감·날짜·조회 전부 노출** — 검색 경로가 `deleted_at` 을 SELECT 하지 않아 레이아웃의 `isDeleted` 분기가 불발했고, rowMap 이 title/content 만 가리고 나머지는 `...r` 스프레드로 통과시켰다. 일반 목록은 전부 마스킹되는 정보다.

## 변경

- `author-activity-panel.svelte`·`member/[id]/+page.svelte`: `label.linkable` 분기 — 삭제 항목은 `<span>`(비링크). 패널은 snippet 2개로 4곳 중복 정리.
- `[boardId]/+page.server.ts`: SELECT 에 `deleted_at`(0000 정규화) 추가, 삭제 행은 스프레드 금지·최소 tombstone 만 명시 구성 → 민감 필드가 `__data.json` 에서 원천 제거. 8개 리스트 레이아웃의 기존 deleted 분기가 일반 목록과 동일하게 렌더.
- `self_deleted` 폴백(`[postId]/+page.server.ts`) + 타입 — 백엔드 짝 PR 이 `deleted_by` 를 drop 해도 자진삭제 댓글 스레드 판정 유지. **이 PR 이 백엔드보다 먼저 배포돼야 한다.**

## 백엔드 짝

damoang/angple-backend (활동 피드 삭제 자리표시자 + transform 서버 drop) — 별도 PR, 이 PR 라이브 후 머지.