### PR TITLE
fix: 뒤로가기 전체 로드에서 스크롤이 맨 아래로 clamp 되는 창 제거 (bug/13339)

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -10,6 +10,32 @@
           SvelteKit은 history.pushState/replaceState를 호출 시점에 live로 참조하므로(클라이언트
           번들보다 먼저 실행되는) 이 래퍼가 내부 내비게이션에도 적용된다.
         -->
+        <!--
+          bug/13339 (13022·13221 3차 재발): 스와이프 뒤로가기가 bfcache 미스로 전체 로드가
+          되면 문서가 scrollRestoration='auto' 로 시작한다 — SvelteKit 이 "페이지를 떠날 때
+          auto 로 되돌리기" 때문(client.js "Reset scrollRestoration to auto when leaving page",
+          F5 리로드의 네이티브 복원을 살리려는 의도).
+
+          그 결과 하이드레이션 전(아이폰에서 수 초) Safari 가 아직 짧은 문서에 네이티브
+          복원을 시도해 **맨 아래로 clamp** 하고, 이후 우리의 높이 대기 복원과 레이스가 된다.
+          레이스에서 지면 맨 밑에 고착 — "간헐적으로 맨 아래로 떨어진다"의 정체.
+
+          뒤로/앞으로(back_forward) 전체 로드일 때만 문서 최상단에서 manual 을 선점해
+          스크롤을 쓰는 주체를 하나(우리 복원 코드)로 만든다.
+          ⛔ reload 타입에는 걸지 않는다 — F5 네이티브 복원은 SvelteKit 이 의도적으로
+          남긴 동작이다. SvelteKit 은 어차피 초기화 때 manual 로 바꾸므로, 이 선점은
+          그 시점을 앞당길 뿐 최종 상태를 바꾸지 않는다.
+        -->
+        <script>
+            try {
+                var __nav = performance.getEntriesByType('navigation')[0];
+                if (__nav && __nav.type === 'back_forward') {
+                    history.scrollRestoration = 'manual';
+                }
+            } catch (e) {
+                /* 미지원 브라우저는 기존 동작 유지 */
+            }
+        </script>
         <script>
             (function () {
                 if (typeof history === 'undefined') return;


### PR DESCRIPTION
## 세 번째 재발이다

| 제보 | 수정 | 결과 |
|---|---|---|
| 13022 (7/16) | #1796 목록 높이 대기 복원 | 재발 |
| 13221 (8/3) | #1948 글 상세에도 적용 | **재발 (13339)** |

> 방문 기록 및 웹 사이트 데이터 지우기 후 재로그인하고 스와이프로 뒤로 이동 시
> **여전히** 맨 아래로 이동하는 경우가 **간헐적으로** 발생합니다.

## 남아 있던 창 — 우리 코드가 개입하지 못하는 구간

앞선 두 수정은 "높이 준비 전 scrollTo → clamp" 를 **우리 코드**에서 없앴다.
그런데 SvelteKit 은 **페이지를 떠날 때 `scrollRestoration` 을 `auto` 로 되돌린다**:

```js
// @sveltejs/kit client.js
// Reset scrollRestoration to auto when leaving page, allowing page reload
```

스와이프 뒤로가기가 **bfcache 미스**로 전체 로드가 되면 문서가 `auto` 로 시작하고,
하이드레이션 전(아이폰에서 수 초) **Safari 가 아직 짧은 문서에 네이티브 복원**을 시도해
맨 아래로 clamp 한다. 이후 우리의 높이 대기 복원과 레이스가 되고, 지면 맨 밑에 고착된다.

**bfcache 히트/미스가 갈리므로 "간헐적"** — 제보 그대로다. 「데이터 지우기 후에도」인
이유도 설명된다: 이건 저장소가 아니라 내비게이션 타이밍 문제다.

## 가설 하나는 실측으로 기각했다

"높이 대기 3초 상한이 부족한가" → 목록 문서 높이는 **3초 내 98~100% 도달**
(CPU 4배 감속, 3초 후 성장 4~8px). 상한 문제가 아니다. 남는 것은 복원 주체가
둘(Safari 네이티브 + 우리)인 레이스뿐이다.

## 수정 — 스크롤을 쓰는 주체를 하나로

`back_forward` 전체 로드일 때만 **문서 최상단**(첫 인라인 스크립트)에서 `manual` 을 선점한다.

```js
var nav = performance.getEntriesByType("navigation")[0];
if (nav && nav.type === "back_forward") history.scrollRestoration = "manual";
```

- ⛔ **reload 타입에는 걸지 않는다** — F5 네이티브 복원은 SvelteKit 이 의도적으로 남긴
  동작이라, 전면 manual 은 "F5 후 맨 위로" 회귀를 만든다
- SvelteKit 은 어차피 초기화 때 manual 로 바꾸므로 **최종 상태는 동일**, 시점만 앞당긴다
- 복원 자체는 기존 높이 대기 유틸(#1796/#1948)과 app.html bfcache 경로가 그대로 담당
- 앵커(`#c_123`) 스크롤은 scrollRestoration 과 별개 메커니즘이라 영향 없다

## ⚠️ 한계 (정직하게)

iOS Safari 를 서버에서 재현할 수 없어, 이 수정은 **코드 근거(auto 리셋 확인) + 소거법**으로
도출했다. 배포 후 제보자 재확인이 최종 검증이다. 세 번 "고쳤다"고 했던 건이라
**완료 안내는 제보자 확인 후**에 한다.

## 검증

- [ ] 데스크톱: F5 리로드 후 스크롤 복원 유지 (reload 타입 제외 확인)
- [ ] 데스크톱: 뒤로가기 스크롤 복원 정상 (SvelteKit SPA 경로 회귀 없음)
- [ ] 앵커 링크(#c_) 진입 정상
- [ ] iPhone Safari 실기기: 긴 목록 → 상세 → 다른 앱 전환(메모리 압박) → 복귀 → 스와이프백 반복
- [ ] 제보자 재확인 (완료 안내는 그 후)