### PR TITLE
fix: drop draft category not in current board's list

### DIFF
--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -413,7 +413,8 @@
             title = draft.title;
             // bug/12981: 스트립 이전에 저장된 기존 draft 의 죽은 blob: 도 복원 시 걷어낸다
             content = stripBlobMedia(draft.content);
-            category = draft.category;
+            // bug/12827: 이 게시판에 없는 카테고리(게시판 카테고리 개편·타 게시판 draft)는 버린다
+            category = draft.category && categories.includes(draft.category) ? draft.category : '';
             isSecret = draft.isSecret;
             tags = draft.tags || [];
             link1 = draft.link1 || '';
@@ -683,7 +684,10 @@
     }): void {
         title = draft.title;
         content = draft.content;
-        category = draft.category;
+        // bug/12827: DraftList 는 모든 게시판의 임시저장을 보여주므로, 다른 게시판
+        // draft 를 불러오면 그 게시판의 카테고리가 딸려 온다(자유게시판 글에
+        // 「여행·답사」가 박힌 사고). 현재 게시판에 있는 카테고리만 받는다.
+        category = draft.category && categories.includes(draft.category) ? draft.category : '';
         isSecret = draft.isSecret;
         tags = draft.tags || [];
         link1 = draft.link1 || '';


### PR DESCRIPTION
## 문제 (bug/12827)

임시저장 목록(DraftList)은 `draft_*` 키 전체를 스캔해 **모든 게시판의 draft** 를 보여준다. 다른 게시판 draft 를 불러오면 `category` 까지 현재 폼에 복원되고, 카테고리 select 가 없는 게시판(자유게시판 등)에서는 화면에 보이지도 않은 채 제출에 실려 저장된다. 실제 free 게시판에 타 게시판 말머리 25건 오염 확인(「진행중」11·「이벤트」5 등).

## 수정

`handleLoadDraft`·`restoreDraft` 모두 현재 게시판 카테고리 목록(`categories`)에 있는 값만 복원, 없으면 빈 값.

백엔드 검증(angple-backend 별도 PR: bo_category_list 대조)과 짝.
