### PR TITLE
fix: 소셜 연동 파괴 중단 + 이상징후 관측 (1/2단계)

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/binding-observer.ts
+++ b/apps/web/src/lib/server/auth/oauth/binding-observer.ts
@@ -1,0 +1,61 @@
+/**
+ * 소셜 계정 바인딩 이상징후 관측 (2026-08-03).
+ *
+ * ⛔ 관측 전용이다. 여기서 로그인을 막지 않는다.
+ *    차단으로 전환하기 전에 "실제로 몇 명이 걸리는지"를 먼저 재기 위한 단계다.
+ *    사전 계산이 불가능하다 — 소셜 프로필 테이블에 프로바이더 이메일이 없어서
+ *    어떤 로그인이 이메일 매칭 경로를 타는지 DB 만으로는 알 수 없다.
+ *
+ * ⛔ 파드 로그(console)만 쓰면 안 된다. 파드가 재기동되면 이전 로그가 사라져
+ *    "0건"이 "없었다"로 오독된다(2026-08-02 429 조사에서 실제로 겪음).
+ *    그래서 재기동을 견디는 `audit_logs` 테이블에 남긴다.
+ *
+ * 개인정보는 넣지 않는다 — mb_id·provider·사유 코드까지만.
+ */
+import pool from '$lib/server/db.js';
+
+export type BindingObservation =
+    /** 이메일 매칭으로 들어가려는 계정이 이미 다른 신원과 연결돼 있음 (탈취 경로 후보) */
+    | 'email_match_into_bound_account'
+    /** 로그인한 신원과 계정에 저장된 신원이 다름 — 예전 코드는 여기서 덮어썼다 */
+    | 'identifier_mismatch_write_skipped'
+    /** 이 신원이 다른 회원에게 연결돼 있음 — 예전 코드는 그 행을 DELETE 했다 */
+    | 'identifier_bound_other_member_delete_skipped';
+
+const ACTION = 'social_binding_observation';
+
+/**
+ * 관측 1건 기록. **실패해도 로그인에 영향을 주지 않는다.**
+ * 기록 실패로 로그인이 깨지면 관측이 사고가 된다 — 반드시 삼킨다.
+ */
+export async function observeBinding(
+    kind: BindingObservation,
+    detail: { mbId: string; provider: string; otherMbId?: string; clientIp?: string }
+): Promise<void> {
+    // 파드 로그에도 남긴다(실시간 확인용). 집계 근거는 audit_logs 다.
+    console.warn(`[social-binding] ${kind}`, {
+        mbId: detail.mbId,
+        provider: detail.provider,
+        otherMbId: detail.otherMbId
+    });
+
+    try {
+        await pool.query(
+            `INSERT INTO audit_logs
+                 (created_at, user_id, action, resource, resource_id, details, client_ip)
+             VALUES (NOW(3), ?, ?, 'social_profile', ?, ?, ?)`,
+            [
+                detail.mbId,
+                ACTION,
+                detail.provider,
+                JSON.stringify({ kind, otherMbId: detail.otherMbId ?? null }),
+                detail.clientIp ?? ''
+            ]
+        );
+    } catch (err) {
+        console.error(
+            '[social-binding] 관측 기록 실패(무시)',
+            err instanceof Error ? err.message : 'unknown'
+        );
+    }
+}

--- a/apps/web/src/lib/server/auth/oauth/social-profile.test.ts
+++ b/apps/web/src/lib/server/auth/oauth/social-profile.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 소셜 연동 저장 계약 (2026-08-03 관측 모드).
+ *
+ * 배경: 로그인 경로가 (a) 남의 (provider, identifier) 행을 DELETE 하고
+ * (b) 대상 계정의 identifier 를 덮어썼다. 그래서 서로 다른 사람이 한 계정을 오갔고,
+ * 덮어쓰기 때문에 조회하면 늘 1:1 로 보여 사고가 드러나지 않았다.
+ *
+ * 이번 단계는 **차단이 아니라 관측**이다. 지키는 계약:
+ *   1. 정상 재로그인은 그대로 동작한다 (여기가 깨지면 전 회원 로그인 불가)
+ *   2. 식별자가 2개 이상인 계정(실측 69건)에서도 내 행을 정확히 찾아 갱신한다
+ *   3. 남의 행을 DELETE 하지 않는다
+ *   4. 신원이 다르면 덮어쓰지 않고 건너뛴다 (로그인 자체는 막지 않는다)
+ */
+
+const query = vi.fn();
+vi.mock('$lib/server/db.js', () => ({ default: { query: (...a: unknown[]) => query(...a) } }));
+
+const observeBinding = vi.fn();
+vi.mock('./binding-observer.js', () => ({
+    observeBinding: (...a: unknown[]) => observeBinding(...a)
+}));
+
+import { upsertSocialProfile } from './social-profile';
+import type { OAuthUserProfile } from './types';
+
+const profile = (identifier: string) =>
+    ({
+        identifier,
+        email: 'x@example.com',
+        displayName: 'tester',
+        photoUrl: '',
+        profileUrl: ''
+    }) as OAuthUserProfile;
+
+const row = (mp_no: number, mb_id: string, identifier: string) => ({ mp_no, mb_id, identifier });
+
+/** 호출 순서: ① findSocialProfile ② findSocialProfilesByMemberProvider ③ 쓰기 */
+function mockDb(byIdentifier: unknown | null, memberRows: unknown[]) {
+    query.mockReset();
+    observeBinding.mockReset();
+    query
+        .mockResolvedValueOnce([byIdentifier ? [byIdentifier] : []])
+        .mockResolvedValueOnce([memberRows])
+        .mockResolvedValue([{ affectedRows: 1 }]);
+}
+
+const sqls = () => query.mock.calls.map((c) => String(c[0]));
+const kinds = () => observeBinding.mock.calls.map((c) => c[0]);
+
+describe('upsertSocialProfile — 관측 모드', () => {
+    beforeEach(() => {
+        query.mockReset();
+        observeBinding.mockReset();
+    });
+
+    it('정상 재로그인: 같은 신원이면 UPDATE 한다', async () => {
+        mockDb(null, [row(10, 'naver_a', 'ID-1')]);
+        await upsertSocialProfile('naver_a', 'naver', profile('ID-1'));
+
+        expect(sqls().filter((s) => /UPDATE/i.test(s))).toHaveLength(1);
+        expect(kinds()).toEqual([]);
+    });
+
+    it('연동이 없으면 INSERT 한다 (신규 가입)', async () => {
+        mockDb(null, []);
+        await upsertSocialProfile('naver_new', 'naver', profile('ID-9'));
+
+        expect(sqls().some((s) => /INSERT/i.test(s))).toBe(true);
+        expect(kinds()).toEqual([]);
+    });
+
+    it('식별자 2개인 계정에서도 내 행을 찾아 갱신한다 (락아웃 방지)', async () => {
+        mockDb(null, [row(10, 'naver_a', 'ID-1'), row(11, 'naver_a', 'ID-2')]);
+        await upsertSocialProfile('naver_a', 'naver', profile('ID-2'));
+
+        const update = query.mock.calls.find((c) => /UPDATE/i.test(String(c[0])));
+        expect(update).toBeDefined();
+        // 내 행(mp_no=11)을 갱신해야 한다 — LIMIT 1 로 걸린 다른 행이 아니라
+        expect((update?.[1] as unknown[]).at(-1)).toBe(11);
+        expect(kinds()).toEqual([]);
+    });
+
+    it('신원이 다르면 덮어쓰지 않고 관측만 한다', async () => {
+        mockDb(null, [row(12, 'naver_v', 'OWNER-ID')]);
+        await upsertSocialProfile('naver_v', 'naver', profile('INTRUDER-ID'));
+
+        expect(sqls().some((s) => /UPDATE|INSERT/i.test(s))).toBe(false);
+        expect(kinds()).toContain('identifier_mismatch_write_skipped');
+    });
+
+    it('그 신원이 다른 회원에게 있어도 DELETE 하지 않는다', async () => {
+        mockDb(row(20, 'naver_other', 'ID-1'), []);
+        await upsertSocialProfile('naver_me', 'naver', profile('ID-1'));
+
+        expect(sqls().some((s) => /DELETE/i.test(s))).toBe(false);
+        expect(kinds()).toContain('identifier_bound_other_member_delete_skipped');
+    });
+});

--- a/apps/web/src/lib/server/auth/oauth/social-profile.ts
+++ b/apps/web/src/lib/server/auth/oauth/social-profile.ts
@@ -6,6 +6,7 @@ import pool from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import type { OAuthUserProfile, SocialProfileRow } from './types.js';
 import { createHash } from 'crypto';
+import { observeBinding } from './binding-observer.js';
 
 /** 프로바이더 + identifier로 소셜 프로필 조회 */
 export async function findSocialProfile(
@@ -29,6 +30,23 @@ export async function findSocialProfileByMember(
         [mbId, provider.toLowerCase()]
     );
     return (rows[0] as SocialProfileRow) || null;
+}
+
+/**
+ * mb_id + provider 의 **모든** 소셜 프로필 조회.
+ *
+ * `findSocialProfileByMember` 는 `LIMIT 1` 인데 `ORDER BY` 가 없어, 식별자가 2개 이상인
+ * 계정(실측 69건)에서 어느 행이 나올지 정해져 있지 않다. 로그인 신원 판정에는 이 함수를 쓴다.
+ */
+export async function findSocialProfilesByMemberProvider(
+    mbId: string,
+    provider: string
+): Promise<SocialProfileRow[]> {
+    const [rows] = await pool.query<RowDataPacket[]>(
+        'SELECT * FROM g5_member_social_profiles WHERE mb_id = ? AND provider = ? ORDER BY mp_register_day',
+        [mbId, provider.toLowerCase()]
+    );
+    return rows as SocialProfileRow[];
 }
 
 /** mb_id로 연결된 모든 소셜 프로필 조회 */
@@ -128,17 +146,38 @@ export async function upsertSocialProfile(
     const providerLower = provider.toLowerCase();
     const objectSha = createHash('sha1').update(JSON.stringify(profile)).digest('hex');
 
-    // 다른 회원에게 연결된 동일 프로바이더+identifier 레코드 삭제
-    await pool.query(
-        'DELETE FROM g5_member_social_profiles WHERE provider = ? AND identifier = ? AND mb_id != ?',
-        [providerLower, profile.identifier, mbId]
-    );
+    // ⛔ 예전에는 여기서 다른 회원의 동일 (provider, identifier) 행을 DELETE 했다.
+    //    로그인 한 번에 남의 연동이 조용히 끊기고, 사고 흔적까지 사라졌다.
+    //    이제 지우지 않고 관측만 한다(로그인 동작은 종전과 동일).
+    const conflicting = await findSocialProfile(providerLower, profile.identifier);
+    if (conflicting && conflicting.mb_id !== mbId) {
+        await observeBinding('identifier_bound_other_member_delete_skipped', {
+            mbId,
+            provider: providerLower,
+            otherMbId: conflicting.mb_id
+        });
+    }
 
-    // 기존 레코드 확인
-    const existing = await findSocialProfileByMember(mbId, providerLower);
+    // 이 회원 + 이 provider 의 **모든** 행을 본다.
+    // ⛔ 한 행만 보면 안 된다 — 식별자가 2개 이상인 계정이 실측 69건 있고,
+    //    LIMIT 1 은 ORDER BY 가 없어 어느 행이 나올지 정해져 있지 않다.
+    //    그 계정 주인이 '다른 쪽' 신원으로 로그인할 때 오판하게 된다.
+    const rows = await findSocialProfilesByMemberProvider(mbId, providerLower);
+    const mine = rows.find((r) => r.identifier === profile.identifier);
 
-    if (existing) {
-        // 업데이트
+    if (!mine && rows.length > 0) {
+        // 로그인한 신원이 이 계정에 등록돼 있지 않다.
+        // ⛔ 예전에는 기존 행의 identifier 를 이 신원으로 **덮어썼다.** 그래서 원 주인의
+        //    연동이 사라지고 조회하면 언제나 1:1 로 보였다. 이제 쓰지 않고 관측만 한다.
+        await observeBinding('identifier_mismatch_write_skipped', {
+            mbId,
+            provider: providerLower
+        });
+        return;
+    }
+
+    if (mine) {
+        // 같은 신원 — 표시명·프로필 이미지 등만 갱신 (identifier 는 그대로)
         await pool.query(
             `UPDATE g5_member_social_profiles
 			 SET object_sha = ?, identifier = ?, profileurl = ?, photourl = ?,
@@ -150,7 +189,7 @@ export async function upsertSocialProfile(
                 profile.profileUrl || '',
                 profile.photoUrl || '',
                 profile.displayName || '',
-                existing.mp_no
+                mine.mp_no
             ]
         );
     } else {

--- a/apps/web/src/routes/plugin/social/+server.ts
+++ b/apps/web/src/routes/plugin/social/+server.ts
@@ -10,7 +10,12 @@ import { normalizeProviderName, getProvider } from '$lib/server/auth/oauth/provi
 import { resolveOrigin } from '$lib/server/auth/oauth/config.js';
 import { safeRedirectUrl } from '$lib/server/safe-redirect.js';
 import { validateOAuthState } from '$lib/server/auth/oauth/state.js';
-import { findSocialProfile, upsertSocialProfile } from '$lib/server/auth/oauth/social-profile.js';
+import {
+    findSocialProfile,
+    findSocialProfilesByMemberProvider,
+    upsertSocialProfile
+} from '$lib/server/auth/oauth/social-profile.js';
+import { observeBinding } from '$lib/server/auth/oauth/binding-observer.js';
 import { getMemberById, findMemberByEmail, isMemberActive } from '$lib/server/auth/oauth/member.js';
 import { generateRefreshToken } from '$lib/server/auth/jwt.js';
 import {
@@ -90,8 +95,27 @@ async function handleCallback(
         if (existingProfile?.mb_id) {
             mbId = existingProfile.mb_id;
         } else if (profile.email) {
+            // 레거시(그누보드) 회원의 소셜 전환용 매칭.
+            //
+            // ⛔ 프로바이더가 준 이메일을 이 사람이 실제로 통제하는지는 확인할 수 없다.
+            //    프로바이더의 "등록 이메일"은 외부 주소를 그대로 넣을 수 있는 값이라,
+            //    대상 계정이 이미 다른 신원과 연결돼 있으면 전환이 아니라 교차 접근이다.
+            //    다만 여기서 곧바로 막으면 몇 명이 걸리는지 모른 채 사람을 끊게 된다
+            //    (사전 계산 불가 — 소셜 프로필 테이블에 프로바이더 이메일이 없다).
+            //    그래서 이번 단계는 **관측만** 하고, 실측 후 차단으로 전환한다.
             const memberByEmail = await findMemberByEmail(profile.email);
             if (memberByEmail) {
+                const bound = await findSocialProfilesByMemberProvider(
+                    memberByEmail.mb_id,
+                    providerName
+                );
+                if (bound.length > 0 && !bound.some((r) => r.identifier === profile.identifier)) {
+                    await observeBinding('email_match_into_bound_account', {
+                        mbId: memberByEmail.mb_id,
+                        provider: providerName,
+                        clientIp
+                    });
+                }
                 mbId = memberByEmail.mb_id;
             }
         }


### PR DESCRIPTION
소셜 로그인 경로가 **연동 정보를 파괴**하고 있었다. 이번 단계는 그 파괴만 멈추고, 이상징후를 **관측**한다. **로그인 동작은 종전과 동일하다.**

## 무엇이 문제였나

`upsertSocialProfile` 이 로그인마다 두 가지를 했다.

1. 다른 회원의 동일 `(provider, identifier)` 행을 **DELETE** — 로그인 한 번에 남의 연동이 조용히 끊겼다
2. 대상 계정의 `identifier` 를 로그인한 신원으로 **UPDATE** — 원 주인의 연동이 사라지고, **조회하면 언제나 1:1 로 보여** 이상이 드러나지 않았다

2번이 특히 나빴다. 실제 문의 건을 조사할 때 "식별자가 1:1이니 오류 없음"으로 판정했다가 뒤집혔다. 증거가 지워지는 구조였다.

## 이번 변경

- 위 DELETE·UPDATE 를 **하지 않는다.** 신원이 다르면 **쓰기를 건너뛰고 관측만** 한다
- `findSocialProfilesByMemberProvider` 신설 — 판정에 그 회원+provider 의 **모든 행**을 본다
- 관측을 `audit_logs` 에 남긴다 (`action='social_binding_observation'`)

**로그인 흐름은 바뀌지 않는다.** 성공하던 로그인은 그대로 성공한다.

## ⛔ LIMIT 1 판정을 버린 이유 — 실측

처음엔 "신원이 다르면 로그인 거부"로 짰다. **PR 전에 블라스트 반경을 실측했더니 사람을 끊는 설계였다.**

`findSocialProfileByMember` 는 `LIMIT 1` 인데 **`ORDER BY` 가 없다.** 식별자가 2개 이상인 계정은 어느 행이 돌아올지 정해져 있지 않아, 그 계정 주인이 *다른 쪽* 신원으로 로그인하면 거부된다 — 게다가 될 때도 있고 안 될 때도 있다.

| 실측 | 값 |
|---|---|
| 식별자 2개 이상 계정 | **69** (연동행 139) |
| 활성 | **68** |
| **최근 3개월 내 로그인** | **49** ← 막혔을 사람 |

그래서 판정을 "모든 행 중에 내 신원이 있는가"로 바꿨다. 69건 전원 정상 동작한다 (테스트로 고정).

## 관측을 audit_logs 에 남기는 이유

파드 로그만 쓰면 재기동 시 이전 기록이 사라져 **"0건"이 "없었다"로 오독**된다. (8/2 429 조사에서 실제로 겪었다 — 파드가 11분 전 재기동돼 로그 창이 그만큼밖에 없었다.)

기록 실패는 삼킨다. **관측이 로그인을 깨뜨리면 관측이 사고**가 된다.

## 이번에 넣지 않은 것

**이메일 매칭 경로의 차단.** 걸리는 인원을 **사전 계산할 수단이 없다** — 소셜 프로필 테이블에 프로바이더 이메일 컬럼이 없어 어떤 로그인이 그 경로를 타는지 DB 만으로는 알 수 없다. 관측으로 실측한 뒤 별도 PR 로 전환한다.

`linkSocialProfile`(회원설정에서 본인이 명시적으로 연동)은 **건드리지 않았다.** 로그인한 본인의 의도적 행위라 성격이 다르다.

## Test plan

- [ ] 정상 재로그인 (naver/google/kakao/apple 각각) — 성공하고 identifier 불변
- [ ] 신규 가입 → `/register` 이동 정상
- [ ] 식별자 2개인 계정에서 양쪽 신원 모두 로그인 성공
- [ ] 신원 불일치 시 UPDATE/INSERT 미발생 + `audit_logs` 기록
- [ ] 다른 회원 행 DELETE 미발생
- [ ] `audit_logs` 기록 실패해도 로그인 성공
- [ ] `member/settings/social` 명시적 연동/해제 회귀 없음