### PR TITLE
feat(angtt): 작품 사전 자동 채우기 — A단계 (수집·등록)

### DIFF
--- a/apps/web/src/lib/server/angtt-catalog-sync.ts
+++ b/apps/web/src/lib/server/angtt-catalog-sync.ts
@@ -1,0 +1,166 @@
+/**
+ * 앙티티 작품 사전 자동 채우기 — A단계 (수집 + upsert).
+ *
+ * ## 왜 필요한가
+ *
+ * `angple_entities` 에 작품이 5개뿐이라(호프·동궁·참교육 외 2), 자동 연결(#1818)이
+ * 걸릴 사전 자체가 비어 있었다. 「오디세이」·「스파이더맨」은 **등록조차 안 된 상태**라
+ * 글이 아무리 많아도 카드가 붙지 않았다. 개봉은 매주 있는데 등록은 손으로 했다.
+ *
+ * ## ⛔ 기존 안전장치를 무너뜨리지 않는다
+ *
+ * `angtt-auto-link.ts` 는 의도적으로 보수적이다 — 작품별 옵트인(`meta.auto_link`)과
+ * 문맥어(`meta.context_terms`)를 요구한다. 「참교육」처럼 일반어와 겹치는 제목,
+ * 「호프」처럼 생맥주집을 뜻하기도 하는 제목 때문이다.
+ *
+ * 수백 편을 `auto_link: true` 로 쏟아부으면 그 설계가 무너진다. 그래서 **A단계는
+ * 전부 `status='pending'` · `auto_link` 미설정으로만 넣는다.** 자동 활성화 규칙은
+ * B단계에서 별도로 판단한다.
+ *
+ * ## ⛔ 기존 행의 meta 는 절대 덮어쓰지 않는다
+ *
+ * 지금 있는 5개의 `context_terms` 는 사람이 손으로 고른 것이다(「호프」는 30개).
+ * upsert 가 이걸 날리면 자동 연결 품질이 통째로 떨어진다.
+ */
+import pool from '$lib/server/db';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+import { normalizeWorkTitle } from './angtt-dictionary-logic';
+
+/** TMDB 는 페이지당 20건. 개봉작은 몇 페이지면 충분하다 — 전량 크롤이 목적이 아니다. */
+const MAX_PAGES = 3;
+
+/** 한 번에 처리할 상한. 폭주 방지. */
+const MAX_ITEMS = 120;
+
+export interface CatalogSyncResult {
+    /** TMDB 에서 받은 건수 */
+    fetched: number;
+    /** 새로 등록한 작품 */
+    inserted: number;
+    /** 이미 있어 건드리지 않은 작품 */
+    skipped: number;
+    /** 제목이 비었거나 정규화 후 빈 값이라 버린 건 */
+    invalid: number;
+    /** 사람이 읽을 요약 — ⛔ 내부 API 응답에 반드시 실어야 한다(아래 주석 참조) */
+    message: string;
+}
+
+interface TmdbMovie {
+    id: number;
+    title?: string;
+    original_title?: string;
+    poster_path?: string | null;
+    release_date?: string | null;
+}
+
+function tmdbKey(): string | null {
+    // ⛔ 폴백을 만들지 말 것. `env.A || env.B` 는 사고 기계다 — 어느 값이 쓰였는지
+    //    아무도 모르게 된다. SOPS 가 단일 근원이고, 없으면 없는 것이다.
+    const k = process.env.TMDB_API_KEY;
+    return k && k.trim() ? k.trim() : null;
+}
+
+async function fetchPage(key: string, path: string, page: number): Promise<TmdbMovie[]> {
+    const url = `https://api.themoviedb.org/3/movie/${path}?language=ko-KR&region=KR&page=${page}`;
+    const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${key}`, accept: 'application/json' },
+        signal: AbortSignal.timeout(10_000)
+    });
+    if (!res.ok) throw new Error(`TMDB ${path} p${page} → HTTP ${res.status}`);
+    const json = (await res.json()) as { results?: TmdbMovie[] };
+    return json.results ?? [];
+}
+
+/** 별칭 목록 — 한국어 제목·원제. 정규화 후 중복 제거. */
+function buildAliases(m: TmdbMovie): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of [m.title, m.original_title]) {
+        const t = (raw ?? '').trim();
+        if (!t) continue;
+        const norm = normalizeWorkTitle(t);
+        if (!norm || seen.has(norm)) continue;
+        seen.add(norm);
+        out.push(t);
+    }
+    return out;
+}
+
+/**
+ * TMDB 개봉작을 받아 `angple_entities` 에 없는 것만 넣는다.
+ *
+ * 멱등성은 `external_ids.tmdb` 로 보장한다.
+ * ⛔ 슬러그로 맞추면 동명이작(리메이크·시리즈)에서 서로를 덮어쓴다.
+ */
+export async function syncAngttCatalog(): Promise<CatalogSyncResult> {
+    const key = tmdbKey();
+    if (!key) {
+        // ⛔ 조용히 성공하면 안 된다. "동기화가 돌았는데 0건" 과 "키가 없어 아예 안 돌았다" 는
+        //    완전히 다른 상태인데, 둘 다 200 으로 보이면 몇 주를 모르고 지나간다.
+        const message = 'TMDB_API_KEY 가 없어 동기화를 건너뜁니다';
+        console.warn('[angtt-catalog]', message);
+        return { fetched: 0, inserted: 0, skipped: 0, invalid: 0, message };
+    }
+
+    const movies = new Map<number, TmdbMovie>();
+    for (const path of ['now_playing', 'upcoming']) {
+        for (let p = 1; p <= MAX_PAGES; p++) {
+            const list = await fetchPage(key, path, p);
+            if (list.length === 0) break;
+            for (const m of list) {
+                if (m?.id && !movies.has(m.id)) movies.set(m.id, m);
+            }
+            if (movies.size >= MAX_ITEMS) break;
+        }
+        if (movies.size >= MAX_ITEMS) break;
+    }
+
+    let inserted = 0;
+    let skipped = 0;
+    let invalid = 0;
+
+    for (const m of [...movies.values()].slice(0, MAX_ITEMS)) {
+        const title = (m.title ?? m.original_title ?? '').trim();
+        const slug = normalizeWorkTitle(title);
+        if (!title || !slug) {
+            invalid++;
+            continue;
+        }
+
+        // 이미 등록됐는지: tmdb id 우선, 없으면 slug 로 한 번 더 본다.
+        // slug 검사는 사람이 손으로 넣은 기존 5개를 다시 넣지 않기 위한 것이다.
+        const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT id FROM angple_entities
+             WHERE JSON_EXTRACT(external_ids, '$.tmdb') = ? OR slug = ?
+             LIMIT 1`,
+            [m.id, slug]
+        );
+        if (rows.length > 0) {
+            skipped++;
+            continue;
+        }
+
+        // ⛔ status='pending' · meta 에 auto_link 를 넣지 않는다.
+        //    자동 연결은 옵트인이므로, 넣지 않으면 자동으로 걸리지 않는다 = 안전한 기본값.
+        const [res] = await pool.query<ResultSetHeader>(
+            `INSERT INTO angple_entities
+               (type, canonical_title, slug, aliases, poster_url, external_ids,
+                meta, release_date, status, created_at, updated_at)
+             VALUES ('movie', ?, ?, ?, ?, ?, ?, ?, 'pending', NOW(3), NOW(3))`,
+            [
+                title,
+                slug,
+                JSON.stringify(buildAliases(m)),
+                m.poster_path ? `https://image.tmdb.org/t/p/w500${m.poster_path}` : null,
+                JSON.stringify({ tmdb: m.id }),
+                JSON.stringify({ source: 'tmdb' }),
+                m.release_date || null
+            ]
+        );
+        if (res.affectedRows > 0) inserted++;
+    }
+
+    const message = `TMDB ${movies.size}건 중 신규 ${inserted}건 등록, 기존 ${skipped}건 유지, 제외 ${invalid}건`;
+    console.info('[angtt-catalog]', message);
+    return { fetched: movies.size, inserted, skipped, invalid, message };
+}

--- a/apps/web/src/routes/api/internal/angtt/catalog-sync/+server.ts
+++ b/apps/web/src/routes/api/internal/angtt/catalog-sync/+server.ts
@@ -1,0 +1,35 @@
+/**
+ * 앙티티 작품 사전 동기화 — 내부 전용 (A단계, 수동 호출).
+ *
+ * TMDB 개봉작을 받아 `angple_entities` 에 없는 작품만 `status='pending'` 으로 넣는다.
+ * 자동 활성화(`auto_link`)는 B단계에서 별도로 판단한다 — 여기서는 켜지 않는다.
+ *
+ * ⛔ 응답에 처리 건수를 **반드시** 싣는다. 이 프로젝트에는 "없는 라우트도 200
+ *    `{"data":null}` 을 돌려주는" 함정이 있어(경로 오타 = silent 200), 배포 후
+ *    `{"success":true}` 만 보고 "돌았구나" 하면 몇 주를 모르고 지나간다.
+ *    호출 후 `result.message` 에 실제 숫자가 찍히는지 눈으로 확인할 것.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { syncAngttCatalog } from '$lib/server/angtt-catalog-sync';
+import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/internal-api';
+
+export const POST: RequestHandler = async ({ request }) => {
+    if (!isInternalAppRequest(request)) {
+        return internalOnlyErrorResponse();
+    }
+
+    try {
+        const result = await syncAngttCatalog();
+        return json({ success: true, result });
+    } catch (error) {
+        console.error('[angtt-catalog] 동기화 실패:', error);
+        return json(
+            {
+                success: false,
+                message: error instanceof Error ? error.message : '동기화에 실패했습니다.'
+            },
+            { status: 500 }
+        );
+    }
+};


### PR DESCRIPTION
## 문제

> 영화 오디세이 하단에 앙티티 안 나온다, 스파이더맨도 그렇고

`angple_entities` 에 작품이 **5개뿐**이다(호프·동궁·참교육 외 2).
자동 연결(#1818)은 **등록된 작품의 제목·별칭을 글에서 찾는** 방식이라, 사전에 없는 작품은
글이 아무리 많아도 카드가 붙지 않는다. **오디세이·스파이더맨은 등록조차 안 돼 있었다.**

개봉은 매주 있는데 등록은 손으로 했다.

## ⛔ 기존 안전장치를 무너뜨리지 않는 것이 이 작업의 핵심

`angtt-auto-link.ts` 는 의도적으로 보수적이다. 주석에 이유가 적혀 있다:

> 「참교육」처럼 일반어와 겹치는 이름은 옵트인하지 않으면 절대 자동 연결되지 않는다.
> 「호프」는 생맥주집을 뜻하기도 하므로 영화 문맥어를 요구한다.

**수백 편을 `auto_link: true` 로 쏟아부으면 그 설계가 무너진다.** 「괴물」·「친구」 같은
제목은 일상어로 쓰이고, 오연결은 회원 글에 엉뚱한 작품 카드가 붙는 눈에 보이는 사고다.

→ **A단계는 전부 `status=pending` 으로 넣고 `meta` 에 `auto_link` 를 넣지 않는다.**
자동 연결이 옵트인이라 넣지 않으면 걸리지 않는다 — **수백 편이 들어와도 오연결이 0.**
활성화 규칙은 B단계에서 별도 판단한다.

## ⛔ 기존 행을 건드리지 않는다

지금 있는 5개의 `context_terms` 는 사람이 손으로 고른 것이다(「호프」는 30개).
`external_ids.tmdb` **또는** `slug` 로 이미 있는지 확인해 건너뛴다.

멱등성 키는 `external_ids.tmdb` 다. **slug 로 맞추면 동명이작(리메이크·시리즈)이 서로를
덮어쓴다.**

## 두 함정 대비

**1) 키가 없으면 조용히 성공하지 않는다**

「동기화가 돌았는데 0건」과 「키가 없어 아예 안 돌았다」는 완전히 다른 상태인데,
둘 다 200 으로 보이면 몇 주를 모르고 지나간다. 경고 로그 + `message` 에 사유를 싣는다.

**2) 응답에 처리 건수를 싣는다**

이 프로젝트에는 **경로 오타 시 없는 라우트도 200 `{"data":null}`** 을 돌려주는 함정이 있다.
`{"success":true}` 만 보고 "돌았구나" 하면 안 된다. 호출 후 `result.message` 의 숫자를 볼 것.

⛔ 크리덴셜 폴백(`env.A || env.B`)은 만들지 않았다. **SOPS 가 단일 근원**이다.

## 배포 후 필요한 것

`TMDB_API_KEY` 를 SOPS 에 넣어야 실제로 돈다. 넣기 전에는 동기화가
`TMDB_API_KEY 가 없어 동기화를 건너뜁니다` 를 반환한다(의도된 동작).

## 검증

- [ ] 키 없이 호출 → `success:true` 이지만 `message` 에 키 부재가 명시되는지
- [ ] 키 넣고 1회 호출 → 응답 `message` 에 **실제 건수**가 찍히는지
- [ ] 오디세이·스파이더맨이 `pending` 으로 들어오는지
- [ ] **두 번 호출해도 중복 행이 안 생기는지** (external_ids.tmdb)
- [ ] ⛔ **기존 5개의 `meta.context_terms` 가 그대로인지** (덮어쓰기 없음)
- [ ] ⛔ 새로 들어온 작품에 **자동 연결이 걸리지 않는지** (auto_link 미설정 = 안전)
- [ ] 내부 API 가 외부 요청을 막는지

## 후속

- **B단계** — 자동 활성화 규칙(4자 이상 + 일반어 차단목록) → 승인 없이도 안전한 작품만 켜기
- **C단계** — systemd 타이머 하루 1회
- 드라마·예능은 TMDB TV 가 한국 편성과 어긋나 별건

설계 근거: `triage/SPRINT_CONTRACT_angtt_auto_catalog.md`