### PR TITLE
feat(noti): 알림 종류를 앞에서 구분되게 표시 (bug/13242)

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -10,14 +10,14 @@
     import { browser } from '$app/environment';
     import { normalizeWebUrl, toRelativeIfSameOrigin } from '$lib/utils/url-normalizer';
     import Bell from '@lucide/svelte/icons/bell';
-    import MessageSquare from '@lucide/svelte/icons/message-square';
-    import Reply from '@lucide/svelte/icons/reply';
-    import AtSign from '@lucide/svelte/icons/at-sign';
-    import Heart from '@lucide/svelte/icons/heart';
-    import Star from '@lucide/svelte/icons/star';
-    import Mail from '@lucide/svelte/icons/mail';
-    import Info from '@lucide/svelte/icons/info';
     import Check from '@lucide/svelte/icons/check';
+    // 알림 종류 표시는 두 화면(드롭다운·알림함)이 같은 모듈을 쓴다 — bug/13242
+    import { getNotificationIcon } from '$lib/utils/notification-icon.js';
+    import {
+        getNotificationColor,
+        getNotificationEmoji,
+        getNotificationLabel
+    } from '$lib/utils/notification-type.js';
     import Loader2 from '@lucide/svelte/icons/loader-2';
     import Settings from '@lucide/svelte/icons/settings';
 
@@ -77,44 +77,6 @@
 
         const normalized = normalizeWebUrl(url, { baseOrigin: window.location.origin });
         return toRelativeIfSameOrigin(normalized, window.location.origin);
-    }
-
-    function getNotificationIcon(type: string) {
-        switch (type) {
-            case 'comment':
-                return MessageSquare;
-            case 'reply':
-                return Reply;
-            case 'mention':
-                return AtSign;
-            case 'like':
-                return Heart;
-            case 'memo':
-                return Mail;
-            case 'levelup':
-                return Star;
-            default:
-                return Info;
-        }
-    }
-
-    function getNotificationColor(type: string): string {
-        switch (type) {
-            case 'comment':
-                return 'text-blue-500';
-            case 'reply':
-                return 'text-green-500';
-            case 'mention':
-                return 'text-purple-500';
-            case 'like':
-                return 'text-red-500';
-            case 'memo':
-                return 'text-orange-500';
-            case 'levelup':
-                return 'text-yellow-500';
-            default:
-                return 'text-muted-foreground';
-        }
     }
 
     function formatTime(dateString: string): string {
@@ -425,8 +387,21 @@
                             <Icon class="h-4 w-4 {getNotificationColor(notification.type)}" />
                         </div>
                         <div class="min-w-0 flex-1">
+                            <!-- ⛔ 종류 표식은 반드시 제목 '앞'에 온다. line-clamp-1 은 뒤에서
+                                 자르므로, 뒤에 두면 닉네임이 길 때 종류가 먼저 사라진다
+                                 (bug/13242 제보 그대로의 증상). -->
                             <p class="text-foreground line-clamp-1 text-[13px] font-medium">
-                                {notification.title}
+                                {#if getNotificationEmoji(notification.type)}
+                                    <span
+                                        class="mr-0.5"
+                                        title={getNotificationLabel(notification.type)}
+                                        aria-hidden="true"
+                                        >{getNotificationEmoji(notification.type)}</span
+                                    >
+                                    <span class="sr-only"
+                                        >{getNotificationLabel(notification.type)}</span
+                                    >
+                                {/if}{notification.title}
                             </p>
                             {#if notification.parent_subject}
                                 <p class="text-muted-foreground mt-0.5 line-clamp-1 text-[11px]">

--- a/apps/web/src/lib/utils/notification-icon.ts
+++ b/apps/web/src/lib/utils/notification-icon.ts
@@ -1,0 +1,46 @@
+/**
+ * 알림 종류 → lucide 아이콘.
+ *
+ * 색·이모지·이름은 `notification-type.ts` 가 단일 근원이다. 여기는 컴포넌트 참조만
+ * 담당한다 — 아이콘 임포트를 순수 모듈에 섞으면 단위 테스트가 svelte 변환에 묶인다.
+ *
+ * ⛔ 드롭다운(`notification-dropdown.svelte`)과 알림함(`routes/notifications`)이
+ *    **같은 함수를 import** 해야 한다. 예전에는 두 곳에 switch 문이 복붙돼 있어서
+ *    한쪽만 고치면 같은 알림이 화면마다 다른 아이콘으로 보였다(bug/13242 작업 중 발견).
+ */
+import AtSign from '@lucide/svelte/icons/at-sign';
+import FileText from '@lucide/svelte/icons/file-text';
+import Heart from '@lucide/svelte/icons/heart';
+import Info from '@lucide/svelte/icons/info';
+import Mail from '@lucide/svelte/icons/mail';
+import MessageSquare from '@lucide/svelte/icons/message-square';
+import Newspaper from '@lucide/svelte/icons/newspaper';
+import Reply from '@lucide/svelte/icons/reply';
+import Star from '@lucide/svelte/icons/star';
+import UserPlus from '@lucide/svelte/icons/user-plus';
+
+export function getNotificationIcon(type: string) {
+    switch (type) {
+        case 'comment':
+            return MessageSquare;
+        case 'reply':
+            return Reply;
+        case 'mention':
+            return AtSign;
+        case 'like':
+        case 'like_comment':
+            return Heart;
+        case 'memo':
+            return Mail;
+        case 'subscribe':
+            return FileText;
+        case 'follow':
+            return UserPlus;
+        case 'digest':
+            return Newspaper;
+        case 'levelup':
+            return Star;
+        default:
+            return Info;
+    }
+}

--- a/apps/web/src/lib/utils/notification-type.test.ts
+++ b/apps/web/src/lib/utils/notification-type.test.ts
@@ -5,6 +5,16 @@ import {
     getNotificationLabel
 } from './notification-type';
 
+/**
+ * 표식의 첫 '글자'(대상: 📄 글 / 💬 댓글).
+ *
+ * ⛔ `str[0]` 을 쓰면 안 된다. 이모지는 서로게이트 쌍이라 인덱싱이 반쪽만 준다.
+ *    하필 📄(U+1F4C4)와 💬(U+1F4AC)는 상위 서로게이트가 둘 다 D83D 로 같아서,
+ *    `[0]` 비교는 **서로 다른 이모지를 같다고 판정**한다(CI 에서 이걸로 한 번 터졌다).
+ *    Array spread 는 코드포인트 단위로 쪼개므로 안전하다.
+ */
+const firstGlyph = (s: string): string => [...s][0] ?? '';
+
 describe('getNotificationEmoji', () => {
     // ⛔ 제보(bug/13242)의 핵심. 이 넷이 서로 달라야 제보가 해결된다.
     it('댓글·답글·글 공감·댓글 공감이 모두 다른 표식을 가진다', () => {
@@ -15,18 +25,20 @@ describe('getNotificationEmoji', () => {
 
     it('첫 글자가 대상(글/댓글)을 가리킨다', () => {
         // 글에 관한 일
-        expect(getNotificationEmoji('comment').startsWith('📄')).toBe(true);
-        expect(getNotificationEmoji('like').startsWith('📄')).toBe(true);
-        expect(getNotificationEmoji('subscribe').startsWith('📄')).toBe(true);
+        expect(firstGlyph(getNotificationEmoji('comment'))).toBe('📄');
+        expect(firstGlyph(getNotificationEmoji('like'))).toBe('📄');
+        expect(firstGlyph(getNotificationEmoji('subscribe'))).toBe('📄');
         // 댓글에 관한 일
-        expect(getNotificationEmoji('reply').startsWith('💬')).toBe(true);
-        expect(getNotificationEmoji('like_comment').startsWith('💬')).toBe(true);
+        expect(firstGlyph(getNotificationEmoji('reply'))).toBe('💬');
+        expect(firstGlyph(getNotificationEmoji('like_comment'))).toBe('💬');
     });
 
     // ⛔ 색이 아니라 모양으로 갈려야 한다 — 흑백 폴백에서도 구분되도록.
     it('글 공감과 댓글 공감은 하트 색이 아니라 앞 글자로 갈린다', () => {
         expect(getNotificationEmoji('like')).not.toBe(getNotificationEmoji('like_comment'));
-        expect(getNotificationEmoji('like')[0]).not.toBe(getNotificationEmoji('like_comment')[0]);
+        expect(firstGlyph(getNotificationEmoji('like'))).not.toBe(
+            firstGlyph(getNotificationEmoji('like_comment'))
+        );
     });
 
     it('구독 새 글과 팔로우 새 글이 구분된다 — 예전엔 둘 다 회색 system 이었다', () => {

--- a/apps/web/src/lib/utils/notification-type.test.ts
+++ b/apps/web/src/lib/utils/notification-type.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getNotificationColor,
+    getNotificationEmoji,
+    getNotificationLabel
+} from './notification-type';
+
+describe('getNotificationEmoji', () => {
+    // ⛔ 제보(bug/13242)의 핵심. 이 넷이 서로 달라야 제보가 해결된다.
+    it('댓글·답글·글 공감·댓글 공감이 모두 다른 표식을 가진다', () => {
+        const marks = ['comment', 'reply', 'like', 'like_comment'].map(getNotificationEmoji);
+        expect(new Set(marks).size).toBe(4);
+        expect(marks.every((m) => m.length > 0)).toBe(true);
+    });
+
+    it('첫 글자가 대상(글/댓글)을 가리킨다', () => {
+        // 글에 관한 일
+        expect(getNotificationEmoji('comment').startsWith('📄')).toBe(true);
+        expect(getNotificationEmoji('like').startsWith('📄')).toBe(true);
+        expect(getNotificationEmoji('subscribe').startsWith('📄')).toBe(true);
+        // 댓글에 관한 일
+        expect(getNotificationEmoji('reply').startsWith('💬')).toBe(true);
+        expect(getNotificationEmoji('like_comment').startsWith('💬')).toBe(true);
+    });
+
+    // ⛔ 색이 아니라 모양으로 갈려야 한다 — 흑백 폴백에서도 구분되도록.
+    it('글 공감과 댓글 공감은 하트 색이 아니라 앞 글자로 갈린다', () => {
+        expect(getNotificationEmoji('like')).not.toBe(getNotificationEmoji('like_comment'));
+        expect(getNotificationEmoji('like')[0]).not.toBe(getNotificationEmoji('like_comment')[0]);
+    });
+
+    it('구독 새 글과 팔로우 새 글이 구분된다 — 예전엔 둘 다 회색 system 이었다', () => {
+        expect(getNotificationEmoji('subscribe')).not.toBe(getNotificationEmoji('follow'));
+    });
+
+    // ⛔ 배포 순서(be/web)가 어긋나도 알림함이 깨지면 안 된다.
+    it('모르는 타입은 조용히 폴백한다', () => {
+        expect(getNotificationEmoji('what_is_this')).toBe('');
+        expect(getNotificationColor('what_is_this')).toBe('text-muted-foreground');
+        expect(getNotificationLabel('what_is_this')).toBe('알림');
+    });
+
+    it('통합 묶음은 표식을 붙이지 않는다 — 본문에 이미 개수가 있다', () => {
+        expect(getNotificationEmoji('merged')).toBe('');
+    });
+});
+
+describe('getNotificationLabel', () => {
+    // 이모지는 스크린리더가 읽지 않거나 엉뚱하게 읽는다. 이름이 본문이다.
+    it('구분이 필요한 종류마다 서로 다른 한글 이름을 가진다', () => {
+        const labels = [
+            'comment',
+            'reply',
+            'like',
+            'like_comment',
+            'mention',
+            'memo',
+            'subscribe',
+            'follow'
+        ].map(getNotificationLabel);
+        expect(new Set(labels).size).toBe(8);
+    });
+});
+
+describe('getNotificationColor', () => {
+    it('구분이 필요한 종류는 색도 다르다', () => {
+        expect(getNotificationColor('like')).not.toBe(getNotificationColor('like_comment'));
+        expect(getNotificationColor('comment')).not.toBe(getNotificationColor('reply'));
+        expect(getNotificationColor('subscribe')).not.toBe(getNotificationColor('follow'));
+    });
+});

--- a/apps/web/src/lib/utils/notification-type.ts
+++ b/apps/web/src/lib/utils/notification-type.ts
@@ -1,0 +1,91 @@
+/**
+ * 알림 종류 표시 규칙 (bug/13242).
+ *
+ * ## 제보
+ *
+ * > 알림이 올 때 이 메시지가 댓글인지, 본문에 대한 좋아요인지, 아니면 댓글에 대한
+ * > 좋아요인지 알아 보기가 어렵습니다. 알림 폭에 비해 아이디의 길이 등이 가변적이라
+ * > **뒷문자열이 잘려서** 생기는 문제같은데요. 각 알림 앞에 접두어를 달면…
+ *
+ * ## 왜 앞에 붙여야 하는가
+ *
+ * 알림 제목은 `{닉네임}님이 회원님의 글에 댓글을 남겼습니다` 꼴이고 화면은 이것을
+ * `line-clamp-1` 로 자른다. 즉 **종류를 알려주는 부분이 가장 먼저 사라진다.**
+ * 닉네임이 길수록 정확히 종류만 없어진다 — 제보자 캡처가 그 상태였다.
+ *
+ * 그래서 종류 표식을 **문자열 맨 앞**에 둔다. 잘림은 뒤에서 일어나므로 앞은 항상 살아남는다.
+ *
+ * ## 이모지 두 글자 = [대상][동작]
+ *
+ * 사용자 결정(2026-08-05). 첫 글자만 보면 **글에 관한 일인지 댓글에 관한 일인지**
+ * 바로 알 수 있다.
+ *
+ * | | 대상 | 동작 |
+ * |---|---|---|
+ * | 📄 글 | 💬 댓글 | ❤️ 공감 · ✍️ 작성 · ↩️ 답글 |
+ *
+ * ⛔ 색으로만 구분하지 말 것. 처음 설계에서 글 공감 ❤️ / 댓글 공감 💙 로 색만 달리
+ *    했는데, 흑백 폴백에서는 같은 하트가 되어 구분이 사라진다. 모양이 달라야 한다.
+ */
+
+/** 백엔드 `mapNotificationType` 이 내려주는 값과 1:1 로 맞춘다. */
+export type NotificationType =
+    | 'comment'
+    | 'reply'
+    | 'like'
+    | 'like_comment'
+    | 'mention'
+    | 'memo'
+    | 'subscribe'
+    | 'follow'
+    | 'digest'
+    | 'levelup'
+    | 'merged'
+    | 'system';
+
+interface NotificationTypeMeta {
+    /** 제목 앞에 붙는 표식 */
+    emoji: string;
+    /** 아이콘 색 (Tailwind) */
+    color: string;
+    /** 스크린리더·title 용 한글 이름. 이모지는 읽히지 않으므로 이쪽이 본문이다. */
+    label: string;
+}
+
+const META: Record<NotificationType, NotificationTypeMeta> = {
+    comment: { emoji: '📄💬', color: 'text-blue-500', label: '내 글에 댓글' },
+    reply: { emoji: '💬↩️', color: 'text-green-500', label: '내 댓글에 답글' },
+    like: { emoji: '📄❤️', color: 'text-red-500', label: '글 공감' },
+    like_comment: { emoji: '💬❤️', color: 'text-rose-400', label: '댓글 공감' },
+    mention: { emoji: '📣', color: 'text-purple-500', label: '멘션' },
+    memo: { emoji: '✉️', color: 'text-orange-500', label: '쪽지' },
+    subscribe: { emoji: '📄✍️', color: 'text-sky-600', label: '구독 게시판 새 글' },
+    follow: { emoji: '👤✍️', color: 'text-teal-600', label: '팔로우한 분의 새 글' },
+    digest: { emoji: '📰', color: 'text-amber-600', label: '새 글 요약' },
+    levelup: { emoji: '⭐', color: 'text-yellow-500', label: '레벨업' },
+    // 통합 묶음(merge=target)은 한 줄에 「댓글 2 · 좋아요 3」처럼 개수를 직접 쓴다.
+    // 종류가 이미 본문에 있으므로 표식을 겹쳐 붙이지 않는다.
+    merged: { emoji: '', color: 'text-muted-foreground', label: '알림' },
+    system: { emoji: '', color: 'text-muted-foreground', label: '알림' }
+};
+
+function meta(type: string): NotificationTypeMeta {
+    // ⛔ 모르는 타입은 반드시 조용히 폴백해야 한다. 백엔드가 새 종류를 추가했을 때
+    //    프론트가 먼저 배포돼 있어도(또는 그 반대여도) 알림함이 깨지면 안 된다.
+    return META[type as NotificationType] ?? META.system;
+}
+
+/** 제목 앞에 붙일 표식. 없으면 빈 문자열. */
+export function getNotificationEmoji(type: string): string {
+    return meta(type).emoji;
+}
+
+/** 아이콘 색 (Tailwind 클래스) */
+export function getNotificationColor(type: string): string {
+    return meta(type).color;
+}
+
+/** 사람이 읽는 종류 이름 — title 속성과 스크린리더용 */
+export function getNotificationLabel(type: string): string {
+    return meta(type).label;
+}

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -8,14 +8,14 @@
     import type { GroupedNotificationListResponse, GroupedNotification } from '$lib/api/types.js';
     import { onMount } from 'svelte';
     import Bell from '@lucide/svelte/icons/bell';
-    import MessageSquare from '@lucide/svelte/icons/message-square';
-    import Reply from '@lucide/svelte/icons/reply';
-    import AtSign from '@lucide/svelte/icons/at-sign';
-    import Heart from '@lucide/svelte/icons/heart';
-    import Star from '@lucide/svelte/icons/star';
-    import Mail from '@lucide/svelte/icons/mail';
-    import Info from '@lucide/svelte/icons/info';
     import Check from '@lucide/svelte/icons/check';
+    // 알림 종류 표시는 두 화면(드롭다운·알림함)이 같은 모듈을 쓴다 — bug/13242
+    import { getNotificationIcon } from '$lib/utils/notification-icon.js';
+    import {
+        getNotificationColor,
+        getNotificationEmoji,
+        getNotificationLabel
+    } from '$lib/utils/notification-type.js';
     import Trash2 from '@lucide/svelte/icons/trash-2';
     import Loader2 from '@lucide/svelte/icons/loader-2';
     import ArrowLeft from '@lucide/svelte/icons/arrow-left';
@@ -37,46 +37,12 @@
         { key: 'like', label: '공감' },
         { key: 'mention', label: '멘션' },
         { key: 'memo', label: '쪽지' },
-        { key: 'system', label: '시스템' }
+        // ⛔ '시스템' 이 아니라 '새 글' 이다. 이 필터는 ph_from_case IN
+        //    ('write','inquire','answer') 인데 실제 내용은 30일 기준 구독·팔로우
+        //    새 글 101만건이고 inquire/answer 는 0건이다(bug/13242).
+        //    백엔드 필터 값(system)은 그대로 두고 이름만 사실에 맞춘다.
+        { key: 'system', label: '새 글' }
     ];
-
-    function getNotificationIcon(type: string) {
-        switch (type) {
-            case 'comment':
-                return MessageSquare;
-            case 'reply':
-                return Reply;
-            case 'mention':
-                return AtSign;
-            case 'like':
-                return Heart;
-            case 'memo':
-                return Mail;
-            case 'levelup':
-                return Star;
-            default:
-                return Info;
-        }
-    }
-
-    function getNotificationColor(type: string): string {
-        switch (type) {
-            case 'comment':
-                return 'text-blue-500';
-            case 'reply':
-                return 'text-green-500';
-            case 'mention':
-                return 'text-purple-500';
-            case 'like':
-                return 'text-red-500';
-            case 'memo':
-                return 'text-orange-500';
-            case 'levelup':
-                return 'text-yellow-500';
-            default:
-                return 'text-muted-foreground';
-        }
-    }
 
     function formatTime(dateString: string): string {
         const date = new Date(dateString);
@@ -332,6 +298,19 @@
                         <!-- 내용 -->
                         <div class="min-w-0 flex-1">
                             <div class="flex items-center gap-1.5">
+                                <!-- ⛔ 종류 표식은 제목 '앞'에. truncate 는 뒤에서 자르므로
+                                     뒤에 두면 닉네임이 길 때 종류가 먼저 사라진다 (bug/13242). -->
+                                {#if getNotificationEmoji(notification.type)}
+                                    <span
+                                        class="shrink-0 text-sm"
+                                        title={getNotificationLabel(notification.type)}
+                                        aria-hidden="true"
+                                        >{getNotificationEmoji(notification.type)}</span
+                                    >
+                                    <span class="sr-only"
+                                        >{getNotificationLabel(notification.type)}</span
+                                    >
+                                {/if}
                                 <span
                                     class="truncate text-sm {notification.has_unread
                                         ? 'text-foreground font-semibold'


### PR DESCRIPTION
백엔드 대응: angple-backend#614 (먼저 배포되어야 새 종류가 내려온다)

## 문제

> 알림 폭에 비해 아이디의 길이 등이 가변적이라 **뒷문자열이 잘려서** 생기는 문제같은데요.
> 각 알림 앞에 [댓], [💙] 처럼 **접두어**를 달면 직관성이 확 올라가지 않을까합니다.

제목이 `{닉네임}님이 …댓글을 남겼습니다` 꼴인데 화면은 `line-clamp-1` 로 자른다.
즉 **종류를 알려주는 부분이 가장 먼저 사라지고 닉네임만 남는다.** 제보 캡처가 그 상태다.

## 변경 ① 종류 표식을 제목 맨 앞에

잘림은 뒤에서 일어나므로 앞은 항상 살아남는다. 표식은 **[대상][동작] 두 글자**다 —
첫 글자만 봐도 글에 관한 일인지 댓글에 관한 일인지 알 수 있다.

| | |
|---|---|
| 📄💬 내 글에 댓글 | 💬↩️ 내 댓글에 답글 |
| 📄❤️ 글 공감 | 💬❤️ **댓글 공감** |
| 📄✍️ 구독 새 글 | 👤✍️ 팔로우한 분 새 글 |
| 📣 멘션 · ✉️ 쪽지 · 📰 요약 · ⭐ 레벨업 | |

⛔ 글 공감/댓글 공감을 하트 **색**(❤️/💙)으로만 가르지 않았다. 흑백 폴백에서 같은
하트가 되어 구분이 사라진다. **모양이 달라야 한다.**

이모지는 `aria-hidden`, 옆에 `sr-only` 한글 이름을 둔다 — 스크린리더는 이모지를 읽지
않거나 엉뚱하게 읽으므로 이름이 본문이다.

## 변경 ② 아이콘·색 매핑 중복 제거 (선행 필수)

드롭다운과 알림함에 **같은 switch 문이 두 벌** 있었다. 한쪽만 고치면 같은 알림이
화면마다 다른 아이콘으로 보인다.

- `notification-type.ts` — 순수 규칙(이모지·색·이름) + 단위 테스트
- `notification-icon.ts` — lucide 컴포넌트 참조 (아이콘 임포트를 순수 모듈에 섞으면
  단위 테스트가 svelte 변환에 묶인다)

새 종류 `subscribe`·`follow`·`like_comment`·`digest` 추가.
**모르는 종류는 조용히 폴백**한다 — be/web 배포 순서가 어긋나도 알림함이 깨지지 않는다.

## 곁가지: 필터 이름 「시스템」 → 「새 글」

이 필터는 `ph_from_case IN (write,inquire,answer)` 인데 실제 내용은 30일 기준
**구독·팔로우 새 글 101만건**이고 `inquire`/`answer` 는 **0건**이다. 백엔드 필터 값
(`system`)은 그대로 두고 **이름만 사실에 맞췄다** — 결과 집합은 동일하다.

## 검증

- [ ] 댓글·답글·글 공감·댓글 공감이 한 화면에 섞여 나올 때 서로 구분되는지
- [ ] 닉네임 20자 이상 알림에서도 **맨 앞 표식이 살아 있는지** (360px)
- [ ] 드롭다운과 `/notifications` 가 **같은 아이콘·색·표식**을 쓰는지
- [ ] be 미배포 상태(옛 type)에서도 알림함이 정상 렌더되는지 — 폴백 확인
- [ ] 읽음·삭제·필터 회귀 없음
- [ ] `pnpm test:unit -- --run`