### PR TITLE
feat(board): 읽은 공지 접기 — 목록 최상단을 새 글에 돌려준다

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -108,6 +108,29 @@
         <link rel="dns-prefetch" href="https://s3.damoang.net" />
         <link rel="preconnect" href="https://r2.damoang.net" crossorigin />
         <link rel="dns-prefetch" href="https://r2.damoang.net" />
+        <!--
+          광고 호스트 연결 비용 절감 (2026-08-04 모바일 실측).
+
+          ⛔ preconnect 는 "곧 쓸 연결"에만 건다. 늦게 붙는 호스트에 걸면 연결 슬롯만
+             차지해 초반 자원과 경쟁한다. 그래서 첫 요청 시점을 기준으로 골랐다.
+
+            호스트                                연결비용   첫요청     판정
+            pagead2.googlesyndication.com          79ms      150ms   preconnect ✅
+            cdn.jsdelivr.net                       36ms      150ms   이미 있음(그래서 36ms)
+            fundingchoicesmessages.google.com      95ms    1,127ms   dns-prefetch 만
+            safeframe.googlesyndication.com        93ms    1,422ms   ⛔ 너무 늦음
+            ep1.adtrafficquality.google            74ms    1,587ms   ⛔ 너무 늦음
+            www.google.co.kr                       85ms    1,810ms   ⛔ 너무 늦음
+
+          preconnect 가 걸린 jsdelivr 는 36ms, 안 걸린 호스트는 79~95ms 였다.
+          같은 페이지 안에서 대조되므로 효과 근거가 된다.
+
+          ⛔ securepubads.g.doubleclick.net 은 넣지 않는다 — 실측에서 연결 비용이
+             잡히지 않았다(앞선 요청의 연결을 재사용). 넣으면 슬롯만 낭비한다.
+        -->
+        <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin />
+        <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
+        <link rel="dns-prefetch" href="https://fundingchoicesmessages.google.com" />
         <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
         <link
             rel="preload"

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -109,28 +109,30 @@
         <link rel="preconnect" href="https://r2.damoang.net" crossorigin />
         <link rel="dns-prefetch" href="https://r2.damoang.net" />
         <!--
-          광고 호스트 연결 비용 절감 (2026-08-04 모바일 실측).
+          ⛔ **광고 호스트에 preconnect 를 걸지 말 것.** 시도했고 효과가 없었다(2026-08-04 실측).
 
-          ⛔ preconnect 는 "곧 쓸 연결"에만 건다. 늦게 붙는 호스트에 걸면 연결 슬롯만
-             차지해 초반 자원과 경쟁한다. 그래서 첫 요청 시점을 기준으로 골랐다.
+          `pagead2.googlesyndication.com` 에 preconnect + dns-prefetch 를 넣고
+          카나리/운영을 각 5회 반복 측정했다. 캐시 없는 새 컨텍스트로 쟀다.
 
-            호스트                                연결비용   첫요청     판정
-            pagead2.googlesyndication.com          79ms      150ms   preconnect ✅
-            cdn.jsdelivr.net                       36ms      150ms   이미 있음(그래서 36ms)
-            fundingchoicesmessages.google.com      95ms    1,127ms   dns-prefetch 만
-            safeframe.googlesyndication.com        93ms    1,422ms   ⛔ 너무 늦음
-            ep1.adtrafficquality.google            74ms    1,587ms   ⛔ 너무 늦음
-            www.google.co.kr                       85ms    1,810ms   ⛔ 너무 늦음
+            연결비용(중앙)   preconnect 없음 73ms  →  있음 86ms
+            LOAD(중앙)       preconnect 없음 1,559ms → 있음 1,639ms
 
-          preconnect 가 걸린 jsdelivr 는 36ms, 안 걸린 호스트는 79~95ms 였다.
-          같은 페이지 안에서 대조되므로 효과 근거가 된다.
+          효과가 없는 정도가 아니라 소폭 나빴다. 그래서 되돌렸다(#1961 → revert).
 
-          ⛔ securepubads.g.doubleclick.net 은 넣지 않는다 — 실측에서 연결 비용이
-             잡히지 않았다(앞선 요청의 연결을 재사용). 넣으면 슬롯만 낭비한다.
+          ## 왜 안 되는가
+
+          처음에 "cdn.jsdelivr.net 은 preconnect 가 있어서 36ms, 광고 호스트는 없어서
+          79~95ms" 라고 판단했는데 **상관관계를 인과로 읽은 것**이었다. jsdelivr 가 빠른
+          이유는 preconnect 가 아니라 엣지 위치·연결 재사용 쪽이다.
+
+          광고 스크립트는 head 안에서 곧바로 로드를 시작하므로 preconnect 가 몇 ms
+          앞서봐야 실익이 없다. 오히려 연결 슬롯을 미리 잡아 초기 자원과 경쟁한다.
+
+          ## 다시 시도하려면
+
+          단발 측정으로 판단하지 말 것. 광고 서버 응답은 회차 편차가 커서
+          1회 측정은 무의미하다. **최소 5회 반복 + 중앙값 + 대조군**이 필요하다.
         -->
-        <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin />
-        <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
-        <link rel="dns-prefetch" href="https://fundingchoicesmessages.google.com" />
         <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity -->
         <link
             rel="preload"

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -33,6 +33,13 @@ export interface UiSettings {
     contentBlur: boolean;
     hidePostList: boolean;
     hideReadNotices: boolean;
+    /**
+     * 읽은 공지를 접어 두고 개수만 표시한다(펼치기 가능).
+     *
+     * ⛔ `hideReadNotices`(완전 숨김)와 다른 항목이다. 둘 다 켜지면 숨김이 이긴다 —
+     *    안 보이기로 한 것을 접기가 되살리면 설정을 무시하는 셈이 된다.
+     */
+    collapseReadNotices: boolean;
     muteKeywords: string[];
     showNewComments: boolean;
     // 단축키
@@ -78,6 +85,9 @@ const DEFAULTS: UiSettings = {
     contentBlur: true,
     hidePostList: false,
     hideReadNotices: false,
+    // 기본 켜짐 — 고정 공지가 여러 개인 게시판에서 읽은 공지가 목록 최상단을 계속
+    // 차지하는 것이 본래 문제였다. 개수는 알려주고 언제든 펼칠 수 있으므로 정보 손실이 없다.
+    collapseReadNotices: true,
     muteKeywords: [],
     showNewComments: true,
     enableKeyboardShortcuts: true,
@@ -324,6 +334,13 @@ function createUiSettingsStore() {
         },
         setHideReadNotices(v: boolean) {
             settings.hideReadNotices = v;
+            save();
+        },
+        get collapseReadNotices() {
+            return settings.collapseReadNotices;
+        },
+        setCollapseReadNotices(v: boolean) {
+            settings.collapseReadNotices = v;
             save();
         },
         get muteKeywords() {

--- a/apps/web/src/lib/utils/notice-collapse.test.ts
+++ b/apps/web/src/lib/utils/notice-collapse.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+    collapsedNoticeCount,
+    isReadNoticeHidden,
+    shouldShowCollapseButton,
+    type NoticeCollapseState
+} from './notice-collapse';
+
+const s = (o: Partial<NoticeCollapseState> = {}): NoticeCollapseState => ({
+    hideRead: false,
+    collapseRead: true,
+    expanded: false,
+    ...o
+});
+
+describe('isReadNoticeHidden', () => {
+    it('기본(접기 켬, 안 펼침) — 읽은 공지는 감춘다', () => {
+        expect(isReadNoticeHidden(s())).toBe(true);
+    });
+
+    it('펼치면 보인다', () => {
+        expect(isReadNoticeHidden(s({ expanded: true }))).toBe(false);
+    });
+
+    it('접기를 끄면 예전처럼 그대로 보인다 — 회귀 없음', () => {
+        expect(isReadNoticeHidden(s({ collapseRead: false }))).toBe(false);
+    });
+
+    // ⛔ 이 테스트가 설정 존중의 방어선이다.
+    it('숨기기가 접기·펼침보다 우선한다', () => {
+        expect(isReadNoticeHidden(s({ hideRead: true }))).toBe(true);
+        expect(isReadNoticeHidden(s({ hideRead: true, expanded: true }))).toBe(true);
+        expect(isReadNoticeHidden(s({ hideRead: true, collapseRead: false }))).toBe(true);
+    });
+});
+
+describe('collapsedNoticeCount', () => {
+    it('접힌 상태에서는 읽은 개수를 그대로 알린다', () => {
+        expect(collapsedNoticeCount(s(), 4)).toBe(4);
+    });
+
+    it('펼친 뒤에는 0 — 버튼이 사라진다', () => {
+        expect(collapsedNoticeCount(s({ expanded: true }), 4)).toBe(0);
+    });
+
+    it('접기를 끄면 0', () => {
+        expect(collapsedNoticeCount(s({ collapseRead: false }), 4)).toBe(0);
+    });
+
+    // ⛔ 눌러도 안 펼쳐지는 버튼을 보여주면 고장으로 오해된다.
+    it('숨기기를 켠 분에게는 펼치기 버튼을 띄우지 않는다', () => {
+        expect(collapsedNoticeCount(s({ hideRead: true }), 4)).toBe(0);
+    });
+
+    it('읽은 공지가 없으면 0', () => {
+        expect(collapsedNoticeCount(s(), 0)).toBe(0);
+    });
+});
+
+describe('shouldShowCollapseButton', () => {
+    it('펼친 상태에서만 접기 버튼이 보인다', () => {
+        expect(shouldShowCollapseButton(s({ expanded: true }), 3)).toBe(true);
+        expect(shouldShowCollapseButton(s(), 3)).toBe(false);
+    });
+
+    it('접기를 껐으면 접기 버튼도 없다', () => {
+        expect(shouldShowCollapseButton(s({ expanded: true, collapseRead: false }), 3)).toBe(false);
+    });
+
+    it('숨기기를 켰으면 접기 버튼도 없다', () => {
+        expect(shouldShowCollapseButton(s({ expanded: true, hideRead: true }), 3)).toBe(false);
+    });
+
+    it('읽은 공지가 없으면 접기 버튼도 없다', () => {
+        expect(shouldShowCollapseButton(s({ expanded: true }), 0)).toBe(false);
+    });
+});

--- a/apps/web/src/lib/utils/notice-collapse.ts
+++ b/apps/web/src/lib/utils/notice-collapse.ts
@@ -1,0 +1,50 @@
+/**
+ * 읽은 공지 접기 규칙.
+ *
+ * 목록 페이지와 테스트가 **같은 함수를 import** 한다. 규칙을 화면에 인라인으로 두면
+ * 테스트가 로직을 복붙하게 되고, 구현이 바뀌어도 테스트는 영원히 초록이다
+ * (2026-08-03 blocked-comment-filter 사고).
+ *
+ * ## 세 가지 상태가 섞인다
+ *
+ * | hideReadNotices | collapseReadNotices | 펼침 | 읽은 공지 |
+ * |---|---|---|---|
+ * | 켬 | — | — | 아예 안 보임 (사용자가 그렇게 정했다) |
+ * | 끔 | 끔 | — | 그대로 보임 (예전 동작) |
+ * | 끔 | 켬 | 접힘 | 개수만 표시 |
+ * | 끔 | 켬 | 펼침 | 보임 |
+ *
+ * ⛔ `hideReadNotices`(완전 숨김)가 접기보다 우선한다. 안 보이기로 한 것을 접기가
+ *    되살리면 설정을 무시하는 셈이 된다.
+ */
+
+export interface NoticeCollapseState {
+    /** 설정 → 화면 설정 → '읽은 공지 숨기기' */
+    hideRead: boolean;
+    /** 목록 설정 → '읽은 공지 접기' */
+    collapseRead: boolean;
+    /** 이번 화면에서 사용자가 펼쳤는가 */
+    expanded: boolean;
+}
+
+/** 읽은 공지 한 건을 지금 감출 것인가 */
+export function isReadNoticeHidden(s: NoticeCollapseState): boolean {
+    if (s.hideRead) return true;
+    if (!s.collapseRead) return false;
+    return !s.expanded;
+}
+
+/**
+ * '펼치기' 버튼에 표시할 개수. 0 이면 버튼을 그리지 않는다.
+ *
+ * ⛔ hideRead 일 때 0 이어야 한다 — 눌러도 안 펼쳐지므로 고장으로 오해된다.
+ */
+export function collapsedNoticeCount(s: NoticeCollapseState, readCount: number): number {
+    if (s.hideRead || !s.collapseRead || s.expanded) return 0;
+    return readCount;
+}
+
+/** '접기' 버튼을 보일 것인가 (펼친 뒤 되돌릴 수단) */
+export function shouldShowCollapseButton(s: NoticeCollapseState, readCount: number): boolean {
+    return s.expanded && readCount > 0 && s.collapseRead && !s.hideRead;
+}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -27,6 +27,8 @@
     import Lock from '@lucide/svelte/icons/lock';
     import Search from '@lucide/svelte/icons/search';
     import Megaphone from '@lucide/svelte/icons/megaphone';
+    import ChevronDown from '@lucide/svelte/icons/chevron-down';
+    import ChevronUp from '@lucide/svelte/icons/chevron-up';
     import Pin from '@lucide/svelte/icons/pin';
     import Tag from '@lucide/svelte/icons/tag';
     import X from '@lucide/svelte/icons/x';
@@ -54,6 +56,11 @@
     } from '$lib/utils/board-permissions.js';
     import * as Tooltip from '$lib/components/ui/tooltip/index.js';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import {
+        isReadNoticeHidden,
+        collapsedNoticeCount as collapsedNoticeCountOf,
+        shouldShowCollapseButton
+    } from '$lib/utils/notice-collapse';
     import { densityStore } from '$lib/stores/density.svelte.js';
     import { readPostStyleStore, type ReadPostStyle } from '$lib/stores/read-post-style.svelte.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
@@ -553,21 +560,53 @@
     });
     // 차단 키워드 적용: 차단된 글은 목록에서 완전 제외 (#11935)
     const filteredPosts = $derived(posts.filter((p) => !uiSettingsStore.isMuted(p.title)));
+    /**
+     * 읽은 공지 접기 (기본 접힘). 펼침 토글로 다시 볼 수 있다.
+     *
+     * 자유게시판처럼 고정 공지가 여러 개인 곳에서, 이미 읽은 공지가 매번 목록
+     * 최상단을 차지해 정작 새 글이 밀린다. 읽은 것은 접어두고 개수만 알린다.
+     *
+     * ⛔ 기존 `hideReadNotices` 설정(읽은 공지 완전 숨김)과 별개다.
+     *    그 설정을 켜 두신 분은 펼쳐도 안 보이는 게 맞다 — 스스로 끄겠다고 하신 것이라
+     *    여기서 되살리면 설정을 무시하는 셈이 된다.
+     */
+    let showReadNotices = $state(false);
+
+    /** 규칙은 $lib/utils/notice-collapse 하나만 안다 — 화면과 테스트가 같은 함수를 쓴다 */
+    const noticeCollapseState = $derived({
+        hideRead: uiSettingsStore.hideReadNotices,
+        collapseRead: uiSettingsStore.collapseReadNotices,
+        expanded: showReadNotices
+    });
+
+    /** 이 공지를 지금 감출 것인가 */
+    function isNoticeCollapsed(n: { id: number }): boolean {
+        if (!readPostsStore.isRead(boardId, n.id)) return false;
+        return isReadNoticeHidden(noticeCollapseState);
+    }
+
     const importantNotices = $derived(
-        notices.filter(
-            (n) =>
-                n.notice_type === 'important' &&
-                !(uiSettingsStore.hideReadNotices && readPostsStore.isRead(boardId, n.id))
-        )
+        notices.filter((n) => n.notice_type === 'important' && !isNoticeCollapsed(n))
     );
     const normalNotices = $derived(
-        notices.filter(
-            (n) =>
-                n.notice_type !== 'important' &&
-                !(uiSettingsStore.hideReadNotices && readPostsStore.isRead(boardId, n.id))
-        )
+        notices.filter((n) => n.notice_type !== 'important' && !isNoticeCollapsed(n))
     );
-    const hasNotices = $derived(importantNotices.length > 0 || normalNotices.length > 0);
+
+    /** 읽은 공지 총 개수 — 펼치기·접기 버튼 노출 판단에 쓴다 */
+    const readNoticeCount = $derived(
+        notices.filter((n) => readPostsStore.isRead(boardId, n.id)).length
+    );
+
+    const collapsedNoticeCount = $derived(
+        collapsedNoticeCountOf(noticeCollapseState, readNoticeCount)
+    );
+    const showCollapseButton = $derived(
+        shouldShowCollapseButton(noticeCollapseState, readNoticeCount)
+    );
+
+    const hasNotices = $derived(
+        importantNotices.length > 0 || normalNotices.length > 0 || collapsedNoticeCount > 0
+    );
     const shuffledPromos = $derived.by(() => {
         const arr = [...promotionPosts];
         for (let i = arr.length - 1; i > 0; i--) {
@@ -943,6 +982,21 @@
                                     checked={uiSettingsStore.titleBold}
                                     onCheckedChange={(v) => (uiSettingsStore.titleBold = v)}
                                     >글 제목 굵게 표시</DropdownMenuCheckboxItem
+                                >
+                                <!--
+                                    읽은 공지 접기 — 목록 위 인라인 토글은 그 페이지에서만
+                                    유효하고 이동하면 초기화된다. 여기 두면 설정으로 남는다.
+
+                                    ⛔ '읽은 공지 숨기기'(설정 → 화면 설정)와 다른 항목이다.
+                                       숨기기 = 아예 안 보임 / 접기 = 개수만 알리고 펼칠 수 있음.
+                                       숨기기를 켠 분에게는 접기가 무의미하므로 비활성화한다.
+                                -->
+                                <DropdownMenuCheckboxItem
+                                    checked={uiSettingsStore.collapseReadNotices}
+                                    disabled={uiSettingsStore.hideReadNotices}
+                                    onCheckedChange={(v) =>
+                                        uiSettingsStore.setCollapseReadNotices(v)}
+                                    >읽은 공지 접기</DropdownMenuCheckboxItem
                                 >
                             </DropdownMenuContent>
                         </DropdownMenu>
@@ -1336,6 +1390,31 @@
                 {/if}
                 <!-- 공지사항 (목록 내부) -->
                 {#if hasNotices && !isSearching}
+                    <!--
+                        읽은 공지 펼침 토글.
+                        레이아웃(classic/card/…)과 무관하게 공지 블록 맨 위에 한 번만 그린다.
+                        접힌 게 없으면 collapsedNoticeCount 가 0 이라 나타나지 않는다.
+                    -->
+                    {#if collapsedNoticeCount > 0}
+                        <button
+                            type="button"
+                            onclick={() => (showReadNotices = true)}
+                            class="text-muted-foreground hover:text-foreground hover:bg-accent/50 flex w-full items-center gap-1.5 px-4 py-1.5 text-left text-xs transition-colors"
+                        >
+                            <ChevronDown class="size-3.5 shrink-0" />
+                            <span>읽은 공지 {collapsedNoticeCount}개 펼치기</span>
+                        </button>
+                    {:else if showCollapseButton}
+                        <!-- 펼친 뒤 다시 접을 수단. 없으면 되돌릴 방법이 없다. -->
+                        <button
+                            type="button"
+                            onclick={() => (showReadNotices = false)}
+                            class="text-muted-foreground hover:text-foreground hover:bg-accent/50 flex w-full items-center gap-1.5 px-4 py-1.5 text-left text-xs transition-colors"
+                        >
+                            <ChevronUp class="size-3.5 shrink-0" />
+                            <span>읽은 공지 접기</span>
+                        </button>
+                    {/if}
                     {#if listLayoutId === 'classic'}
                         {#each importantNotices as notice (`${notice.source_board ?? boardId}:${notice.id}`)}
                             <a

--- a/apps/web/src/routes/api/my/ui-settings/+server.ts
+++ b/apps/web/src/routes/api/my/ui-settings/+server.ts
@@ -29,6 +29,7 @@ const ALLOWED_KEYS = new Set<string>([
     'contentBlur',
     'hidePostList',
     'hideReadNotices',
+    'collapseReadNotices',
     'muteKeywords',
     'showNewComments',
     'enableKeyboardShortcuts',


### PR DESCRIPTION
## 왜

자유게시판처럼 **고정 공지가 여러 개인 곳**(현재 4개)에서 이미 읽은 공지가 매번
목록 최상단을 차지해 정작 새 글이 밀립니다.

| 고정된 공지 | 등록일 |
|---|---|
| 다모앙에서 욕설 처리 기준은 어디까지인가요? | 25/01/22 |
| 다모앙을 응원하는 두 가지 방법 | 26/06/23 |
| 앙님들을 위한 안내 | 26/07/20 |
| 운영자로서 죄송합니다. | 26/07/30 |

## 동작

```
읽은 공지 3개 펼치기   ← 기본 (접힘)
읽은 공지 접기         ← 펼친 뒤 되돌리기
```

## 기존 설정과의 관계

**「읽은 공지 숨기기」(설정 → 화면 설정)는 그대로 둡니다.** 새 항목은 **「읽은 공지 접기」** 입니다.

| | 동작 |
|---|---|
| 숨기기 | 아예 안 보임 — 사용자가 그렇게 정했다 |
| 접기 | 개수만 알리고 언제든 펼칠 수 있음 |

⛔ **숨기기가 접기보다 우선합니다.** 안 보이기로 한 것을 접기가 되살리면 설정을
무시하는 셈입니다. 숨기기를 켠 분에게는 **펼치기 버튼도 띄우지 않습니다** —
눌러도 안 펼쳐지면 고장으로 오해됩니다.

## 어디에 두었나

목록 설정 드롭다운(톱니)의 「글 제목 굵게 표시」 아래입니다.
화면 위 인라인 토글은 그 페이지에서만 유효하고 이동하면 초기화되므로,
**설정으로도 남게** 했습니다.

## 규칙을 한 곳에 모았습니다

`lib/utils/notice-collapse.ts` 에 판정 함수를 두고 **화면과 테스트가 같은 함수를 import** 합니다.
화면에 인라인으로 두면 테스트가 로직을 복붙하게 되고, 구현이 바뀌어도 테스트는 영원히 초록입니다.

## ⛔ ALLOWED_KEYS

`api/my/ui-settings` 의 `ALLOWED_KEYS` 에 `collapseReadNotices` 를 추가했습니다.
빠뜨리면 **PUT 이 성공했다고 응답하면서 값을 버립니다** — 같은 함정을 오늘
`hideBlockedComments` 에서 이미 한 번 겪었습니다.

## 검증

- [ ] 자유게시판에서 공지를 읽은 뒤 목록 복귀 → 「읽은 공지 N개 펼치기」 노출
- [ ] 펼치기 → 공지 보임 + 「읽은 공지 접기」 로 바뀜
- [ ] 설정 드롭다운에서 「읽은 공지 접기」 끄기 → 예전처럼 항상 노출 (회귀 0)
- [ ] 「읽은 공지 숨기기」 켠 상태 → 접기 항목 비활성, 펼치기 버튼 없음
- [ ] 새로고침 후에도 설정 유지 (ALLOWED_KEYS 확인)