### PR TITLE
fix(content): tighten paragraph spacing and align editor with render

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -2056,9 +2056,17 @@
         margin-bottom: 0.5rem;
     }
 
-    /* 문단 스타일 */
+    /* 문단 스타일
+     *
+     * ⛔ 게시 후 렌더(markdown.svelte 의 .prose p)와 **같은 값**이어야 한다.
+     *    예전엔 여기에 margin-top 도 line-height 도 없어서, 작성 화면은
+     *    ~36px 로 보이다가 게시하면 40.8px 로 벌어졌다. 제보 문구가
+     *    "엔터치면 띄엄띄엄 **올라갑니다**" 였던 이유다(qa/82197).
+     *    한쪽만 바꾸면 괴리가 다시 생기므로 두 파일을 함께 고칠 것. */
     :global(.tiptap-content .tiptap p) {
-        margin-bottom: 0.75rem;
+        margin-top: 0.35rem;
+        line-height: 1.8;
+        margin-bottom: 0.35rem;
     }
 
     /* 목록 스타일 */

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -392,9 +392,20 @@
         margin-bottom: 0.5rem;
     }
 
+    /* 문단 여백 (qa/82197 — "엔터치면 너무 띄엄띄엄")
+     *
+     * 실측: 최근 글 3,208건 중 91.8% 가 **한 줄마다 한 문단**이다
+     * (Shift+Enter 로 <br> 을 쓰는 글은 7.9%). 즉 회원 대다수는 엔터를
+     * "줄바꿈"으로 쓰는데, 문단마다 0.75rem 을 물리면 사실상 모든 줄에
+     * 12px 이 더 붙는다 — 16px 기준 줄 간격이 40.8px 로 벌어졌다.
+     * 0.35rem 으로 낮추면 34.4px(-16%). 진짜 문단 구분은 빈 줄
+     * (아래 p:empty 1.8em)이 계속 담당하므로 문단감은 유지된다.
+     *
+     * ⛔ line-height 1.8 은 이번에 건드리지 않는다. 두 축을 한꺼번에
+     *    바꾸면 반응이 나빴을 때 원인을 가릴 수 없다. */
     .prose :global(p) {
-        margin-top: 0.75rem;
-        margin-bottom: 0.75rem;
+        margin-top: 0.35rem;
+        margin-bottom: 0.35rem;
         font-size: inherit;
         line-height: 1.8;
     }


### PR DESCRIPTION
## qa/82197 2차 — 본문 줄 간격 (A+C)

1차(fe#1984, 줄바꿈 버튼·marked 고정)에 이어 **렌더 간격**을 조정한다.

### 근거(실측)
- 최근 글 3,208건 중 **91.8%가 한 줄마다 한 문단**(Shift+Enter 로 `<br>` 쓰는 글은 7.9%)
- 즉 회원 대다수가 엔터를 줄바꿈으로 쓰는데 문단마다 0.75rem 을 물려 **사실상 모든 줄에 12px**이 더 붙었다 → 16px 기준 줄 간격 40.8px
- 같은 요구가 bug #224 → #1767 → #7809 → qa/82197 로 **네 번째**

### 변경
- **A**: `.prose p` 마진 0.75rem → **0.35rem** (40.8 → 34.4px, **-16%**). 문단 구분은 빈 줄(`p:empty` 1.8em)이 계속 담당
- **C**: 에디터 문단 CSS에 `margin-top`·`line-height` 추가해 **렌더와 동일**하게. 예전엔 작성 화면이 ~36px 로 보이다 게시하면 40.8px 로 벌어졌다(제보 문구가 "엔터치면 띄엄띄엄 **올라갑니다**" 였던 이유)

⛔ `line-height: 1.8` 은 유지한다 — 두 축을 함께 바꾸면 반응이 나빴을 때 원인을 가릴 수 없다.

### 영향·되돌리기
전 게시물 렌더가 즉시 바뀐다(CSS라 재저장 없음). 되돌리기는 값 두 개 원복이면 끝.