### PR TITLE
fix(auth): 앱 OAuth 복귀 인터스티셜 — Android 소셜 로그인 불가/404 수정

### DIFF
--- a/apps/web/src/routes/auth/app-return/+server.ts
+++ b/apps/web/src/routes/auth/app-return/+server.ts
@@ -1,0 +1,78 @@
+import type { RequestHandler } from './$types';
+
+/**
+ * GET /auth/app-return?code=… | ?error=…&provider=…
+ *
+ * 네이티브 앱 OAuth 복귀 인터스티셜.
+ *
+ * 배경(#app-login-404): 콜백에서 앱 스킴(damoang://oauth-callback)으로 **서버 302**를
+ * 보내면 iOS(ASWebAuthenticationSession)는 가로채지만, Android Chrome 커스텀 탭은
+ * 서버발 커스텀 스킴 리다이렉트를 차단하고 에러 페이지를 띄운다(사용자 제보: "404가
+ * 스쳐간다", 로그인 실패). 그래서 같은 오리진의 이 페이지로 302 한 뒤,
+ *  1) JS location.replace 로 스킴 이동(iOS 세션이 이 시점에 가로챔)
+ *  2) Android 는 intent:// 폴백(스킴+패키지 명시)으로 재시도
+ *  3) 자동 이동이 막히면 사용자가 버튼을 눌러 복귀(사용자 제스처는 항상 허용)
+ *
+ * 전달 파라미터는 code/error/provider 만 화이트리스트로 통과시킨다.
+ */
+const APP_SCHEME_BASE = 'damoang://oauth-callback';
+const ANDROID_PACKAGE = 'net.damoang.community';
+const PASS_PARAMS = ['code', 'error', 'provider'] as const;
+
+export const GET: RequestHandler = async ({ url }) => {
+    const qs = new URLSearchParams();
+    for (const key of PASS_PARAMS) {
+        const v = url.searchParams.get(key);
+        if (v) qs.set(key, v);
+    }
+    const query = qs.toString();
+    const appUrl = query ? `${APP_SCHEME_BASE}?${query}` : APP_SCHEME_BASE;
+    const intentUrl =
+        `intent://oauth-callback${query ? `?${query}` : ''}` +
+        `#Intent;scheme=damoang;package=${ANDROID_PACKAGE};end`;
+
+    const html = `<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex,nofollow" />
+<title>다모앙 앱으로 돌아가는 중…</title>
+<style>
+  body { font-family: -apple-system, sans-serif; display: flex; flex-direction: column;
+         align-items: center; justify-content: center; min-height: 90vh; gap: 16px;
+         background: #fafafa; color: #222; margin: 0; padding: 24px; text-align: center; }
+  a.btn { display: inline-block; padding: 14px 28px; border-radius: 12px; background: #222;
+          color: #fff; text-decoration: none; font-size: 16px; font-weight: 600; }
+  p { color: #666; font-size: 14px; margin: 0; }
+</style>
+</head>
+<body>
+<p id="msg">다모앙 앱으로 돌아가는 중…</p>
+<a class="btn" href="${appUrl}" id="open">다모앙 앱 열기</a>
+<script>
+  (function () {
+    var appUrl = ${JSON.stringify(appUrl)};
+    var intentUrl = ${JSON.stringify(intentUrl)};
+    var isAndroid = /android/i.test(navigator.userAgent);
+    // iOS: 인증 세션이 이 네비게이션을 가로채 앱으로 복귀한다.
+    // Android: 스킴 직행이 막히면 intent:// 로 한 번 더 시도한다.
+    try { window.location.replace(appUrl); } catch (e) {}
+    if (isAndroid) {
+      document.getElementById('open').setAttribute('href', intentUrl);
+      setTimeout(function () {
+        try { window.location.replace(intentUrl); } catch (e) {}
+      }, 400);
+    }
+  })();
+</script>
+</body>
+</html>`;
+
+    return new Response(html, {
+        headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'no-store'
+        }
+    });
+};

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -101,12 +101,12 @@ async function generateInviteTempNickname(provider: string): Promise<string> {
 }
 
 /**
- * 에러 리다이렉트. 네이티브 앱 모드(appMode)면 앱 스킴(damoang://oauth-callback?error=)으로 복귀시켜
- * 인앱 브라우저가 웹 /login 에 갇히는 것을 방지한다. 아니면 기존대로 웹 로그인으로.
+ * 에러 리다이렉트. 네이티브 앱 모드(appMode)면 /auth/app-return 인터스티셜을 거쳐 앱 스킴으로
+ * 복귀시킨다(Android 는 서버 302→커스텀 스킴이 차단되므로 직행 금지, #app-login-404).
  */
 function redirectError(errorCode: string, appMode: boolean): never {
     if (appMode) {
-        redirect(302, `damoang://oauth-callback?error=${encodeURIComponent(errorCode)}`);
+        redirect(302, `/auth/app-return?error=${encodeURIComponent(errorCode)}`);
     }
     redirect(302, `/login?error=${encodeURIComponent(errorCode)}`);
 }
@@ -239,7 +239,7 @@ async function handleCallback(
                 const existingByEmail = await findMemberByEmail(profile.email);
                 if (existingByEmail) {
                     if (stateData.appMode) {
-                        redirect(302, 'damoang://oauth-callback?error=email_exists');
+                        redirect(302, '/auth/app-return?error=email_exists');
                     }
                     redirect(302, '/login?error=email_exists');
                 }
@@ -257,7 +257,7 @@ async function handleCallback(
             ) {
                 redirect(
                     302,
-                    `damoang://oauth-callback?error=no_account&provider=${encodeURIComponent(providerName)}`
+                    `/auth/app-return?error=no_account&provider=${encodeURIComponent(providerName)}`
                 );
             }
 
@@ -370,7 +370,7 @@ async function handleCallback(
                 }
                 if (stateData.appMode) {
                     // 앱 모드: 비활성/이용제한 계정은 앱으로 에러 복귀 (임시계정 우회 생성 금지)
-                    redirect(302, 'damoang://oauth-callback?error=account_inactive');
+                    redirect(302, '/auth/app-return?error=account_inactive');
                 }
                 redirect(302, '/login?error=account_inactive');
             }
@@ -477,7 +477,7 @@ async function handleCallback(
                 mb_level: Number(member.mb_level ?? 1),
                 mb_email: member.mb_email || ''
             });
-            redirect(302, `damoang://oauth-callback?code=${encodeURIComponent(appLoginCode)}`);
+            redirect(302, `/auth/app-return?code=${encodeURIComponent(appLoginCode)}`);
         }
 
         // 원래 페이지로 리다이렉트


### PR DESCRIPTION
## 증상 (실사용자 제보 2건, 2026-08-07)
- "안드로이드는 로그인이 안된대"
- Ben님: "다모앙앱에서 구글로 로그인하니 404 에러가 스쳐가요"

## 원인
`auth/callback/[provider]`가 앱 모드에서 `redirect(302, 'damoang://oauth-callback?…')` — **서버 302로 커스텀 스킴**. iOS(ASWebAuthenticationSession)는 가로채지만 **Android Chrome 커스텀 탭은 차단**하고 에러 페이지를 표시 → 앱 복귀 실패 = Android 소셜 로그인 전체 불가.

## 수정
- 신규 **GET /auth/app-return** 인터스티셜(같은 오리진이라 302 안전): JS `location.replace(damoang://…)` → iOS 세션이 여기서 가로챔 / Android는 `intent://…#Intent;scheme=damoang;package=net.damoang.community;end` 폴백 / 실패 시 수동 버튼(사용자 제스처는 항상 허용). 파라미터는 code/error/provider 화이트리스트.
- 콜백의 스킴 302 **6곳 전부** `/auth/app-return` 경유로 치환.

## 영향
- 앱 재배포 불필요(웹 배포만으로 즉시 적용), iOS 기존 동작 보존.
- svelte-check: 신규/변경 파일 무결(기존 26 errors는 main 부채).

## 검증 계획
canary 배포 → Android 실기기에서 카카오/구글 로그인 E2E → prod.