### PR TITLE
알림 묶어 보기 (웹) — merge 배선·설정 토글

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2024,10 +2024,13 @@ class ApiClient {
     async getGroupedNotifications(
         page: number = 1,
         limit: number = 20,
-        filterType: string = ''
+        filterType: string = '',
+        merge: boolean = false
     ): Promise<GroupedNotificationListResponse> {
         const params = new URLSearchParams({ page: String(page), limit: String(limit) });
         if (filterType) params.set('type', filterType);
+        // merge=target: 같은 글의 좋아요·댓글을 한 줄로(대상 단위 통합 묶음)
+        if (merge) params.set('merge', 'target');
         const response = await this.request<GroupedNotificationListResponse>(
             `/notifications/grouped?${params}`,
             {},
@@ -2039,10 +2042,21 @@ class ApiClient {
     /**
      * 그룹 알림 읽음 처리
      */
-    async markGroupAsRead(boTable: string, wrId: number, fromCase: string): Promise<void> {
+    async markGroupAsRead(
+        boTable: string,
+        wrId: number,
+        fromCase: string,
+        targetKey?: string
+    ): Promise<void> {
         await this.request<void>('/notifications/group/read', {
             method: 'POST',
-            body: JSON.stringify({ bo_table: boTable, wr_id: wrId, from_case: fromCase })
+            // target_key 가 있으면 서버가 병합 묶음 키 식으로 읽음 처리한다
+            body: JSON.stringify({
+                bo_table: boTable,
+                wr_id: wrId,
+                from_case: fromCase,
+                ...(targetKey ? { target_key: targetKey } : {})
+            })
         });
     }
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2063,12 +2063,19 @@ class ApiClient {
     /**
      * 그룹 알림 삭제
      */
-    async deleteNotificationGroup(boTable: string, wrId: number, fromCase: string): Promise<void> {
+    async deleteNotificationGroup(
+        boTable: string,
+        wrId: number,
+        fromCase: string,
+        targetKey?: string
+    ): Promise<void> {
         const params = new URLSearchParams({
             bo_table: boTable,
             wr_id: String(wrId),
             from_case: fromCase
         });
+        // 병합 묶음은 목록·읽음과 같은 파생 키 식으로 삭제한다
+        if (targetKey) params.set('target_key', targetKey);
         await this.request<void>(`/notifications/group?${params}`, {
             method: 'DELETE'
         });

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1052,6 +1052,11 @@ export interface GroupedNotification {
     has_unread: boolean;
     latest_at: string;
     from_case: string;
+    /** 병합 모드(merge=target) 전용 */
+    target_key?: string;
+    good_count?: number;
+    comment_count?: number;
+    reply_count?: number;
 }
 
 export interface GroupedNotificationListResponse {

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -6,6 +6,7 @@
     import type { GroupedNotification } from '$lib/api/types.js';
     import { onMount, tick } from 'svelte';
     import { goto } from '$app/navigation';
+    import { isNotiMergeEnabled } from '$lib/utils/noti-merge-pref.js';
     import { browser } from '$app/environment';
     import { normalizeWebUrl, toRelativeIfSameOrigin } from '$lib/utils/url-normalizer';
     import Bell from '@lucide/svelte/icons/bell';
@@ -191,7 +192,7 @@
         isLoading = true;
         loadError = false;
         try {
-            const response = await apiClient.getGroupedNotifications(1, 10);
+            const response = await apiClient.getGroupedNotifications(1, 10, '', isNotiMergeEnabled());
             notifications = response.items;
             unreadCount = response.unread_count;
             writeUnreadCache(response.unread_count);
@@ -212,7 +213,8 @@
                 await apiClient.markGroupAsRead(
                     notification.bo_table,
                     notification.wr_id,
-                    notification.from_case
+                    notification.from_case,
+                    notification.target_key
                 );
                 notification.has_unread = false;
                 unreadCount = Math.max(0, unreadCount - notification.unread_count);

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -403,7 +403,7 @@
             {:else if notifications.length === 0}
                 <div class="text-muted-foreground py-8 text-center text-sm">알림이 없습니다</div>
             {:else}
-                {#each notifications as notification (notification.bo_table + ':' + notification.wr_id + ':' + notification.from_case)}
+                {#each notifications as notification (notification.bo_table + ':' + notification.wr_id + ':' + notification.from_case + ':' + (notification.target_key ?? ''))}
                     {@const Icon = getNotificationIcon(notification.type)}
                     <DropdownMenu.Item
                         class="flex cursor-pointer items-start gap-2.5 px-3 py-2 {notification.has_unread

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -192,7 +192,12 @@
         isLoading = true;
         loadError = false;
         try {
-            const response = await apiClient.getGroupedNotifications(1, 10, '', isNotiMergeEnabled());
+            const response = await apiClient.getGroupedNotifications(
+                1,
+                10,
+                '',
+                isNotiMergeEnabled()
+            );
             notifications = response.items;
             unreadCount = response.unread_count;
             writeUnreadCache(response.unread_count);

--- a/apps/web/src/lib/utils/noti-merge-pref.ts
+++ b/apps/web/src/lib/utils/noti-merge-pref.ts
@@ -1,0 +1,28 @@
+/**
+ * 알림 묶어 보기(대상 단위 통합) 개인 설정.
+ *
+ * localStorage 기반 — 서버 스키마(g5_noti_preference)에 컬럼을 추가하려면 DDL 이 필요해
+ * v1 은 기기별 설정으로 간다. 기본 켬: 안읽음이 3분의 1로 주는(30일 실측 3.1×) 수혜를
+ * 기본 제공하고, 유형별로 따로 보고 싶은 회원만 끈다.
+ */
+import { browser } from '$app/environment';
+
+const KEY = 'angple_noti_merge';
+
+export function isNotiMergeEnabled(): boolean {
+    if (!browser) return true;
+    try {
+        return localStorage.getItem(KEY) !== '0';
+    } catch {
+        return true;
+    }
+}
+
+export function setNotiMergeEnabled(enabled: boolean): void {
+    if (!browser) return;
+    try {
+        localStorage.setItem(KEY, enabled ? '1' : '0');
+    } catch {
+        // 저장 실패는 무시 — 설정이 안 남을 뿐 동작은 정상
+    }
+}

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -35,6 +35,7 @@
     import UserPlus from '@lucide/svelte/icons/user-plus';
     import { browser } from '$app/environment';
     import { onMount } from 'svelte';
+    import { isNotiMergeEnabled, setNotiMergeEnabled } from '$lib/utils/noti-merge-pref.js';
     import { page } from '$app/stores';
     import {
         uiSettingsStore,
@@ -304,6 +305,7 @@
         noti_board_subscribe: true,
         like_threshold: 1
     });
+    let notiMerge = $state(true);
     let notiLoading = $state(false);
     let notiSaving = $state(false);
     let notiSaveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -341,6 +343,7 @@
     let hydrated = $state(false);
 
     onMount(() => {
+        notiMerge = isNotiMergeEnabled();
         hydrated = true;
         loadSubscriptions();
         loadFollowing();
@@ -1140,6 +1143,23 @@
                     <CardDescription>알림 종류별 수신 여부를 설정합니다.</CardDescription>
                 </CardHeader>
                 <CardContent class="space-y-4">
+                    <!-- 묶어 보기 — localStorage 기기별 설정(DDL 회피). 수신 여부와 무관한 표시 방식 -->
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <Label>알림 묶어 보기</Label>
+                            <p class="text-muted-foreground text-xs">
+                                같은 글의 좋아요·댓글을 한 줄로 묶어 보여줍니다 (이 기기에만 적용)
+                            </p>
+                        </div>
+                        <Switch
+                            checked={notiMerge}
+                            onCheckedChange={(v) => {
+                                notiMerge = v;
+                                setNotiMergeEnabled(v);
+                            }}
+                        />
+                    </div>
+                    <Separator />
                     {#if notiLoading}
                         <p class="text-muted-foreground text-xs">로딩 중...</p>
                     {:else}

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -211,7 +211,8 @@
             await apiClient.deleteNotificationGroup(
                 notification.bo_table,
                 notification.wr_id,
-                notification.from_case
+                notification.from_case,
+                notification.target_key
             );
             if (notificationData) {
                 notificationData.items = notificationData.items.filter(

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
+    import { isNotiMergeEnabled } from '$lib/utils/noti-merge-pref.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import type { PageData } from './$types.js';
     import { apiClient } from '$lib/api/index.js';
@@ -111,7 +112,8 @@
             notificationData = await apiClient.getGroupedNotifications(
                 data.page,
                 data.limit,
-                activeFilter
+                activeFilter,
+                isNotiMergeEnabled()
             );
         } catch (err) {
             error = err instanceof Error ? err.message : '알림을 불러오는데 실패했습니다.';
@@ -135,7 +137,8 @@
                 await apiClient.markGroupAsRead(
                     notification.bo_table,
                     notification.wr_id,
-                    notification.from_case
+                    notification.from_case,
+                    notification.target_key
                 );
                 const unreadDelta = notification.unread_count;
                 notification.has_unread = false;


### PR DESCRIPTION
be#608(대상 단위 통합 묶음)의 웹측 배선입니다. client에 merge 인자·target_key 전달, 드롭다운·전체 페이지가 개인 설정(localStorage, 기본 켬)으로 병합 모드 조회, 알림 설정 탭에 「알림 묶어 보기」 토글. 제목은 서버 생성이라 목록 렌더 무변경. ⛔ be#608이 prod에 먼저 있어야 켜집니다 — 병합 파라미터는 구 백엔드에서 무시되어 기존 동작으로 폴백(안전).