### PR TITLE
chore(web): AdMob app-ads.txt 추가 (앱 광고 인증)

### DIFF
--- a/apps/web/static/app-ads.txt
+++ b/apps/web/static/app-ads.txt
@@ -1,0 +1,3 @@
+google.com, pub-5124617752473025, DIRECT, f08c47fec0942fa0
+google.com, pub-5124617752473025, RESELLER, f08c47fec0942fa0
+google.com, pub-6922133409882969, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 배경
다모앙 앱(iOS net.damoang.app / Android net.damoang.community)에 AdMob을 붙이며, AdMob 콘솔이 앱 인증을 위해 `https://damoang.net/app-ads.txt` 에 게시자 라인을 요구합니다. 현재 라이브 `app-ads.txt` 에는 레거시 `pub-5124617752473025` 만 있고 앱 AdMob 계정(**pub-6922133409882969**, 주식회사 SDK)이 없어 인증이 실패합니다.

## 변경
`apps/web/static/app-ads.txt` 추가 (add-only):
```
google.com, pub-5124617752473025, DIRECT, f08c47fec0942fa0
google.com, pub-5124617752473025, RESELLER, f08c47fec0942fa0
google.com, pub-6922133409882969, DIRECT, f08c47fec0942fa0
```
- 기존 레거시 `pub-5124` 두 줄(DIRECT+RESELLER) **유지** + 앱 AdMob `pub-6922` DIRECT **추가**.

## ⚠️ 확인 필요 (배포 파이프라인)
- `apps/web/.gitignore:27` 에 `/static/ads.txt` 가 있어 **ads.txt 는 배포 시점 주입/수동관리**(레포 미추적)됩니다. 그래서 라이브 ads.txt(pub-2456/5124/6922 5줄)와 레포 `ads-txt.ts`(2줄)가 다릅니다.
- 반면 **app-ads.txt 는 .gitignore 대상이 아니라** 이 PR로 레포에 정식 추적합니다.
- 라이브 app-ads.txt 소스가 S3/레포 어디에도 없어(전 버킷·전 레포 확인) **별도 주입 경로**로 추정됩니다. 배포가 app-ads.txt 를 주입한다면 이 static 파일과 **정합(혹은 그쪽에 pub-6922 추가)** 확인 부탁드립니다.

## 검증
- 배포 후 `curl https://damoang.net/app-ads.txt` 에 3줄(위 내용) 확인 → AdMob 콘솔 "앱 인증" 재시도.