### PR TITLE
사이드바에 월별 후원 현황 카드

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -448,14 +448,16 @@
                 <span aria-hidden="true" class="leading-none">→</span>
             </a>
             <!--
-                다모앙 마을(벽돌한장) 1줄 카드. 후원이 벽돌로 쌓이는 곳이라 후원 카드 계열에 붙인다.
+                월별 후원 현황(/brickang) 1줄 카드. 후원 카드 계열이라 바로 아래에 붙인다.
+                문구가 '다모앙 마을'이 아니라 '월별 후원 현황'인 이유: 이 링크로 가서
+                맨 먼저 보이는 것이 월별 후원 그래프라, 라벨과 도착 지점을 맞춘 것이다.
                 ⛔ 위 두 카드와 달리 **내부 링크**다 — target="_blank" 를 붙이지 않는다.
             -->
             <a
                 href="/brickang"
                 class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 mt-2 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
             >
-                <span>🧱 다모앙 마을</span>
+                <span>♡ 월별 후원 현황</span>
                 <span aria-hidden="true" class="leading-none">→</span>
             </a>
         {/if}

--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -447,6 +447,17 @@
                 <span>♡ 마음메시지 신청하기</span>
                 <span aria-hidden="true" class="leading-none">→</span>
             </a>
+            <!--
+                다모앙 마을(벽돌한장) 1줄 카드. 후원이 벽돌로 쌓이는 곳이라 후원 카드 계열에 붙인다.
+                ⛔ 위 두 카드와 달리 **내부 링크**다 — target="_blank" 를 붙이지 않는다.
+            -->
+            <a
+                href="/brickang"
+                class="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 mt-2 flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors"
+            >
+                <span>🧱 다모앙 마을</span>
+                <span aria-hidden="true" class="leading-none">→</span>
+            </a>
         {/if}
         <div class:hidden={!widgetLayoutStore.hasEnabledAds}>
             {#if compact}{:else}


### PR DESCRIPTION
## 왜

후원이 벽돌로 쌓이는 곳(`/brickang`)인데 사이드바에 들어가는 길이 없었습니다. 후원하기·마음메시지 신청하기와 같은 계열이라 바로 아래에 같은 1줄 카드 스타일로 붙입니다.

```
♡ 다모앙 후원하기      →
♡ 마음메시지 신청하기   →
🧱 다모앙 마을         →   ← 신규
```

## 주의

- ⛔ 앞 두 카드와 달리 **내부 링크**라 `target="_blank"` 를 붙이지 않았습니다
- 데스크톱 전용(`{#if !compact}`) — 앞 카드들과 동일
- `sidebar.svelte` 는 premium 포크가 없어 코어 수정이 안전합니다(확인함)

## 짝 PR

`/brickang` HUD 재배치 = premium#143