### PR TITLE
fix: 뒤로가기 시 맨 아래로 떨어지는 문제 — 글 상세에도 적용 (bug/13221)

### DIFF
--- a/apps/web/src/lib/utils/scroll-restore.test.ts
+++ b/apps/web/src/lib/utils/scroll-restore.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * 뒤로가기 스크롤 복원 계약.
+ *
+ * 지키는 것: **문서가 목표 높이에 못 미치는 동안에는 scrollTo 를 부르지 않는다.**
+ * 이 한 줄이 "뒤로 가면 화면이 맨 아래로 떨어진다"(#9401·#13022·#13221)의 방지선이다.
+ * 짧은 문서에 scrollTo(큰 값) 을 하면 브라우저가 맨 아래로 clamp 하고 그대로 고착된다.
+ *
+ * node 환경(테스트 project 'server')이라 DOM 이 없다. 필요한 전역만 주입해 검증한다.
+ */
+
+import { createScrollSnapshot } from './scroll-restore';
+
+const scrollTo = vi.fn();
+let scrollHeight = 0;
+let scrollY = 0;
+let rafQueue: FrameRequestCallback[] = [];
+let resizeCallbacks: (() => void)[] = [];
+
+const g = globalThis as unknown as Record<string, unknown>;
+const saved: Record<string, unknown> = {};
+
+function drainFrames(n: number) {
+    for (let i = 0; i < n; i++) {
+        const q = rafQueue;
+        rafQueue = [];
+        if (q.length === 0) return;
+        q.forEach((cb) => cb(0));
+    }
+}
+
+beforeEach(() => {
+    scrollTo.mockReset();
+    scrollHeight = 0;
+    scrollY = 0;
+    rafQueue = [];
+    resizeCallbacks = [];
+
+    for (const k of ['window', 'document', 'requestAnimationFrame', 'ResizeObserver']) {
+        saved[k] = g[k];
+    }
+
+    g.window = {
+        get scrollY() {
+            return scrollY;
+        },
+        innerHeight: 800,
+        scrollTo: (x: number, y: number) => {
+            scrollTo(x, y);
+            // 브라우저처럼 clamp 한다 — 이 동작이 있어야 사고를 재현할 수 있다
+            scrollY = Math.min(y, Math.max(0, scrollHeight - 800));
+        }
+    };
+    g.document = {
+        documentElement: {
+            get scrollHeight() {
+                return scrollHeight;
+            }
+        }
+    };
+    g.requestAnimationFrame = (cb: FrameRequestCallback) => {
+        rafQueue.push(cb);
+        return rafQueue.length;
+    };
+    g.ResizeObserver = class {
+        constructor(cb: () => void) {
+            resizeCallbacks.push(cb);
+        }
+        observe() {}
+        disconnect() {}
+    };
+});
+
+afterEach(() => {
+    for (const k of Object.keys(saved)) g[k] = saved[k];
+});
+
+describe('createScrollSnapshot', () => {
+    it('capture 는 현재 스크롤 위치를 담는다', () => {
+        scrollY = 1234;
+        expect(createScrollSnapshot().capture()).toEqual({ scrollY: 1234 });
+    });
+
+    it('⛔ 문서가 짧으면 scrollTo 를 부르지 않는다 (맨 아래 clamp 방지)', () => {
+        scrollHeight = 900; // 최대 스크롤 100 < 목표 5000
+        createScrollSnapshot().restore({ scrollY: 5000 });
+        drainFrames(70);
+
+        expect(scrollTo).not.toHaveBeenCalled();
+        expect(scrollY).toBe(0); // 맨 아래로 끌려가지 않았다
+    });
+
+    it('문서 높이가 따라오면 그때 복원한다', () => {
+        scrollHeight = 900;
+        createScrollSnapshot().restore({ scrollY: 5000 });
+        drainFrames(3);
+        expect(scrollTo).not.toHaveBeenCalled();
+
+        scrollHeight = 6000; // 이미지·댓글이 로드돼 문서가 길어졌다
+        drainFrames(3);
+
+        expect(scrollTo).toHaveBeenCalledWith(0, 5000);
+        expect(scrollY).toBe(5000);
+    });
+
+    it('rAF 상한을 넘긴 뒤에도 ResizeObserver 가 복원한다', () => {
+        scrollHeight = 900;
+        createScrollSnapshot().restore({ scrollY: 5000 });
+        drainFrames(70); // rAF 소진
+        expect(scrollTo).not.toHaveBeenCalled();
+
+        scrollHeight = 6000;
+        resizeCallbacks.forEach((cb) => cb());
+
+        expect(scrollTo).toHaveBeenCalledWith(0, 5000);
+    });
+
+    it('맨 위였으면 아무것도 하지 않는다 (스와이프 제스처 간섭 방지)', () => {
+        scrollHeight = 6000;
+        createScrollSnapshot().restore({ scrollY: 0 });
+        drainFrames(70);
+        resizeCallbacks.forEach((cb) => cb());
+
+        expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('도달하면 더 이상 스크롤하지 않는다 (사용자 조작 방해 금지)', () => {
+        scrollHeight = 6000;
+        createScrollSnapshot().restore({ scrollY: 5000 });
+        drainFrames(70);
+        const callsAfterRestore = scrollTo.mock.calls.length;
+
+        resizeCallbacks.forEach((cb) => cb());
+        expect(scrollTo.mock.calls.length).toBe(callsAfterRestore);
+    });
+});

--- a/apps/web/src/lib/utils/scroll-restore.ts
+++ b/apps/web/src/lib/utils/scroll-restore.ts
@@ -1,0 +1,88 @@
+/**
+ * 뒤로가기 스크롤 위치 복원 (목록·상세 공용).
+ *
+ * ⛔ **문서 높이를 확인하지 않고 `scrollTo(target)` 을 부르면 안 된다.**
+ *    뒤로 돌아온 직후에는 이미지·광고·임베드·댓글이 아직 안 그려져 문서가 짧다.
+ *    그때 목표 위치로 스크롤하면 브라우저가 **맨 아래로 clamp** 하고, 높이가 끝내
+ *    안 따라오면 그 상태로 고착된다 — "뒤로 가면 맨 밑으로 떨어진다" 현상.
+ *    (#9401 → #13022 목록 페이지, #13221 글 상세 페이지)
+ *
+ * 그래서 목표 높이에 도달하기 전에는 아예 호출하지 않고, 높이가 따라올 때까지 재시도한다.
+ *   - rAF 최대 60프레임(~1s)
+ *   - 그 뒤는 ResizeObserver 로 문서 높이 변화마다 재시도 (3초 상한)
+ *
+ * ⛔ 이 로직을 페이지마다 복붙하지 말 것. 2026-03 에 목록만 고치고 상세를 빠뜨려
+ *    같은 증상이 5개월 더 남아 있었다. 스크롤 복원이 필요한 페이지는 이 유틸을 쓴다.
+ */
+
+/** 목표와 이 정도 차이는 도달로 본다 (서브픽셀·주소창 높이 변동 흡수) */
+const TOLERANCE_PX = 2;
+/** rAF 재시도 상한 — 이후는 ResizeObserver 가 이어받는다 */
+const MAX_FRAMES = 60;
+/** 늦게 로드되는 자산까지 기다리는 상한. 넘으면 포기한다 */
+const OBSERVE_TIMEOUT_MS = 3000;
+
+export interface ScrollSnapshotValue {
+    scrollY: number;
+}
+
+/**
+ * SvelteKit `snapshot` 으로 그대로 쓸 수 있는 객체를 만든다.
+ *
+ * ```svelte
+ * <script lang="ts" module>
+ *     export const snapshot = createScrollSnapshot();
+ * </script>
+ * ```
+ */
+export function createScrollSnapshot(): {
+    capture: () => ScrollSnapshotValue;
+    restore: (value: ScrollSnapshotValue) => void;
+} {
+    return {
+        capture: () => ({ scrollY: window.scrollY }),
+
+        restore: (value: ScrollSnapshotValue) => {
+            const target = value?.scrollY ?? 0;
+            // 맨 위였으면 복원할 것이 없다. 굳이 건드리면 스와이프 제스처와 충돌만 난다.
+            if (target <= 0) return;
+
+            let tries = 0;
+            let done = false;
+
+            /** 문서가 목표에 닿았을 때만 스크롤한다 — clamp 방지의 핵심 */
+            const tryScroll = () => {
+                const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+                if (maxScroll >= target - TOLERANCE_PX) {
+                    window.scrollTo(0, target);
+                    if (Math.abs(window.scrollY - target) <= TOLERANCE_PX) done = true;
+                }
+            };
+
+            const attempt = () => {
+                if (done) return;
+                tryScroll();
+                tries++;
+                if (!done && tries < MAX_FRAMES) requestAnimationFrame(attempt);
+            };
+            requestAnimationFrame(attempt);
+
+            // 이미지·광고가 로드돼 문서 높이가 바뀔 때마다 재시도
+            if (typeof ResizeObserver !== 'undefined') {
+                const ro = new ResizeObserver(() => {
+                    if (done) {
+                        ro.disconnect();
+                        return;
+                    }
+                    tryScroll();
+                    if (done) ro.disconnect();
+                });
+                ro.observe(document.documentElement);
+                setTimeout(() => {
+                    done = true;
+                    ro.disconnect();
+                }, OBSERVE_TIMEOUT_MS);
+            }
+        }
+    };
+}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1,55 +1,10 @@
 <script lang="ts" module>
-    import type { Snapshot } from './$types.js';
+    import { createScrollSnapshot } from '$lib/utils/scroll-restore.js';
 
-    // 뒤로가기 시 스크롤 위치 복원. 이미지/광고 로드로 문서 높이가 뒤늦게 확장되는 케이스
-    // (특히 iOS Safari) 까지 커버하기 위해 ResizeObserver 로 목표 위치에 도달할 때까지
-    // 반복 재시도 (#9401 — 상세에서 뒤로가기 시 목록 최하단으로 떨어지는 현상).
-    export const snapshot: Snapshot<{ scrollY: number }> = {
-        capture: () => ({ scrollY: window.scrollY }),
-        restore: (value) => {
-            const target = value.scrollY;
-            if (target <= 0) return;
-
-            let tries = 0;
-            let done = false;
-            const maxTries = 60; // requestAnimationFrame 60프레임 (~1s). 이후는 ResizeObserver 가 커버
-
-            // 문서가 목표 높이에 못 미치는 동안에는 scrollTo 를 호출하지 않는다.
-            // 짧은 문서(이미지/광고 로드 전)에 scrollTo(target) 하면 맨 밑으로 clamp 되고,
-            // 높이가 끝내 안 따라오면 그 상태로 고착돼 "목록이 맨 밑으로" 현상이 된다(#13022).
-            const tryScroll = () => {
-                const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
-                if (maxScroll >= target - 2) {
-                    window.scrollTo(0, target);
-                    if (Math.abs(window.scrollY - target) <= 2) done = true;
-                }
-            };
-            const attempt = () => {
-                if (done) return;
-                tryScroll();
-                tries++;
-                if (!done && tries < maxTries) requestAnimationFrame(attempt);
-            };
-            requestAnimationFrame(attempt);
-
-            // 이미지/광고가 로드돼 문서 높이가 변경될 때마다 재시도
-            if (typeof ResizeObserver !== 'undefined') {
-                const ro = new ResizeObserver(() => {
-                    if (done) {
-                        ro.disconnect();
-                        return;
-                    }
-                    tryScroll();
-                    if (done) ro.disconnect();
-                });
-                ro.observe(document.documentElement);
-                setTimeout(() => {
-                    done = true;
-                    ro.disconnect();
-                }, 3000);
-            }
-        }
-    };
+    // 뒤로가기 시 스크롤 위치 복원 (#9401·#13022).
+    // 구현은 $lib/utils/scroll-restore 로 옮겼다 — 상세 페이지가 같은 로직을 복붙 없이
+    // 쓰게 하기 위해서다. 한쪽만 고치는 일이 실제로 있었다(#13221).
+    export const snapshot = createScrollSnapshot();
 </script>
 
 <script lang="ts">

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1,17 +1,12 @@
 <script lang="ts" module>
-    import type { Snapshot } from './$types.js';
+    import { createScrollSnapshot } from '$lib/utils/scroll-restore.js';
 
-    // 뒤로가기 시 스크롤 위치 즉시 복원
-    export const snapshot: Snapshot<{ scrollY: number }> = {
-        capture: () => ({ scrollY: window.scrollY }),
-        restore: (value) => {
-            // Safari 타이밍 이슈 대응: rAF + setTimeout 이중 보호
-            requestAnimationFrame(() => window.scrollTo(0, value.scrollY));
-            setTimeout(() => {
-                requestAnimationFrame(() => window.scrollTo(0, value.scrollY));
-            }, 100);
-        }
-    };
+    // 뒤로가기 시 스크롤 위치 복원.
+    // ⛔ 예전에는 rAF + setTimeout(100ms) 로 문서 높이를 보지 않고 scrollTo 했다.
+    //    돌아온 직후에는 이미지·임베드·댓글이 아직 없어 문서가 짧아, 브라우저가 맨 아래로
+    //    clamp 하고 그대로 고착됐다(#13221). 목록 페이지에서 같은 증상을 이미 겪고
+    //    고쳤는데(#9401·#13022) 상세에는 적용되지 않았다. 이제 같은 구현을 공유한다.
+    export const snapshot = createScrollSnapshot();
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## 증상

「아이폰 사파리에서 왼쪽 스와이프로 뒤로 가기 시 화면 맨 아래로 가는 버그」 (bug/13221). 제보자는 재현이 어렵다고 하셨는데, 이미지·광고 로딩 타이밍에 달려 있어 회선 상태에 따라 갈립니다.

## 원인 — 이미 고쳤던 버그의 **누락된 절반**

글 상세 페이지의 스크롤 복원이 **문서 높이를 보지 않고** `scrollTo` 를 불렀습니다.

```js
requestAnimationFrame(() => window.scrollTo(0, value.scrollY));
setTimeout(() => requestAnimationFrame(() => window.scrollTo(0, value.scrollY)), 100);
```

뒤로 돌아온 직후에는 이미지·임베드·댓글이 아직 없어 문서가 짧습니다. 그 상태에서 목표 위치로 스크롤하면 브라우저가 **맨 아래로 clamp** 하고, 높이가 끝내 안 따라오면 그대로 고착됩니다.

**같은 증상을 목록 페이지에서 이미 겪고 고쳤습니다** (#9401 → #13022). 코드 주석에 원인까지 정확히 적혀 있었는데, **상세 페이지에는 적용되지 않아 5개월 더 남아 있었습니다.**

## 변경

- `$lib/utils/scroll-restore` 신설 — 목록 페이지의 **검증된 구현을 그대로** 옮겼습니다
  (목표 높이 도달 전 `scrollTo` 금지 + rAF 60프레임 + `ResizeObserver` 3초 상한)
- **글 상세**: 가드 없던 구현을 교체
- **목록**: 동작 동일, 유틸로 위임

새 로직을 짠 것이 아니라 운영에서 검증된 코드를 공유하게 만든 것입니다. 한쪽만 고치는 일이 실제로 있었기 때문에 복붙을 남기지 않았습니다.

## 대조군으로 확인했습니다

문서가 짧은 상태(최대 스크롤 100 < 목표 5000)에서 두 구현을 각각 돌렸습니다.

```
옛 구현: scrollTo 호출 2회, 최종 scrollY=100 (문서 바닥=100) → ⚠️ 맨 아래로 고착
새 구현: scrollTo 호출 0회, 최종 scrollY=0                  → 정상(건드리지 않음)
```

이 시나리오를 `scroll-restore.test.ts` 로 고정했습니다. 통과만 확인하는 테스트가 되지 않도록, **옛 구현이면 실패하는** 단언을 넣었습니다.

## Test plan

- [ ] 목록 → 글 → 뒤로: 목록 스크롤 위치 복원 (기존 동작 회귀 없음)
- [ ] 글에서 스크롤 → 다른 화면 → 뒤로: 맨 아래로 떨어지지 않음
- [ ] 맨 위에서 뒤로: 스크롤 개입 없음 (스와이프 제스처 간섭 방지)
- [ ] 이미지 많은 글에서 느린 회선 시뮬레이션