### PR TITLE
feat(giving): 당첨자를 닉네임으로 표시

### DIFF
--- a/apps/web/src/lib/features/giving/api.ts
+++ b/apps/web/src/lib/features/giving/api.ts
@@ -11,6 +11,8 @@ const BASE = '/api/plugins/giving';
 export interface GivingDrawResult {
     method: string;
     winner_mb_id: string | null;
+    /** 표시용 mb_id→닉네임 맵 (구 응답에는 없음 — mb_id 폴백) */
+    nicknames?: Record<string, string> | null;
     winning_number: number | null;
     seed: string | null;
     seed_hash: string | null;

--- a/apps/web/src/lib/features/giving/draw-result.svelte
+++ b/apps/web/src/lib/features/giving/draw-result.svelte
@@ -9,6 +9,8 @@
     const winners: string[] = $derived(
         result?.winners ?? (draw.winner_mb_id ? [draw.winner_mb_id] : [])
     );
+    // 표시는 닉네임, 저장·키는 mb_id 정본 유지. 구 응답(맵 없음)은 mb_id 폴백.
+    const nick = (id: string) => draw.nicknames?.[id] ?? id;
 
     // Commit-reveal 검증: SeedHash(seed) === seed_hash 인지 브라우저에서 재계산.
     let seedVerified = $state<null | boolean>(null);
@@ -52,7 +54,7 @@
         {#if draw.method === 'lowest_unique' && draw.winning_number != null}
             <p class="text-foreground text-sm">
                 당첨 번호 <strong class="text-primary">{draw.winning_number}</strong> —
-                <strong>{winners[0]}</strong>
+                <strong>{nick(winners[0])}</strong>
             </p>
         {:else}
             <p class="text-foreground mb-1 text-sm">당첨자</p>
@@ -61,7 +63,7 @@
                     <li
                         class="rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
                     >
-                        {w}
+                        {nick(w)}
                     </li>
                 {/each}
             </ul>


### PR DESCRIPTION
## 목적
나눔 상세 개표 결과 당첨자 배지가 mb_id 노출 → 닉네임 표시.

## 변경
- `GivingDrawResult` 에 `nicknames?: Record<string,string> | null` 타입 추가
- `draw-result.svelte` 당첨자 렌더 2곳(`winning_number` 문구·배지 목록)을 `nicknames[id] ?? id` 폴백으로 표시. each 키는 mb_id 유지

## 하위호환
맵이 없는 구 백엔드 응답에서도 기존과 동일하게 mb_id 표시 — 배포 순서 무관.

## 짝 PR
backend: damoang/angple-backend `feat/giving-winner-nickname`