### PR TITLE
feat(omok): online match client with entry fee consent

### DIFF
--- a/apps/web/src/lib/components/features/game/omok-online.svelte
+++ b/apps/web/src/lib/components/features/game/omok-online.svelte
@@ -1,0 +1,351 @@
+<script lang="ts">
+    /**
+     * 오목 온라인 대전 (WebSocket).
+     *
+     * 서버: cmd/omok-ws (angple-backend) — 착수 유효성·승패 판정은 전부 서버가 한다.
+     * 이 컴포넌트는 좌표를 보내고 서버가 확정한 상태를 그린다.
+     *
+     * ⛔ 참가비 1,000P 가 걸리므로 큐 진입 전에 반드시 동의를 받는다.
+     *    포인트가 조용히 빠져나가는 화면은 만들지 않는다.
+     */
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { Badge } from '$lib/components/ui/badge/index.js';
+    import * as Card from '$lib/components/ui/card/index.js';
+    import { onDestroy } from 'svelte';
+
+    const SIZE = 15;
+    const CELL = 32;
+    const PAD = CELL;
+    const W = PAD * 2 + (SIZE - 1) * CELL;
+
+    type Phase = 'idle' | 'connecting' | 'queued' | 'playing' | 'over';
+
+    let phase = $state<Phase>('idle');
+    let board = $state<number[][]>(emptyBoard());
+    let myColor = $state(0);
+    let currentPlayer = $state(1);
+    let roomId = $state('');
+    let opponent = $state<{ nickname?: string; rating?: number } | null>(null);
+    let message = $state('');
+    let entryFee = $state(1000);
+    let queuePosition = $state(0);
+    let turnLeft = $state(0);
+    let result = $state<{ youWon: boolean; reason: string } | null>(null);
+    let myStats = $state<{ wins: number; losses: number; draws: number; rating: number } | null>(
+        null
+    );
+    let agreed = $state(false);
+    let socket: WebSocket | null = null;
+    let turnTimer: ReturnType<typeof setInterval> | null = null;
+
+    const isMyTurn = $derived(phase === 'playing' && currentPlayer === myColor);
+
+    function emptyBoard(): number[][] {
+        return Array.from({ length: SIZE }, () => Array(SIZE).fill(0));
+    }
+
+    function wsUrl(): string {
+        const token = authStore.accessToken ?? '';
+        const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        // 브라우저 WebSocket 은 헤더를 못 붙여서 토큰을 쿼리로 전달한다(서버가 둘 다 받는다).
+        return `${proto}//${location.host}/omok-ws/?token=${encodeURIComponent(token)}`;
+    }
+
+    function send(type: string, data: Record<string, unknown> = {}) {
+        socket?.send(JSON.stringify({ type, data }));
+    }
+
+    function startTurnCountdown(seconds: number) {
+        if (turnTimer) clearInterval(turnTimer);
+        turnLeft = seconds;
+        turnTimer = setInterval(() => {
+            turnLeft = Math.max(0, turnLeft - 1);
+            if (turnLeft === 0 && turnTimer) {
+                clearInterval(turnTimer);
+                turnTimer = null;
+            }
+        }, 1000);
+    }
+
+    function connect(mode: 'random' | 'rating') {
+        if (!authStore.isAuthenticated) {
+            message = '로그인 후 이용할 수 있습니다.';
+            return;
+        }
+        phase = 'connecting';
+        message = '';
+        socket = new WebSocket(wsUrl());
+
+        socket.onopen = () => send('join_matching_queue', { mode });
+        socket.onerror = () => {
+            message = '대전 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+            phase = 'idle';
+        };
+        socket.onclose = () => {
+            if (phase !== 'over') phase = 'idle';
+        };
+        socket.onmessage = (ev) => {
+            let msg: Record<string, unknown>;
+            try {
+                msg = JSON.parse(ev.data);
+            } catch {
+                return;
+            }
+            handleMessage(msg);
+        };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function handleMessage(msg: any) {
+        switch (msg.type) {
+            case 'connected':
+                entryFee = msg.entryFee ?? 1000;
+                myStats = msg.stats ?? null;
+                break;
+            case 'matching_status':
+                if (msg.status === 'queued') {
+                    phase = 'queued';
+                    queuePosition = msg.position ?? 0;
+                    entryFee = msg.entryFee ?? entryFee;
+                } else if (msg.status === 'matched') {
+                    roomId = msg.roomId;
+                    opponent = msg.opponent ?? null;
+                } else if (msg.status === 'error') {
+                    message = msg.message ?? '매칭에 실패했습니다.';
+                    phase = 'idle';
+                    close();
+                }
+                break;
+            case 'game_start':
+                phase = 'playing';
+                board = msg.gameState?.board ?? emptyBoard();
+                myColor = msg.playerColor ?? 0;
+                currentPlayer = msg.gameState?.currentPlayer ?? 1;
+                startTurnCountdown(msg.turnSeconds ?? 60);
+                break;
+            case 'move':
+                board[msg.y][msg.x] = msg.player;
+                board = board;
+                currentPlayer = msg.currentPlayer ?? currentPlayer;
+                startTurnCountdown(60);
+                break;
+            case 'game_restored':
+                phase = 'playing';
+                board = msg.gameState?.board ?? board;
+                myColor = msg.gameState?.playerColor ?? myColor;
+                currentPlayer = msg.gameState?.currentPlayer ?? currentPlayer;
+                message = '대국에 다시 연결했습니다.';
+                break;
+            case 'opponent_disconnected':
+                message = msg.message ?? '상대방의 연결이 끊겼습니다.';
+                break;
+            case 'opponent_reconnected':
+                message = '상대방이 다시 접속했습니다.';
+                break;
+            case 'game_over':
+                phase = 'over';
+                result = { youWon: !!msg.youWon, reason: msg.reason ?? '' };
+                myStats = msg.stats ?? myStats;
+                if (msg.message) message = msg.message;
+                if (turnTimer) {
+                    clearInterval(turnTimer);
+                    turnTimer = null;
+                }
+                break;
+            case 'error':
+                message = msg.message ?? '';
+                break;
+        }
+    }
+
+    function play(x: number, y: number) {
+        if (!isMyTurn || board[y][x] !== 0) return;
+        send('move', { roomId, x, y });
+    }
+
+    function surrender() {
+        if (!confirm('기권하시겠습니까? 패배로 기록됩니다.')) return;
+        send('surrender', { roomId });
+    }
+
+    function cancelQueue() {
+        send('cancel_matching');
+        phase = 'idle';
+        close();
+    }
+
+    function close() {
+        socket?.close();
+        socket = null;
+        if (turnTimer) {
+            clearInterval(turnTimer);
+            turnTimer = null;
+        }
+    }
+
+    function resetToIdle() {
+        board = emptyBoard();
+        result = null;
+        opponent = null;
+        roomId = '';
+        phase = 'idle';
+        close();
+    }
+
+    onDestroy(close);
+
+    const reasonText: Record<string, string> = {
+        five: '오목 완성',
+        resign: '기권',
+        timeout: '시간 초과',
+        disconnect: '상대 이탈',
+        draw: '무승부'
+    };
+</script>
+
+<Card.Root>
+    <Card.Header>
+        <Card.Title class="flex items-center gap-2 text-base">
+            온라인 대전
+            {#if myStats}
+                <Badge variant="secondary">
+                    {myStats.wins}승 {myStats.losses}패 · {myStats.rating}
+                </Badge>
+            {/if}
+        </Card.Title>
+        <Card.Description>
+            같은 시간에 접속한 앙님과 겨룹니다. 참가비 <b>{entryFee.toLocaleString()}P</b>가
+            필요합니다.
+        </Card.Description>
+    </Card.Header>
+    <Card.Content class="space-y-3">
+        {#if message}
+            <p class="text-sm text-amber-600 dark:text-amber-400">{message}</p>
+        {/if}
+
+        {#if phase === 'idle'}
+            <div class="space-y-3 rounded-lg border p-4">
+                <p class="text-sm">
+                    대국이 시작되면 <b>{entryFee.toLocaleString()}P가 차감</b>됩니다. 참가비는
+                    돌려받지 못하며 승패는 전적과 점수에만 반영됩니다. 자리를 비우거나 창을 닫으면
+                    <b>패배로 처리</b>됩니다.
+                </p>
+                <label class="flex items-center gap-2 text-sm">
+                    <input type="checkbox" bind:checked={agreed} class="h-4 w-4" />
+                    위 내용을 확인했습니다.
+                </label>
+                <div class="flex flex-wrap gap-2">
+                    <Button disabled={!agreed} onclick={() => connect('random')}>바로 대전</Button>
+                    <Button variant="outline" disabled={!agreed} onclick={() => connect('rating')}>
+                        비슷한 실력끼리
+                    </Button>
+                </div>
+            </div>
+        {:else if phase === 'connecting'}
+            <p class="text-muted-foreground text-sm">대전 서버에 연결 중…</p>
+        {:else if phase === 'queued'}
+            <div class="space-y-2 rounded-lg border p-4">
+                <p class="text-sm">상대를 찾고 있습니다… (대기 {queuePosition}번째)</p>
+                <p class="text-muted-foreground text-xs">
+                    매칭이 되는 순간 참가비가 차감됩니다. 아직 차감되지 않았습니다.
+                </p>
+                <Button variant="ghost" size="sm" onclick={cancelQueue}>취소</Button>
+            </div>
+        {/if}
+
+        {#if phase === 'playing' || phase === 'over'}
+            <div class="flex flex-wrap items-center gap-2 text-sm">
+                <Badge variant={myColor === 1 ? 'default' : 'secondary'}>
+                    나 · {myColor === 1 ? '흑' : '백'}
+                </Badge>
+                <span class="text-muted-foreground">vs</span>
+                <Badge variant="outline">
+                    {opponent?.nickname ?? '상대'}{opponent?.rating ? ` (${opponent.rating})` : ''}
+                </Badge>
+                {#if phase === 'playing'}
+                    <span
+                        class="ml-auto {isMyTurn
+                            ? 'font-semibold text-emerald-600'
+                            : 'text-muted-foreground'}"
+                    >
+                        {isMyTurn ? `내 차례 · ${turnLeft}초` : '상대 차례'}
+                    </span>
+                {/if}
+            </div>
+
+            <div class="overflow-x-auto">
+                <svg
+                    viewBox="0 0 {W} {W}"
+                    style="width:{W}px;max-width:100%"
+                    class="rounded bg-amber-100"
+                >
+                    {#each Array(SIZE) as _, i (i)}
+                        <line
+                            x1={PAD}
+                            y1={PAD + i * CELL}
+                            x2={W - PAD}
+                            y2={PAD + i * CELL}
+                            stroke="#8b5e34"
+                            stroke-width="1"
+                        />
+                        <line
+                            x1={PAD + i * CELL}
+                            y1={PAD}
+                            x2={PAD + i * CELL}
+                            y2={W - PAD}
+                            stroke="#8b5e34"
+                            stroke-width="1"
+                        />
+                    {/each}
+                    {#each board as row, y (y)}
+                        {#each row as cell, x (x)}
+                            {#if cell !== 0}
+                                <circle
+                                    cx={PAD + x * CELL}
+                                    cy={PAD + y * CELL}
+                                    r={CELL * 0.42}
+                                    fill={cell === 1 ? '#111' : '#fff'}
+                                    stroke="#333"
+                                />
+                            {:else if phase === 'playing'}
+                                <rect
+                                    x={PAD + x * CELL - CELL / 2}
+                                    y={PAD + y * CELL - CELL / 2}
+                                    width={CELL}
+                                    height={CELL}
+                                    fill="transparent"
+                                    class={isMyTurn ? 'cursor-pointer' : 'cursor-not-allowed'}
+                                    role="button"
+                                    tabindex="-1"
+                                    aria-label={`${x + 1}, ${y + 1} 에 두기`}
+                                    onclick={() => play(x, y)}
+                                    onkeydown={(e) => e.key === 'Enter' && play(x, y)}
+                                />
+                            {/if}
+                        {/each}
+                    {/each}
+                </svg>
+            </div>
+
+            {#if phase === 'playing'}
+                <Button variant="outline" size="sm" onclick={surrender}>기권</Button>
+            {:else if result}
+                <div class="space-y-2 rounded-lg border p-4">
+                    <p class="text-base font-semibold">
+                        {result.youWon ? '🎉 승리했습니다!' : '아쉽게 패했습니다.'}
+                        <span class="text-muted-foreground text-sm font-normal">
+                            ({reasonText[result.reason] ?? result.reason})
+                        </span>
+                    </p>
+                    {#if myStats}
+                        <p class="text-muted-foreground text-sm">
+                            전적 {myStats.wins}승 {myStats.losses}패 {myStats.draws}무 · 점수 {myStats.rating}
+                        </p>
+                    {/if}
+                    <Button size="sm" onclick={resetToIdle}>다시 하기</Button>
+                </div>
+            {/if}
+        {/if}
+    </Card.Content>
+</Card.Root>

--- a/apps/web/src/routes/games/omok/+page.svelte
+++ b/apps/web/src/routes/games/omok/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
     import OmokGame from '$lib/components/features/game/omok-game.svelte';
+    import OmokOnline from '$lib/components/features/game/omok-online.svelte';
     import { SeoHead } from '$lib/seo/index.js';
+    import { authStore } from '$lib/stores/auth.svelte.js';
+
+    // 온라인 대전은 로그인·참가비가 필요하므로 기본 탭은 AI 연습으로 둔다.
+    let tab = $state<'ai' | 'online'>('ai');
 </script>
 
 <SeoHead
@@ -14,7 +19,43 @@
     <div class="mb-6">
         <a href="/games" class="text-muted-foreground hover:text-foreground text-sm">← 게임 목록</a>
         <h1 class="text-foreground mt-2 text-2xl font-bold">오목</h1>
-        <p class="text-muted-foreground text-sm">AI 또는 친구와 오목 대결 (5줄 먼저 만들면 승리)</p>
+        <p class="text-muted-foreground text-sm">5줄을 먼저 만들면 승리합니다.</p>
     </div>
-    <OmokGame />
+
+    <div class="mb-4 inline-flex rounded-lg border p-1">
+        <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm {tab === 'ai'
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground'}"
+            onclick={() => (tab = 'ai')}
+        >
+            AI와 연습
+        </button>
+        <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm {tab === 'online'
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground'}"
+            onclick={() => (tab = 'online')}
+        >
+            온라인 대전
+        </button>
+    </div>
+
+    {#if tab === 'ai'}
+        <OmokGame />
+    {:else if authStore.isAuthenticated}
+        <OmokOnline />
+    {:else}
+        <div class="rounded-lg border p-6 text-center">
+            <p class="text-sm">온라인 대전은 로그인 후 이용할 수 있습니다.</p>
+            <a
+                href="/login?redirect=%2Fgames%2Fomok"
+                class="text-primary mt-2 inline-block text-sm underline"
+            >
+                로그인하기
+            </a>
+        </div>
+    {/if}
 </div>


### PR DESCRIPTION
## 오목 온라인 대전 — 웹 클라이언트 (Part A 마지막 조각)

be#626(서버)·be#628(배포)과 짝. 지금 `/games/omok` 은 서버와 무관한 로컬 AI 게임이라 **서버를 살려도 붙을 클라이언트가 없었다**.

### 변경
- `/games/omok` 에 「AI와 연습」/「온라인 대전」 탭. **기존 AI 게임은 그대로 보존**(기본 탭)
- `omok-online.svelte` 신규 — `wss://…/omok-ws/?token=` 로 연결(브라우저 WebSocket 은 헤더를 못 붙여 쿼리로 전달, 서버가 둘 다 받음)
- **⛔ 참가비 동의 없이는 큐 진입 불가** — 1,000P 차감·환불 없음·이탈 시 패배를 명시하고 체크박스 동의를 받는다. 대기 중에는 "아직 차감되지 않았다"고 알린다. 포인트가 조용히 빠져나가는 화면은 만들지 않는다
- 대기 순번 / 내 차례 60초 카운트다운 / 기권 / 결과(승패·사유·전적·점수)
- 재접속 시 `game_restored` 로 진행 중 대국 복구
- 비로그인은 로그인 안내(참가비가 걸리므로 익명 대국 없음)
- 착수 유효성·승패는 **서버 판정만** 신뢰 — 클라이언트는 좌표만 보낸다

### ⛔ 아직 동작하지 않는다
서버가 뜨려면 남은 두 가지가 선행되어야 한다(be#628 참조):
1. angple-k8s 에 매니페스트 반영·apply
2. 호스트 nginx `/omok-ws/` → NodePort 30084 변경

그 전까지 「온라인 대전」 탭은 연결 실패 안내만 뜬다(AI 연습은 정상).