### PR TITLE
fix(board): 게시글 제목 익명 flex 텍스트 잘림 방지 (bug/13388)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -201,17 +201,22 @@
                 {#if post.is_secret}
                     <Lock class="text-muted-foreground h-6 w-6 shrink-0" />
                 {/if}
-                {#if post.is_discipline_related}
-                    <DisciplinedContent
-                        inline
-                        isLoggedIn={authStore.isAuthenticated}
-                        bind:revealed={discReveal}
-                    >
+                <!-- bug/13388: 맨몸 텍스트는 익명 flex item 이 되어 min-width/줄바꿈을
+                     제어할 수 없고, iOS WebKit 에서 줄바꿈 폭 오계산 → 1행 넘침이
+                     조상 overflow-x:hidden 에 잘려 글자가 소실된다. 실요소로 감싼다. -->
+                <span class="min-w-0 [overflow-wrap:anywhere]">
+                    {#if post.is_discipline_related}
+                        <DisciplinedContent
+                            inline
+                            isLoggedIn={authStore.isAuthenticated}
+                            bind:revealed={discReveal}
+                        >
+                            {post.title}
+                        </DisciplinedContent>
+                    {:else}
                         {post.title}
-                    </DisciplinedContent>
-                {:else}
-                    {post.title}
-                {/if}
+                    {/if}
+                </span>
                 {#if isLockedPost}
                     <span
                         class="bg-destructive/10 text-destructive inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium"

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -473,17 +473,20 @@
             <CardTitle
                 class="text-foreground flex items-center gap-2 text-xl font-bold sm:text-2xl"
             >
-                {#if post.is_discipline_related}
-                    <DisciplinedContent
-                        inline
-                        isLoggedIn={authStore.isAuthenticated}
-                        bind:revealed={discReveal}
-                    >
+                <!-- bug/13388: basic.svelte 와 동일 — 익명 flex 텍스트를 실요소로 감싼다 -->
+                <span class="min-w-0 [overflow-wrap:anywhere]">
+                    {#if post.is_discipline_related}
+                        <DisciplinedContent
+                            inline
+                            isLoggedIn={authStore.isAuthenticated}
+                            bind:revealed={discReveal}
+                        >
+                            {post.title}
+                        </DisciplinedContent>
+                    {:else}
                         {post.title}
-                    </DisciplinedContent>
-                {:else}
-                    {post.title}
-                {/if}
+                    {/if}
+                </span>
             </CardTitle>
 
             <!-- 리포트 기간 배지 -->


### PR DESCRIPTION
## bug/13388 — 모바일웹 제목 글자 소실

스크린샷 판독: 1행이 컨테이너 폭을 넘어간 채 반글자로 잘리고, 넘친 글자(「안군 "협」)가 통째로 사라진 뒤 2행이 이어짐. 데스크톱 전 폭에서 재현 불가 → 브라우저 특이(iOS WebKit 추정).

**원인 구조**: `CardTitle`이 `flex flex-wrap gap-2` 컨테이너이고 제목이 **맨몸 텍스트 노드**(익명 flex item)로 들어감. 익명 아이템은 CSS 로 min-width·wrap 제어가 불가하고, WebKit 에서 줄바꿈 가용폭 오계산 시 1행 넘침 → 조상 `overflow-x:hidden` 클립 → 글자 소실.

**수정**: 제목을 `span.min-w-0.[overflow-wrap:anywhere]` 실요소로 감쌈 (view/basic + view/report). 마크업 구조만 변경, 로직 무변경.