### PR TITLE
fix(poll): 투표 생성 실패 — 프록시 trailing slash

### DIFF
--- a/apps/web/src/routes/api/plugins/poll/[...path]/+server.ts
+++ b/apps/web/src/routes/api/plugins/poll/[...path]/+server.ts
@@ -29,7 +29,12 @@ async function proxyRequest(
 ): Promise<Response> {
     const path = params.path || '';
     const url = new URL(request.url);
-    const targetUrl = `${BACKEND_URL}/api/plugins/poll/${path}${url.search}`;
+    // ⛔ path 가 빈 경우(투표 생성 POST /api/plugins/poll)에 슬래시를 붙이면
+    //    백엔드 라우트(POST "/api/plugins/poll")와 어긋나 Gin 이 307 리다이렉트를 내고,
+    //    리다이렉트를 타며 인증 헤더가 유실돼 생성이 실패한다(실사용자 오류로 확인, 2026-08-09).
+    const targetUrl = path
+        ? `${BACKEND_URL}/api/plugins/poll/${path}${url.search}`
+        : `${BACKEND_URL}/api/plugins/poll${url.search}`;
 
     try {
         const headers = new Headers();


### PR DESCRIPTION
## 증상
투표 만들기 폼에서 '만들기' 클릭 시 "잠시 후 다시 시도해 주세요" (실사용자 free/6956009 확인, 첨부 스크린샷).

## 원인
프록시가 `POST /api/plugins/poll`(빈 rest 경로)을 백엔드 `/api/plugins/poll/`(**trailing slash**)로 전달 → Gin RedirectTrailingSlash 가 307 → 리다이렉트를 타며 인증 헤더 유실 → 생성 실패. angple_polls 0행(모든 생성 시도 실패) 실측.
백엔드 직접 확인: POST `/api/plugins/poll`=401(정상), `/api/plugins/poll/`=307.

## 수정
빈 경로면 슬래시 없이 `/api/plugins/poll` 로 전달. 투표/마감 등 path 있는 경로는 무영향.