### PR TITLE
fix(giving-widget): tab=all 로 채움 풀 확장 (premium 과 정합)

### DIFF
--- a/widgets/giving/index.svelte
+++ b/widgets/giving/index.svelte
@@ -34,7 +34,8 @@
     onMount(async () => {
         try {
             // timedFetch: 12s timeout + 1회 retry. (audit 2026-05-01 §3-1)
-            const res = await timedFetch('/api/plugins/giving/list?tab=active&limit=5&sort=urgent');
+            const res = await timedFetch(// tab=all: 진행중(임박순) 우선 + 최신 글 채움 — premium 포크와 동일 정책 (be#605 세트)
+                '/api/plugins/giving/list?tab=all&limit=5&sort=urgent');
             if (res.ok) {
                 const data = await res.json();
                 if (data.success) {


### PR DESCRIPTION
be#605 정렬과 세트. premium 포크(실서빙)와 같은 정책으로 코어도 tab=all. 상세는 premium PR 참조.