### PR TITLE
fix(support): 소모임 돌보기 당주 배지를 '서포터즈'로

### DIFF
--- a/apps/web/src/routes/[boardId]/support/+page.svelte
+++ b/apps/web/src/routes/[boardId]/support/+page.svelte
@@ -191,7 +191,9 @@
     <div class="flex flex-wrap items-center gap-2">
         <h1 class="text-xl font-semibold">{data.subject} 돌보기</h1>
         {#if data.isOwner}
-            <Badge variant="secondary">당주</Badge>
+            <!-- 당주=자발적 봉사자. '운영진'으로 자기 오해하지 않도록 이 화면에선 '서포터즈'로 표기.
+                 (실제 관리자를 뜻하는 아래 isSiteAdmin '운영진'과 안내 문구는 그대로 둔다) -->
+            <Badge variant="secondary">서포터즈</Badge>
         {:else if data.isSiteAdmin}
             <Badge variant="outline">운영진</Badge>
         {/if}


### PR DESCRIPTION
## 배경
소모임 돌보기(/support) 화면에서 당주(자발적 봉사자)가 '운영진'으로 자신을 오해할 수 있다는 지적.

## 변경
- `/support` 화면 상단 역할 배지: 당주일 때 `당주` → `서포터즈` (이 화면 한정, 1곳).

## 그대로 두는 것 (의도적)
- `isSiteAdmin` 배지 `운영진` — 실제 사이트 관리자라 유지.
- '최종 처리는 운영진이 확정합니다' 등 안내 문구 — 실제 최종 삭제를 하는 관리자를 가리키므로 유지.

단일 라벨 변경, 로직 무변.