### PR TITLE
fix: 댓글 iframe 임베드 공백(13417) + 알림 벨 팬텀(13419)

### DIFF
--- a/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
+++ b/apps/web/src/lib/components/features/notification/notification-dropdown.svelte
@@ -246,8 +246,12 @@
     // 쏘면 열기만 해도 8만 건이 비가역으로 읽음 처리되는 문제(13367)가 있었다.
     // 자동읽음 설정 게이트는 제거 — seen 은 파괴적이지 않아 옵션일 이유가 없다.
     // ⛔ 이번 로드가 성공했을 때만 처리한다 — 보지도 못한 알림의 뱃지를 지우면 안 된다.
+    //    (그 게이트는 호출부 loadAndMarkSeen 의 ok 검사가 담당한다.)
+    // ⛔ bug/13419: 여기서 read 기준 unreadCount(안읽음 수)로 게이트하면 안 된다. 벨 배지는
+    //    seen 기준(ph_id > lastSeen)이라, 회원이 알림함을 안 열고 스레드에서 직접 읽으면
+    //    안읽음은 0인데 seen 포인터는 안 올라가 벨이 영구히 켜진다("다 확인했는데 종이 울림").
+    //    로드가 성공(=실제로 알림함을 봄)했으면 무조건 seen 을 갱신한다. seen 은 비파괴적이다.
     async function markSeenOnOpen(): Promise<void> {
-        if (unreadCount <= 0) return;
         try {
             await apiClient.markNotificationsSeen();
             unreadCount = 0;

--- a/plugins/auto-embed/lib/platforms/reddit.ts
+++ b/plugins/auto-embed/lib/platforms/reddit.ts
@@ -1,25 +1,49 @@
 import type { EmbedInfo, EmbedPlatform } from '../types';
 
 /**
- * Reddit 임베딩 플랫폼
+ * Reddit 임베딩 플랫폼 (iframe 방식)
+ *
+ * bug/13417: 이 댓글 사본이 legacy blockquote 위젯을 출력했는데, 변환 스크립트가
+ * 로드되지 않아 500px 짜리 빈 박스만 남아 공백이 됐다. 본문 사본(#12044 iframe 방식)과
+ * 동기화한다.
  */
 export const reddit: EmbedPlatform = {
     name: 'reddit',
-    patterns: [/(?:www\.)?reddit\.com\/(r|user)\/[\w:.]{2,21}\/comments\/\w{5,9}/],
+    patterns: [
+        /(?:www\.)?reddit\.com\/(r|user)\/[\w:.]{2,21}\/comments\/\w{5,9}/,
+        /(?:www\.)?reddit\.com\/(r|user)\/[\w:.]{2,21}\/s\/[\w-]+/
+    ],
 
     extract(url: string): EmbedInfo | null {
-        const match = url.match(
-            /(?:www\.)?reddit\.com\/(r|user)\/([\w:.]{2,21})\/comments\/(\w{5,9})(?:\/([\w%\\-]+))?/
+        const commentsMatch = url.match(
+            /(?:www\.)?reddit\.com\/(r|user)\/([\w:.]{2,21})\/comments\/(\w{5,9})(?:\/([\w%\-]+))?/
         );
-        if (match) {
+        if (commentsMatch) {
             return {
                 platform: 'reddit',
-                id: match[3],
+                id: commentsMatch[3],
                 url,
                 params: {
-                    type: match[1],
-                    subreddit: match[2],
-                    slug: match[4] || ''
+                    type: commentsMatch[1],
+                    subreddit: commentsMatch[2],
+                    slug: commentsMatch[4] || ''
+                }
+            };
+        }
+        // 앱 단축 링크 (/r/.../s/...) — redirect URL이라 임베드 불가, 링크로만 표시
+        const shortMatch = url.match(
+            /(?:www\.)?reddit\.com\/(r|user)\/([\w:.]{2,21})\/s\/([\w-]+)/
+        );
+        if (shortMatch) {
+            return {
+                platform: 'reddit',
+                id: shortMatch[3],
+                url,
+                params: {
+                    type: shortMatch[1],
+                    subreddit: shortMatch[2],
+                    slug: '',
+                    isShortLink: 'true'
                 }
             };
         }
@@ -27,8 +51,24 @@ export const reddit: EmbedPlatform = {
     },
 
     render(info: EmbedInfo): string {
-        const postUrl = `https://www.reddit.com/${info.params?.type}/${info.params?.subreddit}/comments/${info.id}${info.params?.slug ? '/' + info.params.slug : ''}`;
+        // 앱 단축링크는 redirect URL이라 iframe 임베드 불가 → 링크 카드로 표시
+        if (info.params?.isShortLink) {
+            return `<a href="${info.url}" target="_blank" rel="noopener noreferrer" class="text-primary underline">${info.url}</a>`;
+        }
 
-        return `<blockquote class="reddit-embed-bq" style="height:500px" data-embed-height="740"><a href="${postUrl}">Reddit 게시글</a></blockquote>`;
+        const slug = info.params?.slug ? `/${info.params.slug}` : '';
+        // #12044: redditmedia.com 은 embed.reddit.com 으로 301 redirect 되며, 이 redirect 가
+        // sandbox/CSP 환경에서 정상 처리되지 않아 임베드가 비어있는 채로 남는다.
+        // 처음부터 최종 도메인(embed.reddit.com)을 사용한다.
+        const embedUrl = `https://embed.reddit.com/${info.params?.type}/${info.params?.subreddit}/comments/${info.id}${slug}/?ref_source=embed&embed=true&theme=dark`;
+
+        return `<iframe
+			src="${embedUrl}"
+			title="Reddit post"
+			frameborder="0"
+			scrolling="yes"
+			sandbox="allow-scripts allow-same-origin allow-popups"
+			style="width: 100%; min-height: 400px; max-height: 600px; border-radius: 8px;"
+		></iframe>`;
     }
 };

--- a/plugins/auto-embed/lib/platforms/youtube.ts
+++ b/plugins/auto-embed/lib/platforms/youtube.ts
@@ -36,8 +36,12 @@ export const youtube: EmbedPlatform = {
                     platform: isShorts ? 'youtube-shorts' : 'youtube',
                     id: videoId,
                     url,
-                    aspectRatio: isShorts ? 177.78 : 56.25,
-                    maxWidth: isShorts ? 400 : undefined,
+                    // youtube /embed/ 는 shorts 도 16:9 player 로 렌더하므로 항상 16:9.
+                    // 9:16(177.78%) 컨테이너로 두면 위아래 거대한 빈 공간이 생긴다(bug/13417,
+                    // 본문 사본은 #1496 에서 이미 고쳐졌는데 이 댓글 사본만 stale 이었다).
+                    // 폭은 maxWidth(CSS) 로 제한한다 — 본문 사본과 동일.
+                    aspectRatio: 56.25,
+                    maxWidth: isShorts ? 400 : 560,
                     params: Object.keys(params).length > 0 ? params : undefined
                 };
             }


### PR DESCRIPTION
대기 시간 딥다이브 2건.

**13417** — 댓글 auto-embed 사본이 본문 사본보다 stale: youtube shorts aspectRatio(177.78→56.25), reddit(legacy blockquote→embed.reddit.com iframe). 본문은 정상, 댓글만 공백이던 원인.

**13419** — 벨 배지는 seen 기준인데 markSeenOnOpen 이 read 기준 unreadCount 로 게이트 → 스레드 직접 읽어 안읽음=0 되면 seen 안 올라가 벨 영구 고착. 로드 성공 시 무조건 seen. (백엔드 정합성 통일은 별건)