### PR TITLE
내 신고 내역 페이지 (/my/reports)

### DIFF
--- a/apps/web/src/lib/components/features/my/my-nav.svelte
+++ b/apps/web/src/lib/components/features/my/my-nav.svelte
@@ -8,6 +8,7 @@
     import Bookmark from '@lucide/svelte/icons/bookmark';
     import NotepadText from '@lucide/svelte/icons/notepad-text';
     import Users from '@lucide/svelte/icons/users';
+    import Flag from '@lucide/svelte/icons/flag';
     import Palette from '@lucide/svelte/icons/palette';
     import Settings from '@lucide/svelte/icons/settings';
     import type { Component } from 'svelte';
@@ -49,7 +50,8 @@
                     '/my/blocked',
                     '/my/scraps',
                     '/my/memos',
-                    '/my/following'
+                    '/my/following',
+                    '/my/reports'
                 ].some((href) => pathname.startsWith(href)),
             children: [
                 { href: '/my/points', label: '포인트', icon: Coins, exact: false },
@@ -57,7 +59,8 @@
                 { href: '/my/scraps', label: '스크랩', icon: Bookmark, exact: false },
                 { href: '/my/following', label: '팔로잉', icon: Users, exact: false },
                 { href: '/my/blocked', label: '차단목록', icon: Ban, exact: false },
-                { href: '/my/memos', label: '회원메모', icon: NotepadText, exact: false }
+                { href: '/my/memos', label: '회원메모', icon: NotepadText, exact: false },
+                { href: '/my/reports', label: '신고 내역', icon: Flag, exact: false }
             ]
         },
         {

--- a/apps/web/src/lib/server/my-reports.ts
+++ b/apps/web/src/lib/server/my-reports.ts
@@ -22,6 +22,8 @@ const LABEL_NO_TITLE = '(제목 없음)';
 
 export interface MyReportItem {
     boardId: string;
+    /** 신고 대상 wr_id — (boardId, targetId) 가 그룹 PK 라 목록 키로 안전하다 */
+    targetId: number;
     boardName: string;
     /** 'post' | 'comment' */
     targetType: 'post' | 'comment';
@@ -196,6 +198,7 @@ export async function getMyReports(
 
         return {
             boardId: g.sg_table,
+            targetId: g.sg_id,
             boardName: boardNames.get(g.sg_table) ?? g.sg_table,
             targetType: isComment ? 'comment' : 'post',
             title,

--- a/apps/web/src/lib/server/my-reports.ts
+++ b/apps/web/src/lib/server/my-reports.ts
@@ -1,0 +1,214 @@
+/**
+ * 내가 신고한 목록 (/my/reports) 데이터 접근.
+ *
+ * ⛔ 처리 결과는 **조회 자체를 하지 않는다.** `g5_na_singo` 의 processed·monitoring_*·admin_*·
+ *    hold 는 SELECT 컬럼에 없다 — "무엇을 신고했는지"까지만 보여준다는 정책(신고자 통보 금지
+ *    원칙과의 충돌 회피)을 쿼리 수준에서 강제한다. `SELECT *` 로 바꾸는 순간 정책이 깨진다.
+ *
+ * 그룹핑: 제출 한 번에 사유(sg_type)별로 행이 여러 개 들어가지만(백엔드가 사유 루프 INSERT),
+ * 같은 제출은 (sg_table, sg_id, mb_id) 중복 차단 + 단일 now 공유이므로
+ * (sg_table, sg_id) 그룹이 정확히 "신고 1건"이다.
+ */
+import { readPool } from '$lib/server/db.js';
+import type { RowDataPacket } from 'mysql2';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
+
+const SAFE_TABLE_RE = /^[a-zA-Z0-9_]+$/;
+
+/** 대괄호 = 상태 표기 규약(#13097 계열). 삭제·비밀은 제목을 노출하지 않고 링크도 걸지 않는다. */
+const LABEL_DELETED_POST = '[삭제된 게시물]';
+const LABEL_SECRET_POST = '[비밀글]';
+const LABEL_NO_TITLE = '(제목 없음)';
+
+export interface MyReportItem {
+    boardId: string;
+    boardName: string;
+    /** 'post' | 'comment' */
+    targetType: 'post' | 'comment';
+    /** 마스킹이 끝난 표시 제목 (댓글이면 원글 제목) */
+    title: string;
+    /** null 이면 링크를 걸지 않는다(삭제·비밀) */
+    href: string | null;
+    /** 신고한 댓글이 그 뒤 삭제된 경우 */
+    commentDeleted: boolean;
+    /** 사유 코드들 — 라벨 변환은 클라이언트 `getReportReasonLabel` 몫 */
+    reasonCodes: number[];
+    /** 내가 적은 상세 사유 (내 입력물) */
+    detail: string;
+    reportedAt: string;
+}
+
+export interface MyReportsResult {
+    items: MyReportItem[];
+    total: number;
+    page: number;
+    totalPages: number;
+    /** ⛔ 조회 실패를 0건으로 위장하지 않는다 — UI 가 이 필드로 분기한다 */
+    error: boolean;
+}
+
+interface GroupRow extends RowDataPacket {
+    sg_table: string;
+    sg_id: number;
+    sg_parent: number;
+    sg_time: Date | string;
+    sg_desc: string | null;
+    types: string;
+}
+
+interface WriteRow extends RowDataPacket {
+    wr_id: number;
+    wr_subject: string | null;
+    wr_option: string | null;
+    wr_deleted_at: Date | string | null;
+    wr_is_comment: number;
+}
+
+/** search/+server.ts 선례와 같은 판정식 — '0000-00-00' 과 빈 문자열은 살아있는 글로 본다 */
+function isDeleted(v: unknown): boolean {
+    return v !== null && v !== undefined && String(v) !== '0000-00-00 00:00:00' && String(v) !== '';
+}
+
+export async function getMyReports(
+    mbId: string,
+    page: number,
+    limit = 20
+): Promise<MyReportsResult> {
+    const offset = (Math.max(1, page) - 1) * limit;
+    const empty: MyReportsResult = { items: [], total: 0, page, totalPages: 1, error: false };
+
+    let groups: GroupRow[];
+    let total: number;
+    try {
+        // sg_flag=0 — 게시물(글·댓글)만. 1·2 는 앙몰 상품후기/문의로 대상 테이블 체계가 다르다.
+        const [[countRows], [rows]] = await Promise.all([
+            readPool.query<RowDataPacket[]>(
+                `SELECT COUNT(DISTINCT sg_table, sg_id) AS total
+                   FROM g5_na_singo
+                  WHERE mb_id = ? AND sg_flag = 0`,
+                [mbId]
+            ),
+            readPool.query<GroupRow[]>(
+                `SELECT sg_table, sg_id,
+                        MIN(sg_parent) AS sg_parent,
+                        MIN(sg_time)   AS sg_time,
+                        MIN(sg_desc)   AS sg_desc,
+                        GROUP_CONCAT(DISTINCT sg_type ORDER BY sg_type) AS types
+                   FROM g5_na_singo
+                  WHERE mb_id = ? AND sg_flag = 0
+                  GROUP BY sg_table, sg_id
+                  ORDER BY sg_time DESC
+                  LIMIT ?, ?`,
+                [mbId, offset, limit]
+            )
+        ]);
+        total = Number(countRows[0]?.total ?? 0);
+        groups = rows;
+    } catch (err) {
+        console.error('[my-reports] 목록 조회 실패:', err);
+        return { ...empty, error: true };
+    }
+    if (groups.length === 0) {
+        return { ...empty, total, totalPages: Math.max(1, Math.ceil(total / limit)) };
+    }
+
+    // ── 대상 글 배치 조회 (보드별 IN — scrap.ts·new-posts.ts 관용구) ──
+    // 댓글 신고는 댓글 행(sg_id)과 원글 행(sg_parent) 둘 다 필요하다:
+    // 제목은 원글에서, "댓글이 그 뒤 삭제됐는지"는 댓글 행에서 본다.
+    const idsByTable = new Map<string, Set<number>>();
+    for (const g of groups) {
+        if (!SAFE_TABLE_RE.test(g.sg_table)) continue;
+        const set = idsByTable.get(g.sg_table) ?? new Set<number>();
+        set.add(g.sg_id);
+        if (g.sg_parent) set.add(g.sg_parent);
+        idsByTable.set(g.sg_table, set);
+    }
+
+    const writeMap = new Map<string, WriteRow>(); // "table:wrId"
+    const disciplinedMap = new Map<string, Set<number>>(); // table → wr_id 집합
+    const boardNames = new Map<string, string>();
+
+    await Promise.all([
+        ...[...idsByTable.entries()].map(async ([table, ids]) => {
+            try {
+                const [rows] = await readPool.query<WriteRow[]>(
+                    `SELECT wr_id, wr_subject, wr_option, wr_deleted_at, wr_is_comment
+                       FROM \`g5_write_${table}\`
+                      WHERE wr_id IN (?)`,
+                    [[...ids]]
+                );
+                for (const r of rows) writeMap.set(`${table}:${r.wr_id}`, r);
+            } catch {
+                // 보드가 삭제돼 테이블이 없으면 대상도 '[삭제된 게시물]' 로 떨어진다
+            }
+            try {
+                disciplinedMap.set(table, await findDisciplinedIds(table, [...ids]));
+            } catch {
+                disciplinedMap.set(table, new Set());
+            }
+        }),
+        (async () => {
+            try {
+                const [rows] = await readPool.query<RowDataPacket[]>(
+                    `SELECT bo_table, bo_subject FROM g5_board WHERE bo_table IN (?)`,
+                    [[...idsByTable.keys()]]
+                );
+                for (const r of rows) boardNames.set(String(r.bo_table), String(r.bo_subject));
+            } catch {
+                // 이름을 못 얻으면 bo_table 원문으로 표기
+            }
+        })()
+    ]);
+
+    const items: MyReportItem[] = groups.map((g) => {
+        const isComment = g.sg_id !== g.sg_parent && g.sg_parent > 0;
+        const titleSourceId = isComment ? g.sg_parent : g.sg_id;
+        const post = writeMap.get(`${g.sg_table}:${titleSourceId}`);
+        const commentRow = isComment ? writeMap.get(`${g.sg_table}:${g.sg_id}`) : undefined;
+        const disciplined = disciplinedMap.get(g.sg_table) ?? new Set<number>();
+
+        // 대상 상태 재판정 — 신고 시점의 제목이 아니라 **지금 상태** 기준. 신고 후 글이
+        // 삭제·비밀 처리됐다면 이 목록이 원제목 유출 통로가 되면 안 된다.
+        let title: string;
+        let href: string | null;
+        if (!post || isDeleted(post.wr_deleted_at)) {
+            title = LABEL_DELETED_POST;
+            href = null;
+        } else if ((post.wr_option ?? '').includes('secret')) {
+            title = LABEL_SECRET_POST;
+            href = null;
+        } else if (disciplined.has(titleSourceId)) {
+            // 근거글은 상세가 blur+워터마크로 열리는 정책이라 링크는 유지한다
+            title = DISCIPLINED_TITLE;
+            href = isComment
+                ? `/${g.sg_table}/${g.sg_parent}#c_${g.sg_id}`
+                : `/${g.sg_table}/${g.sg_id}`;
+        } else {
+            title = (post.wr_subject ?? '').trim() || LABEL_NO_TITLE;
+            href = isComment
+                ? `/${g.sg_table}/${g.sg_parent}#c_${g.sg_id}`
+                : `/${g.sg_table}/${g.sg_id}`;
+        }
+
+        const commentDeleted = isComment && (!commentRow || isDeleted(commentRow.wr_deleted_at));
+        // 삭제된 댓글의 앵커는 죽어 있다 — 원글이 살아 있으면 앵커만 뗀다
+        if (commentDeleted && href) href = `/${g.sg_table}/${g.sg_parent}`;
+
+        return {
+            boardId: g.sg_table,
+            boardName: boardNames.get(g.sg_table) ?? g.sg_table,
+            targetType: isComment ? 'comment' : 'post',
+            title,
+            href,
+            commentDeleted,
+            reasonCodes: String(g.types ?? '')
+                .split(',')
+                .map(Number)
+                .filter((n) => Number.isFinite(n)),
+            detail: (g.sg_desc ?? '').trim(),
+            reportedAt: new Date(g.sg_time).toISOString()
+        };
+    });
+
+    return { items, total, page, totalPages: Math.max(1, Math.ceil(total / limit)), error: false };
+}

--- a/apps/web/src/routes/my/reports/+page.server.ts
+++ b/apps/web/src/routes/my/reports/+page.server.ts
@@ -1,0 +1,22 @@
+/**
+ * /my/reports — 내가 신고한 목록.
+ *
+ * 인증 게이트는 /my/+layout.server.ts 가 이미 처리한다(비로그인 → /login redirect).
+ * 데이터는 SvelteKit 서버 직접 쿼리 — Go 백엔드에 na_singo 핸들러가 없고,
+ * /my 목록 계열(scraps·following)의 기존 방식과 같다.
+ */
+import type { PageServerLoad } from './$types';
+import { getMyReports } from '$lib/server/my-reports.js';
+
+export const load: PageServerLoad = async ({ url, locals, depends }) => {
+    depends('app:my-reports');
+
+    const mbId = locals.user?.id;
+    const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10) || 1);
+
+    if (!mbId) {
+        return { reports: { items: [], total: 0, page: 1, totalPages: 1, error: false } };
+    }
+
+    return { reports: await getMyReports(mbId, page) };
+};

--- a/apps/web/src/routes/my/reports/+page.svelte
+++ b/apps/web/src/routes/my/reports/+page.svelte
@@ -99,7 +99,7 @@
             </div>
         {:else}
             <ul class="divide-border divide-y">
-                {#each reports.items as item (item.boardId + ':' + item.href + ':' + item.reportedAt)}
+                {#each reports.items as item (item.boardId + ':' + item.targetId)}
                     <li class="px-4 py-3">
                         <div class="flex items-start justify-between gap-3">
                             <div class="min-w-0 flex-1">
@@ -144,7 +144,7 @@
                                     </p>
                                 {/if}
                             </div>
-                            <time class="text-muted-foreground shrink-0 text-xs">
+                            <time datetime={item.reportedAt} class="text-muted-foreground shrink-0 text-xs">
                                 {formatDate(item.reportedAt)}
                             </time>
                         </div>

--- a/apps/web/src/routes/my/reports/+page.svelte
+++ b/apps/web/src/routes/my/reports/+page.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+    /**
+     * 내가 신고한 목록 (SSR).
+     *
+     * ⛔ 처리 결과(인용/기각/처리중)는 표시하지 않는다 — "무엇을 신고했는지"까지만.
+     *    신고자 통보 금지 원칙과의 충돌을 화면 설계에서 회피한 것으로, 서버도
+     *    처리 컬럼을 아예 SELECT 하지 않는다($lib/server/my-reports.ts).
+     */
+    import { goto } from '$app/navigation';
+    import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { Badge } from '$lib/components/ui/badge/index.js';
+    import Flag from '@lucide/svelte/icons/flag';
+    import MessageSquare from '@lucide/svelte/icons/message-square';
+    import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+    import ChevronRight from '@lucide/svelte/icons/chevron-right';
+    import { getReportReasonLabel } from '$lib/utils/report-reasons.js';
+    import type { PageData } from './$types.js';
+
+    let { data }: { data: PageData } = $props();
+
+    const reports = $derived(data.reports);
+
+    function formatDate(iso: string): string {
+        const d = new Date(iso);
+        return d.toLocaleDateString('ko-KR', {
+            timeZone: 'Asia/Seoul',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        });
+    }
+
+    function goToPage(pageNum: number): void {
+        const params = new URLSearchParams();
+        params.set('page', String(pageNum));
+        goto(`/my/reports?${params.toString()}`);
+    }
+
+    function getPageNumbers(current: number, total: number): (number | '...')[] {
+        if (total <= 5) {
+            return Array.from({ length: total }, (_, i) => i + 1);
+        }
+        const pages: (number | '...')[] = [];
+        if (current <= 3) {
+            for (let i = 1; i <= 4; i++) pages.push(i);
+            pages.push('...');
+            pages.push(total);
+        } else if (current >= total - 2) {
+            pages.push(1);
+            pages.push('...');
+            for (let i = total - 3; i <= total; i++) pages.push(i);
+        } else {
+            pages.push(1);
+            pages.push('...');
+            for (let i = current - 1; i <= current + 1; i++) pages.push(i);
+            pages.push('...');
+            pages.push(total);
+        }
+        return pages;
+    }
+</script>
+
+<svelte:head>
+    <title>신고 내역 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+</svelte:head>
+
+<Card class="border-border bg-background rounded-xl border shadow-sm">
+    <CardHeader class="border-border border-b px-4 py-4">
+        <div class="flex items-center gap-3">
+            <div class="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
+                <Flag class="text-primary h-5 w-5" />
+            </div>
+            <div>
+                <CardTitle class="text-xl leading-tight">신고 내역</CardTitle>
+                <p class="text-muted-foreground text-sm">
+                    회원님이 신고하신 내역 {reports.total.toLocaleString()}건입니다.
+                </p>
+            </div>
+        </div>
+    </CardHeader>
+
+    <CardContent class="p-0">
+        {#if reports.error}
+            <div class="py-16 text-center">
+                <p class="text-foreground mb-1 text-lg font-medium">
+                    신고 내역을 불러오지 못했습니다
+                </p>
+                <p class="text-muted-foreground text-sm">잠시 후 다시 시도해 주세요.</p>
+            </div>
+        {:else if reports.items.length === 0}
+            <div class="py-16 text-center">
+                <div
+                    class="bg-muted mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full"
+                >
+                    <Flag class="text-muted-foreground h-8 w-8" />
+                </div>
+                <p class="text-foreground mb-1 text-lg font-medium">신고하신 내역이 없습니다</p>
+            </div>
+        {:else}
+            <ul class="divide-border divide-y">
+                {#each reports.items as item (item.boardId + ':' + item.href + ':' + item.reportedAt)}
+                    <li class="px-4 py-3">
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="min-w-0 flex-1">
+                                <div class="flex flex-wrap items-center gap-1.5">
+                                    <span class="text-muted-foreground shrink-0 text-xs">
+                                        [{item.boardName}]
+                                    </span>
+                                    {#if item.targetType === 'comment'}
+                                        <MessageSquare
+                                            class="text-muted-foreground h-3.5 w-3.5 shrink-0"
+                                        />
+                                    {/if}
+                                    {#if item.href}
+                                        <a
+                                            href={item.href}
+                                            class="text-foreground hover:text-primary truncate text-sm font-medium"
+                                        >
+                                            {item.title}
+                                        </a>
+                                    {:else}
+                                        <!-- 삭제·비밀 대상은 링크를 걸지 않는다 -->
+                                        <span class="text-muted-foreground truncate text-sm">
+                                            {item.title}
+                                        </span>
+                                    {/if}
+                                    {#if item.targetType === 'comment'}
+                                        <span class="text-muted-foreground shrink-0 text-xs">
+                                            글의 댓글{item.commentDeleted ? ' (삭제됨)' : ''}
+                                        </span>
+                                    {/if}
+                                </div>
+                                <div class="mt-1.5 flex flex-wrap items-center gap-1.5">
+                                    {#each item.reasonCodes as code (code)}
+                                        <Badge variant="outline" class="text-xs font-normal">
+                                            {getReportReasonLabel(code)}
+                                        </Badge>
+                                    {/each}
+                                </div>
+                                {#if item.detail}
+                                    <p class="text-muted-foreground mt-1.5 line-clamp-2 text-xs">
+                                        {item.detail}
+                                    </p>
+                                {/if}
+                            </div>
+                            <time class="text-muted-foreground shrink-0 text-xs">
+                                {formatDate(item.reportedAt)}
+                            </time>
+                        </div>
+                    </li>
+                {/each}
+            </ul>
+
+            {#if reports.totalPages > 1}
+                <div
+                    class="border-border flex items-center justify-center gap-1 border-t px-4 py-4"
+                >
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        class="h-8 w-8 p-0"
+                        disabled={reports.page <= 1}
+                        onclick={() => goToPage(reports.page - 1)}
+                        aria-label="이전 페이지"
+                    >
+                        <ChevronLeft class="h-4 w-4" />
+                    </Button>
+                    {#each getPageNumbers(reports.page, reports.totalPages) as p, i (String(p) + i)}
+                        {#if p === '...'}
+                            <span class="text-muted-foreground px-1 text-sm">…</span>
+                        {:else}
+                            <Button
+                                variant={p === reports.page ? 'default' : 'outline'}
+                                size="sm"
+                                class="h-8 w-8 p-0"
+                                onclick={() => goToPage(p)}
+                            >
+                                {p}
+                            </Button>
+                        {/if}
+                    {/each}
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        class="h-8 w-8 p-0"
+                        disabled={reports.page >= reports.totalPages}
+                        onclick={() => goToPage(reports.page + 1)}
+                        aria-label="다음 페이지"
+                    >
+                        <ChevronRight class="h-4 w-4" />
+                    </Button>
+                </div>
+            {/if}
+        {/if}
+    </CardContent>
+</Card>

--- a/apps/web/src/routes/my/reports/+page.svelte
+++ b/apps/web/src/routes/my/reports/+page.svelte
@@ -144,7 +144,10 @@
                                     </p>
                                 {/if}
                             </div>
-                            <time datetime={item.reportedAt} class="text-muted-foreground shrink-0 text-xs">
+                            <time
+                                datetime={item.reportedAt}
+                                class="text-muted-foreground shrink-0 text-xs"
+                            >
                                 {formatDate(item.reportedAt)}
                             </time>
                         </div>


### PR DESCRIPTION
## 왜

"내가 무엇을 신고했는지" 볼 수 있는 화면이 **레거시에도 지금도 없었습니다**(레거시 전수 확인 — 회원 지면의 신고 UI는 제출 모달·글별 신고자 목록뿐). 신규 기능입니다.

## 정책 — 처리 결과는 보여주지 않습니다

인용/기각/처리중 표시 일절 없음. 신고자에게 처리 결과를 알리지 않는 운영 원칙과 충돌하지 않도록 **"무엇을 신고했는지"까지만**이며, 서버가 처리 컬럼(`processed`·`monitoring_*`·`admin_*`·`hold`)을 **SELECT 자체에서 제외**해 쿼리 수준에서 강제합니다.

## 구현

- `(sg_table, sg_id)` 그룹핑 = 신고 1건 (사유별 다중 행 + 제출 중복 차단 + 단일 now 실측 근거). 사유는 `GROUP_CONCAT`, 라벨은 기존 `report-reasons.ts` 재사용
- **대상 상태를 지금 기준으로 재판정** — 신고 후 삭제·비밀 처리된 글의 원제목이 이 목록으로 새면 안 됩니다: `[삭제된 게시물]`/`[비밀글]` 치환 + 링크 제거, 이용제한 근거글은 `[이용제한 근거 글]`(blur 정책이라 링크 유지)
- 댓글 신고: 원글 제목 + 「글의 댓글」, `#c_` 앵커. 댓글이 그 뒤 삭제됐으면 (삭제됨) 표기 + 죽은 앵커 제거
- 조회 실패는 `error` 필드로 — 빈 목록 위장 금지
- 신규 파일 3(`$lib/server/my-reports.ts` · `+page.server.ts` · `+page.svelte`) + `my-nav` 등록 2곳. Go 백엔드·DDL 무변경

## 실측

표본 신고자 쿼리: 복수 사유 `23,25` 병합 ✓ · 댓글 신고 판별 ✓ · idx_mb_id 필터 rows=9 ✓