### PR TITLE
feat(profile): 공감 내역의 삭제글을 자리표시자로 (#13174 후속)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/liked/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/liked/+server.ts
@@ -28,6 +28,7 @@ interface WriteRow extends RowDataPacket {
     wr_id: number;
     wr_subject: string;
     wr_datetime: string;
+    is_deleted: number;
 }
 
 interface CountRow extends RowDataPacket {
@@ -112,10 +113,13 @@ export const GET: RequestHandler = async ({ params, url }) => {
         await Promise.all(
             Array.from(groupedByBoard.entries()).map(async ([boTable, wrIds]) => {
                 try {
+                    // #13174 후속: 삭제글도 가져와 [삭제된 게시물] 자리표시자로 표시한다.
+                    // 종전 is_deleted=0 은 공감했던 글이 삭제되면 내역에서 조용히 사라졌다.
                     const [writeRows] = await pool.query<WriteRow[]>(
-                        `SELECT write_id AS wr_id, title AS wr_subject, source_created_at AS wr_datetime
+                        `SELECT write_id AS wr_id, title AS wr_subject, source_created_at AS wr_datetime,
+                                is_deleted
                            FROM member_activity_feed
-                          WHERE board_id = ? AND write_id IN (?) AND activity_type = 1 AND is_deleted = 0`,
+                          WHERE board_id = ? AND write_id IN (?) AND activity_type = 1`,
                         [boTable, wrIds]
                     );
                     for (const w of writeRows) {
@@ -131,14 +135,18 @@ export const GET: RequestHandler = async ({ params, url }) => {
         for (const row of goodRows) {
             const w = writeMap.get(`${row.bo_table}:${row.wr_id}`);
             if (!w) continue;
+            // 삭제글: 피드에 캐시된 원제를 서버에서 비우고 deleted 플래그만 내린다.
+            // (민감 필드는 서버가 drop — 클라 가림 금지)
+            const deleted = Number(w.is_deleted) === 1;
             items.push({
                 bo_table: row.bo_table,
                 bo_subject: boardSubjects.get(row.bo_table) || row.bo_table,
                 wr_id: w.wr_id,
-                wr_subject: w.wr_subject,
+                wr_subject: deleted ? '' : w.wr_subject,
                 wr_datetime: w.wr_datetime,
                 bg_datetime: row.bg_datetime,
-                href: `/${row.bo_table}/${w.wr_id}`
+                deleted,
+                href: deleted ? '' : `/${row.bo_table}/${w.wr_id}`
             });
         }
 

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -163,6 +163,7 @@
         wr_id: number;
         wr_subject: string;
         bg_datetime: string;
+        deleted?: boolean; // #13174 후속: 삭제글은 자리표시자(비링크)
         href: string;
     }
 
@@ -976,24 +977,47 @@
                         <ul class="divide-border divide-y">
                             {#each likedPosts as liked (liked.wr_id)}
                                 <li>
-                                    <a
-                                        href={liked.href}
-                                        class="hover:bg-muted flex items-center gap-2.5 px-4 py-2 no-underline transition-all duration-200 ease-out"
-                                    >
-                                        <span
-                                            class="bg-muted text-muted-foreground hidden shrink-0 rounded px-1.5 py-0.5 text-xs sm:inline-block"
+                                    <!-- #13174 후속: 삭제글은 링크 없는 자리표시자 -->
+                                    {#if liked.deleted}
+                                        <div
+                                            class="flex items-center gap-2.5 px-4 py-2 transition-all duration-200 ease-out"
                                         >
-                                            {liked.bo_subject}
-                                        </span>
-                                        <span class="min-w-0 flex-1 truncate leading-relaxed">
-                                            {liked.wr_subject}
-                                        </span>
-                                        <span
-                                            class="text-muted-foreground hidden shrink-0 text-xs sm:inline-block"
+                                            <span
+                                                class="bg-muted text-muted-foreground hidden shrink-0 rounded px-1.5 py-0.5 text-xs sm:inline-block"
+                                            >
+                                                {liked.bo_subject}
+                                            </span>
+                                            <span
+                                                class="text-muted-foreground min-w-0 flex-1 truncate leading-relaxed"
+                                            >
+                                                [삭제된 게시물]
+                                            </span>
+                                            <span
+                                                class="text-muted-foreground hidden shrink-0 text-xs sm:inline-block"
+                                            >
+                                                {formatDate(liked.bg_datetime)}
+                                            </span>
+                                        </div>
+                                    {:else}
+                                        <a
+                                            href={liked.href}
+                                            class="hover:bg-muted flex items-center gap-2.5 px-4 py-2 no-underline transition-all duration-200 ease-out"
                                         >
-                                            {formatDate(liked.bg_datetime)}
-                                        </span>
-                                    </a>
+                                            <span
+                                                class="bg-muted text-muted-foreground hidden shrink-0 rounded px-1.5 py-0.5 text-xs sm:inline-block"
+                                            >
+                                                {liked.bo_subject}
+                                            </span>
+                                            <span class="min-w-0 flex-1 truncate leading-relaxed">
+                                                {liked.wr_subject}
+                                            </span>
+                                            <span
+                                                class="text-muted-foreground hidden shrink-0 text-xs sm:inline-block"
+                                            >
+                                                {formatDate(liked.bg_datetime)}
+                                            </span>
+                                        </a>
+                                    {/if}
                                 </li>
                             {/each}
                         </ul>


### PR DESCRIPTION
## 문제

프로필 공감 내역 탭이 `is_deleted=0` 으로 좁혀, 공감했던 글이 삭제되면 내역에서 **조용히 사라졌다**. 13174 본편(활동 피드 자리표시자)과 같은 계열의 잔여 표면.

## 변경

- `liked/+server.ts`: 삭제글도 조회하되 **원제는 서버에서 blank** + `deleted` 플래그·href 제거
- 프로필 렌더: `deleted` 행은 `[삭제된 게시물]` 비링크 자리표시자 (13102 표기 규칙 — 대괄호=상태)

공감 시각(bg_datetime)·게시판명은 유지 — 내가 언제 어디에 공감했는지는 내역의 본질 정보다.