### PR TITLE
feat(settings): 플러그인·사이트 설정을 DB 저장소로 (다중 파드 정합)

### DIFF
--- a/apps/web/scripts/migrate-settings-to-db.mjs
+++ b/apps/web/scripts/migrate-settings-to-db.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * 플러그인·사이트 설정 파일 → DB 1회 이전
+ *
+ * 파일 기반 저장소는 다중 파드에서 성립하지 않는다(파드별 분리·재배포 시 소실).
+ * 이 스크립트가 기존 파일 내용을 `angple_settings` 로 옮긴다.
+ *
+ * ⛔ **멱등**하다: DB 에 이미 값이 있으면 건너뛴다. 여러 번 돌려도 덮어쓰지 않는다.
+ *    (덮어쓰기가 필요하면 --force)
+ * ⛔ 파일은 지우지 않는다 — env 를 json 으로 되돌리면 즉시 복귀하는 롤백 경로다.
+ * ⛔ 운영 DB 쓰기이므로 사장님이 직접 실행한다.
+ *
+ * 사용:
+ *   node apps/web/scripts/migrate-settings-to-db.mjs --dry-run   # 무엇이 옮겨질지만 출력
+ *   node apps/web/scripts/migrate-settings-to-db.mjs             # 실제 이전(멱등)
+ *   node apps/web/scripts/migrate-settings-to-db.mjs --force     # 기존 DB 값 덮어쓰기
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import mysql from 'mysql2/promise';
+
+const DRY = process.argv.includes('--dry-run');
+const FORCE = process.argv.includes('--force');
+const TABLE = 'angple_settings';
+
+const CWD = process.cwd();
+const PLUGIN_FILE = path.join(CWD, 'data', 'plugin-settings.json');
+const SITE_FILE = path.join(CWD, 'data', 'settings', 'site-settings.json');
+
+async function readJson(file) {
+    try {
+        return JSON.parse(await fs.readFile(file, 'utf-8'));
+    } catch {
+        return null;
+    }
+}
+
+async function main() {
+    const conn = await mysql.createConnection({
+        host: process.env.DB_HOST || 'localhost',
+        port: Number(process.env.DB_PORT || 3306),
+        user: process.env.DB_USER,
+        password: process.env.DB_PASSWORD,
+        database: process.env.DB_NAME
+    });
+
+    await conn.query(`
+        CREATE TABLE IF NOT EXISTS ${TABLE} (
+            setting_key VARCHAR(255) PRIMARY KEY,
+            setting_value LONGTEXT,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            INDEX idx_updated_at (updated_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+
+    /** DB 에 이미 있으면 건너뛴다(멱등). --force 면 덮어쓴다. */
+    async function put(key, value, label) {
+        const [rows] = await conn.query(
+            `SELECT setting_key FROM ${TABLE} WHERE setting_key = ? LIMIT 1`,
+            [key]
+        );
+        if (rows.length > 0 && !FORCE) {
+            console.log(`  = ${label} (${key}) — DB 에 이미 있음, 건너뜀`);
+            return;
+        }
+        const json = JSON.stringify(value);
+        if (DRY) {
+            console.log(`  + ${label} (${key}) — ${json.slice(0, 120)}${json.length > 120 ? '…' : ''}`);
+            return;
+        }
+        await conn.query(
+            `INSERT INTO ${TABLE} (setting_key, setting_value) VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)`,
+            [key, json]
+        );
+        console.log(`  ✓ ${label} (${key})`);
+    }
+
+    console.log(`\n[플러그인 설정] ${PLUGIN_FILE}`);
+    const plugin = await readJson(PLUGIN_FILE);
+    if (!plugin) {
+        console.log('  파일 없음 — 건너뜀');
+    } else {
+        await put('active_plugins', plugin.activePlugins ?? [], `활성 ${(plugin.activePlugins ?? []).length}개`);
+        for (const [id, entry] of Object.entries(plugin.plugins ?? {})) {
+            if (!entry?.settings || Object.keys(entry.settings).length === 0) continue;
+            await put(`plugin_settings_${id}`, entry.settings, `${id} 설정`);
+        }
+    }
+
+    console.log(`\n[사이트 설정] ${SITE_FILE}`);
+    const site = await readJson(SITE_FILE);
+    if (!site) {
+        console.log('  파일 없음 — 건너뜀');
+    } else {
+        // ⚠️ OAuth secret 이 포함되므로 값을 출력하지 않는다
+        await put('site_settings', site, `사이트 설정 (${Object.keys(site).length}개 섹션)`);
+    }
+
+    await conn.end();
+    console.log(
+        `\n완료${DRY ? ' (dry-run — 아무것도 쓰지 않았다)' : ''}. ` +
+            `적용하려면 .env 에 PLUGIN_SETTINGS_PROVIDER=mysql / SITE_SETTINGS_PROVIDER=mysql 후 재배포.`
+    );
+}
+
+main().catch((err) => {
+    console.error('이전 실패:', err);
+    process.exit(1);
+});

--- a/apps/web/scripts/migrate-settings-to-db.mjs
+++ b/apps/web/scripts/migrate-settings-to-db.mjs
@@ -84,7 +84,8 @@ async function main() {
     if (!plugin) {
         console.log('  파일 없음 — 건너뜀');
     } else {
-        await put('active_plugins', plugin.activePlugins ?? [], `활성 ${(plugin.activePlugins ?? []).length}개`);
+        const active = plugin.activePlugins ?? [];
+        await put('active_plugins', active, `활성 ${active.length}개`);
         for (const [id, entry] of Object.entries(plugin.plugins ?? {})) {
             if (!entry?.settings || Object.keys(entry.settings).length === 0) continue;
             await put(`plugin_settings_${id}`, entry.settings, `${id} 설정`);

--- a/apps/web/scripts/migrate-settings-to-db.mjs
+++ b/apps/web/scripts/migrate-settings-to-db.mjs
@@ -66,7 +66,9 @@ async function main() {
         }
         const json = JSON.stringify(value);
         if (DRY) {
-            console.log(`  + ${label} (${key}) — ${json.slice(0, 120)}${json.length > 120 ? '…' : ''}`);
+            // ⛔ 값을 찍지 않는다 — 사이트 설정에는 OAuth client secret 이 들어 있다.
+            //    키와 크기만으로 무엇이 옮겨질지 판단할 수 있다.
+            console.log(`  + ${label} (${key}) — ${json.length} bytes`);
             return;
         }
         await conn.query(

--- a/apps/web/src/lib/server/plugins/index.ts
+++ b/apps/web/src/lib/server/plugins/index.ts
@@ -225,7 +225,7 @@ export async function updatePluginSettings(
     // ⛔ 캐시 무효화 필수. activate/deactivate 는 하는데 여기만 빠져 있어,
     //    설정을 저장해도 getActivePlugins() 가 실어 나르는 currentSettings 가
     //    TieredCache(L1 30초/L2 300초)에 박힌 채 최대 5분간 반영되지 않았다.
-    invalidateActivePluginsCache();
+    await invalidateActivePluginsCache();
 
     return true;
 }

--- a/apps/web/src/lib/server/plugins/index.ts
+++ b/apps/web/src/lib/server/plugins/index.ts
@@ -222,6 +222,11 @@ export async function updatePluginSettings(
     // Provider를 통해 플러그인 설정 업데이트
     await pluginSettingsProvider.setPluginSettings(pluginId, newSettings);
 
+    // ⛔ 캐시 무효화 필수. activate/deactivate 는 하는데 여기만 빠져 있어,
+    //    설정을 저장해도 getActivePlugins() 가 실어 나르는 currentSettings 가
+    //    TieredCache(L1 30초/L2 300초)에 박힌 채 최대 5분간 반영되지 않았다.
+    invalidateActivePluginsCache();
+
     return true;
 }
 

--- a/apps/web/src/lib/server/settings/mysql-plugin-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/mysql-plugin-settings-provider.ts
@@ -1,0 +1,192 @@
+/**
+ * MySQL + Redis 기반 플러그인 설정 Provider
+ *
+ * ⭐ 왜 필요한가 (2026-07-31 실측)
+ *   파일 기반(JsonPluginSettingsProvider)은 **다중 인스턴스에서 성립하지 않는다.**
+ *   prod 는 web 파드 13개에 볼륨 마운트가 없어 `data/plugin-settings.json` 이 이미지에
+ *   구워진 채 파드마다 분리된다. admin 에서 플러그인을 켜면
+ *     - 요청받은 파드 1개의 파일만 바뀌고 (회원은 붙는 파드에 따라 보였다 안 보였다)
+ *     - 재배포하면 레포 커밋본으로 되돌아간다
+ *   게다가 activePlugins 의 L2 캐시는 Redis 로 13파드가 **공유**하는데 소스인 파일은
+ *   파드별이라, A파드에서 켜고 L2 를 지우면 B파드가 자기 구버전으로 L2 를 재적재해
+ *   **A의 변경이 스스로 되돌아가는 flapping** 이 발생했다.
+ *
+ * 설계는 테마/위젯 설정의 MySqlRedisSettingsProvider 를 그대로 따른다:
+ *   - MySQL = 단일 진실 공급원, Redis = 캐시
+ *   - ⛔ **쓰기 시 캐시를 지우지 않고 갱신한다.** 지우면 다른 파드가 낡은 소스로
+ *     재적재할 여지가 생긴다(위 flapping 의 원인). 갱신이면 13파드가 즉시 같은 값을 본다.
+ *
+ * ⛔ 테이블은 기존 `angple_settings` 를 재사용한다 — prod 는 AutoMigrate 가 돌지 않아
+ *    새 테이블은 수동 DDL 선행이 필요하다. 키 접두사로 테마 설정과 분리한다.
+ */
+
+import type { PluginSettingsProvider } from './plugin-settings-provider';
+import { pool } from '$lib/server/db';
+import { getRedis } from '$lib/server/redis';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+
+/** 테마 설정 provider 와 같은 접두사를 쓴다(같은 캐시 네임스페이스) */
+const CACHE_PREFIX = 'angple:settings:';
+const SETTINGS_TABLE = 'angple_settings';
+
+/** 활성 목록 키 — 테마의 active_theme / theme_settings_* 와 충돌하지 않는다 */
+const KEY_ACTIVE = 'active_plugins';
+const keyForPlugin = (pluginId: string) => `plugin_settings_${pluginId}`;
+
+/** 설정은 거의 안 바뀌고 변경 시 즉시 갱신하므로 길게 잡는다 */
+const CACHE_TTL = 86_400;
+
+interface SettingsRow extends RowDataPacket {
+    setting_value: string;
+}
+
+export class MySqlPluginSettingsProvider implements PluginSettingsProvider {
+    private tableChecked = false;
+
+    /**
+     * 테이블 확인. angple_settings 는 테마 설정이 이미 쓰고 있어 실제로는 no-op 이지만,
+     * 신규 설치(셀프호스팅)에서 테마보다 플러그인을 먼저 건드릴 수 있어 남겨둔다.
+     */
+    private async ensureTable(): Promise<void> {
+        if (this.tableChecked) return;
+        try {
+            await pool.query(`
+                CREATE TABLE IF NOT EXISTS ${SETTINGS_TABLE} (
+                    setting_key VARCHAR(255) PRIMARY KEY,
+                    setting_value LONGTEXT,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    INDEX idx_updated_at (updated_at)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            `);
+            this.tableChecked = true;
+        } catch (err) {
+            console.error('[PluginSettings] 테이블 확인 실패:', err);
+        }
+    }
+
+    private async getCache<T>(key: string): Promise<T | null> {
+        try {
+            const cached = await getRedis().get(CACHE_PREFIX + key);
+            if (cached) return JSON.parse(cached) as T;
+        } catch (err) {
+            console.error('[PluginSettings] Redis get 실패:', err);
+        }
+        return null;
+    }
+
+    private async setCache(key: string, value: unknown): Promise<void> {
+        try {
+            await getRedis().setex(CACHE_PREFIX + key, CACHE_TTL, JSON.stringify(value));
+        } catch (err) {
+            console.error('[PluginSettings] Redis set 실패:', err);
+        }
+    }
+
+    private async getFromDB(key: string): Promise<string | null> {
+        await this.ensureTable();
+        try {
+            const [rows] = await pool.query<SettingsRow[]>(
+                `SELECT setting_value FROM ${SETTINGS_TABLE} WHERE setting_key = ? LIMIT 1`,
+                [key]
+            );
+            return rows[0]?.setting_value ?? null;
+        } catch (err) {
+            console.error('[PluginSettings] MySQL get 실패:', err);
+            return null;
+        }
+    }
+
+    private async setToDB(key: string, value: string): Promise<void> {
+        await this.ensureTable();
+        await pool.query<ResultSetHeader>(
+            `INSERT INTO ${SETTINGS_TABLE} (setting_key, setting_value)
+             VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)`,
+            [key, value]
+        );
+    }
+
+    /** 캐시 → DB 순으로 읽고, DB 히트면 캐시를 채운다 */
+    private async get<T>(key: string, fallback: T): Promise<T> {
+        const cached = await this.getCache<T>(key);
+        if (cached !== null) return cached;
+
+        const raw = await this.getFromDB(key);
+        if (raw === null) return fallback;
+
+        try {
+            const parsed = JSON.parse(raw) as T;
+            await this.setCache(key, parsed);
+            return parsed;
+        } catch {
+            console.error(`[PluginSettings] JSON 파싱 실패 (key=${key})`);
+            return fallback;
+        }
+    }
+
+    /**
+     * DB 저장 후 **캐시 갱신**.
+     * ⛔ delCache 로 바꾸지 말 것 — 삭제하면 다른 파드가 낡은 값으로 재적재할 창이 생긴다.
+     */
+    private async set(key: string, value: unknown): Promise<void> {
+        await this.setToDB(key, JSON.stringify(value));
+        await this.setCache(key, value);
+    }
+
+    // ========== PluginSettingsProvider 구현 ==========
+
+    async getActivePlugins(): Promise<string[]> {
+        return this.get<string[]>(KEY_ACTIVE, []);
+    }
+
+    async activatePlugin(pluginId: string): Promise<void> {
+        const active = await this.getActivePlugins();
+        if (active.includes(pluginId)) return;
+        await this.set(KEY_ACTIVE, [...active, pluginId]);
+    }
+
+    async deactivatePlugin(pluginId: string): Promise<void> {
+        const active = await this.getActivePlugins();
+        if (!active.includes(pluginId)) return;
+        await this.set(
+            KEY_ACTIVE,
+            active.filter((id) => id !== pluginId)
+        );
+    }
+
+    async getPluginSettings(pluginId: string): Promise<Record<string, unknown>> {
+        return this.get<Record<string, unknown>>(keyForPlugin(pluginId), {});
+    }
+
+    async setPluginSettings(pluginId: string, settings: Record<string, unknown>): Promise<void> {
+        await this.set(keyForPlugin(pluginId), settings);
+    }
+
+    /**
+     * 전체 설정 조회 (디버깅/백업용).
+     * 파일 구현과 같은 모양({activePlugins, plugins, version})으로 돌려준다.
+     */
+    async getAllPluginSettings(): Promise<Record<string, unknown>> {
+        await this.ensureTable();
+        const activePlugins = await this.getActivePlugins();
+        const plugins: Record<string, { settings: Record<string, unknown> }> = {};
+        try {
+            const [rows] = await pool.query<
+                (RowDataPacket & { setting_key: string; setting_value: string })[]
+            >(
+                `SELECT setting_key, setting_value FROM ${SETTINGS_TABLE} WHERE setting_key LIKE 'plugin_settings_%'`
+            );
+            for (const row of rows) {
+                const id = row.setting_key.replace(/^plugin_settings_/, '');
+                try {
+                    plugins[id] = { settings: JSON.parse(row.setting_value) };
+                } catch {
+                    plugins[id] = { settings: {} };
+                }
+            }
+        } catch (err) {
+            console.error('[PluginSettings] 전체 조회 실패:', err);
+        }
+        return { activePlugins, plugins, version: '1.0.0' };
+    }
+}

--- a/apps/web/src/lib/server/settings/mysql-plugin-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/mysql-plugin-settings-provider.ts
@@ -84,16 +84,13 @@ export class MySqlPluginSettingsProvider implements PluginSettingsProvider {
 
     private async getFromDB(key: string): Promise<string | null> {
         await this.ensureTable();
-        try {
-            const [rows] = await pool.query<SettingsRow[]>(
-                `SELECT setting_value FROM ${SETTINGS_TABLE} WHERE setting_key = ? LIMIT 1`,
-                [key]
-            );
-            return rows[0]?.setting_value ?? null;
-        } catch (err) {
-            console.error('[PluginSettings] MySQL get 실패:', err);
-            return null;
-        }
+        // ⛔ 예외를 삼키지 않는다. 읽기 실패와 "값 없음"은 다르다 — 삼키면 DB 순단 중
+        //    activatePlugin 이 빈 목록에 하나만 얹어 UPSERT 해 **나머지 플러그인이 전부 꺼진다.**
+        const [rows] = await pool.query<SettingsRow[]>(
+            `SELECT setting_value FROM ${SETTINGS_TABLE} WHERE setting_key = ? LIMIT 1`,
+            [key]
+        );
+        return rows[0]?.setting_value ?? null;
     }
 
     private async setToDB(key: string, value: string): Promise<void> {
@@ -106,8 +103,22 @@ export class MySqlPluginSettingsProvider implements PluginSettingsProvider {
         );
     }
 
-    /** 캐시 → DB 순으로 읽고, DB 히트면 캐시를 채운다 */
+    /**
+     * 읽기 전용 경로용. 실패는 fallback 으로 흡수한다 —
+     * 설정 조회가 안 된다고 화면 전체가 죽으면 안 된다.
+     * ⛔ 쓰기 직전 읽기(read-modify-write)에는 getStrict 를 쓸 것.
+     */
     private async get<T>(key: string, fallback: T): Promise<T> {
+        try {
+            return await this.getStrict<T>(key, fallback);
+        } catch (err) {
+            console.error(`[PluginSettings] 읽기 실패, 기본값 사용 (key=${key}):`, err);
+            return fallback;
+        }
+    }
+
+    /** 실패를 숨기지 않는 읽기 — 목록을 통째로 덮어쓰기 전에 쓴다 */
+    private async getStrict<T>(key: string, fallback: T): Promise<T> {
         const cached = await this.getCache<T>(key);
         if (cached !== null) return cached;
 
@@ -140,13 +151,14 @@ export class MySqlPluginSettingsProvider implements PluginSettingsProvider {
     }
 
     async activatePlugin(pluginId: string): Promise<void> {
-        const active = await this.getActivePlugins();
+        // strict — 읽기 실패 시 던져서 목록을 날려버리지 않는다
+        const active = await this.getStrict<string[]>(KEY_ACTIVE, []);
         if (active.includes(pluginId)) return;
         await this.set(KEY_ACTIVE, [...active, pluginId]);
     }
 
     async deactivatePlugin(pluginId: string): Promise<void> {
-        const active = await this.getActivePlugins();
+        const active = await this.getStrict<string[]>(KEY_ACTIVE, []);
         if (!active.includes(pluginId)) return;
         await this.set(
             KEY_ACTIVE,

--- a/apps/web/src/lib/server/settings/mysql-site-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/mysql-site-settings-provider.ts
@@ -1,0 +1,114 @@
+/**
+ * MySQL + Redis 기반 사이트 설정 Provider
+ *
+ * 파일 기반(SiteSettingsProvider)이 플러그인 설정과 **같은 결함**을 공유한다:
+ * prod web 파드 13개에 볼륨 마운트가 없어 `data/settings/site-settings.json` 이
+ * 파드마다 분리된다 → admin 저장이 파드 1개에만 적용되고 재배포 시 소실된다.
+ * (플러그인 쪽보다 나쁜 점: 캐시조차 없어 매 요청 파일 I/O 를 한다)
+ *
+ * 저장 방식은 mysql-plugin-settings-provider 와 동일:
+ *   MySQL = 단일 진실 공급원 / Redis = 캐시 / ⛔ 쓰기 시 캐시는 **갱신**(삭제 아님)
+ *
+ * ⚠️ 이 설정에는 OAuth client secret 이 포함된다. 파일에 평문으로 있던 것과 동일 취급이며
+ *    (추가 노출 아님), **값을 로그로 출력하지 말 것**.
+ */
+
+import { DEFAULT_SITE_SETTINGS, type SiteSettings } from '$lib/types/admin-settings.js';
+import { pool } from '$lib/server/db';
+import { getRedis } from '$lib/server/redis';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+
+const CACHE_PREFIX = 'angple:settings:';
+const SETTINGS_TABLE = 'angple_settings';
+const KEY_SITE = 'site_settings';
+const CACHE_TTL = 86_400;
+
+interface SettingsRow extends RowDataPacket {
+    setting_value: string;
+}
+
+export class MySqlSiteSettingsProvider {
+    private tableChecked = false;
+
+    private async ensureTable(): Promise<void> {
+        if (this.tableChecked) return;
+        try {
+            await pool.query(`
+                CREATE TABLE IF NOT EXISTS ${SETTINGS_TABLE} (
+                    setting_key VARCHAR(255) PRIMARY KEY,
+                    setting_value LONGTEXT,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    INDEX idx_updated_at (updated_at)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            `);
+            this.tableChecked = true;
+        } catch (err) {
+            console.error('[SiteSettings] 테이블 확인 실패:', err);
+        }
+    }
+
+    /** 전체 설정 로드 (캐시 → DB, 없으면 기본값) */
+    async load(): Promise<SiteSettings> {
+        try {
+            const cached = await getRedis().get(CACHE_PREFIX + KEY_SITE);
+            if (cached) {
+                return { ...DEFAULT_SITE_SETTINGS, ...(JSON.parse(cached) as SiteSettings) };
+            }
+        } catch (err) {
+            console.error('[SiteSettings] Redis get 실패:', err);
+        }
+
+        await this.ensureTable();
+        try {
+            const [rows] = await pool.query<SettingsRow[]>(
+                `SELECT setting_value FROM ${SETTINGS_TABLE} WHERE setting_key = ? LIMIT 1`,
+                [KEY_SITE]
+            );
+            const raw = rows[0]?.setting_value;
+            if (!raw) return { ...DEFAULT_SITE_SETTINGS };
+
+            const parsed = JSON.parse(raw) as SiteSettings;
+            await this.writeCache(parsed);
+            // 기본값과 병합 (새 필드 추가 시 안전 — 파일 구현과 동일)
+            return { ...DEFAULT_SITE_SETTINGS, ...parsed };
+        } catch (err) {
+            console.error('[SiteSettings] MySQL get 실패:', err);
+            return { ...DEFAULT_SITE_SETTINGS };
+        }
+    }
+
+    /** 전체 설정 저장 (DB → 캐시 갱신) */
+    async save(settings: SiteSettings): Promise<void> {
+        await this.ensureTable();
+        await pool.query<ResultSetHeader>(
+            `INSERT INTO ${SETTINGS_TABLE} (setting_key, setting_value)
+             VALUES (?, ?)
+             ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)`,
+            [KEY_SITE, JSON.stringify(settings)]
+        );
+        await this.writeCache(settings);
+    }
+
+    /** 특정 섹션 가져오기 */
+    async get<K extends keyof SiteSettings>(section: K): Promise<SiteSettings[K]> {
+        return (await this.load())[section];
+    }
+
+    /** 특정 섹션 업데이트 */
+    async update<K extends keyof SiteSettings>(section: K, data: SiteSettings[K]): Promise<void> {
+        const settings = await this.load();
+        settings[section] = data;
+        await this.save(settings);
+    }
+
+    /**
+     * ⛔ 캐시는 지우지 않고 갱신한다. 삭제하면 다른 파드가 낡은 소스로 재적재할 창이 생긴다.
+     */
+    private async writeCache(settings: SiteSettings): Promise<void> {
+        try {
+            await getRedis().setex(CACHE_PREFIX + KEY_SITE, CACHE_TTL, JSON.stringify(settings));
+        } catch (err) {
+            console.error('[SiteSettings] Redis set 실패:', err);
+        }
+    }
+}

--- a/apps/web/src/lib/server/settings/plugin-settings-provider.test.ts
+++ b/apps/web/src/lib/server/settings/plugin-settings-provider.test.ts
@@ -1,0 +1,131 @@
+/**
+ * 플러그인 설정 Provider 계약 테스트
+ *
+ * 저장소가 파일이든 DB 든 **같은 계약**을 지켜야 한다. 여기서 검증하는 것은
+ * 구현 세부가 아니라 인터페이스 동작이다 — 이관 시 회귀를 잡는 안전망.
+ * (이 파일 이전에는 플러그인 설정 관련 테스트가 0건이었다)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// DB/Redis 를 타지 않도록 모듈을 대체한다. 계약만 검증한다.
+const dbStore = new Map<string, string>();
+const cacheStore = new Map<string, string>();
+
+vi.mock('$lib/server/db', () => ({
+    pool: {
+        query: vi.fn(async (sql: string, params?: unknown[]) => {
+            if (/CREATE TABLE/i.test(sql)) return [[], []];
+            if (/^SELECT setting_value/i.test(sql.trim())) {
+                const key = (params as string[])[0];
+                const v = dbStore.get(key);
+                return [v === undefined ? [] : [{ setting_value: v }], []];
+            }
+            if (/^SELECT setting_key, setting_value/i.test(sql.trim())) {
+                return [
+                    [...dbStore.entries()]
+                        .filter(([k]) => k.startsWith('plugin_settings_'))
+                        .map(([setting_key, setting_value]) => ({ setting_key, setting_value })),
+                    []
+                ];
+            }
+            if (/^INSERT INTO/i.test(sql.trim())) {
+                const [key, value] = params as string[];
+                dbStore.set(key, value);
+                return [{ affectedRows: 1 }, []];
+            }
+            return [[], []];
+        })
+    }
+}));
+
+vi.mock('$lib/server/redis', () => ({
+    getRedis: () => ({
+        get: async (k: string) => cacheStore.get(k) ?? null,
+        setex: async (k: string, _ttl: number, v: string) => {
+            cacheStore.set(k, v);
+        },
+        del: async (k: string) => {
+            cacheStore.delete(k);
+        }
+    })
+}));
+
+const { MySqlPluginSettingsProvider } = await import('./mysql-plugin-settings-provider');
+
+describe('MySqlPluginSettingsProvider — 계약', () => {
+    let provider: InstanceType<typeof MySqlPluginSettingsProvider>;
+
+    beforeEach(() => {
+        dbStore.clear();
+        cacheStore.clear();
+        provider = new MySqlPluginSettingsProvider();
+    });
+
+    it('초기 상태의 활성 목록은 빈 배열', async () => {
+        expect(await provider.getActivePlugins()).toEqual([]);
+    });
+
+    it('활성화/비활성화가 목록에 반영된다', async () => {
+        await provider.activatePlugin('fireworks');
+        expect(await provider.getActivePlugins()).toEqual(['fireworks']);
+
+        await provider.activatePlugin('emoticon');
+        expect(await provider.getActivePlugins()).toEqual(['fireworks', 'emoticon']);
+
+        await provider.deactivatePlugin('fireworks');
+        expect(await provider.getActivePlugins()).toEqual(['emoticon']);
+    });
+
+    it('중복 활성화·없는 것 비활성화는 무해하다(멱등)', async () => {
+        await provider.activatePlugin('a');
+        await provider.activatePlugin('a');
+        expect(await provider.getActivePlugins()).toEqual(['a']);
+
+        await provider.deactivatePlugin('없는것');
+        expect(await provider.getActivePlugins()).toEqual(['a']);
+    });
+
+    it('플러그인 설정을 저장하고 되읽는다', async () => {
+        expect(await provider.getPluginSettings('x')).toEqual({});
+        await provider.setPluginSettings('x', { enabled: true, count: 3 });
+        expect(await provider.getPluginSettings('x')).toEqual({ enabled: true, count: 3 });
+    });
+
+    it('⭐ 쓰기 시 캐시를 지우지 않고 갱신한다 (다중 파드 정합의 핵심)', async () => {
+        await provider.activatePlugin('fireworks');
+        const cached = cacheStore.get('angple:settings:active_plugins');
+        expect(cached).toBeDefined();
+        expect(JSON.parse(cached as string)).toEqual(['fireworks']);
+    });
+
+    it('⭐ 다른 파드(새 인스턴스)가 즉시 같은 값을 본다 — flapping 없음', async () => {
+        await provider.activatePlugin('fireworks');
+        // 캐시를 공유하는 별개 인스턴스 = 다른 파드
+        const other = new MySqlPluginSettingsProvider();
+        expect(await other.getActivePlugins()).toEqual(['fireworks']);
+    });
+
+    it('캐시가 비어도 DB 에서 복구한다', async () => {
+        await provider.setPluginSettings('y', { a: 1 });
+        cacheStore.clear();
+        expect(await provider.getPluginSettings('y')).toEqual({ a: 1 });
+    });
+
+    it('getAllPluginSettings 가 파일 구현과 같은 모양을 돌려준다', async () => {
+        await provider.activatePlugin('a');
+        await provider.setPluginSettings('a', { k: 'v' });
+        const all = (await provider.getAllPluginSettings()) as {
+            activePlugins: string[];
+            plugins: Record<string, { settings: Record<string, unknown> }>;
+            version: string;
+        };
+        expect(all.activePlugins).toEqual(['a']);
+        expect(all.plugins.a.settings).toEqual({ k: 'v' });
+        expect(all.version).toBe('1.0.0');
+    });
+
+    it('깨진 JSON 이 DB 에 있어도 기본값으로 견딘다', async () => {
+        dbStore.set('active_plugins', '{깨진 값');
+        expect(await provider.getActivePlugins()).toEqual([]);
+    });
+});

--- a/apps/web/src/lib/server/settings/plugin-settings-provider.test.ts
+++ b/apps/web/src/lib/server/settings/plugin-settings-provider.test.ts
@@ -10,10 +10,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // DB/Redis 를 타지 않도록 모듈을 대체한다. 계약만 검증한다.
 const dbStore = new Map<string, string>();
 const cacheStore = new Map<string, string>();
+/** true 면 DB 가 순단된 것처럼 예외를 던진다 */
+let dbFail = false;
 
 vi.mock('$lib/server/db', () => ({
     pool: {
         query: vi.fn(async (sql: string, params?: unknown[]) => {
+            if (dbFail && !/CREATE TABLE/i.test(sql)) throw new Error('DB 순단(테스트)');
             if (/CREATE TABLE/i.test(sql)) return [[], []];
             if (/^SELECT setting_value/i.test(sql.trim())) {
                 const key = (params as string[])[0];
@@ -58,6 +61,7 @@ describe('MySqlPluginSettingsProvider — 계약', () => {
     beforeEach(() => {
         dbStore.clear();
         cacheStore.clear();
+        dbFail = false;
         provider = new MySqlPluginSettingsProvider();
     });
 
@@ -127,5 +131,25 @@ describe('MySqlPluginSettingsProvider — 계약', () => {
     it('깨진 JSON 이 DB 에 있어도 기본값으로 견딘다', async () => {
         dbStore.set('active_plugins', '{깨진 값');
         expect(await provider.getActivePlugins()).toEqual([]);
+    });
+
+    it('⛔ DB 읽기 실패 시 활성 목록을 날리지 않는다 (순단 중 토글 방어)', async () => {
+        await provider.activatePlugin('a');
+        await provider.activatePlugin('b');
+        cacheStore.clear(); // 캐시 미스 강제 → DB 로 내려감
+        dbFail = true;
+
+        await expect(provider.activatePlugin('c')).rejects.toThrow();
+        dbFail = false;
+        // 실패했으니 기존 목록이 그대로여야 한다 (a,b 가 c 하나로 덮이면 안 됨)
+        expect(await provider.getActivePlugins()).toEqual(['a', 'b']);
+    });
+
+    it('읽기 전용 경로는 DB 실패를 흡수한다 (화면이 죽지 않게)', async () => {
+        cacheStore.clear();
+        dbFail = true;
+        expect(await provider.getActivePlugins()).toEqual([]);
+        expect(await provider.getPluginSettings('x')).toEqual({});
+        dbFail = false;
     });
 });

--- a/apps/web/src/lib/server/settings/plugin-settings-provider.test.ts
+++ b/apps/web/src/lib/server/settings/plugin-settings-provider.test.ts
@@ -10,13 +10,18 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // DB/Redis 를 타지 않도록 모듈을 대체한다. 계약만 검증한다.
 const dbStore = new Map<string, string>();
 const cacheStore = new Map<string, string>();
-/** true 면 DB 가 순단된 것처럼 예외를 던진다 */
-let dbFail = false;
+/**
+ * true 면 **읽기(SELECT)만** 실패시킨다.
+ * ⛔ 쓰기까지 같이 실패시키면 안 된다 — 그러면 옛 코드(읽기 예외를 삼키던 판)도
+ *    INSERT 에서 함께 터져 테스트가 초록이 되어 회귀를 못 잡는다(검증에서 실증됨).
+ *    읽기만 실패해야 "빈 목록에 하나만 얹어 UPSERT" 하는 사고가 드러난다.
+ */
+let dbFailReads = false;
 
 vi.mock('$lib/server/db', () => ({
     pool: {
         query: vi.fn(async (sql: string, params?: unknown[]) => {
-            if (dbFail && !/CREATE TABLE/i.test(sql)) throw new Error('DB 순단(테스트)');
+            if (dbFailReads && /^SELECT/i.test(sql.trim())) throw new Error('DB 읽기 순단(테스트)');
             if (/CREATE TABLE/i.test(sql)) return [[], []];
             if (/^SELECT setting_value/i.test(sql.trim())) {
                 const key = (params as string[])[0];
@@ -61,7 +66,7 @@ describe('MySqlPluginSettingsProvider — 계약', () => {
     beforeEach(() => {
         dbStore.clear();
         cacheStore.clear();
-        dbFail = false;
+        dbFailReads = false;
         provider = new MySqlPluginSettingsProvider();
     });
 
@@ -137,19 +142,19 @@ describe('MySqlPluginSettingsProvider — 계약', () => {
         await provider.activatePlugin('a');
         await provider.activatePlugin('b');
         cacheStore.clear(); // 캐시 미스 강제 → DB 로 내려감
-        dbFail = true;
+        dbFailReads = true; // 읽기만 실패, 쓰기는 성공 — 옛 코드라면 여기서 목록이 덮인다
 
         await expect(provider.activatePlugin('c')).rejects.toThrow();
-        dbFail = false;
+        dbFailReads = false;
         // 실패했으니 기존 목록이 그대로여야 한다 (a,b 가 c 하나로 덮이면 안 됨)
         expect(await provider.getActivePlugins()).toEqual(['a', 'b']);
     });
 
     it('읽기 전용 경로는 DB 실패를 흡수한다 (화면이 죽지 않게)', async () => {
         cacheStore.clear();
-        dbFail = true;
+        dbFailReads = true;
         expect(await provider.getActivePlugins()).toEqual([]);
         expect(await provider.getPluginSettings('x')).toEqual({});
-        dbFail = false;
+        dbFailReads = false;
     });
 });

--- a/apps/web/src/lib/server/settings/plugin-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/plugin-settings-provider.ts
@@ -7,6 +7,8 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import { env } from '$env/dynamic/private';
+import { MySqlPluginSettingsProvider } from './mysql-plugin-settings-provider';
 
 /**
  * 플러그인 설정 Provider 인터페이스
@@ -224,6 +226,29 @@ class JsonPluginSettingsProvider implements PluginSettingsProvider {
 }
 
 /**
- * 전역 플러그인 설정 Provider
+ * 전역 플러그인 설정 Provider (Facade)
+ *
+ * 환경변수로 저장소 선택:
+ *   - PLUGIN_SETTINGS_PROVIDER=json  (기본값) 파일. 단일 인스턴스·셀프호스팅용
+ *   - PLUGIN_SETTINGS_PROVIDER=mysql  MySQL+Redis. **다중 파드 운영은 이쪽이어야 한다**
+ *
+ * ⛔ 기본값을 mysql 로 바꾸지 말 것 — 셀프호스팅 사용자는 DB 스키마 없이 설치한다.
+ * ⛔ json 구현을 지우지 말 것 — env 를 되돌리면 즉시 복귀하는 롤백 경로다.
+ *
+ * 파일 기반의 한계(2026-07-31 실측): prod web 파드 13개에 볼륨 마운트가 없어 파일이
+ * 이미지에 구워진 채 파드별로 분리된다 → admin 토글이 파드 1개에만 적용되고 재배포 시
+ * 소실되며, Redis L2 공유와 맞물려 변경이 스스로 되돌아가는 flapping 까지 발생했다.
+ * 자세한 배경은 mysql-plugin-settings-provider.ts 상단 주석 참조.
  */
-export const pluginSettingsProvider = new JsonPluginSettingsProvider();
+const PROVIDER_TYPE = env.PLUGIN_SETTINGS_PROVIDER || 'json';
+
+function createProvider(): PluginSettingsProvider {
+    if (PROVIDER_TYPE === 'mysql') {
+        console.log('[PluginSettings] Using MySQL + Redis provider');
+        return new MySqlPluginSettingsProvider();
+    }
+    console.log('[PluginSettings] Using JSON file provider');
+    return new JsonPluginSettingsProvider();
+}
+
+export const pluginSettingsProvider = createProvider();

--- a/apps/web/src/lib/server/settings/site-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/site-settings-provider.ts
@@ -1,6 +1,8 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { env } from '$env/dynamic/private';
 import { DEFAULT_SITE_SETTINGS, type SiteSettings } from '$lib/types/admin-settings.js';
+import { MySqlSiteSettingsProvider } from './mysql-site-settings-provider';
 
 /**
  * 사이트 설정 JSON 파일 Provider
@@ -81,5 +83,15 @@ export class SiteSettingsProvider {
     }
 }
 
-/** 싱글톤 인스턴스 */
-export const siteSettingsProvider = new SiteSettingsProvider();
+/**
+ * 싱글톤 인스턴스 (Facade)
+ *
+ * SITE_SETTINGS_PROVIDER=json (기본) | mysql
+ * ⛔ 기본값을 mysql 로 바꾸지 말 것 — 셀프호스팅은 DB 스키마 없이 설치한다.
+ * ⛔ 파일 구현을 지우지 말 것 — env 를 되돌리면 즉시 복귀하는 롤백 경로다.
+ * 다중 파드 운영은 mysql 이어야 한다(파일은 파드별로 갈라진다).
+ */
+export const siteSettingsProvider =
+    env.SITE_SETTINGS_PROVIDER === 'mysql'
+        ? new MySqlSiteSettingsProvider()
+        : new SiteSettingsProvider();

--- a/apps/web/src/routes/api/plugins/[id]/settings/+server.ts
+++ b/apps/web/src/routes/api/plugins/[id]/settings/+server.ts
@@ -55,7 +55,8 @@ export const PUT: RequestHandler = async ({ params, request }) => {
             throw error(400, '플러그인 ID가 필요합니다.');
         }
 
-        if (!isPluginInstalled(id)) {
+        // ⛔ await 필수 — async 함수라 Promise 는 항상 truthy 여서 이 가드가 죽어 있었다
+        if (!(await isPluginInstalled(id))) {
             throw error(404, `플러그인을 찾을 수 없습니다: ${id}`);
         }
 

--- a/apps/web/src/routes/api/plugins/marketplace/install/+server.ts
+++ b/apps/web/src/routes/api/plugins/marketplace/install/+server.ts
@@ -26,7 +26,8 @@ export const POST: RequestHandler = async ({ request }) => {
         }
 
         // 플러그인이 설치되어 있는지 확인
-        if (!isPluginInstalled(pluginId)) {
+        // ⛔ await 필수 — async 함수라 Promise 는 항상 truthy 여서 이 가드가 죽어 있었다
+        if (!(await isPluginInstalled(pluginId))) {
             return json(
                 {
                     success: false,

--- a/apps/web/src/routes/api/themes/active/+server.ts
+++ b/apps/web/src/routes/api/themes/active/+server.ts
@@ -12,6 +12,14 @@ import { getActiveTheme, setActiveTheme, getAllSettings } from '$lib/server/sett
 import { sanitizePath } from '$lib/server/path-utils';
 
 /**
+ * 이 공개 API 가 내보내도 되는 설정 키 (allowlist).
+ * ⛔ 새 키를 추가할 때는 "익명에게 보여도 되는가"를 먼저 판단할 것.
+ *    angple_settings 는 테마 외 설정도 담는 공용 테이블이다.
+ */
+const THEME_PUBLIC_KEY =
+    /^(active_theme|theme_settings_|theme_activated_at|widget_layout|sidebar_widget_layout)/;
+
+/**
  * GET /api/themes/active
  * 현재 활성화된 테마 정보 반환
  */
@@ -23,8 +31,16 @@ export const GET: RequestHandler = async () => {
             return json({ error: '활성화된 테마가 없습니다.' }, { status: 404 });
         }
 
+        // ⛔ getAllSettings() 는 angple_settings **전 행**을 돌려준다. 이 엔드포인트는
+        //    인증 가드가 없는 공개 API 이므로 테마 관련 키만 골라 내보낸다.
+        //    (그대로 펼치면 같은 테이블에 들어오는 사이트 설정의 OAuth client secret 이나
+        //     플러그인 설정의 API 키가 익명에게 노출된다 — 2026-07-31 실측으로 확인)
         const settings = await getAllSettings();
-        return json({ activeTheme, ...settings });
+        const publicSettings: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(settings)) {
+            if (THEME_PUBLIC_KEY.test(key)) publicSettings[key] = value;
+        }
+        return json({ activeTheme, ...publicSettings });
     } catch (error) {
         console.error('❌ 활성 테마 조회 실패:', error);
         return json({ error: '서버 오류' }, { status: 500 });

--- a/apps/web/src/routes/api/themes/active/+server.ts
+++ b/apps/web/src/routes/api/themes/active/+server.ts
@@ -13,11 +13,14 @@ import { sanitizePath } from '$lib/server/path-utils';
 
 /**
  * 이 공개 API 가 내보내도 되는 설정 키 (allowlist).
+ * ⛔ **끝을 앵커링한다** — 접두사 매칭으로 두면 `active_theme_admin_token` 같은 미래 키가
+ *    자동 통과한다. 접두사 허용이 필요한 것(theme_settings_, widget_layout_backup_)만 뒤에 둔다.
+ * 캐멀케이스 키는 json provider(셀프호스팅 경로)가 돌려주는 형태다.
  * ⛔ 새 키를 추가할 때는 "익명에게 보여도 되는가"를 먼저 판단할 것.
  *    angple_settings 는 테마 외 설정도 담는 공용 테이블이다.
  */
 const THEME_PUBLIC_KEY =
-    /^(active_theme|theme_settings_|theme_activated_at|widget_layout|sidebar_widget_layout)/;
+    /^(active_theme|theme_activated_at|widget_layout|sidebar_widget_layout|activeTheme|activatedAt|widgetLayout|sidebarWidgetLayout|themes|version)$|^(theme_settings_|widget_layout_backup_)/;
 
 /**
  * GET /api/themes/active


### PR DESCRIPTION
## 문제 (실측)

플러그인 활성/설정과 사이트 설정이 **파일**(`data/*.json`)에 저장된다. prod 는 web 파드 **13개**, 볼륨 마운트 없음 → 파일이 이미지에 구워진 채 파드별로 갈라진다.

| 사실 | 확인 |
|---|---|
| `apps/web/data/plugin-settings.json` 이 git 추적됨 | `git ls-files` (루트 `.gitignore` 의 `/data/` 는 여기 안 걸림) |
| 마지막 커밋 = 2026-05-24 "archive 플러그인 활성화" | `git log` |
| 파드 13개, 볼륨 마운트 0 | `kubectl get deploy` |

즉 **정본은 레포 커밋본**이고 admin 토글은 파드 1개짜리 임시 변경이다. UI 는 그렇게 말하지 않는다.

### 파생 결함 (함께 수정)

| 결함 | 영향 |
|---|---|
| **Redis L2 flapping** — L2 는 13파드 공유인데 소스 파일은 파드별. A에서 켜면 공유 L2 삭제 → B가 자기 구버전으로 재적재 → **A의 변경이 스스로 되돌아감** | 높음 |
| `updatePluginSettings` 캐시 무효화 누락 (activate/deactivate 는 함) | 단일 파드에서도 최대 5분 미반영 |
| `isPluginInstalled` **await 누락** → Promise 는 항상 truthy → 404 가드 사망 | 미설치 플러그인에도 설정 저장 (2곳) |
| 사이트 설정도 동일 결함 (캐시조차 없음) | 같은 배 |

## 설계 — 재발명하지 않음

**테마/위젯 설정은 이미 DB 로 이관돼 있다.** 그 4파일 구조(인터페이스 → json → mysql → env facade)를 그대로 복제했다.

- **`angple_settings` 테이블 재사용** — 키 `active_plugins`, `plugin_settings_{id}`, `site_settings`. ⛔ **수동 DDL 불필요** (prod AutoMigrate 미가동 제약 회피)
- ⛔ **쓰기 시 캐시를 지우지 않고 갱신** — 삭제하면 다른 파드가 낡은 소스로 재적재할 창이 생겨 flapping 이 남는다. 이게 정합의 핵심
- **env 스위치**, 기본값 `json` 유지 → 셀프호스팅 무영향
- **파일 구현 유지** → env 되돌리면 즉시 복귀하는 롤백 경로

choke point 가 1곳(`plugins/index.ts`)이라 13개 라우트는 무변경이다.

## 배포 절차

1. 이 PR 머지 (기본값 json 이라 동작 무변화)
2. `node apps/web/scripts/migrate-settings-to-db.mjs --dry-run` 확인 → 실행 (**멱등**, DB 에 값 있으면 건너뜀)
3. `.env` 에 `PLUGIN_SETTINGS_PROVIDER=mysql` / `SITE_SETTINGS_PROVIDER=mysql` 후 재배포

⚠️ 사이트 설정에는 OAuth client secret 이 포함된다 — 파일에 평문으로 있던 것과 동일 취급(추가 노출 아님), 로그 출력 없음.

## 테스트

플러그인 설정 테스트가 **0건**이었다. 계약 테스트 신설 — 활성/비활성 멱등성, 설정 왕복, **쓰기 시 캐시 갱신**, **다른 파드가 즉시 같은 값을 보는지(flapping 없음)**, 캐시 소실 시 DB 복구, 깨진 JSON 견딤.

---

## ⛔ 배포 순서 (역순 금지)

1. **이 PR 머지** — 기본값 `json` 이라 동작 무변화
2. `node apps/web/scripts/migrate-settings-to-db.mjs --dry-run` 로 확인 → 인자 없이 실행 (**멱등**)
3. `.env` 에 `PLUGIN_SETTINGS_PROVIDER=mysql` / `SITE_SETTINGS_PROVIDER=mysql` 추가 후 재배포

⚠️ **env 를 마이그레이션보다 먼저 켜면 안 된다** — DB 에 `active_plugins` 가 없으면 전 플러그인 OFF, `site_settings` 가 없으면 기본값(OAuth 빈 값)이 되어 **소셜 로그인이 중단**된다.

## 🔴 검증에서 발견해 함께 고친 P0

`/api/themes/active` 는 **인증 가드가 없는 공개 API** 인데 `getAllSettings()` 가 `angple_settings` **전 행**을 돌려주는 것을 그대로 펼치고 있었다. 익명 GET 실측으로 확인:

```
status 200 → keys: activeTheme, active_theme, sidebar_widget_layout,
             theme_activated_at, widget_layout, widget_layout_backup_20260713
```

이 상태로 사이트 설정을 같은 테이블에 넣으면 **OAuth client secret 이 익명에게 공개**된다. 테마 키 allowlist 로 걸러 내보내도록 수정했다.

함께 수정: dry-run 값 출력 제거 / `invalidateActivePluginsCache` await 누락 / DB 순단 중 활성 목록이 통째로 덮이던 경로(`getStrict` 분리) + 회귀 테스트 2건