### PR TITLE
fix(post): make the comment-jump counter look like a button

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -42,6 +42,7 @@
     import { ReactionBar } from '$lib/components/features/reaction/index.js';
     import { AvatarStack } from '$lib/components/ui/avatar-stack/index.js';
     import Info from '@lucide/svelte/icons/info';
+    import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import Pin from '@lucide/svelte/icons/pin';
     import ShareButton from '$lib/components/post/share-button.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
@@ -329,13 +330,19 @@
             >
                 <span>조회 {post.views.toLocaleString()}</span>
                 <span>공감 {likeCount.toLocaleString()}</span>
+                <!-- bug/13376: 옆의 조회·공감과 똑같이 생겨서 누를 수 있는 줄 몰랐다는
+                     제보. hover 만으로는 터치 기기에서 아무 단서가 되지 못한다.
+                     테두리와 아래 화살표로 "눌러서 아래로 간다"를 정지 상태에서 보인다. -->
                 <button
                     type="button"
-                    class="hover:text-foreground transition-colors"
+                    class="border-border hover:bg-muted hover:text-foreground -my-0.5 inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0.5 transition-colors"
+                    aria-label="댓글 {post.comments_count}개로 이동"
                     onclick={() =>
                         document.getElementById('comments')?.scrollIntoView({ behavior: 'smooth' })}
-                    >댓글 {post.comments_count.toLocaleString()}</button
                 >
+                    댓글 {post.comments_count.toLocaleString()}
+                    <ChevronDown class="h-3 w-3" aria-hidden="true" />
+                </button>
             </div>
         </div>
 

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -56,6 +56,7 @@
     import { ReactionBar } from '$lib/components/features/reaction/index.js';
     import { AvatarStack } from '$lib/components/ui/avatar-stack/index.js';
     import Info from '@lucide/svelte/icons/info';
+    import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import type { ViewLayoutProps } from '../types.js';
     import ReportCharts from './report-charts.svelte';
 
@@ -568,13 +569,17 @@
             >
                 <span>조회 {post.views.toLocaleString()}</span>
                 <span>공감 {likeCount.toLocaleString()}</span>
+                <!-- bug/13376 — basic.svelte 와 같은 이유로 같은 모양을 쓴다. -->
                 <button
                     type="button"
-                    class="hover:text-foreground transition-colors"
+                    class="border-border hover:bg-muted hover:text-foreground -my-0.5 inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0.5 transition-colors"
+                    aria-label="댓글 {post.comments_count}개로 이동"
                     onclick={() =>
                         document.getElementById('comments')?.scrollIntoView({ behavior: 'smooth' })}
-                    >댓글 {post.comments_count.toLocaleString()}</button
                 >
+                    댓글 {post.comments_count.toLocaleString()}
+                    <ChevronDown class="h-3 w-3" aria-hidden="true" />
+                </button>
             </div>
         </div>
     </CardHeader>


### PR DESCRIPTION
## bug/13376

글 상단 오른쪽의 「댓글 N」은 **누르면 댓글로 내려가는 버튼**인데, 바로 옆의 「조회 N」·「공감 N」과 똑같은 평문으로 보인다. 눌릴 수 있다는 단서가 `hover:text-foreground` 색 변화 하나뿐이라, **터치 기기에서는 단서가 아예 없다**.

제보자는 "인풋을 받을 수 있는 버튼이라는 걸 좀 전에야 알게 됐다"며, 그동안 댓글을 쓸 때마다 매번 맨 아래까지 스크롤해 왔다고 한다. 기능이 있는데 아무도 모르면 없는 것과 같다.

### 변경
테두리와 아래 화살표를 붙여 **정지 상태에서** "눌러서 아래로 간다"가 보이게 한다. `aria-label` 도 함께 붙여 스크린리더에서 목적지가 드러나게 했다.

같은 코드가 `basic`·`report` 두 뷰 레이아웃에 복사돼 있어 함께 고친다(premium 오버라이드는 없음을 확인).

### 하지 않은 것
조회·공감은 그대로 둔다. 이 둘은 실제로 누를 수 없으므로, 버튼처럼 보이게 하면 반대로 거짓 단서가 된다.