### PR TITLE
fix: 차단 댓글 필터를 마운트 이후에만 적용 (하이드레이션 구조 불일치 차단)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -418,13 +418,32 @@
     }
 
     /**
+     * ⛔ localStorage 기반 설정을 렌더 **구조**에 그대로 쓰면 하이드레이션이 깨진다.
+     *    SSR 은 DEFAULTS(꺼짐)라 전체 목록을, 클라이언트는 저장값을 읽어 줄어든 목록을
+     *    그리므로 노드 수가 갈린다. 그래서 마운트 이후에만 반영한다.
+     *    (같은 이유의 선례: routes/member/settings/ui/+page.svelte 의 `hydrated`)
+     *
+     * 대가: 설정을 켠 사용자에게 차단 댓글 자리표시자가 아주 잠깐 보였다 사라진다.
+     * 본문이 아니라 한 줄짜리 자리표시자라 노출 문제는 없고, 구조 불일치를 아예
+     * 만들지 않는 편이 안전하다.
+     */
+    let commentsHydrated = $state(false);
+    onMount(() => {
+        commentsHydrated = true;
+    });
+
+    /**
      * 실제로 그릴 댓글 목록 (#13224).
      *
      * 규칙 본체는 $lib/utils/blocked-comment-filter 에 있다 — 구현과 테스트가 같은 것을
      * 쓰게 하려는 것이다. 여기 인라인으로 복사하지 말 것.
      */
     const visibleComments = $derived.by(() =>
-        filterVisibleComments(commentTree, uiSettingsStore.hideBlockedComments, isBlockedComment)
+        filterVisibleComments(
+            commentTree,
+            commentsHydrated && uiSettingsStore.hideBlockedComments,
+            isBlockedComment
+        )
     );
 
     function toggleBlockedComment(commentId: string): void {


### PR DESCRIPTION
## 문제

`hideBlockedComments` 는 localStorage 기반이라 **SSR 은 기본값(꺼짐)** 으로 전체 목록을, **클라이언트는 저장값** 을 읽어 줄어든 목록을 그립니다. 렌더 구조(노드 수)가 갈리므로 하이드레이션이 어긋납니다.

## 왜 검증 대신 차단을 택했나

실동작으로 확인하려 했으나 **차단 회원이 있는 계정이 없어 재현이 막혔습니다.** 코드 판독으로는 「최종 DOM 은 맞을 것」으로 보이나 깜박임·재렌더 여부는 확인하지 못했습니다.

확인이 막힌 상황에서 「확인해보니 괜찮더라」보다 **「애초에 생길 수 없게」** 가 낫다고 판단했습니다.

## 변경

마운트 이후에만 필터를 적용합니다. 레포에 **같은 이유의 선례** 가 있어 그 관용구를 그대로 따랐습니다 — `routes/member/settings/ui/+page.svelte`:

> ⛔ localStorage 기반 설정을 `{#if}` 구조 조건에 그대로 쓰면 하이드레이션이 깨진다. SSR 은 DEFAULTS, 클라이언트는 저장값이라 구조가 갈린다.

## 대가

설정을 켠 사용자에게 차단 댓글 **자리표시자가 아주 잠깐 보였다 사라집니다.** 본문이 아니라 한 줄짜리 자리표시자(「내가 차단한 회원의 댓글입니다」)라 노출 문제는 없습니다.

## Test plan

- [ ] 설정 OFF(기본): 동작 무변경
- [ ] 설정 ON: 마운트 후 차단 댓글이 사라지는지
- [ ] 하이드레이션 경고 0
- [ ] 답글 있는 차단 댓글은 여전히 자리표시자 유지