### PR TITLE
feat(editor): 본문 앙티콘을 글씨처럼 옆으로 배열

### DIFF
--- a/apps/web/src/lib/components/features/editor/emoticon-node.ts
+++ b/apps/web/src/lib/components/features/editor/emoticon-node.ts
@@ -1,0 +1,76 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+/**
+ * Emoticon — 본문 에디터에서 앙티콘을 **글씨처럼** 다루는 인라인 노드.
+ *
+ * ## 왜 별도 노드인가
+ *
+ * 본문 에디터의 이미지는 `LinkedImage`(`inline: false`)가 담당한다. 그 설정 때문에
+ * 앙티콘도 블록으로 들어가 **한 줄을 통째로 차지했다.** 실제 저장된 글을 보면
+ * `<img>` 가 `<p>` 의 형제로 최상위에 놓인다:
+ *
+ * ```html
+ * <img src="/emoticons/onion-021.gif"><p>ㄷㄷㄷㄷ</p>
+ * ```
+ *
+ * 반면 댓글 에디터는 `Image.configure({ inline: true })` 라 처음부터 옆으로 붙었다.
+ * 즉 같은 기능이 두 화면에서 다르게 동작하고 있었다.
+ *
+ * ⛔ **`LinkedImage` 의 `inline` 을 뒤집어 해결하지 말 것.** 그 노드는 **사진 첨부에도
+ *    같이 쓰인다.** 인라인이 되면 큰 사진이 문단 안으로 끼어들어 본문 레이아웃이 무너진다.
+ *    앙티콘만 담는 노드를 따로 두는 이유다.
+ *
+ * ## atom 인 이유
+ *
+ * 앙티콘은 내부를 편집할 것이 없다. `atom: true` 로 두면 커서가 통째로 지나가고
+ * 백스페이스 한 번에 하나가 지워진다 — 글자와 같은 감각이 된다.
+ *
+ * ## ⛔ priority 가 핵심이다
+ *
+ * `LinkedImage` 의 파스 규칙은 `img[src]` 로 **모든 이미지**를 잡는다. 이 노드가 먼저
+ * 평가되지 않으면 기존 글을 수정하려고 열 때 앙티콘이 도로 블록 이미지로 잡혀
+ * 원래대로 돌아간다. 확장 우선순위와 파스 규칙 우선순위를 **둘 다** 올려 둔다.
+ *
+ * ## 알려진 영향
+ *
+ * 기존 글은 `<img>` 가 문단 **밖**에 저장돼 있다. 그 글을 **수정하려고 열면** 앙티콘이
+ * 인접 문단 안으로 들어오고, 저장하면 HTML 구조가 바뀐다. 보이는 결과는 자연스럽지만
+ * 작성자가 건드리지 않은 부분이 바뀌는 것이므로 검증 항목에 포함한다.
+ * 읽기 전용 경로(목록·상세)는 DB 를 그대로 렌더하므로 영향이 없다.
+ */
+export const Emoticon = Node.create({
+    name: 'emoticon',
+
+    // Image 계열(기본 100)보다 먼저 스키마·파스 규칙이 평가되도록.
+    priority: 1100,
+
+    inline: true,
+    group: 'inline',
+    atom: true,
+    draggable: false,
+    selectable: true,
+
+    addAttributes() {
+        return {
+            src: { default: null },
+            alt: { default: null }
+        };
+    },
+
+    parseHTML() {
+        return [
+            {
+                // 앙티콘은 항상 /emoticons/ 아래에서 온다 — 사진 첨부와 겹치지 않는다.
+                tag: 'img[src^="/emoticons/"]',
+                priority: 100
+            }
+        ];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        // class 는 렌더 CSS 와의 계약이다.
+        // styles/components.css 의 `.emoticon-inline { display: inline; vertical-align: middle }`
+        // 가 이 클래스를 읽는다. 바꾸려면 그쪽도 함께 봐야 한다.
+        return ['img', mergeAttributes({ class: 'emoticon-inline' }, HTMLAttributes)];
+    }
+});

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -6,6 +6,8 @@
     import ItalicExtension from '@tiptap/extension-italic';
     import Link from '@tiptap/extension-link';
     import { LinkedImage } from './linked-image.js';
+    // 앙티콘 전용 인라인 노드 — 사진 첨부(LinkedImage)와 분리해야 하는 이유는 그 파일 주석 참조
+    import { Emoticon } from './emoticon-node.js';
     import Placeholder from '@tiptap/extension-placeholder';
     import Underline from '@tiptap/extension-underline';
     import TextAlign from '@tiptap/extension-text-align';
@@ -267,7 +269,13 @@
                         class: 'text-primary underline'
                     }
                 }),
+                // ⛔ Emoticon 은 LinkedImage 보다 앞에 둔다. 파스 규칙이 `img[src]` 로
+                //    겹치므로, 확장 우선순위(1100)와 함께 순서로도 의도를 남긴다.
+                Emoticon,
                 LinkedImage.configure({
+                    // ⛔ 이 false 를 뒤집어 앙티콘을 인라인으로 만들지 말 것.
+                    //    이 노드는 사진 첨부에도 쓰여, 인라인이 되면 큰 사진이 문단 안으로
+                    //    끼어들어 본문 레이아웃이 무너진다. 앙티콘은 Emoticon 노드가 담당한다.
                     inline: false,
                     allowBase64: true
                     // #12858: 본문 HTML 에 max-w-full rounded-lg 유틸 클래스를 baked-in 하지 않는다.
@@ -1074,10 +1082,15 @@
         // 팩 이모티콘: {emo:filename}
         const emoMatch = text.match(/^\{emo:([^}]+)\}$/);
         if (emoMatch) {
+            // ⛔ setImage 를 쓰면 블록 이미지로 들어가 한 줄을 통째로 차지한다.
+            //    앙티콘은 글씨처럼 흘러야 하므로 인라인 Emoticon 노드로 넣는다.
             editor
                 .chain()
                 .focus()
-                .setImage({ src: `/emoticons/${emoMatch[1]}`, alt: emoMatch[1] })
+                .insertContent({
+                    type: 'emoticon',
+                    attrs: { src: `/emoticons/${emoMatch[1]}`, alt: emoMatch[1] }
+                })
                 .run();
             showEmoticonPicker = false;
             return;
@@ -2080,6 +2093,16 @@
         max-width: 100%;
         height: auto;
         margin: 0.75rem 0;
+    }
+
+    /* 앙티콘은 사진이 아니라 글자다 — 위 이미지 규칙의 세로 여백을 받으면 안 된다.
+       크기 상한은 전역 `.emoticon-inline:not([width]) { max-height: 2.5em }`(components.css)이
+       담당하므로 여기서 다시 정하지 않는다. ⛔ 여기에 width 를 넣지 말 것 — width 속성이
+       있는 앙티콘의 크기 지정을 죽인다(bug#13145·13159·13165 와 같은 함정). */
+    :global(.tiptap-content .tiptap img.emoticon-inline) {
+        display: inline;
+        margin: 0;
+        vertical-align: middle;
     }
 
     /* 작성자가 '본문 폭 맞춤'을 선택한 이미지만 전폭 (뷰의 .prose img.dm-fit-width 와 일치) */


### PR DESCRIPTION
## 요구

> 본문이나 댓글에 앙티콘은 1줄인데, 옆으로 배열도 가능한가? 글씨처럼?

## 실측 — 댓글은 이미 되고, 본문만 안 됐다

| | Image 설정 | 결과 |
|---|---|---|
| 댓글 `comment-editor.svelte:74` | `Image.configure({ inline: true })` | 옆으로 붙음 ✅ |
| **본문** `tiptap-editor.svelte:271` | **`LinkedImage({ inline: false })`** | 한 줄씩 차지 ❌ |

DB 에 저장된 글을 열어 보면 앙티콘이 문단 **밖**에 있다:

```html
<img src="/emoticons/onion-021.gif"><p>ㄷㄷㄷㄷ</p>
```

렌더 CSS 는 이미 준비돼 있었다 — `styles/components.css:324`
`.emoticon-inline { display: inline; vertical-align: middle }`.
**막고 있던 것은 에디터의 노드 종류뿐이었다.**

## ⛔ LinkedImage 를 뒤집지 않은 이유

그 노드는 **사진 첨부에도 같이 쓰인다.** `inline` 으로 바꾸면 큰 사진이 문단 안으로
끼어들어 본문 레이아웃이 무너진다.

그래서 앙티콘만 담는 **`Emoticon` 노드**를 새로 만들었다 — `inline: true, atom: true`.
`atom` 이라 커서가 통째로 지나가고 백스페이스 한 번에 하나가 지워진다. 글자와 같은 감각이다.

**priority 가 핵심이다.** `LinkedImage` 의 파스 규칙은 `img[src]` 로 모든 이미지를 잡는다.
`Emoticon` 이 먼저 평가되지 않으면 기존 글을 수정하려고 열 때 도로 블록 이미지가 된다.
확장 우선순위(1100)와 파스 규칙 우선순위를 **둘 다** 올리고 등록 순서로도 의도를 남겼다.

## 폭 걱정은 없었다 (예상이 빗나간 부분)

처음엔 `damoang-meme-` 팩 200px 때문에 모바일에서 줄바꿈될 거라 봤다. 틀렸다 —
본문은 `{emo:}` 토큰이 아니라 **날 `<img>` 로 저장돼 width 속성이 없어서**
`:not([width])` 의 `max-height: 2.5em` 캡이 이미 걸려 있다.

에디터 CSS 에서는 앙티콘을 이미지 세로 여백(`margin: .75rem 0`)에서 제외했다.
⛔ 여기에 `width` 를 다시 넣지 않았다 — 넣으면 width 속성이 있는 앙티콘의 크기 지정이
죽는다(#13145·13159·13165 와 같은 함정).

## ⚠️ 알려진 영향 — 기존 글 편집 시

기존 글은 `<img>` 가 문단 밖에 저장돼 있다. 그 글을 **수정하려고 열면** 앙티콘이 인접 문단
안으로 들어오고, 저장하면 HTML 구조가 바뀐다. 보이는 결과는 자연스럽지만 **작성자가
건드리지 않은 부분이 바뀌는 것**이라 검증에 포함했다.
읽기 전용 경로(목록·상세)는 DB 를 그대로 렌더하므로 **영향 없다.**

## 검증

- [ ] 본문에서 앙티콘 2~3개 연속 삽입 → 한 줄에 나란히
- [ ] 앙티콘 + 글자 혼합 시 같은 줄에서 흐르는지
- [ ] 앙티콘 사이 커서 이동·백스페이스 하나씩 삭제 (atom)
- [ ] ⛔ **사진 첨부는 여전히 블록** — 문단 안으로 끼어들지 않는지
- [ ] 사진 정렬·링크(LinkedImage) 기능 정상
- [ ] 댓글 에디터 무변경
- [ ] 앙티콘 있는 예전 글을 열고 **저장 안 하면** DB 무변경 / 저장 시 앙티콘 유실·중복 없음
- [ ] 기존 글 읽기 화면 그대로

## 후속 (범위 밖)

1. **Noto 움직이는 이모지**는 `fonts.gstatic.com` URL 이라 이 노드에 안 걸려 여전히
   블록이다. 같은 피커에서 나오는데 동작이 갈린다 — 별건으로 판단 필요.
2. **글/댓글 앙티콘 크기 불일치** — 글은 width 없음(2.5em 캡), 댓글은 팩별 폭(80~200px).
3. **본문 저장 형식** — `comment-form` 은 저장 시 `<img>` → `{emo:}` 로 되돌리는데
   `post-form` 에는 그 처리가 없다. 통일하면 2번도 해소되나 기존 글 렌더 경로가 바뀐다.

설계 근거: `triage/SPRINT_CONTRACT_inline_emoticon_post.md`