### PR TITLE
feat: 인라인 스포일러 쓰레드식 반짝이 입자

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -2455,13 +2455,49 @@
         opacity: 0.65;
     }
 
-    /* 인라인 스포일러(8/7) — 본문 markdown.svelte 와 동일 규칙. 댓글은 자체 렌더라 별도. */
+    /* 인라인 스포일러(8/7→8/8 쓰레드식 입자) — 본문 markdown.svelte 와 동일 규칙.
+       댓글은 자체 렌더라 별도. 키프레임(dm-sp-drift/twinkle)은 components.css 전역. */
     :global(.comment-body span.dm-spoiler) {
-        background: #5a5a61;
         color: transparent;
-        border-radius: 3px;
+        border-radius: 4px;
         cursor: pointer;
         text-shadow: none;
+        box-decoration-break: clone;
+        -webkit-box-decoration-break: clone;
+        background-color: color-mix(in srgb, var(--foreground) 8%, transparent);
+        background-image: radial-gradient(
+                circle at 25% 35%,
+                color-mix(in srgb, var(--foreground) 90%, transparent) 1px,
+                transparent 1.6px
+            ),
+            radial-gradient(
+                circle at 70% 60%,
+                color-mix(in srgb, var(--foreground) 70%, transparent) 1px,
+                transparent 1.6px
+            ),
+            radial-gradient(
+                circle at 45% 80%,
+                color-mix(in srgb, var(--foreground) 55%, transparent) 0.8px,
+                transparent 1.4px
+            ),
+            radial-gradient(
+                circle at 85% 25%,
+                color-mix(in srgb, var(--foreground) 40%, transparent) 0.8px,
+                transparent 1.4px
+            );
+        background-size:
+            11px 11px,
+            15px 15px,
+            19px 19px,
+            23px 23px;
+        animation:
+            dm-sp-drift 2.6s linear infinite,
+            dm-sp-twinkle 1.4s ease-in-out infinite alternate;
+    }
+    @media (prefers-reduced-motion: reduce) {
+        :global(.comment-body span.dm-spoiler) {
+            animation: none;
+        }
     }
     :global(.comment-body span.dm-spoiler::selection),
     :global(.comment-body span.dm-spoiler *::selection) {
@@ -2470,7 +2506,9 @@
     }
     :global(.comment-body span.dm-spoiler.dm-spoiler-open) {
         color: inherit;
-        background: color-mix(in srgb, currentColor 10%, transparent);
+        background-image: none;
+        animation: none;
+        background-color: color-mix(in srgb, currentColor 10%, transparent);
     }
 
     /* 이미지 로딩 실패 시 숨김 처리 */

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -413,13 +413,52 @@
     }
 
     /* 인라인 스포일러(8/7) — 기본은 가림. PC 드래그(::selection) 또는 클릭으로 공개.
+       쓰레드(Threads)식 반짝이 입자(8/8): 민무늬 회색은 하이라이트로 오인돼 눈에 안 띈다는
+       피드백. 오버레이(::after)가 아니라 span 배경에 직접 거는 이유 — 여러 줄에 걸친
+       스포일러는 배경만이 줄 조각(fragment) 단위로 칠해져 이웃 글자를 덮지 않는다.
        ⚠️ 댓글은 이 컴포넌트를 안 쓴다 — comment-list.svelte 에 같은 규칙 별도. */
     .prose :global(span.dm-spoiler) {
-        background: #5a5a61;
         color: transparent;
-        border-radius: 3px;
+        border-radius: 4px;
         cursor: pointer;
         text-shadow: none;
+        box-decoration-break: clone;
+        -webkit-box-decoration-break: clone;
+        background-color: color-mix(in srgb, var(--foreground) 8%, transparent);
+        background-image: radial-gradient(
+                circle at 25% 35%,
+                color-mix(in srgb, var(--foreground) 90%, transparent) 1px,
+                transparent 1.6px
+            ),
+            radial-gradient(
+                circle at 70% 60%,
+                color-mix(in srgb, var(--foreground) 70%, transparent) 1px,
+                transparent 1.6px
+            ),
+            radial-gradient(
+                circle at 45% 80%,
+                color-mix(in srgb, var(--foreground) 55%, transparent) 0.8px,
+                transparent 1.4px
+            ),
+            radial-gradient(
+                circle at 85% 25%,
+                color-mix(in srgb, var(--foreground) 40%, transparent) 0.8px,
+                transparent 1.4px
+            );
+        background-size:
+            11px 11px,
+            15px 15px,
+            19px 19px,
+            23px 23px;
+        animation:
+            dm-sp-drift 2.6s linear infinite,
+            dm-sp-twinkle 1.4s ease-in-out infinite alternate;
+    }
+    /* dm-sp-drift/twinkle 키프레임은 components.css(전역) — 댓글 표면과 공유. */
+    @media (prefers-reduced-motion: reduce) {
+        .prose :global(span.dm-spoiler) {
+            animation: none;
+        }
     }
     .prose :global(span.dm-spoiler::selection),
     .prose :global(span.dm-spoiler *::selection) {
@@ -428,7 +467,9 @@
     }
     .prose :global(span.dm-spoiler.dm-spoiler-open) {
         color: inherit;
-        background: color-mix(in srgb, currentColor 10%, transparent);
+        background-image: none;
+        animation: none;
+        background-color: color-mix(in srgb, currentColor 10%, transparent);
     }
 
     /* 작성자가 고른 표시 폭 프리셋 (bug/13379). height:auto 가 있어야 재작성 단계에서

--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -487,3 +487,23 @@ img[src*='/emoticons/']:not([width]) {
 .spoiler-content {
     padding: 0.5rem 0.75rem;
 }
+
+/* 인라인 스포일러(dm-spoiler) 쓰레드식 입자 애니메이션 — 본문(markdown.svelte)과
+   댓글(comment-list.svelte) 두 표면이 공유하는 전역 키프레임. */
+@keyframes dm-sp-drift {
+    to {
+        background-position:
+            11px 0,
+            -15px 8px,
+            10px -19px,
+            -23px -6px;
+    }
+}
+@keyframes dm-sp-twinkle {
+    from {
+        filter: brightness(0.85);
+    }
+    to {
+        filter: brightness(1.25);
+    }
+}


### PR DESCRIPTION
## 배경
8/7 도입한 인라인 스포일러(회색 막대)가 하이라이트로 오인돼 눈에 안 띈다는 피드백. 쓰레드(Threads) 앱처럼 반짝이는 입자로 교체.

## 변경
- 본문(`markdown.svelte`)·댓글(`comment-list.svelte`) 두 표면의 `dm-spoiler` 가림 CSS 를 입자 애니메이션으로 교체
- 키프레임은 `components.css` 전역 1곳 공유
- `box-decoration-break: clone` — 여러 줄 스포일러도 줄 조각 단위 페인트(오버레이 방식의 이웃 글자 가림 문제 없음)
- `var(--foreground)` 기반이라 테마 자동 대응, `prefers-reduced-motion` 존중

## 불변
- 동작(기본 가림·탭 토글·PC 드래그 열람)·저장 형식(`dm-spoiler`) 그대로 — 기존 글 자동 소급
- 에디터 안 표시(점선 테두리)는 유지 — 작성 중엔 내용이 보여야 함