### PR TITLE
fix: 이모티콘 검증이 비이미지 파일을 손상으로 오탐 (workflow)

### DIFF
--- a/.github/workflows/optimize-emoticons.yml
+++ b/.github/workflows/optimize-emoticons.yml
@@ -76,11 +76,16 @@ jobs:
           import os, sys
           from PIL import Image
           d = 'apps/web/static/emoticons'
+          # ⛔ 이미지가 아닌 파일이 섞여 있다(onion-license.txt 등). 확장자로 걸러야 한다.
+          #    안 거르면 라이선스 텍스트를 이미지로 열려다 실패해 '손상'으로 오탐한다.
+          EXTS = ('.webp', '.gif', '.png', '.jpg', '.jpeg')
           bad = []
+          checked = 0
           for f in sorted(os.listdir(d)):
               p = os.path.join(d, f)
-              if not os.path.isfile(p):
+              if not os.path.isfile(p) or not f.lower().endswith(EXTS):
                   continue
+              checked += 1
               try:
                   with Image.open(p) as im:
                       im.verify()
@@ -91,7 +96,7 @@ jobs:
               for b in bad[:30]:
                   print('  ', b)
               sys.exit(1)
-          print(f'✅ 전 파일 정상 ({len(os.listdir(d))}개)')
+          print(f'✅ 이미지 전수 정상 ({checked}개 검사)')
           PY
 
       - name: Create pull request


### PR DESCRIPTION
`apply` 실행이 실패했는데 **실제로 깨진 파일은 없었습니다.** `onion-license.txt`(라이선스 텍스트)를 이미지로 열려다 실패한 것이 「손상」으로 잡혔습니다.

```
❌ 손상된 파일:
   onion-license.txt: cannot identify image file ...
```

이모티콘 디렉터리에는 이미지가 아닌 파일이 섞여 있습니다. 확장자로 걸러 이미지만 검사하도록 고칩니다.

**검사한 개수도 함께 출력**하게 했습니다 — 필터가 과해져 0개만 검사하고 통과하는 상황을 사람이 알아챌 수 있어야 합니다.

## 게이트는 제대로 작동했습니다

이상을 발견해 **PR 생성을 막았습니다.** 판정 기준만 틀렸을 뿐, 「의심스러우면 멈춘다」는 동작 자체는 의도대로였습니다.

## Test plan

- [ ] `apply=true` 재실행 시 검증 통과하고 PR 이 생성되는지
- [ ] 검사 개수가 1,203개(전체 1,204 − 텍스트 1)로 나오는지