### PR TITLE
feat(seo): 자동차 주제 허브 파일럿 (L0) — 차종별 큐레이션 페이지

### DIFF
--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -185,6 +185,24 @@ export interface JsonLdRatedItem {
     aggregateRating: JsonLdAggregateRating;
 }
 
+/** 주제 큐레이션 허브(CollectionPage + ItemList) — 자동차 허브 등 */
+export interface JsonLdCollectionPage {
+    '@context': 'https://schema.org';
+    '@type': 'CollectionPage';
+    name: string;
+    description: string;
+    url: string;
+    mainEntity: {
+        '@type': 'ItemList';
+        itemListElement: Array<{
+            '@type': 'ListItem';
+            position: number;
+            url: string;
+            name: string;
+        }>;
+    };
+}
+
 export type JsonLdData =
     | JsonLdWebSite
     | JsonLdArticle
@@ -194,7 +212,8 @@ export type JsonLdData =
     | JsonLdFAQPage
     | JsonLdQAPage
     | JsonLdVideoObject
-    | JsonLdRatedItem;
+    | JsonLdRatedItem
+    | JsonLdCollectionPage;
 
 /** 페이지네이션 SEO 정보 */
 export interface PaginationSeo {

--- a/apps/web/src/lib/server/car-hub-topics.ts
+++ b/apps/web/src/lib/server/car-hub-topics.ts
@@ -1,0 +1,81 @@
+/**
+ * 자동차 주제 허브 파일럿 (SEO L0) — 차종/주제 화이트리스트.
+ * 설계: docs/seo-niche-hub-design-20260731.html
+ *
+ * 왜 화이트리스트인가: 빈약 허브(thin content) 대량 생성은 도메인 전체 품질을
+ * 떨어뜨려 역효과다. GSC 수요 + car 게시판 글 수(2026-07-31 실측)가 확인된
+ * 주제만 수동 시드한다. 글 20개 미만 주제는 넣지 않는다.
+ *
+ * keywords: g5_write_car 제목(wr_subject) LIKE 매칭에 쓰는 동의어.
+ *           개별 글을 못 고치므로, 허브가 이 키워드로 글을 모아 정보 랭킹을 잡는다.
+ */
+export interface CarHubTopic {
+    /** URL slug (영문·숫자·하이픈). /car/hub/{slug} */
+    slug: string;
+    /** 표시명·검색 키워드의 대표값 */
+    title: string;
+    /** 제목 LIKE 매칭 키워드(대표명 포함) */
+    keywords: string[];
+    /** 색인용 소개문(1~2문장). thin page 방지 + 문맥 키워드 */
+    intro: string;
+}
+
+export const CAR_HUB_TOPICS: readonly CarHubTopic[] = [
+    {
+        slug: 'tesla',
+        title: '테슬라',
+        keywords: ['테슬라', 'Tesla', '모델Y', '모델3', 'FSD', 'EAP', '오토파일럿'],
+        intro: '다모앙 자동차 게시판에 모인 테슬라 오너들의 실사용 후기입니다. 오토파일럿·FSD·EAP 경험, 충전·주행거리, 모델Y·모델3 구매기와 관리 팁을 한곳에서 모아 봅니다.'
+    },
+    {
+        slug: 'ev',
+        // ⚠️ 'EV' 같은 2자 ASCII 는 'REVIEW'·'level' 등 과매칭 위험이라 제외.
+        // 전기차 글은 '전기차'·차종명(EV6/EV9 은 별도)으로 충분히 잡힌다.
+        title: '전기차',
+        keywords: ['전기차', '전동화', '충전', '완속', '급속', '보조금'],
+        intro: '전기차 오너와 예비 오너들의 실경험을 모았습니다. 충전 인프라·주행거리·유지비·보조금 등 전기차 구매와 운용에 필요한 다모앙 커뮤니티의 생생한 정보입니다.'
+    },
+    {
+        slug: 'ioniq',
+        title: '아이오닉',
+        keywords: ['아이오닉', 'IONIQ', '아이오닉5', '아이오닉6', '아이오닉9'],
+        intro: '현대 아이오닉 시리즈(5·6·9) 오너들의 후기 모음입니다. 충전·주행·V2L·실내 활용 등 아이오닉 실사용 경험을 다모앙에서 확인하세요.'
+    },
+    {
+        slug: 'bmw',
+        // 'iX'·'i4' 는 'MIX'·'matrix' 등 과매칭 위험이라 제외. BMW 전기차 글도 'BMW'·'비엠'으로 잡힌다.
+        title: 'BMW',
+        keywords: ['BMW', '비엠', '520d', '530d', 'X3', 'X5'],
+        intro: 'BMW 오너들의 실사용 후기와 정비·관리 경험을 모았습니다. 세단부터 SUV, 전기차 i 시리즈까지 다모앙 자동차 게시판의 BMW 이야기입니다.'
+    },
+    {
+        slug: 'genesis',
+        title: '제네시스',
+        keywords: ['제네시스', 'Genesis', 'GV70', 'GV80', 'G80', 'G90', 'GV60'],
+        intro: '제네시스 오너들의 실사용 후기 모음입니다. G80·G90 세단과 GV70·GV80 SUV, 전동화 GV60까지 다모앙 커뮤니티의 제네시스 경험을 확인하세요.'
+    },
+    {
+        slug: 'benz',
+        // 'EQ' 는 'Frequency' 등 과매칭 위험이라 제외. 벤츠 전기차(EQ 라인) 글도 '벤츠'·'메르세데스'로 잡힌다.
+        title: '벤츠',
+        keywords: ['벤츠', 'Benz', '메르세데스', 'E클래스', 'C클래스', 'GLC'],
+        intro: '메르세데스-벤츠 오너들의 실사용 후기와 관리 경험입니다. E·C클래스 세단, GLC SUV, EQ 전기차까지 다모앙 자동차 게시판의 벤츠 이야기.'
+    },
+    {
+        slug: 'volvo',
+        title: '볼보',
+        keywords: ['볼보', 'Volvo', 'XC60', 'XC90', 'XC40', 'S90'],
+        intro: '볼보 오너들의 안전·주행 후기 모음입니다. XC 시리즈 SUV와 세단, 전동화 모델까지 다모앙 커뮤니티의 볼보 실사용 경험을 확인하세요.'
+    },
+    {
+        slug: 'audi',
+        title: '아우디',
+        keywords: ['아우디', 'Audi', 'A6', 'Q5', 'Q7', 'e-tron', 'e트론'],
+        intro: '아우디 오너들의 실사용 후기와 정비 경험입니다. A 시리즈 세단, Q 시리즈 SUV, e-tron 전기차까지 다모앙 자동차 게시판의 아우디 이야기.'
+    }
+] as const;
+
+/** slug → topic (없으면 undefined) */
+export function findCarHubTopic(slug: string): CarHubTopic | undefined {
+    return CAR_HUB_TOPICS.find((t) => t.slug === slug);
+}

--- a/apps/web/src/routes/car/hub/[topic]/+page.server.ts
+++ b/apps/web/src/routes/car/hub/[topic]/+page.server.ts
@@ -1,0 +1,76 @@
+/**
+ * 자동차 주제 허브 (SEO L0 파일럿) — /car/hub/{topic}
+ * 설계: docs/seo-niche-hub-design-20260731.html
+ *
+ * 커뮤니티는 개별 글을 못 고친다(사용자 작성). 그래서 흩어진 대화체 글을
+ * 주제 허브로 묶어, 허브가 정보 키워드로 랭킹을 잡게 한다.
+ * 이 서버 로더는 화이트리스트 주제의 g5_write_car 글을 제목 매칭으로 모은다.
+ */
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+import { findCarHubTopic } from '$lib/server/car-hub-topics';
+
+const MIN_POSTS = 3; // thin content 방지: 글 3개 미만 주제는 404
+const LIST_LIMIT = 40;
+
+interface CarPostRow extends RowDataPacket {
+    wr_id: number;
+    wr_subject: string;
+    wr_name: string;
+    wr_datetime: string;
+    wr_hit: number;
+    wr_comment: number;
+    wr_good: number;
+}
+
+export const load: PageServerLoad = async ({ params, setHeaders }) => {
+    const topic = findCarHubTopic(params.topic);
+    if (!topic) throw error(404, '존재하지 않는 자동차 주제입니다.');
+
+    // 제목에 키워드 중 하나라도 포함된 글. 삭제·비밀글 제외.
+    // g5_write_car 는 1.1만 행으로 작아 LIKE 스캔이 저렴하고, 아래 CDN 캐시로 재요청은 흡수된다.
+    const likeClauses = topic.keywords.map(() => 'wr_subject LIKE ?').join(' OR ');
+    const likeParams = topic.keywords.map((k) => `%${k}%`);
+
+    let rows: CarPostRow[] = [];
+    try {
+        const [result] = await pool.query<CarPostRow[]>(
+            `SELECT wr_id, wr_subject, wr_name, wr_datetime, wr_hit, wr_comment, wr_good
+               FROM g5_write_car
+              WHERE wr_is_comment = 0
+                AND wr_deleted_at IS NULL
+                AND (wr_option IS NULL OR wr_option NOT LIKE '%secret%')
+                AND (${likeClauses})
+              ORDER BY wr_datetime DESC
+              LIMIT ?`,
+            [...likeParams, LIST_LIMIT]
+        );
+        rows = result;
+    } catch (e) {
+        console.error('[car-hub] query 실패:', e);
+        throw error(500, '주제 글을 불러오지 못했습니다.');
+    }
+
+    if (rows.length < MIN_POSTS) {
+        // 아직 글이 얕은 주제는 허브를 만들지 않는다(thin page 페널티 회피).
+        throw error(404, '아직 준비 중인 주제입니다.');
+    }
+
+    // 개인화 없음 → 공개 캐시. 크롤러·재방문 부하를 CDN 이 흡수한다.
+    setHeaders({ 'cache-control': 'public, s-maxage=600, max-age=120' });
+
+    return {
+        topic,
+        posts: rows.map((r) => ({
+            id: r.wr_id,
+            subject: r.wr_subject,
+            author: r.wr_name,
+            datetime: r.wr_datetime,
+            hit: r.wr_hit ?? 0,
+            comments: r.wr_comment ?? 0,
+            good: r.wr_good ?? 0
+        }))
+    };
+};

--- a/apps/web/src/routes/car/hub/[topic]/+page.svelte
+++ b/apps/web/src/routes/car/hub/[topic]/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+    /**
+     * 자동차 주제 허브 (SEO L0 파일럿).
+     * 설계: docs/seo-niche-hub-design-20260731.html
+     * - 키워드화된 title/H1 + 소개문(색인 텍스트) + 큐레이션 글 목록(내부링크)
+     * - CollectionPage + ItemList + BreadcrumbList 구조화 데이터
+     */
+    import { SeoHead, getSiteUrl, createBreadcrumbJsonLd } from '$lib/seo/index.js';
+    import type { SeoConfig } from '$lib/seo/types.js';
+
+    let { data } = $props();
+
+    const siteUrl = getSiteUrl();
+    const hubUrl = `${siteUrl}/car/hub/${data.topic.slug}`;
+    const pageTitle = `${data.topic.title} 후기·정보 모음 | 다모앙 자동차`;
+
+    function fmtDate(s: string): string {
+        return (s || '').slice(0, 10);
+    }
+
+    // CollectionPage + ItemList: 이 허브가 "주제 큐레이션 페이지"임을 구글에 명시.
+    const collectionJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: pageTitle,
+        description: data.topic.intro,
+        url: hubUrl,
+        mainEntity: {
+            '@type': 'ItemList',
+            itemListElement: data.posts.map((p, i) => ({
+                '@type': 'ListItem',
+                position: i + 1,
+                url: `${siteUrl}/car/${p.id}`,
+                name: p.subject
+            }))
+        }
+    };
+
+    const seoConfig: SeoConfig = {
+        meta: {
+            title: pageTitle,
+            description: data.topic.intro,
+            canonicalUrl: hubUrl
+        },
+        og: {
+            title: pageTitle,
+            description: data.topic.intro,
+            type: 'website',
+            url: hubUrl
+        },
+        jsonLd: [
+            createBreadcrumbJsonLd([
+                { name: '홈', url: siteUrl },
+                { name: '자동차', url: `${siteUrl}/car` },
+                { name: data.topic.title, url: hubUrl }
+            ]),
+            collectionJsonLd
+        ]
+    };
+</script>
+
+<SeoHead config={seoConfig} />
+
+<div class="mx-auto max-w-4xl px-4 py-6">
+    <nav class="text-muted-foreground mb-3 text-sm">
+        <a href="/car" class="hover:underline">자동차</a>
+        <span aria-hidden="true"> › </span>
+        <span>{data.topic.title}</span>
+    </nav>
+
+    <h1 class="mb-2 text-2xl font-bold">{data.topic.title} 후기·정보 모음</h1>
+    <p class="text-muted-foreground mb-6 leading-relaxed">{data.topic.intro}</p>
+
+    <h2 class="border-border mb-3 border-b pb-2 text-lg font-semibold">
+        최신 {data.topic.title} 글 ({data.posts.length})
+    </h2>
+
+    <ul class="divide-border divide-y">
+        {#each data.posts as post (post.id)}
+            <li class="py-2.5">
+                <a href="/car/{post.id}" class="group flex items-baseline justify-between gap-3">
+                    <span
+                        class="group-hover:text-primary flex-1 truncate font-medium transition-colors"
+                    >
+                        {post.subject}
+                        {#if post.comments > 0}
+                            <span class="text-primary ml-1 text-sm">[{post.comments}]</span>
+                        {/if}
+                    </span>
+                    <span class="text-muted-foreground shrink-0 text-xs">
+                        {post.author} · {fmtDate(post.datetime)}
+                    </span>
+                </a>
+            </li>
+        {/each}
+    </ul>
+
+    <div class="mt-6">
+        <a href="/car" class="text-primary text-sm hover:underline">→ 자동차 게시판 전체 보기</a>
+    </div>
+</div>

--- a/apps/web/src/routes/car/hub/[topic]/+page.svelte
+++ b/apps/web/src/routes/car/hub/[topic]/+page.svelte
@@ -6,7 +6,7 @@
      * - CollectionPage + ItemList + BreadcrumbList 구조화 데이터
      */
     import { SeoHead, getSiteUrl, createBreadcrumbJsonLd } from '$lib/seo/index.js';
-    import type { SeoConfig } from '$lib/seo/types.js';
+    import type { SeoConfig, JsonLdCollectionPage } from '$lib/seo/types.js';
 
     let { data } = $props();
 
@@ -19,7 +19,7 @@
     }
 
     // CollectionPage + ItemList: 이 허브가 "주제 큐레이션 페이지"임을 구글에 명시.
-    const collectionJsonLd = {
+    const collectionJsonLd: JsonLdCollectionPage = {
         '@context': 'https://schema.org',
         '@type': 'CollectionPage',
         name: pageTitle,

--- a/apps/web/src/routes/sitemap-static.xml/+server.ts
+++ b/apps/web/src/routes/sitemap-static.xml/+server.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from './$types';
+import { CAR_HUB_TOPICS } from '$lib/server/car-hub-topics';
 
 /**
  * 정적 페이지 Sitemap
@@ -17,7 +18,13 @@ export const GET: RequestHandler = async ({ url }) => {
         { loc: '/level', priority: '0.2', changefreq: 'yearly' },
         { loc: '/guide', priority: '0.3', changefreq: 'monthly' },
         { loc: '/faq', priority: '0.3', changefreq: 'monthly' },
-        { loc: '/advertising', priority: '0.2', changefreq: 'monthly' }
+        { loc: '/advertising', priority: '0.2', changefreq: 'monthly' },
+        // 자동차 주제 허브(SEO L0 파일럿). changefreq daily — 최신 글이 매일 갱신됨.
+        ...CAR_HUB_TOPICS.map((t) => ({
+            loc: `/car/hub/${t.slug}`,
+            priority: '0.6',
+            changefreq: 'daily'
+        }))
     ];
 
     const urls = staticPages.map(


### PR DESCRIPTION
## 배경
GSC 실측(설계: docs/seo-niche-hub-design-20260731.html): car 게시판 노출 22.7만·순위 8.9위 = 최대 미회수. 커뮤니티는 개별 글을 SEO 최적화할 수 없으니(사용자 작성), **흩어진 대화체 글을 주제 허브로 묶어** 허브가 정보 키워드로 랭킹을 잡게 한다.

## 변경
- **`/car/hub/{slug}`** 신규 라우트: 화이트리스트 8개 차종(테슬라 1230글·전기차 957·아이오닉·BMW 344·제네시스·벤츠 133·볼보·아우디). `g5_write_car` 제목 매칭 글을 SSR 큐레이션
- 키워드화된 title/H1 + 소개문(색인 텍스트, 8개 각기 다름) + 글 목록(개별 글 내부링크) + **CollectionPage/ItemList/BreadcrumbList JSON-LD**
- thin(글 3개 미만)·미등록 slug → 404 (품질 페널티 회피)
- 공개 캐시 `s-maxage=600` (크롤러 부하 흡수)
- sitemap-static 에 허브 URL 8개 등록

## 안전 설계
- **개별 글 무변경**. 신규 페이지라 기존 게시판 라우트(`/car`, `/car/{id}`) 무영향 — svelte-kit sync 로 라우트 독립 생성 확인(Evaluator)
- 삭제글 필터 `wr_deleted_at IS NULL`(tombstone 마스킹 정책 준수), 비밀글 `wr_option NOT LIKE '%secret%'`
- SQL 파라미터 바인딩(인젝션 불가)

## 검증
- **Evaluator 독립 검증 2건 지적 반영**: (1) 삭제글 필터 누락 → 추가(테슬라/전기차 매칭 중 삭제글 8건 제외 실측) (2) 2자 ASCII 키워드 과매칭(EV→'REVIEW', iX→'MIX', EQ→'Frequency', FSD 쇼바글이 테슬라+벤츠 오염) → EV/EQ/iX/i4 제거, 차종·브랜드명으로 커버
- 라우트 충돌(매처 삼킴 함정) 없음 확인
- 타입체크/prettier는 CI

## 배포 후 측정 (설계 L0 완료 기준)
2주 후 허브 URL 의 GSC 노출·순위 등장 + car 게시판 전체 CTR‰ 추세. 통하면 L1(주식) 확장, 안 통하면 원인 분석. **가드**: 허브 생성 후 무관 게시판(free 등) 노출 하락 시 즉시 중단(품질 희석 신호)