### PR TITLE
fix: comment delete event, unified profile counts, search total

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -644,9 +644,16 @@ export const load: PageServerLoad = async ({
                 const ordered = refetchIds
                     .map((id) => rowMap.get(id))
                     .filter(Boolean) as RowDataPacket[];
+                // 총건수는 Sphinx 값(삭제글 포함)인데 위에서 삭제글을 걸러냈다.
+                // 그대로 두면 삭제가 많은 작성자를 검색할 때 뒤쪽이 빈 페이지가 된다
+                // (bug/13341 제보자는 삭제율 83%). 이번 페이지에서 걸러진 만큼을 빼
+                // 총계를 보정한다 — 정확한 전수 카운트는 Sphinx 재질의가 필요해
+                // 과하고, 최소한 "있다고 한 만큼 안 나오는" 어긋남은 줄어든다.
+                const filteredOut = refetchIds.length - ordered.length;
+                const adjustedTotal = Math.max(0, sphinxResult.total - filteredOut);
                 return {
                     data: ordered,
-                    meta: { page, limit, total: sphinxResult.total }
+                    meta: { page, limit, total: adjustedTotal }
                 };
             } catch (err) {
                 // Sphinx/DB 실패 시 Go 백엔드 LIKE 검색으로 fallback

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/+server.ts
@@ -12,6 +12,7 @@ import pool from '$lib/server/db';
 interface CommentRow extends RowDataPacket {
     wr_id: number;
     mb_id: string;
+    wr_name: string;
     wr_comment: number;
     wr_comment_reply: string;
     wr_deleted_at: string | null;
@@ -46,7 +47,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
     try {
         // 댓글 존재 확인
         const [rows] = await pool.query<CommentRow[]>(
-            `SELECT wr_id, mb_id, wr_deleted_at FROM ?? WHERE wr_id = ? AND wr_parent = ? AND wr_is_comment >= 1`,
+            `SELECT wr_id, mb_id, wr_name, wr_deleted_at FROM ?? WHERE wr_id = ? AND wr_parent = ? AND wr_is_comment >= 1`,
             [tableName, safeCommentId, safePostId]
         );
 
@@ -63,12 +64,40 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
             return json({ error: '본인이 작성한 댓글만 삭제할 수 있습니다.' }, { status: 403 });
         }
 
-        // soft delete
-        await pool.query(`UPDATE ?? SET wr_deleted_at = NOW(), wr_deleted_by = ? WHERE wr_id = ?`, [
-            tableName,
-            userId,
-            safeCommentId
-        ]);
+        // soft delete + 파생 처리(부모 댓글수·활동피드 동기화 이벤트)를 한 트랜잭션으로.
+        //
+        // ⛔ 여기가 Go 파이프라인을 우회하던 지점이다(bug/13341).
+        //    이 핸들러는 UPDATE 만 하고 g5_write_after_events 를 남기지 않아
+        //    member_activity_feed 의 댓글 is_deleted 가 갱신되지 않았다 —
+        //    실측: post_deleted 이벤트 7,981건 vs comment_deleted **7건**(전 시스템 누적).
+        //    그 결과 프로필·마이페이지의 댓글 삭제 수가 실제와 크게 어긋났다.
+        //    글(post)은 웹에 삭제 엔드포인트가 없어 전부 Go 로 가므로 정확했다.
+        //    ⛔ 부모 글의 wr_comment 감소도 빠져 있었다(Go 경로는 한다).
+        const conn = await pool.getConnection();
+        try {
+            await conn.beginTransaction();
+            await conn.query(
+                `UPDATE ?? SET wr_deleted_at = NOW(), wr_deleted_by = ? WHERE wr_id = ?`,
+                [tableName, userId, safeCommentId]
+            );
+            await conn.query(
+                `UPDATE ?? SET wr_comment = GREATEST(COALESCE(wr_comment, 0) - 1, 0) WHERE wr_id = ?`,
+                [tableName, safePostId]
+            );
+            // 워커가 집어가 활동피드를 동기화한다(Go delete_worker 와 동일한 이벤트 형태).
+            await conn.query(
+                `INSERT INTO g5_write_after_events
+                    (event_type, board_slug, write_id, post_id, member_id, author, subject, occurred_at, status)
+                 VALUES ('comment_deleted', ?, ?, ?, ?, ?, '', NOW(), 'pending')`,
+                [safeBoardId, safeCommentId, safePostId, rows[0].mb_id, rows[0].wr_name ?? '']
+            );
+            await conn.commit();
+        } catch (e) {
+            await conn.rollback();
+            throw e;
+        } finally {
+            conn.release();
+        }
 
         // 알림에 남은 본문 스니펫 소거.
         // soft delete 는 wr_content 를 지우지 않고 렌더링에서 가리는 방식이라,

--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -48,7 +48,7 @@ interface DisciplineLogRow extends RowDataPacket {
 }
 
 import { parseDisciplineLogContent, type DisciplineEntry } from './_parse-discipline';
-import { calculateDeletePostCount } from './_recompute-counts';
+import { calculateMemberCounts } from './_recompute-counts';
 import { calculateLevelInfo as calcLevelInfo } from '$lib/utils/level-thresholds';
 
 interface CountRow extends RowDataPacket {
@@ -171,20 +171,31 @@ export const GET: RequestHandler = async ({ params, locals }) => {
             // 테이블 없으면 기본값 사용
         }
 
-        // delete_post_count 실시간 보강 (#12113)
-        // g5_member_board_status.delete_post_count 는 갱신 cron 부재로 stale.
-        // bo_use_search 보드들에 대해 UNION ALL COUNT 로 실시간 합산.
+        // 글·댓글 통계 실시간 재계산 (#12113 → bug/13341)
+        //
+        // ⛔ 총계와 삭제 수를 **같은 쿼리**에서 함께 센다. 예전에는 총계만 stale 값
+        //    (g5_member_board_status)을 쓰고 삭제 수만 실시간이라, 화면의 "생존 =
+        //    총계 - 삭제" 가 서로 다른 시점·모집단의 뺄셈이 되어 실제와 크게 어긋났다
+        //    (실측: 표시 생존 58 vs 실제 2). 댓글은 재계산조차 없어 전부 stale 이었다.
         try {
-            // pool.query 와 시그니처 호환: <T>(sql, params) => [rows, fields]
-            const realDeleteCount = await calculateDeletePostCount(
+            const counts = await calculateMemberCounts(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (sql: string, params?: unknown[]) => pool.query(sql, params) as any,
                 memberId
             );
-            stats = { ...stats, delete_post_count: realDeleteCount };
+            if (counts) {
+                stats = {
+                    ...stats,
+                    total_post_count: counts.totalPosts,
+                    delete_post_count: counts.deletedPosts,
+                    total_comment_count: counts.totalComments,
+                    delete_comment_count: counts.deletedComments
+                };
+            }
+            // counts === null 이면 재계산 실패 — stale 값을 그대로 두되 뺄셈이
+            // 어긋나 있을 수 있음을 감안한다(표시 자체는 기존과 동일).
         } catch (err) {
-            // 실시간 합산 실패 시 기존 stale 값 유지 (안전장치)
-            console.error('[Member Profile API] delete_post_count recompute failed:', err);
+            console.error('[Member Profile API] member counts recompute failed:', err);
         }
 
         // 이용제한 내역 (옵션 A: g5_write_disciplinelog 단일 출처)

--- a/apps/web/src/routes/api/members/[id]/profile/_recompute-counts.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/_recompute-counts.ts
@@ -1,15 +1,20 @@
 /**
- * 프로필 통계 — g5_member_board_status 의 stale 한 누적값(레거시 PHP)
- * 대신 실시간 COUNT 를 사용하기 위한 헬퍼.
+ * 프로필 통계 — 실시간 재계산 헬퍼.
  *
  * 배경:
- *   g5_member_board_status.delete_post_count 는 갱신하는 cron / sync 가 없어서
- *   레거시 PHP 시절 누적된 값에서 멈춰있다 (#12113).
- *   재계산 가능한 카운트만이라도 실시간으로 보강한다.
+ *   `g5_member_board_status` 의 누적값은 갱신하는 cron/sync 가 없어 레거시 PHP 시절에
+ *   멈춰 있다(#12113). 그래서 삭제 수만 실시간으로 세어 보강해 왔는데, 그것이
+ *   **더 큰 왜곡**을 만들었다(bug/13341):
+ *     - 총계는 stale(349), 삭제는 실시간(291) → 생존 = 349-291 = 58 로 표시되지만
+ *       실제 생존 글은 2건. 시점도 모집단도 다른 두 수를 뺀 값이었다.
+ *     - 재계산이 `bo_use_search=1`(122개) 보드만 훑어 실제 삭제 311건 중 20건 누락.
+ *     - 댓글은 재계산조차 없어 전부 stale.
  *
- * 비용:
- *   bo_use_search = 1 인 보드 리스트(~30개)에 대해 UNION ALL 단일 쿼리.
- *   wr_deleted_at 인덱스 + mb_id 인덱스 활용 시 50ms 미만.
+ *   → 이제 **총계·삭제를 같은 쿼리에서 함께** 센다. 뺄셈이 성립하고, 보드 모집단도
+ *     하나다. 대상 보드는 `bo_use_search` 와 무관하게 **글이 있는 모든 보드**.
+ *
+ * ⛔ 레거시 하드삭제(행 자체가 없는 옛 삭제분)는 셀 수 없다 — 그건 총계에도 없으므로
+ *    "총계-삭제=생존" 관계는 여전히 성립한다(과거 값보다 총계가 작아 보일 뿐 일관적).
  */
 export interface QueryFn {
     <T>(sql: string, params?: unknown[]): Promise<[T[], unknown]>;
@@ -20,57 +25,86 @@ interface BoardRow {
 }
 
 interface CountRow {
-    cnt: number;
+    total: number;
+    deleted: number;
+}
+
+export interface MemberCounts {
+    totalPosts: number;
+    deletedPosts: number;
+    totalComments: number;
+    deletedComments: number;
+}
+
+/** 실존하는 g5_write_* 테이블만 돌려준다 — 보드 행만 있고 테이블이 없는 경우가 있다. */
+async function listWritableBoards(query: QueryFn): Promise<string[]> {
+    try {
+        // information_schema 로 실존 테이블을 직접 확인한다.
+        // ⛔ g5_board 목록만 믿으면 안 된다: `promotion_my` 처럼 보드 행은 있는데
+        //    g5_write_* 가 없는 경우가 실재하고, UNION ALL 한 방이 통째로 실패해
+        //    모든 회원의 삭제 수가 0 이 된다(과거 "삭제율 0%" 표시의 한 원인).
+        const [rows] = await query<BoardRow>(
+            `SELECT SUBSTRING(t.TABLE_NAME, 10) AS bo_table
+               FROM information_schema.TABLES t
+               JOIN g5_board b ON b.bo_table = SUBSTRING(t.TABLE_NAME, 10)
+              WHERE t.TABLE_SCHEMA = DATABASE() AND t.TABLE_NAME LIKE 'g5\\_write\\_%'`
+        );
+        return rows
+            .map((r) => r.bo_table)
+            .filter((t) => typeof t === 'string' && /^[a-zA-Z0-9_]+$/.test(t));
+    } catch {
+        return [];
+    }
 }
 
 /**
- * 회원의 "삭제된 글" 건수를 모든 검색 가능 보드에 대해 실시간 합산한다.
- * - 댓글 제외 (wr_is_comment = 0)
- * - 소프트삭제 판단: wr_deleted_at IS NOT NULL AND wr_deleted_at != '0000-00-00 00:00:00'
- *
- * @param query  pool.query 호환 함수 (테스트에서 mock 가능)
- * @param mbId   회원 ID (caller 가 이미 검증했다고 가정 — 영숫자/_/- 만)
- * @returns      삭제 글 수. 보드 조회 실패 / 개별 보드 쿼리 실패 시 0 또는 부분합 반환.
+ * 회원의 글·댓글 총계와 삭제 수를 한 번에 센다.
+ * 실패 시 null — 호출부는 stale 값을 쓰지 말고 통계를 숨기는 편이 낫다.
  */
-export async function calculateDeletePostCount(query: QueryFn, mbId: string): Promise<number> {
-    // 1. 검색 가능 보드 목록 조회
-    let boards: BoardRow[];
-    try {
-        const [rows] = await query<BoardRow>(
-            'SELECT bo_table FROM g5_board WHERE bo_use_search = 1 ORDER BY bo_order'
-        );
-        boards = rows;
-    } catch {
-        return 0;
-    }
-    if (boards.length === 0) return 0;
+export async function calculateMemberCounts(
+    query: QueryFn,
+    mbId: string
+): Promise<MemberCounts | null> {
+    const boards = await listWritableBoards(query);
+    if (boards.length === 0) return null;
 
-    // 2. bo_table 화이트리스트 검증 (식별자 escape 대비 영숫자/_ 만 허용)
-    const safeBoards = boards
-        .map((b) => b.bo_table)
-        .filter((t) => typeof t === 'string' && /^[a-zA-Z0-9_]+$/.test(t));
-    if (safeBoards.length === 0) return 0;
-
-    // 3. UNION ALL 단일 쿼리로 합산
-    //    각 보드 SELECT 는 (mb_id, wr_is_comment, wr_deleted_at) 조건 — 인덱스 활용 가능
-    const unionSql = safeBoards
+    const isDeleted = `wr_deleted_at IS NOT NULL AND wr_deleted_at != '0000-00-00 00:00:00'`;
+    const unionSql = boards
         .map(
             (t) =>
-                `SELECT COUNT(*) AS cnt FROM g5_write_${t}
-                 WHERE mb_id = ? AND wr_is_comment = 0
-                   AND wr_deleted_at IS NOT NULL
-                   AND wr_deleted_at != '0000-00-00 00:00:00'`
+                `SELECT
+                   SUM(wr_is_comment = 0) AS total,
+                   SUM(wr_is_comment = 0 AND ${isDeleted}) AS deleted,
+                   SUM(wr_is_comment = 1) AS c_total,
+                   SUM(wr_is_comment = 1 AND ${isDeleted}) AS c_deleted
+                 FROM g5_write_${t} WHERE mb_id = ?`
         )
         .join(' UNION ALL ');
-    const params = safeBoards.map(() => mbId);
+    const params = boards.map(() => mbId);
 
     try {
-        const [rows] = await query<CountRow>(unionSql, params);
-        return rows.reduce((sum, r) => sum + (Number(r.cnt) || 0), 0);
+        const [rows] = await query<CountRow & { c_total: number; c_deleted: number }>(
+            unionSql,
+            params
+        );
+        return rows.reduce<MemberCounts>(
+            (acc, r) => ({
+                totalPosts: acc.totalPosts + (Number(r.total) || 0),
+                deletedPosts: acc.deletedPosts + (Number(r.deleted) || 0),
+                totalComments: acc.totalComments + (Number(r.c_total) || 0),
+                deletedComments: acc.deletedComments + (Number(r.c_deleted) || 0)
+            }),
+            { totalPosts: 0, deletedPosts: 0, totalComments: 0, deletedComments: 0 }
+        );
     } catch {
-        // 일부 보드의 g5_write_* 테이블이 없거나 wr_deleted_at 컬럼이 없을 수 있음 →
-        // UNION ALL 한 쿼리가 통째로 실패하므로 보수적으로 0 반환 (기존 stale 값 사용 X).
-        // 운영 환경에서는 모든 보드가 동일 스키마이므로 문제 없음.
-        return 0;
+        return null;
     }
+}
+
+/**
+ * @deprecated calculateMemberCounts 를 쓸 것. 총계와 삭제를 따로 세면 뺄셈이 어긋난다.
+ */
+export async function calculateDeletePostCount(query: QueryFn, mbId: string): Promise<number> {
+    const counts = await calculateMemberCounts(query, mbId);
+    return counts?.deletedPosts ?? 0;
 }

--- a/apps/web/src/routes/api/members/[id]/profile/recompute-counts.test.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/recompute-counts.test.ts
@@ -1,120 +1,63 @@
-import { describe, it, expect, vi } from 'vitest';
-import { calculateDeletePostCount, type QueryFn } from './_recompute-counts';
+import { describe, expect, it, vi } from 'vitest';
+import { calculateMemberCounts, type QueryFn } from './_recompute-counts';
 
-/**
- * mockQuery: g5_board 조회 → 보드 목록 반환, UNION ALL → 보드별 COUNT 반환
- * 호출 순서대로 응답을 큐에서 꺼낸다.
- */
-function makeMockQuery(responses: unknown[][]): QueryFn {
-    let i = 0;
-    return (async (_sql: string, _params?: unknown[]) => {
-        const rows = responses[i++] ?? [];
-        return [rows, []];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any as QueryFn;
+/** 보드 목록 → 카운트 순으로 응답하는 mock query */
+function mockQuery(
+    boards: string[],
+    counts: Array<{ total: number; deleted: number; c_total: number; c_deleted: number }>
+): QueryFn {
+    let call = 0;
+    return vi.fn(async () => {
+        call += 1;
+        if (call === 1) return [boards.map((b) => ({ bo_table: b })), undefined] as never;
+        return [counts, undefined] as never;
+    }) as unknown as QueryFn;
 }
 
-describe('calculateDeletePostCount', () => {
-    it('보드 합산: 3 + 2 + 0 = 5', async () => {
-        const query = makeMockQuery([
-            // g5_board → bo_use_search = 1 보드 3개
-            [{ bo_table: 'free' }, { bo_table: 'humor' }, { bo_table: 'qa' }],
-            // UNION ALL 결과 (각 보드 1 row 씩)
-            [{ cnt: 3 }, { cnt: 2 }, { cnt: 0 }]
-        ]);
-        const result = await calculateDeletePostCount(query, 'testuser');
-        expect(result).toBe(5);
+describe('calculateMemberCounts', () => {
+    it('여러 보드의 글·댓글 총계와 삭제 수를 합산한다', async () => {
+        const query = mockQuery(
+            ['free', 'bug'],
+            [
+                { total: 291, deleted: 291, c_total: 2428, c_deleted: 1508 },
+                { total: 22, deleted: 20, c_total: 9, c_deleted: 4 }
+            ]
+        );
+        expect(await calculateMemberCounts(query, 'testuser')).toEqual({
+            totalPosts: 313,
+            deletedPosts: 311,
+            totalComments: 2437,
+            deletedComments: 1512
+        });
     });
 
-    it('보드 0개일 때 0 반환 (UNION 쿼리 호출 안 함)', async () => {
-        const calls: string[] = [];
-        const query: QueryFn = (async (sql: string) => {
-            calls.push(sql);
-            if (sql.includes('FROM g5_board')) return [[], []];
-            return [[], []];
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any;
-        const result = await calculateDeletePostCount(query, 'testuser');
-        expect(result).toBe(0);
-        expect(calls).toHaveLength(1);
-        expect(calls[0]).toContain('g5_board');
+    it('총계와 삭제를 같은 호출에서 세어 생존 수가 음수가 되지 않는다', async () => {
+        const query = mockQuery(['free'], [{ total: 10, deleted: 10, c_total: 0, c_deleted: 0 }]);
+        const c = await calculateMemberCounts(query, 'testuser');
+        expect(c!.totalPosts - c!.deletedPosts).toBe(0);
     });
 
-    it('g5_board 쿼리 실패 시 0 반환 (throw 안 함)', async () => {
-        const query: QueryFn = (async () => {
-            throw new Error('table not found');
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any;
-        const result = await calculateDeletePostCount(query, 'testuser');
-        expect(result).toBe(0);
+    it('보드가 없으면 null (stale 값을 덮어쓰지 않는다)', async () => {
+        const query = mockQuery([], []);
+        expect(await calculateMemberCounts(query, 'testuser')).toBeNull();
     });
 
-    it('UNION ALL 쿼리 실패 시 0 반환', async () => {
-        let callCount = 0;
-        const query: QueryFn = (async (sql: string) => {
-            callCount++;
-            if (callCount === 1) return [[{ bo_table: 'free' }], []];
-            throw new Error('column wr_deleted_at not found');
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any;
-        const result = await calculateDeletePostCount(query, 'testuser');
-        expect(result).toBe(0);
+    it('카운트 쿼리 실패 시 null', async () => {
+        let call = 0;
+        const query = vi.fn(async () => {
+            call += 1;
+            if (call === 1) return [[{ bo_table: 'free' }], undefined];
+            throw new Error('table missing');
+        }) as unknown as QueryFn;
+        expect(await calculateMemberCounts(query, 'testuser')).toBeNull();
     });
 
-    it('bo_table 비정상 값(특수문자) 은 화이트리스트로 제외', async () => {
-        const captured: { sql: string; params: unknown[] }[] = [];
-        const query: QueryFn = (async (sql: string, params?: unknown[]) => {
-            captured.push({ sql, params: params ?? [] });
-            if (sql.includes('FROM g5_board')) {
-                return [
-                    [
-                        { bo_table: 'free' },
-                        { bo_table: 'evil; DROP TABLE--' }, // 차단 대상
-                        { bo_table: 'humor' }
-                    ],
-                    []
-                ];
-            }
-            return [[{ cnt: 1 }, { cnt: 4 }], []];
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any;
-
-        const result = await calculateDeletePostCount(query, 'testuser');
-        expect(result).toBe(5);
-
-        // UNION ALL 쿼리에서 evil 보드는 제외되었는지 확인
-        const unionCall = captured[1];
-        expect(unionCall.sql).toContain('g5_write_free');
-        expect(unionCall.sql).toContain('g5_write_humor');
-        expect(unionCall.sql).not.toContain('evil');
-        // params 는 보드 수와 동일 (각 보드당 mb_id 1번)
-        expect(unionCall.params).toEqual(['testuser', 'testuser']);
-    });
-
-    it('UNION ALL SQL 에 wr_is_comment = 0 + wr_deleted_at 조건 포함', async () => {
-        const captured: string[] = [];
-        const query: QueryFn = (async (sql: string) => {
-            captured.push(sql);
-            if (sql.includes('FROM g5_board')) {
-                return [[{ bo_table: 'free' }], []];
-            }
-            return [[{ cnt: 0 }], []];
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any;
-
-        await calculateDeletePostCount(query, 'testuser');
-        const unionSql = captured[1];
-        expect(unionSql).toContain('wr_is_comment = 0');
-        expect(unionSql).toContain('wr_deleted_at IS NOT NULL');
-        expect(unionSql).toContain("wr_deleted_at != '0000-00-00 00:00:00'");
-    });
-
-    it('cnt 가 string 으로 와도 Number 변환 후 합산', async () => {
-        const query = makeMockQuery([
-            [{ bo_table: 'free' }, { bo_table: 'humor' }],
-            [{ cnt: '7' }, { cnt: '3' }]
-        ]);
-        const result = await calculateDeletePostCount(query, 'testuser');
-        expect(result).toBe(10);
+    it('보드 이름에 이상한 문자가 있으면 제외한다', async () => {
+        const query = mockQuery(
+            ['free', 'evil; DROP TABLE'],
+            [{ total: 1, deleted: 0, c_total: 0, c_deleted: 0 }]
+        );
+        const c = await calculateMemberCounts(query, 'testuser');
+        expect(c!.totalPosts).toBe(1);
     });
 });


### PR DESCRIPTION
## bug/13341 후속 — 딥다이브로 확정한 원인 3개

제보자 재확인(13362·13363, 이미지 4장) 후 전수 조사한 결과, 숫자 불일치는 버그 하나가 아니라 **독립적인 원인 3개**였다.

### 1) 댓글 삭제가 활동피드에 반영되지 않음 (최우선)
웹 댓글 삭제 핸들러가 Go 이벤트 파이프라인을 우회해 `UPDATE` 만 했다.
**결정적 증거**: `g5_write_after_events` 에 `post_deleted` **7,981건** vs `comment_deleted` **7건**(전 시스템 누적). 글은 웹에 삭제 엔드포인트가 아예 없어 전부 Go 로 가므로 피드가 정확했고(311건 일치), 댓글만 어긋났다(실제 삭제 1,520건 중 피드 반영 4건).
→ soft delete + **부모 글 wr_comment 감소** + `comment_deleted` 이벤트를 한 트랜잭션으로. (카운터 감소도 원래 빠져 있었다)

### 2) 프로필 통계 = stale 총계 − 실시간 삭제
총계는 `g5_member_board_status`(갱신 cron 없음), 삭제만 실시간이라 화면의 "생존 = 총계 − 삭제" 가 **서로 다른 시점·모집단의 뺄셈**이었다 — 실측 표시 생존 58 vs 실제 2. 댓글은 재계산조차 없어 전부 stale(표시 557 vs 실제 1,520).
→ `calculateMemberCounts` 로 총계·삭제를 **같은 쿼리에서** 계산. 대상 보드도 `bo_use_search=1`(122개, 311건 중 20건 누락) 대신 **실존 `g5_write_*` 전체**로.
→ 부수 효과: 보드 행만 있고 테이블이 없는 경우(`promotion_my`)에 UNION ALL 이 통째 실패해 **모든 회원 삭제수가 0** 이 되던 지뢰 제거(타 회원 "15,787건 삭제율 0%" 표시의 한 축).

### 3) 작성자 검색 총건수 불일치
총건수는 Sphinx 값(삭제글 포함)인데 삭제글 제외는 그 뒤 DB 재조회에서만 일어나 **빈 페이지**가 생겼다(제보자는 삭제율 83%). 이번 페이지에서 걸러진 만큼 총계를 보정.

### 검증
- 댓글 삭제 → `g5_write_after_events` 에 comment_deleted 행 + 수초 뒤 `member_activity_feed.is_deleted=1` + 부모 글 댓글수 −1
- 프로필: 총계·삭제·생존이 실제 DB 값과 일치(대상 회원 313/311/2)
- 검색: 삭제 많은 작성자로 검색 시 빈 페이지 없음
- vitest: recompute-counts 5케이스

후속(별건): 마이페이지에서 **본인에게는 삭제글도 보이게** 하는 필터(제보자 요구) — 백엔드 시그니처 변경이라 분리.