### PR TITLE
feat(editor): image display-width presets 25/50/75% (bug/13379)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -2418,6 +2418,21 @@
         display: none;
     }
 
+    /* 표시 폭 프리셋 (bug/13379) — 본문(markdown.svelte .prose img.dm-w-*)과 동일 규칙.
+       댓글은 자체 렌더(@html)라 여기 별도로 둔다. 유튜브 480px 이 별도였던 것과 같은 이유. */
+    :global(.comment-body img.dm-w-25) {
+        width: 25%;
+        height: auto;
+    }
+    :global(.comment-body img.dm-w-50) {
+        width: 50%;
+        height: auto;
+    }
+    :global(.comment-body img.dm-w-75) {
+        width: 75%;
+        height: auto;
+    }
+
     /* 댓글 스포일러 블록 */
     :global(.comment-body .spoiler-block) {
         border: 1px solid var(--border);

--- a/apps/web/src/lib/components/features/editor/linked-image.ts
+++ b/apps/web/src/lib/components/features/editor/linked-image.ts
@@ -23,6 +23,22 @@ export const LinkedImage = Image.extend({
                 parseHTML: (el: HTMLElement) => el.classList?.contains('dm-fit-width') ?? false,
                 renderHTML: (attrs: { fitWidth?: boolean }) =>
                     attrs.fitWidth ? { class: 'dm-fit-width' } : {}
+            },
+            // 작성자가 고른 표시 폭 프리셋(%). class="dm-w-25|50|75" 로 저장·복원 (bug/13379).
+            // px(width attr)가 아니라 % 인 이유: 큰 사진은 px 절반도 모바일에서
+            // max-width:100% 상한에 걸려 차이가 안 보인다. fitWidth 와 같은 원칙 —
+            // 렌더 시점 추측 없이 저장된 의도만 존중. UI 가 fitWidth 와 상호 배타를 보장한다.
+            sizePercent: {
+                default: null,
+                parseHTML: (el: HTMLElement) => {
+                    for (const c of el.classList ?? []) {
+                        const m = /^dm-w-(25|50|75)$/.exec(c);
+                        if (m) return parseInt(m[1], 10);
+                    }
+                    return null;
+                },
+                renderHTML: (attrs: { sizePercent?: number | null }) =>
+                    attrs.sizePercent ? { class: `dm-w-${attrs.sizePercent}` } : {}
             }
         };
     },

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -176,7 +176,8 @@
         codeBlock: false,
         link: false,
         image: false,
-        imageFitWidth: false
+        imageFitWidth: false,
+        imageSizePercent: null as number | null
     });
 
     let canUndo = $state(false);
@@ -235,7 +236,8 @@
             codeBlock: e.isActive('codeBlock'),
             link: e.isActive('link'),
             image: e.isActive('image'),
-            imageFitWidth: e.getAttributes('image').fitWidth === true
+            imageFitWidth: e.getAttributes('image').fitWidth === true,
+            imageSizePercent: (e.getAttributes('image').sizePercent ?? null) as number | null
         };
         const undo = e.can().undo();
         const redo = e.can().redo();
@@ -921,14 +923,45 @@
     function toggleImageFitWidth(): void {
         if (!editor) return;
         const current = editor.getAttributes('image').fitWidth === true;
-        editor.chain().focus().updateAttributes('image', { fitWidth: !current }).run();
+        editor
+            .chain()
+            .focus()
+            .updateAttributes('image', { fitWidth: !current, sizePercent: null })
+            .run();
+    }
+
+    // 표시 폭 프리셋(25/50/75%, bug/13379). 같은 값 재클릭 = 해제(원본 크기).
+    // fitWidth·픽셀 width 와 상호 배타 — 크기 지정 수단이 겹치면 어느 것이 이겼는지
+    // 작성자가 알 수 없게 되므로, 프리셋을 고르는 순간 나머지를 지운다.
+    function setImageSizePercent(pct: number): void {
+        if (!editor) return;
+        const current = (editor.getAttributes('image').sizePercent ?? null) as number | null;
+        if (current === pct) {
+            editor.chain().focus().updateAttributes('image', { sizePercent: null }).run();
+            return;
+        }
+        editor
+            .chain()
+            .focus()
+            .updateAttributes('image', {
+                sizePercent: pct,
+                fitWidth: false,
+                width: null,
+                height: null
+            })
+            .run();
     }
 
     function resetImageSize(): void {
         editor
             ?.chain()
             .focus()
-            .updateAttributes('image', { fitWidth: false, width: null, height: null })
+            .updateAttributes('image', {
+                fitWidth: false,
+                sizePercent: null,
+                width: null,
+                height: null
+            })
             .run();
     }
 
@@ -1428,7 +1461,23 @@
                 <ImageIcon class="h-4 w-4" />
             </Button>
             {#if isActive.image}
-                <!-- 이미지 선택 시에만: 크기 컨트롤 (저장된 의도만 존중, 렌더 추측 없음) -->
+                <!-- 이미지 선택 시에만: 크기 컨트롤 (저장된 의도만 존중, 렌더 추측 없음)
+                     프리셋(%)은 bug/13379 — "이모티콘 크기 조정처럼" 중간 크기를 달라는 요청 -->
+                {#each [25, 50, 75] as pct (pct)}
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onclick={() => setImageSizePercent(pct)}
+                        {disabled}
+                        class="h-8 whitespace-nowrap px-2 text-xs {getButtonClass(
+                            isActive.imageSizePercent === pct
+                        )}"
+                        title="이미지를 본문 폭의 {pct}% 크기로 표시합니다 (다시 누르면 원본)"
+                    >
+                        {pct}%
+                    </Button>
+                {/each}
                 <Button
                     type="button"
                     variant="ghost"
@@ -2146,6 +2195,17 @@
     /* 작성자가 '본문 폭 맞춤'을 선택한 이미지만 전폭 (뷰의 .prose img.dm-fit-width 와 일치) */
     :global(.tiptap-content .tiptap img.dm-fit-width) {
         width: 100%;
+    }
+
+    /* 표시 폭 프리셋 (뷰의 .prose img.dm-w-* 와 일치 — bug/13379) */
+    :global(.tiptap-content .tiptap img.dm-w-25) {
+        width: 25%;
+    }
+    :global(.tiptap-content .tiptap img.dm-w-50) {
+        width: 50%;
+    }
+    :global(.tiptap-content .tiptap img.dm-w-75) {
+        width: 75%;
     }
 
     /* 이미지 링크 표시 (에디터 내 링크 있는 이미지) */

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -370,6 +370,22 @@
         height: auto;
     }
 
+    /* 작성자가 고른 표시 폭 프리셋 (bug/13379). height:auto 가 있어야 재작성 단계에서
+       주입되는 aspect-ratio 4/3 자리표시가 로드 후 실제 비율로 풀린다.
+       ⚠️ 댓글은 이 컴포넌트를 안 쓴다 — comment-list.svelte 에 같은 규칙이 따로 있다. */
+    .prose :global(img.dm-w-25) {
+        width: 25%;
+        height: auto;
+    }
+    .prose :global(img.dm-w-50) {
+        width: 50%;
+        height: auto;
+    }
+    .prose :global(img.dm-w-75) {
+        width: 75%;
+        height: auto;
+    }
+
     /* Tailwind Typography 플러그인이 없을 경우를 위한 기본 스타일 */
     .prose :global(h1) {
         font-size: 1.75em;


### PR DESCRIPTION
## bug/13379 — "이모티콘 크기 조정처럼 첨부 이미지도"

이미지를 선택하면 지금은 「↔ 본문 폭」과 「원본」 둘뿐이다. 그 사이가 없어서, 스크린샷 반쪽짜리나 짤막한 참고 이미지도 자연 크기 아니면 전폭이다.

## 파이프라인은 이미 있었다

#13007(content-image-sizing-architecture)이 깔아 둔 것 — `LinkedImage` 는 width attr 를 읽고 지울 줄 알며, 렌더러는 "저장된 크기만 존중, 렌더 시점 추측 없음". 실제로 width 붙은 구 SunEditor 글들이 지금도 정상 렌더된다. **빠진 것은 버튼뿐이다.**

## 변경

이미지 선택 시 **25% / 50% / 75%** 버튼 추가. `dm-fit-width` 패턴 그대로 클래스 기반(`dm-w-25/50/75`)이다.

- **px 가 아니라 % 인 이유**: 4000px 사진의 절반(2000px)도 모바일에선 `max-width:100%` 상한에 걸려 차이가 안 보인다. % 는 모든 화면에서 의도대로 나온다
- **상호 배타**: 프리셋을 고르면 fitWidth·픽셀 width 를 지우고, 본문 폭을 고르면 프리셋을 지운다. 같은 값 재클릭 = 해제
- `height: auto` 동반 — 재작성 단계가 주입하는 `aspect-ratio 4/3` 자리표시가 로드 후 실제 비율로 풀리게

## 표면 전수 (⛔ 복붙 화면 함정)

렌더 표면이 둘이다:
- 본문: `markdown.svelte` `.prose img.dm-w-*`
- **댓글: `comment-list.svelte` 자체 렌더(@html)** — 유튜브 480px 이 별도였던 것과 같은 이유로 같은 규칙을 별도로 둔다

`class` 는 양쪽 새니타이저 ALLOWED_ATTR 에 이미 있음을 확인했다(dm-fit-width 가 라이브라는 것이 증거). premium 오버라이드 없음.

## 범위에서 뺀 것
댓글 **에디터**(comment-editor.svelte, 별도 컴포넌트)의 크기 UI 는 이번에 안 넣는다 — 댓글에 이미 저장된 dm-w-* 는 렌더되지만, 댓글 작성 중 크기 선택은 별건.