### PR TITLE
feat: notification seen/read separation and reliability fixes

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2010,6 +2010,16 @@ class ApiClient {
     }
 
     /**
+     * 알림함 열람 기록 (seen) — 뱃지만 소거되고 항목별 읽음 상태는 그대로다.
+     * (seen/read 분리 — bug/13367·13332·13206·12991)
+     */
+    async markNotificationsSeen(): Promise<void> {
+        await this.request<void>('/notifications/seen', {
+            method: 'POST'
+        });
+    }
+
+    /**
      * 알림 삭제
      */
     async deleteNotification(notificationId: number): Promise<void> {

--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -6,7 +6,7 @@
     import type { GroupedNotification } from '$lib/api/types.js';
     import { onMount, tick } from 'svelte';
     import { goto } from '$app/navigation';
-    import { isNotiMergeEnabled, isNotiAutoReadEnabled } from '$lib/utils/noti-merge-pref.js';
+    import { isNotiMergeEnabled } from '$lib/utils/noti-merge-pref.js';
     import { browser } from '$app/environment';
     import { normalizeWebUrl, toRelativeIfSameOrigin } from '$lib/utils/url-normalizer';
     import Bell from '@lucide/svelte/icons/bell';
@@ -240,17 +240,16 @@
         }
     }
 
-    // #12991: 종을 열어 목록을 봤으면 확인한 것으로 본다 — 배지를 서버까지 읽음
-    // 처리해 해소한다("모두 읽음"을 따로 누르지 않아도 숫자가 다시 뜨지 않는다).
-    // ⛔ 이번에 연 목록의 '새 알림' 강조(has_unread)는 지우지 않는다 — 무엇이 새로
-    //    왔는지는 보여야 한다. handleMarkAllAsRead(버튼)와 다른 점이 그것뿐이다.
-    // ⛔ 이번 로드가 성공했을 때만 처리한다 — 보지도 못한 알림을 읽음으로 만들면 안 된다.
-    //    (loadError 플래그로 게이트하면 안 된다: 이전 목록이 남은 채 실패한 경우
-    //     false 로 남아, 새로 온 알림을 렌더 없이 읽음 처리하게 된다)
+    // #12991 → seen/read 분리(bug/13367·13332·13206 체인의 종결):
+    // 종을 열면 "봤다(seen)"만 서버에 기록해 뱃지를 지운다 — 12991 의 원요구.
+    // 항목별 읽음(굵은 표시)은 각 알림을 클릭할 때만 지워진다. 예전처럼 read-all 을
+    // 쏘면 열기만 해도 8만 건이 비가역으로 읽음 처리되는 문제(13367)가 있었다.
+    // 자동읽음 설정 게이트는 제거 — seen 은 파괴적이지 않아 옵션일 이유가 없다.
+    // ⛔ 이번 로드가 성공했을 때만 처리한다 — 보지도 못한 알림의 뱃지를 지우면 안 된다.
     async function markSeenOnOpen(): Promise<void> {
         if (unreadCount <= 0) return;
         try {
-            await apiClient.markAllNotificationsAsRead();
+            await apiClient.markNotificationsSeen();
             unreadCount = 0;
             writeUnreadCache(0);
         } catch (err) {
@@ -261,8 +260,7 @@
     // 열림·재시도 공용: 로드가 성공한 경우에만 배지를 해소한다.
     async function loadAndMarkSeen(): Promise<void> {
         const ok = await loadNotifications();
-        // 자동 읽음을 끈 회원은 열어도 읽음 처리하지 않는다(bug/13206).
-        if (ok && isNotiAutoReadEnabled()) await markSeenOnOpen();
+        if (ok) await markSeenOnOpen();
     }
 
     function handleOpenChange(open: boolean): void {
@@ -272,17 +270,23 @@
     }
 
     onMount(() => {
-        // 페이지 로드 시 자동 prime (hover 없이도 알림 수 표시)
-        // auth 초기화(layout onMount)가 완료된 후 호출해야 하므로 200ms 대기
-        if (!unreadPrimed && document.visibilityState === 'visible') {
-            setTimeout(() => primeUnreadCount(), 200);
-        }
-
         let interval: ReturnType<typeof setInterval> | null = null;
 
         function startPolling() {
             if (interval || !unreadPrimed) return;
             interval = setInterval(loadUnreadCount, 180_000);
+        }
+
+        // 페이지 로드 시 자동 prime (hover 없이도 알림 수 표시)
+        // auth 초기화(layout onMount)가 완료된 후 호출해야 하므로 200ms 대기.
+        // ⛔ prime 직후 여기서 폴링을 시작해야 한다 — 아래의 동기 startPolling() 게이트는
+        //    이 시점(unreadPrimed=false)에 항상 헛발이라, 탭을 계속 보고 있는 사용자는
+        //    폴링이 영영 시작되지 않았다(12954→13033→13089 "숫자가 안 바뀜" 체인의 원인).
+        if (!unreadPrimed && document.visibilityState === 'visible') {
+            setTimeout(() => {
+                primeUnreadCount();
+                startPolling();
+            }, 200);
         }
 
         function stopPolling() {

--- a/apps/web/src/lib/utils/noti-merge-pref.ts
+++ b/apps/web/src/lib/utils/noti-merge-pref.ts
@@ -8,7 +8,6 @@
 import { browser } from '$app/environment';
 
 const KEY = 'angple_noti_merge';
-const AUTOREAD_KEY = 'angple_noti_autoread';
 
 export function isNotiMergeEnabled(): boolean {
     if (!browser) return true;
@@ -28,27 +27,6 @@ export function setNotiMergeEnabled(enabled: boolean): void {
     }
 }
 
-/**
- * 종을 열 때 자동으로 읽음 처리할지(#12991).
- *
- * 기본 켬 — "종을 한 번 눌러 확인했으면 숫자가 계속 뜨지 않았으면" 하는 요청(#12991)이
- * 먼저 있었다. 다만 그 반대를 원하는 분도 있어(bug/13206 "여러 개가 한 번에 읽음 처리된다")
- * 끌 수 있게 한다. 끄면 개별 알림을 클릭하거나 「모두 읽기」를 눌러야 읽음이 된다.
- */
-export function isNotiAutoReadEnabled(): boolean {
-    if (!browser) return true;
-    try {
-        return localStorage.getItem(AUTOREAD_KEY) !== '0';
-    } catch {
-        return true;
-    }
-}
-
-export function setNotiAutoReadEnabled(enabled: boolean): void {
-    if (!browser) return;
-    try {
-        localStorage.setItem(AUTOREAD_KEY, enabled ? '1' : '0');
-    } catch {
-        // 저장 실패는 무시
-    }
-}
+// 「열람 시 자동 읽음(AUTOREAD_KEY)」 설정은 seen/read 분리(bug/13367)로 제거됐다.
+// 종을 열면 뱃지만 사라지고(seen), 읽음은 클릭한 알림만 처리되므로 설정이 필요 없다.
+// 기존 localStorage 값은 무시된다.

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -94,32 +94,42 @@ function fireAndForgetCommentLikeSideEffects(options: {
                     return;
                 }
 
-                await pool.query(
-                    `DELETE FROM g5_na_noti WHERE bo_table = ? AND wr_id = ? AND rel_mb_id = ? AND ph_from_case = 'good'`,
-                    [options.boardId, options.commentId, options.actorMbId]
-                );
-
                 const [parentRows] = await pool.query<WriteRow[]>(
                     `SELECT wr_subject FROM ?? WHERE wr_id = ?`,
                     [options.tableName, options.postId]
                 );
                 const parentSubject = parentRows[0]?.wr_subject || '';
 
-                await pool.query(
-                    `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
-                     VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?, ?)`,
-                    [
-                        options.boardId,
-                        options.commentId,
-                        options.authorMbId,
-                        options.actorMbId,
-                        options.actorNick,
-                        `${options.actorNick}님이 회원님의 댓글을 추천했습니다.`,
-                        `/${options.boardId}/${options.postId}#c_${options.commentId}`,
-                        parentSubject,
-                        options.postId
-                    ]
-                );
+                // DELETE→INSERT 는 한 트랜잭션으로 — 동시 요청이 갈라지면 중복 알림 2건이 남는다
+                const conn = await pool.getConnection();
+                try {
+                    await conn.beginTransaction();
+                    await conn.query(
+                        `DELETE FROM g5_na_noti WHERE bo_table = ? AND wr_id = ? AND rel_mb_id = ? AND ph_from_case = 'good'`,
+                        [options.boardId, options.commentId, options.actorMbId]
+                    );
+                    await conn.query(
+                        `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
+                         VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?, ?)`,
+                        [
+                            options.boardId,
+                            options.commentId,
+                            options.authorMbId,
+                            options.actorMbId,
+                            options.actorNick,
+                            `${options.actorNick}님이 회원님의 댓글을 추천했습니다.`,
+                            `/${options.boardId}/${options.postId}#c_${options.commentId}`,
+                            parentSubject,
+                            options.postId
+                        ]
+                    );
+                    await conn.commit();
+                } catch (e) {
+                    await conn.rollback();
+                    throw e;
+                } finally {
+                    conn.release();
+                }
             })().catch(() => undefined)
         );
     }

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -93,25 +93,36 @@ function fireAndForgetPostLikeSideEffects(options: {
                     return;
                 }
 
-                await pool.query(
-                    `DELETE FROM g5_na_noti WHERE bo_table = ? AND wr_id = ? AND rel_mb_id = ? AND ph_from_case = 'good'`,
-                    [options.boardId, options.postId, options.actorMbId]
-                );
-                await pool.query(
-                    `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
-                     VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?, ?)`,
-                    [
-                        options.boardId,
-                        options.postId,
-                        options.authorMbId,
-                        options.actorMbId,
-                        options.actorNick,
-                        `${options.actorNick}님이 회원님의 글을 추천했습니다.`,
-                        `/${options.boardId}/${options.postId}`,
-                        options.postSubject,
-                        options.postId
-                    ]
-                );
+                // DELETE→INSERT 는 한 트랜잭션으로 — 동시 요청이 갈라지면 중복 알림 2건이 남는다
+                const conn = await pool.getConnection();
+                try {
+                    await conn.beginTransaction();
+                    await conn.query(
+                        `DELETE FROM g5_na_noti WHERE bo_table = ? AND wr_id = ? AND rel_mb_id = ? AND ph_from_case = 'good'`,
+                        [options.boardId, options.postId, options.actorMbId]
+                    );
+                    await conn.query(
+                        `INSERT INTO g5_na_noti (ph_to_case, ph_from_case, bo_table, wr_id, mb_id, rel_mb_id, rel_mb_nick, rel_msg, rel_url, ph_readed, ph_datetime, parent_subject, wr_parent)
+                         VALUES ('good', 'good', ?, ?, ?, ?, ?, ?, ?, 'N', CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?, ?)`,
+                        [
+                            options.boardId,
+                            options.postId,
+                            options.authorMbId,
+                            options.actorMbId,
+                            options.actorNick,
+                            `${options.actorNick}님이 회원님의 글을 추천했습니다.`,
+                            `/${options.boardId}/${options.postId}`,
+                            options.postSubject,
+                            options.postId
+                        ]
+                    );
+                    await conn.commit();
+                } catch (e) {
+                    await conn.rollback();
+                    throw e;
+                } finally {
+                    conn.release();
+                }
             })().catch(() => undefined)
         );
     }

--- a/apps/web/src/routes/api/mentions/notify/+server.ts
+++ b/apps/web/src/routes/api/mentions/notify/+server.ts
@@ -7,6 +7,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
+import { getAuthUser } from '$lib/server/auth';
 
 interface NotifyRequest {
     mentions: string[]; // 닉네임 배열
@@ -30,9 +31,44 @@ function stripHtmlTags(str: string): string {
     return result;
 }
 
-export const POST: RequestHandler = async ({ request }) => {
+// 회원당 멘션 알림 호출 레이트리밋 — 파드 인메모리(분당 5회면 정상 사용은 충분).
+// ⛔ 파드별 독립이라 완벽하지 않지만, 무인증이던 시절의 무한 주입을 막는 1차 방어선.
+const MENTION_RATE_WINDOW_MS = 60_000;
+const MENTION_RATE_MAX = 5;
+const mentionCallLog = new Map<string, number[]>();
+
+function mentionRateLimited(mbID: string): boolean {
+    const now = Date.now();
+    const calls = (mentionCallLog.get(mbID) ?? []).filter((t) => now - t < MENTION_RATE_WINDOW_MS);
+    if (calls.length >= MENTION_RATE_MAX) {
+        mentionCallLog.set(mbID, calls);
+        return true;
+    }
+    calls.push(now);
+    mentionCallLog.set(mbID, calls);
+    if (mentionCallLog.size > 10_000) mentionCallLog.clear(); // 무한 성장 방지
+    return false;
+}
+
+export const POST: RequestHandler = async ({ request, cookies }) => {
+    // ⛔ 인증 필수 + 발신자는 세션에서 — 본문의 senderId/senderNick 을 믿으면
+    //    임의 회원 사칭으로 알림을 주입할 수 있다 (알림 딥다이브에서 발견된 구멍).
+    const user = await getAuthUser(cookies);
+    if (!user) {
+        return json({ error: '로그인이 필요합니다.' }, { status: 401 });
+    }
+    const senderId = user.mb_id;
+    const senderNick = user.mb_nick || user.mb_name || user.mb_id;
+
+    if (mentionRateLimited(senderId)) {
+        return json(
+            { error: '요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.' },
+            { status: 429 }
+        );
+    }
+
     const body: NotifyRequest = await request.json();
-    const { mentions, boardId, postId, commentId, content, senderNick, senderId, postTitle } = body;
+    const { mentions, boardId, postId, commentId, content, postTitle } = body;
 
     if (!mentions || mentions.length === 0) {
         return json({ sent: 0 });
@@ -40,10 +76,6 @@ export const POST: RequestHandler = async ({ request }) => {
 
     if (!boardId || !postId) {
         return json({ error: 'boardId, postId 필수' }, { status: 400 });
-    }
-
-    if (!senderId) {
-        return json({ error: 'senderId 필수' }, { status: 400 });
     }
 
     // 닉네임 유효성 검사

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -35,12 +35,7 @@
     import UserPlus from '@lucide/svelte/icons/user-plus';
     import { browser } from '$app/environment';
     import { onMount } from 'svelte';
-    import {
-        isNotiMergeEnabled,
-        setNotiMergeEnabled,
-        isNotiAutoReadEnabled,
-        setNotiAutoReadEnabled
-    } from '$lib/utils/noti-merge-pref.js';
+    import { isNotiMergeEnabled, setNotiMergeEnabled } from '$lib/utils/noti-merge-pref.js';
     import { page } from '$app/stores';
     import {
         uiSettingsStore,
@@ -311,7 +306,6 @@
         like_threshold: 1
     });
     let notiMerge = $state(true);
-    let notiAutoRead = $state(true);
     let notiLoading = $state(false);
     let notiSaving = $state(false);
     let notiSaveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -350,7 +344,6 @@
 
     onMount(() => {
         notiMerge = isNotiMergeEnabled();
-        notiAutoRead = isNotiAutoReadEnabled();
         hydrated = true;
         loadSubscriptions();
         loadFollowing();
@@ -1193,25 +1186,9 @@
                         />
                     </div>
                     <Separator />
-                    <!-- 자동 읽음 — #12991(열면 배지 해소)과 bug/13206(자동으로 읽히는 게 불편)이
-                         반대 요구라 설정으로 가른다. 기본 켬으로 기존 동작 보존. -->
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <Label>열람 시 자동 읽음 처리</Label>
-                            <p class="text-muted-foreground text-xs">
-                                알림 종을 열면 읽지 않은 알림이 모두 읽음으로 처리됩니다. 끄면 개별
-                                알림을 클릭하거나 「모두 읽기」를 눌러야 읽음이 됩니다 (이 기기에만
-                                적용)
-                            </p>
-                        </div>
-                        <Switch
-                            checked={notiAutoRead}
-                            onCheckedChange={(v) => {
-                                notiAutoRead = v;
-                                setNotiAutoReadEnabled(v);
-                            }}
-                        />
-                    </div>
+                    <!-- 「열람 시 자동 읽음 처리」 설정은 제거됨 — seen/read 분리(bug/13367)로
+                         종을 열면 뱃지만 사라지고 읽음은 클릭한 알림만 처리되므로,
+                         #12991(숫자 해소)과 13206(자동 읽힘 불편)이 설정 없이 동시에 만족된다. -->
                     <Separator />
                     {#if notiLoading}
                         <p class="text-muted-foreground text-xs">로딩 중...</p>

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -181,13 +181,19 @@
                 notification.target_key
             );
             if (notificationData) {
-                notificationData.items = notificationData.items.filter(
-                    (n) =>
-                        !(
-                            n.bo_table === notification.bo_table &&
-                            n.wr_id === notification.wr_id &&
-                            n.from_case === notification.from_case
-                        )
+                // merge 모드에선 서버가 target_key 로 지우므로 로컬 필터도 같은 키를 쓴다 —
+                // from_case 는 전부 'merged' 라 그 기준으로 거르면 오제거/미제거가 난다.
+                notificationData.items = notificationData.items.filter((n) =>
+                    notification.target_key
+                        ? !(
+                              n.bo_table === notification.bo_table &&
+                              n.target_key === notification.target_key
+                          )
+                        : !(
+                              n.bo_table === notification.bo_table &&
+                              n.wr_id === notification.wr_id &&
+                              n.from_case === notification.from_case
+                          )
                 );
                 notificationData.total--;
             }
@@ -199,6 +205,8 @@
 
     onMount(() => {
         loadNotifications();
+        // 알림함 페이지 진입도 '봤다(seen)' — 뱃지만 소거, 항목 읽음은 클릭 시 (bug/13367)
+        apiClient.markNotificationsSeen().catch(() => undefined);
     });
 
     $effect(() => {


### PR DESCRIPTION
## 알림 정비 P0·P1 프런트 (be#625 와 짝 — **be 먼저 prod 승격 필수**: /notifications/seen 신설 API 의존)

- **seen/read 분리**: 종·알림함 열람 시 read-all 대신 `POST /notifications/seen` — 뱃지만 소거, 항목 읽음은 클릭한 알림만. 13367·13332·13206·12991 재발 체인의 종결(레딧·페이스북 모델)
- 「열람 시 자동 읽음」 설정 제거 — seen 은 비파괴라 옵션일 이유가 없어짐. 기존 localStorage 값 무시, 설정 UI 항목 삭제
- **뱃지 폴링 미시작 결함 수정** — prime(200ms 지연)보다 폴링 게이트가 먼저 동기 실행돼 탭을 계속 보는 사용자는 180초 폴링이 영영 시작되지 않았다. "알림 숫자가 안 바뀐다" 3연속 제보(12954→13033→13089)의 원인
- **멘션 알림 API 보안**: 인증 필수, 발신자(senderId/senderNick)는 세션에서 강제(본문 신뢰 금지 — 사칭 주입 가능하던 구멍), 분당 5회 레이트리밋
- 공감 알림 DELETE→INSERT 트랜잭션(글·댓글 2곳) — 동시 요청 중복 알림 방지
- 알림함 그룹 삭제 로컬 필터를 merge 모드에선 target_key 기준으로(오제거/미제거)

## 검증
- 벨 열기 → 뱃지 0·항목 안읽음 유지·클릭한 것만 읽음
- 탭 유지 상태에서 새 알림 → 180초 내 뱃지 갱신
- 비로그인 멘션 API → 401, senderId 위조 무시