### PR TITLE
feat(observability): capture call stacks for hydration warnings

### DIFF
--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -494,6 +494,34 @@ if (typeof window !== 'undefined') {
         return null;
     }
 
+    // 하이드레이션 경고에는 Error 객체가 없다. Svelte 가 문자열만 넘기기 때문에
+    // 종전에는 stack 이 전부 '(no stack)' 이었고(실측: 3일 435,378건 중 93%),
+    // 그래서 "어느 컴포넌트에서 갈리는가"를 데이터로 좁힐 수 없었다.
+    // 호출 시점에 Error 를 만들어 호출 스택을 대신 뜬다.
+    //
+    // ⛔ 수집기는 스키마에 없는 필드를 버린다(js_errors 컬럼 고정). 그래서 진단에
+    //    필요한 부가 정보는 새 필드가 아니라 stack 머리에 실어 보낸다.
+    //    at=페이지 시작 후 경과(ms) — 하이드레이션과 인라인 스크립트(테마 적용·
+    //    Clarity·다크모드 폴백)의 경합 가설을 이 값 분포로 직접 검증한다.
+    //
+    // Error 생성은 공짜가 아니고, 이 코드가 도는 시점이 하필 하이드레이션 중이다.
+    // guardedSend 의 스로틀(같은 메시지 5건)에 걸려 버려질 몫까지 만들지 않도록
+    // 합성 횟수를 페이지 로드당 따로 묶는다. 컴포넌트 특정에는 몇 건이면 족하다.
+    let synthesizedStacks = 0;
+    const MAX_SYNTHESIZED_STACKS = 8;
+
+    function buildStack(err: Error | undefined): string {
+        const head = `at=${Math.round(performance.now())}ms`;
+        if (err?.stack) return `${head}\n${err.stack.slice(0, 1500)}`;
+        if (synthesizedStacks >= MAX_SYNTHESIZED_STACKS) return `${head}\n(no stack)`;
+        synthesizedStacks++;
+        // 상위 프레임 몇 개면 컴포넌트 특정에 충분하다. 전량을 담으면 저장만 늘고
+        // 아래쪽은 전부 Svelte 내부라 판별에 기여하지 않는다.
+        const synthetic = new Error('hydration-capture').stack ?? '';
+        const frames = synthetic.split('\n').slice(1, 13).join('\n');
+        return `${head}\n(synthesized)\n${frames}`.slice(0, 1500);
+    }
+
     function captureFromConsole(args: unknown[], channel: 'error' | 'warn') {
         const first = String(args[0] ?? '');
         const hit = classifyConsoleMessage(first);
@@ -510,7 +538,7 @@ if (typeof window !== 'undefined') {
             reason: hit.reason,
             channel,
             message: `${first} ${detail}`.trim().slice(0, 400),
-            stack: err?.stack?.slice(0, 1500) || '(no stack)',
+            stack: buildStack(err),
             url: window.location.href,
             userAgent: navigator.userAgent
         });


### PR DESCRIPTION
## 문제 — 빈도는 보이는데 위치를 못 좁힌다

fe#1887 로 하이드레이션 실패 수집을 고친 뒤(7/28), 규모가 드러났다.

| | 3일 실측 |
|---|---|
| `anchor_detached` | 203,779건 / **3,876명** |
| `hydration_mismatch` | 178,560건 / 3,163명 |
| `Failed to hydrate: HierarchyRequestError` | 23,368건 / 717명 |

3,876명은 사실상 활동 회원 전부다. 홈에서만 1인당 하루 10건꼴이라 **매 로드마다 몇 건씩** 나고 있다는 뜻이고, 이 규모는 확장 프로그램으로 설명되지 않는다(확장 모양인 `HierarchyRequestError` 는 717명, 전체의 5%다).

그런데 **stack 이 435,378건 중 93%가 `(no stack)`** 이다. Svelte 는 하이드레이션 경고를 문자열로만 넘겨 Error 객체가 없고, 수집 코드는 `err?.stack ?? '(no stack)'` 이었다. 그래서 "어느 컴포넌트에서 갈리는가"를 데이터로 좁힐 방법이 없다.

가설 셋 중 둘은 이미 반증했다 — 확장 스택은 435,378건 중 55건뿐이고, 운영 HTML 을 태그 스택으로 검사한 결과 **구조 위반 0건**이었다. 남은 후보는 하이드레이션 전에 DOM 을 건드리는 인라인 스크립트 3종(테마 즉시적용·Clarity·다크모드 폴백)인데, 확인하려면 위치와 타이밍이 필요하다.

## 변경

- **`console.warn` 시점에 Error 를 만들어 호출 스택을 뜬다.** 배포에 소스맵(16.4MB, `sources` 에 실제 `.svelte` 경로 포함)이 들어 있어 프레임을 원본으로 되돌릴 수 있다.
- **`at=<ms>`** 를 함께 싣는다. 경고가 페이지 시작 몇 ms 에 나는지 분포를 보면 인라인 스크립트와의 경합 가설이 바로 갈린다.

⛔ 수집기는 스키마에 없는 필드를 버린다(`js_errors` 컬럼 고정). 그래서 새 필드가 아니라 **`stack` 머리에** 실었다.

## 비용

Error 생성 시점이 하필 하이드레이션 중이라, `guardedSend` 스로틀(같은 메시지 5건)에 걸려 버려질 몫까지 만들지 않도록 **합성 횟수를 페이지 로드당 8건**으로 따로 묶었다. 상위 12 프레임만 담는다 — 그 아래는 전부 Svelte 내부라 판별에 기여하지 않는다.

전송 건수는 늘지 않는다(스로틀·레이트리밋 그대로). 늘어나는 것은 기존 이벤트의 `stack` 길이뿐이고, 수집기 상한 1500자 안이다.

## 다음
하루치 데이터가 쌓이면 프레임을 소스맵으로 되돌려 컴포넌트를 특정한다. `/messages` 의 하루 20~50건(bug/12774 — 쪽지 새로고침 5단계 재발)도 이 데이터로 함께 판정된다.