### PR TITLE
feat(mypage): 내 글·내 댓글 검색 UI (bug/12292)

### DIFF
--- a/apps/web/src/routes/my/+page.server.ts
+++ b/apps/web/src/routes/my/+page.server.ts
@@ -51,8 +51,12 @@ async function loadMyPageData(
     tab: string,
     page: number,
     limit: number,
-    headers: Record<string, string>
+    headers: Record<string, string>,
+    /** 내 글·내 댓글 검색어. 빈 문자열이면 검색 없음 (bug/12292) */
+    q: string
 ): Promise<MyPageData> {
+    // 백엔드가 2자 미만을 무시하지만, 굳이 왕복시키지 않는다.
+    const qs = q ? `&q=${encodeURIComponent(q)}` : '';
     const result: MyPageData = {
         expSummary: null,
         posts: null,
@@ -78,7 +82,7 @@ async function loadMyPageData(
         let tabPromise: Promise<void>;
 
         if (tab === 'posts') {
-            tabPromise = fetch(`${BACKEND_URL}/api/v1/my/posts?page=${page}&limit=${limit}`, {
+            tabPromise = fetch(`${BACKEND_URL}/api/v1/my/posts?page=${page}&limit=${limit}${qs}`, {
                 headers,
                 signal: AbortSignal.timeout(BACKEND_TIMEOUT)
             }).then(async (res) => {
@@ -86,10 +90,13 @@ async function loadMyPageData(
                 result.posts = parsePaginated<FreePost>(await safeJson(res), page, limit);
             });
         } else if (tab === 'comments') {
-            tabPromise = fetch(`${BACKEND_URL}/api/v1/my/comments?page=${page}&limit=${limit}`, {
-                headers,
-                signal: AbortSignal.timeout(BACKEND_TIMEOUT)
-            }).then(async (res) => {
+            tabPromise = fetch(
+                `${BACKEND_URL}/api/v1/my/comments?page=${page}&limit=${limit}${qs}`,
+                {
+                    headers,
+                    signal: AbortSignal.timeout(BACKEND_TIMEOUT)
+                }
+            ).then(async (res) => {
                 if (!res.ok) return;
                 result.comments = parsePaginated<MyComment>(await safeJson(res), page, limit);
             });
@@ -131,6 +138,11 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     const tab = url.searchParams.get('tab') || 'posts';
     const page = Number(url.searchParams.get('page')) || 1;
     const limit = 20;
+    // 검색은 글·댓글 탭에서만 의미가 있다. 다른 탭에 q 가 남아 있어도 무시한다.
+    const q =
+        tab === 'posts' || tab === 'comments'
+            ? (url.searchParams.get('q') || '').trim().slice(0, 50)
+            : '';
 
     const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -141,11 +153,12 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     }
 
     // 스트리밍: tabData를 await 하지 않음 → 스켈레톤 먼저 렌더링
-    const tabDataPromise = loadMyPageData(tab, page, limit, headers);
+    const tabDataPromise = loadMyPageData(tab, page, limit, headers, q);
 
     return {
         tab,
         page,
+        q,
         /** 스트리밍: Promise로 반환 → 클라이언트에서 {#await} 사용 */
         streamed: {
             tabData: tabDataPromise

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -34,14 +34,49 @@
         { id: 'stats', label: '전체분석', icon: BarChart3 }
     ];
 
-    // 탭 변경
+    // 검색 (bug/12292) — 글·댓글 탭에서만
+    const canSearch = $derived(data.tab === 'posts' || data.tab === 'comments');
+    let searchInput = $state(data.q ?? '');
+
+    // ⛔ 평범한 let. $state 로 두고 아래 $effect 에서 읽고 쓰면 자기 재트리거가 난다
+    //    (2026-08-01 auth 429 사고). 여기서는 data.q 만 읽고 searchInput 에 쓴다.
+    let lastAppliedQ = data.q ?? '';
+    $effect(() => {
+        const q = data.q ?? '';
+        if (q !== lastAppliedQ) {
+            lastAppliedQ = q;
+            searchInput = q;
+        }
+    });
+
+    function buildMyUrl(opts: { tab?: string; page?: number; q?: string }): string {
+        const tab = opts.tab ?? data.tab;
+        const q = opts.q ?? data.q ?? '';
+        const params = new URLSearchParams({ tab });
+        // 검색어는 글·댓글 탭에서만 의미가 있다.
+        if (q && (tab === 'posts' || tab === 'comments')) params.set('q', q);
+        if (opts.page && opts.page > 1) params.set('page', String(opts.page));
+        return `/my?${params}`;
+    }
+
+    // 탭 변경 — 검색어는 유지한다. 같은 말을 글에서도 댓글에서도 찾는 게 자연스럽다.
     function changeTab(tabId: string): void {
-        goto(`/my?tab=${tabId}`);
+        goto(buildMyUrl({ tab: tabId }));
     }
 
     // 페이지 변경
     function goToPage(pageNum: number): void {
-        goto(`/my?tab=${data.tab}&page=${pageNum}`);
+        goto(buildMyUrl({ page: pageNum }));
+    }
+
+    // ⛔ 검색 시 page 를 1 로 되돌린다. 안 그러면 3페이지에서 검색해 결과가 0건이 된다.
+    function submitSearch(): void {
+        goto(buildMyUrl({ q: searchInput.trim(), page: 1 }));
+    }
+
+    function clearSearch(): void {
+        searchInput = '';
+        goto(buildMyUrl({ q: '', page: 1 }));
     }
 
     // 날짜 포맷
@@ -213,6 +248,44 @@
         {/each}
     </div>
 
+    <!-- 검색 (글·댓글 탭 전용) — bug/12292 -->
+    {#if canSearch}
+        <form
+            class="mb-4"
+            onsubmit={(e) => {
+                e.preventDefault();
+                submitSearch();
+            }}
+        >
+            <div class="flex gap-2">
+                <input
+                    type="search"
+                    bind:value={searchInput}
+                    placeholder={data.tab === 'posts' ? '내가 쓴 글 검색' : '내가 쓴 댓글 검색'}
+                    aria-label={data.tab === 'posts' ? '내가 쓴 글 검색' : '내가 쓴 댓글 검색'}
+                    class="border-input bg-background focus-visible:ring-ring min-w-0 flex-1 rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2"
+                />
+                <Button type="submit" size="sm" class="shrink-0">찾기</Button>
+                {#if data.q}
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        class="shrink-0"
+                        onclick={clearSearch}>지우기</Button
+                    >
+                {/if}
+            </div>
+            <!-- ⛔ 한계를 숨기지 않는다. content_preview 가 255자라 긴 글의 뒷부분은 찾히지
+                 않는다. 안 적으면 "왜 안 나오지"가 된다. -->
+            <p class="text-muted-foreground mt-1.5 text-xs">
+                {data.tab === 'posts'
+                    ? '제목과 본문 앞부분에서 찾습니다.'
+                    : '댓글 내용과 원글 제목에서 찾습니다.'}
+            </p>
+        </form>
+    {/if}
+
     <!-- 탭 콘텐츠 (스트리밍) -->
     {#await data.streamed?.tabData}
         <!-- 스켈레톤 -->
@@ -271,7 +344,11 @@
                             </ul>
                         {:else}
                             <p class="text-muted-foreground py-8 text-center">
-                                작성한 글이 없습니다.
+                                {#if data.q}
+                                    '{data.q}'에 해당하는 글이 없습니다.
+                                {:else}
+                                    작성한 글이 없습니다.
+                                {/if}
                             </p>
                         {/if}
                     </CardContent>
@@ -353,7 +430,11 @@
                             </ul>
                         {:else}
                             <p class="text-muted-foreground py-8 text-center">
-                                작성한 댓글이 없습니다.
+                                {#if data.q}
+                                    '{data.q}'에 해당하는 댓글이 없습니다.
+                                {:else}
+                                    작성한 댓글이 없습니다.
+                                {/if}
                             </p>
                         {/if}
                     </CardContent>


### PR DESCRIPTION
백엔드 대응: **angple-backend#615** (먼저 배포되어야 `q` 가 동작한다)

회원 제안으로 2026-05-10 접수된 뒤 87일 열려 있던 건입니다.

## 화면

글·댓글 탭에만 검색창을 둔다. 공감·전체분석 탭에는 의미가 없어 `q` 가 URL 에 남아 있어도
서버가 무시한다.

- **URL 에 `?q=` 반영** — 공유·뒤로가기가 동작해야 한다
- **탭을 바꿔도 검색어 유지** — 같은 말을 글에서도 댓글에서도 찾는 게 자연스럽다
- ⛔ **검색 시 `page` 를 1 로** — 안 그러면 3페이지에서 검색해 결과가 0건이 된다
- 빈 결과 문구에 검색어를 넣는다(`xxx에 해당하는 글이 없습니다`).
  그냥 "없습니다"면 **검색이 걸린 건지 원래 없는 건지 구분이 안 된다**

## 한계를 숨기지 않는다

입력창 아래에 한 줄:

> 제목과 본문 앞부분에서 찾습니다. / 댓글 내용과 원글 제목에서 찾습니다.

백엔드가 `content_preview`(255자)에서 찾기 때문에 **긴 글의 뒷부분은 찾히지 않는다.**
안 적으면 "왜 안 나오지"가 된다.

## ⛔ $effect 가드

`data.q` 를 입력창에 동기화하는 `$effect` 의 가드 변수는 **평범한 `let`** 이다.
`$state` 로 두고 그 안에서 읽고 쓰면 자기 재트리거가 난다(2026-08-01 auth 429 사고).
이 `$effect` 는 `data.q` 만 읽고 `searchInput` 에만 쓴다.

## 검증

- [ ] 글·댓글 탭에만 검색창이 보이는지 (공감·전체분석엔 없음)
- [ ] 검색 → URL 에 `?q=` 반영, 뒤로가기 동작
- [ ] 탭 전환 시 검색어 유지
- [ ] 3페이지에서 검색 → **1페이지로 초기화**
- [ ] 결과 0건일 때 검색어가 문구에 나오는지
- [ ] 「지우기」로 검색 해제
- [ ] be 미배포 상태에서도 화면이 깨지지 않는지 (`q` 를 서버가 무시할 뿐)
- [ ] 360px 폭에서 입력창·버튼 줄바꿈 정상
- [ ] `pnpm check` · `pnpm lint`