### PR TITLE
fix: require login for discipline log pages, disallow sensitive boards in robots

### DIFF
--- a/apps/web/src/routes/disciplinelog/+page.server.ts
+++ b/apps/web/src/routes/disciplinelog/+page.server.ts
@@ -2,10 +2,16 @@
  * 이용제한 기록 목록 - SSR 데이터 로드
  */
 import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
 import { backendFetch } from '$lib/server/backend-fetch.js';
 import { safeJson } from '$lib/api/safe-json.js';
 
-export const load: PageServerLoad = async ({ url }) => {
+export const load: PageServerLoad = async ({ url, locals }) => {
+    // bug/13348: 이용제한 기록은 회원 전용 — 게스트(검색엔진·봇 포함)에게 노출하지 않는다
+    if (!locals.user) {
+        redirect(302, `/login?redirect=${encodeURIComponent(url.pathname + url.search)}`);
+    }
+
     const page = Number(url.searchParams.get('page')) || 1;
     const limit = 20;
     const memberId = url.searchParams.get('member_id')?.trim() || '';
@@ -16,12 +22,14 @@ export const load: PageServerLoad = async ({ url }) => {
     }
 
     try {
-        const response = await backendFetch(endpoint, {
-            headers: {
-                Accept: 'application/json',
-                'User-Agent': 'Angple-Web-SSR/1.0'
-            }
-        });
+        const headers: Record<string, string> = {
+            Accept: 'application/json',
+            'User-Agent': 'Angple-Web-SSR/1.0'
+        };
+        if (locals.accessToken) {
+            headers['Authorization'] = `Bearer ${locals.accessToken}`;
+        }
+        const response = await backendFetch(endpoint, { headers });
 
         if (!response.ok) {
             return { logs: [], total: 0, page, limit, memberId };

--- a/apps/web/src/routes/disciplinelog/[id]/+page.server.ts
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.server.ts
@@ -7,13 +7,25 @@
  * 클릭(SPA 네비게이션)에도 그대로 반영된다.
  */
 import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
 import { backendFetch } from '$lib/server/backend-fetch.js';
 import { safeJson } from '$lib/api/safe-json.js';
 import type { DisciplineLogDetail, DisciplineLogListItem } from '$lib/api/discipline-log.js';
 
-const SSR_HEADERS = { Accept: 'application/json', 'User-Agent': 'Angple-Web-SSR/1.0' };
+export const load: PageServerLoad = async ({ params, url, locals }) => {
+    // bug/13348: 이용제한 기록은 회원 전용 — 게스트(검색엔진·봇 포함)에게 노출하지 않는다
+    if (!locals.user) {
+        redirect(302, `/login?redirect=${encodeURIComponent(url.pathname)}`);
+    }
 
-export const load: PageServerLoad = async ({ params }) => {
+    const SSR_HEADERS: Record<string, string> = {
+        Accept: 'application/json',
+        'User-Agent': 'Angple-Web-SSR/1.0'
+    };
+    if (locals.accessToken) {
+        SSR_HEADERS['Authorization'] = `Bearer ${locals.accessToken}`;
+    }
+
     const id = Number(params.id);
     if (!Number.isFinite(id) || id <= 0) {
         return {

--- a/apps/web/src/routes/robots.txt/+server.ts
+++ b/apps/web/src/routes/robots.txt/+server.ts
@@ -33,6 +33,11 @@ Disallow: /member/
 Disallow: /messages/
 Disallow: /my/
 
+# 회원 전용 운영 게시판 — 소명·신고누적·이용제한 기록 (bug/13348)
+Disallow: /claim
+Disallow: /truthroom
+Disallow: /disciplinelog
+
 # 외부 링크 추적
 Disallow: /go/
 Disallow: /link/


### PR DESCRIPTION
## bug/13348 — 민감 게시판 게스트 차단 (2/2, web)

소명(claim)·신고누적(truthroom)·이용제한 기록(disciplinelog)이 게스트·검색엔진에 노출되면 당사자 이름 검색 시 영구 노출된다. 회원 공개(규정상 보호수단)는 유지하고 게스트 경계만 바꾼다.

- disciplinelog 목록·상세 SSR: `locals.user` 없으면 /login 리다이렉트, 백엔드 호출에 Authorization 전달(백엔드 PR 이 API 에 인증을 걸므로 필요)
- robots.txt: /claim /truthroom /disciplinelog Disallow
- claim·truthroom 은 일반 게시판 — 서버 레벨 게이트가 이미 있으므로 g5_board+v2_boards 레벨 변경(DB, 별도 실행)으로 잠긴다
- sitemap 은 세 보드 모두 bo_use_search=0 이라 기존부터 미포함