### PR TITLE
fix(mention): route mention clicks by data-id (bug/13396)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -29,6 +29,7 @@
     import { highlightAllCodeBlocks } from '$lib/utils/code-highlight';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
     import { enhanceWikiangLinks } from '$lib/utils/wikiang-link.js';
+    import { fixMentionLinks } from '$lib/utils/mention-link-fix.js';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
     import { SvelteMap, SvelteSet } from 'svelte/reactivity';
     import type { Component } from 'svelte';
@@ -960,7 +961,10 @@
         void processedComments.size;
         const el = commentListEl;
         if (!el) return;
-        tick().then(() => enhanceWikiangLinks(el));
+        tick().then(() => {
+            enhanceWikiangLinks(el);
+            fixMentionLinks(el);
+        });
     });
 
     // 인라인 스포일러 클릭 공개 — 위임 리스너 1개(1회 설치형, 반응형 읽기 없음)

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -11,6 +11,7 @@
     import { processContent as processEmbeds } from '$lib/plugins/auto-embed/embedder.js';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
     import { enhanceWikiangLinks } from '$lib/utils/wikiang-link.js';
+    import { fixMentionLinks } from '$lib/utils/mention-link-fix.js';
     import {
         buildThumbnailSrcSet,
         isTransformableMediaImage,
@@ -300,7 +301,10 @@
         void renderedHtml;
         const el = proseEl;
         if (!el || !browser) return;
-        tick().then(() => enhanceWikiangLinks(el));
+        tick().then(() => {
+            enhanceWikiangLinks(el);
+            fixMentionLinks(el);
+        });
     });
 
     // 인라인 스포일러 클릭 공개 — 위임 리스너 하나. 반응형 값을 읽지 않는 1회 설치형.

--- a/apps/web/src/lib/utils/mention-link-fix.ts
+++ b/apps/web/src/lib/utils/mention-link-fix.ts
@@ -10,9 +10,7 @@
  * 위키앙 배지와 같은 렌더 후 보정 패턴 · 두 표면(본문/댓글) 각각에서 호출된다.
  */
 export function fixMentionLinks(container: HTMLElement): void {
-    const spans = container.querySelectorAll<HTMLElement>(
-        'span.mention[data-id]:not([data-mfix])'
-    );
+    const spans = container.querySelectorAll<HTMLElement>('span.mention[data-id]:not([data-mfix])');
     spans.forEach((sp) => {
         sp.dataset.mfix = '1';
         const id = sp.dataset.id;

--- a/apps/web/src/lib/utils/mention-link-fix.ts
+++ b/apps/web/src/lib/utils/mention-link-fix.ts
@@ -1,0 +1,33 @@
+/**
+ * 멘션 클릭을 data-id(mb_id)로 보정한다 (bug/13396).
+ *
+ * TipTap 멘션 스팬은 정확한 mb_id 를 data-id 로 들고 있는데, 렌더 후처리
+ * (highlightMentions)가 스팬 **안의 텍스트**를 닉네임 기반 /member/<nick> 링크로
+ * 다시 감싼다. 닉네임에 보이지 않는 문자(U+2800 등)가 있으면 정규식이 중간에서
+ * 끊겨 존재하지 않는 주소가 되고 "회원을 찾을 수 없습니다"가 뜬다.
+ *
+ * 여기서는 스팬이 이미 아는 mb_id 로 href 를 덮어쓴다 — 닉네임이 어떻든 정확하다.
+ * 위키앙 배지와 같은 렌더 후 보정 패턴 · 두 표면(본문/댓글) 각각에서 호출된다.
+ */
+export function fixMentionLinks(container: HTMLElement): void {
+    const spans = container.querySelectorAll<HTMLElement>(
+        'span.mention[data-id]:not([data-mfix])'
+    );
+    spans.forEach((sp) => {
+        sp.dataset.mfix = '1';
+        const id = sp.dataset.id;
+        if (!id) return;
+        const href = `/member/${encodeURIComponent(id)}`;
+        const inner = sp.querySelectorAll<HTMLAnchorElement>('a');
+        if (inner.length > 0) {
+            inner.forEach((a) => (a.href = href));
+        } else {
+            // 안에 링크가 없으면 스팬 자체를 클릭 가능하게
+            const a = document.createElement('a');
+            a.href = href;
+            a.className = 'mention-link';
+            while (sp.firstChild) a.appendChild(sp.firstChild);
+            sp.appendChild(a);
+        }
+    });
+}


### PR DESCRIPTION
## bug/13396 — @멘션 클릭 시 "회원을 찾을 수 없습니다"

닉네임이 `PWL⠀`(끝에 **U+2800 투명문자**)인 회원 멘션 → 렌더 후처리가 스팬 안 텍스트를 닉네임 기반 `/member/<nick>` 으로 재링크 → 정규식이 투명문자에서 끊겨 `/member/PWL`(실존 안 함).

**수정**: `span.mention[data-id]` 가 이미 아는 **mb_id 로 href 덮어쓰기** — 닉네임이 어떤 문자든 정확한 프로필로 간다. 본문·댓글 두 표면, `data-mfix` 중복 방지(위키앙 배지와 동일 패턴).

**후속(별건)**: 닉네임 가입/변경 시 비표시 문자 차단 · 기존 계정 닉 정리 정책 판단.