### PR TITLE
feat(content): wikiang badges next to namu.wiki links (hybrid)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -28,6 +28,7 @@
     import { onMount, tick } from 'svelte';
     import { highlightAllCodeBlocks } from '$lib/utils/code-highlight';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
+    import { enhanceWikiangLinks } from '$lib/utils/wikiang-link.js';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { SvelteMap, SvelteSet } from 'svelte/reactivity';
     import type { Component } from 'svelte';
@@ -952,6 +953,14 @@
         if (commentListEl) {
             return attachLightbox(commentListEl);
         }
+    });
+
+    // 위키앙 배지 — 댓글 렌더 갱신마다 스캔 (data-wikiang 마킹이 중복 방지)
+    $effect(() => {
+        void processedComments.size;
+        const el = commentListEl;
+        if (!el) return;
+        tick().then(() => enhanceWikiangLinks(el));
     });
 
     // 인라인 스포일러 클릭 공개 — 위임 리스너 1개(1회 설치형, 반응형 읽기 없음)
@@ -2423,6 +2432,22 @@
         border-radius: 0.375rem;
         margin: 0.5rem 0;
         display: block;
+    }
+
+    /* 위키앙 배지 — 본문과 동일 칩 (댓글 자체 렌더라 별도) */
+    :global(.comment-body a.wikiang-link) {
+        font-size: 0.78em;
+        margin-left: 0.3rem;
+        padding: 0.05rem 0.4rem;
+        border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+        border-radius: 999px;
+        text-decoration: none;
+        white-space: nowrap;
+        opacity: 0.85;
+    }
+    :global(.comment-body a.wikiang-link--new) {
+        border-style: dashed;
+        opacity: 0.65;
     }
 
     /* 인라인 스포일러(8/7) — 본문 markdown.svelte 와 동일 규칙. 댓글은 자체 렌더라 별도. */

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -10,6 +10,7 @@
     import { normalizeHtmlMediaUrls } from '$lib/utils/media-url';
     import { processContent as processEmbeds } from '$lib/plugins/auto-embed/embedder.js';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
+    import { enhanceWikiangLinks } from '$lib/utils/wikiang-link.js';
     import {
         buildThumbnailSrcSet,
         isTransformableMediaImage,
@@ -293,6 +294,15 @@
     });
 
     // 클라이언트에서 플러그인 필터 적용
+    // 위키앙 배지 — 렌더 결과가 바뀔 때마다 나무위키 링크를 스캔한다.
+    // renderedHtml 만 읽고 상태를 쓰지 않는다(재트리거 금지). 중복은 data-wikiang 마킹이 막는다.
+    $effect(() => {
+        void renderedHtml;
+        const el = proseEl;
+        if (!el || !browser) return;
+        tick().then(() => enhanceWikiangLinks(el));
+    });
+
     // 인라인 스포일러 클릭 공개 — 위임 리스너 하나. 반응형 값을 읽지 않는 1회 설치형.
     $effect(() => {
         const el = proseEl;
@@ -380,6 +390,22 @@
     .prose :global(img.dm-fit-width) {
         width: 100%;
         height: auto;
+    }
+
+    /* 위키앙 배지 (8/7 하이브리드) — 나무위키 링크 옆 작은 칩 */
+    .prose :global(a.wikiang-link) {
+        font-size: 0.78em;
+        margin-left: 0.3rem;
+        padding: 0.05rem 0.4rem;
+        border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+        border-radius: 999px;
+        text-decoration: none;
+        white-space: nowrap;
+        opacity: 0.85;
+    }
+    .prose :global(a.wikiang-link--new) {
+        border-style: dashed;
+        opacity: 0.65;
     }
 
     /* 인라인 스포일러(8/7) — 기본은 가림. PC 드래그(::selection) 또는 클릭으로 공개.

--- a/apps/web/src/lib/utils/wikiang-link.ts
+++ b/apps/web/src/lib/utils/wikiang-link.ts
@@ -1,0 +1,70 @@
+/**
+ * 나무위키 링크 옆 위키앙 배지 (8/7 하이브리드 승인)
+ *
+ * 컨테이너 안의 namu.wiki/w/ 링크를 스캔해, 문서 제목을 뽑아
+ * /api/wikiang/exists 로 배치 확인한 뒤:
+ *   - 위키앙에 있으면  「위키앙 문서 보기」
+ *   - 없으면          「위키앙에 작성하기」  ← 막다른 길 대신 기여 유도
+ * 두 경우 모두 wikiang.org/w/<제목> 으로 간다(없는 문서는 위키앙이 작성 UI 안내).
+ *
+ * 표면 2곳(본문 markdown.svelte · 댓글 comment-list)의 렌더 후 effect 에서 부른다.
+ * 재렌더 중복 방지 = data-wikiang 마킹. 실패는 조용히(배지 생략) — 원문 영향 0.
+ */
+const BADGE_CLASS = 'wikiang-link';
+
+function titleFromNamuHref(href: string): string | null {
+    try {
+        const u = new URL(href);
+        if (!u.hostname.endsWith('namu.wiki')) return null;
+        if (!u.pathname.startsWith('/w/')) return null;
+        const t = decodeURIComponent(u.pathname.slice(3)).trim();
+        // 앵커(#s-1)는 URL 해시라 pathname 에 없음. 하위 문서(슬래시 포함)는 그대로 둔다.
+        return t.length > 0 && t.length <= 255 ? t : null;
+    } catch {
+        return null;
+    }
+}
+
+export async function enhanceWikiangLinks(container: HTMLElement): Promise<void> {
+    const anchors = container.querySelectorAll<HTMLAnchorElement>(
+        'a[href*="namu.wiki/w/"]:not([data-wikiang])'
+    );
+    if (anchors.length === 0) return;
+
+    const byTitle = new Map<string, HTMLAnchorElement[]>();
+    anchors.forEach((a) => {
+        a.dataset.wikiang = '1';
+        const t = titleFromNamuHref(a.href);
+        if (!t) return;
+        const list = byTitle.get(t) ?? [];
+        list.push(a);
+        byTitle.set(t, list);
+    });
+    if (byTitle.size === 0) return;
+
+    let exists = new Set<string>();
+    try {
+        const titles = [...byTitle.keys()].slice(0, 20);
+        const res = await fetch(
+            `/api/wikiang/exists?titles=${encodeURIComponent(titles.join('|'))}`
+        );
+        if (res.ok) exists = new Set<string>((await res.json()).exists ?? []);
+    } catch {
+        // 존재 확인 실패 → 전부 '작성하기' 로 표시 (fail-open, 링크 자체는 유효)
+    }
+
+    for (const [title, list] of byTitle) {
+        const has = exists.has(title);
+        for (const a of list) {
+            // 이미 배지가 붙은 앵커(재호출 경합) 방지
+            if (a.nextElementSibling?.classList?.contains(BADGE_CLASS)) continue;
+            const badge = document.createElement('a');
+            badge.className = BADGE_CLASS + (has ? '' : ` ${BADGE_CLASS}--new`);
+            badge.href = `https://wikiang.org/w/${encodeURIComponent(title)}`;
+            badge.target = '_blank';
+            badge.rel = 'noopener noreferrer';
+            badge.textContent = has ? '위키앙 문서 보기' : '위키앙에 작성하기';
+            a.after(badge);
+        }
+    }
+}

--- a/apps/web/src/routes/api/wikiang/exists/+server.ts
+++ b/apps/web/src/routes/api/wikiang/exists/+server.ts
@@ -1,0 +1,71 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { readPool } from '$lib/server/db';
+import type { RowDataPacket } from 'mysql2';
+
+/**
+ * 위키앙 문서 존재 배치 조회 (8/7 위키 연결 — 하이브리드 승인)
+ *
+ * GET ?titles=제목1|제목2  (최대 20개)
+ * → { exists: string[] }   존재하는 제목만
+ *
+ * 본문·댓글의 나무위키 링크 옆에 「위키앙 문서 보기 / 작성하기」를 가르는 용도.
+ * wikiang 은 같은 Angple 멀티사이트라 외부 API 없이 직조회한다
+ * (wka_wiki.wikiang_pages — lib/server/wiki.ts 와 같은 저장소).
+ *
+ * ⚠️ 실패는 전부 fail-open(빈 배열) — 이 기능이 죽어도 화면은 그대로다.
+ *    단 조용히 죽지 않게 5분에 한 번은 로그를 남긴다(조용한 실패 금지 원칙).
+ */
+const CACHE_TTL_MS = 5 * 60_000;
+const cache = new Map<string, { exists: boolean; at: number }>();
+let lastErrLogAt = 0;
+
+export const GET: RequestHandler = async ({ url, setHeaders }) => {
+    const raw = url.searchParams.get('titles') ?? '';
+    const titles = [
+        ...new Set(
+            raw
+                .split('|')
+                .map((t) => t.trim())
+                .filter((t) => t.length > 0 && t.length <= 255)
+        )
+    ].slice(0, 20);
+
+    setHeaders({ 'Cache-Control': 'public, max-age=300' });
+    if (titles.length === 0) return json({ exists: [] });
+
+    const now = Date.now();
+    const need: string[] = [];
+    const found: string[] = [];
+    for (const t of titles) {
+        const c = cache.get(t);
+        if (c && now - c.at < CACHE_TTL_MS) {
+            if (c.exists) found.push(t);
+        } else {
+            need.push(t);
+        }
+    }
+
+    if (need.length > 0) {
+        try {
+            const [rows] = await readPool.query<RowDataPacket[]>(
+                // ⛔ DB 명시(wka_wiki.) 필수 — 이 라우트는 damoang 풀에서 돈다.
+                `SELECT title FROM wka_wiki.wikiang_pages WHERE title IN (${need.map(() => '?').join(',')})`,
+                need
+            );
+            const hit = new Set(rows.map((r) => String(r.title)));
+            for (const t of need) {
+                const ok = hit.has(t);
+                cache.set(t, { exists: ok, at: now });
+                if (ok) found.push(t);
+            }
+        } catch (e) {
+            if (now - lastErrLogAt > CACHE_TTL_MS) {
+                lastErrLogAt = now;
+                console.error('[wikiang/exists] 조회 실패 (fail-open):', e);
+            }
+            // fail-open: 이번 요청분은 미존재 취급(작성하기 링크로 표시됨)
+        }
+    }
+    return json({ exists: found });
+};


### PR DESCRIPTION
8/7 하이브리드 승인안 구현.

## 동작
본문·댓글의 `namu.wiki/w/…` 링크 옆에 작은 칩:
- 위키앙에 문서 있음 → **「위키앙 문서 보기」** (실선 테두리)
- 없음 → **「위키앙에 작성하기」** (점선·연하게) — 현재 위키앙 119문서라 대부분 이쪽. 막다른 길이 아니라 기여 입구다

**원본 링크는 치환하지 않는다** — 배지만 옆에 붙는다.

## 구조 (정찰 결과 반영)
- wikiang = 같은 Angple 멀티사이트 → `/api/wikiang/exists` 가 `wka_wiki.wikiang_pages` **DB 직조회** (외부 API 없음, 배치 최대 20제목·서버 5분 캐시·CDN 300s)
- **fail-open**: DB 권한/장애 시 배지는 '작성하기'로 강등되거나 생략될 뿐 원문 영향 0. 단 5분 스로틀 로그로 조용히 죽지 않게(⛔조용한 실패 금지)
- 표면 2곳 각각(본문 `.prose`·댓글 `.comment-body`) — 렌더 후 effect 스캔, `data-wikiang` 마킹으로 재렌더 중복 방지. effect 는 렌더 산출물만 읽고 상태를 쓰지 않는다(재트리거 금지 원칙)
- PII 이동 없음(외부로 나가는 건 회원 클릭뿐) — wikiang 법적 분리 원칙 유지

## 카나리 확인 항목
① `/api/wikiang/exists?titles=12월` → `{"exists":["12월"]}` (실존 문서) — **damoang 풀 DB 유저의 wka_wiki 읽기 권한 실증** (없으면 fail-open 로그 확인) ② 나무위키 링크 있는 글에서 배지 렌더·중복 없음 ③ 다크모드 칩 가독성