### PR TITLE
feat(observability): report only the final comment-backfill failure

### DIFF
--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -491,6 +491,12 @@ if (typeof window !== 'undefined') {
         if (first.startsWith('[upload-fail]')) {
             return { type: 'upload_fail', reason: 'upload_fail' };
         }
+        // 댓글 백필 최종 실패 — 3회 재시도가 모두 실패하고 목록이 빈 상태.
+        // ⛔ 여기 등록하지 않으면 console 에만 남고 수집되지 않는다. 이 분류기를
+        //    거치지 않는 메시지는 전송 자체가 안 된다.
+        if (first.startsWith('[comments] backfill-failed')) {
+            return { type: 'comments_backfill_failed', reason: 'backfill_failed' };
+        }
         return null;
     }
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1498,6 +1498,8 @@
     // 재시도가 없어 "불러오는 중"에 고착되는 사례(#12668: 간헐 발생, 새로고침하면 보임)가 있어
     // 짧은 백오프로 몇 번 재시도한다. 실제 0개이거나 채워지면 종료.
     let backfillInProgress = false;
+    // 마지막 재시도의 실패 사유. 최종 실패로 확정될 때 한 번만 보고한다.
+    let lastBackfillError: unknown = null;
     async function backfillWithRetry(cancel?: AbortSignal): Promise<void> {
         if (backfillInProgress) return;
         backfillInProgress = true;
@@ -1508,8 +1510,12 @@
                 if (cancel?.aborted) return;
                 try {
                     await refetchComments(cancel);
-                } catch {
-                    // 전송 실패 — 재시도
+                } catch (err) {
+                    // 전송 실패 — 재시도. 여기서는 보고하지 않는다.
+                    // 재시도가 3회라 중간 실패까지 보고하면 사건 1건이 로그 3건으로
+                    // 부풀어, 실제 피해 규모를 3배로 오독하게 된다(2026-08-07 실측:
+                    // TimeoutError 12,497건 / 2,067명이 실은 1인당 1~2건의 사건이었다).
+                    lastBackfillError = err;
                 }
                 if (comments.length > 0 || commentsTotal === 0) return;
                 await new Promise((resolve) => setTimeout(resolve, 800 * (attempt + 1)));
@@ -1517,6 +1523,16 @@
             if (cancel?.aborted) return;
             // 3회 모두 실패 + 여전히 빈 목록 → 에러/복구 UI 노출(무한 "불러오는 중" 고착 방지).
             if (comments.length === 0 && commentsTotal > 0) {
+                // ⭐ 여기가 유일한 실제 피해 지점이다 — 3회 모두 실패했고 댓글이 비었다.
+                // 종전에는 이 상태가 로그에 전혀 남지 않아, 복구 UI 를 실제로 본 사람이
+                // 몇 명인지 알 수 없었다(중간 재시도의 TimeoutError 만 잔뜩 쌓였다).
+                const reason =
+                    lastBackfillError instanceof Error
+                        ? `${lastBackfillError.name}: ${lastBackfillError.message}`
+                        : String(lastBackfillError ?? 'unknown');
+                console.error(
+                    `[comments] backfill-failed: ${data.post?.id} 댓글 ${commentsTotal}개인데 0개 — ${reason}`
+                );
                 commentsError = true;
             }
         } finally {


### PR DESCRIPTION
## 배경

`TimeoutError: signal timed out` 이 24시간 12,497건·2,067명으로 상위에 올라와 딥다이브했다. 결론은 **P0 가 아니었다**.

- 서버는 느리지 않다 — 문제 글들의 댓글 API 실측 **0.11초**(8초 한도의 1/70)
- 실패해도 **유실 경로가 없다**. `comments = all` 은 성공 시에만 실행돼 기존 댓글을 빈 목록으로 덮어쓰지 않는다
- 3회 재시도가 있고, 끝내 실패하면 무한 스피너가 아니라 복구 UI 가 뜬다(#12668 대응)

## 문제는 관측 쪽이었다

**1) 사건이 3배로 부풀어 보인다.** 재시도가 3회라 사건 1건이 `TimeoutError` 3건을 남긴다. 1인당 5~7건처럼 보이던 것이 실은 **1~2건의 사건**이었다.

**2) 진짜 피해는 안 보인다.** 실제 사용자 피해는 `commentsError = true`(3회 모두 실패 + 목록 빈 상태) 하나뿐인데, 이 상태가 **로그에 전혀 남지 않았다.** 복구 UI 를 본 사람이 몇 명인지 알 방법이 없었다.

## 변경

- 중간 재시도의 실패 사유는 `lastBackfillError` 에 보관만 하고 보고하지 않는다
- 최종 실패로 확정될 때 `[comments] backfill-failed` 를 **한 번만** 남긴다(글 번호·기대 댓글 수·사유 포함)
- ⛔ `hooks.client.ts` 분류기에 등록했다. **이걸 빠뜨리면 console 에만 남고 수집되지 않는다** — 분류기를 거치지 않는 메시지는 전송 자체가 안 된다

동작은 바꾸지 않는다. 재시도 횟수·타임아웃·복구 UI 모두 그대로다.

## 이후
하루치가 쌓이면 `comments_backfill_failed` 건수로 실제 피해 규모를 판정한다. 지금은 분모조차 모른다 — 파드 재기동으로 nginx 로그가 소멸해 댓글 API 총 호출 수를 구하지 못했다.