### PR TITLE
feat(reaction): 본문·댓글 리액션 이모지 8종 추가

### DIFF
--- a/apps/web/src/lib/config/reaction-config.ts
+++ b/apps/web/src/lib/config/reaction-config.ts
@@ -53,7 +53,16 @@ const EMOJIS: EmoticonDef[] = [
     { reaction: 'emoji:1f440', category: 'emoji', renderType: 'emoji', emoji: '👀' },
     { reaction: 'emoji:2b55', category: 'emoji', renderType: 'emoji', emoji: '⭕' },
     { reaction: 'emoji:274c', category: 'emoji', renderType: 'emoji', emoji: '❌' },
-    { reaction: 'emoji:2753', category: 'emoji', renderType: 'emoji', emoji: '❓' }
+    { reaction: 'emoji:2753', category: 'emoji', renderType: 'emoji', emoji: '❓' },
+    // 추가(2026-08-10): 🙏 요청 + 슬랙 단골 반응들
+    { reaction: 'emoji:1f64f', category: 'emoji', renderType: 'emoji', emoji: '🙏' },
+    { reaction: 'emoji:1f44f', category: 'emoji', renderType: 'emoji', emoji: '👏' },
+    { reaction: 'emoji:1f64c', category: 'emoji', renderType: 'emoji', emoji: '🙌' },
+    { reaction: 'emoji:1f44c', category: 'emoji', renderType: 'emoji', emoji: '👌' },
+    { reaction: 'emoji:2705', category: 'emoji', renderType: 'emoji', emoji: '✅' },
+    { reaction: 'emoji:1f4af', category: 'emoji', renderType: 'emoji', emoji: '💯' },
+    { reaction: 'emoji:1f62d', category: 'emoji', renderType: 'emoji', emoji: '😭' },
+    { reaction: 'emoji:1fae1', category: 'emoji', renderType: 'emoji', emoji: '🫡' }
 ];
 
 // 앙티콘 세트 (다모앙 커스텀 GIF)


### PR DESCRIPTION
## 추가
현재 리액션 이모지 세트에 슬랙 단골 반응 8종 추가: 🙏 👏 🙌 👌 ✅ 💯 😭 🫡
(🙏 요청 + 사장님 승인 세트)

## 변경
- `apps/web/src/lib/config/reaction-config.ts` `EMOJIS` 배열에만 추가. 피커·리액션바에 자동 반영.

## 백엔드 무변 (확인)
- `/api/reactions`는 리액션 값을 화이트리스트가 아니라 패턴(`^[a-zA-Z0-9:_-]+$`)+차단목록(blocklist) 방식으로 검증 → `emoji:1f64f` 등 신규 코드 그대로 통과. DDL·마이그레이션 없음.