### PR TITLE
fix(editor): add line-break button and pin markdown options

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -35,9 +35,15 @@
         DialogTitle,
         DialogFooter
     } from '$lib/components/ui/dialog/index.js';
-    import { marked } from 'marked';
+    import { Marked } from 'marked';
     import TurndownService from 'turndown';
     import { isImageFile } from '$lib/utils/image-convert.js';
+
+    // ⛔ 전역 `marked` 싱글턴을 쓰지 않는다. breaks:true 를 켜는 곳이
+    //    markdown.svelte 의 모듈 최상위라서, 글 상세를 한 번도 안 거치고
+    //    글쓰기로 바로 들어오면(북마크·새로고침·공유시트) breaks 가 false 로 남아
+    //    마크다운 모드에서 줄바꿈이 통째로 뭉쳤다. 로컬 인스턴스로 고정한다.
+    const marked = new Marked({ gfm: true, breaks: true });
 
     const lowlight = createLowlight(common);
     const turndown = new TurndownService({
@@ -46,6 +52,7 @@
     });
 
     // 아이콘
+    import CornerDownLeft from '@lucide/svelte/icons/corner-down-left';
     import Bold from '@lucide/svelte/icons/bold';
     import Italic from '@lucide/svelte/icons/italic';
     import UnderlineIcon from '@lucide/svelte/icons/underline';
@@ -772,6 +779,12 @@
     }
 
     // 툴바 버튼 클릭 핸들러
+    // 줄바꿈(<br>) 삽입 — 모바일에는 Shift+Enter 가 없어 이 버튼이 유일한 경로다.
+    // 엔터는 새 문단(<p>)이라 본문 간격이 넓어지는데(qa/82197), 붙여 쓰고 싶을 때 쓴다.
+    function insertLineBreak(): void {
+        editor?.chain().focus().setHardBreak().run();
+    }
+
     function toggleBold(): void {
         editor?.chain().focus().toggleBold().run();
     }
@@ -1301,6 +1314,23 @@
                 <Redo class="h-4 w-4" />
             </Button>
         </div>
+
+        <div class="bg-border mx-1 h-6 w-px" role="separator"></div>
+
+        <!-- 줄바꿈 — 모바일에는 Shift+Enter 가 없다(qa/82197). 툴바 앞쪽에 둬야
+             가로 스크롤에서 화면 밖으로 밀리지 않는다. -->
+        <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onclick={insertLineBreak}
+            {disabled}
+            class="h-8 w-8 p-0"
+            title="줄바꿈 (문단을 나누지 않고 다음 줄로)"
+            aria-label="줄바꿈 삽입"
+        >
+            <CornerDownLeft class="h-4 w-4" />
+        </Button>
 
         <div class="bg-border mx-1 h-6 w-px" role="separator"></div>
 


### PR DESCRIPTION
## qa/82197 — 「엔터 치면 너무 띄엄띄엄」 1차 (무위험분만)

### 실측으로 확인한 사실
- 엔터는 새 문단(`<p>`)을 만들고, 렌더 CSS가 문단마다 여백을 청구한다: `.prose p { margin: .75rem 0; line-height: 1.8 }` → **엔터 40.8px vs Shift+엔터 28.8px (42% 차이)**
- 최근 글 3,208건 중 **91.8%가 한 줄마다 `<p>`** (Shift+엔터 사용 7.9%). 즉 회원 대다수가 엔터를 줄바꿈으로 쓰는데 렌더가 매 줄에 12px를 더 붙인다
- 같은 요구가 bug #224 → #1767 → #7809 로 이미 세 번 올라왔고 마진·엔터 의미를 건드린 커밋은 **한 번도 없다**

### 이 PR 이 고치는 것 (렌더는 건드리지 않음)
1. **툴바에 「줄바꿈」 버튼** — 모바일에는 Shift+Enter 가 없어 `<br>` 에 도달할 방법이 **아예 없었다**(에디터에 모바일 분기 0줄, 하드브레이크 버튼 부재). 가로 스크롤에서 밀리지 않도록 툴바 앞쪽(실행취소 옆)에 배치
2. **마크다운 모드의 `marked` 를 로컬 인스턴스로 고정**(gfm+breaks) — 기존엔 전역 싱글턴을 썼는데 `breaks:true` 를 켜는 곳이 `markdown.svelte` **모듈 최상위**라, 글 상세를 거치지 않고 글쓰기로 직행하면(북마크·새로고침·공유시트) `breaks:false` 로 남아 줄바꿈이 통째로 뭉쳤다. 회원들이 서로 안내하던 "MD 모드로 바꾸세요" 우회법이 **때에 따라 듣지 않던 이유**

### ⚠️ 하지 않은 것 (별도 판단 필요)
- `.prose p` 마진·line-height 조정 → **기존 글 전체 렌더가 즉시 바뀐다**
- 에디터 CSS를 렌더와 일치시키기 → 작성 화면이 지금 ~36px 로 보이다가 게시하면 40.8px 로 벌어진다(사용자가 "올라가면 띄엄띄엄"이라 하는 이유). 위 항목과 함께 가야 함
- 엔터 의미 자체를 `<br>` 로 바꾸기 → 목록·인용에서 회귀 위험

### 검증
- 모바일 폭에서 툴바 첫 화면에 줄바꿈 버튼이 보이는지
- 버튼 클릭 시 `<br>` 삽입(문단 안 나뉨), 기존 Shift+Enter 동작 유지
- 글 상세를 거치지 않고 `/free/write` 직접 진입 → MD 모드에서 단일 개행이 `<br>` 로 변환되는지