### PR TITLE
fix(sidebar): 마음메시지 없을 때 점선 플레이스홀더를 그리지 않음

### DIFF
--- a/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
+++ b/apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte
@@ -286,17 +286,8 @@
         </a>
     {:else if useFallback}
         {#if position === 'sidebar'}
-            <!-- 사이드바: 마음메시지/광고 없으면 빈 플레이스홀더 -->
-            <div
-                class="flex items-center justify-center rounded-lg border border-dashed border-slate-200 bg-slate-50/50 dark:border-slate-700 dark:bg-slate-800/30"
-                style:min-height="40px"
-            >
-                <a
-                    href="/message"
-                    class="text-[10px] text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
-                    >마음메시지가 없습니다</a
-                >
-            </div>
+            <!-- 사이드바: 보여줄 마음메시지가 없으면 **아무것도 그리지 않는다**.
+                 점선 플레이스홀더는 빈 자리를 오히려 부각시켜 사이드바를 어수선하게 만들었다. -->
         {:else if gamFallback}
             <!-- GAM 폴백 (gamFallback=true일 때만) -->
             <AdSlot position={gamPosition} {height} slotKey={`damoang-banner-${position}`} />


### PR DESCRIPTION
## 변경

사이드바에 보여줄 마음메시지가 없을 때 뜨던 점선 플레이스홀더를 제거합니다.

```html
<!-- 이전 -->
<div class="... border-dashed ..." style="min-height:40px">
  <a href="/message">마음메시지가 없습니다</a>
</div>
```

빈 자리를 오히려 부각시켜 사이드바가 어수선해 보였습니다. 없으면 아무것도 그리지 않는 편이 낫습니다.

**데이터가 있을 때의 카드**(제목·이미지·더보기 링크)는 **그대로 유지**됩니다. 이 변경은 `position === 'sidebar'` 이면서 표시할 항목이 없는 경우에만 해당합니다.

## 위치

`apps/web/src/lib/components/ui/damoang-banner/damoang-banner.svelte` — `position === 'sidebar'` 분기

같은 문자열이 `celebration-rolling.svelte` 에도 있지만 그쪽은 **높이 h-9 의 다른 컴포넌트**로, 이번 대상이 아닙니다(사장님이 지목한 마크업의 `min-height:40px` + `text-[10px]` 은 damoang-banner 쪽).

## 함께 진행된 것 (코드 아님)

소모임(`trending-groups`) 위젯이 사이드바에서 사라진 건 **DB 레이아웃(`angple_settings.sidebar_widget_layout`)에서 빠진 것**이라 코드 변경이 아닙니다. 별도 SQL 로 복구합니다.
