### PR TITLE
feat: 차단한 회원을 추천자 목록에서 숨김 (#13428)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
+++ b/apps/web/src/lib/components/features/board/comment-likers-dialog.svelte
@@ -8,6 +8,7 @@
     import { loadPluginComponent } from '$lib/utils/plugin-optional-loader';
     import { formatDateTime } from '$lib/utils/format-date.js';
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
+    import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
 
     // 동적 플러그인 임포트: member-memo
     let MemoBadge = $state<Component | null>(null);
@@ -55,8 +56,14 @@
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const json = await res.json();
             const data = json.data;
-            likers = data.likers ?? [];
-            total = data.total ?? 0;
+            // #13428: 내가 차단한 회원은 추천자 목록에서 가린다(뷰어별 필터, 공유 캐시라 서버 불가).
+            const raw: LikerInfo[] = data.likers ?? [];
+            const filtered =
+                blockedUsersStore.ids.size === 0
+                    ? raw
+                    : raw.filter((l) => !blockedUsersStore.isBlocked(l.mb_id));
+            likers = filtered;
+            total = Math.max(filtered.length, (data.total ?? 0) - (raw.length - filtered.length));
         } catch (err) {
             console.error('Failed to load comment likers:', err);
         } finally {

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -147,6 +147,7 @@
     import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import { commentTracker } from '$lib/stores/comment-tracker.svelte.js';
     import { disciplineRevealStore } from '$lib/stores/discipline-reveal.svelte.js';
+    import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
     import { onDestroy } from 'svelte';
     import { TouchGestureService } from '$lib/services/touch-gestures.svelte.js';
 
@@ -642,6 +643,14 @@
     let likersPage = $state(1);
     let isLoadingMoreLikers = $state(false);
     const LIKERS_PER_PAGE = 20;
+
+    // #13428: 내가 차단한 회원은 추천자 목록에서 가린다. 목록 캐시(Redis)는 뷰어별이 아니라
+    // 공유라 서버에서 못 거른다 — 뷰어의 차단 목록(blockedUsersStore)으로 클라에서 필터한다.
+    // total 은 가려진 수만큼 줄여 "N명 공감"이 보이는 목록과 어긋나지 않게 한다.
+    function excludeBlockedLikers(list: LikerInfo[]): LikerInfo[] {
+        if (blockedUsersStore.ids.size === 0) return list;
+        return list.filter((l) => !blockedUsersStore.isBlocked(l.mb_id));
+    }
 
     // 인라인 메모 편집 대상 (추천인 목록 내)
     let editingMemoFor = $state<string | null>(null);
@@ -1385,8 +1394,15 @@
                 1,
                 LIKERS_PER_PAGE
             );
-            likers = response.likers ?? [];
-            likersTotal = response.total ?? 0;
+            {
+                const raw = response.likers ?? [];
+                const filtered = excludeBlockedLikers(raw);
+                likers = filtered;
+                likersTotal = Math.max(
+                    filtered.length,
+                    (response.total ?? 0) - (raw.length - filtered.length)
+                );
+            }
         } catch (err) {
             console.error('Failed to load likers:', err);
         } finally {
@@ -1407,8 +1423,15 @@
                 nextPage,
                 LIKERS_PER_PAGE
             );
-            likers = [...likers, ...(response.likers ?? [])];
-            likersTotal = response.total ?? 0;
+            {
+                const raw = response.likers ?? [];
+                const filtered = excludeBlockedLikers(raw);
+                likers = [...likers, ...filtered];
+                likersTotal = Math.max(
+                    likers.length,
+                    (response.total ?? 0) - (raw.length - filtered.length)
+                );
+            }
             likersPage = nextPage;
         } catch (err) {
             console.error('Failed to load more likers:', err);
@@ -1426,8 +1449,15 @@
         }
         try {
             const response = await apiClient.getPostLikers(boardId, String(data.post.id), 1, 5);
-            likers = response.likers ?? [];
-            likersTotal = response.total ?? 0;
+            {
+                const raw = response.likers ?? [];
+                const filtered = excludeBlockedLikers(raw);
+                likers = filtered;
+                likersTotal = Math.max(
+                    filtered.length,
+                    (response.total ?? 0) - (raw.length - filtered.length)
+                );
+            }
         } catch (err) {
             console.error('Failed to load liker avatars:', err);
         }


### PR DESCRIPTION
## 배경
PWL 제안 bug/13428 (13224 차단자 댓글 숨김의 연장). 차단한 회원이 남의 글/댓글을 추천하면 추천자 목록에 노출되던 것을 가린다.

## 방식
추천자 목록 API는 Redis **공유 캐시**(뷰어 무관)라 서버 필터는 캐시 오염을 부른다. 뷰어의 차단 목록(`blockedUsersStore`, 이미 댓글·글 숨김에 쓰는 것)으로 **클라이언트에서 필터**. 가려진 수만큼 total 감산해 카운트 정합.

## 범위
- 글 추천자: 아바타 스택·더보기·다이얼로그 (`+page.svelte` 3경로)
- 댓글 추천자: `comment-likers-dialog.svelte`
- `scope='message'`(쪽지만 차단)는 콘텐츠 숨김 대상 아님(스토어가 이미 제외, #12916)

## 불변
서버·저장·집계 무접촉. 차단 안 한 사용자는 변화 없음(store 빈 Set 이면 원본 그대로).