### PR TITLE
fix(routes): reserve /support slug and unify board pagination type

### DIFF
--- a/apps/web/src/params/entityslug.ts
+++ b/apps/web/src/params/entityslug.ts
@@ -18,7 +18,7 @@ import type { ParamMatcher } from '@sveltejs/kit';
  *    이 일치 여부는 entityslug.test.ts 가 실제 디렉터리를 읽어 검사하므로,
  *    빠뜨리면 사람이 기억하지 못해도 **CI 가 먼저 실패한다**.
  */
-export const RESERVED = new Set(['write', 'manage']);
+export const RESERVED = new Set(['write', 'manage', 'support']);
 
 export const match: ParamMatcher = (param) => {
     if (param.length === 0) return false;

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -255,7 +255,12 @@ export const load: PageServerLoad = async ({
             postsData: {
                 posts: [],
                 notices: [],
-                pagination: { page, limit, total: 0, totalPages: 0 },
+                pagination: {
+                    page,
+                    limit,
+                    total: 0,
+                    totalPages: 0
+                } as PostsCacheData['pagination'],
                 error: '로그인 후 검색할 수 있습니다.'
             },
             promotionData: [],


### PR DESCRIPTION
main 의 CI 가 빨간 상태여서 고친다. 두 건 모두 이번 배포분의 변경과는 무관한 기존 결함이고, 각각을 잡아내라고 만들어 둔 가드가 실제로 잡아냈다.

## 1) `/[boardId]/support` 가 매처 예약어에 빠져 있었다

소모임 돌보기 콘솔을 추가하면서 `entityslug` 매처의 `RESERVED` 에 등록하지 않았다. 등록하지 않으면 `/angtt/[slug=entityslug]` 가 `/[boardId]/support` 보다 먼저 잡혀 **콘솔이 404** 가 된다 — 7/20 앙TT 글쓰기 404 와 같은 경로다.

`entityslug.test.ts` 가 실제 디렉터리를 읽어 대조하도록 만들어 둔 덕분에 사람이 기억하지 못해도 CI 가 먼저 실패했다. 의도대로 동작한 것이니 가드는 그대로 둔다.

## 2) 게시판 pagination 타입이 합집합으로 갈라졌다

비로그인 검색 조기 반환의 `pagination` 리터럴이 좁은 타입이라 `postsData` 가 두 갈래로 갈라졌고, `+page.svelte` 에서 `hasNext`·`dateMode`·`nextCursor` 를 읽는 4곳이 타입 오류를 냈다. 같은 파일 694행과 동일하게 캐시 타입으로 맞춘다.

같은 함수 안에 "모든 return 이 같은 필드를 가져야 합집합으로 갈라지지 않는다"는 주석이 이미 있었는데, pagination 한 겹 아래에서 같은 일이 반복됐다.

## 영향
런타임 동작 변화는 `/angtt/support` 뿐이고 나머지는 타입 정합성 교정이다.