### PR TITLE
feat: rename group console to /support and add temporary content actions

### DIFF
--- a/apps/web/src/lib/board-content-url.test.ts
+++ b/apps/web/src/lib/board-content-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { parseContentUrl } from './board-content-url';
+
+describe('parseContentUrl', () => {
+    it('표준 글 주소', () => {
+        expect(parseContentUrl('https://damoang.net/stock/17145')).toEqual({
+            boardId: 'stock',
+            postId: 17145,
+            commentId: null
+        });
+    });
+
+    it('댓글 앵커 3형태', () => {
+        for (const anchor of ['#c_777', '#comment_777', '#comment-777']) {
+            expect(parseContentUrl(`https://damoang.net/stock/16734${anchor}`)).toEqual({
+                boardId: 'stock',
+                postId: 16734,
+                commentId: 777
+            });
+        }
+    });
+
+    it('레거시 board.php 주소 (+댓글 앵커)', () => {
+        expect(
+            parseContentUrl('https://damoang.net/bbs/board.php?bo_table=stock&wr_id=11941')
+        ).toEqual({ boardId: 'stock', postId: 11941, commentId: null });
+        expect(
+            parseContentUrl('https://damoang.net/bbs/board.php?bo_table=stock&wr_id=11941#c_12000')
+        ).toEqual({ boardId: 'stock', postId: 11941, commentId: 12000 });
+    });
+
+    it('상대경로 수용', () => {
+        expect(parseContentUrl('/coffee/123')).toEqual({
+            boardId: 'coffee',
+            postId: 123,
+            commentId: null
+        });
+    });
+
+    it('외부 호스트 거부', () => {
+        expect(parseContentUrl('https://evil.example.com/stock/17145')).toBeNull();
+    });
+
+    it('글 번호 아닌 경로·잘못된 입력 거부', () => {
+        expect(parseContentUrl('https://damoang.net/stock')).toBeNull();
+        expect(parseContentUrl('https://damoang.net/stock/abc')).toBeNull();
+        expect(parseContentUrl('')).toBeNull();
+        expect(parseContentUrl('not a url')).toBeNull();
+    });
+
+    it('보드 슬러그 검증 (인젝션 방지)', () => {
+        expect(
+            parseContentUrl('https://damoang.net/bbs/board.php?bo_table=a;drop&wr_id=1')
+        ).toBeNull();
+    });
+});

--- a/apps/web/src/lib/board-content-url.ts
+++ b/apps/web/src/lib/board-content-url.ts
@@ -1,0 +1,57 @@
+/**
+ * 게시글/댓글 URL 파서 — 소모임 돌보기(임시 조치)에서 당주가 붙여넣는 주소를 해석한다.
+ *
+ * 파싱만 담당한다. 어느 보드의 당주인지, 대상이 실존하는지는 호출부(서버)가 검사한다.
+ *
+ * 수용 형태 (전부 실서비스에서 생성되는 주소들):
+ * - https://damoang.net/{board}/{postId}
+ * - .../{board}/{postId}#c_{id} · #comment_{id} · #comment-{id}  (댓글 앵커)
+ * - 레거시 /bbs/board.php?bo_table={board}&wr_id={postId}(#c_{id})
+ * - 도메인 없는 상대경로 /{board}/{postId}
+ */
+
+export interface ParsedContentUrl {
+    boardId: string;
+    postId: number;
+    /** 댓글 앵커가 있으면 그 댓글의 wr_id, 없으면 null (= 글 자체) */
+    commentId: number | null;
+}
+
+const ALLOWED_HOSTS = new Set(['damoang.net', 'www.damoang.net']);
+const BOARD_RE = /^[a-zA-Z0-9_]+$/;
+
+function parseCommentAnchor(hash: string): number | null {
+    const m = hash.match(/^#(?:c_|comment[_-])(\d+)$/);
+    if (!m) return null;
+    const id = Number(m[1]);
+    return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export function parseContentUrl(raw: string): ParsedContentUrl | null {
+    const input = raw.trim();
+    if (!input) return null;
+
+    let url: URL;
+    try {
+        // 상대경로도 받는다 — 당주가 주소창의 경로만 복사해 오는 경우.
+        url = new URL(input, 'https://damoang.net');
+    } catch {
+        return null;
+    }
+    if (!ALLOWED_HOSTS.has(url.hostname)) return null;
+
+    // 레거시 그누보드 주소
+    if (url.pathname === '/bbs/board.php') {
+        const boardId = url.searchParams.get('bo_table') ?? '';
+        const postId = Number(url.searchParams.get('wr_id'));
+        if (!BOARD_RE.test(boardId) || !Number.isInteger(postId) || postId <= 0) return null;
+        return { boardId, postId, commentId: parseCommentAnchor(url.hash) };
+    }
+
+    // 표준 /{board}/{postId}
+    const m = url.pathname.match(/^\/([a-zA-Z0-9_]+)\/(\d+)\/?$/);
+    if (!m) return null;
+    const postId = Number(m[2]);
+    if (!Number.isInteger(postId) || postId <= 0) return null;
+    return { boardId: m[1], postId, commentId: parseCommentAnchor(url.hash) };
+}

--- a/apps/web/src/lib/server/board-support.ts
+++ b/apps/web/src/lib/server/board-support.ts
@@ -1,0 +1,87 @@
+/**
+ * 소모임 돌보기(임시 조치) — 이력 저장소 헬퍼 (서버 전용)
+ *
+ * 이력의 정본은 audit_logs 다. g5_da_content_history 는 operation 이
+ * ENUM('수정','삭제') 라 당주 조치를 담을 수 없다(DDL 회피 결정).
+ *
+ * audit_logs 매핑:
+ * - action      = 'board_owner.support_lock' | 'board_owner.support_unlock' (인덱스 있음)
+ * - resource    = boardId
+ * - resource_id = wr_id (문자열)
+ * - details     = JSON { is_comment, author_id, author_name, wr_7_prev|wr_7_restored,
+ *                        url, reason, subject }
+ */
+import type { RowDataPacket } from 'mysql2/promise';
+import { readPool } from '$lib/server/db';
+
+export const ACT_LOCK = 'board_owner.support_lock';
+export const ACT_UNLOCK = 'board_owner.support_unlock';
+
+export interface SupportHistoryRow {
+    id: number;
+    action: string;
+    operatedBy: string;
+    operatedAt: string;
+    wrId: number;
+    details: Record<string, unknown>;
+}
+
+function parseDetails(raw: unknown): Record<string, unknown> {
+    try {
+        const v = JSON.parse(String(raw ?? '{}'));
+        return v && typeof v === 'object' ? v : {};
+    } catch {
+        return {};
+    }
+}
+
+/** 이 보드의 당주 조치 이력 (최신순). action 인덱스 선필터 후 보드로 좁힌다. */
+export async function listSupportHistory(
+    boardId: string,
+    limit = 50
+): Promise<SupportHistoryRow[]> {
+    const [rows] = await readPool.query<RowDataPacket[]>(
+        `SELECT id, action, user_id, created_at, resource_id, details
+           FROM audit_logs
+          WHERE action IN (?, ?) AND resource = ?
+          ORDER BY id DESC
+          LIMIT ?`,
+        [ACT_LOCK, ACT_UNLOCK, boardId, limit]
+    );
+    return rows.map((r) => ({
+        id: Number(r.id),
+        action: String(r.action),
+        operatedBy: String(r.user_id ?? ''),
+        operatedAt: String(r.created_at ?? ''),
+        wrId: Number(r.resource_id),
+        details: parseDetails(r.details)
+    }));
+}
+
+/** 대상의 마지막 당주 조치 — unlock 권한 판정과 wr_7 복원값의 근거. */
+export async function getLastSupportAction(
+    boardId: string,
+    wrId: number
+): Promise<{ action: string; details: Record<string, unknown> } | null> {
+    const [rows] = await readPool.query<RowDataPacket[]>(
+        `SELECT action, details FROM audit_logs
+          WHERE action IN (?, ?) AND resource = ? AND resource_id = ?
+          ORDER BY id DESC LIMIT 1`,
+        [ACT_LOCK, ACT_UNLOCK, boardId, String(wrId)]
+    );
+    if (!rows[0]) return null;
+    return { action: String(rows[0].action), details: parseDetails(rows[0].details) };
+}
+
+/** 대상별 최신 조치가 '잠금'인 건수 = 현재 당주 잠금 중인 대상 수. */
+export async function countActiveSupportLocks(boardId: string): Promise<number> {
+    const rows = await listSupportHistory(boardId, 500);
+    const lastByTarget = new Map<number, string>();
+    for (const r of rows) {
+        // 최신순이므로 처음 만난 것이 그 대상의 마지막 조치
+        if (!lastByTarget.has(r.wrId)) lastByTarget.set(r.wrId, r.action);
+    }
+    let n = 0;
+    for (const a of lastByTarget.values()) if (a === ACT_LOCK) n++;
+    return n;
+}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1052,8 +1052,8 @@
                  보인다는 것 자체가 권한이 있다는 뜻이다. 링크가 없으면 URL 을 직접 쳐야 했다. -->
             {#if data.canManageBoard}
                 <div class="mb-3 text-right">
-                    <a href="/{boardId}/manage" class="text-primary text-sm underline">
-                        소모임 관리
+                    <a href="/{boardId}/support" class="text-primary text-sm underline">
+                        소모임 돌보기
                     </a>
                 </div>
             {/if}

--- a/apps/web/src/routes/[boardId]/manage/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/manage/+page.server.ts
@@ -1,103 +1,11 @@
 /**
- * 소모임 관리 화면 (당주 콘솔) — 서버 로드
+ * 구 소모임 관리 화면 — /support(돌보기)로 개명되었다.
  *
- * ⛔ 여기서 권한을 확정한다. 권한이 없으면 데이터를 아예 만들지 않고 404 를 낸다.
- *    403 이 아니라 404 인 이유: 403 은 "여기 관리 화면이 있다"를 알려준다.
+ * 기존 당주들의 북마크·습관을 지키기 위해 영구 리다이렉트만 남긴다.
  */
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import type { RowDataPacket } from 'mysql2';
-import pool, { readPool } from '$lib/server/db';
-import { getAuthUser } from '$lib/server/auth';
-import { getBoardOwnerContext, getBoardIntro } from '$lib/server/board-owner';
 
-export const load: PageServerLoad = async ({ params, cookies }) => {
-    const { boardId } = params;
-
-    const user = await getAuthUser(cookies);
-    const ctx = await getBoardOwnerContext(boardId, user);
-    if (!ctx) throw error(404, 'Not Found');
-
-    const [boardRows] = await pool.query<RowDataPacket[]>(
-        `SELECT COALESCE(bo_notice, '')        AS bo_notice,
-                COALESCE(bo_category_list, '') AS bo_category_list,
-                COALESCE(bo_use_category, 0)   AS bo_use_category
-           FROM g5_board WHERE bo_table = ?`,
-        [boardId]
-    );
-    const board = boardRows[0] ?? {};
-
-    // 고정된 공지의 제목까지 함께 보여준다 — 번호만 보고는 무엇을 고정했는지 알 수 없다.
-    const noticeIds = String(board.bo_notice || '')
-        .split(',')
-        .map((s) => Number(s.trim()))
-        .filter((n) => Number.isInteger(n) && n > 0);
-
-    let notices: Array<{ id: number; subject: string }> = [];
-    if (noticeIds.length > 0) {
-        try {
-            const [rows] = await pool.query<RowDataPacket[]>(
-                `SELECT wr_id, wr_subject FROM ??
-                  WHERE wr_id IN (?) AND wr_is_comment = 0 AND wr_deleted_at IS NULL`,
-                [`g5_write_${boardId}`, noticeIds]
-            );
-            const found = new Map(rows.map((r) => [Number(r.wr_id), String(r.wr_subject || '')]));
-            // bo_notice 의 순서를 유지한다. 사라진 글은 제목 없이 번호만 남겨 정리할 수 있게 한다.
-            notices = noticeIds.map((id) => ({ id, subject: found.get(id) ?? '' }));
-        } catch {
-            notices = noticeIds.map((id) => ({ id, subject: '' }));
-        }
-    }
-
-    // 활동 현황 — 당주가 소모임 상태를 파악할 유일한 수단.
-    //
-    // ⚠️ g5_write_* 에는 wr_datetime 인덱스가 없다. 기간 조건을 그 테이블에 직접 걸면
-    //    풀스캔이 된다(g5_write_car 실측 13.6만 행). 관리 화면을 열 때마다 그걸 도는 건
-    //    7/20 스왑 스래싱·7/21 EBS IOPS 502 이력을 생각하면 위험하다.
-    //    → 기간 필터는 bn_datetime 인덱스가 있는 g5_board_new 로 걸고(실측 5.2천 행),
-    //      삭제글 제외만 PK 조인으로 붙인다. 실측 결과 직접 집계와 수치가 정확히 일치했다.
-    // ⚠️ 읽기는 readPool 로 보낸다(설정 없으면 writer 로 자동 폴백).
-    let stats = { posts30d: 0, comments30d: 0, writers30d: 0, totalPosts: 0 };
-    try {
-        const [rows] = await readPool.query<RowDataPacket[]>(
-            `SELECT SUM(w.wr_is_comment = 0)              AS posts30d,
-                    SUM(w.wr_is_comment = 1)              AS comments30d,
-                    COUNT(DISTINCT NULLIF(w.mb_id, ''))   AS writers30d
-               FROM g5_board_new n
-               JOIN ?? w ON w.wr_id = n.wr_id
-              WHERE n.bo_table = ?
-                AND n.bn_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)
-                AND w.wr_deleted_at IS NULL`,
-            [`g5_write_${boardId}`, boardId]
-        );
-        const r = rows[0] ?? {};
-        stats.posts30d = Number(r.posts30d ?? 0);
-        stats.comments30d = Number(r.comments30d ?? 0);
-        stats.writers30d = Number(r.writers30d ?? 0);
-    } catch {
-        // 통계 실패가 관리 화면 전체를 막지 않는다.
-    }
-
-    try {
-        // wr_is_comment + wr_deleted_at 인덱스를 탄다(실측 5.5천 행).
-        const [rows] = await readPool.query<RowDataPacket[]>(
-            `SELECT COUNT(*) AS total FROM ?? WHERE wr_is_comment = 0 AND wr_deleted_at IS NULL`,
-            [`g5_write_${boardId}`]
-        );
-        stats.totalPosts = Number(rows[0]?.total ?? 0);
-    } catch {
-        // 무시 — 0 으로 남는다.
-    }
-
-    return {
-        boardId,
-        subject: ctx.subject,
-        isOwner: ctx.isOwner,
-        isSiteAdmin: ctx.isSiteAdmin,
-        intro: await getBoardIntro(boardId),
-        useCategory: Number(board.bo_use_category ?? 0) === 1,
-        categoryList: String(board.bo_category_list || ''),
-        notices,
-        stats
-    };
+export const load: PageServerLoad = async ({ params }) => {
+    redirect(301, `/${params.boardId}/support`);
 };

--- a/apps/web/src/routes/[boardId]/support/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/support/+page.server.ts
@@ -1,0 +1,134 @@
+/**
+ * 소모임 돌보기 화면 (당주 콘솔) — 서버 로드
+ *
+ * "관리"가 아니라 "돌보기" — 당주는 자발적 봉사자다. (구 /manage 는 301 리다이렉트)
+ *
+ * ⛔ 여기서 권한을 확정한다. 권한이 없으면 데이터를 아예 만들지 않고 404 를 낸다.
+ *    403 이 아니라 404 인 이유: 403 은 "여기 관리 화면이 있다"를 알려준다.
+ */
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import type { RowDataPacket } from 'mysql2';
+import pool, { readPool } from '$lib/server/db';
+import { getAuthUser } from '$lib/server/auth';
+import { getBoardOwnerContext, getBoardIntro } from '$lib/server/board-owner';
+import { ACT_LOCK, listSupportHistory } from '$lib/server/board-support';
+
+export const load: PageServerLoad = async ({ params, cookies }) => {
+    const { boardId } = params;
+
+    const user = await getAuthUser(cookies);
+    const ctx = await getBoardOwnerContext(boardId, user);
+    if (!ctx) throw error(404, 'Not Found');
+
+    const [boardRows] = await pool.query<RowDataPacket[]>(
+        `SELECT COALESCE(bo_notice, '')        AS bo_notice,
+                COALESCE(bo_category_list, '') AS bo_category_list,
+                COALESCE(bo_use_category, 0)   AS bo_use_category
+           FROM g5_board WHERE bo_table = ?`,
+        [boardId]
+    );
+    const board = boardRows[0] ?? {};
+
+    // 고정된 공지의 제목까지 함께 보여준다 — 번호만 보고는 무엇을 고정했는지 알 수 없다.
+    const noticeIds = String(board.bo_notice || '')
+        .split(',')
+        .map((s) => Number(s.trim()))
+        .filter((n) => Number.isInteger(n) && n > 0);
+
+    let notices: Array<{ id: number; subject: string }> = [];
+    if (noticeIds.length > 0) {
+        try {
+            const [rows] = await pool.query<RowDataPacket[]>(
+                `SELECT wr_id, wr_subject FROM ??
+                  WHERE wr_id IN (?) AND wr_is_comment = 0 AND wr_deleted_at IS NULL`,
+                [`g5_write_${boardId}`, noticeIds]
+            );
+            const found = new Map(rows.map((r) => [Number(r.wr_id), String(r.wr_subject || '')]));
+            // bo_notice 의 순서를 유지한다. 사라진 글은 제목 없이 번호만 남겨 정리할 수 있게 한다.
+            notices = noticeIds.map((id) => ({ id, subject: found.get(id) ?? '' }));
+        } catch {
+            notices = noticeIds.map((id) => ({ id, subject: '' }));
+        }
+    }
+
+    // 활동 현황 — 당주가 소모임 상태를 파악할 유일한 수단.
+    //
+    // ⚠️ g5_write_* 에는 wr_datetime 인덱스가 없다. 기간 조건을 그 테이블에 직접 걸면
+    //    풀스캔이 된다(g5_write_car 실측 13.6만 행). 관리 화면을 열 때마다 그걸 도는 건
+    //    7/20 스왑 스래싱·7/21 EBS IOPS 502 이력을 생각하면 위험하다.
+    //    → 기간 필터는 bn_datetime 인덱스가 있는 g5_board_new 로 걸고(실측 5.2천 행),
+    //      삭제글 제외만 PK 조인으로 붙인다. 실측 결과 직접 집계와 수치가 정확히 일치했다.
+    // ⚠️ 읽기는 readPool 로 보낸다(설정 없으면 writer 로 자동 폴백).
+    let stats = { posts30d: 0, comments30d: 0, writers30d: 0, totalPosts: 0 };
+    try {
+        const [rows] = await readPool.query<RowDataPacket[]>(
+            `SELECT SUM(w.wr_is_comment = 0)              AS posts30d,
+                    SUM(w.wr_is_comment = 1)              AS comments30d,
+                    COUNT(DISTINCT NULLIF(w.mb_id, ''))   AS writers30d
+               FROM g5_board_new n
+               JOIN ?? w ON w.wr_id = n.wr_id
+              WHERE n.bo_table = ?
+                AND n.bn_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY)
+                AND w.wr_deleted_at IS NULL`,
+            [`g5_write_${boardId}`, boardId]
+        );
+        const r = rows[0] ?? {};
+        stats.posts30d = Number(r.posts30d ?? 0);
+        stats.comments30d = Number(r.comments30d ?? 0);
+        stats.writers30d = Number(r.writers30d ?? 0);
+    } catch {
+        // 통계 실패가 관리 화면 전체를 막지 않는다.
+    }
+
+    try {
+        // wr_is_comment + wr_deleted_at 인덱스를 탄다(실측 5.5천 행).
+        const [rows] = await readPool.query<RowDataPacket[]>(
+            `SELECT COUNT(*) AS total FROM ?? WHERE wr_is_comment = 0 AND wr_deleted_at IS NULL`,
+            [`g5_write_${boardId}`]
+        );
+        stats.totalPosts = Number(rows[0]?.total ?? 0);
+    } catch {
+        // 무시 — 0 으로 남는다.
+    }
+
+    // 임시 조치 이력 (audit_logs) — 대상별 최신 조치가 '잠금'이면 현재 잠금 중.
+    let supportHistory: Awaited<ReturnType<typeof listSupportHistory>> = [];
+    try {
+        supportHistory = await listSupportHistory(boardId, 50);
+    } catch {
+        // 이력 실패가 화면 전체를 막지 않는다 — 빈 목록으로 진행.
+    }
+    const lastByTarget = new Map<number, string>();
+    for (const h of supportHistory) {
+        if (!lastByTarget.has(h.wrId)) lastByTarget.set(h.wrId, h.action);
+    }
+    const activeLocks = new Set(
+        [...lastByTarget.entries()].filter(([, a]) => a === ACT_LOCK).map(([id]) => id)
+    );
+
+    return {
+        boardId,
+        subject: ctx.subject,
+        isOwner: ctx.isOwner,
+        isSiteAdmin: ctx.isSiteAdmin,
+        intro: await getBoardIntro(boardId),
+        useCategory: Number(board.bo_use_category ?? 0) === 1,
+        categoryList: String(board.bo_category_list || ''),
+        notices,
+        stats,
+        supportHistory: supportHistory.map((h) => ({
+            id: h.id,
+            action: h.action,
+            operatedBy: h.operatedBy,
+            operatedAt: h.operatedAt,
+            wrId: h.wrId,
+            isComment: Boolean(h.details.is_comment),
+            authorName: String(h.details.author_name ?? ''),
+            subjectText: String(h.details.subject ?? ''),
+            reason: String(h.details.reason ?? ''),
+            url: String(h.details.url ?? ''),
+            active: activeLocks.has(h.wrId) && h.action === ACT_LOCK
+        }))
+    };
+};

--- a/apps/web/src/routes/[boardId]/support/+page.svelte
+++ b/apps/web/src/routes/[boardId]/support/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     /**
-     * 소모임 관리 화면 (당주 콘솔)
+     * 소모임 돌보기 화면 (당주 콘솔)
      *
      * 권한 판정은 +page.server.ts 가 끝냈다. 여기 도달했다는 것 자체가 권한이 있다는 뜻이라
      * 화면에서 권한으로 무언가를 가리지 않는다 — 가릴 데이터는 애초에 내려오지 않는다.
@@ -11,9 +11,80 @@
     import { Textarea } from '$lib/components/ui/textarea/index.js';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import Pin from '@lucide/svelte/icons/pin';
+    import EyeOff from '@lucide/svelte/icons/eye-off';
     import type { PageData } from './$types';
 
     let { data }: { data: PageData } = $props();
+
+    // ── 임시 조치 (잠시 가려두기) ──
+    interface ActionPreview {
+        target_id: number;
+        post_id: number;
+        is_comment: boolean;
+        author: string;
+        subject: string;
+        locked: boolean;
+    }
+    let actionUrl = $state('');
+    let actionReason = $state('');
+    let preview = $state<ActionPreview | null>(null);
+    let actionBusy = $state(false);
+
+    async function callSupportAction(action: 'preview' | 'lock' | 'unlock', url: string) {
+        const res = await fetch(`/api/boards/${data.boardId}/support/actions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action, url, reason: actionReason })
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok || !body.success) {
+            throw new Error(body.error || '처리하지 못했습니다.');
+        }
+        return body.data as ActionPreview;
+    }
+
+    async function loadPreview() {
+        if (actionBusy || !actionUrl.trim()) return;
+        actionBusy = true;
+        message = '';
+        try {
+            preview = await callSupportAction('preview', actionUrl);
+        } catch (e) {
+            preview = null;
+            notify(e instanceof Error ? e.message : '확인하지 못했습니다.', true);
+        } finally {
+            actionBusy = false;
+        }
+    }
+
+    async function applyLock() {
+        if (actionBusy || !preview) return;
+        if (!confirm('이 대상을 잠시 가려둘까요? 삭제가 아니며, 최종 처리는 운영진이 확정합니다.'))
+            return;
+        actionBusy = true;
+        try {
+            await callSupportAction('lock', actionUrl);
+            notify('가려두었습니다. 운영진이 확인 후 최종 처리합니다.');
+            location.reload();
+        } catch (e) {
+            notify(e instanceof Error ? e.message : '조치하지 못했습니다.', true);
+            actionBusy = false;
+        }
+    }
+
+    async function releaseLock(url: string) {
+        if (actionBusy) return;
+        if (!confirm('가려둔 것을 해제할까요?')) return;
+        actionBusy = true;
+        try {
+            await callSupportAction('unlock', url);
+            notify('해제했습니다.');
+            location.reload();
+        } catch (e) {
+            notify(e instanceof Error ? e.message : '해제하지 못했습니다.', true);
+            actionBusy = false;
+        }
+    }
 
     let intro = $state(data.intro);
     let categories = $state<string[]>(
@@ -85,11 +156,11 @@
     }
 </script>
 
-<svelte:head><title>{data.subject} 관리</title></svelte:head>
+<svelte:head><title>{data.subject} 돌보기</title></svelte:head>
 
 <div class="mx-auto max-w-3xl space-y-4 p-4">
     <div class="flex flex-wrap items-center gap-2">
-        <h1 class="text-xl font-semibold">{data.subject} 관리</h1>
+        <h1 class="text-xl font-semibold">{data.subject} 돌보기</h1>
         {#if data.isOwner}
             <Badge variant="secondary">당주</Badge>
         {:else if data.isSiteAdmin}
@@ -126,6 +197,107 @@
                     <div class="text-muted-foreground text-xs">전체 글</div>
                 </div>
             </div>
+        </Card.Content>
+    </Card.Root>
+
+    <Card.Root>
+        <Card.Header>
+            <Card.Title class="flex items-center gap-2 text-base">
+                <EyeOff class="h-4 w-4" /> 잠시 가려두기
+            </Card.Title>
+            <Card.Description>
+                광고·주제와 무관한 글처럼 소모임 취지에 맞지 않는 글이나 댓글의 주소를 붙여넣으면
+                잠시 가려집니다. <b>삭제가 아닌 임시 노출 제한</b>이며, 최종 처리는 운영진이
+                확정합니다. 모든 조치는 기록에 남습니다.
+            </Card.Description>
+        </Card.Header>
+        <Card.Content class="space-y-3">
+            <div class="flex flex-col gap-2 sm:flex-row">
+                <Input
+                    class="flex-1"
+                    placeholder="글 또는 댓글 주소 (예: https://damoang.net/{data.boardId}/12345)"
+                    bind:value={actionUrl}
+                />
+                <Button
+                    variant="outline"
+                    disabled={actionBusy || !actionUrl.trim()}
+                    onclick={loadPreview}
+                >
+                    확인
+                </Button>
+            </div>
+            {#if preview}
+                <div class="space-y-2 rounded border p-3">
+                    <div class="flex items-center gap-2 text-sm">
+                        <Badge variant="outline">{preview.is_comment ? '댓글' : '글'}</Badge>
+                        <span class="min-w-0 truncate font-medium"
+                            >{preview.subject || '(제목 없음)'}</span
+                        >
+                        <span class="text-muted-foreground shrink-0">— {preview.author}</span>
+                        {#if preview.locked}
+                            <Badge variant="secondary">이미 가려짐</Badge>
+                        {/if}
+                    </div>
+                    {#if !preview.locked}
+                        <Input
+                            placeholder="사유 (선택, 200자 이내 — 운영진과 기록에 공유됩니다)"
+                            maxlength={200}
+                            bind:value={actionReason}
+                        />
+                        <Button disabled={actionBusy} onclick={applyLock}>잠시 가려두기</Button>
+                    {/if}
+                </div>
+            {/if}
+
+            {#if data.supportHistory.length > 0}
+                <div class="space-y-1 pt-2">
+                    <p class="text-muted-foreground text-xs font-medium">조치 기록</p>
+                    <ul class="space-y-1">
+                        {#each data.supportHistory as h (h.id)}
+                            <li
+                                class="flex items-center justify-between gap-2 rounded border p-2 text-sm"
+                            >
+                                <div class="min-w-0">
+                                    <div class="flex items-center gap-2">
+                                        <Badge variant={h.active ? 'secondary' : 'outline'}>
+                                            {h.action.endsWith('unlock')
+                                                ? '해제'
+                                                : h.active
+                                                  ? '가려둠'
+                                                  : '가림(종료)'}
+                                        </Badge>
+                                        <Badge variant="outline"
+                                            >{h.isComment ? '댓글' : '글'}</Badge
+                                        >
+                                        <a
+                                            href={h.url || `/${data.boardId}/${h.wrId}`}
+                                            class="min-w-0 truncate hover:underline"
+                                        >
+                                            {h.subjectText || `${h.wrId}번`}
+                                        </a>
+                                    </div>
+                                    <div class="text-muted-foreground mt-0.5 text-xs">
+                                        {h.operatedAt} · {h.operatedBy}
+                                        {#if h.reason}
+                                            · {h.reason}{/if}
+                                    </div>
+                                </div>
+                                {#if h.active}
+                                    <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        disabled={actionBusy}
+                                        onclick={() =>
+                                            releaseLock(h.url || `/${data.boardId}/${h.wrId}`)}
+                                    >
+                                        해제
+                                    </Button>
+                                {/if}
+                            </li>
+                        {/each}
+                    </ul>
+                </div>
+            {/if}
         </Card.Content>
     </Card.Root>
 

--- a/apps/web/src/routes/api/boards/[boardId]/support/actions/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/support/actions/+server.ts
@@ -1,0 +1,239 @@
+/**
+ * 소모임 돌보기 — 임시 조치 API
+ * POST /api/boards/[boardId]/support/actions
+ *
+ * 당주가 자기 소모임의 글/댓글 주소를 붙여넣어 임시 노출 제한(잠금)을 걸거나 푼다.
+ * 삭제가 아니다 — 최종 처리(삭제 확정/해제)는 운영진이 한다.
+ *
+ * 잠금의 실체는 신고잠김과 같은 `wr_7='lock'` — 렌더(작성자 수정·삭제 차단, 댓글
+ * 블라인드, 마이페이지 제외)와 해제가 기존 인프라를 그대로 탄다.
+ *
+ * ⛔ wr_7 은 신고 카운트 숫자와 겸용 컬럼이다. 잠글 때 이전값을 이력에 보존하고,
+ *    해제 시 그 값을 복원한다. 단순 '' 초기화는 임계 근처 신고 카운트를 지운다.
+ * ⛔ 이력은 audit_logs 를 쓴다 — g5_da_content_history 는 operation 이
+ *    ENUM('수정','삭제') 라 새 동작을 못 담는다(DDL 회피). audit_logs 는 manage
+ *    API 가 이미 쓰는 감사 채널이고 action 인덱스가 있다.
+ * ⛔ 이력 기록은 best-effort 가 아니라 **필수 경로**다 — 이력 없는 당주 조치는
+ *    운영진이 확정할 수 없고, 해제 시 복원값도 이력에서 나온다. 실패하면 잠금도
+ *    롤백한다. (댓글삭제 API 가 감사 없이 UPDATE 하던 전례를 반복하지 않는다.)
+ * ⛔ 권한 없음은 404 — 403 은 "여기 조치 API 가 있다"를 알려준다 (manage 관례).
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { RowDataPacket } from 'mysql2/promise';
+import pool from '$lib/server/db';
+import { getAuthUser } from '$lib/server/auth';
+import { getBoardOwnerContext } from '$lib/server/board-owner';
+import { parseContentUrl } from '$lib/board-content-url';
+import {
+    ACT_LOCK,
+    ACT_UNLOCK,
+    countActiveSupportLocks,
+    getLastSupportAction
+} from '$lib/server/board-support';
+
+const REASON_MAX = 200;
+/** 보드당 동시 잠금 상한 — 남용(무더기 잠금) 1차 방어선 */
+const ACTIVE_LOCK_LIMIT = 20;
+
+interface TargetRow extends RowDataPacket {
+    wr_id: number;
+    wr_parent: number;
+    wr_is_comment: number;
+    mb_id: string;
+    wr_name: string;
+    wr_subject: string;
+    wr_content: string;
+    wr_7: string;
+}
+
+export const POST: RequestHandler = async ({ params, request, cookies, getClientAddress }) => {
+    const { boardId } = params;
+
+    const user = await getAuthUser(cookies);
+    const ctx = await getBoardOwnerContext(boardId, user);
+    if (!ctx) return json({ success: false, error: 'Not Found' }, { status: 404 });
+
+    let body: { url?: string; action?: string; reason?: string };
+    try {
+        body = await request.json();
+    } catch {
+        return json({ success: false, error: '잘못된 요청입니다.' }, { status: 400 });
+    }
+
+    const action = body.action;
+    if (action !== 'preview' && action !== 'lock' && action !== 'unlock') {
+        return json({ success: false, error: '알 수 없는 동작입니다.' }, { status: 400 });
+    }
+    const reason = (body.reason ?? '').trim().slice(0, REASON_MAX);
+
+    const parsed = parseContentUrl(body.url ?? '');
+    if (!parsed || parsed.boardId !== boardId) {
+        return json(
+            { success: false, error: '이 소모임의 글/댓글 주소가 아닙니다.' },
+            { status: 400 }
+        );
+    }
+
+    // 대상 실조회 — 댓글이면 앵커의 id 로 조회하고 부모 글 일치까지 검증한다.
+    const table = `g5_write_${boardId}`;
+    const targetId = parsed.commentId ?? parsed.postId;
+    const [rows] = await pool.query<TargetRow[]>(
+        `SELECT wr_id, wr_parent, wr_is_comment, COALESCE(mb_id,'') AS mb_id,
+                COALESCE(wr_name,'') AS wr_name, COALESCE(wr_subject,'') AS wr_subject,
+                LEFT(COALESCE(wr_content,''), 80) AS wr_content,
+                COALESCE(wr_7,'') AS wr_7
+           FROM ?? WHERE wr_id = ? AND wr_deleted_at IS NULL`,
+        [table, targetId]
+    );
+    const target = rows[0];
+    const isComment = parsed.commentId !== null;
+    if (
+        !target ||
+        (isComment && (target.wr_is_comment !== 1 || target.wr_parent !== parsed.postId)) ||
+        (!isComment && target.wr_is_comment !== 0)
+    ) {
+        return json(
+            { success: false, error: '대상 글/댓글을 찾을 수 없습니다. (삭제되었을 수 있습니다)' },
+            { status: 404 }
+        );
+    }
+
+    const summary = {
+        target_id: target.wr_id,
+        post_id: parsed.postId,
+        is_comment: isComment,
+        author: target.wr_name,
+        subject: isComment ? target.wr_content : target.wr_subject,
+        locked: target.wr_7 === 'lock'
+    };
+
+    if (action === 'preview') {
+        return json({ success: true, data: summary });
+    }
+
+    const auditInsert = `INSERT INTO audit_logs
+        (created_at, user_id, action, resource, resource_id, details, client_ip)
+        VALUES (NOW(3), ?, ?, ?, ?, ?, ?)`;
+
+    if (action === 'lock') {
+        if (target.wr_7 === 'lock') {
+            return json({ success: false, error: '이미 조치된 대상입니다.' }, { status: 409 });
+        }
+        if ((await countActiveSupportLocks(boardId)) >= ACTIVE_LOCK_LIMIT) {
+            return json(
+                {
+                    success: false,
+                    error: `동시에 가려둘 수 있는 글은 ${ACTIVE_LOCK_LIMIT}건까지입니다. 운영진 확인을 기다려 주세요.`
+                },
+                { status: 400 }
+            );
+        }
+
+        const conn = await pool.getConnection();
+        try {
+            await conn.beginTransaction();
+            await conn.query(`UPDATE ?? SET wr_7 = 'lock' WHERE wr_id = ?`, [table, target.wr_id]);
+            // 이력 — 실패 시 전체 롤백 (필수 경로)
+            await conn.query(auditInsert, [
+                user!.mb_id,
+                ACT_LOCK,
+                boardId,
+                String(target.wr_id),
+                JSON.stringify({
+                    is_comment: target.wr_is_comment,
+                    author_id: target.mb_id,
+                    author_name: target.wr_name,
+                    wr_7_prev: target.wr_7,
+                    url: body.url,
+                    reason,
+                    subject: summary.subject
+                }),
+                getClientAddress()
+            ]);
+            await conn.commit();
+        } catch (e) {
+            await conn.rollback();
+            console.error('[support/actions] lock 실패:', boardId, target.wr_id, e);
+            return json({ success: false, error: '조치에 실패했습니다.' }, { status: 500 });
+        } finally {
+            conn.release();
+        }
+
+        // 글 잠금은 새글 목록의 신고 표시도 동기화 (report_autolock 관례, best-effort)
+        if (!isComment) {
+            try {
+                await pool.query(
+                    `UPDATE g5_board_new SET wr_singo = 'lock' WHERE bo_table = ? AND wr_id = ?`,
+                    [boardId, target.wr_id]
+                );
+            } catch {
+                /* 목록 표식 실패가 조치를 되돌리지 않는다 */
+            }
+        }
+        return json({ success: true, data: { ...summary, locked: true } });
+    }
+
+    // action === 'unlock'
+    // 해제는 "최신 이력이 당주잠금"인 대상만 — 신고누적 자동잠금·운영진 잠금을
+    // 당주가 임의로 풀 수 없다. 사이트 관리자는 예외.
+    if (target.wr_7 !== 'lock') {
+        return json({ success: false, error: '잠금 상태가 아닙니다.' }, { status: 409 });
+    }
+    const last = await getLastSupportAction(boardId, target.wr_id);
+    if (last?.action !== ACT_LOCK && !ctx.isSiteAdmin) {
+        return json(
+            {
+                success: false,
+                error: '이 잠금은 소모임 조치가 아니라 여기서 풀 수 없습니다. 운영진에게 문의해 주세요.'
+            },
+            { status: 403 }
+        );
+    }
+
+    let restored = '';
+    const prev = last?.details?.wr_7_prev;
+    if (last?.action === ACT_LOCK && typeof prev === 'string' && prev !== 'lock') {
+        restored = prev;
+    }
+
+    const conn = await pool.getConnection();
+    try {
+        await conn.beginTransaction();
+        await conn.query(`UPDATE ?? SET wr_7 = ? WHERE wr_id = ?`, [table, restored, target.wr_id]);
+        await conn.query(auditInsert, [
+            user!.mb_id,
+            ACT_UNLOCK,
+            boardId,
+            String(target.wr_id),
+            JSON.stringify({
+                is_comment: target.wr_is_comment,
+                author_id: target.mb_id,
+                author_name: target.wr_name,
+                wr_7_restored: restored,
+                reason,
+                subject: summary.subject
+            }),
+            getClientAddress()
+        ]);
+        await conn.commit();
+    } catch (e) {
+        await conn.rollback();
+        console.error('[support/actions] unlock 실패:', boardId, target.wr_id, e);
+        return json({ success: false, error: '해제에 실패했습니다.' }, { status: 500 });
+    } finally {
+        conn.release();
+    }
+
+    if (!isComment) {
+        try {
+            await pool.query(
+                `UPDATE g5_board_new SET wr_singo = '' WHERE bo_table = ? AND wr_id = ?`,
+                [boardId, target.wr_id]
+            );
+        } catch {
+            /* best-effort */
+        }
+    }
+    return json({ success: true, data: { ...summary, locked: false } });
+};


### PR DESCRIPTION
## 소모임 당주 콘솔 개편 1차 (newgroup/1193)

소모임장이 리딩 광고·주제무관 글에 선조치 수단이 없어 help@ 메일로만 처리하던 문제(주식한당 사례 4건)의 해소.

### 개명 — '관리'가 아니라 '돌보기'
- `/{boardId}/manage` → `/{boardId}/support`, 구 경로는 301 (북마크 보호)
- 진입 링크 「소모임 관리」→「소모임 돌보기」 — 당주는 자발적 봉사자라는 정체성에 맞춤

### 임시 조치 (잠시 가려두기)
- 글/댓글 **주소를 붙여넣으면** 미리보기 후 잠금 — 실체는 신고잠김과 같은 `wr_7='lock'` 재사용(작성자 수정·삭제 차단, 댓글 블라인드, 마이페이지 제외가 기존 렌더로 공짜)
- **삭제 아님** — 화면·확인창·안내문 모두 '임시 노출 제한, 최종 처리는 운영진 확정' 명시
- ⛔ `wr_7`은 신고 카운트 겸용 → 이전값을 이력에 보존, 해제 시 복원
- ⛔ 신고누적 자동잠금·운영진 잠금은 당주가 해제 불가(대상의 최신 이력이 당주잠금일 때만, 사이트관리자 예외)
- 이력 = **audit_logs** (`g5_da_content_history`는 operation이 ENUM('수정','삭제')라 불가 — DDL 회피). action=`board_owner.support_lock/unlock`, details에 사유·원상태·대상 스냅샷
- 이력 INSERT는 트랜잭션 **필수 경로** — 실패 시 잠금도 롤백 (감사 없는 조치 금지)
- 남용 방어: 보드당 동시 잠금 20건 상한
- 글 잠금 시 `g5_board_new.wr_singo` 동기화 (report_autolock 관례)

### URL 파서 (+vitest 8케이스)
표준 `/{board}/{id}` · 댓글 앵커 3형태(`#c_`·`#comment_`·`#comment-`) · 레거시 `board.php` · 상대경로. 외부 호스트·슬러그 인젝션 거부.

### 검증 계획
- 당주로 잠금 → 작성자 버튼 소멸·댓글 블라인드 확인, 해제 → wr_7 이전값 복원
- 자동잠금 글 해제 시도 → 거부 / 비당주 404 / 타보드 URL 400
- /manage → 301 /support

후속(별건 PR): intro HTML 커스텀 영역(Sprint 2), newgroup 안내댓글(Sprint 3), bo_admin 정비(운영 데이터), 운영진 알림 폴러.