### PR TITLE
fix(security): 회원 실명(mb_name) 무인증 노출 제거

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -703,7 +703,7 @@ export interface LikeResponse {
 // 추천자 목록 응답
 export interface LikerInfo {
     mb_id: string;
-    mb_name: string;
+    // mb_name(실명) 제거 — 2026-08-08 개인정보 전수점검. 표시는 nick, 폴백은 id.
     mb_nick: string; // 닉네임
     mb_image?: string; // 프로필 이미지 URL
     mb_image_updated_at?: string; // 이미지 변경 시각 (캐시 버스팅용)

--- a/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
+++ b/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
@@ -97,7 +97,7 @@
                                 {#if likerIcon}
                                     <img
                                         src={likerIcon}
-                                        alt={liker.mb_nick || liker.mb_name}
+                                        alt={liker.mb_nick || liker.mb_id}
                                         class="size-8 rounded-full object-cover"
                                         onerror={(e) => {
                                             const img = e.currentTarget as HTMLImageElement;
@@ -109,13 +109,13 @@
                                     <div
                                         class="bg-primary text-primary-foreground hidden size-8 items-center justify-center rounded-full text-sm"
                                     >
-                                        {(liker.mb_nick || liker.mb_name).charAt(0).toUpperCase()}
+                                        {(liker.mb_nick || liker.mb_id).charAt(0).toUpperCase()}
                                     </div>
                                 {:else}
                                     <div
                                         class="bg-primary text-primary-foreground flex size-8 items-center justify-center rounded-full text-sm"
                                     >
-                                        {(liker.mb_nick || liker.mb_name).charAt(0).toUpperCase()}
+                                        {(liker.mb_nick || liker.mb_id).charAt(0).toUpperCase()}
                                     </div>
                                 {/if}
 
@@ -125,7 +125,7 @@
                                             href="/member/{liker.mb_id}"
                                             class="text-foreground hover:text-primary truncate text-sm font-medium"
                                         >
-                                            {liker.mb_nick || liker.mb_name}
+                                            {liker.mb_nick || liker.mb_id}
                                         </a>
                                         {#if memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                                             <MemoBadge

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2746,7 +2746,7 @@
                                                 liker.mb_image,
                                                 liker.mb_image_updated_at
                                             )}
-                                            alt={liker.mb_nick || liker.mb_name}
+                                            alt={liker.mb_nick || liker.mb_id}
                                             class="size-8 rounded-full object-cover"
                                             onerror={(e) => {
                                                 const img = e.currentTarget as HTMLImageElement;
@@ -2759,17 +2759,13 @@
                                         <div
                                             class="bg-primary text-primary-foreground hidden size-8 items-center justify-center rounded-full text-sm"
                                         >
-                                            {(liker.mb_nick || liker.mb_name)
-                                                .charAt(0)
-                                                .toUpperCase()}
+                                            {(liker.mb_nick || liker.mb_id).charAt(0).toUpperCase()}
                                         </div>
                                     {:else}
                                         <div
                                             class="bg-primary text-primary-foreground flex size-8 items-center justify-center rounded-full text-sm"
                                         >
-                                            {(liker.mb_nick || liker.mb_name)
-                                                .charAt(0)
-                                                .toUpperCase()}
+                                            {(liker.mb_nick || liker.mb_id).charAt(0).toUpperCase()}
                                         </div>
                                     {/if}
 
@@ -2780,7 +2776,7 @@
                                                 href="/member/{liker.mb_id}"
                                                 class="text-foreground hover:text-primary truncate text-sm font-medium"
                                             >
-                                                {liker.mb_nick || liker.mb_name}
+                                                {liker.mb_nick || liker.mb_id}
                                             </a>
                                             {#if authStore.isAuthenticated && memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                                                 <MemoBadge

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
@@ -40,7 +40,6 @@ function maskIp(ip: string | null | undefined): string {
 interface LikerRow extends RowDataPacket {
     mb_id: string;
     mb_nick: string;
-    mb_name: string;
     mb_image_url: string;
     mb_image_updated_at: string | null;
     bg_ip: string;
@@ -116,8 +115,10 @@ export const GET: RequestHandler = async ({ params, url, cookies, request }) => 
         const total = countRows[0]?.total ?? 0;
 
         // 추천자 목록 (최신순)
+        // ⛔ 2026-08-08 개인정보 전수점검: mb_name(실명)은 응답에 싣지 않는다.
+        //    표시는 닉네임이고, 닉네임이 비면 mb_id 로 폴백한다(실명 대신).
         const [likerRows] = await pool.query<LikerRow[]>(
-            `SELECT g.mb_id, m.mb_nick, m.mb_name, COALESCE(m.mb_image_url, '') as mb_image_url, m.mb_image_updated_at, g.bg_ip, g.bg_datetime
+            `SELECT g.mb_id, m.mb_nick, COALESCE(m.mb_image_url, '') as mb_image_url, m.mb_image_updated_at, g.bg_ip, g.bg_datetime
 			 FROM g5_board_good g
 			 JOIN g5_member m ON g.mb_id = m.mb_id
 			 WHERE g.bo_table = ? AND g.wr_id = ? AND g.bg_flag = 'good'
@@ -128,7 +129,6 @@ export const GET: RequestHandler = async ({ params, url, cookies, request }) => 
 
         const likers = likerRows.map((row) => ({
             mb_id: row.mb_id,
-            mb_name: row.mb_name,
             mb_nick: row.mb_nick,
             mb_image: row.mb_image_url || '',
             mb_image_updated_at: row.mb_image_updated_at || undefined,

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
@@ -44,7 +44,6 @@ interface LikerRow extends RowDataPacket {
     wr_id: number;
     mb_id: string;
     mb_nick: string;
-    mb_name: string;
     mb_image_url: string;
     mb_image_updated_at: string | null;
     bg_ip: string;
@@ -129,9 +128,9 @@ export const GET: RequestHandler = async ({ params, url, cookies, request }) => 
         // 댓글별 추천자 목록 (limit개씩, 최신순)
         // ROW_NUMBER() 윈도우 함수로 댓글별 limit 적용
         const [likerRows] = await pool.query<LikerRow[]>(
-            `SELECT sub.wr_id, sub.mb_id, sub.mb_nick, sub.mb_name, sub.mb_image_url, sub.mb_image_updated_at, sub.bg_ip, sub.bg_datetime
+            `SELECT sub.wr_id, sub.mb_id, sub.mb_nick, sub.mb_image_url, sub.mb_image_updated_at, sub.bg_ip, sub.bg_datetime
 			 FROM (
-			   SELECT g.wr_id, g.mb_id, m.mb_nick, m.mb_name, COALESCE(m.mb_image_url, '') as mb_image_url, m.mb_image_updated_at, g.bg_ip, g.bg_datetime,
+			   SELECT g.wr_id, g.mb_id, m.mb_nick, COALESCE(m.mb_image_url, '') as mb_image_url, m.mb_image_updated_at, g.bg_ip, g.bg_datetime,
 			          ROW_NUMBER() OVER (PARTITION BY g.wr_id ORDER BY g.bg_datetime DESC) AS rn
 			   FROM g5_board_good g
 			   JOIN g5_member m ON g.mb_id = m.mb_id
@@ -147,7 +146,6 @@ export const GET: RequestHandler = async ({ params, url, cookies, request }) => 
             {
                 likers: Array<{
                     mb_id: string;
-                    mb_name: string;
                     mb_nick: string;
                     mb_image: string;
                     mb_image_updated_at?: string;
@@ -170,7 +168,6 @@ export const GET: RequestHandler = async ({ params, url, cookies, request }) => 
             if (data[key]) {
                 data[key].likers.push({
                     mb_id: row.mb_id,
-                    mb_name: row.mb_name,
                     mb_nick: row.mb_nick,
                     mb_image: row.mb_image_url || '',
                     mb_image_updated_at: row.mb_image_updated_at || undefined,

--- a/apps/web/src/routes/api/members/search/+server.ts
+++ b/apps/web/src/routes/api/members/search/+server.ts
@@ -41,8 +41,10 @@ export const GET: RequestHandler = async ({ url }) => {
         }
 
         const searchPattern = `%${query}%`;
+        // ⛔ 2026-08-08 개인정보 전수점검: mb_name(실명)은 무인증 검색 응답에
+        //    싣지 않는다. 멘션 자동완성 등 소비처는 mb_nick/mb_id 만 쓴다(실측).
         const [rows] = await pool.query<RowDataPacket[]>(
-            `SELECT mb_id, mb_nick, mb_name, IFNULL(as_level, 1) as as_level
+            `SELECT mb_id, mb_nick, IFNULL(as_level, 1) as as_level
 			 FROM g5_member
 			 WHERE (mb_nick LIKE ? OR mb_id LIKE ?)
 			   AND mb_leave_date = ''
@@ -58,7 +60,6 @@ export const GET: RequestHandler = async ({ url }) => {
         const members = rows.map((row) => ({
             mb_id: row.mb_id,
             mb_nick: row.mb_nick,
-            mb_name: row.mb_name,
             as_level: row.as_level
         }));
 


### PR DESCRIPTION
전수 조사(2026-08-08) P1. 무인증 API 두 곳이 회원 **실명**(mb_name)을 응답에 실었다.

- `/api/members/search?q=` — 부분일치로 실명+mb_id 대량 열거 가능. 소비처(멘션 자동완성)는 nick/id만 사용 확인 → 제거.
- 댓글 추천자 목록 — 실명 노출(IP는 이미 마스킹). 표시 폴백을 `mb_nick || mb_id`로 변경, 서버·타입에서 mb_name 제거.

P0(users·tenants·saas 무인증)는 be#638 + 엣지 차단으로 별도 처리.