### PR TITLE
fix(noti): 묶음 알림에 종류 표식·아이콘 되살리기 (bug/13332)

### DIFF
--- a/apps/web/src/lib/utils/notification-icon.ts
+++ b/apps/web/src/lib/utils/notification-icon.ts
@@ -12,6 +12,7 @@ import AtSign from '@lucide/svelte/icons/at-sign';
 import FileText from '@lucide/svelte/icons/file-text';
 import Heart from '@lucide/svelte/icons/heart';
 import Info from '@lucide/svelte/icons/info';
+import Layers from '@lucide/svelte/icons/layers';
 import Mail from '@lucide/svelte/icons/mail';
 import MessageSquare from '@lucide/svelte/icons/message-square';
 import Newspaper from '@lucide/svelte/icons/newspaper';
@@ -40,6 +41,12 @@ export function getNotificationIcon(type: string) {
             return Newspaper;
         case 'levelup':
             return Star;
+        // 여러 종류가 섞인 묶음 — 겹친 모양으로 "여러 개"를 나타낸다 (bug/13332).
+        // ⛔ Bell 은 알림 종 버튼이 이미 쓰고 있어 헷갈린다.
+        case 'merged_post':
+        case 'merged_comment':
+        case 'merged':
+            return Layers;
         default:
             return Info;
     }

--- a/apps/web/src/lib/utils/notification-type.test.ts
+++ b/apps/web/src/lib/utils/notification-type.test.ts
@@ -52,8 +52,22 @@ describe('getNotificationEmoji', () => {
         expect(getNotificationLabel('what_is_this')).toBe('알림');
     });
 
-    it('통합 묶음은 표식을 붙이지 않는다 — 본문에 이미 개수가 있다', () => {
-        expect(getNotificationEmoji('merged')).toBe('');
+    // ⛔ bug/13332 의 재발 방지선.
+    //    묶음 알림에 표식이 없으면 「알림 묶어 보기」(기본 켬) 사용자에게는 사실상 모든
+    //    알림이 같은 회색 느낌표가 된다. 제보자가 "댓글과 답글 구분이 어렵다"고 한 상태다.
+    it('섞인 묶음도 표식을 가지며 대상(글/댓글)이 구분된다', () => {
+        expect(getNotificationEmoji('merged_post')).not.toBe('');
+        expect(getNotificationEmoji('merged_comment')).not.toBe('');
+        expect(getNotificationEmoji('merged_post')).not.toBe(
+            getNotificationEmoji('merged_comment')
+        );
+        expect(firstGlyph(getNotificationEmoji('merged_post'))).toBe('📄');
+        expect(firstGlyph(getNotificationEmoji('merged_comment'))).toBe('💬');
+    });
+
+    // be 배포가 web 보다 늦어도 화면이 회색으로 죽지 않아야 한다.
+    it('옛 merged 값도 표식을 가진다', () => {
+        expect(getNotificationEmoji('merged')).not.toBe('');
     });
 });
 

--- a/apps/web/src/lib/utils/notification-type.ts
+++ b/apps/web/src/lib/utils/notification-type.ts
@@ -40,6 +40,9 @@ export type NotificationType =
     | 'follow'
     | 'digest'
     | 'levelup'
+    // 여러 종류가 한 줄로 묶인 알림. 대상(글/댓글)만 구분해 준다 — bug/13332
+    | 'merged_post'
+    | 'merged_comment'
     | 'merged'
     | 'system';
 
@@ -63,9 +66,19 @@ const META: Record<NotificationType, NotificationTypeMeta> = {
     follow: { emoji: '👤✍️', color: 'text-teal-600', label: '팔로우한 분의 새 글' },
     digest: { emoji: '📰', color: 'text-amber-600', label: '새 글 요약' },
     levelup: { emoji: '⭐', color: 'text-yellow-500', label: '레벨업' },
-    // 통합 묶음(merge=target)은 한 줄에 「댓글 2 · 좋아요 3」처럼 개수를 직접 쓴다.
-    // 종류가 이미 본문에 있으므로 표식을 겹쳐 붙이지 않는다.
-    merged: { emoji: '', color: 'text-muted-foreground', label: '알림' },
+    // 여러 종류가 섞인 묶음 — bug/13332
+    //
+    // ⛔ 처음엔 "개수가 제목에 있으니 표식은 필요 없다"고 판단해 회색으로 뒀는데, 그게 바로
+    //    제보의 원인이었다. 「알림 묶어 보기」가 기본 켬이라 사실상 모든 알림이 같은 회색
+    //    느낌표가 됐고, 제보자는 "댓글과 답글 구분이 어려워서 번거롭다"고 적었다.
+    //    개수는 제목에 있어도, 목록을 훑을 때 눈이 먼저 닿는 건 왼쪽 아이콘이다.
+    //
+    //    한 종류뿐인 묶음은 백엔드가 정확한 종류로 내려주므로 여기 오지 않는다.
+    //    여기는 진짜로 섞인 경우다 — 대상(글/댓글)만이라도 알려준다.
+    merged_post: { emoji: '📄🔔', color: 'text-indigo-500', label: '내 글에 여러 반응' },
+    merged_comment: { emoji: '💬🔔', color: 'text-violet-500', label: '내 댓글에 여러 반응' },
+    // 옛 백엔드가 내려보내던 값 — be 배포 전에도 화면이 깨지지 않도록 남긴다.
+    merged: { emoji: '🔔', color: 'text-muted-foreground', label: '여러 반응' },
     system: { emoji: '', color: 'text-muted-foreground', label: '알림' }
 };
 


### PR DESCRIPTION
백엔드 대응: **angple-backend#617**

## 제보

> 댓글과 답글 구분이 어려워서 확인하기 번거롭습니다. **캐시 강력 고침을 해도 동일**합니다.
> **아이콘 사라진지 2-3일** 되는 거 같아요.

브라우저 문제가 아니었다. 「알림 묶어 보기」(기본 켬)에서 백엔드가 `type="merged"` 를
내려보내는데 아이콘 매핑에 그 케이스가 없어 `default` → **Info 회색 느낌표**로 떨어졌다.
「2-3일 전부터」는 통합 묶음 기능이 들어간 시점과 맞는다.

## ⛔ 내 판단이 틀렸던 지점

8/5 알림 종류 작업(#1967)에서 `merged` 를 **"개수가 제목에 있으니 표식은 필요 없다"**고
보고 **일부러 회색으로 뒀다.** 그게 바로 이 제보의 원인이었다.

개수가 제목에 있어도 **목록을 훑을 때 눈이 먼저 닿는 건 왼쪽 아이콘**이다.
제보자는 개수를 못 본 게 아니라, 스무 줄을 훑으며 종류를 가려낼 수단이 없었던 것이다.

## 변경

| type | 표식 | 이름 |
|---|---|---|
| `merged_post` | 📄🔔 | 내 글에 여러 반응 |
| `merged_comment` | 💬🔔 | 내 댓글에 여러 반응 |
| `merged`(옛 값) | 🔔 | 여러 반응 |

- **첫 글자로 글/댓글이 갈린다** — 기존 [대상][동작] 규약과 같다
- 아이콘은 `Layers`. ⛔ `Bell` 은 **알림 종 버튼이 이미 쓰고 있어** 헷갈린다
- **옛 `merged` 값도 표식을 갖게 남긴다** — be 배포가 web 보다 늦어도 회색으로 죽지 않는다

한 종류뿐인 묶음은 백엔드가 정확한 종류(`like`/`like_comment`/`comment`/`reply`)로
내려주므로 여기 오지 않는다.

## 회귀 방지 테스트

표식 13종이 서로 유일한지, `merged_post`/`merged_comment` 의 첫 글자가 📄/💬 인지 고정했다.
⛔ 서로게이트 쌍이라 `str[0]` 이 아니라 코드포인트 단위로 비교한다(오늘 이걸로 CI 가 한 번 터졌다).

## 검증

- [ ] 좋아요만 / 댓글만 / 답글만 묶인 알림이 각각 제 아이콘인지
- [ ] **섞인 묶음**에서 글/댓글이 구분되는지
- [ ] be 미배포 상태(옛 `merged`)에서도 회색이 아닌지
- [ ] 「알림 묶어 보기」를 끈 사용자 화면 무변경
- [ ] 드롭다운과 `/notifications` 가 같은 아이콘인지
- [ ] `pnpm test:unit -- --run`