### PR TITLE
feat(seo): 앙지도(angmap) 별점 LocalBusiness 매핑 — 맛집 리치결과 + GSC 오류 해소

### DIFF
--- a/apps/web/src/lib/seo/json-ld.ts
+++ b/apps/web/src/lib/seo/json-ld.ts
@@ -180,12 +180,25 @@ export function createVideoObjectJsonLd(options: {
     return data;
 }
 
+/** 장소(지도) 게시판 — 카테고리가 지역명이라 board 기반으로 LocalBusiness 매핑. */
+const PLACE_BOARDS: ReadonlySet<string> = new Set(['angmap']);
+
 /**
- * 앙티티 카테고리(ca_name) → schema.org 타입.
+ * 앙티티/앙지도 → schema.org 타입.
  * 구글 리뷰 리치결과(별점 노출) 지원 타입을 우선 매핑. 미지원 카테고리는 CreativeWork
- * (스키마는 유효하나 리치결과는 미보장). 다중 카테고리(병원=LocalBusiness 등)는 후속.
+ * (스키마는 유효하나 리치결과는 미보장).
+ *
+ * ⚠️ 앙지도(angmap)는 ca_name 이 음식종류가 아니라 **지역명(전남·서울…)** 이라 카테고리
+ *    매핑으로는 CreativeWork 로 떨어져 GSC "parent_node 개체유형 잘못" 오류가 났다
+ *    (2026-07-31, angmap/15135). board 기반으로 LocalBusiness 매핑한다 — 회원이 여러
+ *    맛집을 리뷰하는 사이트라 구글 LocalBusiness 리뷰 스니펫 정책("다른 로컬 비즈니스
+ *    리뷰 수집 사이트")에 적격이고, 별점 리치결과도 살아난다.
  */
-export function ratingSchemaTypeForCategory(category?: string): JsonLdRatedItem['@type'] {
+export function ratingSchemaTypeForCategory(
+    category?: string,
+    boardId?: string
+): JsonLdRatedItem['@type'] {
+    if (boardId && PLACE_BOARDS.has(boardId)) return 'LocalBusiness';
     switch ((category || '').trim()) {
         // 드라마도 Movie 로 — Google 리뷰 스니펫 지원 타입은 Movie 이고 TVSeries 는 미지원이라,
         // ★ 리치결과를 실제로 띄우려면 Movie 로 매핑한다(스키마상 무해).
@@ -244,6 +257,7 @@ const REVIEW_SNIPPET_SUPPORTED_TYPES: ReadonlySet<string> = new Set([
 export function createRatedItemJsonLd(options: {
     name: string;
     category?: string;
+    boardId?: string;
     ratingValue: number;
     ratingCount: number;
     url?: string;
@@ -254,7 +268,7 @@ export function createRatedItemJsonLd(options: {
     if (!options.ratingCount || options.ratingCount < 1) return null;
     if (!(options.ratingValue > 0)) return null;
 
-    const type = ratingSchemaTypeForCategory(options.category);
+    const type = ratingSchemaTypeForCategory(options.category, options.boardId);
     if (!REVIEW_SNIPPET_SUPPORTED_TYPES.has(type)) return null;
 
     const item: JsonLdRatedItem = {

--- a/apps/web/src/lib/seo/rated-item.test.ts
+++ b/apps/web/src/lib/seo/rated-item.test.ts
@@ -22,6 +22,32 @@ describe('ratingSchemaTypeForCategory — 앙티티 카테고리 → schema.org 
         expect(ratingSchemaTypeForCategory(undefined)).toBe('CreativeWork');
         expect(ratingSchemaTypeForCategory('')).toBe('CreativeWork');
     });
+    it('앙지도(angmap)는 board 기반으로 LocalBusiness — ca_name(지역명) 무관', () => {
+        // 지역명이 카테고리라 category 매핑으론 CreativeWork 였던 것을 board 로 교정.
+        expect(ratingSchemaTypeForCategory('전남', 'angmap')).toBe('LocalBusiness');
+        expect(ratingSchemaTypeForCategory('서울', 'angmap')).toBe('LocalBusiness');
+        expect(ratingSchemaTypeForCategory(undefined, 'angmap')).toBe('LocalBusiness');
+        // 다른 게시판은 기존 매핑 유지(회귀 없음)
+        expect(ratingSchemaTypeForCategory('영화', 'angtt')).toBe('Movie');
+    });
+});
+
+describe('createRatedItemJsonLd — angmap 은 LocalBusiness 로 별점 생성(오류 해소 + 리치결과 유지)', () => {
+    const base = { ratingValue: 4, ratingCount: 1, url: 'https://damoang.net/angmap/15135' };
+    it('angmap 장소는 LocalBusiness + aggregateRating (CreativeWork null 아님)', () => {
+        const r = createRatedItemJsonLd({
+            ...base,
+            name: '목포 동부시장내 삼촌네회수산',
+            category: '전남',
+            boardId: 'angmap'
+        });
+        expect(r).not.toBeNull();
+        expect(r?.['@type']).toBe('LocalBusiness');
+        expect(r?.aggregateRating.ratingValue).toBe(4);
+    });
+    it('boardId 없으면 기존대로 category 매핑(회귀 없음)', () => {
+        expect(createRatedItemJsonLd({ ...base, name: '무제', category: '음악' })).toBeNull(); // CreativeWork → 생략
+    });
 });
 
 describe('createRatedItemJsonLd — 리뷰 스니펫 미지원 타입은 블록 생략 (GSC parent_node 오류 방지)', () => {

--- a/apps/web/src/lib/seo/types.ts
+++ b/apps/web/src/lib/seo/types.ts
@@ -177,8 +177,9 @@ export interface JsonLdAggregateRating {
 
 /** JSON-LD - 평점 대상 아이템 (작품/장소 등 + aggregateRating). 앙티티(리뷰) 게시판용. */
 export interface JsonLdRatedItem {
-    // Movie/Book/VideoGame/Event = Google 리뷰 스니펫(★) 지원. CreativeWork = 폴백(스키마 유효, 리치결과 미보장).
-    '@type': 'Movie' | 'Book' | 'VideoGame' | 'Event' | 'CreativeWork';
+    // Movie/Book/VideoGame/Event/LocalBusiness = Google 리뷰 스니펫(★) 지원.
+    // LocalBusiness = 앙지도(angmap) 맛집/장소. CreativeWork = 폴백(스키마 유효, 리치결과 미보장).
+    '@type': 'Movie' | 'Book' | 'VideoGame' | 'Event' | 'LocalBusiness' | 'CreativeWork';
     name: string;
     url?: string;
     image?: string;

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1883,6 +1883,7 @@
                           ''
                       ).trim(),
                       category: data.post.category,
+                      boardId,
                       ratingValue: data.post.rating.avg,
                       ratingCount: data.post.rating.count,
                       url: postUrl,


### PR DESCRIPTION
## 배경
GSC '리뷰 스니펫 parent_node 개체유형 잘못'(angmap/15135, 목포 삼촌네회수산). #1914(리뷰 스니펫 fix)는 CreativeWork 를 **생략**해 오류만 껐는데, **angmap 은 ca_name 이 음식종류가 아니라 지역명(전남·서울…)** 이라 카테고리 매핑으로 안 잡혀 CreativeWork 로 떨어진 것.

## 왜 LocalBusiness 인가
angmap 맛집은 로컬 검색에서 **별점 리치결과(★) 가치가 큼**(CTR). 생략보다 살리는 게 낫다. angmap = 회원이 여러 맛집을 리뷰하는 사이트라 구글 LocalBusiness 리뷰 스니펫 정책('다른 로컬 비즈니스 리뷰 수집')에 적격(self-serving 아님).

## 변경
- `ratingSchemaTypeForCategory(category, boardId?)`: PLACE_BOARDS(angmap) → LocalBusiness. 지역명 카테고리 무관
- `createRatedItemJsonLd` boardId 옵션 + 호출부 전달. LocalBusiness 는 이미 화이트리스트라 오류 없이 별점 유지
- JsonLdRatedItem @type 에 LocalBusiness 추가

## 검증
- 테스트 14 통과(angmap→LocalBusiness, 다른 게시판 회귀 없음), svelte-check 0 errors
- #1914 와 순서: #1914 가 먼저/함께 있어야 CreativeWork 케이스 안전. 이 PR 은 그 위에 angmap 만 LocalBusiness 로 승격

## 후속
angmap wr 필드에 주소/좌표 비어있어 address/geo 미포함. 좌표 소스 찾으면 LocalBusiness 강화(로컬 리치결과 극대화).