### PR TITLE
feat: 플러그인 토글 반영 안내 + 원본이 큰 이모티콘 팩 표시 폭 상향

### DIFF
--- a/apps/web/src/lib/utils/content-transform.test.ts
+++ b/apps/web/src/lib/utils/content-transform.test.ts
@@ -349,9 +349,32 @@ describe('transformEmoticons - 팩별 기본 폭 (bug#13145)', () => {
         expect(result).toContain('width="200"');
     });
 
-    it('밈 외 팩은 기존대로 50px', () => {
-        expect(transformEmoticons('{emo:damoang-emo-042.gif}')).toContain('width="50"');
+    // 2026-08-04 — 원본이 큰 팩만 개별 상향했다. 일괄 상향은 실측으로 기각.
+    it('원본이 큰 팩은 개별 상향값을 쓴다', () => {
+        expect(transformEmoticons('{emo:damoang-emo-042.gif}')).toContain('width="80"');
+        expect(transformEmoticons('{emo:moon-emo-001.gif}')).toContain('width="100"');
+        expect(transformEmoticons('{emo:damoang-sol-003.gif}')).toContain('width="100"');
+        expect(transformEmoticons('{emo:president-001.jpg}')).toContain('width="100"');
+    });
+
+    // ⛔ startsWith 라 'president-' 는 'lee-president-001' 을 잡지 못한다.
+    //    별도 항목이 없으면 이 팩만 50px 로 남는다.
+    it('lee-president 도 따로 잡힌다', () => {
+        expect(transformEmoticons('{emo:lee-president-002.webp}')).toContain('width="100"');
+    });
+
+    // ⛔ 이 테스트가 이번 변경의 안전장치다. onion 은 264개짜리 최대 팩인데
+    //    원본이 50px 라, 키우면 확대되어 계단이 보인다. 절대 올리지 말 것.
+    it('onion 은 원본이 50px 라 그대로 둔다 — 올리면 뭉개진다', () => {
         expect(transformEmoticons('{emo:onion-133.gif}')).toContain('width="50"');
+    });
+
+    it('DINKIssTyle 계열도 여유가 없어 그대로 50px', () => {
+        expect(transformEmoticons('{emo:DINKIssTyle-face-003.webp}')).toContain('width="50"');
+        expect(transformEmoticons('{emo:DINKIssTyle-3d-ang-001.webp}')).toContain('width="50"');
+    });
+
+    it('팩에 속하지 않는 파일은 기본 50px', () => {
         expect(transformEmoticons('{emo:smile.gif}')).toContain('width="50"');
     });
 

--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -42,7 +42,42 @@ const ALLOWED_EXTENSIONS = ['.gif', '.png', '.jpg', '.jpeg', '.webp'];
  *    이미 올라간 글의 밈 크기가 한꺼번에 바뀐다(2026-07 자유게시판 기준
  *    이모티콘 사용 글 3,547건 중 크기를 직접 지정한 글은 4건뿐이었다).
  */
-const PACK_DEFAULT_WIDTH: ReadonlyArray<readonly [string, number]> = [['damoang-meme-', 200]];
+/**
+ * 2026-08-04 추가 — 원본이 큰데 50px 로 찍히던 팩들.
+ *
+ * ⛔ **일괄 상향(DEFAULT_WIDTH 50 → 80)은 실측으로 기각했다.** 원본이 작은 팩이 있어
+ *    키우면 확대되어 뭉개진다. 팩별 원본 폭 중앙값(2026-08-04, 운영 파일 실측):
+ *
+ *      팩                개수   원본폭 중앙   판정
+ *      onion             264        50 px    ⛔ 그대로 둔다. 50px 표시가 이미 1:1 이다
+ *      DINKIssTyle-face   12        64 px    ⛔ 여유 없음
+ *      DINKIssTyle-*      33~      128 px    ⛔ 여유 작음
+ *      damoang-emo        90       223 px    → 80
+ *      damoang-sol        10       360 px    → 100
+ *      moon-emo           31       360 px    → 100
+ *      president          15       500 px    → 100
+ *      lee-president       5       560 px    → 100
+ *
+ *    `onion` 은 가장 큰 팩(264개)인데 원본이 50px 다. 80px 로 올리면 1.6배 확대라
+ *    계단이 보인다. 파일을 키울 방법도 없다 — 원본이 그 크기다.
+ *
+ * ⛔ 접두사는 **소문자**여야 한다. defaultWidthFor 가 파일명을 lower 로 바꿔 비교한다.
+ *    대문자로 적으면 규칙이 조용히 죽는다(예: 'DINKIssTyle-' 은 절대 안 걸린다).
+ *
+ * ⛔ 접두사 끝의 하이픈을 빼지 말 것. 'president-' 를 'president' 로 적으면
+ *    같은 값이라 무해하지만, 반대로 'lee-president-' 를 빠뜨리면 그 팩은 50px 로 남는다
+ *    ('president-' 는 'lee-president-001' 을 잡지 못한다 — startsWith 이다).
+ *
+ * ⛔ 기존 글에 소급 적용된다(아래 damoang-meme 항목의 설명과 같은 이유).
+ */
+const PACK_DEFAULT_WIDTH: ReadonlyArray<readonly [string, number]> = [
+    ['damoang-meme-', 200],
+    ['moon-emo-', 100],
+    ['lee-president-', 100],
+    ['president-', 100],
+    ['damoang-sol-', 100],
+    ['damoang-emo-', 80]
+];
 
 /**
  * 파일명이 속한 팩의 기본 표시 폭을 반환. 일치하는 팩이 없으면 DEFAULT_WIDTH.

--- a/apps/web/src/routes/admin/plugins/+page.svelte
+++ b/apps/web/src/routes/admin/plugins/+page.svelte
@@ -110,6 +110,27 @@
                 </div>
             </div>
 
+            <!--
+                반영 시점 안내.
+
+                끄기가 "안 먹는" 것처럼 보이는 일이 반복돼 넣었다(2026-08-04 폭죽 건).
+                서버·DB 는 즉시 바뀐다. 바뀌지 않는 건 **이미 열려 있는 브라우저 탭** 이다 —
+                body-end 슬롯에 상주하는 컴포넌트는 onMount 가 탭당 한 번만 돌아
+                끈 뒤에도 새로고침 전까지 그대로 살아 있다.
+
+                ⛔ "적용까지 시간이 걸립니다" 같은 뭉뚱그린 문구를 쓰지 말 것.
+                   원인이 시간이 아니라 탭이라 그렇게 쓰면 계속 기다리게 된다.
+            -->
+            <div
+                class="mb-6 rounded-lg border border-amber-300/70 bg-amber-50/70 px-4 py-3 text-sm dark:border-amber-800/50 dark:bg-amber-950/25"
+            >
+                <p class="font-medium">플러그인을 켜고 끈 뒤에는 새로고침이 필요합니다.</p>
+                <p class="text-muted-foreground mt-1">
+                    변경은 서버에 즉시 저장되지만, <strong>이미 열려 있는 탭</strong>에는 반영되지
+                    않습니다. 화면에서 확인하실 때는 해당 탭을 새로고침해 주세요.
+                </p>
+            </div>
+
             <!-- 플러그인 목록 -->
             {#if plugins.length === 0 && !pluginStore.isLoading}
                 <Card>


### PR DESCRIPTION
두 건을 묶었습니다. 둘 다 이모티콘·플러그인 화면 관련이고 서로 영향이 없습니다.

## 1. 관리자 플러그인 화면 — 반영 시점 안내

플러그인을 꺼도 「안 꺼진다」는 오해가 반복됐습니다. **서버·DB 는 즉시 바뀝니다.**
바뀌지 않는 건 **이미 열려 있는 탭**입니다 — `body-end` 슬롯에 상주하는 컴포넌트는
`onMount` 가 탭당 한 번만 돌아 새로고침 전까지 그대로 살아 있습니다.

⛔ 「적용까지 시간이 걸립니다」 같은 문구를 쓰지 않았습니다. 원인이 시간이 아니라
탭이라, 그렇게 쓰면 계속 기다리게 됩니다.

> 이 건의 배경 조사에서 **앞선 진단이 오진이었음**을 확인했습니다. 「설정이 파일에
> 저장돼 파드마다 다르다」는 낡은 체크아웃(detached `72c6871f`)을 읽은 탓이고,
> 실제로는 PR #1928(7/31)로 **이미 MySQL+Redis 를 쓰고 있습니다**.
> 정정 내용은 `/home/damoang/docs/settings-persistence-architecture.html` 에 있습니다.

## 2. 이모티콘 팩별 표시 폭

기본 폭을 50 → 80 으로 **일괄 상향하려다 실측으로 기각**했습니다.
원본이 작은 팩은 키우면 확대되어 뭉개집니다.

| 팩 | 개수 | 원본폭 중앙 | 조치 |
|---|---|---|---|
| **onion** | **264** | **50px** | ⛔ **그대로** — 50px 표시가 이미 1:1 |
| DINKIssTyle-face | 12 | 64px | ⛔ 그대로 |
| DINKIssTyle-* | 33+ | 128px | ⛔ 그대로 |
| damoang-emo | 90 | 223px | 50 → **80** |
| damoang-sol | 10 | 360px | 50 → **100** |
| moon-emo | 31 | 360px | 50 → **100** |
| president | 15 | 500px | 50 → **100** |
| lee-president | 5 | 560px | 50 → **100** |

`onion` 은 가장 큰 팩인데 원본이 50px 라 80px 로 올리면 1.6배 확대입니다.
파일을 키울 방법도 없습니다 — 원본이 그 크기입니다. **이 팩을 지키는 테스트를 따로 뒀습니다.**

### ⛔ 두 가지 함정을 테스트로 고정

- **접두사는 소문자여야 합니다** — `defaultWidthFor` 가 비교 전에 `lower()` 합니다.
  대문자로 적으면 규칙이 조용히 죽습니다
- **`startsWith` 라 `president-` 가 `lee-president-001` 을 잡지 못합니다** —
  별도 항목이 없으면 그 팩만 50px 로 남습니다

### 실제 렌더 경로 확인

`post_content` 필터가 **둘**입니다(코어 `transformEmoticons`, premium `emoticon` 플러그인
`replaceEmoticons`). premium 쪽은 팩별 폭이 없어 만약 그쪽이 이기면 이 변경이 무의미해집니다.

**운영에서 실제 브라우저로 확인했습니다** — 크기 미지정 밈이 `width=200` 으로 렌더됩니다.
premium 은 `DEFAULT_WIDTH=50` 뿐이므로 **코어가 적용되고 있습니다.**

## 소급 적용

기존 글에 적용됩니다. 저장된 본문은 `{emo:...}` 숏코드 그대로이고 폭은 렌더 시점에
정해지기 때문입니다. 데이터 변경은 없습니다.

## 관찰만

`damoang-meme-018.gif` 는 원본 192px 인데 200px 로 표시됩니다(미세 확대).
밈 팩 200px 결정은 유지하되, 원본이 작은 밈은 나중에 개별로 볼 여지가 있습니다.