### PR TITLE
chore: 이모티콘 최적화 도구 (스크립트 + CI 워크플로)

### DIFF
--- a/.github/workflows/optimize-emoticons.yml
+++ b/.github/workflows/optimize-emoticons.yml
@@ -1,0 +1,152 @@
+name: Optimize Emoticons
+
+# ⛔ 이 작업은 운영 서버에서 돌리지 않는다. 이모티콘 재인코딩은 무거운 CPU 작업이라
+#    응답시간을 악화시킨다(2026-08-03 「느리다」 제보 대응 중 확인). 러너에서만 돌린다.
+#
+# 수동 실행 전용. 결과는 브랜치 + PR 로 받아 사람이 확인하고 머지한다.
+# 자동 실행하지 않는 이유: 이미지가 깨져도 CI 는 통과한다. 눈으로 봐야 한다.
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_width:
+        description: '목표 최대 폭(px). 본문 최대 표시 200px × 레티나 2배 = 400 이 기본'
+        required: false
+        default: '400'
+      min_bytes:
+        description: '이 크기(byte) 미만은 건드리지 않음'
+        required: false
+        default: '102400'
+      apply:
+        description: '실제 반영 여부. false 면 dry-run 으로 결과만 본다'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  optimize:
+    name: Optimize emoticon assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Pillow
+        run: pip install --quiet 'Pillow>=11'
+
+      - name: Record before
+        id: before
+        run: |
+          SIZE=$(du -sb apps/web/static/emoticons | cut -f1)
+          COUNT=$(ls apps/web/static/emoticons | wc -l)
+          echo "size=$SIZE" >> $GITHUB_OUTPUT
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          echo "적용 전: ${COUNT}개 / $((SIZE/1048576))MB"
+
+      - name: Optimize
+        id: run
+        run: |
+          set -o pipefail
+          ARGS="apps/web/static/emoticons --max-width ${{ inputs.max_width }} --min-bytes ${{ inputs.min_bytes }}"
+          if [ "${{ inputs.apply }}" = "true" ]; then ARGS="$ARGS --apply"; fi
+          python3 scripts/optimize-emoticons.py $ARGS 2>&1 | tee optimize.log
+          {
+            echo '## 이모티콘 최적화 결과'
+            echo
+            echo '```'
+            tail -60 optimize.log
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+      # ⛔ 변환이 조용히 깨뜨렸는지 반드시 확인한다. 스크립트 자체 검증과 별개로,
+      #    전 파일을 다시 열어 손상 여부를 본다. 이미지가 깨져도 빌드는 통과한다.
+      - name: Verify all images still open
+        if: inputs.apply
+        run: |
+          python3 - <<'PY'
+          import os, sys
+          from PIL import Image
+          d = 'apps/web/static/emoticons'
+          bad = []
+          for f in sorted(os.listdir(d)):
+              p = os.path.join(d, f)
+              if not os.path.isfile(p):
+                  continue
+              try:
+                  with Image.open(p) as im:
+                      im.verify()
+              except Exception as e:
+                  bad.append(f'{f}: {str(e)[:60]}')
+          if bad:
+              print('❌ 손상된 파일:')
+              for b in bad[:30]:
+                  print('  ', b)
+              sys.exit(1)
+          print(f'✅ 전 파일 정상 ({len(os.listdir(d))}개)')
+          PY
+
+      - name: Create pull request
+        if: inputs.apply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet; then
+            echo "변경 없음 — PR 생성 생략"; exit 0
+          fi
+          AFTER=$(du -sb apps/web/static/emoticons | cut -f1)
+          BEFORE=${{ steps.before.outputs.size }}
+          SAVED=$(( (BEFORE - AFTER) / 1048576 ))
+          BRANCH="chore/optimize-emoticons-${{ github.run_id }}"
+          git config user.name  'angple'
+          git config user.email 'sdk@sdk.xyz'
+          git checkout -b "$BRANCH"
+          git add apps/web/static/emoticons
+          git commit -m "chore: 이모티콘 해상도 최적화 (${SAVED}MB 절감)
+
+          본문 최대 표시 폭이 200px(parser.ts MAX_WIDTH)인데 원본이 640~925px 라
+          표시 대비 최대 13배였다. 레티나 2배를 감안한 ${{ inputs.max_width }}px 로 줄인다.
+          화면에 보이는 차이는 없다.
+
+          애니메이션 프레임은 보존한다. 파일명·확장자·포맷도 그대로라
+          기존 글의 참조가 깨지지 않는다.
+
+          $((BEFORE/1048576))MB → $((AFTER/1048576))MB
+
+          ⛔ 운영 서버가 아니라 CI 러너에서 변환했다. 재인코딩은 무거운 CPU 작업이라
+          운영에서 돌리면 응답시간이 나빠진다."
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: 이모티콘 해상도 최적화 (${SAVED}MB 절감)" \
+            --body "$(cat <<EOF
+          자동 생성 PR (\`optimize-emoticons\` 워크플로, run \`${{ github.run_id }}\`).
+
+          ## 결과
+          $((BEFORE/1048576))MB → $((AFTER/1048576))MB (**${SAVED}MB 절감**)
+
+          목표 최대 폭 \`${{ inputs.max_width }}px\` / 최소 대상 크기 \`${{ inputs.min_bytes }}\` byte
+
+          ## 무엇을 했나
+          해상도만 줄였다. **애니메이션 프레임·파일명·확장자·포맷은 그대로**라
+          기존 글의 \`<img src="/emoticons/...">\` 참조가 깨지지 않는다.
+
+          본문 표시 폭은 최대 200px(\`parser.ts\` \`MAX_WIDTH\`)이고 선택창은 32~40px 인데
+          원본이 640~925px 였다. 레티나 2배를 감안해도 400px 면 충분하다.
+
+          ## ⛔ 머지 전 반드시 확인할 것
+          - [ ] **이모티콘 몇 개를 실제로 열어 눈으로 확인** — 애니메이션이 살아 있는지,
+                화질이 뭉개지지 않았는지. CI 는 이미지가 깨져도 통과한다
+          - [ ] 선택창에서 전체 팩이 정상 표시되는지
+          - [ ] 기존 글의 이모티콘이 그대로 보이는지
+
+          상세 로그는 워크플로 실행 요약(Summary)에 있다.
+          EOF
+          )"

--- a/scripts/optimize-emoticons.py
+++ b/scripts/optimize-emoticons.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""이모티콘 용량 최적화 — 해상도만 줄이고 **애니메이션은 보존**한다.
+
+⛔ 운영 서버에서 실행하지 말 것. 무거운 CPU 작업이라 응답시간을 악화시킨다.
+   CI 러너에서 돌린다(.github/workflows/optimize-emoticons.yml).
+
+## 왜 해상도인가 (2026-08-03 실측)
+
+이모티콘은 본문에서 **최대 200px**(`parser.ts` 의 `MAX_WIDTH`), 기본 50px 로 표시된다.
+선택창은 32~40px 다. 그런데 원본은 640×473, 631×925 처럼 크다 — 표시 대비 최대 13배.
+
+→ 레티나 2배를 감안해도 **400px 면 충분하다.** 그 이상은 내려보내도 화면에 안 보인다.
+→ 프레임(애니메이션)은 건드리지 않는다. 움직임이 이모티콘의 본질이다.
+
+## 안전장치
+
+- 원본보다 **커지면 되돌린다**(작아질 때만 채택)
+- 저장 후 **다시 열어 프레임 수·크기를 검증**한다. 하나라도 어긋나면 되돌린다
+- 파일명·확장자·포맷 **불변**. 기존 글 참조가 깨지지 않는다
+- 임계값 미만(작은 파일)은 손대지 않는다 — 835개는 이미 20KB 미만이다
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+
+from PIL import Image, ImageSequence
+
+# 본문 최대 표시 200px × 레티나 2배. 이보다 크면 화면에서 차이가 안 보인다.
+TARGET_MAX_W = 400
+# 이 크기 미만은 건드리지 않는다. 줄여봐야 얻는 게 없고 위험만 생긴다.
+MIN_BYTES = 100 * 1024
+
+
+def load_frames(im: Image.Image) -> list[Image.Image]:
+    return [f.copy() for f in ImageSequence.Iterator(im)]
+
+
+def resize_animated(path: str, target_w: int) -> tuple[int, int, str] | None:
+    """축소본을 임시파일로 만든다. 이득이 없거나 검증 실패면 None."""
+    before = os.path.getsize(path)
+    with Image.open(path) as im:
+        fmt = im.format or ""
+        w, h = im.size
+        n_frames = getattr(im, "n_frames", 1)
+        if w <= target_w:
+            return None  # 이미 충분히 작다
+        ratio = target_w / w
+        new_size = (target_w, max(1, round(h * ratio)))
+        frames = load_frames(im)
+        durations = [f.info.get("duration", im.info.get("duration", 100)) for f in frames]
+        loop = im.info.get("loop", 0)
+
+    resized = [f.convert("RGBA").resize(new_size, Image.LANCZOS) for f in frames]
+
+    fd, tmp = tempfile.mkstemp(suffix=os.path.splitext(path)[1])
+    os.close(fd)
+    try:
+        if fmt == "WEBP":
+            resized[0].save(tmp, format="WEBP", save_all=len(resized) > 1,
+                            append_images=resized[1:], duration=durations, loop=loop,
+                            quality=80, method=4)
+        elif fmt == "GIF":
+            pal = [f.convert("P", palette=Image.ADAPTIVE, colors=256) for f in resized]
+            pal[0].save(tmp, format="GIF", save_all=len(pal) > 1, append_images=pal[1:],
+                        duration=durations, loop=loop, optimize=True, disposal=2)
+        else:
+            resized[0].save(tmp, format=fmt)
+    except Exception as e:  # noqa: BLE001
+        os.unlink(tmp)
+        print(f"  ⚠️  {os.path.basename(path)}: 변환 실패 — {str(e)[:70]}")
+        return None
+
+    after = os.path.getsize(tmp)
+
+    # ── 검증: 다시 열어 프레임 수와 크기를 확인한다 ──────────────────────
+    try:
+        with Image.open(tmp) as chk:
+            if chk.size != new_size:
+                raise ValueError(f"크기 불일치 {chk.size} != {new_size}")
+            got = getattr(chk, "n_frames", 1)
+            if got != n_frames:
+                raise ValueError(f"프레임 손실 {got} != {n_frames}")
+    except Exception as e:  # noqa: BLE001
+        os.unlink(tmp)
+        print(f"  ⚠️  {os.path.basename(path)}: 검증 실패 — {str(e)[:70]} (원본 유지)")
+        return None
+
+    if after >= before:
+        os.unlink(tmp)
+        return None  # 이득 없음
+
+    return before, after, tmp
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dir", help="이모티콘 디렉터리")
+    ap.add_argument("--apply", action="store_true", help="실제로 덮어쓴다 (미지정 시 dry-run)")
+    ap.add_argument("--max-width", type=int, default=TARGET_MAX_W)
+    ap.add_argument("--min-bytes", type=int, default=MIN_BYTES)
+    a = ap.parse_args()
+
+    files = sorted(
+        f for f in os.listdir(a.dir)
+        if os.path.isfile(os.path.join(a.dir, f))
+        and f.lower().endswith((".webp", ".gif", ".png"))
+    )
+    total_before = total_after = 0
+    changed = skipped = failed = 0
+
+    print(f"대상 디렉터리: {a.dir}")
+    print(f"목표 최대 폭 {a.max_width}px / 최소 크기 {a.min_bytes // 1024}KB / "
+          f"{'적용' if a.apply else 'DRY-RUN'}\n")
+
+    for name in files:
+        path = os.path.join(a.dir, name)
+        size = os.path.getsize(path)
+        if size < a.min_bytes:
+            skipped += 1
+            continue
+        r = resize_animated(path, a.max_width)
+        if r is None:
+            skipped += 1
+            continue
+        before, after, tmp = r
+        total_before += before
+        total_after += after
+        changed += 1
+        print(f"  {before/1024:>8.0f}KB → {after/1024:>7.0f}KB "
+              f"({100*(1-after/before):>4.0f}% 감소)  {name}")
+        if a.apply:
+            shutil.move(tmp, path)
+        else:
+            os.unlink(tmp)
+
+    print(f"\n대상 {len(files)}개 중 변경 {changed} / 건너뜀 {skipped} / 실패 {failed}")
+    if changed:
+        print(f"합계 {total_before/1048576:.1f}MB → {total_after/1048576:.1f}MB "
+              f"({100*(1-total_after/total_before):.0f}% 감소, "
+              f"{(total_before-total_after)/1048576:.1f}MB 절감)")
+    if not a.apply:
+        print("\n※ DRY-RUN 이었다. 실제 반영하려면 --apply")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**이미지는 하나도 바뀌지 않습니다.** 도구만 추가합니다.

## 배경 — 「전체적으로 느리다」 제보 조사

서버·배포 문제가 아니었습니다.

| 계층 | 실측 |
|---|---|
| 백엔드(Go) | p95 **11.5ms**, 5xx 0 |
| origin(SSR) | p95 287~355ms — **하루 종일 평탄, 배포 시점 계단 없음** |
| DB | 3초↑ 쿼리 **0**, 접속 299 |
| 노드 | CPU 25%, load 3.12/16코어 |
| 엣지 | CF `HIT`, `immutable` 1년, TTFB 50ms |

전달은 정상인데 **받을 게 많았습니다.** 이모티콘 **1,204개 / 125MB**, 그중 **183개(15%)가 전체의 90%(112.9MB)** 를 차지합니다.

## 원인은 해상도

| 위치 | 표시 크기 | 원본 |
|---|---|---|
| 본문 기본 | 50px (`DEFAULT_WIDTH`) | 640×473, 631×925 … |
| 본문 최대 | **200px** (`MAX_WIDTH`) | 〃 |
| 선택창 | 32~40px | 〃 |

표시 대비 **최대 13배**입니다. 레티나 2배를 감안해도 **400px 면 충분**하고, 그 이상은 내려보내도 화면에 차이가 없습니다.

## 무엇을 만들었나

**`scripts/optimize-emoticons.py`** — 해상도만 줄이고 **애니메이션 프레임은 보존**합니다. 파일명·확장자·포맷 불변이라 기존 글의 `<img src="/emoticons/...">` 참조가 깨지지 않습니다.

안전장치:
- 원본보다 **커지면 되돌립니다**
- 저장 후 **다시 열어 프레임 수·크기를 검증**하고 어긋나면 되돌립니다
- 임계값 미만은 손대지 않습니다 (835개는 이미 20KB 미만)

**`.github/workflows/optimize-emoticons.yml`** — 수동 실행 전용, **dry-run 기본**. 실행 후 전 파일을 다시 열어 손상 여부를 확인하고 결과를 PR 로 만듭니다.

## ⛔ 설계상 못박은 것

**운영 서버에서 돌리지 않습니다.** 재인코딩은 무거운 CPU 작업이라 응답시간을 악화시킵니다. 러너에서만 돌게 했습니다.

**자동 실행하지 않습니다.** **이미지가 깨져도 CI 는 통과합니다.** 눈으로 봐야 하는 종류라 수동 실행 + PR 검토로 뒀습니다.

## 표본 검증

```
5,214KB → 1,413KB (73% 감소)  damoang-meme-009.gif
2,173KB → 1,145KB (47% 감소)  southsky-003.webp
합계 7.2MB → 2.5MB (65% 감소)   프레임 수·크기 검증 통과
```

## ⚠️ 이 작업으로 풀리지 않는 것

- **origin p95 300ms 는 줄지 않습니다.** 이모티콘은 정적 자산이라 SSR 시간과 무관합니다. 로그인 사용자의 SSR 300ms 는 **별개 과제**이고 아직 원인 미상입니다
- **즉시 체감되지 않습니다.** 파일명이 같아 브라우저·CF 에 1년 캐시된 옛 파일이 그대로 쓰입니다. 새 방문자부터 서서히 효과가 납니다

## Test plan

- [ ] CI 통과 (이미지 변경 0이므로 빌드 영향 없음)
- [ ] 머지 후 워크플로 **dry-run** 실행 → 183개 전체 절감량 확인
- [ ] 숫자 확인 후 `--apply` → 결과 PR 을 **눈으로** 검토