### PR TITLE
fix(security): 팔로우그래프 무인증 차단 + my/following 실명 제거

### DIFF
--- a/apps/web/src/routes/api/members/[id]/followers/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/followers/+server.ts
@@ -25,7 +25,12 @@ interface CountRow extends RowDataPacket {
     count: number;
 }
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
+    // ⛔ 2026-08-08 개인정보 전수점검: 무인증 팔로우그래프 열람 차단(profile 게이트와 동일, #12501).
+    if (!locals.user) {
+        return json({ success: false, error: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
     const targetId = params.id;
 
     if (!targetId || !/^[a-zA-Z0-9_-]+$/.test(targetId)) {

--- a/apps/web/src/routes/api/members/[id]/following/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/following/+server.ts
@@ -25,7 +25,12 @@ interface CountRow extends RowDataPacket {
     count: number;
 }
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
+    // ⛔ 2026-08-08 개인정보 전수점검: 무인증 팔로우그래프 열람 차단(profile 게이트와 동일, #12501).
+    if (!locals.user) {
+        return json({ success: false, error: '로그인이 필요합니다.' }, { status: 401 });
+    }
+
     const memberId = params.id;
 
     if (!memberId || !/^[a-zA-Z0-9_-]+$/.test(memberId)) {

--- a/apps/web/src/routes/api/my/following/+server.ts
+++ b/apps/web/src/routes/api/my/following/+server.ts
@@ -11,7 +11,6 @@ import { internalOnlyErrorResponse, isInternalAppRequest } from '$lib/server/int
 
 interface FollowMemberRow extends RowDataPacket {
     mb_id: string;
-    mb_name: string;
     mb_nick: string;
 }
 
@@ -27,7 +26,7 @@ export const GET: RequestHandler = async ({ cookies, request }) => {
 
     try {
         const [rows] = await readPool.query<FollowMemberRow[]>(
-            `SELECT f.target_id AS mb_id, m.mb_name, m.mb_nick
+            `SELECT f.target_id AS mb_id, m.mb_nick
 			 FROM g5_member_follow f
 			 JOIN g5_member m
 			   ON f.target_id COLLATE utf8mb4_unicode_ci = m.mb_id COLLATE utf8mb4_unicode_ci
@@ -40,7 +39,6 @@ export const GET: RequestHandler = async ({ cookies, request }) => {
             success: true,
             data: rows.map((r) => ({
                 mb_id: r.mb_id,
-                mb_name: r.mb_name,
                 mb_nick: r.mb_nick
             }))
         });


### PR DESCRIPTION
전수 재조사 2차 확정분(웹).

- `members/[id]/followers`·`following`: **무인증으로 임의 회원 팔로우그래프 전량 열람** 가능(profile #12501 게이트 우회). 실측 200 확인 → 로그인 게이트 추가.
- `my/following`: 응답에 **실명(mb_name)** 잔존(8/8 스윕 누락) → 제거.