### PR TITLE
fix(editor): stop dropping images silently when upload fails

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -95,6 +95,22 @@ const NOTIFICATION_READ_CONFIG: Partial<RetryConfig> = {
 // 클라이언트에서 직접 사용할 일이 줄어듦 (exchangeToken 등 레거시 호환용으로 유지)
 
 /**
+ * 업로드 중 발생한 예외를 사람이 읽을 수 있는 문구로 바꾼다.
+ *
+ * AbortError 의 기본 문구는 "signal is aborted without reason" 이라 그대로
+ * 보여주면 아무것도 알려주지 못한다. 이 문구는 실패 알림에 그대로 실린다.
+ */
+function toUploadError(err: unknown, file: File): Error {
+    if (err instanceof Error && err.name === 'AbortError') {
+        const mb = (file.size / (1024 * 1024)).toFixed(1);
+        return new Error(
+            `업로드가 시간 안에 끝나지 않았습니다 (${mb}MB). 연결 상태를 확인해 주세요.`
+        );
+    }
+    return err instanceof Error ? err : new Error('업로드 실패');
+}
+
+/**
  * API 클라이언트
  *
  * 🔒 보안 기능:
@@ -1687,6 +1703,21 @@ class ApiClient {
     }
 
     /**
+     * 업로드 타임아웃 — 파일 크기에 비례시킨다.
+     *
+     * bug/13371: 종전에는 이미지에 30초 고정이었다. 모바일 회선에서 9~10MB 사진은
+     * 30초 안에 못 올려 AbortError 로 끊기고, 재시도 2회도 같은 이유로 끊긴 뒤
+     * 에디터가 본문에서 그 이미지를 조용히 지웠다("사진이 사라진다" 제보의 실체).
+     * 실효 100KB/s 를 바닥으로 잡아 여유를 준다 — 느린 회선을 기다려 주되,
+     * 진짜 끊긴 연결에 무한정 매달리지는 않도록 상한을 둔다.
+     */
+    private uploadTimeoutMs(file: File): number {
+        const base = file.type.startsWith('video/') ? 120_000 : 30_000;
+        const perSize = Math.ceil(file.size / (100 * 1024)) * 1000;
+        return Math.min(Math.max(base, perSize), 300_000);
+    }
+
+    /**
      * 파일 업로드 (SvelteKit /api/media/images → S3, IAM Role 인증)
      * 🔒 인증 필요
      */
@@ -1717,9 +1748,8 @@ class ApiClient {
 
         // bug/12981: 자매 uploadImage(아래)와 동일한 타임아웃+재시도 — 모바일 회선에서
         // POST 가 stall 하면 무기한 hang 해 에디터 blob 이 잔존하던 비대칭 해소.
-        // 동영상은 파일이 커서 30초로는 정상 업로드도 끊길 수 있어 여유를 둔다.
         const MAX_RETRIES = 2;
-        const UPLOAD_TIMEOUT_MS = file.type.startsWith('video/') ? 120_000 : 30_000;
+        const UPLOAD_TIMEOUT_MS = this.uploadTimeoutMs(file);
         let lastError: Error | null = null;
         let response: Response | null = null;
 
@@ -1738,7 +1768,7 @@ class ApiClient {
                 clearTimeout(timeoutId);
                 break;
             } catch (err) {
-                lastError = err instanceof Error ? err : new Error('업로드 실패');
+                lastError = toUploadError(err, file);
                 if (attempt < MAX_RETRIES) {
                     await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
                     continue;
@@ -1820,7 +1850,7 @@ class ApiClient {
         }
 
         const MAX_RETRIES = 2;
-        const UPLOAD_TIMEOUT_MS = 30_000;
+        const UPLOAD_TIMEOUT_MS = this.uploadTimeoutMs(file);
         let lastError: Error | null = null;
         let response: Response | null = null;
 
@@ -1839,7 +1869,7 @@ class ApiClient {
                 clearTimeout(timeoutId);
                 break;
             } catch (err) {
-                lastError = err instanceof Error ? err : new Error('업로드 실패');
+                lastError = toUploadError(err, file);
                 if (attempt < MAX_RETRIES) {
                     await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
                     continue;
@@ -1855,7 +1885,9 @@ class ApiClient {
             const errorBody = await response.text().catch(() => '');
             let errorMessage = '이미지 업로드에 실패했습니다.';
             if (response.status === 413) {
-                errorMessage = '파일 크기가 너무 큽니다. (최대 10MB)';
+                // 실제 한도는 서버(/api/media/images)가 형식별로 판정한다.
+                // 여기서 숫자를 적으면 서버 값과 어긋나 잘못 안내하게 된다.
+                errorMessage = '파일 크기가 너무 큽니다.';
             } else {
                 try {
                     const parsed = JSON.parse(errorBody);

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -280,6 +280,29 @@
     }
 
     // 에디터 미디어 업로드 핸들러 (이미지 + 동영상, 드래그앤드롭 / 붙여넣기 / 다이얼로그)
+    // bug/13371: 업로드가 실패하면 에디터가 본문에서 그 이미지를 지운다.
+    // 종전에는 그 사실을 콘솔에만 남겨, 작성자는 사진이 소리 없이 사라진 것으로만
+    // 겪었다(여섯 장을 잃고 나서야 알아챈 제보가 있었다). 이제는 무엇이 왜 빠졌는지
+    // 반드시 알린다. 여러 장을 한꺼번에 올리다 실패하면 알림창이 그 수만큼 뜨므로
+    // 잠깐 모아 한 번만 띄운다.
+    let uploadFailures: string[] = [];
+    let uploadFailureTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function notifyUploadFailure(fileName: string, err: unknown): void {
+        const reason = err instanceof Error ? err.message : '알 수 없는 오류';
+        uploadFailures.push(`· ${fileName} — ${reason}`);
+        if (uploadFailureTimer) clearTimeout(uploadFailureTimer);
+        uploadFailureTimer = setTimeout(() => {
+            const list = uploadFailures.join('\n');
+            uploadFailures = [];
+            uploadFailureTimer = null;
+            alert(
+                `아래 파일을 올리지 못해 본문에서 빠졌습니다.\n\n${list}\n\n` +
+                    '다시 넣어 주세요. 사진이 크면 시간이 오래 걸릴 수 있습니다.'
+            );
+        }, 800);
+    }
+
     async function handleEditorImageUpload(
         file: File
     ): Promise<{ url: string; originUrl?: string } | null> {
@@ -293,6 +316,7 @@
             return { url: result.url, originUrl: result.origin_url };
         } catch (err) {
             console.error('[upload-fail] media-upload:', err);
+            notifyUploadFailure(file.name, err);
             return null;
         }
     }
@@ -311,6 +335,7 @@
             return { url: result.url, posterUrl: result.thumbnail_url };
         } catch (err) {
             console.error('[upload-fail] video-upload:', err);
+            notifyUploadFailure(file.name, err);
             return null;
         }
     }


### PR DESCRIPTION
## bug/13371 — "사진이 여섯 장이나 사라졌습니다"

제보자는 사진 아래에 설명을 달아 가며 글을 쓰다가, **사진만 없어지고 자기 멘트만 남은 것**을 뒤늦게 발견했다. 경고도 표시도 없었다.

### 원인
에디터는 업로드가 실패하면 본문에서 그 이미지 노드를 **지운다**(`uploadAndSwap` → `removeImageBySrc`). 그런데 실패 사실은 `console.error` 로만 남았다. 작성자 화면에는 아무 일도 일어나지 않은 것처럼 보인다.

그리고 그 실패가 실제로 자주 일어나고 있었다. 업로드 타임아웃이 **파일 크기와 무관하게 30초 고정**이라, 모바일 회선에서 9~10MB 사진은 시간 안에 못 올려 `AbortError` 로 끊긴다. 재시도 2회도 매번 처음부터 다시 올리므로 같은 이유로 끊긴다. 동영상만 120초로 예외를 뒀는데, 요즘 폰 사진이 그 크기에 근접한다는 점이 빠져 있었다.

ClickHouse 실측(8/6): `[upload-fail] media-upload: AbortError` 가 시간당 5~10건씩 꾸준했고, 전부 화면에는 흔적을 남기지 않았다.

### 변경
- **타임아웃을 크기에 비례시킨다** — 실효 100KB/s 를 바닥으로, 상한 5분. 느린 회선을 기다려 주되 끊긴 연결에 무한정 매달리지는 않는다
- **실패를 반드시 알린다** — 무엇이 왜 빠졌는지 알린다. 여러 장이 함께 실패하면 알림창이 그 수만큼 뜨지 않도록 잠깐 모아 한 번만 띄운다
- `AbortError` 의 기본 문구 "signal is aborted without reason" 을 사람이 읽을 수 있는 말로 바꾼다
- 413 안내가 "최대 10MB" 라고 단언했는데 서버 실제 한도는 이미지 20MB·GIF 8MB 로 형식마다 다르다. 숫자를 빼고 서버 문구를 그대로 전달한다

### 제보자가 함께 요청한 것
"10MB 넘는 사진은 아예 안 들어가고 경고가 떴으면 좋겠다" — 이번 변경으로 실패 시 사유가 안내되므로 그 요구는 충족된다. 다만 **본문 삽입 영역에 한도가 안 보인다**(첨부 영역에만 표기)는 지적은 별건 UI 작업으로 남긴다.