### PR TITLE
feat(hello): 가입인사 글쓰기 전 예절 안내 자막 (1회)

### DIFF
--- a/apps/web/src/lib/components/features/board/write-etiquette-subtitle.svelte
+++ b/apps/web/src/lib/components/features/board/write-etiquette-subtitle.svelte
@@ -1,0 +1,184 @@
+<!--
+  가입인사 글쓰기 전 예절 안내 — 영화 자막처럼 화면 가운데에 잠깐 떴다 사라진다.
+
+  왜 모달이 아닌가: 모달은 "닫기"를 누르게 만들어 읽지 않고 닫는 습관을 만든다.
+  자막은 누를 것이 없어서 읽히고, 저절로 사라져서 방해가 되지 않는다.
+
+  ⛔ hello 게시판 1회 한정. 규칙은 `$lib/utils/write-etiquette-notice.ts` 가 단일 근원이다.
+-->
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import {
+        ETIQUETTE_LINE_DURATION_MS,
+        ETIQUETTE_NOTICE_LINES,
+        ETIQUETTE_NOTICE_SEEN_KEY,
+        shouldShowEtiquetteNotice
+    } from '$lib/utils/write-etiquette-notice.js';
+
+    let { boardId, isAuthenticated = false }: { boardId: string; isAuthenticated?: boolean } =
+        $props();
+
+    // SSR 에서는 항상 false — localStorage 를 모르는 상태로 그리면 hydration 이 어긋난다.
+    let visible = $state(false);
+    let lineIndex = $state(0);
+    let reduceMotion = $state(false);
+
+    // ⛔ 평범한 let. $state 로 두고 $effect 안에서 읽고 쓰면 자기 재트리거가 난다
+    //    (2026-08-01 auth 429 사고).
+    let timers: ReturnType<typeof setTimeout>[] = [];
+
+    function clearTimers(): void {
+        for (const t of timers) clearTimeout(t);
+        timers = [];
+    }
+
+    function dismiss(): void {
+        clearTimers();
+        visible = false;
+    }
+
+    onMount(() => {
+        let seenMark: string | null = null;
+        try {
+            seenMark = localStorage.getItem(ETIQUETTE_NOTICE_SEEN_KEY);
+        } catch {
+            // 시크릿 모드 등 localStorage 차단 환경 — 기록을 못 읽으면 '안 본 것'으로 본다.
+            // 매번 뜨는 쪽이 한 번도 못 보는 쪽보다 낫다.
+            seenMark = null;
+        }
+
+        if (!shouldShowEtiquetteNotice({ boardId, seenMark, isAuthenticated })) {
+            return;
+        }
+
+        reduceMotion =
+            typeof matchMedia === 'function' &&
+            matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        // 본 기록은 '띄우기로 결정한 순간' 남긴다. 다 보고 나서 남기면 도중에 뒤로가기한
+        // 사람에게 영원히 다시 뜬다.
+        try {
+            localStorage.setItem(ETIQUETTE_NOTICE_SEEN_KEY, new Date().toISOString());
+        } catch {
+            // 저장 실패는 치명적이지 않다 — 다음에 한 번 더 볼 뿐이다.
+        }
+
+        visible = true;
+        timers.push(setTimeout(() => (armed = true), 400));
+
+        const hold = reduceMotion ? 1800 : ETIQUETTE_LINE_DURATION_MS;
+        if (reduceMotion) {
+            // 애니메이션을 원치 않는 분에게는 두 줄을 한 번에 보여주고 짧게 끝낸다.
+            lineIndex = ETIQUETTE_NOTICE_LINES.length;
+            timers.push(setTimeout(dismiss, hold));
+        } else {
+            for (let i = 1; i < ETIQUETTE_NOTICE_LINES.length; i++) {
+                timers.push(setTimeout(() => (lineIndex = i), hold * i));
+            }
+            timers.push(setTimeout(dismiss, hold * ETIQUETTE_NOTICE_LINES.length));
+        }
+
+        // ⛔ 모든 분기에서 정리된다 — onMount 반환값 하나로 모아 둔 이유.
+        return clearTimers;
+    });
+
+    // 넘기기 수단은 창 단위로 단다. 스크림 div 에 onclick 을 달면 상호작용 요소가 아닌
+    // 것에 클릭 핸들러가 붙어 a11y 규칙에 걸리고, 그렇다고 버튼을 만들면 "읽지 않고 닫기"를
+    // 유도한다. 화면 아무 곳이나 눌러도 넘어가되 마크업은 순수하게 둔다.
+    //
+    // ⛔ 400ms 무장 지연이 필요하다. 글쓰기 버튼을 누른 그 입력의 뒤따르는 이벤트가
+    //    자막을 즉시 지워버리면 아무도 읽지 못한다.
+    let armed = false;
+
+    function onKeydown(e: KeyboardEvent): void {
+        if (e.key === 'Escape') dismiss();
+    }
+
+    function onPointerDown(): void {
+        if (armed) dismiss();
+    }
+</script>
+
+<svelte:window
+    onkeydown={visible ? onKeydown : undefined}
+    onpointerdown={visible ? onPointerDown : undefined}
+/>
+
+{#if visible}
+    <div class="etiquette-scrim" class:reduce={reduceMotion} role="status" aria-live="polite">
+        <p class="etiquette-eyebrow">가입인사를 남기기 전에</p>
+        {#each ETIQUETTE_NOTICE_LINES as line, i (line)}
+            {#if reduceMotion || i <= lineIndex}
+                <p class="etiquette-line" class:current={reduceMotion || i === lineIndex}>
+                    {line}
+                </p>
+            {/if}
+        {/each}
+    </div>
+{/if}
+
+<style>
+    .etiquette-scrim {
+        position: fixed;
+        inset: 0;
+        z-index: 60;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        padding: 1.5rem;
+        text-align: center;
+        /* 영화 자막의 조건 — 배경이 어두워야 글자가 읽힌다. 완전 불투명은 아니라
+           뒤의 글쓰기 화면이 비쳐 "잠깐 지나가는 안내"로 읽힌다. */
+        background: rgb(0 0 0 / 0.62);
+        backdrop-filter: blur(2px);
+        animation: etiquette-fade-in 320ms ease-out;
+    }
+
+    .etiquette-scrim.reduce {
+        animation: none;
+    }
+
+    .etiquette-eyebrow {
+        margin: 0 0 0.25rem;
+        font-size: 0.8125rem;
+        letter-spacing: 0.08em;
+        color: rgb(255 255 255 / 0.62);
+    }
+
+    .etiquette-line {
+        margin: 0;
+        max-width: 22rem;
+        font-size: 1.0625rem;
+        line-height: 1.6;
+        font-weight: 600;
+        color: rgb(255 255 255 / 0.42);
+        transition: color 420ms ease-out;
+    }
+
+    .etiquette-line.current {
+        color: rgb(255 255 255 / 0.97);
+    }
+
+    .etiquette-scrim.reduce .etiquette-line {
+        color: rgb(255 255 255 / 0.97);
+        transition: none;
+    }
+
+    @media (min-width: 640px) {
+        .etiquette-line {
+            max-width: 30rem;
+            font-size: 1.25rem;
+        }
+    }
+
+    @keyframes etiquette-fade-in {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+</style>

--- a/apps/web/src/lib/utils/write-etiquette-notice.test.ts
+++ b/apps/web/src/lib/utils/write-etiquette-notice.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+    ETIQUETTE_NOTICE_BOARD,
+    ETIQUETTE_NOTICE_LINES,
+    shouldShowEtiquetteNotice,
+    type EtiquetteNoticeContext
+} from './write-etiquette-notice';
+
+const ctx = (o: Partial<EtiquetteNoticeContext> = {}): EtiquetteNoticeContext => ({
+    boardId: ETIQUETTE_NOTICE_BOARD,
+    seenMark: null,
+    isAuthenticated: true,
+    ...o
+});
+
+describe('shouldShowEtiquetteNotice', () => {
+    it('가입인사 첫 글쓰기에서 뜬다', () => {
+        expect(shouldShowEtiquetteNotice(ctx())).toBe(true);
+    });
+
+    // ⛔ 사용자 결정(2026-08-05) "hello 게시판만 1회로" 의 방어선.
+    it('한 번 본 사람에게는 다시 뜨지 않는다', () => {
+        expect(shouldShowEtiquetteNotice(ctx({ seenMark: '1' }))).toBe(false);
+        expect(shouldShowEtiquetteNotice(ctx({ seenMark: '2026-08-05T00:00:00.000Z' }))).toBe(
+            false
+        );
+    });
+
+    // ⛔ 이 테스트가 확대 압력을 막는다. 매 글마다 뜨는 안내는 소음이다.
+    it('다른 게시판에서는 뜨지 않는다', () => {
+        for (const board of ['free', 'promotion', 'bug', 'trade', '']) {
+            expect(shouldShowEtiquetteNotice(ctx({ boardId: board }))).toBe(false);
+        }
+    });
+
+    it('비로그인 상태에서는 뜨지 않는다', () => {
+        expect(shouldShowEtiquetteNotice(ctx({ isAuthenticated: false }))).toBe(false);
+    });
+});
+
+describe('ETIQUETTE_NOTICE_LINES', () => {
+    // 문구가 규정과 어긋나면 안내가 아니라 오정보다.
+    it('경어체와 초성 비속어를 모두 다룬다', () => {
+        const all = ETIQUETTE_NOTICE_LINES.join(' ');
+        expect(all).toContain('경어체');
+        expect(all).toContain('초성');
+    });
+
+    // ⛔ 어투 규약: 안내문은 존댓말. 자막이 반말이면 그 자체로 규정 위반 예시가 된다.
+    it('모든 줄이 존댓말로 끝난다', () => {
+        for (const line of ETIQUETTE_NOTICE_LINES) {
+            expect(line).toMatch(/(습니다|합니다|해요|세요)$/);
+        }
+    });
+});

--- a/apps/web/src/lib/utils/write-etiquette-notice.ts
+++ b/apps/web/src/lib/utils/write-etiquette-notice.ts
@@ -1,0 +1,57 @@
+/**
+ * 가입인사 글쓰기 전 예절 안내 자막 — 표시 여부 규칙.
+ *
+ * 화면(`write-etiquette-subtitle.svelte`)과 테스트가 **같은 함수를 import** 한다.
+ * 규칙을 컴포넌트 안에 인라인으로 두면 테스트가 로직을 복붙하게 되고, 구현이 바뀌어도
+ * 테스트는 영원히 초록이다 (2026-08-03 blocked-comment-filter 사고).
+ *
+ * ## 왜 hello 게시판만인가
+ *
+ * 가입인사는 **새 회원이 이 사이트에 처음 글을 쓰는 자리**다. 경어체·비속어 규정을
+ * 모르고 첫 글에서 어기면, 본인은 영문을 모른 채 주의를 받고 시작한다. 규정을 읽을
+ * 확률이 가장 낮은 사람에게 규정이 가장 필요한 순간이라 여기에만 붙인다.
+ *
+ * ⛔ 다른 게시판으로 확대하지 말 것. 매번 글 쓸 때마다 뜨는 안내는 안내가 아니라 소음이고,
+ *    원주민이 가장 먼저 이탈한다.
+ *
+ * ## 왜 1회인가
+ *
+ * 사용자 결정(2026-08-05): "hello 게시판만 1회로". 두 번째부터는 이미 아는 사람에게
+ * 화면을 가리는 비용만 남는다.
+ */
+
+/** localStorage 키 — 레벨 감지 스토어(`angple_lastKnownLevel`)와 같은 규약. */
+export const ETIQUETTE_NOTICE_SEEN_KEY = 'angple_helloEtiquetteSeen';
+
+/** 이 안내를 붙이는 게시판. 배열이 아니라 상수 하나 — 확대 압력을 코드로 막는다. */
+export const ETIQUETTE_NOTICE_BOARD = 'hello';
+
+export interface EtiquetteNoticeContext {
+    /** 지금 글을 쓰는 게시판 */
+    boardId: string;
+    /** localStorage 에 이미 본 기록이 있는가 (없으면 null) */
+    seenMark: string | null;
+    /** 로그인 회원인가 — 비회원은 애초에 글을 못 쓴다 */
+    isAuthenticated: boolean;
+}
+
+/**
+ * 지금 자막을 띄울 것인가.
+ *
+ * ⛔ 서버에서는 호출하지 말 것. localStorage 를 읽어야 답이 정해지므로 SSR 에서 부르면
+ *    hydration 불일치가 난다. 컴포넌트는 마운트 이후에만 이 함수를 부른다.
+ */
+export function shouldShowEtiquetteNotice(ctx: EtiquetteNoticeContext): boolean {
+    if (ctx.boardId !== ETIQUETTE_NOTICE_BOARD) return false;
+    if (!ctx.isAuthenticated) return false;
+    return !ctx.seenMark;
+}
+
+/** 자막에 실을 문구. `/register/welcome` 의 규정 표현과 같은 말을 쓴다. */
+export const ETIQUETTE_NOTICE_LINES: readonly string[] = [
+    '다모앙은 경어체(존댓말)로 이야기합니다',
+    '초성을 포함한 모든 비속어는 쓰지 않습니다'
+];
+
+/** 자막 한 줄이 머무는 시간(ms). */
+export const ETIQUETTE_LINE_DURATION_MS = 2600;

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -22,6 +22,7 @@
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import { Button } from '$lib/components/ui/button/index.js';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
+    import WriteEtiquetteSubtitle from '$lib/components/features/board/write-etiquette-subtitle.svelte';
 
     let { data }: { data: PageData } = $props();
 
@@ -250,6 +251,9 @@
                 {error}
             </div>
         {/if}
+
+        <!-- 가입인사 예절 자막 (hello 게시판 1회) — 글을 쓸 수 있는 분에게만 뜬다 -->
+        <WriteEtiquetteSubtitle {boardId} isAuthenticated={authStore.isAuthenticated} />
 
         <h1 class="text-foreground mb-4 text-xl font-bold">{boardTitle} — 새 글 작성</h1>
 


### PR DESCRIPTION
## 왜

가입인사는 **새 회원이 이 사이트에 처음 글을 쓰는 자리**다. 경어체·비속어 규정을 모르고
첫 글에서 어기면 본인은 영문도 모른 채 주의를 받고 시작한다. 규정을 읽을 확률이 가장 낮은
사람에게 규정이 가장 필요한 순간이라 여기에만 붙인다.

## 무엇

글쓰기 화면 진입 시 화면 가운데에 영화 자막처럼 두 줄이 차례로 떴다 사라진다.

> 가입인사를 남기기 전에
> **다모앙은 경어체(존댓말)로 이야기합니다**
> **초성을 포함한 모든 비속어는 쓰지 않습니다**

문구는 `/register/welcome` 의 규정 표현과 일치시켰다.

**모달이 아닌 이유** — 모달은 "닫기"를 누르게 만들어 읽지 않고 닫는 습관을 만든다.
자막은 누를 것이 없어서 읽히고, 저절로 사라져서 방해가 되지 않는다.

## 범위 (⛔ 확대 금지)

- **hello 게시판만.** 게시판 목록이 아니라 상수 하나(`ETIQUETTE_NOTICE_BOARD`)로 두어
  확대 압력을 코드로 막았고, 단위 테스트가 다른 게시판에서 뜨지 않음을 고정한다.
  매 글마다 뜨는 안내는 안내가 아니라 소음이고 원주민이 가장 먼저 이탈한다.
- **1회만.** localStorage `angple_helloEtiquetteSeen`.

## 세부

- `prefers-reduced-motion` 이면 두 줄을 한 번에, 짧게(1.8s) 보여준다
- Esc 또는 화면 아무 곳이나 눌러 넘길 수 있다. **400ms 무장 지연** — 글쓰기 버튼을 누른
  그 입력의 뒤따르는 이벤트로 자막이 즉시 사라지면 아무도 읽지 못한다
- 스크림 div 에 onclick 을 달지 않았다(비상호작용 요소 a11y 규칙). 넘기기는 창 단위 리스너
- SSR 에서는 그리지 않는다 — localStorage 를 모르는 상태로 그리면 hydration 이 어긋난다
- 타이머는 `onMount` 반환값 하나로 모아 **모든 분기에서** 정리된다
- 무장 플래그는 `$state` 가 아닌 평범한 `let` (자기 재트리거 방지, 2026-08-01 auth 429 사고)
- 표시 기록은 "띄우기로 결정한 순간" 남긴다. 다 본 뒤에 남기면 도중에 뒤로가기한 사람에게
  영원히 다시 뜬다
- localStorage 차단 환경(시크릿 모드 등)은 "안 본 것"으로 본다 — 매번 뜨는 쪽이
  한 번도 못 보는 쪽보다 낫다

## 검증

- [ ] `/hello/write` 첫 진입 → 자막 2줄 순차 표시 후 자동 소멸
- [ ] 새로고침 후 재진입 → 뜨지 않음
- [ ] `/free/write` 등 다른 게시판 → 뜨지 않음
- [ ] Esc / 탭 / 화면 터치로 즉시 넘김. 진입 직후 400ms 안에는 안 사라짐
- [ ] 모션 최소화 설정에서 두 줄 동시 표시
- [ ] 모바일 360px 에서 문구 줄바꿈 정상, 가로 스크롤 없음