### PR TITLE
새글모음: 범위 칩·글/댓글 탭·삭제글 차단

### DIFF
--- a/apps/web/src/lib/server/new-posts.ts
+++ b/apps/web/src/lib/server/new-posts.ts
@@ -31,12 +31,33 @@ export interface NewPostsResult {
     nextCursor: number | null;
 }
 
+/**
+ * 범위 프리셋 화이트리스트.
+ *
+ * ⛔ 여기에 없는 값은 `''` 로 강등된다(`feed/+page.server.ts`). 열린 집합으로 두면 크롤러가
+ *    던지는 임의 문자열마다 캐시 키·CDN 엔트리가 생겨 원본 부하가 증폭된다.
+ * ⭐ 이 Set 을 비우면 쿼리 코드를 건드리지 않고 서버측 기능이 꺼진다(킬스위치).
+ */
+export const FEED_SCOPE_PRESETS = new Set(['', 'nofree']);
+
+/**
+ * 새글모음을 지배하는 보드. 실측(2026-08-01): 7일 83,323건 중 `free` 가 89.8%.
+ * 사이트 특수 사실이라 상수로 격리한다 — 쿼리 로직에 흩뿌리지 않는다.
+ */
+const MAJOR_BOARD = 'free';
+
 // --- 캐시 ---
 
-/** 새글 결과 캐시: L1 30초, L2 60초 (새글이 빈번하므로 짧게) */
-const feedCache = new TieredCache<NewPostsResult>('feed', 30_000, 60, 200);
+/**
+ * 새글 결과 캐시: L1 30초, L2 60초 (새글이 빈번하므로 짧게)
+ *
+ * ⛔ 네임스페이스가 'feed2' 인 이유: 삭제글을 거르면서 **같은 키의 내용이 바뀌었다.**
+ *    구 'feed' 엔트리가 살아 있으면 배포 직후 삭제글이 그대로 나온다. 구키는 TTL 로 소멸한다.
+ * maxSize 는 scope 만큼 키가 늘어나므로 200 → 400.
+ */
+const feedCache = new TieredCache<NewPostsResult>('feed2', 30_000, 60, 400);
 
-/** COUNT(*) 캐시: key = "view:grId", TTL 10분 */
+/** COUNT(*) 캐시: key = "view:grId:scope", TTL 10분 */
 const countCache = new Map<string, { total: number; expiry: number }>();
 const COUNT_CACHE_TTL = 10 * 60 * 1000; // 10분
 
@@ -44,6 +65,105 @@ const COUNT_CACHE_TTL = 10 * 60 * 1000; // 10분
 let boardGroupsCache: { data: { gr_id: string; gr_subject: string }[]; expiry: number } | null =
     null;
 const BOARD_GROUPS_CACHE_TTL = 60 * 60 * 1000; // 1시간
+
+/** 검색 노출 보드 → 그룹 매핑 캐시: TTL 10분 (보드 신설이 프리셋에 반영되는 지연 상한) */
+let searchableBoardsCache: { data: { bo_table: string; gr_id: string }[]; expiry: number } | null =
+    null;
+const SEARCHABLE_BOARDS_CACHE_TTL = 10 * 60 * 1000; // 10분
+
+async function getSearchableBoards(): Promise<{ bo_table: string; gr_id: string }[]> {
+    if (searchableBoardsCache && Date.now() < searchableBoardsCache.expiry) {
+        return searchableBoardsCache.data;
+    }
+    const [rows] = await readPool.query<RowDataPacket[]>(
+        'SELECT bo_table, gr_id FROM g5_board WHERE bo_use_search = 1'
+    );
+    const data = rows as { bo_table: string; gr_id: string }[];
+    searchableBoardsCache = { data, expiry: Date.now() + SEARCHABLE_BOARDS_CACHE_TTL };
+    return data;
+}
+
+/** WHERE 절 조립 결과. 보드 교집합이 비면 `empty` — 쿼리를 아예 쏘지 않는다. */
+type FeedParam = string | number | string[];
+
+interface FeedWhere {
+    conditions: string[];
+    /** `IN (?)` 에는 배열이 통째로 하나의 파라미터로 들어간다 (mysql2 가 펼친다) */
+    params: FeedParam[];
+    empty: boolean;
+}
+
+/**
+ * 목록·COUNT 가 **같은 WHERE 를 쓰도록** 한 곳에서 만든다.
+ *
+ * ⛔ 예전에는 두 곳에 복붙돼 있었다. 조건을 하나 추가할 때 한쪽만 고치면
+ *    "목록엔 안 보이는데 건수는 그대로" 같은 어긋남이 조용히 생긴다.
+ *
+ * ⭐ 그룹 필터를 `b.gr_id = ?` 로 걸지 않고 보드 목록으로 풀어 `bn.bo_table IN (...)` 으로 거는
+ *    이유: `g5_board.gr_id` 에 인덱스가 없어 JOIN 조건으로 걸면 드라이빙 테이블이 `b` 로
+ *    뒤집히며 **임시테이블 + 파일소트**가 된다(EXPLAIN 실측). `bn.bo_table` 술어는
+ *    백워드 PK 스캔을 유지한다.
+ */
+async function buildFeedWhere(opts: {
+    view: string;
+    grId: string;
+    scope: string;
+    cursor?: number;
+}): Promise<FeedWhere> {
+    const conditions: string[] = [
+        'b.bo_use_search = 1',
+        'bn.bn_datetime > DATE_SUB(NOW(), INTERVAL 7 DAY)'
+    ];
+    const params: FeedParam[] = [];
+
+    if (opts.view === 'w') {
+        conditions.push('bn.wr_id = bn.wr_parent');
+    } else if (opts.view === 'c') {
+        conditions.push('bn.wr_id != bn.wr_parent');
+    }
+
+    const excludeMajor = opts.scope === 'nofree';
+
+    if (opts.grId) {
+        // 그룹 + 범위를 **교집합 하나**로 계산한다 — 둘의 우선순위 규칙이 필요 없어진다.
+        const boards = (await getSearchableBoards())
+            .filter((b) => b.gr_id === opts.grId)
+            .map((b) => b.bo_table)
+            .filter((t) => /^[a-zA-Z0-9_]+$/.test(t)) // 기존 조립부와 같은 검증
+            .filter((t) => !excludeMajor || t !== MAJOR_BOARD);
+
+        // ⛔ 빈 배열을 IN 에 넣으면 `IN (NULL)` 이 되어 조용히 0건이 된다. 명시적으로 끊는다.
+        if (boards.length === 0) {
+            return { conditions, params, empty: true };
+        }
+        conditions.push('bn.bo_table IN (?)');
+        params.push(boards);
+    } else if (excludeMajor) {
+        // 단일 제외는 `<>` 가 가장 싸다 — 기준(필터 없음)과 같은 실행계획이 나온다.
+        conditions.push('bn.bo_table <> ?');
+        params.push(MAJOR_BOARD);
+    }
+
+    if (opts.cursor && opts.cursor > 0) {
+        conditions.push('bn.bn_id < ?');
+        params.push(opts.cursor);
+    }
+
+    return { conditions, params, empty: false };
+}
+
+/**
+ * 소프트 삭제 판정. 판정식은 `routes/api/search/+server.ts:125-131` 선례를 그대로 따른다
+ * (`0000-00-00` 와 빈 문자열까지 살아있는 글로 본다).
+ */
+function isDeleted(deletedAt: unknown): boolean {
+    return (
+        deletedAt !== null &&
+        deletedAt !== undefined &&
+        String(deletedAt) !== '0000-00-00 00:00:00' &&
+        String(deletedAt) !== ''
+    );
+}
 
 /** HTML 태그, 이모지 코드 제거 및 미리보기 추출 */
 function extractContentPreview(rawContent: string, maxLen = 100): string {
@@ -81,67 +201,46 @@ export async function getNewPosts(
     page: number,
     perPage: number = 30,
     cursor?: number,
-    sort: FeedSort = 'latest'
+    sort: FeedSort = 'latest',
+    scope: string = ''
 ): Promise<NewPostsResult> {
     // Redis 2-tier 캐시 확인 (L1 30초, L2 60초)
-    const feedCacheKey = `${view}:${grId}:${page}:${cursor || 0}:${sort}`;
+    // ⛔ scope 를 키에 넣지 않으면 L2(전 사용자 공유)에서 「전체」와 「자유게시판 제외」 결과가
+    //    서로에게 샌다. 아래 COUNT 키도 마찬가지 — **두 곳 다** 넣어야 한다.
+    const feedCacheKey = `${view}:${grId}:${scope}:${page}:${cursor || 0}:${sort}`;
     const cached = await feedCache.get(feedCacheKey);
     if (cached) return cached;
 
-    const conditions: string[] = [
-        'b.bo_use_search = 1',
-        'bn.bn_datetime > DATE_SUB(NOW(), INTERVAL 7 DAY)'
-    ];
-    const params: (string | number)[] = [];
-
-    // 원글/댓글 필터
-    if (view === 'w') {
-        conditions.push('bn.wr_id = bn.wr_parent');
-    } else if (view === 'c') {
-        conditions.push('bn.wr_id != bn.wr_parent');
-    }
-
-    // 그룹 필터
-    if (grId) {
-        conditions.push('b.gr_id = ?');
-        params.push(grId);
-    }
-
     // 최신순일 때만 커서 기반 페이지네이션 사용
-    if (sort === 'latest' && cursor && cursor > 0) {
-        conditions.push('bn.bn_id < ?');
-        params.push(cursor);
+    const listWhere = await buildFeedWhere({
+        view,
+        grId,
+        scope,
+        cursor: sort === 'latest' ? cursor : undefined
+    });
+    if (listWhere.empty) {
+        return { items: [], total: 0, nextCursor: null };
     }
-
-    const whereClause = 'WHERE ' + conditions.join(' AND ');
+    const params = listWhere.params;
+    const whereClause = 'WHERE ' + listWhere.conditions.join(' AND ');
 
     // COUNT(*) — 캐시 우선 (커서 무관, 필터 기준)
-    const cacheKey = `${view}:${grId}`;
+    const cacheKey = `${view}:${grId}:${scope}`;
     const cachedCount = countCache.get(cacheKey);
     let total: number;
     if (cachedCount && Date.now() < cachedCount.expiry) {
         total = cachedCount.total;
     } else {
-        // 커서 조건 제외한 원본 WHERE로 카운트
-        const countConditions: string[] = [
-            'b.bo_use_search = 1',
-            'bn.bn_datetime > DATE_SUB(NOW(), INTERVAL 7 DAY)'
-        ];
-        const countParams: (string | number)[] = [];
-        if (view === 'w') countConditions.push('bn.wr_id = bn.wr_parent');
-        else if (view === 'c') countConditions.push('bn.wr_id != bn.wr_parent');
-        if (grId) {
-            countConditions.push('b.gr_id = ?');
-            countParams.push(grId);
-        }
-        const countWhere = 'WHERE ' + countConditions.join(' AND ');
+        // 커서 조건만 뺀 같은 WHERE 로 카운트 (빌더 공유 — 목록과 어긋날 수 없다)
+        const countWhereParts = await buildFeedWhere({ view, grId, scope });
+        const countWhere = 'WHERE ' + countWhereParts.conditions.join(' AND ');
 
         const [countRows] = await readPool.query<RowDataPacket[]>(
             `SELECT COUNT(*) as total
 			 FROM g5_board_new bn
 			 JOIN g5_board b ON bn.bo_table = b.bo_table
 			 ${countWhere}`,
-            countParams
+            countWhereParts.params
         );
         total = countRows[0]?.total || 0;
         countCache.set(cacheKey, { total, expiry: Date.now() + COUNT_CACHE_TTL });
@@ -197,7 +296,7 @@ export async function getNewPosts(
         const wrIds = tableRows.map((r) => r.wr_id);
         try {
             const [writeRows] = await readPool.query<RowDataPacket[]>(
-                `SELECT wr_id, wr_subject, wr_content, wr_name, wr_comment, wr_hit
+                `SELECT wr_id, wr_subject, wr_content, wr_name, wr_comment, wr_hit, wr_deleted_at
 				 FROM \`g5_write_${boTable}\`
 				 WHERE wr_id IN (?)`,
                 [wrIds]
@@ -219,6 +318,11 @@ export async function getNewPosts(
     for (const row of rows) {
         const writeData = writeDataMap.get(`${row.bo_table}:${row.wr_id}`);
         if (writeData) {
+            // 삭제글은 목록에서 뺀다. `g5_board_new` 는 소프트 삭제 때 정리되지 않아
+            // (실측: 최근 7일 삭제 1,385건 중 1,027건 잔존) 여기서 걸러야 제목·작성자가 안 샌다.
+            // 원본 행이 아예 없는 경우를 이미 조용히 건너뛰고 있으므로(위 if) 그 동작과 일관된다.
+            if (isDeleted(writeData.wr_deleted_at)) continue;
+
             const isDisciplined = disciplinedSet.has(`${row.bo_table}:${row.wr_id}`);
             items.push({
                 bn_id: row.bn_id,
@@ -255,8 +359,14 @@ export async function getNewPosts(
         items = items.slice(offset, offset + perPage);
     }
 
-    // 다음 페이지 커서: 마지막 항목의 bn_id
-    const nextCursor = sort === 'latest' && items.length > 0 ? items[items.length - 1].bn_id : null;
+    // 다음 페이지 커서: **조회된 원본 행**의 마지막 bn_id.
+    //
+    // ⛔ items 를 쓰면 안 된다. 한 페이지가 전부 걸러지는 경우(삭제글만 있는 구간) items 가
+    //    비어 nextCursor 가 null 이 되고, 뒤에 남은 글이 있는데도 **다음 페이지가 막힌다.**
+    //    삭제 필터를 넣으면서 그 확률이 올라갔으므로 함께 고친다.
+    //    `rows.length === perPage` 는 마지막 페이지 판정까지 겸한다.
+    const nextCursor =
+        sort === 'latest' && rows.length === perPage ? rows[rows.length - 1].bn_id : null;
 
     const result: NewPostsResult = { items, total, nextCursor };
 
@@ -272,8 +382,22 @@ export async function getBoardGroups(): Promise<{ gr_id: string; gr_subject: str
         return boardGroupsCache.data;
     }
 
+    // ⛔ 예전에는 `g5_group` 전량을 반환해 드롭다운에 **글이 0건인 그룹**(운영용·휴지통·
+    //    unused·audit·nerv·beta)까지 전부 떴다. 고를 수는 있는데 고르면 빈 목록이 나오는
+    //    선택지다. 새글모음이 다루는 범위(검색 노출 보드 + 최근 7일)와 같은 기준으로 맞춘다.
     const [rows] = await readPool.query<RowDataPacket[]>(
-        'SELECT gr_id, gr_subject FROM g5_group ORDER BY gr_order, gr_id'
+        `SELECT g.gr_id, g.gr_subject
+		   FROM g5_group g
+		  WHERE EXISTS (
+		        SELECT 1 FROM g5_board b
+		         WHERE b.gr_id = g.gr_id AND b.bo_use_search = 1
+		           AND EXISTS (
+		               SELECT 1 FROM g5_board_new bn
+		                WHERE bn.bo_table = b.bo_table
+		                  AND bn.bn_datetime > DATE_SUB(NOW(), INTERVAL 7 DAY)
+		           )
+		  )
+		  ORDER BY g.gr_order, g.gr_id`
     );
     const data = rows as { gr_id: string; gr_subject: string }[];
     boardGroupsCache = { data, expiry: Date.now() + BOARD_GROUPS_CACHE_TTL };

--- a/apps/web/src/routes/feed/+page.server.ts
+++ b/apps/web/src/routes/feed/+page.server.ts
@@ -5,7 +5,12 @@
  * posts: 스트리밍 (Promise, 스켈레톤 → 데이터)
  */
 import type { PageServerLoad } from './$types';
-import { getNewPosts, getBoardGroups, type FeedSort } from '$lib/server/new-posts.js';
+import {
+    getNewPosts,
+    getBoardGroups,
+    FEED_SCOPE_PRESETS,
+    type FeedSort
+} from '$lib/server/new-posts.js';
 
 export const load: PageServerLoad = async ({ url }) => {
     const view = (url.searchParams.get('view') as string) || '';
@@ -15,11 +20,16 @@ export const load: PageServerLoad = async ({ url }) => {
     const cursor = parseInt(url.searchParams.get('cursor') || '0', 10) || undefined;
     const perPage = 30;
 
+    // ⛔ 프리셋 밖의 값은 '' 로 강등한다. 열어두면 임의 문자열마다 캐시 키·CDN 엔트리가 생겨
+    //    누구나 무한 캐시미스를 만들 수 있다.
+    const rawScope = url.searchParams.get('scope') || '';
+    const scope = FEED_SCOPE_PRESETS.has(rawScope) ? rawScope : '';
+
     // groups는 캐시됨 → 즉시 await (필터 UI 바로 렌더링)
     const groups = await getBoardGroups();
 
     // posts는 스트리밍 → await 하지 않음 (스켈레톤 먼저 보여줌)
-    const postsPromise = getNewPosts(view, grId, page, perPage, cursor, sort);
+    const postsPromise = getNewPosts(view, grId, page, perPage, cursor, sort, scope);
 
     return {
         /** 스트리밍: Promise로 반환 → 클라이언트에서 {#await} 사용 */
@@ -30,6 +40,7 @@ export const load: PageServerLoad = async ({ url }) => {
         currentView: view,
         currentGroup: grId,
         currentSort: sort,
+        currentScope: scope,
         page,
         perPage
     };

--- a/apps/web/src/routes/feed/+page.svelte
+++ b/apps/web/src/routes/feed/+page.svelte
@@ -4,7 +4,9 @@
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import { Button } from '$lib/components/ui/button/index.js';
     import * as Select from '$lib/components/ui/select/index.js';
+    import { browser } from '$app/environment';
     import Newspaper from '@lucide/svelte/icons/newspaper';
+    import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import Eye from '@lucide/svelte/icons/eye';
     import FeedSkeleton from '$lib/components/features/feed/feed-skeleton.svelte';
@@ -13,11 +15,20 @@
 
     let { data }: { data: PageData } = $props();
 
-    // 필터 옵션
+    // 글/댓글 — 「만」을 뺐다. 세그먼트 자체가 배타 선택을 표현하고, 모바일 폭도 아낀다.
     const viewOptions = [
         { value: '', label: '전체' },
-        { value: 'w', label: '글만' },
-        { value: 'c', label: '댓글만' }
+        { value: 'w', label: '글' },
+        { value: 'c', label: '댓글' }
+    ];
+    /**
+     * 범위 — 자유게시판이 새글모음의 89.8%(7일 실측)라 목록의 게시판 이름이 30행 중 27행이
+     * 같은 값이 된다. 이 칩을 눌러야 "다른 게시판에서 무슨 일이 있나"가 비로소 보인다.
+     * ⛔ 값은 서버 `FEED_SCOPE_PRESETS` 와 같은 집합이어야 한다.
+     */
+    const scopeOptions = [
+        { value: '', label: '전체' },
+        { value: 'nofree', label: '자유게시판 제외' }
     ];
     const sortOptions = [
         { value: 'latest', label: '최신순' },
@@ -25,8 +36,20 @@
         { value: 'views', label: '조회순' }
     ];
 
-    const selectedViewLabel = $derived(
-        viewOptions.find((o) => o.value === data.currentView)?.label || '전체'
+    let showAdvanced = $state(false);
+
+    const hasActiveFilter = $derived(
+        Boolean(data.currentView || data.currentScope || data.currentGroup)
+    );
+
+    /** 빈 목록에서 빠져나오는 길. 기억한 값도 함께 지운다 — 안 그러면 다음 방문에 되돌아온다. */
+    function resetFilters(): void {
+        savePrefs({ view: '', scope: '' });
+        goto('/feed');
+    }
+
+    const scopeLabel = $derived(
+        scopeOptions.find((o) => o.value === data.currentScope)?.label || '전체'
     );
 
     const selectedGroupLabel = $derived(
@@ -39,8 +62,58 @@
         sortOptions.find((o) => o.value === data.currentSort)?.label || '최신순'
     );
 
+    /**
+     * 보기 설정 기억.
+     *
+     * ⛔ 쿠키로 하면 안 된다 — 이 응답에는 `Cache-Control: public, s-maxage=10` 이 붙어 있어
+     *    쿠키로 응답을 가르면 공유 캐시가 남의 취향을 서빙한다. 서버는 이 선호를 몰라야 한다.
+     * 실측 근거: `view=w` 가 `page=1` 과 함께 반복 등장 = 매 방문 다시 고르고 있었다.
+     */
+    const PREFS_KEY = 'angple_feed_prefs';
+    let prefsRestored = false;
+
+    function savePrefs(patch: { view?: string; scope?: string }): void {
+        if (!browser) return;
+        try {
+            const cur = JSON.parse(localStorage.getItem(PREFS_KEY) || '{}');
+            localStorage.setItem(PREFS_KEY, JSON.stringify({ ...cur, ...patch }));
+        } catch {
+            // 저장 실패는 무시 — 기억이 안 될 뿐 화면은 정상이다
+        }
+    }
+
+    $effect(() => {
+        if (!browser || prefsRestored) return;
+        prefsRestored = true;
+
+        // ⛔ 쿼리스트링이 **하나라도** 있으면 복원하지 않는다.
+        //    `?view=c` 같은 공유 링크가 개인 설정에 덮이면 안 된다. URL 이 항상 이긴다.
+        if (window.location.search) return;
+
+        let saved: { view?: string; scope?: string };
+        try {
+            saved = JSON.parse(localStorage.getItem(PREFS_KEY) || '{}');
+        } catch {
+            return;
+        }
+
+        const params = new URLSearchParams();
+        // 기본값('')은 파라미터 부재로 표현되므로 truthy 인 것만 복원한다 —
+        // "전체를 골랐는데 다시 글만으로 튕기는" 되돌이가 이 조건에서 자연히 끊긴다.
+        if (saved.view && viewOptions.some((o) => o.value === saved.view)) {
+            params.set('view', saved.view);
+        }
+        if (saved.scope && scopeOptions.some((o) => o.value === saved.scope)) {
+            params.set('scope', saved.scope);
+        }
+        if ([...params].length === 0) return;
+
+        goto(`${window.location.pathname}?${params}`, { replaceState: true });
+    });
+
     // 필터 변경
     function updateFilter(key: string, value: string): void {
+        if (key === 'view' || key === 'scope') savePrefs({ [key]: value });
         const url = new URL(window.location.href);
         if (value) {
             url.searchParams.set(key, value);
@@ -123,23 +196,89 @@
                         <div>
                             <h1 class="text-foreground text-xl font-bold leading-tight">새글</h1>
                             <p class="text-muted-foreground text-sm">
-                                전체 {result.total.toLocaleString()}건
+                                {scopeLabel}
+                                {result.total.toLocaleString()}건
                             </p>
                         </div>
                     </div>
 
-                    <!-- 필터 -->
-                    <div class="flex flex-wrap gap-2">
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        class="text-muted-foreground h-9 gap-1.5 text-sm"
+                        aria-expanded={showAdvanced}
+                        onclick={() => (showAdvanced = !showAdvanced)}
+                    >
+                        <SlidersHorizontal class="h-4 w-4" />
+                        {showAdvanced ? '접기' : '자세한 조건'}
+                    </Button>
+                </div>
+
+                <!--
+                    글/댓글(콘텐츠 종류)과 범위(출처)는 직교하는 축이다.
+                    같은 모양을 쓰면 상하 관계로 오해되므로 세그먼트 ↔ 칩으로 모양을 달리한다.
+                    각 그룹을 자기 div 로 감싸 wrap 이 **그룹 단위**로 일어나게 한다
+                    (칩이 낱개로 흩어지면 어느 축인지 알 수 없다).
+                -->
+                <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+                    <!--
+                        ⛔ Tabs 컴포넌트를 쓰지 않는다. 이건 패널 전환이 아니라 **내비게이션**이다.
+                           role="tab" 은 "누르면 tabpanel 이 바뀐다"고 알리는데 여기엔 패널이 없어
+                           보조기기에 거짓을 말하게 된다. 모양만 세그먼트로 하고 의미는 버튼으로 둔다.
+                    -->
+                    <div
+                        role="group"
+                        aria-label="글과 댓글 중 볼 항목"
+                        class="bg-muted flex h-9 items-center gap-0.5 rounded-lg p-0.5"
+                    >
+                        {#each viewOptions as opt (opt.value)}
+                            <button
+                                type="button"
+                                aria-pressed={data.currentView === opt.value}
+                                class="rounded-md px-3 py-1 text-sm transition-colors {data.currentView ===
+                                opt.value
+                                    ? 'bg-background text-foreground font-medium shadow-sm'
+                                    : 'text-muted-foreground hover:text-foreground'}"
+                                onclick={() => updateFilter('view', opt.value)}
+                            >
+                                {opt.label}
+                            </button>
+                        {/each}
+                    </div>
+
+                    <div class="flex items-center gap-1">
+                        {#each scopeOptions as opt (opt.value)}
+                            <button
+                                type="button"
+                                aria-pressed={data.currentScope === opt.value}
+                                class="rounded-md px-2.5 py-1.5 text-sm transition-colors {data.currentScope ===
+                                opt.value
+                                    ? 'bg-accent text-accent-foreground font-medium'
+                                    : 'text-muted-foreground hover:bg-muted'}"
+                                onclick={() => updateFilter('scope', opt.value)}
+                            >
+                                {opt.label}
+                            </button>
+                        {/each}
+                    </div>
+                </div>
+
+                <!--
+                    정렬·그룹은 실측 사용 0회라 접어 둔다. **지우지는 않는다** —
+                    "안 쓴다"가 "없애도 된다"는 아니고, 되돌리기가 {#if} 제거뿐이어야 한다.
+                -->
+                {#if showAdvanced}
+                    <div class="border-border mt-3 flex flex-wrap gap-2 border-t pt-3">
                         <Select.Root
                             type="single"
-                            value={data.currentView}
-                            onValueChange={(v) => updateFilter('view', v || '')}
+                            value={data.currentSort}
+                            onValueChange={(v) => updateFilter('sort', v || 'latest')}
                         >
-                            <Select.Trigger class="h-9 w-[100px] text-sm"
-                                >{selectedViewLabel}</Select.Trigger
+                            <Select.Trigger class="h-9 w-[110px] text-sm"
+                                >{selectedSortLabel}</Select.Trigger
                             >
                             <Select.Content>
-                                {#each viewOptions as opt (opt.value)}
+                                {#each sortOptions as opt (opt.value)}
                                     <Select.Item value={opt.value}>{opt.label}</Select.Item>
                                 {/each}
                             </Select.Content>
@@ -161,23 +300,8 @@
                                 {/each}
                             </Select.Content>
                         </Select.Root>
-
-                        <Select.Root
-                            type="single"
-                            value={data.currentSort}
-                            onValueChange={(v) => updateFilter('sort', v || 'latest')}
-                        >
-                            <Select.Trigger class="h-9 w-[110px] text-sm"
-                                >{selectedSortLabel}</Select.Trigger
-                            >
-                            <Select.Content>
-                                {#each sortOptions as opt (opt.value)}
-                                    <Select.Item value={opt.value}>{opt.label}</Select.Item>
-                                {/each}
-                            </Select.Content>
-                        </Select.Root>
                     </div>
-                </div>
+                {/if}
             </CardHeader>
 
             <!-- 목록 -->
@@ -189,8 +313,22 @@
                         >
                             <Newspaper class="text-muted-foreground h-8 w-8" />
                         </div>
-                        <p class="text-foreground mb-1 text-lg font-medium">아직 새 글이 없어요</p>
-                        <p class="text-muted-foreground text-sm">첫 번째 글을 작성해보세요!</p>
+                        {#if hasActiveFilter}
+                            <!-- 필터 때문에 빈 것을 "글이 없다"고 하면 거짓말이 된다 -->
+                            <p class="text-foreground mb-1 text-lg font-medium">
+                                선택하신 조건에 해당하는 새 글이 없습니다
+                            </p>
+                            <p class="text-muted-foreground mb-4 text-sm">
+                                조건을 바꾸어 다시 확인해 보세요.
+                            </p>
+                            <Button variant="outline" size="sm" onclick={resetFilters}>
+                                전체 보기
+                            </Button>
+                        {:else}
+                            <p class="text-foreground mb-1 text-lg font-medium">
+                                최근 7일 동안 올라온 새 글이 없습니다
+                            </p>
+                        {/if}
                     </div>
                 {:else}
                     <div class="divide-border divide-y">


### PR DESCRIPTION
## 왜

새글모음은 헤더 최상위 메뉴인데, 열어 보면 **열에 아홉이 자유게시판**입니다.

| 구성 (7일 실측) | 건수 | 비중 |
|---|---|---|
| `free` | 74,858 | **89.8%** |
| `hello` | 2,025 | 2.4% |
| 소모임 91개 보드 합계 | 4,122 | 4.9% |

자유게시판을 볼 사람은 `/free`로 직행합니다. 이 지면의 고유 가치인 *"다른 게시판에서 무슨 일이 있나"*가 90% 노이즈에 묻혀 있었고, 목록의 게시판 이름조차 30행 중 27행이 같은 값이라 정보 구실을 못 했습니다.

**그룹 필터 사용 0회를 "수요 없음"으로 읽지 않았습니다.** 원본 로그(전 파드 32만 줄, 1시간, `/feed` 22건)에서 글/댓글은 13회, 그룹·정렬은 0회였습니다. 발견성 문제는 아닙니다 — 같은 행 같은 크기의 컨트롤이 13회 쓰였습니다. 진짜 이유는 **표현 가능성**입니다. 그룹 Select는 *포함*만 표현하는데 "free를 빼고 나머지 전부"는 이 컨트롤로 표현할 방법이 없습니다. 포함형은 `/car`·`/stock` 보드 페이지가 이미 상위호환이라 안 쓰이는 게 당연합니다.

## 무엇

- **범위 칩** `[전체 / 자유게시판 제외]` — 값은 화이트리스트라 임의 문자열이 캐시 키·CDN 엔트리를 늘리지 못합니다. Set을 비우면 서버측 기능이 꺼집니다
- **글/댓글 세그먼트** — 드롭다운 라벨이 "전체"라 무엇을 거르는지 말해주지 않았습니다. 사용 0회인 정렬·그룹은 `[자세한 조건]` 안으로 **이동**(제거 아님). ⛔Tabs 컴포넌트는 쓰지 않았습니다 — 패널 전환이 아니라 내비게이션이라 `role="tab"`이 가리킬 tabpanel이 없습니다
- **선택 기억** — `view=w`가 `page=1`과 함께 반복 등장한 건 매 방문 다시 고르고 있었다는 뜻입니다. ⛔쿠키 금지(응답에 `s-maxage=10`이 붙어 공유 캐시가 남의 취향을 서빙), 쿼리스트링이 하나라도 있으면 복원하지 않아 **공유 링크가 이깁니다**

## 같이 고친 것

- **삭제글 노출** — 상위 3,000행에 12건이 제목·작성자·본문 미리보기째 나왔습니다. 7/31 삭제 콘텐츠 마스킹에서 목록·검색·활동피드는 다 막았는데 새글모음만 별도 쿼리 경로라 빠졌습니다(`g5_board_new`는 소프트 삭제 때 정리되지 않아 최근 7일 1,385건 중 1,027건 잔존)
- **`nextCursor` 결함** — `items` 기준이라 한 페이지가 전부 걸러지면 `null`이 되어 뒤에 글이 남았는데도 다음 페이지가 막혔습니다. 삭제 필터가 확률을 올리므로 함께 고쳤습니다
- **그룹 필터 실행계획** — `b.gr_id`는 인덱스가 없어 드라이빙 테이블이 뒤집힙니다. 보드 목록으로 풀어 `bn.bo_table`로 겁니다.

  ⚠️ **개선 폭은 그룹마다 다릅니다**(검증에서 정정). 소모임(91개 보드)은 temporary+filesort가 사라지고 0.11s→0.08s. 반면 `community`(7개 보드)는 그 안에 `free`가 있어 **새 경로에서도 플랜이 되돌아오고 시간도 동등**(0.95s→0.90s)했습니다. 회귀는 없습니다.
- **0건 그룹** — 드롭다운에 운영용·휴지통·audit 등 고르면 빈 목록이 나오는 선택지가 전부 떴습니다(16개 → 7개)
- **WHERE 복붙 통합** — 목록과 COUNT가 복붙이라 한쪽만 고치면 "목록엔 없는데 건수는 그대로"가 조용히 생깁니다. 캐시 키 **두 곳 모두**에 scope를 넣었습니다(L2는 전 사용자 공유)

## 하지 않은 것

- 소모임 칩 — `/groups` 전용 지면이 이미 담당
- 기본값을 free 제외로 뒤집기 — 83,323→8,465로 보여 장애로 인식됩니다
- 임의 보드 다중선택 — 캐시 키가 2^N
- 정렬·그룹 제거 — 이동만
- DDL·백엔드·CDN 정책 무변경

## 승격 전 카나리 실측 필요

코드로는 확인했으나 **떠 있지 않으면 볼 수 없는 것** 2가지:

- 파드 2개 이상에서 「전체」 → 「자유게시판 제외」 연속 조회 시 free 행 0건 (L2 Redis 공유 캐시 격리)
- 360px 2줄 / 640px 1줄 반응형, SSR/hydration 경고 0

## 출시 후 판정 기준

「자유게시판 제외」에 대한 **직접 로그 증거는 없습니다**(구성비 89.8%에서 추론, 필터 표본 22건). 사전에 못박습니다 — 7일간 `scope=nofree` 비중이 **3% 미만이면 칩을 철회**합니다.