### PR TITLE
fix(poll): plugin.json category 를 'plugin' 으로 (스캐너 필터 통과)

### DIFF
--- a/plugins/poll/plugin.json
+++ b/plugins/poll/plugin.json
@@ -6,7 +6,7 @@
         "name": "Damoang Team",
         "url": "https://damoang.net"
     },
-    "category": "content",
+    "category": "plugin",
     "description": "글에 붙이는 간이 투표 — 작성자가 선택지를 만들고 회원이 한 표씩",
     "components": [
         {


### PR DESCRIPTION
## 원인
투표 위젯이 안 뜨던 최종 원인. 플러그인 스캐너(`scanner.ts` `loadPluginManifest`)는 `category !== 'plugin'` 매니페스트를 버린다(테마 제외 목적). 기존 활성 플러그인은 전부 category 필드가 없어 기본값 'plugin'으로 통과했는데, poll 만 `"content"`로 명시해 `getActivePlugins` 조립에서 제외됐다.

DB active_plugins·Redis·파드 디스크에 모두 poll 이 있었는데도 `/api/plugins/active`가 12개만 반환한 이유.

## 수정
`plugins/poll/plugin.json` category `content`→`plugin`. 이 배포 후 위젯이 실제로 뜬다.