### PR TITLE
fix(noti): 알림 스피너·유령 뱃지 + 보존버튼 중복 (버그 딥다이브)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -28,7 +28,6 @@
     import Users from '@lucide/svelte/icons/users';
     import Lock from '@lucide/svelte/icons/lock';
     import Flag from '@lucide/svelte/icons/flag';
-    import ScrapButton from '$lib/components/post/scrap-button.svelte';
     import DealEndReportButton from '$lib/components/features/board/deal-end-report-button.svelte';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { DisciplinedContent } from '$lib/components/ui/discipline-related';
@@ -757,11 +756,10 @@
                     {/if}
                 {/if}
 
-                <!-- 스크랩 + 공유 + 신고 (우측 정렬) -->
+                <!-- 공유 + 신고 (우측 정렬) — 스크랩(보존) 버튼은 상단 툴바에 있어 여기선 제외한다.
+                     (bug/13447: #11666 이 하단에 스크랩을 중복 추가해 두 개로 보였고, 하단본은
+                      initialScrapped 상태도 안 받아 표시가 부정확했다. 상태가 올바른 상단본만 유지) -->
                 <div class="ml-auto flex items-center gap-1">
-                    {#if authStore.isAuthenticated}
-                        <ScrapButton {boardId} postId={post.id} size="sm" variant="ghost" />
-                    {/if}
                     {#if board?.use_sns}
                         <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -477,11 +477,18 @@ async function proxyRequest(
             }
         }
 
+        // 알림 그룹 목록(/notifications/grouped, merge=target 포함)은 유저별 최근 3천 행을
+        // 집계하는 무거운 쿼리라 콜드 버퍼풀·경합 시 4초를 넘길 수 있다. 4초에 죽이면
+        // 스피너·간헐 실패(bug/13089)로 끝나고, 로드 실패 시 벨의 MarkSeen 이 안 돌아
+        // 유령 뱃지(bug/13449)까지 이어진다. 클라 타임아웃(10초)보다 위로 둬 느려도 실데이터가
+        // 오게 한다(빈 폴백으로 뱃지를 잘못 지우지 않기 위해 폴백 대신 타임아웃 상향).
+        const timeoutMs = path.startsWith('notifications/grouped') ? 12_000 : PROXY_TIMEOUT_MS;
+
         const response = await fetch(targetUrl, {
             method,
             headers,
             body,
-            signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
+            signal: AbortSignal.timeout(timeoutMs),
             // @ts-expect-error - Node.js fetch specific option
             duplex: body instanceof ReadableStream ? 'half' : undefined
         });

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -204,11 +204,13 @@
     }
 
     onMount(() => {
-        loadNotifications();
         // 알림함 페이지 진입도 '봤다(seen)' — 뱃지만 소거, 항목 읽음은 클릭 시 (bug/13367)
         apiClient.markNotificationsSeen().catch(() => undefined);
     });
 
+    // 초기 진입·페이지네이션(data.page 변경) 모두 이 $effect 한 곳에서 로드한다.
+    // (기존엔 onMount 도 loadNotifications 를 불러 진입 시 무거운 grouped 쿼리가 2번 나갔다 —
+    //  4초 프록시 타임아웃을 더 자주 넘겨 스피너·유령 뱃지를 악화시켰다. bug/13089)
     $effect(() => {
         if (data.page) {
             loadNotifications();


### PR DESCRIPTION
버그게시판 딥다이브로 확정한 웹 버그 3건. 백엔드 무변.

## bug/13089 (알림 스피너·간헐 로드 실패)
- `api/v1/[...path]/+server.ts`: grouped 엔드포인트 프록시 타임아웃 **4초→12초**(클라 10초보다 위). grouped는 유저별 최근 3천행 집계라 콜드/경합 시 4초를 넘겨 504→스피너로 끝났음.
- `notifications/+page.svelte`: onMount·$effect **이중 로드 제거**(무거운 쿼리 2번→1번). $effect가 초기+페이지네이션 담당.

## bug/13449 (다 확인했는데 유령 카운트)
- **13089의 연쇄 결과였음**: 목록 로드가 실패하면 벨의 MarkSeen이 안 돌아(if(ok) 게이트) seen 뱃지가 영구 고착. 타임아웃 상향으로 로드가 성공하면 MarkSeen 정상 발화→해소. 게이트 자체는 올바르므로 유지.

## bug/13447 (보존 버튼 2개)
- 게시글에 ScrapButton 2개(상단 툴바 #238 + 하단 액션바 #11666). 하단본은 initialScrapped 미전달로 상태도 부정확. **하단(basic.svelte:763) 제거**, 상태 올바른 상단만 유지. 공유·신고는 하단 유지.

## 범위 밖(별도 추적)
- 앱 전용 버그(13444·13426·13430·13402·13407·13119)=task 앱추적. 정책요청(13451 등)=운영. 방송 +1 설계=유지.