### PR TITLE
fix: 소셜 바인딩 관측을 라이브 콜백 경로에 추가

### DIFF
--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -12,9 +12,11 @@ import { safeRedirectUrl } from '$lib/server/safe-redirect.js';
 import { validateOAuthState, peekAppMode } from '$lib/server/auth/oauth/state.js';
 import {
     findSocialProfile,
+    findSocialProfilesByMemberProvider,
     linkSocialProfile,
     upsertSocialProfile
 } from '$lib/server/auth/oauth/social-profile.js';
+import { observeBinding } from '$lib/server/auth/oauth/binding-observer.js';
 import {
     getMemberById,
     findMemberByEmail,
@@ -205,8 +207,27 @@ async function handleCallback(
         if (existingProfile?.mb_id) {
             mbId = existingProfile.mb_id;
         } else if (profile.email) {
+            // 레거시(그누보드) 회원의 소셜 전환용 매칭.
+            //
+            // ⛔ 프로바이더가 준 이메일을 이 사람이 실제로 통제하는지는 확인할 수 없다.
+            //    "등록 이메일"은 외부 주소를 그대로 넣을 수 있는 값이라, 대상 계정이 이미
+            //    다른 신원과 연결돼 있으면 전환이 아니라 교차 접근이다.
+            //    지금 곧바로 막으면 몇 명이 걸리는지 모른 채 사람을 끊게 되므로
+            //    (사전 계산 불가 — 소셜 프로필에 프로바이더 이메일이 없다) 이번 단계는
+            //    **관측만** 한다. 실측 후 차단으로 전환한다.
             const memberByEmail = await findMemberByEmail(profile.email);
             if (memberByEmail) {
+                const bound = await findSocialProfilesByMemberProvider(
+                    memberByEmail.mb_id,
+                    providerName
+                );
+                if (bound.length > 0 && !bound.some((r) => r.identifier === profile.identifier)) {
+                    await observeBinding('email_match_into_bound_account', {
+                        mbId: memberByEmail.mb_id,
+                        provider: providerName,
+                        clientIp
+                    });
+                }
                 mbId = memberByEmail.mb_id;
             }
         }

--- a/apps/web/src/routes/auth/native/apple/+server.ts
+++ b/apps/web/src/routes/auth/native/apple/+server.ts
@@ -13,7 +13,12 @@ import { json, type RequestHandler } from '@sveltejs/kit';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { env } from '$env/dynamic/private';
 import { getOAuthKeys } from '$lib/server/auth/oauth/config.js';
-import { findSocialProfile, upsertSocialProfile } from '$lib/server/auth/oauth/social-profile.js';
+import {
+    findSocialProfile,
+    findSocialProfilesByMemberProvider,
+    upsertSocialProfile
+} from '$lib/server/auth/oauth/social-profile.js';
+import { observeBinding } from '$lib/server/auth/oauth/binding-observer.js';
 import { getMemberById, findMemberByEmail, isMemberActive } from '$lib/server/auth/oauth/member.js';
 import {
     generateSocialMbId,
@@ -113,8 +118,17 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         let mbId: string | null = existingProfile?.mb_id ?? null;
 
         if (!mbId && verifiedEmail) {
+            // Apple 은 검증된 이메일이라 위험도가 낮지만, 계측 공백을 만들지 않기 위해
+            // 같은 기준으로 관측한다. ⛔ 여기서 막지 않는다(관측 단계).
             const byEmail = await findMemberByEmail(verifiedEmail);
             if (byEmail) {
+                const bound = await findSocialProfilesByMemberProvider(byEmail.mb_id, 'apple');
+                if (bound.length > 0 && !bound.some((r) => r.identifier === identifier)) {
+                    await observeBinding('email_match_into_bound_account', {
+                        mbId: byEmail.mb_id,
+                        provider: 'apple'
+                    });
+                }
                 mbId = byEmail.mb_id;
             }
         }


### PR DESCRIPTION
#1946 의 후속. **관측 전용이며 로그인을 막지 않는다.**

## 문제

#1946 은 이메일 매칭 관측을 `/plugin/social/` 에만 넣었는데 **그 경로는 레거시**다.

- 모든 provider 의 `redirect_uri` = `config.ts` 의 `getCallbackUrl()` → **`/auth/callback/{provider}`**
- 로그인 UI 는 `/auth/start` 로 간다
- `hooks.server.ts` 가 `/plugin/social/` 를 **"OAuth 콜백 (레거시 경로)"** 로 명시

그래서 `email_match_into_bound_account` 관측이 **구조적으로 0** 이 나온다.

## 왜 이게 심각한가

그 관측값이 곧 **"차단으로 전환하면 막힐 사람 수"** 다. 0 을 보고 "막아도 안전"이라 판정하면, **블라스트 반경 실측 때문에 폐기했던 락아웃(최근 3개월 로그인 49건)을 그대로 재현**한다. 이 PR 계열의 존재 이유가 무효화된다.

## 변경

- `/auth/callback/[provider]/+server.ts` 에 동일 관측 추가
- `/auth/native/apple/+server.ts` 에도 추가 — Apple 은 검증된 이메일이라 위험도가 낮지만 계측 공백을 남기지 않는다

`upsertSocialProfile` 안의 관측 2종은 원래부터 모든 호출부에서 동작한다(변경 없음).

## Test plan

- [ ] 정상 소셜 로그인 4종 회귀 없음
- [ ] 운영 반영 후 `audit_logs` 에 `email_match_into_bound_account` 가 잡히는지
- [ ] ⛔ 집계는 **이 배포 시각 이후**로만 센다. 그 이전 0 은 무효