### PR TITLE
fix(comments): 라우트 이탈 후 boardId=undefined 로 나가던 요청 차단

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -28,6 +28,7 @@
     // 코어 레이아웃 초기화 (중복 호출 안전)
     initCoreLayouts();
     import { PromotionInlinePost } from '$lib/components/ui/promotion-inline-post/index.js';
+    import { isValidBoardId } from '$lib/utils/board-id.js';
 
     interface PromotionPost {
         wrId: number;
@@ -199,6 +200,10 @@
     // 페이지 변경 (목록 페이지에서는 AJAX, 상세 페이지에서는 list 로 navigate)
     async function goToPage(page: number): Promise<void> {
         if (page < 1 || page > totalPages || page === currentPage) return;
+        // 이 컴포넌트는 글 상세 하단에 붙고 boardId 를 상위의 data.boardId 에서 받는다.
+        // 라우트를 떠나면 그 값이 사라져 `/api/v1/boards/undefined/posts` 로 요청이 나갔다
+        // (백엔드가 200 `{"data":null}` 을 주어 "더 볼 글 없음"처럼 조용히 실패).
+        if (!isValidBoardId(boardId)) return;
 
         if (isOnPostDetail) {
             // #11972: 본문 SSR 없이 목록 페이지로 이동
@@ -233,6 +238,7 @@
     // 일시적인 네트워크 오류에도 목록이 영영 비어 있었다).
     async function loadInitial(): Promise<void> {
         if (!browser) return;
+        if (!isValidBoardId(boardId)) return;
 
         error = null;
         loading = true;

--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -238,7 +238,10 @@
     // 일시적인 네트워크 오류에도 목록이 영영 비어 있었다).
     async function loadInitial(): Promise<void> {
         if (!browser) return;
-        if (!isValidBoardId(boardId)) return;
+        // 진입 시점에 고정한다 — 아래에 await 가 있어, 그 사이 라우트를 떠나면
+        // boardId 를 다시 읽을 때 undefined 가 되어 URL 에 문자열로 박힌다.
+        const targetBoardId = boardId;
+        if (!isValidBoardId(targetBoardId)) return;
 
         error = null;
         loading = true;
@@ -256,7 +259,7 @@
             ) {
                 try {
                     const r = await fetch(
-                        `/api/boards/${boardId}/posts/${currentPostId}/page-index`
+                        `/api/boards/${targetBoardId}/posts/${currentPostId}/page-index`
                     );
                     if (r.ok) {
                         const body = (await r.json()) as { page?: number };
@@ -267,7 +270,7 @@
                 }
             }
 
-            const response = await apiClient.getBoardPosts(boardId, startPage, limit, {
+            const response = await apiClient.getBoardPosts(targetBoardId, startPage, limit, {
                 summary: useSummaryListResponse
             });
             posts = response.items;

--- a/apps/web/src/lib/utils/board-id.test.ts
+++ b/apps/web/src/lib/utils/board-id.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isValidBoardId } from './board-id';
+
+describe('isValidBoardId — 라우트 이탈로 사라진 boardId 판정', () => {
+    it('정상 게시판 이름은 통과', () => {
+        for (const v of ['free', 'qa', 'angmap', 'hello', 'bug_report', 'a-b']) {
+            expect(isValidBoardId(v)).toBe(true);
+        }
+    });
+
+    it('⛔ 문자열 "undefined"/"null" 은 무효 — 템플릿 리터럴로 URL 에 박히는 실제 사고 값', () => {
+        expect(isValidBoardId('undefined')).toBe(false);
+        expect(isValidBoardId('null')).toBe(false);
+    });
+
+    it('빈 값·비문자열은 무효', () => {
+        for (const v of ['', undefined, null, 0, 123, {}, []]) {
+            expect(isValidBoardId(v)).toBe(false);
+        }
+    });
+});

--- a/apps/web/src/lib/utils/board-id.ts
+++ b/apps/web/src/lib/utils/board-id.ts
@@ -1,0 +1,15 @@
+/**
+ * boardId 유효성 판정.
+ *
+ * SPA 라우트를 떠난 뒤 뒤늦게 실행되는 비동기 작업이 `data.boardId` 를 읽으면
+ * `undefined` 가 되고, 템플릿 리터럴로 URL 을 만들면 문자열 `"undefined"` 가 경로에
+ * 박혀 `/api/boards/undefined/...` 같은 요청이 나간다. 서버는 이를 게시판 이름으로
+ * 받아 `g5_write_undefined` 를 조회하다 실패한다.
+ *
+ * 그래서 빈 값뿐 아니라 **`"undefined"`/`"null"` 문자열도 무효**로 본다.
+ */
+export function isValidBoardId(value: unknown): value is string {
+    return (
+        typeof value === 'string' && value.length > 0 && value !== 'undefined' && value !== 'null'
+    );
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -80,6 +80,7 @@
     } from '$lib/seo/index.js';
     import type { SeoConfig } from '$lib/seo/types.js';
     import { deriveVideoPoster } from '$lib/utils/video-poster.js';
+    import { isValidBoardId } from '$lib/utils/board-id.js';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
     import { postSlotRegistry } from '$lib/components/features/board/post-slot-registry.js';
@@ -1398,7 +1399,13 @@
     }
 
     // 서버에서 댓글 목록 다시 가져오기
-    async function refetchComments(): Promise<void> {
+    //
+    // #13xxx: 이 함수는 backfill 타이머/재시도 루프에서 **라우트를 떠난 뒤** 실행될 수 있다.
+    // 그때 `boardId`($derived(data.boardId))를 URL 조립 시점에 읽으면 undefined 가 되어
+    // `/api/boards/undefined/posts/{id}/comments` 로 요청이 나갔다(운영 실측 시간당 42건).
+    // → 진입 시점에 boardId 를 **고정**하고, 무효하면 아예 요청하지 않는다.
+    // `cancel` 은 라우트 이탈 시 후속 시도를 멈추기 위한 신호다.
+    async function refetchComments(cancel?: AbortSignal): Promise<void> {
         // 댓글 작성 / 수정 / 삭제 직후 호출되는 경로라 항상 fresh 응답이 필요.
         // 브라우저 HTTP 캐시 / SvelteKit data 캐시가 옛 응답을 반환하면 optimistic
         // update 로 추가된 새 댓글이 덮어써져 "댓글이 바로 안 보인다" (#12294) 가
@@ -1410,7 +1417,10 @@
         const cacheBuster = Date.now();
         // #12937: SPA 로 다른 글로 이동한 뒤 뒤늦게 도착한 응답이 현재 글의 목록을
         // 덮어쓰지 않도록, 요청 시점의 글 ID 를 고정해 적용 직전에 대조한다.
-        const targetPostId = data.post.id;
+        const targetPostId = data.post?.id;
+        // 요청 시점에 boardId 를 고정 — 이후 라우트가 바뀌어도 URL 이 깨지지 않는다.
+        const targetBoardId = boardId;
+        if (!isValidBoardId(targetBoardId) || !targetPostId || cancel?.aborted) return;
         // #12735: 댓글 API 는 페이지당 최대 200개라, 댓글이 200개를 넘는 글은
         // page=1 한 번만 받으면 나머지가 누락된다("대댓글 많은데 안 보임").
         // total_pages 만큼 순차로 모두 받아 합친다. (안전 상한 MAX_PAGES)
@@ -1418,7 +1428,7 @@
         const MAX_PAGES = 15;
         const fetchCommentPage = (p: number) =>
             fetch(
-                `/api/boards/${boardId}/posts/${targetPostId}/comments?page=${p}&limit=${PAGE_SIZE}&_t=${cacheBuster}`,
+                `/api/boards/${targetBoardId}/posts/${targetPostId}/comments?page=${p}&limit=${PAGE_SIZE}&_t=${cacheBuster}`,
                 {
                     cache: 'no-store',
                     // #12937: 모바일 webview 에서 fetch 가 응답 없이 매달리면
@@ -1440,6 +1450,8 @@
             // 나머지 페이지(2..N)를 병렬 로드 — 순차 await 제거로 긴 스레드/신고댓글 도달 지연 완화.
             // Promise.all 은 입력 순서를 보존하므로 page 순서대로 concat 된다.
             if (pagesToLoad > 1) {
+                // 1페이지 응답을 기다리는 사이 라우트를 떠났으면 후속 페이지는 쏘지 않는다.
+                if (cancel?.aborted) return;
                 const rest = await Promise.all(
                     Array.from({ length: pagesToLoad - 1 }, (_, i) => fetchCommentPage(i + 2))
                 );
@@ -1455,7 +1467,7 @@
                 );
             }
             // #12937: 응답 대기 중 다른 글로 이동했다면 폐기 — 이전 글 댓글로 덮어쓰기 방지.
-            if (data.post.id !== targetPostId) return;
+            if (cancel?.aborted || data.post?.id !== targetPostId) return;
             comments = all;
             commentsTotal = total || all.length;
             // 클라가 전량 로드 완료 — backfill 게이트가 재발화하지 않도록 complete 로 확정.
@@ -1477,19 +1489,23 @@
     // 재시도가 없어 "불러오는 중"에 고착되는 사례(#12668: 간헐 발생, 새로고침하면 보임)가 있어
     // 짧은 백오프로 몇 번 재시도한다. 실제 0개이거나 채워지면 종료.
     let backfillInProgress = false;
-    async function backfillWithRetry(): Promise<void> {
+    async function backfillWithRetry(cancel?: AbortSignal): Promise<void> {
         if (backfillInProgress) return;
         backfillInProgress = true;
         try {
             for (let attempt = 0; attempt < 3; attempt++) {
+                // 라우트를 떠났으면 즉시 중단 — 이 가드가 없어 이탈 후에도 800/1600/2400ms
+                // 간격으로 재시도가 계속됐고, 그 요청들이 boardId=undefined 로 나갔다.
+                if (cancel?.aborted) return;
                 try {
-                    await refetchComments();
+                    await refetchComments(cancel);
                 } catch {
                     // 전송 실패 — 재시도
                 }
                 if (comments.length > 0 || commentsTotal === 0) return;
                 await new Promise((resolve) => setTimeout(resolve, 800 * (attempt + 1)));
             }
+            if (cancel?.aborted) return;
             // 3회 모두 실패 + 여전히 빈 목록 → 에러/복구 UI 노출(무한 "불러오는 중" 고착 방지).
             if (comments.length === 0 && commentsTotal > 0) {
                 commentsError = true;
@@ -1510,9 +1526,15 @@
         if (commentsLoadState === 'complete') return;
         const loaded = comments.length;
 
+        // 이 effect 가 만든 모든 비동기 작업의 공통 중단 신호.
+        // ⛔ 아래 분기 중 **어느 하나라도 cleanup 없이 return 하면** 라우트를 떠난 뒤에도
+        //    작업이 계속 돌아 boardId=undefined 요청이 나간다(운영 실측). 분기마다 반드시 반환할 것.
+        const controller = new AbortController();
+        const cancel = () => controller.abort();
+
         if (commentsLoadState === 'failed' || loaded === 0) {
-            void backfillWithRetry();
-            return;
+            void backfillWithRetry(controller.signal);
+            return cancel;
         }
 
         // 앵커(#c_<댓글ID>)로 진입했는데 대상 댓글이 아직 로드 전이면(신고/딥링크) 1500ms 디바운스를
@@ -1521,8 +1543,8 @@
         if (hash.startsWith('#c_')) {
             const anchorId = hash.slice(3);
             if (anchorId && !comments.some((c) => String(c.id) === anchorId)) {
-                void refetchComments();
-                return;
+                void refetchComments(controller.signal);
+                return cancel;
             }
         }
 
@@ -1533,17 +1555,19 @@
         const scheduleBackfill = (delay: number) => {
             timer = window.setTimeout(() => {
                 const active = document.activeElement as HTMLElement | null;
+                if (controller.signal.aborted) return;
                 if (active?.closest('.ProseMirror, [contenteditable="true"], textarea')) {
                     scheduleBackfill(3000);
                     return;
                 }
-                void refetchComments();
+                void refetchComments(controller.signal);
             }, delay);
         };
         scheduleBackfill(1500);
 
         return () => {
             window.clearTimeout(timer);
+            cancel();
         };
     });
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -9,6 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
+import { isValidBoardId } from '$lib/utils/board-id.js';
 import {
     applyAffiliateField,
     fetchCommentAffiliateLinks,
@@ -109,7 +110,10 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
     const isAdmin = (locals.user?.level ?? 0) >= 10;
     const isInternalRequest = isInternalAppRequest(request);
 
-    if (!boardId || !postId) {
+    // `!boardId` 만으로는 부족하다 — 클라이언트가 URL 을 템플릿 리터럴로 만들면 값이 없을 때
+    // 문자열 `"undefined"` 가 경로에 박히고, 그대로 `g5_write_undefined` 를 조회하다 실패한다.
+    // 존재하지 않을 게 확실한 이름은 DB 까지 가기 전에 400 으로 끊는다.
+    if (!isValidBoardId(boardId) || !postId) {
         return json({ success: false, message: 'boardId와 postId가 필요합니다.' }, { status: 400 });
     }
 


### PR DESCRIPTION
## 현상 (운영 실측 2026-07-31)

```
GET /api/boards/undefined/posts/6870394/comments?page=1&limit=200&_t=...  500
    Referer: https://damoang.net/          ← 글 상세가 아니라 홈
GET /api/v1/boards/undefined/posts?page=4&limit=24                        200
    Referer: https://damoang.net/free/6870198
```

파드 로그 기준 **시간당 42건** (`Table 'damoang.g5_write_undefined' doesn't exist`). 실사용자 다수(모바일·데스크톱). 이 요청들은 댓글을 받아오지 못합니다.

## 원인

댓글 backfill `$effect` 의 세 분기 중 **두 곳이 cleanup 없이 return** 합니다.

```js
if (commentsLoadState === 'failed' || loaded === 0) {
    void backfillWithRetry();      // ← 정리 없이 return
    return;
}
...
scheduleBackfill(1500);
return () => window.clearTimeout(timer);   // ← 이 경로만 정리됨
```

`loaded === 0` 은 **새 글에서 항상 참**입니다(SSR 시점 댓글 0). `backfillWithRetry` 는 800/1600/2400ms 간격 3회 재시도인데 중단 신호가 없어 **이탈 후에도 계속 돌았습니다.** 그리고 `refetchComments` 는 URL 조립 때마다 `boardId`(`$derived(data.boardId)`)를 다시 읽으므로, 그 시점엔 값이 사라져 문자열 `"undefined"` 가 경로에 박혔습니다.

발생 글의 `wr_id` 가 전부 최신·연속이던 이유가 이것입니다. DB 실측으로 해당 글들의 댓글 수는 8~75개였습니다(200 초과 아님 — "page 2 이상만 샌다"는 초기 가설은 반증됐습니다).

**두 번째 경로도 같은 뿌리**입니다. `recent-posts` 는 글 상세 하단에만 붙고 `boardId` 를 같은 `data.boardId` 에서 받습니다. 이쪽은 백엔드가 200 `{"data":null}` 을 돌려주어 **"더 볼 글 없음"처럼 조용히 실패**합니다.

## 변경

| | |
|---|---|
| `refetchComments` | 진입 시 `boardId` **고정**, 무효하면 요청 안 함. `AbortSignal` 로 중단 가능 |
| `backfillWithRetry` | 재시도 루프마다 중단 확인 |
| `$effect` | **모든 분기가 cleanup 반환** — 이번 버그의 핵심 |
| `recent-posts` | `goToPage`/`loadInitial` 에 가드 |
| 서버 핸들러 | `"undefined"`/`"null"` 문자열도 400 — DB 왕복·로그 노이즈 제거 |
| `isValidBoardId` | 공용 판정 + 단위 테스트 |

## 검증

- [ ] 새 글 진입 후 1초 내 홈 이동 → `boards/undefined` 요청 0건
- [ ] 정상 글 댓글 전량 로드 회귀 없음 (200개 초과 글 포함)
- [ ] `#c_` 앵커 진입 즉시 로드, 입력 중 backfill 연기 유지
- [ ] 배포 후 파드 로그 `g5_write_undefined` 0건/시간
