### PR TITLE
fix(search): 전체검색이 게시판의 검색 사용 설정(bo_use_search)을 따르도록

### DIFF
--- a/apps/web/src/lib/server/sphinx-search.ts
+++ b/apps/web/src/lib/server/sphinx-search.ts
@@ -5,7 +5,34 @@
  * 글로벌 검색(/api/search)과 보드별 검색(+page.server.ts) 양쪽에서 재사용.
  */
 import sphinxPool from '$lib/server/sphinx.js';
+import pool from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
+
+/**
+ * 검색에서 제외할 게시판 목록 (`g5_board.bo_use_search = 0`).
+ *
+ * 통합 인덱스(all_boards_unified_dist)에는 운영자가 "검색 사용 안 함" 으로 설정한 게시판도
+ * 일부 섞여 들어가 있다. RSS·사이트맵·포인트 랭킹은 모두 `bo_use_search = 1` 을 지키는데
+ * 전체검색만 이 설정을 보지 않아, 소명·익명 게시판 글이 검색 결과에 노출됐다.
+ * 인덱스 구성과 무관하게 **설정이 최종 판단 기준**이 되도록 쿼리 단계에서 막는다.
+ *
+ * 값은 자주 바뀌지 않으므로 캐시하되, 운영자가 설정을 바꾸면 몇 분 안에 반영되게 한다.
+ */
+const EXCLUDED_BOARDS_TTL_MS = 5 * 60 * 1000;
+let excludedBoardsCache: { list: string[]; at: number } | null = null;
+
+async function getSearchExcludedBoards(): Promise<string[]> {
+    const now = Date.now();
+    if (excludedBoardsCache && now - excludedBoardsCache.at < EXCLUDED_BOARDS_TTL_MS) {
+        return excludedBoardsCache.list;
+    }
+    const [rows] = await pool.query<RowDataPacket[]>(
+        'SELECT bo_table FROM g5_board WHERE bo_use_search = 0'
+    );
+    const list = rows.map((r) => String(r.bo_table)).filter((t) => /^[a-zA-Z0-9_-]+$/.test(t));
+    excludedBoardsCache = { list, at: now };
+    return list;
+}
 
 interface SphinxSearchRow extends RowDataPacket {
     wr_id: number;
@@ -169,11 +196,20 @@ export async function searchAllBoards(
     const isCommentSearch = COMMENT_SEARCH_FIELDS.has(field);
     const safeMatch = matchExpr.replace(/'/g, "\\'");
 
+    // 검색 제외 게시판을 쿼리에서 배제한다.
+    // 조회에 실패하면 예외를 그대로 올려 검색을 중단시킨다(fail-closed) — 제외 목록을 모르는 채
+    // 검색하면 비공개 게시판이 노출되기 때문이다. 어차피 결과 렌더링에도 이 DB 가 필요하다.
+    const excluded = await getSearchExcludedBoards();
+    const excludeClause = excluded.length
+        ? ` AND bo_table NOT IN (${excluded.map((t) => `'${t}'`).join(',')})`
+        : '';
+
     const sphinxSql =
         `SELECT id, bo_table, wr_id, wr_subject, wr_content, ` +
         `wr_hit, wr_good, wr_comment, wr_datetime, wr_is_comment, wr_parent ` +
         `FROM all_boards_unified_dist ` +
-        `WHERE MATCH('${safeMatch}') AND wr_is_comment = ${isCommentSearch ? 1 : 0} ` +
+        `WHERE MATCH('${safeMatch}') AND wr_is_comment = ${isCommentSearch ? 1 : 0}` +
+        `${excludeClause} ` +
         `ORDER BY wr_datetime DESC ` +
         `LIMIT ${maxResults}`;
 


### PR DESCRIPTION
## 배경

`g5_board.bo_use_search` 는 "이 게시판을 검색에 쓸지" 를 정하는 설정입니다. 레포 안에서 이 설정을 지키는 곳과 아닌 곳이 갈려 있었습니다.

| 기능 | `bo_use_search` 참조 |
|---|---|
| RSS (`rss/+server.ts`) | ✅ |
| 사이트맵 (`sitemap-boards.xml`) | ✅ |
| 포인트 랭킹 (`point/+page.server.ts`) | ✅ |
| **전체검색** (`sphinx-search.ts` → `/api/search`) | ❌ **참조 없음** |

전체검색은 통합 인덱스를 그대로 조회하고 게시판 조건을 걸지 않았고, `/api/search` 의 후처리도 삭제글 제외뿐이라 게시판 단위 필터가 없었습니다. 그 결과 **검색에서 제외하도록 설정된 게시판의 글도 결과에 포함될 수 있었습니다.**

## 변경

- `searchAllBoards` 가 `bo_use_search = 0` 인 게시판을 `NOT IN` 으로 제외
- 목록은 **5분 캐시** — 운영자가 설정을 바꾸면 곧 반영됩니다
- **fail-closed**: 목록 조회에 실패하면 예외를 전파해 검색을 중단합니다. 제외 대상을 모르는 채로 검색하면 안 되기 때문입니다. 결과 렌더링에도 같은 DB 가 필요하므로 실질적인 기능 손실은 없습니다
- 게시판명은 영숫자·`_`·`-` 만 통과시켜 쿼리 조립을 방어

**설계 의도**: 인덱스에 무엇이 들어있든 **설정이 최종 판단 기준**이 되게 합니다. 인덱스 구성이 바뀌거나 재생성돼도 정책이 유지됩니다.

## 검증

운영 Manticore 에 수정 전후 쿼리를 직접 실행해, 제외 대상 게시판이 결과에서 사라지는 것과 다른 게시판 결과가 그대로인 것을 확인했습니다.

- [ ] 카나리: 일반 검색어 결과가 기존과 동일
- [ ] 카나리: 제외 설정 게시판이 결과에 없음
- [ ] 검색 응답 시간 회귀 없음

## 후속 (별건)

통합 인덱스 정의에서도 해당 게시판을 빼서 이중으로 막을 예정입니다. 코드 차단이 먼저 나가면 인덱스 정리는 급하지 않습니다.
