### PR TITLE
fix(omok): fetch access token on demand for the websocket handshake

### DIFF
--- a/apps/web/src/lib/components/features/game/omok-online.svelte
+++ b/apps/web/src/lib/components/features/game/omok-online.svelte
@@ -8,7 +8,7 @@
      * ⛔ 참가비 1,000P 가 걸리므로 큐 진입 전에 반드시 동의를 받는다.
      *    포인트가 조용히 빠져나가는 화면은 만들지 않는다.
      */
-    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { authStore, authActions } from '$lib/stores/auth.svelte.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import * as Card from '$lib/components/ui/card/index.js';
@@ -45,8 +45,7 @@
         return Array.from({ length: SIZE }, () => Array(SIZE).fill(0));
     }
 
-    function wsUrl(): string {
-        const token = authStore.accessToken ?? '';
+    function wsUrl(token: string): string {
         const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
         // 브라우저 WebSocket 은 헤더를 못 붙여서 토큰을 쿼리로 전달한다(서버가 둘 다 받는다).
         return `${proto}//${location.host}/omok-ws/?token=${encodeURIComponent(token)}`;
@@ -75,24 +74,29 @@
             message = '참가비 안내를 확인하신 뒤 아래 체크박스를 눌러 주세요.';
             return;
         }
-        connect(mode);
+        void connect(mode);
     }
 
-    function connect(mode: 'random' | 'rating') {
+    async function connect(mode: 'random' | 'rating') {
         if (!authStore.isAuthenticated) {
             message = '로그인 후 이용할 수 있습니다.';
             return;
         }
-        if (!authStore.accessToken) {
-            // 토큰이 아직 클라이언트에 없으면 연결해도 401 로 끊긴다.
-            // 원인을 화면에 밝혀 "눌러도 아무 일이 없다" 를 없앤다.
-            message = '로그인 정보를 불러오는 중입니다. 잠시 후 다시 눌러 주세요.';
-            return;
-        }
         phase = 'connecting';
         message = '';
+
+        // 로그인 상태라도 클라이언트에 토큰이 없는 정상 경로가 있다(운영 기본값인
+        // SSR_STRIP_USER + user_basic 쿠키 fast-path). WebSocket 은 헤더를 못 붙여
+        // 토큰을 쿼리로 넘겨야 하므로, 여기서 필요한 순간에 받아 온다.
+        const token = await authActions.ensureAccessToken();
+        if (!token) {
+            message = '로그인 정보를 확인하지 못했습니다. 새로고침한 뒤 다시 시도해 주세요.';
+            phase = 'idle';
+            return;
+        }
+
         try {
-            socket = new WebSocket(wsUrl());
+            socket = new WebSocket(wsUrl(token));
         } catch {
             message = '대전 서버 주소에 연결할 수 없습니다.';
             phase = 'idle';

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -93,6 +93,37 @@ function initFromSSR(
 }
 
 /**
+ * 클라이언트에 액세스 토큰을 확보한다. 이미 있으면 그대로 돌려준다.
+ *
+ * ⚠️ 로그인 상태인데 토큰이 비어 있는 정상 경로가 존재한다.
+ * `SSR_STRIP_USER=true` 면 레이아웃 SSR 이 user·accessToken 을 모두 떼어내고,
+ * `PUBLIC_USER_BASIC_CLIENT_READ=true` 면 클라이언트가 user_basic 쿠키로
+ * **로그인 상태만** 복원한 뒤 `/api/auth/me` 를 건너뛴다(성능 목적).
+ * 쿠키에는 토큰이 없으므로 결과적으로 토큰만 빈 상태가 된다.
+ *
+ * 평소에는 문제가 되지 않는다 — 화면이 쓰는 API 는 전부 SvelteKit 라우트를
+ * 거쳐 httpOnly 세션 쿠키로 인증되기 때문이다. 그러나 브라우저 WebSocket 은
+ * 헤더를 붙일 수 없어 토큰을 쿼리로 넘겨야 한다. 그런 기능만 이 함수로
+ * 필요한 순간에 토큰을 받아 온다(레이아웃의 fast-path 는 건드리지 않는다).
+ */
+async function ensureAccessToken(): Promise<string | null> {
+    const existing = apiClient.getAccessToken?.() ?? null;
+    if (existing) return existing;
+    try {
+        const res = await fetch('/api/auth/me', { credentials: 'same-origin' });
+        if (!res.ok) return null;
+        const me = await res.json();
+        if (me?.accessToken) {
+            apiClient.setAccessToken(me.accessToken);
+            return me.accessToken;
+        }
+    } catch {
+        // 네트워크 실패 — 호출부가 사용자에게 알린다
+    }
+    return null;
+}
+
+/**
  * 인증 상태 초기화
  * 앱 시작 시 호출 — 세션 기반: SSR이 인증 권위, 클라이언트 추가 인증 없음
  */
@@ -170,6 +201,7 @@ export function getError() {
 export const authActions = {
     initAuth,
     initFromSSR,
+    ensureAccessToken,
     fetchCurrentUser,
     resetAuth,
     redirectToLogin,


### PR DESCRIPTION
운영에서 온라인 대전이 **「로그인 정보를 불러오는 중입니다」에서 멈춘다.**

## 원인 — 로그인 상태인데 토큰이 없는 정상 경로가 있었다

운영 환경값이 `SSR_STRIP_USER=true` + `PUBLIC_USER_BASIC_CLIENT_READ=true` 다. 이 조합에서는

1. 레이아웃 SSR 이 캐시 가능하도록 `user`·`accessToken` 을 **둘 다 떼어내고**,
2. 클라이언트가 `user_basic` 쿠키로 **로그인 상태만** 복원한 뒤 `/api/auth/me` 를 **건너뛴다**(매 로드마다 Redis+DB 를 타지 않으려고 일부러 만든 경로).

쿠키에는 토큰이 없으므로 결과적으로 `accessToken` 만 빈 상태가 된다. `+layout.svelte` 의 fast-path 가 `syncAuth({...data, user})` 를 부르는데 `data.accessToken` 은 null 이라 `initFromSSR(..., '')` 로 들어간다.

화면이 쓰는 API 는 전부 SvelteKit 라우트를 거쳐 httpOnly 세션 쿠키로 인증되므로 **평소엔 이 공백이 드러나지 않는다.** 브라우저 WebSocket 만 헤더를 붙일 수 없어 토큰을 쿼리로 넘겨야 하고, 그래서 이 기능에서만 터졌다.

앞선 fe#1986 에서 "토큰 없음"을 화면에 노출하도록 해 둔 덕에 증상이 곧장 원인을 가리켰다. 그 전이라면 빈 토큰으로 붙었다가 401 로 조용히 끊겨 아무 단서도 남지 않았을 것이다(실제로 서버·nginx 양쪽에 요청 0건이었다).

## 변경
`authActions.ensureAccessToken()` — 토큰이 있으면 그대로 쓰고, 없을 때만 `/api/auth/me` 로 받아 `apiClient` 에 넣는다. 오목은 연결 직전에 이걸 부른다.

**레이아웃의 fast-path 는 건드리지 않는다.** 성능을 위해 일부러 만든 경로이고, 여기서 `/api/auth/me` 를 되살리면 모든 페이지 로드가 다시 Redis+DB 를 타게 된다. 토큰이 실제로 필요한 기능만 그때 받아 오는 것이 맞다.

## 앞으로
직접 Go 백엔드를 부르거나 WebSocket 을 여는 기능은 `authStore.accessToken` 을 그냥 읽으면 안 된다. `ensureAccessToken()` 을 거쳐야 한다.