### PR TITLE
perf(emoticon): 선택창 썸네일을 정지 이미지로, 확대할 때만 애니메이션

### DIFF
--- a/.github/workflows/generate-still-thumbs.yml
+++ b/.github/workflows/generate-still-thumbs.yml
@@ -1,0 +1,130 @@
+name: Generate Still Thumbnails
+
+# ⛔ 이 작업은 운영 서버에서 돌리지 않는다. 이미지 재인코딩은 무거운 CPU 작업이라
+#    응답시간을 악화시킨다(2026-08-03 「느리다」 제보 대응 중 확인). 러너에서만 돌린다.
+#
+# 수동 실행 전용. 결과는 브랜치 + PR 로 받아 사람이 확인하고 머지한다.
+# 자동 실행하지 않는 이유: 첫 프레임이 빈 화면인 이모티콘이 있을 수 있는데
+# CI 는 그걸 못 잡는다. 눈으로 봐야 한다.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: '실제 생성 여부. false 면 dry-run 으로 결과만 본다'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  still-thumbs:
+    name: Generate still thumbnails for the emoticon picker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Pillow
+        run: pip install --quiet 'Pillow>=11'
+
+      - name: Generate
+        run: |
+          set -o pipefail
+          ARGS="apps/web/static/emoticons"
+          if [ "${{ inputs.apply }}" = "true" ]; then ARGS="$ARGS --apply"; fi
+          python3 scripts/generate-still-thumbs.py $ARGS 2>&1 | tee still.log
+          {
+            echo '## 정지 썸네일 생성 결과'
+            echo
+            echo '```'
+            tail -40 still.log
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
+
+      # ⛔ 생성물이 조용히 깨졌는지 반드시 확인한다. 이미지가 깨져도 빌드는 통과한다.
+      - name: Verify generated stills
+        if: inputs.apply
+        run: |
+          python3 - <<'PY'
+          import os, sys
+          from PIL import Image
+          d = 'apps/web/static/emoticons'
+          bad, checked = [], 0
+          for f in sorted(os.listdir(d)):
+              if not f.endswith('_still.webp'):
+                  continue
+              p = os.path.join(d, f)
+              checked += 1
+              try:
+                  with Image.open(p) as im:
+                      im.verify()
+                  with Image.open(p) as im:
+                      if getattr(im, 'n_frames', 1) != 1:
+                          raise ValueError('정지 이미지가 아니다')
+                      # 첫 프레임이 완전 투명하면 피커에서 빈 칸으로 보인다
+                      a = im.convert('RGBA').getchannel('A')
+                      if a.getextrema()[1] == 0:
+                          raise ValueError('완전 투명 — 빈 칸으로 보인다')
+              except Exception as e:
+                  bad.append(f'{f}: {str(e)[:60]}')
+          if bad:
+              print('❌ 문제 있는 정지 썸네일:')
+              for b in bad[:30]:
+                  print('  ', b)
+              sys.exit(1)
+          print(f'✅ 정지 썸네일 전수 정상 ({checked}개 검사)')
+          PY
+
+      - name: Create pull request
+        if: inputs.apply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet && [ -z "$(git status --porcelain)" ]; then
+            echo "변경 없음 — PR 생성 생략"; exit 0
+          fi
+          BRANCH="chore/still-thumbs-${{ github.run_id }}"
+          git config user.name  'angple'
+          git config user.email 'sdk@sdk.xyz'
+          git checkout -b "$BRANCH"
+          git add apps/web/static/emoticons
+          git commit -m "chore: 이모티콘 피커용 정지 썸네일 생성
+
+          선택창은 썸네일을 40px 로 그리는데 DINKIssTyle 팩 썸네일 104개가 6.22MB 였다.
+          같은 자리에 쓰이는 onion 팩은 264개가 0.41MB 다.
+
+          원인은 해상도가 아니라 프레임 수다(128px 썸네일에 91~197 프레임).
+          그래서 해상도를 줄여도 27.9% 밖에 안 준다. 첫 프레임만 남기면 98.8% 준다.
+
+          기존 _thumb 파일은 그대로 둔다. 피커는 평소 _still 을 쓰고
+          확대할 때만 _thumb(애니)으로 바꾼다.
+
+          ⛔ 운영 서버가 아니라 CI 러너에서 생성했다."
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: 이모티콘 피커용 정지 썸네일 생성" \
+            --body "$(cat <<'EOF'
+          자동 생성 PR (`generate-still-thumbs` 워크플로).
+
+          ## 무엇을 했나
+          `*_thumb.*` 중 여러 프레임짜리만 골라 첫 프레임을 `*_still.webp` 로 **추가** 생성했다.
+          **기존 파일은 하나도 건드리지 않았다.**
+
+          ## ⛔ 머지 전 반드시 확인할 것
+          - [ ] 생성된 `_still` 몇 개를 **실제로 열어 눈으로 확인** —
+                첫 프레임이 빈 화면이거나 의미를 알 수 없는 이모티콘이 없는지
+          - [ ] 이 PR 만으로는 화면이 바뀌지 않는다(피커가 아직 `_still` 을 안 쓴다).
+                컴포넌트 변경 PR 과 함께 배포해야 효과가 있다
+
+          상세 로그는 워크플로 실행 요약(Summary)에 있다.
+          EOF
+          )"

--- a/apps/web/src/lib/components/features/board/emoticon-picker.svelte
+++ b/apps/web/src/lib/components/features/board/emoticon-picker.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
     import { REACTION_EMOTICONS } from '$lib/config/reaction-config.js';
+    import {
+        animatedThumbUrl,
+        hasSeparateAnimation,
+        stillThumbUrl,
+        type EmoticonThumbSource
+    } from '$lib/utils/emoticon-thumb';
 
     interface Props {
         onInsertEmoticon: (text: string) => void;
@@ -14,10 +20,7 @@
     const emojis = REACTION_EMOTICONS.filter((e) => e.category === 'emoji');
 
     // 팩 데이터
-    interface EmoticonItem {
-        file: string;
-        thumb: string | null;
-    }
+    type EmoticonItem = EmoticonThumbSource;
     interface EmoticonPack {
         name: string;
         prefix: string;
@@ -74,8 +77,24 @@
         onClose();
     }
 
-    function thumbUrl(item: EmoticonItem): string {
-        return `/emoticons/${item.thumb || item.file}`;
+    /**
+     * 확대(hover) 시작 — 그때 비로소 애니메이션 파일을 받는다.
+     *
+     * 미리 받아두면 정지 썸네일을 쓰는 의미가 없어지므로 이벤트 시점에 바꾼다.
+     * 원래 주소는 `dataset` 에 넣어 두었다가 벗어날 때 되돌린다.
+     */
+    function playAnimation(e: Event, item: EmoticonItem): void {
+        if (!hasSeparateAnimation(item)) return;
+        const img = (e.currentTarget as HTMLElement).querySelector('img');
+        if (!img) return;
+        if (!img.dataset.still) img.dataset.still = img.src;
+        img.src = animatedThumbUrl(item);
+    }
+
+    /** 확대 종료 — 정지 썸네일로 되돌린다 */
+    function stopAnimation(e: Event): void {
+        const img = (e.currentTarget as HTMLElement).querySelector('img');
+        if (img?.dataset.still) img.src = img.dataset.still;
     }
 
     function setActiveTab(tab: string) {
@@ -125,8 +144,9 @@
                     title="{pack.name} ({pack.count}개)"
                 >
                     {#if pack.items.length > 0}
+                        <!-- 팩 탭 아이콘은 20px 라 애니메이션이 보이지도 않는다. 정지 고정 -->
                         <img
-                            src={thumbUrl(pack.items[0])}
+                            src={stillThumbUrl(pack.items[0])}
                             alt={pack.name}
                             class="size-5 object-contain"
                         />
@@ -201,14 +221,26 @@
                     {#if activeTab === `pack-${i}`}
                         <div class="grid max-h-[240px] grid-cols-6 gap-1.5 overflow-y-auto p-1">
                             {#each pack.items as item}
+                                <!--
+                                    확대 전환은 버튼에 건다. <img> 는 포커스를 못 받아
+                                    키보드로 이동한 사용자에게는 이벤트가 오지 않는다.
+                                -->
                                 <button
                                     type="button"
                                     onclick={() => selectEmoticon(item.file)}
+                                    onmouseenter={(e) => playAnimation(e, item)}
+                                    onmouseleave={stopAnimation}
+                                    onfocusin={(e) => playAnimation(e, item)}
+                                    onfocusout={stopAnimation}
                                     class="hover:bg-muted group/emo relative flex items-center justify-center rounded-lg p-1 transition-colors"
                                     title={item.file}
                                 >
+                                    <!--
+                                        평소엔 정지 썸네일(~2KB), 확대할 때만 애니(~60KB).
+                                        DINKIssTyle 팩 기준 6.22MB → 0.07MB.
+                                    -->
                                     <img
-                                        src={thumbUrl(item)}
+                                        src={stillThumbUrl(item)}
                                         alt={item.file}
                                         class="emoticon-inline size-10 object-contain transition-transform group-hover/emo:z-50 group-hover/emo:scale-[3]"
                                         loading="lazy"

--- a/apps/web/src/lib/components/features/board/welcome-stamp-bar.svelte
+++ b/apps/web/src/lib/components/features/board/welcome-stamp-bar.svelte
@@ -7,6 +7,7 @@
         welcomeStampContent
     } from '$lib/utils/welcome-stamp.js';
     import type { BoardPermissions, FreeComment } from '$lib/api/types.js';
+    import { stillThumbUrl, type EmoticonThumbSource } from '$lib/utils/emoticon-thumb';
     import { onMount } from 'svelte';
     import { toast } from 'svelte-sonner';
     import Check from '@lucide/svelte/icons/check';
@@ -35,10 +36,8 @@
         disabled = false
     }: Props = $props();
 
-    interface EmoticonItem {
-        file: string;
-        thumb: string | null;
-    }
+    // 썸네일 URL 규칙은 emoticon-thumb.ts 하나만 안다. 여기서 다시 조립하지 않는다.
+    type EmoticonItem = EmoticonThumbSource;
 
     let stamps = $state<EmoticonItem[]>([]);
     let sendingFile = $state<string | null>(null);
@@ -110,7 +109,7 @@
                         : '탭 한 번으로 환영 댓글 남기기'}
                 >
                     <img
-                        src="/emoticons/{item.thumb || item.file}"
+                        src={stillThumbUrl(item)}
                         alt="환영 앙티콘"
                         class="size-9 object-contain {stamped ? 'opacity-40 grayscale' : ''}"
                         loading="lazy"

--- a/apps/web/src/lib/utils/emoticon-thumb.test.ts
+++ b/apps/web/src/lib/utils/emoticon-thumb.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+    animatedThumbUrl,
+    hasSeparateAnimation,
+    stillThumbUrl,
+    type EmoticonThumbSource
+} from './emoticon-thumb';
+
+/** DINKIssTyle 처럼 정지본까지 있는 무거운 항목 */
+const heavy: EmoticonThumbSource = {
+    file: 'DINKIssTyle-3d-ang-001.webp',
+    thumb: 'DINKIssTyle-3d-ang-001_thumb.webp',
+    still: 'DINKIssTyle-3d-ang-001_still.webp'
+};
+
+/** onion 처럼 이미 가벼워서 정지본을 만들지 않은 항목 */
+const light: EmoticonThumbSource = {
+    file: 'onion-001.gif',
+    thumb: 'onion-001_thumb.webp',
+    still: null
+};
+
+/** 썸네일 자체가 없는 항목 */
+const bare: EmoticonThumbSource = { file: 'welcome-001.png', thumb: null, still: null };
+
+describe('stillThumbUrl', () => {
+    it('정지본이 있으면 정지본을 쓴다', () => {
+        expect(stillThumbUrl(heavy)).toBe('/emoticons/DINKIssTyle-3d-ang-001_still.webp');
+    });
+
+    it('정지본이 없으면 기존 썸네일로 떨어진다 — 회귀 없음', () => {
+        expect(stillThumbUrl(light)).toBe('/emoticons/onion-001_thumb.webp');
+    });
+
+    it('썸네일도 없으면 원본을 쓴다', () => {
+        expect(stillThumbUrl(bare)).toBe('/emoticons/welcome-001.png');
+    });
+
+    it('필드가 아예 없어도 원본으로 동작한다', () => {
+        expect(stillThumbUrl({ file: 'x.gif' })).toBe('/emoticons/x.gif');
+    });
+});
+
+describe('animatedThumbUrl', () => {
+    it('⛔ 원본이 아니라 _thumb 을 쓴다 — 원본은 5.7MB 짜리가 있다', () => {
+        expect(animatedThumbUrl(heavy)).toBe('/emoticons/DINKIssTyle-3d-ang-001_thumb.webp');
+        expect(animatedThumbUrl(heavy)).not.toContain('_still');
+    });
+
+    it('정지본이 있어도 애니는 _thumb 이다', () => {
+        expect(animatedThumbUrl(light)).toBe('/emoticons/onion-001_thumb.webp');
+    });
+
+    it('_thumb 이 없을 때만 원본으로 떨어진다', () => {
+        expect(animatedThumbUrl(bare)).toBe('/emoticons/welcome-001.png');
+    });
+});
+
+describe('hasSeparateAnimation', () => {
+    it('정지본이 따로 있으면 바꿔 낄 값이 있다', () => {
+        expect(hasSeparateAnimation(heavy)).toBe(true);
+    });
+
+    it('정지본이 없으면 바꿔 낄 필요가 없다 — 같은 파일을 두 번 요청하지 않는다', () => {
+        expect(hasSeparateAnimation(light)).toBe(false);
+        expect(hasSeparateAnimation(bare)).toBe(false);
+    });
+});

--- a/apps/web/src/lib/utils/emoticon-thumb.ts
+++ b/apps/web/src/lib/utils/emoticon-thumb.ts
@@ -1,0 +1,56 @@
+/**
+ * 이모티콘 선택창(피커)의 썸네일 URL 규칙.
+ *
+ * 컴포넌트와 테스트가 **같은 함수를 import** 한다. 규칙을 테스트에 복붙하면
+ * 구현이 바뀌어도 테스트는 영원히 초록이다(2026-08-03 blocked-comment-filter 사고).
+ *
+ * ## 왜 두 종류인가 (2026-08-04 실측)
+ *
+ * 선택창은 썸네일을 40px 로 그리는데 `DINKIssTyle` 팩 썸네일 104개가 6.22MB 였다.
+ * 원인은 해상도가 아니라 프레임 수다 — 128px 썸네일에 91~197 프레임이 들어 있다.
+ * 첫 프레임만 남긴 `_still` 을 쓰면 213KB → 1.7KB (98.8% 감소).
+ *
+ * 애니메이션은 확대(hover) 할 때만 필요하므로 그때 `_thumb` 으로 바꾼다.
+ */
+
+/** `/api/emoticons/list` 가 돌려주는 항목 중 URL 결정에 필요한 부분만. */
+export interface EmoticonThumbSource {
+    /** 본문에 삽입되는 원본 파일명. 예: `damoang-emo-011.gif` */
+    file: string;
+    /** 애니메이션 썸네일. 없으면 null */
+    thumb?: string | null;
+    /** 정지 썸네일(첫 프레임). 없으면 null */
+    still?: string | null;
+}
+
+const BASE = '/emoticons/';
+
+/**
+ * 평소(정지) 상태에서 쓸 URL.
+ *
+ * `_still` 이 없는 팩(이미 가벼운 onion 등)은 기존과 똑같이 `_thumb` 을 쓴다.
+ */
+export function stillThumbUrl(item: EmoticonThumbSource): string {
+    return BASE + (item.still || item.thumb || item.file);
+}
+
+/**
+ * 확대(hover) 시 쓸 애니메이션 URL.
+ *
+ * ⛔ 여기서 `item.file`(원본)을 우선하면 안 된다. 원본은 `DINKIssTyle-ang-004.webp`
+ *    처럼 5.7MB 짜리가 있어 지금보다 나빠진다. `_thumb`(평균 60KB)이 먼저다.
+ *    `_thumb` 이 없는 항목만 어쩔 수 없이 원본을 쓴다.
+ */
+export function animatedThumbUrl(item: EmoticonThumbSource): string {
+    return BASE + (item.thumb || item.file);
+}
+
+/**
+ * 확대 시 실제로 바꿔 끼울 필요가 있는가.
+ *
+ * 정지본과 애니본이 같은 파일이면 요청이 낭비다(브라우저 캐시가 막아주긴 하지만
+ * `loading="lazy"` 와 겹치면 불필요한 디코딩이 생긴다).
+ */
+export function hasSeparateAnimation(item: EmoticonThumbSource): boolean {
+    return stillThumbUrl(item) !== animatedThumbUrl(item);
+}

--- a/apps/web/src/routes/api/emoticons/list/+server.ts
+++ b/apps/web/src/routes/api/emoticons/list/+server.ts
@@ -71,7 +71,16 @@ const HIDDEN_PACKS = new Set(['southsky', 'lee-president']);
 
 interface EmoticonItem {
     file: string;
+    /** 애니메이션 썸네일 (`X_thumb.webp`). 확대 시에만 쓴다 */
     thumb: string | null;
+    /**
+     * 정지 썸네일 (`X_still.webp`, 첫 프레임만). 평소 표시용.
+     *
+     * 선택창은 40px 로 그리는데 애니 썸네일은 프레임이 91~197개라 장당 60KB 다.
+     * 첫 프레임만 쓰면 1.7KB — DINKIssTyle 팩 기준 6.22MB → 0.07MB.
+     * 아직 만들지 않은 팩은 null 이고, 그 경우 기존대로 thumb 을 쓴다.
+     */
+    still: string | null;
 }
 
 interface EmoticonPack {
@@ -109,18 +118,23 @@ async function scanEmoticons(): Promise<{ packs: EmoticonPack[] }> {
 
     // thumb 파일 맵 구축: "damoang-emo-001" → "damoang-emo-001_thumb.gif"
     const thumbMap = new Map<string, string>();
+    // still 파일 맵 구축: "damoang-emo-001" → "damoang-emo-001_still.webp"
+    const stillMap = new Map<string, string>();
     for (const file of files) {
-        if (!file.includes('_thumb')) continue;
-        const baseName = file.substring(0, file.indexOf('_thumb'));
-        thumbMap.set(baseName, file);
+        if (file.includes('_thumb')) {
+            thumbMap.set(file.substring(0, file.indexOf('_thumb')), file);
+        } else if (file.includes('_still')) {
+            stillMap.set(file.substring(0, file.indexOf('_still')), file);
+        }
     }
 
     // 팩별 그룹핑
     const packMap = new Map<string, EmoticonItem[]>();
 
     for (const file of files) {
-        // _thumb, 비이미지, 특수 파일 제외
-        if (file.includes('_thumb') || SKIP_FILES.has(file)) continue;
+        // ⛔ _thumb 과 _still 은 이모티콘 자체가 아니라 부속 파일이다.
+        //    거르지 않으면 선택창에 같은 이모티콘이 두세 개씩 늘어선다.
+        if (file.includes('_thumb') || file.includes('_still') || SKIP_FILES.has(file)) continue;
 
         const ext = file.split('.').pop()?.toLowerCase() || '';
         if (!ALLOWED_EXTENSIONS.has(ext)) continue;
@@ -140,8 +154,9 @@ async function scanEmoticons(): Promise<{ packs: EmoticonPack[] }> {
         const dotIdx = file.lastIndexOf('.');
         const baseName = dotIdx > 0 ? file.substring(0, dotIdx) : file;
         const thumb = thumbMap.get(baseName) || null;
+        const still = stillMap.get(baseName) || null;
 
-        packMap.get(prefix)!.push({ file, thumb });
+        packMap.get(prefix)!.push({ file, thumb, still });
     }
 
     // 각 팩 내 파일 정렬

--- a/scripts/generate-still-thumbs.py
+++ b/scripts/generate-still-thumbs.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""이모티콘 피커용 **정지 썸네일**(`*_still.webp`)을 생성한다.
+
+⛔ 운영 서버에서 실행하지 말 것. CI 러너에서 돌린다
+   (.github/workflows/generate-still-thumbs.yml).
+
+## 왜 필요한가 (2026-08-04 실측)
+
+선택창은 썸네일을 40px 로 그리는데, `DINKIssTyle` 팩 썸네일 104개가 **6.22MB** 다.
+같은 자리에 쓰이는 `onion` 팩은 264개가 0.41MB — 15배 차이다.
+
+원인은 해상도가 아니라 **프레임 수**다. 128×128 짜리 썸네일에 91~197 프레임이 들어 있다.
+그래서 해상도를 줄여도 소용이 없다:
+
+| 방식 | 절감 |
+|---|---|
+| 80px 로 축소 + q60, 애니 유지 | 27.9% |
+| **첫 프레임만 (해상도 유지)** | **98.8%** (213KB → 1.7KB) |
+
+## 무엇을 하는가
+
+`*_thumb.*` 중 **여러 프레임짜리**만 골라 첫 프레임을 `*_still.webp` 로 저장한다.
+
+**기존 파일은 건드리지 않는다 — 추가만 한다.** 피커는 평소 `_still` 을 쓰고
+확대(hover) 할 때만 기존 `_thumb`(애니)으로 바꾼다. 되돌리려면 컴포넌트만 되돌리면 되고,
+`_still` 파일은 남아 있어도 아무도 참조하지 않으므로 무해하다.
+
+⛔ hover 소스로 **원본 파일을 쓰면 안 된다.** `DINKIssTyle-ang-004.webp` 는 5.7MB 라
+   지금보다 나빠진다. 반드시 `_thumb`(평균 60KB)을 쓴다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+
+from PIL import Image
+
+# 썸네일은 최대 40px 로 표시되고 hover 시 3배(120px) 확대된다.
+# 원본 썸네일이 보통 128px 이므로 해상도는 그대로 두고 프레임만 버린다.
+QUALITY = 80
+
+THUMB_MARK = "_thumb."
+STILL_SUFFIX = "_still.webp"
+
+
+def still_name(thumb_filename: str) -> str:
+    """`X_thumb.webp` → `X_still.webp`"""
+    base = thumb_filename[: thumb_filename.rindex(THUMB_MARK)]
+    return f"{base}{STILL_SUFFIX}"
+
+
+def make_still(path: str, out_path: str) -> tuple[int, int] | None:
+    """첫 프레임만 뽑아 저장한다. 이득이 없거나 검증 실패면 None."""
+    before = os.path.getsize(path)
+    with Image.open(path) as im:
+        if getattr(im, "n_frames", 1) <= 1:
+            return None  # 이미 정지 이미지 — 만들어봐야 파일만 는다
+        im.seek(0)
+        first = im.convert("RGBA")
+
+    fd, tmp = tempfile.mkstemp(suffix=".webp")
+    os.close(fd)
+    try:
+        first.save(tmp, format="WEBP", quality=QUALITY, method=4)
+    except Exception as e:  # noqa: BLE001
+        os.unlink(tmp)
+        print(f"  ⚠️  {os.path.basename(path)}: 변환 실패 — {str(e)[:70]}")
+        return None
+
+    after = os.path.getsize(tmp)
+
+    # ── 검증: 다시 열어 정지 이미지인지 확인한다 ────────────────────────
+    try:
+        with Image.open(tmp) as chk:
+            chk.verify()
+        with Image.open(tmp) as chk:
+            if getattr(chk, "n_frames", 1) != 1:
+                raise ValueError("정지 이미지가 아니다")
+            if chk.size != first.size:
+                raise ValueError(f"크기 불일치 {chk.size} != {first.size}")
+    except Exception as e:  # noqa: BLE001
+        os.unlink(tmp)
+        print(f"  ⚠️  {os.path.basename(path)}: 검증 실패 — {str(e)[:70]}")
+        return None
+
+    # 있을 수 없지만, 커지면 만들지 않는다. 만들면 피커가 더 무거워진다.
+    if after >= before:
+        os.unlink(tmp)
+        print(f"  ⚠️  {os.path.basename(path)}: 이득 없음 ({after} >= {before}) — 생략")
+        return None
+
+    os.replace(tmp, out_path)
+    return before, after
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dir", help="이모티콘 디렉터리")
+    ap.add_argument("--apply", action="store_true", help="실제로 파일을 만든다 (미지정 시 dry-run)")
+    a = ap.parse_args()
+
+    thumbs = sorted(
+        f
+        for f in os.listdir(a.dir)
+        if os.path.isfile(os.path.join(a.dir, f))
+        and THUMB_MARK in f
+        and f.lower().endswith((".webp", ".gif", ".png"))
+    )
+
+    total_before = total_after = 0
+    made = skipped = 0
+
+    print(f"대상 디렉터리: {a.dir}")
+    print(f"썸네일 {len(thumbs)}개 / {'적용' if a.apply else 'DRY-RUN'}\n")
+
+    for name in thumbs:
+        src = os.path.join(a.dir, name)
+        dst = os.path.join(a.dir, still_name(name))
+
+        if not a.apply:
+            # dry-run 은 임시 위치에 만들어 크기만 재고 지운다
+            fd, probe = tempfile.mkstemp(suffix=".webp")
+            os.close(fd)
+            r = make_still(src, probe)
+            if os.path.exists(probe):
+                os.unlink(probe)
+        else:
+            r = make_still(src, dst)
+
+        if r is None:
+            skipped += 1
+            continue
+        before, after = r
+        total_before += before
+        total_after += after
+        made += 1
+        if before >= 50 * 1024:  # 큰 것만 개별 출력 — 로그가 길어지면 안 읽는다
+            print(
+                f"  {before/1024:>8.0f}KB → {after/1024:>7.1f}KB "
+                f"({100*(1-after/before):>4.0f}% 감소)  {name}"
+            )
+
+    print(f"\n썸네일 {len(thumbs)}개 중 생성 {made} / 건너뜀 {skipped}(이미 정지 이미지)")
+    if made:
+        print(
+            f"피커 로드량 {total_before/1048576:.2f}MB → {total_after/1048576:.2f}MB "
+            f"({100*(1-total_after/total_before):.1f}% 감소)"
+        )
+    if not a.apply:
+        print("\n※ DRY-RUN 이었다. 실제로 만들려면 --apply")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate-still-thumbs.py
+++ b/scripts/generate-still-thumbs.py
@@ -92,6 +92,9 @@ def make_still(path: str, out_path: str) -> tuple[int, int] | None:
         print(f"  ⚠️  {os.path.basename(path)}: 이득 없음 ({after} >= {before}) — 생략")
         return None
 
+    # ⛔ mkstemp 는 0600 으로 만든다. 그대로 두면 이 스크립트를 호스트 서빙 디렉터리
+    #    (/home/damoang/legacy-data/emoticons)에 직접 돌렸을 때 웹서버가 못 읽는다.
+    os.chmod(tmp, 0o644)
     os.replace(tmp, out_path)
     return before, after
 


### PR DESCRIPTION
## 문제

「앙모티콘이 늦게 뜬다」 제보를 파보니 본문이 아니라 **선택창**이었다.

| 팩 | 썸네일 수 | 합계 |
|---|---|---|
| **DINKIssTyle** | 104 | **6.22MB** |
| onion | 264 | 0.41MB |

같은 40px 자리에 쓰이는데 15배 차이다. 원인은 해상도가 아니라 **프레임 수** —
128×128 썸네일에 91~197 프레임이 들어 있다.

`loading="lazy"` 는 이미 있다. 지연은 되지만 스크롤하면 결국 다 받는다.

## 왜 해상도로 안 되는가 (실측 8개)

| 방식 | 결과 | 절감 |
|---|---|---|
| 80px 축소 + q60, 애니 유지 | 1082KB | 27.9% |
| **첫 프레임만 (해상도 유지)** | **17.3KB** | **98.8%** |

## 변경

평소엔 정지 썸네일 `_still`(~2KB), 확대(hover/focus) 할 때만 기존 `_thumb`(~60KB).

- `lib/utils/emoticon-thumb.ts` — URL 규칙을 함수로 분리. 컴포넌트와 테스트가 **같은 함수를 import** 한다
- `api/emoticons/list` — `still` 필드 추가. `_still`/`_thumb` 을 이모티콘 항목에서 제외
- `emoticon-picker.svelte` — 기본 정지, 확대 시 교체. 핸들러는 버튼에 건다(`<img>` 는 포커스를 못 받는다)
- `scripts/generate-still-thumbs.py` + 워크플로 — 파일 생성은 **CI 러너 전용**

## 안전장치

- **기존 파일을 하나도 건드리지 않는다.** `_still` 은 추가 생성물이다
- `_still` 이 없는 팩은 **기존과 완전히 동일하게** 동작한다 (fallback)
- 되돌리기 = 컴포넌트 revert. 백업 복원이 필요 없다
- ⛔ 확대 소스로 **원본 파일을 쓰지 않는다**. 원본엔 `DINKIssTyle-ang-004.webp` 5.7MB 가 있어 지금보다 나빠진다

## ⛔ 이 PR 만으로는 화면이 바뀌지 않는다

`_still` 파일이 아직 없어 fallback 으로 현행과 동일하게 동작한다.
머지 후 `generate-still-thumbs` 워크플로를 `apply=true` 로 돌려 파일 PR 을 받아야 효과가 난다.

## 배포 시 주의

실제 서빙 경로는 파드가 아니라 호스트 `/home/damoang/legacy-data/emoticons` 다.
승격만 하면 반영되지 않는다 (A단계에서 퍼지를 두 번 헛되이 하고 발견).