### PR TITLE
fix: add missing closing bracket on FAB container div

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2810,6 +2810,7 @@
     class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 transition-opacity duration-200 md:hidden {typingInInput
         ? 'pointer-events-none opacity-0'
         : 'opacity-100'}"
+>
     <a
         href="/{boardId}"
         class="bg-muted text-muted-foreground flex h-10 w-10 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"


### PR DESCRIPTION
#1976 이 여는 `<div>` 태그의 `>` 누락으로 빌드 실패(attribute_duplicate). 닫는 괄호 한 글자 보충.