### PR TITLE
perf: 광고 호스트 preconnect — 연결 비용 절감 (실측 기반)

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -108,6 +108,29 @@
         <link rel="dns-prefetch" href="https://s3.damoang.net" />
         <link rel="preconnect" href="https://r2.damoang.net" crossorigin />
         <link rel="dns-prefetch" href="https://r2.damoang.net" />
+        <!--
+          광고 호스트 연결 비용 절감 (2026-08-04 모바일 실측).
+
+          ⛔ preconnect 는 "곧 쓸 연결"에만 건다. 늦게 붙는 호스트에 걸면 연결 슬롯만
+             차지해 초반 자원과 경쟁한다. 그래서 첫 요청 시점을 기준으로 골랐다.
+
+            호스트                                연결비용   첫요청     판정
+            pagead2.googlesyndication.com          79ms      150ms   preconnect ✅
+            cdn.jsdelivr.net                       36ms      150ms   이미 있음(그래서 36ms)
+            fundingchoicesmessages.google.com      95ms    1,127ms   dns-prefetch 만
+            safeframe.googlesyndication.com        93ms    1,422ms   ⛔ 너무 늦음
+            ep1.adtrafficquality.google            74ms    1,587ms   ⛔ 너무 늦음
+            www.google.co.kr                       85ms    1,810ms   ⛔ 너무 늦음
+
+          preconnect 가 걸린 jsdelivr 는 36ms, 안 걸린 호스트는 79~95ms 였다.
+          같은 페이지 안에서 대조되므로 효과 근거가 된다.
+
+          ⛔ securepubads.g.doubleclick.net 은 넣지 않는다 — 실측에서 연결 비용이
+             잡히지 않았다(앞선 요청의 연결을 재사용). 넣으면 슬롯만 낭비한다.
+        -->
+        <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin />
+        <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
+        <link rel="dns-prefetch" href="https://fundingchoicesmessages.google.com" />
         <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
         <link
             rel="preload"


### PR DESCRIPTION
## 왜

모바일 실측에서 광고 호스트의 **DNS+TCP+TLS 연결 비용이 79~95ms** 였습니다.
이미 preconnect 가 걸린 `cdn.jsdelivr.net` 은 **36ms** 였습니다.
**같은 페이지 안에서 대조**되므로 효과 근거가 됩니다.

## 무엇을 넣고 무엇을 뺐나

⛔ preconnect 는 **"곧 쓸 연결"에만** 겁니다. 늦게 붙는 호스트에 걸면 연결 슬롯만
차지해 초반 자원과 경쟁합니다. 그래서 **첫 요청 시점**을 기준으로 골랐습니다.

| 호스트 | 연결비용 | 첫 요청 | 판정 |
|---|---|---|---|
| `pagead2.googlesyndication.com` | 79ms | **150ms** | ✅ **preconnect** |
| `fundingchoicesmessages` | 95ms | 1,127ms | dns-prefetch 만 |
| `safeframe.googlesyndication` | 93ms | 1,422ms | ⛔ 제외 |
| `ep1.adtrafficquality` | 74ms | 1,587ms | ⛔ 제외 |
| `www.google.co.kr` | 85ms | 1,810ms | ⛔ 제외 |
| `securepubads.g.doubleclick.net` | **미검출** | — | ⛔ 제외 (연결 재사용 중) |

## ⛔ 광고 자체는 건드리지 않았습니다

첫 화면 광고는 **642KB / 35건**이고 대부분 필수 라이브러리입니다
(`pubads_impl.js` 199KB, `show_ads_impl` 165KB). **수익 직결이라 손대지 않았습니다.**

`adsbygoogle.js` 가 두 번 로드되는 것은 중복이 아니라 **별도 광고 계정
(`ca-pub-2456249131797827`)의 정상 동작**임을 확인했습니다. 건드리지 않습니다.

## 검증

- [ ] 카나리에서 `pagead2` 연결 비용이 줄었는지 (79ms → jsdelivr 수준)
- [ ] 광고가 정상 노출되는지 (preconnect 는 로직 무변경이지만 확인)