### PR TITLE
fix: 뒤로가기 시 example.com 이동 (bug/13209, 12860, 9391)

### DIFF
--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -1,5 +1,4 @@
 import type { HandleClientError } from '@sveltejs/kit';
-import { replaceState } from '$app/navigation';
 import { loadAllPluginClientHooks } from '$lib/client/plugin-client-loader';
 
 // Phase 11 (open-core plugin loader) — client hooks 자동 활성화.
@@ -306,8 +305,39 @@ function recoverStaleClientSilently(reason: string): boolean {
     return true;
 }
 
+// SvelteKit 이 히스토리 state 에 현재 URL 을 적어 두는 키. 뒤로가기(popstate) 때 이 값이
+// 이동 목적지가 된다.
+const SVELTEKIT_PAGE_URL_KEY = 'sveltekit:pageurl';
+
+/**
+ * 과거 버전이 오염시킨 히스토리 항목을 되돌린다.
+ *
+ * 이 파일의 최상위는 SvelteKit 라우터가 뜨기 전에 실행된다. 그때 `$app/navigation` 의
+ * replaceState 를 부르면 아직 자리표시자(`https://example.com`)인 page.url 이 위 키에
+ * 저장됐고, 그 항목으로 뒤로가기하면 example.com 으로 이동했다. 이미 그런 항목을 들고
+ * 있는 세션이 남아 있으므로 부팅 시 한 번 정리한다. SvelteKit 의 초기화가 기존 state 를
+ * 전개해 물려받기 전에 실행돼야 해서 위치를 옮기면 안 된다.
+ */
+function healPoisonedHistoryPageUrl(): void {
+    try {
+        const state = window.history.state as Record<string, unknown> | null;
+        const stored = state?.[SVELTEKIT_PAGE_URL_KEY];
+        if (typeof stored !== 'string') return;
+        if (new URL(stored).origin === window.location.origin) return;
+        window.history.replaceState(
+            { ...state, [SVELTEKIT_PAGE_URL_KEY]: window.location.href },
+            '',
+            window.location.href
+        );
+    } catch {
+        // 히스토리 접근 실패는 부팅을 막을 사유가 아니다
+    }
+}
+
 // app.html 통합 핸들러와 연동: exhausted 상태면 상단 배너 대신 1회 강력 새로고침
 if (typeof window !== 'undefined') {
+    healPoisonedHistoryPageUrl();
+
     const currentUrl = new URL(window.location.href);
     const recoveredWithCacheBust = currentUrl.searchParams.get('_v');
     if (recoveredWithCacheBust) {
@@ -315,7 +345,10 @@ if (typeof window !== 'undefined') {
     }
     if (currentUrl.searchParams.has('_v')) {
         currentUrl.searchParams.delete('_v');
-        replaceState(currentUrl.href, window.history.state);
+        // ⛔ $app/navigation 의 replaceState 를 쓰면 안 된다. 라우터 초기화 전이라
+        // 자리표시자 page.url 이 히스토리에 박히고(위 healPoisonedHistoryPageUrl 참조),
+        // 내부적으로 아직 없는 루트 컴포넌트를 건드려 이 파일의 나머지 초기화까지 중단시킨다.
+        window.history.replaceState(window.history.state, '', currentUrl.href);
     }
 
     const chunkError = (window as any).__angpleChunkError;


### PR DESCRIPTION
## 증상

「이전 페이지로 이동할 시」 `https://example.com/` 으로 이동한다. 2026-03-26 최초 제보 이후 **5개월간 4명 이상**이 같은 증상을 올렸고, 4/5 에 한 차례 수정(#1065)했으나 재발했다.

| wr_id | 날짜 | 환경 |
|---|---|---|
| 9074 | 03-26 | — |
| 9391 | 04-01 | iPhone SE3 / iOS26 Safari |
| ↳ 9392 | 04-02 | **안드로이드 Firefox** — 「메인에서 추천게시물 들어가면 100%」 |
| 12286 | 05-08 | iOS Safari |
| 12860 | 06-30 | iOS Safari |
| 13209 | 08-02 | 「캐시 삭제 많이 해왔다」 |

브라우저·OS 무관이라 확장/기기 문제가 아니고, 캐시 삭제가 듣지 않으니 캐시가 아니라 **히스토리 state** 문제다.

## 원인

`hooks.client.ts` 의 최상위 블록은 SvelteKit 라우터가 뜨기 **전에** 실행된다(생성된 app.js 가 hooks 를 import 한 뒤에야 `kit.start()` 가 불린다).

이 지점에서 `$app/navigation` 의 `replaceState()` 를 부르고 있었다. 이 함수는 URL 만 바꾸지 않고 히스토리 state 에 자기 메타데이터를 함께 적는다 — `@sveltejs/kit@2.53.4` `client.js:2335~2349`:

```js
const opts = {
    [HISTORY_INDEX]: current_history_index,       // start() 전이라 undefined
    [NAVIGATION_INDEX]: current_navigation_index, // undefined
    [PAGE_URL_KEY]: page.url.href,                // ⛔ 아직 자리표시자
    [STATES_KEY]: state
};
history.replaceState(opts, '', resolve_url(url));
page.state = state;
root.$set({ ... });                                // ⛔ root 는 591행에서 대입
```

`page.url` 의 초기값은 SvelteKit 자신이 박아 둔 자리표시자다 (`state.svelte.js:26,39`):

```js
url = $state.raw(new URL('https://example.com'));
```

그래서 그 히스토리 항목에 `sveltekit:pageurl = "https://example.com/"` 가 저장되고, 나중에 그 항목으로 **뒤로가기**하면 popstate 핸들러가 그 값을 그대로 목적지로 쓴다 (`client.js:2650`):

```js
const url = new URL(event.state[PAGE_URL_KEY] ?? location.href);   // → https://example.com/
await navigate({ type: 'popstate', url, ... });                     // → 실제 이동
```

`resolve_url()` 은 `document.baseURI` 기준이라 **url 인자와 무관**하다. 4/5 수정(#1065, 상대경로 → 절대 URL)이 이 버그에 무효였고 재발한 이유다.

### 왜 간헐적인가 / 왜 「100%」인가

`_v` 는 chunk·stale 복구 리로드가 붙이는 캐시버스터다. ClickHouse 3일 집계 기준 `chunk recovery started` **647건(≈일 215건)** — 복구가 걸린 세션만 오염되므로 간헐적이고, 한 번 오염된 항목은 탭을 닫을 때까지 남아 그 항목에서는 매번 재현된다.

### 재현 (운영 대상, 읽기 전용)

`https://damoang.net/?_v=<ts>` 로드 직후:

```
STATE : {"sveltekit:pageurl":"https://example.com/","sveltekit:states":null}
ERRORS: ["TypeError: Cannot read properties of undefined (reading '$set')"]
```

같은 항목을 다시 로드하면 `start()` 가 `{...history.state}` 로 오염값을 유지한 채 유효한 인덱스를 덧붙인다(`client.js:338`):

```
CLEAN STATE: {"sveltekit:history":1785654642828,"sveltekit:navigation":1785654642828,
              "sveltekit:pageurl":"https://example.com/","sveltekit:states":null}
```

이 시점부터 `event.state[HISTORY_INDEX]` 가 truthy 라 popstate 가 정식 분기를 타고 `sveltekit:pageurl` 로 이동한다.

### 동반 발견

`root.$set` 이 undefined 라 **TypeError 가 던져진다.** 모듈 최상위 예외라 **그 아래 초기화가 통째로 중단**된다(chunk-error 리스너 등록 등). 복구 리로드를 탄 사용자는 복구 직후 클라이언트 부팅이 깨진 페이지를 받고 있었다. 원인 수정으로 함께 해소된다.

## 변경

- `_v` 제거를 **네이티브** `history.replaceState` 로 변경. `sveltekit:pageurl` 을 쓰지 않고 루트 컴포넌트도 건드리지 않는다. 기존 state 는 그대로 넘겨 보존한다. SvelteKit 의 history 몽키패치는 `if (DEV && BROWSER)` 게이팅이라 운영에서는 네이티브 그대로다.
- 이미 오염된 항목은 부팅 시 1회 치유. SvelteKit 초기화가 기존 state 를 전개해 물려받기 **전에** 실행돼야 하므로 위치를 옮기면 안 된다.

## 하지 않은 것

- **`beforeNavigate` 로 취소** — SvelteKit 은 취소 시 `history.go(-delta)` 로 되튕긴다. 「뒤로가기 먹통」으로 증상만 바뀐다
- **popstate 선등록 가로채기** — `event.state` 는 이벤트에 실린 스냅샷이라 핸들러 안에서 `history.replaceState` 를 불러도 SvelteKit 이 읽는 값은 안 바뀐다
- **SvelteKit 버전 변경** — 라이브러리는 정상이다. 계약 위반은 우리 호출부다
- **`_v` 복구 기능 제거** — 호출 방식만 고친다
- **다른 탭의 과거 오염 항목 소급 치유** — 현재 항목만 고친다. 이미 열린 탭의 다른 항목은 탭을 닫을 때까지 남는다(신규 오염은 0). 명시적 수용

## Test plan

- [ ] `?_v=<ts>` 로드 후 `history.state.sveltekit:pageurl` 이 없거나 damoang origin
- [ ] 같은 로드에서 `TypeError ... '$set'` 페이지 에러 0건
- [ ] `?_v=` 로드 → 글 진입 → 뒤로가기 → 최종 URL 이 damoang.net
- [ ] 오염 state 를 인위로 심고 재로드 → 치유 확인
- [ ] `_v` 가 주소창에서 여전히 제거되는지 (기능 손실 0)
- [ ] `_v` 없는 일반 로드·SPA 이동 후 뒤로가기 정상

## 후속 (별건)

- `post-list.svelte:23-26` `getBoardId()` 가 절대 URL 에서 `parts[0]='https:'` 를 돌려줘 홈 「공감 글」 읽은-글 표시가 어긋난다 (`explore-preview.svelte:168-171` 동일)
- chunk recovery 일 215건 자체의 원인 (hydration_mismatch 와 함께 별도 조사)