### PR TITLE
fix(omok): surface connection failures + cap comment youtube width

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -2144,6 +2144,9 @@
         aspect-ratio: 16 / 9;
         width: 100% !important;
         height: auto !important;
+        /* bug/13091: PC 에서 댓글 안 영상이 본문만큼 커져 댓글 흐름을 끊었다.
+           모바일은 화면 폭이 곧 상한이라 그대로 두고, 넓은 화면에서만 제한한다. */
+        max-width: 480px;
     }
 
     /* 댓글 내 임베드 컨테이너 스타일 */

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -2056,9 +2056,17 @@
         margin-bottom: 0.5rem;
     }
 
-    /* 문단 스타일 */
+    /* 문단 스타일
+     *
+     * ⛔ 게시 후 렌더(markdown.svelte 의 .prose p)와 **같은 값**이어야 한다.
+     *    예전엔 여기에 margin-top 도 line-height 도 없어서, 작성 화면은
+     *    ~36px 로 보이다가 게시하면 40.8px 로 벌어졌다. 제보 문구가
+     *    "엔터치면 띄엄띄엄 **올라갑니다**" 였던 이유다(qa/82197).
+     *    한쪽만 바꾸면 괴리가 다시 생기므로 두 파일을 함께 고칠 것. */
     :global(.tiptap-content .tiptap p) {
-        margin-bottom: 0.75rem;
+        margin-top: 0.35rem;
+        line-height: 1.8;
+        margin-bottom: 0.35rem;
     }
 
     /* 목록 스타일 */

--- a/apps/web/src/lib/components/features/game/omok-online.svelte
+++ b/apps/web/src/lib/components/features/game/omok-online.svelte
@@ -68,21 +68,51 @@
         }, 1000);
     }
 
+    // ⛔ 동의 전에는 버튼을 비활성으로 두지 않는다 — 눌러도 아무 일이 없으면
+    //    이용자는 "기능이 고장났다" 로 받아들인다. 누르면 이유를 말해준다.
+    function tryConnect(mode: 'random' | 'rating') {
+        if (!agreed) {
+            message = '참가비 안내를 확인하신 뒤 아래 체크박스를 눌러 주세요.';
+            return;
+        }
+        connect(mode);
+    }
+
     function connect(mode: 'random' | 'rating') {
         if (!authStore.isAuthenticated) {
             message = '로그인 후 이용할 수 있습니다.';
             return;
         }
+        if (!authStore.accessToken) {
+            // 토큰이 아직 클라이언트에 없으면 연결해도 401 로 끊긴다.
+            // 원인을 화면에 밝혀 "눌러도 아무 일이 없다" 를 없앤다.
+            message = '로그인 정보를 불러오는 중입니다. 잠시 후 다시 눌러 주세요.';
+            return;
+        }
         phase = 'connecting';
         message = '';
-        socket = new WebSocket(wsUrl());
+        try {
+            socket = new WebSocket(wsUrl());
+        } catch {
+            message = '대전 서버 주소에 연결할 수 없습니다.';
+            phase = 'idle';
+            return;
+        }
 
         socket.onopen = () => send('join_matching_queue', { mode });
         socket.onerror = () => {
             message = '대전 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.';
             phase = 'idle';
         };
-        socket.onclose = () => {
+        socket.onclose = (ev) => {
+            // 정상 종료가 아니면 이유를 남긴다 — 조용히 idle 로 돌아가면
+            // 이용자는 "버튼이 안 먹는다" 로만 느낀다.
+            if (phase === 'connecting' && !message) {
+                message =
+                    ev.code === 1006
+                        ? '대전 서버와 연결이 끊겼습니다. 로그인 상태를 확인한 뒤 다시 시도해 주세요.'
+                        : `연결이 종료되었습니다. (코드 ${ev.code})`;
+            }
             if (phase !== 'over') phase = 'idle';
         };
         socket.onmessage = (ev) => {
@@ -236,8 +266,8 @@
                     위 내용을 확인했습니다.
                 </label>
                 <div class="flex flex-wrap gap-2">
-                    <Button disabled={!agreed} onclick={() => connect('random')}>바로 대전</Button>
-                    <Button variant="outline" disabled={!agreed} onclick={() => connect('rating')}>
+                    <Button onclick={() => tryConnect('random')}>바로 대전</Button>
+                    <Button variant="outline" onclick={() => tryConnect('rating')}>
                         비슷한 실력끼리
                     </Button>
                 </div>

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -392,9 +392,20 @@
         margin-bottom: 0.5rem;
     }
 
+    /* 문단 여백 (qa/82197 — "엔터치면 너무 띄엄띄엄")
+     *
+     * 실측: 최근 글 3,208건 중 91.8% 가 **한 줄마다 한 문단**이다
+     * (Shift+Enter 로 <br> 을 쓰는 글은 7.9%). 즉 회원 대다수는 엔터를
+     * "줄바꿈"으로 쓰는데, 문단마다 0.75rem 을 물리면 사실상 모든 줄에
+     * 12px 이 더 붙는다 — 16px 기준 줄 간격이 40.8px 로 벌어졌다.
+     * 0.35rem 으로 낮추면 34.4px(-16%). 진짜 문단 구분은 빈 줄
+     * (아래 p:empty 1.8em)이 계속 담당하므로 문단감은 유지된다.
+     *
+     * ⛔ line-height 1.8 은 이번에 건드리지 않는다. 두 축을 한꺼번에
+     *    바꾸면 반응이 나빴을 때 원인을 가릴 수 없다. */
     .prose :global(p) {
-        margin-top: 0.75rem;
-        margin-bottom: 0.75rem;
+        margin-top: 0.35rem;
+        margin-bottom: 0.35rem;
         font-size: inherit;
         line-height: 1.8;
     }


### PR DESCRIPTION
## 1) 오목 온라인 대전 — 실사용 첫 시도가 조용히 실패했다

배포 직후 사장님이 시도했으나 **서버 로그·nginx 로그·JS 에러 어디에도 흔적이 없었다**(파드 connections=0, nginx 에 요청 0건). 즉 클라이언트가 연결 시도조차 안 했다는 뜻이고, 화면은 아무 말도 하지 않았다.

원인 후보를 전부 화면에 드러낸다:
- **동의 전 버튼을 `disabled` 로 두던 것 제거** — 눌러도 아무 일이 없으면 이용자는 '고장'으로 받아들인다. 이제 누르면 "체크박스를 눌러 주세요"라고 말해준다 (가장 유력한 원인)
- `accessToken` 이 아직 없으면(하이드레이션 전) 연결 대신 안내
- WebSocket 생성 예외·비정상 종료(1006 등)를 화면 메시지로 노출

## 2) bug/13091 — PC 댓글 유튜브 과대
댓글 속 영상이 본문 폭만큼 커져 댓글 흐름을 끊었다. 모바일은 화면 폭이 곧 상한이라 그대로 두고 **480px 로 제한**.