### PR TITLE
fix: 차단 댓글 숨김 설정 후속 — 서버 저장 누락·토글 위치·테스트 구조 (bug/13224)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -424,11 +424,7 @@
      * 쓰게 하려는 것이다. 여기 인라인으로 복사하지 말 것.
      */
     const visibleComments = $derived.by(() =>
-        filterVisibleComments(
-            commentTree,
-            uiSettingsStore.hideBlockedComments,
-            isBlockedComment
-        )
+        filterVisibleComments(commentTree, uiSettingsStore.hideBlockedComments, isBlockedComment)
     );
 
     function toggleBlockedComment(commentId: string): void {

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -47,6 +47,7 @@
     import History from '@lucide/svelte/icons/history';
     import Heart from '@lucide/svelte/icons/heart';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
+    import { filterVisibleComments } from '$lib/utils/blocked-comment-filter.js';
 
     // 동적 플러그인 임포트: member-memo
     let MemoBadge = $state<Component | null>(null);
@@ -419,25 +420,16 @@
     /**
      * 실제로 그릴 댓글 목록 (#13224).
      *
-     * 설정이 켜져 있으면 차단한 회원의 댓글을 안내문 없이 아예 제외한다.
-     * ⛔ 단 **답글이 달린 댓글은 제외하지 않는다.** 부모를 없애면 거기 답글을 단
-     *    제3자의 댓글이 부모를 잃고 맥락이 끊긴다 — 차단 대상이 아닌 사람이 피해를 본다.
-     *
-     * ⛔ "답글 있음" 을 parent_id 로 판정하면 안 된다. 운영 경로는 API 가 내려주는
-     *    depth 를 그대로 쓰는 **평면 목록**이라(위 commentTree 참조) parent_id 맵이 없다.
-     *    두 경로 모두 depth 순서가 보존된 평면 배열이므로
-     *    **다음 항목의 depth 가 더 크면 답글 있음** 으로 판정한다.
+     * 규칙 본체는 $lib/utils/blocked-comment-filter 에 있다 — 구현과 테스트가 같은 것을
+     * 쓰게 하려는 것이다. 여기 인라인으로 복사하지 말 것.
      */
-    const visibleComments = $derived.by(() => {
-        const tree = commentTree;
-        if (!uiSettingsStore.hideBlockedComments) return tree;
-        return tree.filter((c, i) => {
-            if (!isBlockedComment(c)) return true;
-            const next = tree[i + 1];
-            const hasReplies = !!next && (next.depth ?? 0) > (c.depth ?? 0);
-            return hasReplies;
-        });
-    });
+    const visibleComments = $derived.by(() =>
+        filterVisibleComments(
+            commentTree,
+            uiSettingsStore.hideBlockedComments,
+            isBlockedComment
+        )
+    );
 
     function toggleBlockedComment(commentId: string): void {
         if (expandedBlockedComments.has(commentId)) {

--- a/apps/web/src/lib/utils/blocked-comment-filter.test.ts
+++ b/apps/web/src/lib/utils/blocked-comment-filter.test.ts
@@ -3,39 +3,31 @@ import { describe, expect, it } from 'vitest';
 /**
  * 차단 회원 댓글 숨김 규칙 (#13224).
  *
- * 지키는 계약:
- *   1. 설정이 꺼져 있으면 목록이 그대로다 (기본값 OFF — 현행 100% 유지)
- *   2. 답글이 없는 차단 댓글만 제외한다
- *   3. ⛔ **답글이 달린 차단 댓글은 제외하지 않는다.** 부모를 없애면 거기 답글을 단
- *      제3자의 댓글이 부모를 잃는다 — 차단 대상이 아닌 사람이 피해를 본다.
+ * ⛔ 이 테스트는 **실제 구현을 import 한다.** 예전 판은 같은 로직을 복제해 두어
+ *    구현이 바뀌어도 영원히 초록이었다(계약이 아니라 계약의 사본을 고정했다).
  *
- * ⛔ "답글 있음" 판정은 parent_id 가 아니라 **다음 항목의 depth** 로 한다.
- *    운영 경로는 API 가 내려주는 depth 를 그대로 쓰는 평면 목록이라 parent_id 맵이 없다.
- *    이 테스트는 그 평면 구조를 그대로 흉내낸다.
+ * 지키는 계약:
+ *   1. 설정이 꺼져 있으면 **원본 배열을 그대로**(참조 동일) 돌려준다
+ *   2. 답글이 없는 차단 댓글만 제외한다
+ *   3. ⛔ 답글이 달린 차단 댓글은 제외하지 않는다 — 제3자의 답글이 부모를 잃는다
  */
+import { filterVisibleComments } from './blocked-comment-filter';
 
 type C = { id: number; depth: number; blocked: boolean };
 
-/** comment-list.svelte 의 visibleComments 와 동일한 규칙 */
-function visible(tree: C[], hide: boolean): C[] {
-    if (!hide) return tree;
-    return tree.filter((c, i) => {
-        if (!c.blocked) return true;
-        const next = tree[i + 1];
-        return !!next && (next.depth ?? 0) > (c.depth ?? 0);
-    });
-}
+const visible = (tree: C[], hide: boolean) =>
+    filterVisibleComments(tree, hide, (c) => c.blocked);
 
 const ids = (list: C[]) => list.map((c) => c.id);
 
 describe('차단 회원 댓글 숨김 규칙', () => {
-    it('설정 OFF 면 아무것도 바뀌지 않는다 (기본값)', () => {
+    it('설정 OFF 면 원본을 그대로 돌려준다 (참조 동일 — 불필요한 재렌더 방지)', () => {
         const tree: C[] = [
             { id: 1, depth: 0, blocked: false },
             { id: 2, depth: 0, blocked: true },
             { id: 3, depth: 0, blocked: false }
         ];
-        expect(ids(visible(tree, false))).toEqual([1, 2, 3]);
+        expect(visible(tree, false)).toBe(tree);
     });
 
     it('답글 없는 차단 댓글은 제외한다', () => {

--- a/apps/web/src/lib/utils/blocked-comment-filter.test.ts
+++ b/apps/web/src/lib/utils/blocked-comment-filter.test.ts
@@ -15,8 +15,7 @@ import { filterVisibleComments } from './blocked-comment-filter';
 
 type C = { id: number; depth: number; blocked: boolean };
 
-const visible = (tree: C[], hide: boolean) =>
-    filterVisibleComments(tree, hide, (c) => c.blocked);
+const visible = (tree: C[], hide: boolean) => filterVisibleComments(tree, hide, (c) => c.blocked);
 
 const ids = (list: C[]) => list.map((c) => c.id);
 

--- a/apps/web/src/lib/utils/blocked-comment-filter.ts
+++ b/apps/web/src/lib/utils/blocked-comment-filter.ts
@@ -1,0 +1,39 @@
+/**
+ * 차단한 회원의 댓글을 목록에서 제외하는 규칙 (#13224).
+ *
+ * ⛔ **답글이 달린 댓글은 제외하지 않는다.** 부모를 없애면 거기 답글을 단 제3자의 댓글이
+ *    부모를 잃고 맥락이 끊긴다 — 차단 대상이 아닌 사람이 피해를 본다.
+ *
+ * ⛔ "답글 있음" 을 `parent_id` 로 판정하면 운영에서 틀린다. 댓글 목록은 API 가 depth 를
+ *    주면(운영 경로) **평면 목록 + depth** 를 그대로 쓰고 parent_id 맵을 만들지 않는다.
+ *    두 경로 모두 **pre-order(부모 바로 뒤에 자식)** 평면 배열이므로
+ *    **다음 항목의 depth 가 더 크면 답글 있음** 으로 판정한다.
+ *    → 제외되는 항목은 자식이 0개이므로, 남은 답글은 언제나 부모가 살아 있다.
+ *
+ * ⛔ 이 규칙을 호출부에 인라인으로 복사하지 말 것. 예전에 테스트가 구현을 import 하지 않고
+ *    같은 로직을 **복제**해 두어, 구현이 바뀌어도 테스트가 영원히 초록인 상태였다.
+ *    구현과 테스트가 반드시 이 함수 하나를 공유한다.
+ */
+
+/** depth 를 가진 평면 댓글 목록의 최소 형태 */
+export interface DepthNode {
+    depth?: number;
+}
+
+/**
+ * @param tree      pre-order 로 정렬된 평면 댓글 배열
+ * @param hide      설정값. false 면 원본을 **그대로**(참조 동일) 돌려준다
+ * @param isBlocked 차단 여부 판정자 (서버 플래그 + 클라 스토어 결합은 호출부 책임)
+ */
+export function filterVisibleComments<T extends DepthNode>(
+    tree: T[],
+    hide: boolean,
+    isBlocked: (comment: T) => boolean
+): T[] {
+    if (!hide) return tree;
+    return tree.filter((c, i) => {
+        if (!isBlocked(c)) return true;
+        const next = tree[i + 1];
+        return !!next && (next.depth ?? 0) > (c.depth ?? 0);
+    });
+}

--- a/apps/web/src/routes/api/my/ui-settings/+server.ts
+++ b/apps/web/src/routes/api/my/ui-settings/+server.ts
@@ -42,6 +42,7 @@ const ALLOWED_KEYS = new Set<string>([
     'recommendFontSize',
     'pinSearch',
     'pinMemoSearch',
+    'hideBlockedComments',
     'hideMemo',
     'hideMemoInList',
     'blurMemo',

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -766,6 +766,32 @@
                 <CardHeader>
                     <CardTitle class="flex items-center gap-2">
                         <Ban class="h-5 w-5" />
+                        차단 회원 표시
+                    </CardTitle>
+                    <CardDescription>차단한 회원의 댓글을 어떻게 보여줄지 정합니다.</CardDescription
+                    >
+                </CardHeader>
+                <CardContent class="space-y-3">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <Label>차단한 회원의 댓글 완전히 숨기기</Label>
+                            <p class="text-muted-foreground text-xs">
+                                안내문 없이 아예 표시하지 않습니다. 답글이 달린 댓글은 대화가 끊기지
+                                않도록 안내문을 남깁니다
+                            </p>
+                        </div>
+                        <Switch
+                            checked={uiSettingsStore.hideBlockedComments}
+                            onCheckedChange={(v) => uiSettingsStore.setHideBlockedComments(v)}
+                        />
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle class="flex items-center gap-2">
+                        <Ban class="h-5 w-5" />
                         제목 필터링 (뮤트)
                     </CardTitle>
                     <CardDescription>특정 단어가 포함된 게시글을 목록에서 숨깁니다.</CardDescription
@@ -1405,20 +1431,6 @@
                     <CardDescription>메모 플러그인의 표시 방식을 설정합니다.</CardDescription>
                 </CardHeader>
                 <CardContent class="space-y-4">
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <Label>차단한 회원의 댓글 완전히 숨기기</Label>
-                            <p class="text-muted-foreground text-xs">
-                                안내문 없이 아예 표시하지 않습니다. 답글이 달린 댓글은 대화가 끊기지
-                                않도록 안내문을 남깁니다
-                            </p>
-                        </div>
-                        <Switch
-                            checked={uiSettingsStore.hideBlockedComments}
-                            onCheckedChange={(v) => uiSettingsStore.setHideBlockedComments(v)}
-                        />
-                    </div>
-                    <Separator />
                     <div class="flex items-center justify-between">
                         <div>
                             <Label>메모 배지 가리기</Label>


### PR DESCRIPTION
#1949 검증에서 나온 3건. 승격 전 처리.

## ⛔ 서버 저장이 조용히 실패하고 있었다

`routes/api/my/ui-settings/+server.ts` 의 `ALLOWED_KEYS` 화이트리스트에 `hideBlockedComments` 가 없어 값이 **드롭**됐습니다. 400 도 500 도 아니고 `{success:true}` 를 돌려줍니다.

결과: 토글은 켜지고 동작하지만(localStorage) **서버에는 영원히 저장되지 않습니다.** 기기를 옮기거나 브라우저가 저장소를 비우면 조용히 꺼집니다.

그 파일 주석에 「`UiSettings` 인터페이스와 동일하게 유지한다」는 불변식이 적혀 있는데도 놓쳤습니다. → **UiSettings 에 키를 추가하면 이 화이트리스트도 같이 고쳐야 합니다.**

## 토글이 「메모 설정」 카드 안에 있었다

차단 댓글 설정을 찾는 사람이 메모 카드를 열 이유가 없습니다. **찾을 수 없는 설정은 구현하지 않은 설정입니다.** → 「차단 회원 표시」 독립 카드로 분리해 「제목 필터링(뮤트)」 옆에 배치.

## 테스트가 구현을 import 하지 않았다

`blocked-comment-filter.test.ts` 는 있는데 `blocked-comment-filter.ts` **모듈이 없었습니다.** 테스트가 같은 로직을 복제해 두어 구현이 바뀌어도 **영원히 초록**입니다 — 계약이 아니라 계약의 사본을 고정하고 있었습니다.

→ `$lib/utils/blocked-comment-filter.ts` 를 실제로 만들어 `comment-list.svelte` 와 테스트가 **같은 함수를 import** 합니다. 「설정 OFF 시 원본 참조를 그대로 돌려준다」도 단언에 추가했습니다.

## Test plan

- [ ] 설정 토글 → 서버 `PUT /api/my/ui-settings` 에 키가 실려 저장되는지
- [ ] 다른 기기/브라우저에서 설정이 유지되는지
- [ ] 「차단 회원 표시」 카드가 「기타」 탭에서 보이는지
- [ ] 설정 OFF 시 동작 무변경
- [ ] 답글 있는 차단 댓글은 여전히 자리표시자 유지