### PR TITLE
feat(observability): SSR in-flight gauge — shedding phase 1

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,5 +1,6 @@
 // OpenTelemetry 초기화 (최상단 — 다른 import 전에 로드)
 import '$lib/server/telemetry.js';
+import { trackInflightStart, trackInflightEnd } from '$lib/server/telemetry.js';
 
 import { redirect, type Handle, type HandleServerError } from '@sveltejs/kit';
 import { dev } from '$app/environment';
@@ -761,7 +762,22 @@ const DEV_ONLY_PATHS = ['/api-test', '/api-docs', '/api-doc', '/install'];
 const GLOBAL_API_RATE = { maxRequests: 600, windowMs: 60_000 }; // 분당 600회 (페이지당 ~10 API 호출)
 const WRITE_API_RATE = { maxRequests: 60, windowMs: 60_000 }; // 쓰기 분당 60회
 
-export const handle: Handle = async ({ event, resolve }) => {
+// in-flight 게이지 래퍼 (8/7 heap OOM 후속, 관측만 — 동작 불변).
+// 본 핸들러는 return 지점이 많아 내부에 심지 않고 밖에서 감싼다: finally 가
+// 모든 경로(에러 포함)에서 감소를 보장해야 게이지가 새지 않는다.
+export const handle: Handle = async (input) => {
+    const accept = input.event.request.headers.get('accept') ?? '';
+    const isRender =
+        input.event.url.pathname.endsWith('/__data.json') || accept.includes('text/html');
+    trackInflightStart(isRender);
+    try {
+        return await handleInner(input);
+    } finally {
+        trackInflightEnd(isRender);
+    }
+};
+
+const handleInner: Handle = async ({ event, resolve }) => {
     const { pathname } = event.url;
     const isDataRequest = isSvelteKitDataRequest(event);
 

--- a/apps/web/src/lib/server/telemetry.ts
+++ b/apps/web/src/lib/server/telemetry.ts
@@ -93,6 +93,33 @@ const HEAP_WATCH_ENABLED =
     process.env.HEAP_WATCH_ENABLED === 'true' && (!IS_PRODUCTION || HEAP_SNAPSHOT_ALLOW_PROD);
 let lastHeapDumpAt = 0;
 
+// ── SSR in-flight 게이지 (2026-08-07 heap OOM 후속 — 셰딩 1단계, 관측만) ──
+// 60초 샘플만으로는 러시가 안 보인다: 8/7 사고에서 마지막 정상 샘플과 사망
+// 사이가 70초였다. current 와 함께 "직전 발신 이후 최고치(peak)"를 남겨
+// 스파이크를 놓치지 않는다. 하루치가 쌓이면 이 분포로 SSR_MAX_INFLIGHT
+// 임계를 정한다(2단계). 스트리밍 응답은 Response 반환 시점에 감소한다 —
+// 렌더 비용 관점에선 그걸로 충분하다.
+let inflightAll = 0;
+let inflightRender = 0;
+let inflightPeakAll = 0;
+let inflightPeakRender = 0;
+
+/** 요청 시작 — hooks.server handle 래퍼가 부른다. isRender = 문서/__data.json */
+export function trackInflightStart(isRender: boolean): void {
+    inflightAll++;
+    if (inflightAll > inflightPeakAll) inflightPeakAll = inflightAll;
+    if (isRender) {
+        inflightRender++;
+        if (inflightRender > inflightPeakRender) inflightPeakRender = inflightRender;
+    }
+}
+
+/** 요청 종료(finally 보장) — 시작과 짝이 맞아야 게이지가 안 샌다. */
+export function trackInflightEnd(isRender: boolean): void {
+    inflightAll = Math.max(0, inflightAll - 1);
+    if (isRender) inflightRender = Math.max(0, inflightRender - 1);
+}
+
 if (HEAP_WATCH_DIR && HEAP_WATCH_ENABLED) {
     const heapWatchTimer = setInterval(() => {
         const m = process.memoryUsage();
@@ -207,9 +234,16 @@ if (OTEL_ENABLED) {
                 uptime_s: Math.round(process.uptime()),
                 // Tier 4 audit (2026-04-28): cache size + external ratio diagnostic
                 ssrCacheSize: ssrCache.size,
-                externalRatio: Number(externalRatio.toFixed(3))
+                externalRatio: Number(externalRatio.toFixed(3)),
+                // 셰딩 1단계 게이지 — peak 는 발신 직후 current 로 리셋된다
+                inflight: inflightAll,
+                inflightPeak: inflightPeakAll,
+                render: inflightRender,
+                renderPeak: inflightPeakRender
             })
         );
+        inflightPeakAll = inflightAll;
+        inflightPeakRender = inflightRender;
         // Alert: external > heap*0.5 + heap > 200MB → Buffer/gzip/SDK 외부 메모리 의심
         if (externalRatio > 0.5 && m.heapUsed > 200_000_000) {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
8/7 heap OOM 재발 방지 2단계(셰딩)의 **관측 선행분** — 사장님 전체 승인(8/7).

## 왜
러시 때 파드당 동시 렌더가 몇이었는지 **아무도 모른다.** heap_metrics 는 60초 샘플인데 8/7 사망은 마지막 정상 샘플 70초 뒤였다 — 스파이크가 관측 사이로 빠졌다.

## 무엇
- `handle` 을 밖에서 감싸 in-flight 카운트 (문서/`__data.json` = render 로 구분). 본 핸들러는 return 지점이 많아 내부에 심지 않았다 — **finally 가 에러 포함 전 경로에서 감소를 보장**해야 게이지가 새지 않는다
- `heap_metrics` 에 4필드 동봉: `inflight`/`inflightPeak`/`render`/`renderPeak` — **peak 는 발신 직후 current 로 리셋**되는 창(峰)값이라 60초 사이 스파이크를 놓치지 않는다
- **동작 불변** (셰딩 차단은 2단계 — 하루치 분포로 `SSR_MAX_INFLIGHT` 임계를 정한 뒤 별도 PR)

## 검증
카나리에서 `heap_metrics` 로그에 4필드가 나오는지 + 평시 값이 상식 범위(한 자리~두 자리)인지 확인 후 승격.