### PR TITLE
fix(settings): 글자체 설정이 아무 일도 하지 않던 문제 (qa/82194)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -323,7 +323,14 @@ html {
     /* 1) 기본 폰트 적용 + 스무딩(맥), 커닝/리거처 통일 */
     html {
         scrollbar-gutter: stable;
-        font-family: var(--font-sans);
+        /* ⛔ --user-font-family 를 반드시 먼저 읽어야 한다.
+           설정 → 화면 설정 → 글자체가 이 변수를 html 인라인 스타일로 심는데
+           (ui-settings.svelte.ts applyCSS), **그 변수를 읽는 규칙이 한 곳도 없어서**
+           글자체를 바꿔도 화면이 그대로였다. 운영 빌드에서 `var(--user-font-family`
+           사용처가 0개였다(qa/82194 회원 제보 — "글자체를 바꿔도 적용이 안되네요").
+           아래 `*, ::before, ::after { font-family: inherit }` 덕분에 이 한 줄이
+           페이지 전체에 퍼진다. 미설정이면 기존대로 --font-sans 로 떨어진다. */
+        font-family: var(--user-font-family, var(--font-sans));
         -webkit-font-smoothing: antialiased;
         /* macOS */
         -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## 제보

qa/82194 회원 댓글: *"글자체를 바꿔도 적용이 안되네요 ㅋ"*

## 원인 — 변수는 성실히 설정되고, 아무도 읽지 않았다

설정 → 화면 설정 → 글자체는 `--user-font-family` 를 `<html>` 인라인 스타일로 심는다
(`ui-settings.svelte.ts` `applyCSS`). 그런데 **그 변수를 읽는 CSS 규칙이 한 곳도 없다.**

코드 전체에서 `user-font-family` 참조는 딱 둘 — `setProperty` 와 `removeProperty`.
운영 빌드에서도 확인했다:

```
$ grep -rlo "user-font-family"      /app/build/client   → bundle.DDC5Z3jS.js  (설정하는 JS)
$ grep -rlo "var(--user-font-family" /app/build/client   → (없음)
```

즉 글자체 설정은 **처음부터 아무 일도 하지 않았다.**

## 수정

```css
html {
    font-family: var(--user-font-family, var(--font-sans));
}
```

바로 아래 `*, ::before, ::after { font-family: inherit }` 가 있어 이 한 줄이 페이지 전체에
퍼진다. 미설정이면 기존대로 `--font-sans`(Wanted Sans) 로 떨어지므로 **기본 사용자에게는
변화가 없다.**

## ⚠️ 남는 한계 — 이번 PR 범위 밖

웹폰트는 **Wanted Sans 하나만** 로드된다(jsdelivr). 선택지 중 Pretendard·나눔고딕·본고딕은
`local()` 의존이라 **그 글꼴이 설치된 분에게만** 실제로 그 글꼴로 보이고, 없으면 대체
글꼴로 간다.

따라서 이 수정 이후에도 *"바뀌긴 하는데 고른 그 글꼴은 아닐 수 있다"* 가 맞는 설명이다.
웹폰트 추가는 페이지 무게(현재 글꼴 386KB)와 함께 판단할 별건으로 남긴다.

## 검증

- [ ] 설정 → 화면 설정 → 글자체 변경 시 본문·목록·댓글 글꼴이 실제로 바뀌는지
- [ ] 「기본」 선택 시 Wanted Sans 로 되돌아오는지
- [ ] 설정을 한 번도 건드리지 않은 회원의 화면이 그대로인지 (회귀 없음)
- [ ] 새로고침 후에도 유지되는지 (localStorage + 서버 저장 경로)