### PR TITLE
fix(my/following): 존재하지 않는 컬럼 조회로 팔로잉 목록이 항상 비던 문제

### DIFF
--- a/apps/web/src/routes/my/following/+page.server.ts
+++ b/apps/web/src/routes/my/following/+page.server.ts
@@ -6,7 +6,6 @@ interface FollowingRow extends RowDataPacket {
     mb_id: string;
     mb_nick: string;
     mb_level: number;
-    mb_image: string;
     followed_at: string;
 }
 
@@ -15,8 +14,10 @@ export const load: PageServerLoad = async ({ parent }) => {
 
     try {
         const [rows] = await readPool.query<FollowingRow[]>(
+            // ⛔ g5_member 에 mb_image 컬럼은 없다(실제로는 mb_image_url/_exists/_updated_at).
+            //    화면에서 쓰지도 않는 컬럼을 select 하다 쿼리 전체가 ER_BAD_FIELD_ERROR 로 실패했고,
+            //    catch 가 빈 배열을 돌려주어 "팔로우한 사람 없음"처럼 보였다. 필요한 필드만 조회한다.
             `SELECT f.target_id AS mb_id, m.mb_nick, m.mb_level,
-					COALESCE(m.mb_image, '') AS mb_image,
 					f.created_at AS followed_at
 			 FROM g5_member_follow f
 			 JOIN g5_member m
@@ -31,7 +32,6 @@ export const load: PageServerLoad = async ({ parent }) => {
                 mb_id: r.mb_id,
                 mb_nick: r.mb_nick,
                 mb_level: r.mb_level,
-                mb_image: r.mb_image,
                 followed_at: r.followed_at
             }))
         };


### PR DESCRIPTION
## 현상

운영 로그에 계속 찍히고 있었습니다.

```
[My Following] load error: Error: Unknown column 'm.mb_image' in 'field list'
code: 'ER_BAD_FIELD_ERROR'
```

`g5_member` 에 **`mb_image` 컬럼은 없습니다.** 실제 컬럼은 `mb_image_url` / `mb_image_exists` / `mb_image_updated_at` 이고, 같은 레포의 다른 쿼리(예: `comments/likers-batch/+server.ts:134`)는 올바르게 `COALESCE(m.mb_image_url, '')` 를 씁니다.

## 왜 눈에 안 띄었나

`load` 의 catch 가 `following: []` 를 반환합니다. 그래서 화면에는 에러가 아니라 **"팔로우한 사람이 없습니다"** 로 보입니다 — 팔로잉이 실제로 0명인 것과 구분이 안 됩니다. 서버 로그에만 남았습니다.

## 영향 (운영 DB 실측)

| | |
|---|---|
| 팔로우 관계 | **2,441건** |
| 팔로우한 회원 | **1,208명** |

이 화면을 연 사람은 **전원** 빈 목록을 봤습니다.

## 변경

select 에서 `mb_image` 를 뺐습니다. 화면(`+page.svelte`)은 `mb_id` / `mb_nick` / `followed_at` 만 쓰고 이 값을 **어디에서도 참조하지 않습니다.** 인터페이스와 매핑에서도 함께 제거했습니다.

`/api/my/following/+server.ts` 는 `mb_name, mb_nick` 만 조회해 원래 정상입니다 — 수정 불필요.

## 검증

수정된 쿼리를 운영 DB 에서 직접 실행해 정상 반환을 확인했습니다.

```
mb_id  mb_nick  mb_level  followed_at
ai     다모앙    -1        2026-03-27 10:46:36
```

- [ ] 배포 후 `/my/following` 에서 실제 팔로잉 목록 노출
- [ ] 파드 로그 `ER_BAD_FIELD_ERROR` 0건
