### PR TITLE
feat(settings): 단축 버튼 설명에 '댓글로 이동' 명시

### DIFF
--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -1046,7 +1046,9 @@
                         <SmartphoneIcon class="h-5 w-5" />
                         단축 버튼
                     </CardTitle>
-                    <CardDescription>화면 하단에 플로팅 바로가기 버튼을 표시합니다.</CardDescription
+                    <CardDescription
+                        >화면 하단에 플로팅 바로가기 버튼을 표시합니다. 스크롤 없이 댓글로 바로
+                        이동할 수 있습니다.</CardDescription
                     >
                 </CardHeader>
                 <CardContent class="space-y-4">
@@ -1054,7 +1056,7 @@
                         <div>
                             <Label>단축 버튼 사용</Label>
                             <p class="text-muted-foreground text-xs">
-                                홈, 새로고침, 위로/아래로 + 즐겨찾기 바로가기
+                                홈, 새로고침, 위로/아래로, 댓글로 이동 + 즐겨찾기 바로가기
                             </p>
                         </div>
                         <Switch


### PR DESCRIPTION
makeang/89(스크롤 없이 댓글 쓰기) 대응. 플로팅 단축 버튼에 '댓글로 이동'이 이미 있는데 설정 설명이 언급하지 않아 발견성이 낮았음. 설명에 명시.

- 기본값 OFF 유지(원하는 사람만) — 사용자 지시
- 카드 설명 + 토글 하위 설명에 '댓글로 이동' 추가