### PR TITLE
feat(board): 목록→상세 이동 시 방금 본 목록 재사용 — 하단 목록 스켈레톤 제거

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -4,6 +4,7 @@
     import { apiClient } from '$lib/api/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { takeBoardList } from '$lib/stores/board-list-carryover.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import Search from '@lucide/svelte/icons/search';
     import {
@@ -50,6 +51,8 @@
         initialPosts?: FreePost[];
         initialTotal?: number;
         initialTotalPages?: number;
+        /** 서버(load)가 page-index 를 이미 해소했으면 true — 클라 중복 조회를 건너뛴다 */
+        pageIndexResolved?: boolean;
         promotionPosts?: PromotionPost[];
         displaySettings?: BoardDisplaySettings;
     }
@@ -63,6 +66,7 @@
         initialPosts = [],
         initialTotal = 0,
         initialTotalPages = 1,
+        pageIndexResolved = false,
         promotionPosts = [],
         displaySettings
     }: Props = $props();
@@ -252,6 +256,7 @@
             // 자기 글이 어느 페이지인지 자동 감지해서 그 페이지로 fetch. SSR 가 항상 1 로
             // 고정한 부분을 클라이언트가 보강. PR #1431 의 SPA 재마운트 fix 와 함께 동작.
             if (
+                !pageIndexResolved &&
                 isOnPostDetail &&
                 currentPostId > 0 &&
                 !$pageStore.url.searchParams.has('page') &&
@@ -301,6 +306,22 @@
     onMount(async () => {
         if (!browser) return;
         if (posts.length > 0) return;
+
+        // 목록 → 상세 이동이면 방금 본 목록을 그대로 재사용 — 요청 0회, 스켈레톤 없음.
+        // URL 에 ?page 가 명시돼 있고 들고 온 페이지와 다르면 재사용하지 않는다(공유 링크 우선).
+        const carried = takeBoardList(boardId);
+        if (carried) {
+            const urlPage = Number($pageStore.url.searchParams.get('page')) || 0;
+            if (urlPage === 0 || urlPage === carried.page) {
+                posts = carried.posts;
+                maskAnonymousMessagePosts();
+                totalItems = carried.total;
+                totalPages = carried.totalPages;
+                currentPage = carried.page;
+                loading = false;
+                return;
+            }
+        }
 
         await loadInitial();
         // 일시적 실패(네트워크 순단 등)는 한 번 더 시도하면 대개 성공한다.

--- a/apps/web/src/lib/stores/board-list-carryover.test.ts
+++ b/apps/web/src/lib/stores/board-list-carryover.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import {
-    rememberBoardList,
-    takeBoardList,
-    clearBoardListCarryover
-} from './board-list-carryover';
+import { rememberBoardList, takeBoardList, clearBoardListCarryover } from './board-list-carryover';
 import type { FreePost } from '$lib/api/types';
 
 const post = (id: number) => ({ id, title: 't' + id }) as FreePost;

--- a/apps/web/src/lib/stores/board-list-carryover.test.ts
+++ b/apps/web/src/lib/stores/board-list-carryover.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    rememberBoardList,
+    takeBoardList,
+    clearBoardListCarryover
+} from './board-list-carryover';
+import type { FreePost } from '$lib/api/types';
+
+const post = (id: number) => ({ id, title: 't' + id }) as FreePost;
+
+describe('board-list-carryover — 목록→상세 재사용', () => {
+    beforeEach(() => {
+        clearBoardListCarryover();
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it('같은 보드는 돌려주고, 다른 보드는 null', () => {
+        rememberBoardList({ boardId: 'free', page: 2, posts: [post(1)], total: 30, totalPages: 2 });
+        expect(takeBoardList('free')?.page).toBe(2);
+        expect(takeBoardList('qa')).toBeNull();
+    });
+
+    it('비파괴 읽기 — 연달아 여러 글을 봐도 유지, 반환 배열은 복사본', () => {
+        rememberBoardList({ boardId: 'free', page: 1, posts: [post(1)], total: 1, totalPages: 1 });
+        const a = takeBoardList('free');
+        a!.posts.push(post(99));
+        const b = takeBoardList('free');
+        expect(b!.posts).toHaveLength(1);
+    });
+
+    it('TTL 60초 초과 시 null (폴백 fetch 경로로)', () => {
+        rememberBoardList({ boardId: 'free', page: 1, posts: [post(1)], total: 1, totalPages: 1 });
+        vi.setSystemTime(59_000);
+        expect(takeBoardList('free')).not.toBeNull();
+        vi.setSystemTime(61_000);
+        expect(takeBoardList('free')).toBeNull();
+    });
+
+    it('빈 목록은 기억하지 않는다', () => {
+        rememberBoardList({ boardId: 'free', page: 1, posts: [], total: 0, totalPages: 1 });
+        expect(takeBoardList('free')).toBeNull();
+    });
+});

--- a/apps/web/src/lib/stores/board-list-carryover.ts
+++ b/apps/web/src/lib/stores/board-list-carryover.ts
@@ -1,0 +1,53 @@
+/**
+ * 게시판 목록 재사용(carryover) — 클라이언트 메모리 전용.
+ *
+ * 목록 → 글 상세로 이동하는 사용자는 방금 그 목록을 보고 있었다. 그 데이터를 버리지 않고
+ * 들고 가면 상세 하단 목록을 **요청 0회로 즉시** 그릴 수 있다(스켈레톤 제거).
+ *
+ * 왜 SSR 주입(initialPosts)이 아니라 클라 스토어인가:
+ * - 글 상세 HTML 은 익명 사용자에게 캐시된다. 목록을 SSR 에 실으면 캐시가 사는 동안
+ *   하단 목록이 굳는다(#12315 "특정 날짜 글 고정 노출" 실사고). 이 스토어는 사용자
+ *   본인이 몇 초 전에 본 데이터만 본인에게 보여주므로 그 문제가 원천적으로 없다.
+ * - __data.json 에 목록 24건을 싣지 않아 payload 도 늘지 않는다.
+ *
+ * 원칙:
+ * - 순수 목록 화면(쿼리가 page 뿐)에서만 기억한다 — 검색·카테고리·작성자필터·날짜 화면은
+ *   상세 하단이 가져올 "일반 목록"과 다르므로 재사용하면 틀린 화면이 된다.
+ * - TTL 60초. 지나면 폴백(fetch)이 항상 있다 — 스토어가 비면 지금과 동일하게 동작한다.
+ * - 비파괴 읽기 — 같은 목록에서 여러 글을 연달아 볼 수 있다.
+ */
+import type { FreePost } from '$lib/api/types.js';
+
+export interface CarriedBoardList {
+    boardId: string;
+    page: number;
+    posts: FreePost[];
+    total: number;
+    totalPages: number;
+    savedAt: number;
+}
+
+const TTL_MS = 60_000;
+
+let entry: CarriedBoardList | null = null;
+
+export function rememberBoardList(input: Omit<CarriedBoardList, 'savedAt'>): void {
+    if (!input.posts.length) return;
+    entry = { ...input, savedAt: Date.now() };
+}
+
+export function takeBoardList(boardId: string): CarriedBoardList | null {
+    if (!entry) return null;
+    if (entry.boardId !== boardId) return null;
+    if (Date.now() - entry.savedAt > TTL_MS) {
+        entry = null;
+        return null;
+    }
+    // 배열은 복사해 소비 측 재대입/변형이 스토어·목록 페이지 데이터와 얽히지 않게 한다.
+    return { ...entry, posts: [...entry.posts] };
+}
+
+/** 테스트용 초기화 */
+export function clearBoardListCarryover(): void {
+    entry = null;
+}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -78,6 +78,7 @@
     import User from '@lucide/svelte/icons/user';
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import SearchForm from '$lib/components/features/board/search-form.svelte';
+    import { rememberBoardList } from '$lib/stores/board-list-carryover.js';
     import BulkActionsToolbar from '$lib/components/features/board/bulk-actions-toolbar.svelte';
     import { Checkbox } from '$lib/components/ui/checkbox/index.js';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
@@ -200,6 +201,23 @@
 
     // 현재 페이지 번호 (글 링크에 전달용)
     const listPage = $derived(Number($page.url.searchParams.get('page')) || 1);
+
+    // 목록 → 상세 재사용: 순수 목록 화면(쿼리가 page 뿐)일 때 현재 목록을 기억해 두면
+    // 글 상세 하단 목록이 요청 없이 즉시 그려진다($effect 는 SSR 미실행 — 클라 전용).
+    // 검색·카테고리·작성자필터·날짜 화면은 상세 하단의 "일반 목록"과 다르므로 제외.
+    $effect(() => {
+        const result = data.postsData;
+        if (!result?.posts?.length) return;
+        const extraParams = [...$page.url.searchParams.keys()].filter((k) => k !== 'page');
+        if (extraParams.length > 0) return;
+        rememberBoardList({
+            boardId,
+            page: result.pagination?.page || listPage,
+            posts: result.posts,
+            total: result.pagination?.total ?? result.posts.length,
+            totalPages: result.pagination?.totalPages ?? 1
+        });
+    });
 
     // #12012: 보드별 "내가 쓴 글/댓글" 빠른 필터
     // 백엔드 ?sfl=author|comment_author&stx={mb_id} 재사용 (Sphinx @(mb_id,wr_name) 매칭)

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2636,6 +2636,7 @@
                 initialPage={Number($page.url.searchParams.get('page')) ||
                     data.recentPosts?.page ||
                     1}
+                pageIndexResolved={true}
                 {promotionPosts}
                 displaySettings={data.board?.display_settings}
             />


### PR DESCRIPTION
## 왜

리스트 → 상세로 들어가면 하단 목록이 스켈레톤 → fetch → 표시 순서로 그려집니다. 그런데 **사용자는 방금 그 목록을 보고 있었습니다.** 브라우저 메모리에 있는 데이터를 버리고 서버에 다시 달라고 하는 구조였습니다.

## 왜 SSR 주입이 아닌가

`+page.server.ts` 주석에 이유가 이미 있습니다 — 글 상세 HTML 은 익명 캐시되므로 목록을 SSR 에 실으면 **캐시가 사는 동안 하단 목록이 굳습니다**(#12315 "특정 날짜 글 고정 노출" 실사고). `__data.json` 도 커집니다.

클라 메모리 스토어는 **본인이 몇 초 전에 본 데이터를 본인에게만** 보여주므로 두 문제가 원천적으로 없습니다.

## 무엇

| | |
|---|---|
| `board-list-carryover.ts` 신설 | TTL 60초, 비파괴 읽기(연달아 여러 글 열람 지원), 단위테스트 4건 |
| 목록 페이지 | **순수 목록(쿼리가 `page` 뿐)일 때만** 기억 — 검색·카테고리·작성자필터·날짜 화면은 상세 하단의 "일반 목록"과 다르므로 제외 (#1933 화이트리스트 철학) |
| `RecentPosts` | `onMount` 에서 재사용 → **요청 0회, 스켈레톤은 hydration 한 프레임뿐**. URL `?page` 가 명시돼 있고 들고 온 페이지와 다르면 재사용 안 함(공유 링크 우선). 스토어 미스 시 기존과 동일(fetch 폴백) |
| 직접 진입 폴백 | 서버(load)가 page-index 를 이미 해소하는데 클라가 또 조회하던 **중복 직렬 RTT 제거**(`pageIndexResolved`) — 검색/외부링크 진입도 스켈레톤 시간 절반 |

props 가 아니라 `onMount` 재사용인 이유: SSR 은 스토어를 모르므로 **hydration 불일치가 원천적으로 없습니다.**

## 검증

- [ ] 단위테스트 4건 (TTL·보드 매칭·비파괴·빈 목록)
- [ ] 카나리: 목록→상세 이동 시 하단 목록 즉시 표시(브라우저 확인)
- [ ] 직접 진입(새로고침): 기존과 동일 + page-index 요청 1회 감소
- [ ] 검색 화면에서 진입: 재사용 안 됨(일반 목록 fetch)
