### PR TITLE
feat(profile): 공감 내역 제목 검색 (#13116)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/liked/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/liked/+server.ts
@@ -1,8 +1,8 @@
 /**
  * 회원 공감 내역 API
- * GET /api/members/[id]/liked?page=1&limit=10
+ * GET /api/members/[id]/liked?page=1&limit=10[&q=검색어]
  *
- * 해당 회원이 추천한 글 목록
+ * 해당 회원이 추천한 글 목록. q 가 있으면 제목 검색 (#13116).
  */
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
@@ -37,6 +37,15 @@ interface CountRow extends RowDataPacket {
 
 const MEMBER_LIKED_CACHE_TTL_SEC = 30;
 
+// #13116 제목 검색: 공감이 아주 많은 회원 보호용 스캔 상한. 최근 공감부터 이 개수까지만
+// 검색 대상으로 삼고, 상한에 걸리면 응답에 capped 로 알린다(조용한 잘림 금지).
+const SEARCH_SCAN_CAP = 2000;
+
+/** LIKE 패턴 이스케이프 — %, _, \ 를 리터럴로 */
+function escapeLike(s: string): string {
+    return s.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
+
 export const GET: RequestHandler = async ({ params, url }) => {
     const memberId = params.id;
 
@@ -47,6 +56,9 @@ export const GET: RequestHandler = async ({ params, url }) => {
     const page = Math.max(1, parseInt(url.searchParams.get('page') || '1'));
     const limit = Math.min(Math.max(1, parseInt(url.searchParams.get('limit') || '10')), 30);
     const offset = (page - 1) * limit;
+    // #13116: 제목 검색어 (선택). 2자 미만은 무시 — 한 글자 LIKE 는 사실상 전체 스캔이다.
+    const q = (url.searchParams.get('q') || '').trim().slice(0, 100);
+    const searching = q.length >= 2;
 
     // 탈퇴 회원 공감내역 비노출 (개인정보 분쟁조정 대응)
     if (await isWithdrawnMember(memberId)) {
@@ -55,7 +67,9 @@ export const GET: RequestHandler = async ({ params, url }) => {
 
     try {
         const version = await getMemberLikedVersion(memberId);
-        const cacheKey = `member_liked:${memberId}:${page}:${limit}:v${version}`;
+        const cacheKey = `member_liked:${memberId}:${page}:${limit}:v${version}${
+            searching ? `:q:${encodeURIComponent(q)}` : ''
+        }`;
         try {
             const cached = await getRedis().get(cacheKey);
             if (cached) {
@@ -68,22 +82,33 @@ export const GET: RequestHandler = async ({ params, url }) => {
             // Redis 장애 시 DB fallback
         }
 
-        // 총 추천 수
+        // 총 추천 수 (검색 시에는 필터 후 개수를 아래에서 다시 센다)
         const [countRows] = await pool.query<CountRow[]>(
             `SELECT COUNT(*) AS count FROM g5_board_good WHERE mb_id = ? AND bg_flag = 'good'`,
             [memberId]
         );
-        const total = countRows[0]?.count ?? 0;
+        const allTotal = countRows[0]?.count ?? 0;
 
-        // 추천 목록
-        const [goodRows] = await pool.query<GoodRow[]>(
-            `SELECT bg_id, bo_table, wr_id, bg_datetime
+        // 추천 목록.
+        // 검색 시에는 어느 공감이 제목에 매치될지 모르므로 페이지 오프셋을 걸 수 없다 —
+        // 최근 SEARCH_SCAN_CAP 개를 후보로 가져와 매치 후 JS 에서 페이지네이션한다.
+        const [goodRows] = searching
+            ? await pool.query<GoodRow[]>(
+                  `SELECT bg_id, bo_table, wr_id, bg_datetime
+			 FROM g5_board_good
+			 WHERE mb_id = ? AND bg_flag = 'good'
+			 ORDER BY bg_id DESC
+			 LIMIT ?`,
+                  [memberId, SEARCH_SCAN_CAP]
+              )
+            : await pool.query<GoodRow[]>(
+                  `SELECT bg_id, bo_table, wr_id, bg_datetime
 			 FROM g5_board_good
 			 WHERE mb_id = ? AND bg_flag = 'good'
 			 ORDER BY bg_id DESC
 			 LIMIT ? OFFSET ?`,
-            [memberId, limit, offset]
-        );
+                  [memberId, limit, offset]
+              );
 
         // 게시판명 조회
         const tables = [...new Set(goodRows.map((r) => r.bo_table))];
@@ -115,13 +140,24 @@ export const GET: RequestHandler = async ({ params, url }) => {
                 try {
                     // #13174 후속: 삭제글도 가져와 [삭제된 게시물] 자리표시자로 표시한다.
                     // 종전 is_deleted=0 은 공감했던 글이 삭제되면 내역에서 조용히 사라졌다.
-                    const [writeRows] = await pool.query<WriteRow[]>(
-                        `SELECT write_id AS wr_id, title AS wr_subject, source_created_at AS wr_datetime,
+                    // #13116 검색 시에는 삭제글을 제외한다 — 피드에 캐시된 원제가 매치에
+                    // 쓰이면 검색어를 바꿔가며 삭제글 제목을 탐침할 수 있다(유출).
+                    const [writeRows] = searching
+                        ? await pool.query<WriteRow[]>(
+                              `SELECT write_id AS wr_id, title AS wr_subject, source_created_at AS wr_datetime,
+                                is_deleted
+                           FROM member_activity_feed
+                          WHERE board_id = ? AND write_id IN (?) AND activity_type = 1
+                            AND is_deleted = 0 AND title LIKE ? ESCAPE '\\\\'`,
+                              [boTable, wrIds, `%${escapeLike(q)}%`]
+                          )
+                        : await pool.query<WriteRow[]>(
+                              `SELECT write_id AS wr_id, title AS wr_subject, source_created_at AS wr_datetime,
                                 is_deleted
                            FROM member_activity_feed
                           WHERE board_id = ? AND write_id IN (?) AND activity_type = 1`,
-                        [boTable, wrIds]
-                    );
+                              [boTable, wrIds]
+                          );
                     for (const w of writeRows) {
                         writeMap.set(`${boTable}:${w.wr_id}`, w);
                     }
@@ -150,12 +186,18 @@ export const GET: RequestHandler = async ({ params, url }) => {
             });
         }
 
+        // #13116 검색: 매치된 전체에서 JS 페이지네이션. capped 는 스캔 상한 도달 표시.
+        const total = searching ? items.length : allTotal;
+        const pageItems = searching ? items.slice(offset, offset + limit) : items;
+        const capped = searching && goodRows.length >= SEARCH_SCAN_CAP;
+
         const payload = {
             success: true,
-            data: items,
+            data: pageItems,
             total,
             page,
-            total_pages: Math.ceil(total / limit)
+            total_pages: Math.ceil(total / limit),
+            ...(capped ? { capped: true, scanned: SEARCH_SCAN_CAP } : {})
         };
 
         try {

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -237,11 +237,17 @@
         commentsLoaded = true;
     }
 
-    async function loadLikedPosts(): Promise<void> {
-        if (likedLoaded || !p?.mb_id || p?.is_left || p?.withdrawn) return;
+    // #13116: 공감 내역 제목 검색. 2자 미만은 서버가 무시하므로 전체 목록과 동일.
+    let likedQuery = $state('');
+    let likedSearchTimer: ReturnType<typeof setTimeout> | null = null;
+
+    async function loadLikedPosts(force = false): Promise<void> {
+        if ((likedLoaded && !force) || !p?.mb_id || p?.is_left || p?.withdrawn) return;
         loadingLiked = true;
         try {
-            const res = await fetch(`/api/members/${p.mb_id}/liked?limit=50`);
+            const qs =
+                likedQuery.trim().length >= 2 ? `&q=${encodeURIComponent(likedQuery.trim())}` : '';
+            const res = await fetch(`/api/members/${p.mb_id}/liked?limit=50${qs}`);
             if (res.ok) {
                 const d = await res.json();
                 likedPosts = d.data ?? [];
@@ -249,6 +255,11 @@
         } catch {}
         loadingLiked = false;
         likedLoaded = true;
+    }
+
+    function handleLikedQueryInput(): void {
+        if (likedSearchTimer) clearTimeout(likedSearchTimer);
+        likedSearchTimer = setTimeout(() => void loadLikedPosts(true), 300);
     }
 
     function handleTabChange(tab: string): void {
@@ -965,13 +976,25 @@
 
                 <!-- 공감 내역 탭 -->
                 <Tabs.Content value="liked" class="p-4">
+                    <!-- #13116: 공감한 글 제목 검색 -->
+                    <div class="mb-3">
+                        <input
+                            type="search"
+                            bind:value={likedQuery}
+                            oninput={handleLikedQueryInput}
+                            placeholder="공감한 글 제목 검색 (2자 이상)"
+                            class="border-border bg-background text-foreground placeholder:text-muted-foreground w-full rounded-md border px-3 py-1.5 text-sm focus:outline-none"
+                        />
+                    </div>
                     {#if loadingLiked}
                         <div class="flex justify-center py-8">
                             <Loader2 class="text-muted-foreground h-5 w-5 animate-spin" />
                         </div>
                     {:else if likedPosts.length === 0}
                         <p class="text-muted-foreground py-8 text-center text-sm">
-                            공감 내역이 없습니다.
+                            {likedQuery.trim().length >= 2
+                                ? '검색 결과가 없습니다.'
+                                : '공감 내역이 없습니다.'}
                         </p>
                     {:else}
                         <ul class="divide-border divide-y">


### PR DESCRIPTION
## 요청 (bug/13116)

"내가 공감한 글 검색" — 기존엔 공감 내역 나열만 있고 검색이 없었다 (내가 쓴 글/댓글 검색은 게시판 검색 버튼으로 기존 제공, 13194 안내 완료).

## 변경

- **API**: `/api/members/[id]/liked?q=` — 2자 이상일 때 피드 제목 LIKE 검색. 최근 2000개 공감까지 스캔(상한 도달 시 `capped` 응답 — 조용한 잘림 없음). LIKE 이스케이프, 캐시 키에 q 포함, **비검색 경로 무변경**
- **검색 시 삭제글 제외**: 피드 캐시 원제가 매치에 쓰이면 검색어 반복으로 삭제글 제목 탐침 가능(#13174 서버 drop 원칙과 정합)
- **UI**: 프로필 공감 내역 탭에 검색 입력 (300ms 디바운스, 빈 검색=전체)