### PR TITLE
fix(comment): 댓글 에디터 스포일러 적용 표시 (점선 테두리+배경)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-editor.svelte
+++ b/apps/web/src/lib/components/features/board/comment-editor.svelte
@@ -248,4 +248,15 @@
         font-size: var(--editor-font-size, 1rem);
         line-height: 1.6;
     }
+
+    /* 인라인 스포일러 — 에디터에선 가리지 않고 "표시만"(작성 중 읽어야 하므로).
+       본문 에디터(tiptap-editor.svelte)와 동일한 점선 테두리+옅은 배경으로,
+       모바일에서도 적용 여부가 한눈에 보이게 한다. 뷰의 실제 가림은
+       comment-list(.comment-body)·markdown(.prose)에 별도. */
+    .comment-editor :global(.tiptap span.dm-spoiler) {
+        background: color-mix(in srgb, currentColor 12%, transparent);
+        outline: 1px dashed color-mix(in srgb, currentColor 45%, transparent);
+        outline-offset: 1px;
+        border-radius: 3px;
+    }
 </style>


### PR DESCRIPTION
댓글 에디터에서 부분 스포일러를 적용해도 **에디터 안에서 표시가 안 나** 적용됐는지 애매(특히 아이폰). 본문 에디터엔 있던 `.dm-spoiler` 에디터 스타일이 댓글엔 없었음.

## 변경 (CSS 1규칙)
- `comment-editor.svelte` style에 `.comment-editor :global(.tiptap span.dm-spoiler)` 추가 — 본문 에디터(tiptap-editor.svelte:2227)와 **동일한 점선 테두리+옅은 배경**. 에디터에선 가리지 않고 표시만(작성 중 읽어야 하니), 뷰의 실제 가림은 comment-list/.prose에 별도.

CSS-only, 로직 무변.