### PR TITLE
perf(plugin): 활성 플러그인 L1 캐시 30초 → 3초

### DIFF
--- a/apps/web/src/lib/server/plugins/index.ts
+++ b/apps/web/src/lib/server/plugins/index.ts
@@ -97,10 +97,25 @@ export async function getPluginById(pluginId: string): Promise<InstalledPlugin |
     };
 }
 
-// --- 2-tier 캐시: 활성 플러그인 (L1 30초, L2 5분) ---
+// --- 2-tier 캐시: 활성 플러그인 (L1 3초, L2 5분) ---
+//
+// ⛔ L1 은 **파드마다 따로** 있고, `TieredCache.delete()` 는 그 요청을 처리한 파드의
+//    L1 과 Redis 만 지운다. 무효화를 파드 간에 전파하는 pub/sub 이 없다.
+//    → 관리자가 플러그인을 끄면 나머지 파드(운영 13개)는 L1 TTL 만큼 옛 값을 계속 쓴다.
+//
+// 30초였을 때 폭죽 플러그인에서 "켜기는 되는데 끄기가 안 된다"는 제보가 나왔다.
+// 무효화 로직은 활성·비활성이 대칭이라 버그가 아니었고, 비대칭은 판정 기준에 있었다 —
+// 켜기는 파드 하나만 갱신돼도 "됐다"로 보이지만, 끄기는 13개가 전부 갱신돼야
+// "꺼졌다"로 보인다. 같은 지연이 정반대로 체감된다.
+//
+// 활성 플러그인 목록은 수십 바이트고 L2(Redis)가 받쳐 주므로 3초로 줄여도
+// DB 부하 증가는 무시할 수준이다. 파드 간 지연 30초 → 3초.
+//
+// ⛔ 근본 해결은 아니다. 무효화 pub/sub 전파(TieredCache 전 소비자가 함께 이득)는
+//    별건으로 남긴다. 열어 둔 탭은 body-end 슬롯 특성상 하드 리로드가 필요한 것도 그대로다.
 const activePluginsTieredCache = new TieredCache<InstalledPlugin[]>(
     'plugins:active',
-    30_000,
+    3_000,
     300,
     10
 );


### PR DESCRIPTION
## 배경 — 폭죽 「켜기는 되는데 끄기가 안 된다」의 실체

`TieredCache` 의 L1 은 **파드마다 따로** 있고, `delete()` 는 그 요청을 처리한 파드의 L1 과
Redis 만 지운다. `lib/server/` 전체에 무효화를 파드 간에 전파하는 `publish`/`subscribe` 가
**한 줄도 없다.**

→ 관리자가 플러그인을 꺼도 나머지 파드(운영 13개)는 **L1 TTL 30초** 동안 옛 값을 계속 쓴다.

## 무효화 로직에는 버그가 없다

`activatePlugin` · `deactivatePlugin` 둘 다 `invalidateActivePluginsCache()` 를 부른다.
**대칭이다.** 비대칭은 판정 기준에 있었다:

| | 성공으로 느끼는 조건 |
|---|---|
| 켜기 | **한 번이라도** 보이면 "됐다" |
| 끄기 | **모든 로드에서** 안 보여야 "꺼졌다" |

같은 30초인데 켜기는 파드 하나만 갱신돼도 성공처럼 보이고, 끄기는 13개가 전부 갱신돼야
성공처럼 보인다. 지연은 같고 체감이 정반대다.

## 변경

```diff
-    30_000,
+    3_000,
```

활성 플러그인 목록은 수십 바이트고 L2(Redis 300초)가 받쳐 준다. 3초로 줄여도 DB 부하
증가는 무시할 수준이고, 파드 간 지연이 30초 → 3초가 된다.

## ⛔ 근본 해결이 아니다

- **무효화 pub/sub 전파** — `TieredCache` 를 쓰는 모든 소비자(설정·위젯·테마·플러그인)가
  함께 이득을 본다. 파드당 구독 커넥션 1개가 필요한 중간 규모 작업이라 **별건**으로 남긴다.
- **열어 둔 탭** — 폭죽 오버레이는 `+layout.svelte` 의 `<PluginSlot name="body-end" />` 에
  상주해 **탭당 한 번만 마운트**된다. SPA 이동으로는 사라지지 않고 하드 리로드가 필요하다.
  이건 이 PR 로 해결되지 않는다(관리자 화면 안내는 #1958 로 이미 있음).

## 검증

- [ ] 플러그인 토글 후 3~5초 내 전 파드 반영 (여러 파드에 반복 요청해 확인)
- [ ] DB/Redis 조회량이 유의미하게 늘지 않는지
- [ ] 플러그인 목록·설정 화면 회귀 없음

실측 근거: `triage/FINDING_fireworks_toggle.md`