### PR TITLE
알림 푸터: 모든 알림 보기 / 모두 읽기 / 알림설정

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -367,14 +367,12 @@
     </DropdownMenu.Trigger>
 
     <DropdownMenu.Content class="w-80" align="end">
+        <!--
+            「모두 읽음」 버튼은 푸터로 옮겼다(free/6875994 회원 의견). 여기 있던 조건부
+            버튼은 열자마자 auto-read 로 unreadCount 가 0 이 되어 사실상 보이지 않았다.
+        -->
         <div class="flex items-center justify-between border-b px-3 py-2">
             <span class="text-foreground font-semibold">알림</span>
-            {#if unreadCount > 0}
-                <Button variant="ghost" size="sm" class="h-7 text-xs" onclick={handleMarkAllAsRead}>
-                    <Check class="mr-1 h-3 w-3" />
-                    모두 읽음
-                </Button>
-            {/if}
         </div>
 
         <div class="max-h-80 overflow-y-auto">
@@ -448,6 +446,20 @@
                 >
                     모든 알림 보기
                 </a>
+                <!--
+                    명시적 「모두 읽기」 — 종을 열면 배지(숫자)는 풀리지만 새 알림 강조는
+                    남는다(#12991 설계). 강조까지 한 번에 걷어내는 손잡이가 이 버튼이다.
+                    항상 노출한다 - 지울 게 없을 때 눌러도 무해(멱등)하고, 조건부로 숨기면
+                    "버튼이 없어졌다"는 혼란(free/6875994)이 재발한다.
+                -->
+                <button
+                    type="button"
+                    class="hover:bg-accent flex flex-1 items-center justify-center gap-1 rounded-md py-1.5 text-center text-sm transition-colors"
+                    onclick={handleMarkAllAsRead}
+                >
+                    <Check class="h-3.5 w-3.5" />
+                    모두 읽기
+                </button>
                 <a
                     href="/member/settings/ui?tab=notification"
                     class="hover:bg-accent flex flex-1 items-center justify-center gap-1 rounded-md py-1.5 text-center text-sm transition-colors"


### PR DESCRIPTION
## 왜 (free/6875994 회원 의견)

12991 배지 해소(종을 열면 숫자 소거) 이후 「모든 알림 읽기 버튼이 없어졌다」는 의견이 나왔습니다. **실제로 없어진 게 맞습니다** — 헤더의 「모두 읽음」이 `unreadCount > 0` 조건부인데, 열자마자 auto-read로 0이 되어 사실상 보이지 않는 죽은 UI가 됐습니다.

## 무엇

푸터 3버튼: **모든 알림 보기 / 모두 읽기 / 알림설정**

- 「모두 읽기」는 **항상 노출** — 종을 열면 배지는 풀리지만 새 알림 강조(`has_unread`)는 남는 설계(#12991)라, 강조까지 한 번에 걷어내는 손잡이가 이 버튼입니다. 멱등이라 지울 게 없을 때 눌러도 무해하고, 조건부로 숨기면 같은 혼란이 재발합니다
- 헤더 조건부 버튼은 제거(죽은 UI), 기존 `handleMarkAllAsRead` 재사용 — 신규 API 없음

## 별건 기록

Java 님의 글/댓글 단위 그룹핑 제안은 규모가 달라 별건입니다.