### PR TITLE
feat(mypage): deleted posts/comments tab (bug/13341 follow-up)

### DIFF
--- a/apps/web/src/routes/my/+page.server.ts
+++ b/apps/web/src/routes/my/+page.server.ts
@@ -53,10 +53,13 @@ async function loadMyPageData(
     limit: number,
     headers: Record<string, string>,
     /** 내 글·내 댓글 검색어. 빈 문자열이면 검색 없음 (bug/12292) */
-    q: string
+    q: string,
+    /** 'deleted' = 본인 삭제분만 (bug/13341 후속 — 작성자는 자기 삭제글 목록을 볼 수 있어야 한다) */
+    filter: string
 ): Promise<MyPageData> {
     // 백엔드가 2자 미만을 무시하지만, 굳이 왕복시키지 않는다.
-    const qs = q ? `&q=${encodeURIComponent(q)}` : '';
+    const qs =
+        (q ? `&q=${encodeURIComponent(q)}` : '') + (filter === 'deleted' ? '&filter=deleted' : '');
     const result: MyPageData = {
         expSummary: null,
         posts: null,
@@ -136,6 +139,11 @@ async function loadMyPageData(
 
 export const load: PageServerLoad = async ({ url, locals }) => {
     const tab = url.searchParams.get('tab') || 'posts';
+    // 유효값은 'deleted' 하나 — 그 외는 조용히 기본 목록으로 (URL 조작 무해화)
+    const filter =
+        (tab === 'posts' || tab === 'comments') && url.searchParams.get('filter') === 'deleted'
+            ? 'deleted'
+            : '';
     const page = Number(url.searchParams.get('page')) || 1;
     const limit = 20;
     // 검색은 글·댓글 탭에서만 의미가 있다. 다른 탭에 q 가 남아 있어도 무시한다.
@@ -153,10 +161,11 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     }
 
     // 스트리밍: tabData를 await 하지 않음 → 스켈레톤 먼저 렌더링
-    const tabDataPromise = loadMyPageData(tab, page, limit, headers, q);
+    const tabDataPromise = loadMyPageData(tab, page, limit, headers, q, filter);
 
     return {
         tab,
+        filter,
         page,
         q,
         /** 스트리밍: Promise로 반환 → 클라이언트에서 {#await} 사용 */

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -49,12 +49,21 @@
         }
     });
 
-    function buildMyUrl(opts: { tab?: string; page?: number; q?: string }): string {
+    function buildMyUrl(opts: {
+        tab?: string;
+        page?: number;
+        q?: string;
+        filter?: string;
+    }): string {
         const tab = opts.tab ?? data.tab;
         const q = opts.q ?? data.q ?? '';
+        // 삭제 필터(bug/13341 후속): 페이지 이동에선 유지, 탭 전환에선 해제.
+        // 명시적 선택을 넘어 따라다니면 "글이 다 사라졌다" 오인을 만든다.
+        const filter = opts.filter ?? (opts.tab === undefined ? (data.filter ?? '') : '');
         const params = new URLSearchParams({ tab });
         // 검색어는 글·댓글 탭에서만 의미가 있다.
         if (q && (tab === 'posts' || tab === 'comments')) params.set('q', q);
+        if (filter === 'deleted') params.set('filter', 'deleted');
         if (opts.page && opts.page > 1) params.set('page', String(opts.page));
         return `/my?${params}`;
     }
@@ -311,6 +320,26 @@
                                     ({result.posts.total}개)
                                 </span>
                             {/if}
+                            <!-- bug/13341 후속: 삭제한 글도 본인은 볼 수 있어야 한다 -->
+                            <span class="ml-auto flex gap-1 text-sm font-normal">
+                                <Button
+                                    variant={data.filter === 'deleted' ? 'ghost' : 'secondary'}
+                                    size="sm"
+                                    class="h-7 px-2 text-xs"
+                                    onclick={() => goto(buildMyUrl({ tab: data.tab, filter: '' }))}
+                                >
+                                    남은 글
+                                </Button>
+                                <Button
+                                    variant={data.filter === 'deleted' ? 'secondary' : 'ghost'}
+                                    size="sm"
+                                    class="h-7 px-2 text-xs"
+                                    onclick={() =>
+                                        goto(buildMyUrl({ tab: data.tab, filter: 'deleted' }))}
+                                >
+                                    삭제한 글
+                                </Button>
+                            </span>
                         </CardTitle>
                     </CardHeader>
                     <CardContent>
@@ -318,9 +347,15 @@
                             <ul class="divide-border divide-y">
                                 {#each result.posts.items as post (post.id)}
                                     <li class="py-3 first:pt-0 last:pb-0">
-                                        <a
-                                            href="/{post.board_id || 'free'}/{post.id}"
-                                            class="hover:bg-accent -m-2 block w-full rounded-md p-2 no-underline transition-colors"
+                                        <!-- 삭제한 글은 본문이 없어 열리지 않는다 — 링크 대신 기록만 -->
+                                        <svelte:element
+                                            this={post.deleted_at ? 'div' : 'a'}
+                                            href={post.deleted_at
+                                                ? undefined
+                                                : `/${post.board_id || 'free'}/${post.id}`}
+                                            class="{post.deleted_at
+                                                ? 'opacity-70'
+                                                : 'hover:bg-accent'} -m-2 block w-full rounded-md p-2 no-underline transition-colors"
                                         >
                                             <h3
                                                 class="text-foreground mb-1 line-clamp-1 font-medium"
@@ -337,8 +372,14 @@
                                                 <span>공감 {post.likes}</span>
                                                 <span>·</span>
                                                 <span>댓글 {post.comments_count}</span>
+                                                {#if post.deleted_at}
+                                                    <span>·</span>
+                                                    <span class="text-destructive/70"
+                                                        >삭제 {formatDate(post.deleted_at)}</span
+                                                    >
+                                                {/if}
                                             </div>
-                                        </a>
+                                        </svelte:element>
                                     </li>
                                 {/each}
                             </ul>
@@ -346,6 +387,8 @@
                             <p class="text-muted-foreground py-8 text-center">
                                 {#if data.q}
                                     '{data.q}'에 해당하는 글이 없습니다.
+                                {:else if data.filter === 'deleted'}
+                                    삭제한 글이 없습니다.
                                 {:else}
                                     작성한 글이 없습니다.
                                 {/if}
@@ -393,6 +436,25 @@
                                     ({result.comments.total}개)
                                 </span>
                             {/if}
+                            <span class="ml-auto flex gap-1 text-sm font-normal">
+                                <Button
+                                    variant={data.filter === 'deleted' ? 'ghost' : 'secondary'}
+                                    size="sm"
+                                    class="h-7 px-2 text-xs"
+                                    onclick={() => goto(buildMyUrl({ tab: data.tab, filter: '' }))}
+                                >
+                                    남은 댓글
+                                </Button>
+                                <Button
+                                    variant={data.filter === 'deleted' ? 'secondary' : 'ghost'}
+                                    size="sm"
+                                    class="h-7 px-2 text-xs"
+                                    onclick={() =>
+                                        goto(buildMyUrl({ tab: data.tab, filter: 'deleted' }))}
+                                >
+                                    삭제한 댓글
+                                </Button>
+                            </span>
                         </CardTitle>
                     </CardHeader>
                     <CardContent>


### PR DESCRIPTION
## bug/13341 추가 지적 (8/6 15:38)

> "작성자는 자기가 작성한 글 리스트는 모두 알 수 있어야 한다" — 삭제 필터링(fe#1982)이 삭제글을 **본인에게서도** 숨겨 버렸다.

백엔드는 이미 준비돼 있었다(be#627 `?filter=deleted`, 8/6 승격). **빠진 것은 화면뿐.**

## 변경
- 「내가 쓴 글」·「내가 쓴 댓글」 카드 우측에 **남은/삭제한** 칩 (`?filter=deleted`)
- 삭제 목록 행: 본문이 없어 열리지 않으므로 **링크 대신 정적 행** + `삭제 {날짜}` 표기. 제목은 기존 `getMyPostTitle` 폴백("삭제된 글입니다.") 재사용
- **필터 지속 규칙**: 페이지 이동엔 유지, 탭 전환엔 해제 — 명시적 선택을 넘어 따라다니면 "글이 다 사라졌다" 오인을 만든다
- 잘못된 filter 값은 조용히 기본 목록 (URL 조작 무해화)

## 확인
- 본인 인증 필수 경로(`/my`)라 타인 삭제글 노출 없음 — 백엔드가 mbID 로만 조회
- 반영 후 13341 에 약속한 재공지 댓글 게시 예정