### PR TITLE
feat(post): 첨부목록 텍스트화·기본접힘 + 다운로드/링크 클릭수 라이브 표시

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -54,8 +54,16 @@ export interface FreePost {
     tags?: string[];
     images?: string[];
     videos?: { url: string; filename: string; size: number }[];
-    files?: { url: string; filename: string; size: number }[]; // 일반 첨부파일 (PDF, ZIP 등)
-    downloads?: { url: string; filename: string; size: number }[]; // 전체 다운로드 목록 (이미지/영상 포함)
+    files?: { no?: number; url: string; filename: string; size: number; download_count?: number }[]; // 일반 첨부파일 (PDF, ZIP 등)
+    downloads?: {
+        no?: number;
+        url: string;
+        filename: string;
+        size: number;
+        download_count?: number;
+    }[]; // 전체 다운로드 목록 (이미지/영상 포함)
+    /** 게시글 링크(wr_link1/2)와 클릭수. /files 라우트가 g5_write_{board} 에서 직접 읽어 채운다. */
+    linkHits?: { n: number; url: string; hit: number }[];
     is_secret?: boolean; // 비밀글 여부
     is_comments_disabled?: boolean; // 댓글 비활성화 (읽기 전용 공지)
     is_notice?: boolean; // 공지사항 여부

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -120,15 +120,41 @@
 
     const isLockedPost = $derived(postReportCount === 'lock' || post.extra_7 === 'lock');
 
-    // 첨부파일 목록 접기(#13423): 6개 이상이면 앞 5개만 보이고 나머지는 펼침.
-    // 파일명 식별이 중요한 목록이라 축약 대신 접기를 쓴다.
-    const DOWNLOADS_COLLAPSE_LIMIT = 5;
-    let downloadsExpanded = $state(false);
-    const visibleDownloads = $derived(
-        !post.downloads || downloadsExpanded || post.downloads.length <= DOWNLOADS_COLLAPSE_LIMIT
-            ? (post.downloads ?? [])
-            : post.downloads.slice(0, DOWNLOADS_COLLAPSE_LIMIT)
-    );
+    // 첨부파일 목록: 박스 없는 텍스트 목록 + 기본 접힘(제목 'N개'만). 클릭 시 펼침.
+    // 공간 절약이 목적이라 목록 전체를 접는다(구 #13423 앞5개 노출 방식 대체).
+    let downloadsOpen = $state(false);
+
+    // 다운로드/링크 클릭 낙관적 증가분(비콘 성공과 무관하게 화면 즉시 반영). key=bf_no / link n.
+    let downloadDelta = $state<Record<number, number>>({});
+    let linkDelta = $state<Record<number, number>>({});
+
+    function fireBeacon(url: string) {
+        try {
+            if (navigator.sendBeacon?.(url)) return;
+        } catch {
+            /* sendBeacon 미지원/실패 → fetch 폴백 */
+        }
+        fetch(url, { method: 'POST', keepalive: true }).catch(() => {});
+    }
+
+    // 다운로드 카운트 비콘: 파일 클릭 시 bf_download += 1 (라이브 집계). GA4 이벤트와 별개.
+    function beaconDownload(fileNo: number | undefined | null) {
+        if (fileNo == null) return;
+        downloadDelta = { ...downloadDelta, [fileNo]: (downloadDelta[fileNo] ?? 0) + 1 };
+        fireBeacon(`/api/boards/${boardId}/posts/${post.id}/files/${fileNo}/hit`);
+    }
+
+    // 링크 클릭 비콘: wr_link{n}_hit += 1.
+    function beaconLink(n: number) {
+        linkDelta = { ...linkDelta, [n]: (linkDelta[n] ?? 0) + 1 };
+        fireBeacon(`/api/boards/${boardId}/posts/${post.id}/link-hit?n=${n}`);
+    }
+
+    // 링크 클릭수 = 과거값(linkHits, g5_write_{board}에서 직접 읽음) + 낙관적 증가분.
+    function linkHitFor(n: number): number {
+        const base = post.linkHits?.find((l) => l.n === n)?.hit ?? 0;
+        return base + (linkDelta[n] ?? 0);
+    }
 
     // 첨부 이미지 라이트박스
     let attachedImagesEl: HTMLDivElement;
@@ -544,43 +570,56 @@
                     {/if}
 
                     {#if post.downloads && post.downloads.length > 0}
-                        <div class="mt-6 space-y-2">
-                            <p
-                                class="text-muted-foreground flex items-center gap-1.5 text-sm font-medium"
+                        <div class="mt-6">
+                            <!-- 박스 없는 텍스트 목록 + 기본 접힘: 헤더 클릭 시 펼침 -->
+                            <button
+                                type="button"
+                                onclick={() => (downloadsOpen = !downloadsOpen)}
+                                aria-expanded={downloadsOpen}
+                                class="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-sm font-medium transition-colors"
                             >
                                 <Paperclip class="h-4 w-4" />
                                 첨부파일 {post.downloads.length}개
-                            </p>
-                            {#each visibleDownloads as file, i (i)}
-                                <a
-                                    href={file.url}
-                                    download={file.filename}
-                                    onclick={() => trackFileDownload(boardId, file.filename)}
-                                    class="bg-muted/50 hover:bg-muted flex items-center gap-3 rounded-lg border px-4 py-2.5 transition-colors"
-                                >
-                                    <Download class="text-muted-foreground h-4 w-4 shrink-0" />
-                                    <span class="text-foreground min-w-0 truncate text-sm">
-                                        {file.filename}
-                                    </span>
-                                    {#if file.size}
-                                        <span
-                                            class="text-muted-foreground ml-auto shrink-0 text-xs"
-                                        >
-                                            {formatFileSize(file.size)}
-                                        </span>
-                                    {/if}
-                                </a>
-                            {/each}
-                            {#if !downloadsExpanded && post.downloads.length > DOWNLOADS_COLLAPSE_LIMIT}
-                                <button
-                                    type="button"
-                                    onclick={() => (downloadsExpanded = true)}
-                                    class="bg-muted/50 hover:bg-muted text-muted-foreground flex w-full items-center justify-center gap-1.5 rounded-lg border px-4 py-2.5 text-sm transition-colors"
-                                >
-                                    <ChevronDown class="h-4 w-4" />
-                                    외 {post.downloads.length - DOWNLOADS_COLLAPSE_LIMIT}개 첨부파일
-                                    보기
-                                </button>
+                                <ChevronDown
+                                    class="h-4 w-4 transition-transform {downloadsOpen
+                                        ? 'rotate-180'
+                                        : ''}"
+                                />
+                            </button>
+                            {#if downloadsOpen}
+                                <ul class="mt-2 space-y-1.5">
+                                    {#each post.downloads as file, i (file.no ?? i)}
+                                        <li class="flex items-center gap-2 text-sm">
+                                            <a
+                                                href={file.url}
+                                                download={file.filename}
+                                                onclick={() => {
+                                                    trackFileDownload(boardId, file.filename);
+                                                    beaconDownload(file.no);
+                                                }}
+                                                class="text-foreground hover:text-primary flex min-w-0 flex-1 items-center gap-1.5 hover:underline"
+                                            >
+                                                <Download
+                                                    class="text-muted-foreground h-3.5 w-3.5 shrink-0"
+                                                />
+                                                <span class="truncate">{file.filename}</span>
+                                            </a>
+                                            {#if file.size}
+                                                <span
+                                                    class="text-muted-foreground shrink-0 text-xs"
+                                                >
+                                                    {formatFileSize(file.size)}
+                                                </span>
+                                            {/if}
+                                            <span
+                                                class="text-muted-foreground shrink-0 whitespace-nowrap text-xs"
+                                            >
+                                                다운 {(file.download_count ?? 0) +
+                                                    (downloadDelta[file.no ?? -1] ?? 0)}
+                                            </span>
+                                        </li>
+                                    {/each}
+                                </ul>
                             {/if}
                         </div>
                     {/if}
@@ -598,9 +637,13 @@
                                 rel={post.link1_affiliate
                                     ? 'nofollow noopener sponsored'
                                     : 'noopener noreferrer'}
-                                class="text-primary truncate hover:underline"
+                                onclick={() => beaconLink(1)}
+                                class="text-primary min-w-0 flex-1 truncate hover:underline"
                                 >{post.link1_display || post.link1}</a
                             >
+                            <span class="text-muted-foreground shrink-0 whitespace-nowrap text-xs">
+                                클릭 {linkHitFor(1)}
+                            </span>
                         </div>
                     {/if}
                     {#if post.link2}
@@ -612,9 +655,13 @@
                                 rel={post.link2_affiliate
                                     ? 'nofollow noopener sponsored'
                                     : 'noopener noreferrer'}
-                                class="text-primary truncate hover:underline"
+                                onclick={() => beaconLink(2)}
+                                class="text-primary min-w-0 flex-1 truncate hover:underline"
                                 >{post.link2_display || post.link2}</a
                             >
+                            <span class="text-muted-foreground shrink-0 whitespace-nowrap text-xs">
+                                클릭 {linkHitFor(2)}
+                            </span>
                         </div>
                     {/if}
                 </div>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -229,6 +229,9 @@ export const load: PageServerLoad = async ({
             if (filesData.downloads?.length) {
                 post.downloads = filesData.downloads;
             }
+            if (filesData.links?.length) {
+                post.linkHits = filesData.links;
+            }
         }
 
         // Bluesky handle → DID prefetch (#12050).

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/files/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/files/+server.ts
@@ -27,6 +27,7 @@ interface FileRow extends RowDataPacket {
     bf_width: number;
     bf_height: number;
     bf_filesize: number;
+    bf_download: number; // 다운로드 횟수 (Gnuboard g5_board_file.bf_download)
 }
 
 const IMAGE_EXTENSIONS = /\.(jpg|jpeg|png|gif|webp|bmp|svg|avif)$/i;
@@ -51,20 +52,41 @@ export const GET: RequestHandler = async ({ params }) => {
     try {
         // #12446: 삭제된 게시글의 첨부파일이 노출되는 보안 이슈 차단.
         // 글이 soft-delete 된 경우 첨부 목록을 빈 배열로 반환한다.
+        // 링크(wr_link1/2)와 클릭수(wr_link1_hit/2_hit)도 이 조회에서 함께 가져온다
+        // — 백엔드 PostResponse 가 hit 을 노출하지 않으므로 여기서 직접 읽는다.
         const [postRows] = await pool.query<RowDataPacket[]>(
-            `SELECT wr_id, wr_deleted_at FROM \`g5_write_${safeBoardId}\` WHERE wr_id = ? LIMIT 1`,
+            `SELECT wr_id, wr_deleted_at, wr_link1, wr_link2, wr_link1_hit, wr_link2_hit
+			   FROM \`g5_write_${safeBoardId}\` WHERE wr_id = ? LIMIT 1`,
             [safePostId]
         );
-        const post = postRows[0] as { wr_id: number; wr_deleted_at: string | null } | undefined;
+        const post = postRows[0] as
+            | {
+                  wr_id: number;
+                  wr_deleted_at: string | null;
+                  wr_link1: string | null;
+                  wr_link2: string | null;
+                  wr_link1_hit: number | null;
+                  wr_link2_hit: number | null;
+              }
+            | undefined;
         if (!post) {
-            return json({ images: [], videos: [], files: [], downloads: [] });
+            return json({ images: [], videos: [], files: [], downloads: [], links: [] });
         }
         if (post.wr_deleted_at && post.wr_deleted_at !== '0000-00-00 00:00:00') {
-            return json({ images: [], videos: [], files: [], downloads: [] });
+            return json({ images: [], videos: [], files: [], downloads: [], links: [] });
+        }
+
+        // 게시글 링크 목록 (빈 URL 제외). 클릭수는 얼어붙은 과거값 + 앞으로 라이브 증가.
+        const links: { n: number; url: string; hit: number }[] = [];
+        if (post.wr_link1 && post.wr_link1.trim()) {
+            links.push({ n: 1, url: post.wr_link1.trim(), hit: post.wr_link1_hit || 0 });
+        }
+        if (post.wr_link2 && post.wr_link2.trim()) {
+            links.push({ n: 2, url: post.wr_link2.trim(), hit: post.wr_link2_hit || 0 });
         }
 
         const [rows] = await pool.query<FileRow[]>(
-            `SELECT bf_no, bf_file, bf_fileurl, bf_source, bf_type, bf_width, bf_height, bf_filesize
+            `SELECT bf_no, bf_file, bf_fileurl, bf_source, bf_type, bf_width, bf_height, bf_filesize, bf_download
 			 FROM g5_board_file
 			 WHERE bo_table = ? AND wr_id = ?
 			 ORDER BY bf_no`,
@@ -95,21 +117,25 @@ export const GET: RequestHandler = async ({ params }) => {
                 (row) => !IMAGE_EXTENSIONS.test(row.bf_file) && !VIDEO_EXTENSIONS.test(row.bf_file)
             )
             .map((row) => ({
+                no: row.bf_no,
                 url: getFileUrl(row),
                 filename: row.bf_source || row.bf_file,
-                size: row.bf_filesize || 0
+                size: row.bf_filesize || 0,
+                download_count: row.bf_download || 0
             }));
 
         // 전체 다운로드 목록 (이미지/영상 포함, 원본 파일명)
         const downloads = rows.map((row) => ({
+            no: row.bf_no,
             url: getFileUrl(row),
             filename: row.bf_source || row.bf_file,
-            size: row.bf_filesize || 0
+            size: row.bf_filesize || 0,
+            download_count: row.bf_download || 0
         }));
 
-        return json({ images, videos, files, downloads });
+        return json({ images, videos, files, downloads, links });
     } catch (error) {
         console.error('Board files GET error:', error);
-        return json({ images: [], videos: [], files: [], downloads: [] });
+        return json({ images: [], videos: [], files: [], downloads: [], links: [] });
     }
 };

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/files/[fileNo]/hit/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/files/[fileNo]/hit/+server.ts
@@ -1,0 +1,36 @@
+/**
+ * 첨부파일 다운로드 카운트 비콘
+ *
+ * POST /api/boards/[boardId]/posts/[postId]/files/[fileNo]/hit
+ * → g5_board_file.bf_download += 1 (해당 파일)
+ *
+ * 파일은 CDN 직접 URL 로 서빙되어 다운로드가 집계되지 않았다(옛 PHP 값 프리즈).
+ * 다운로드 링크 클릭 시 navigator.sendBeacon 으로 이 엔드포인트를 불러 앞으로만 라이브 집계.
+ * 익명 허용(그누보드도 익명 카운트). 남용 디듑은 MVP 범위 밖.
+ */
+import type { RequestHandler } from './$types';
+import pool from '$lib/server/db';
+
+export const POST: RequestHandler = async ({ params }) => {
+    const safeBoardId = (params.boardId || '').replace(/[^a-zA-Z0-9_-]/g, '');
+    const wrId = parseInt(params.postId || '', 10);
+    const bfNo = parseInt(params.fileNo || '', 10);
+
+    // bo_table·bf_no 는 파라미터 바인딩이라 인젝션 불가. 잘못된 값은 조용히 무시(204).
+    if (!safeBoardId || Number.isNaN(wrId) || Number.isNaN(bfNo)) {
+        return new Response(null, { status: 204 });
+    }
+
+    try {
+        await pool.query(
+            `UPDATE g5_board_file SET bf_download = bf_download + 1
+			  WHERE bo_table = ? AND wr_id = ? AND bf_no = ?`,
+            [safeBoardId, wrId, bfNo]
+        );
+    } catch (e) {
+        // 집계 실패해도 다운로드 자체엔 영향 없음(파일은 별도 CDN URL).
+        console.error('[files/hit] bf_download 증가 실패:', e);
+    }
+
+    return new Response(null, { status: 204 });
+};

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/link-hit/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/link-hit/+server.ts
@@ -1,0 +1,36 @@
+/**
+ * 게시글 링크(wr_link1/2) 클릭 카운트 비콘
+ *
+ * POST /api/boards/[boardId]/posts/[postId]/link-hit?n=1  (n = 1 | 2)
+ * → g5_write_{board}.wr_link{n}_hit += 1
+ *
+ * 백엔드 PostResponse 는 link_hit 을 노출/증가시키지 않는다(프리즈). 링크 클릭 시
+ * navigator.sendBeacon 으로 이 엔드포인트를 불러 앞으로만 라이브 집계.
+ */
+import type { RequestHandler } from './$types';
+import pool from '$lib/server/db';
+
+export const POST: RequestHandler = async ({ params, url }) => {
+    const safeBoardId = (params.boardId || '').replace(/[^a-zA-Z0-9_-]/g, '');
+    const wrId = parseInt(params.postId || '', 10);
+    const which = Number(url.searchParams.get('n'));
+
+    // which 는 1|2 로 제한 후 고정 컬럼명에만 대입 → 문자열 보간이어도 인젝션 불가.
+    // 테이블명은 정규식 정화(영숫자·_·- 만).
+    if (!safeBoardId || Number.isNaN(wrId) || (which !== 1 && which !== 2)) {
+        return new Response(null, { status: 204 });
+    }
+
+    const col = which === 1 ? 'wr_link1_hit' : 'wr_link2_hit';
+    try {
+        await pool.query(
+            `UPDATE \`g5_write_${safeBoardId}\` SET ${col} = ${col} + 1 WHERE wr_id = ?`,
+            [wrId]
+        );
+    } catch (e) {
+        // 집계 실패해도 링크 이동엔 영향 없음.
+        console.error('[link-hit] wr_link_hit 증가 실패:', e);
+    }
+
+    return new Response(null, { status: 204 });
+};


### PR DESCRIPTION
## 요청
게시글 하단 첨부 목록을 박스 없는 **텍스트 목록 + 기본 접힘**으로 공간 절약, **다운로드 횟수**와 **링크(wr_link1/2) 클릭 횟수** 표시.

## 변경 (전부 web, 백엔드 무변)
- `.../files/+server.ts`: `bf_download` 반환 추가 + soft-delete 체크 쿼리에서 `wr_link1/2`·`wr_link1_hit/2_hit`를 함께 읽어 `links` 반환.
- `+page.server.ts`: `post.linkHits` 병합.
- `basic.svelte`: 첨부 목록 박스 제거→텍스트 + 기본 접힘 토글, 각 파일 '다운 N'; 기존 link1/2 표시에 '클릭 N' + 클릭 비콘.
- 신규 비콘 라우트: `files/[fileNo]/hit`(bf_download+1), `link-hit?n=1|2`(wr_link{n}_hit+1). 보드명 정규식 정화 + which 정수검증으로 injection 가드. sendBeacon+keepalive fetch 폴백.

## 배경/제약
- 기존 카운터는 프리즈 상태(파일 CDN 직접 서빙·백엔드가 hit 증가 안 함)라 클릭 시 라이브로 +1 집계 시작. 과거값은 그대로 노출.
- 본문 속 임의 링크는 범위 밖(구조화 wr_link1/2만).