### PR TITLE
feat(editor): inline spoiler mark — mask selected text only

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -954,6 +954,18 @@
         }
     });
 
+    // 인라인 스포일러 클릭 공개 — 위임 리스너 1개(1회 설치형, 반응형 읽기 없음)
+    $effect(() => {
+        const el = commentListEl;
+        if (!el) return;
+        const onClick = (ev: MouseEvent) => {
+            const sp = (ev.target as HTMLElement | null)?.closest?.('span.dm-spoiler');
+            if (sp && el.contains(sp)) sp.classList.toggle('dm-spoiler-open');
+        };
+        el.addEventListener('click', onClick);
+        return () => el.removeEventListener('click', onClick);
+    });
+
     // 댓글 본문 이미지 data-original 폴백 (최적화된 이미지 로드 실패 시 원본으로 대체)
     $effect(() => {
         void processedComments.size;
@@ -2411,6 +2423,24 @@
         border-radius: 0.375rem;
         margin: 0.5rem 0;
         display: block;
+    }
+
+    /* 인라인 스포일러(8/7) — 본문 markdown.svelte 와 동일 규칙. 댓글은 자체 렌더라 별도. */
+    :global(.comment-body span.dm-spoiler) {
+        background: #5a5a61;
+        color: transparent;
+        border-radius: 3px;
+        cursor: pointer;
+        text-shadow: none;
+    }
+    :global(.comment-body span.dm-spoiler::selection),
+    :global(.comment-body span.dm-spoiler *::selection) {
+        color: #fff;
+        background: #3a3a40;
+    }
+    :global(.comment-body span.dm-spoiler.dm-spoiler-open) {
+        color: inherit;
+        background: color-mix(in srgb, currentColor 10%, transparent);
     }
 
     /* 이미지 로딩 실패 시 숨김 처리 */

--- a/apps/web/src/lib/components/features/editor/spoiler-mark.ts
+++ b/apps/web/src/lib/components/features/editor/spoiler-mark.ts
@@ -1,0 +1,41 @@
+import { Mark, mergeAttributes } from '@tiptap/core';
+
+declare module '@tiptap/core' {
+    interface Commands<ReturnType> {
+        spoilerInline: {
+            /** 선택 텍스트에 인라인 스포일러(모자이크) 마크를 토글한다 */
+            toggleSpoilerInline: () => ReturnType;
+        };
+    }
+}
+
+/**
+ * SpoilerInline — <b> 처럼 선택 부분에만 거는 모자이크 마크 (8/7 사장님 요청).
+ *
+ * 저장 형태 = `<span class="dm-spoiler">…</span>`.
+ * - 뷰(본문 markdown.svelte · 댓글 comment-list.svelte)가 가림/해제 CSS·클릭 토글을 가진다.
+ *   PC 는 드래그(::selection)로도 보인다. 두 표면 모두에 CSS 가 있어야 한다(복붙 표면 함정).
+ * - 블록형 [spoiler](details 변환, content-transform.ts)와는 별개 — 이쪽은 줄 안 일부분용.
+ * - ⛔ 글 저장이 Turndown(HTML→md)을 타므로, tiptap-editor 의 turndown 인스턴스에
+ *   이 span 을 보존하는 keep 규칙이 반드시 있어야 한다. 없으면 저장 순간 벗겨진다.
+ */
+export const SpoilerInline = Mark.create({
+    name: 'spoilerInline',
+
+    parseHTML() {
+        return [{ tag: 'span.dm-spoiler' }];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ['span', mergeAttributes(HTMLAttributes, { class: 'dm-spoiler' }), 0];
+    },
+
+    addCommands() {
+        return {
+            toggleSpoilerInline:
+                () =>
+                ({ commands }) =>
+                    commands.toggleMark(this.name)
+        };
+    }
+});

--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -6,6 +6,7 @@
     import ItalicExtension from '@tiptap/extension-italic';
     import Link from '@tiptap/extension-link';
     import { LinkedImage } from './linked-image.js';
+    import { SpoilerInline } from './spoiler-mark.js';
     // 앙티콘 전용 인라인 노드 — 사진 첨부(LinkedImage)와 분리해야 하는 이유는 그 파일 주석 참조
     import { Emoticon } from './emoticon-node.js';
     import Placeholder from '@tiptap/extension-placeholder';
@@ -50,6 +51,11 @@
         headingStyle: 'atx',
         codeBlockStyle: 'fenced'
     });
+    // ⛔ 인라인 스포일러 보존 — Turndown 은 기본으로 span 을 벗긴다. 이 규칙이 없으면
+    //    저장(HTML→md) 순간 모자이크가 사라지고 내용이 평문으로 노출된다.
+    turndown.keep(
+        (node) => node.nodeName === 'SPAN' && (node as HTMLElement).classList.contains('dm-spoiler')
+    );
 
     // 아이콘
     import CornerDownLeft from '@lucide/svelte/icons/corner-down-left';
@@ -70,6 +76,7 @@
     import Heading3 from '@lucide/svelte/icons/heading-3';
     import LinkIcon from '@lucide/svelte/icons/link';
     import ImageIcon from '@lucide/svelte/icons/image';
+    import EyeOff from '@lucide/svelte/icons/eye-off';
     import Undo from '@lucide/svelte/icons/undo';
     import Redo from '@lucide/svelte/icons/redo';
     import Minus from '@lucide/svelte/icons/minus';
@@ -164,6 +171,7 @@
     // 툴바 상태 (reactive하게 추적)
     let isActive = $state({
         bold: false,
+        spoiler: false,
         italic: false,
         underline: false,
         strike: false,
@@ -224,6 +232,7 @@
         // microtask 로 반응 컨텍스트 밖에서 할당한다(툴바 표시는 사실상 즉시).
         const next = {
             bold: e.isActive('bold'),
+            spoiler: e.isActive('spoilerInline'),
             italic: e.isActive('italic'),
             underline: e.isActive('underline'),
             strike: e.isActive('strike'),
@@ -281,6 +290,7 @@
                 // ⛔ Emoticon 은 LinkedImage 보다 앞에 둔다. 파스 규칙이 `img[src]` 로
                 //    겹치므로, 확장 우선순위(1100)와 함께 순서로도 의도를 남긴다.
                 Emoticon,
+                SpoilerInline,
                 LinkedImage.configure({
                     // ⛔ 이 false 를 뒤집어 앙티콘을 인라인으로 만들지 말 것.
                     //    이 노드는 사진 첨부에도 쓰여, 인라인이 되면 큰 사진이 문단 안으로
@@ -785,6 +795,10 @@
     // 엔터는 새 문단(<p>)이라 본문 간격이 넓어지는데(qa/82197), 붙여 쓰고 싶을 때 쓴다.
     function insertLineBreak(): void {
         editor?.chain().focus().setHardBreak().run();
+    }
+
+    function toggleSpoiler(): void {
+        editor?.chain().focus().toggleSpoilerInline().run();
     }
 
     function toggleBold(): void {
@@ -1418,6 +1432,17 @@
                 title="굵게 (Ctrl+B)"
             >
                 <Bold class="h-4 w-4" />
+            </Button>
+            <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onclick={toggleSpoiler}
+                {disabled}
+                class="h-8 w-8 p-0 {getButtonClass(isActive.spoiler)}"
+                title="모자이크 — 선택한 부분을 가립니다 (읽는 쪽에서 클릭·드래그로 공개)"
+            >
+                <EyeOff class="h-4 w-4" />
             </Button>
             <Button
                 type="button"
@@ -2195,6 +2220,15 @@
     /* 작성자가 '본문 폭 맞춤'을 선택한 이미지만 전폭 (뷰의 .prose img.dm-fit-width 와 일치) */
     :global(.tiptap-content .tiptap img.dm-fit-width) {
         width: 100%;
+    }
+
+    /* 인라인 스포일러 — 에디터에선 가리지 않는다(작성 중 읽어야 하므로 표시만).
+       뷰의 가림 규칙은 markdown.svelte(.prose)·comment-list(.comment-body)에 별도. */
+    :global(.tiptap-content .tiptap span.dm-spoiler) {
+        background: color-mix(in srgb, currentColor 12%, transparent);
+        outline: 1px dashed color-mix(in srgb, currentColor 45%, transparent);
+        outline-offset: 1px;
+        border-radius: 3px;
     }
 
     /* 표시 폭 프리셋 (뷰의 .prose img.dm-w-* 와 일치 — bug/13379) */

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -293,6 +293,18 @@
     });
 
     // 클라이언트에서 플러그인 필터 적용
+    // 인라인 스포일러 클릭 공개 — 위임 리스너 하나. 반응형 값을 읽지 않는 1회 설치형.
+    $effect(() => {
+        const el = proseEl;
+        if (!el) return;
+        const onClick = (ev: MouseEvent) => {
+            const sp = (ev.target as HTMLElement | null)?.closest?.('span.dm-spoiler');
+            if (sp && el.contains(sp)) sp.classList.toggle('dm-spoiler-open');
+        };
+        el.addEventListener('click', onClick);
+        return () => el.removeEventListener('click', onClick);
+    });
+
     $effect(() => {
         // hookVersion을 읽어서 hook 등록 시 $effect 재실행
         const _hv = getHookVersion();
@@ -368,6 +380,25 @@
     .prose :global(img.dm-fit-width) {
         width: 100%;
         height: auto;
+    }
+
+    /* 인라인 스포일러(8/7) — 기본은 가림. PC 드래그(::selection) 또는 클릭으로 공개.
+       ⚠️ 댓글은 이 컴포넌트를 안 쓴다 — comment-list.svelte 에 같은 규칙 별도. */
+    .prose :global(span.dm-spoiler) {
+        background: #5a5a61;
+        color: transparent;
+        border-radius: 3px;
+        cursor: pointer;
+        text-shadow: none;
+    }
+    .prose :global(span.dm-spoiler::selection),
+    .prose :global(span.dm-spoiler *::selection) {
+        color: #fff;
+        background: #3a3a40;
+    }
+    .prose :global(span.dm-spoiler.dm-spoiler-open) {
+        color: inherit;
+        background: color-mix(in srgb, currentColor 10%, transparent);
     }
 
     /* 작성자가 고른 표시 폭 프리셋 (bug/13379). height:auto 가 있어야 재작성 단계에서


### PR DESCRIPTION
8/7 요청: "<b> 태그처럼, **특정 줄만** 모자이크로 보이고 드래그해야 보이는 기능".

## 구현
- **TipTap Mark** (`spoiler-mark.ts`) → `<span class="dm-spoiler">` 저장 · 툴바 EyeOff 버튼(굵게 옆) · 재클릭=해제
- **공개 동작**: PC = 드래그 선택(`::selection` 흰 글자) **또는** 클릭 토글 / 모바일 = 탭 토글(터치엔 드래그 리빌이 없음)
- **에디터 안에선 가리지 않음** — 작성 중 읽어야 하므로 점선 표시만

## 관문 (전수 확인)
- ⛔ **Turndown keep 규칙** — 글 저장이 HTML→md 변환을 타는데 Turndown 은 span 을 기본으로 벗긴다. 이 규칙 없으면 저장 순간 모자이크가 사라지고 **내용이 평문 노출**된다
- 렌더 표면 2곳 각각: markdown.svelte(.prose) + comment-list(.comment-body) — 유튜브 480px 과 같은 이유
- 새니타이저: span·class 모두 기존 허용 목록에 있음 확인
- 클릭 위임은 전용 $effect(1회 설치·전 경로 cleanup) — 재트리거·cleanup 함정 준수

## 확인 방법
글쓰기 → 텍스트 선택 → 👁️ 버튼 → 게시 → 본문에서 가려짐·클릭/드래그 공개, 같은 마크가 담긴 댓글도 동일 동작.