### PR TITLE
fix(ui): 본문 줄 높이 설정 실제 적용 (#13456)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -2136,10 +2136,12 @@
      *    예전엔 여기에 margin-top 도 line-height 도 없어서, 작성 화면은
      *    ~36px 로 보이다가 게시하면 40.8px 로 벌어졌다. 제보 문구가
      *    "엔터치면 띄엄띄엄 **올라갑니다**" 였던 이유다(qa/82197).
-     *    한쪽만 바꾸면 괴리가 다시 생기므로 두 파일을 함께 고칠 것. */
+     *    한쪽만 바꾸면 괴리가 다시 생기므로 두 파일을 함께 고칠 것.
+     *    #13456: 게시 후 렌더와 **같은** var(--content-line-height, 1.8) 를 쓴다 —
+     *    UI 설정 "본문 줄 높이"가 작성 화면·게시 화면에 동일하게 적용되도록. */
     :global(.tiptap-content .tiptap p) {
         margin-top: 0.35rem;
-        line-height: 1.8;
+        line-height: var(--content-line-height, 1.8);
         margin-bottom: 0.35rem;
     }
 

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -383,7 +383,7 @@
 <div
     bind:this={proseEl}
     class="prose prose-neutral dark:prose-invert max-w-none {className}"
-    style="font-size: var(--content-font-size, 16px); overflow-wrap: break-word; word-wrap: break-word; overflow-x: hidden; contain: style;"
+    style="font-size: var(--content-font-size, 16px); line-height: var(--content-line-height, 1.8); overflow-wrap: break-word; word-wrap: break-word; overflow-x: hidden; contain: style;"
 >
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html renderedHtml}
@@ -519,19 +519,21 @@
      * 0.35rem 으로 낮추면 34.4px(-16%). 진짜 문단 구분은 빈 줄
      * (아래 p:empty 1.8em)이 계속 담당하므로 문단감은 유지된다.
      *
-     * ⛔ line-height 1.8 은 이번에 건드리지 않는다. 두 축을 한꺼번에
-     *    바꾸면 반응이 나빴을 때 원인을 가릴 수 없다. */
+     * line-height 는 UI 설정 "본문 줄 높이"(--content-line-height)를 소비한다(#13456).
+     *    이 변수를 읽는 CSS 가 그동안 0곳이라 설정이 죽어 있었다. fallback 1.8 은 현재
+     *    라이브값이자 스토어 normal 값과 같아 설정 미변경 사용자는 그대로다. */
     .prose :global(p) {
         margin-top: 0.35rem;
         margin-bottom: 0.35rem;
         font-size: inherit;
-        line-height: 1.8;
+        line-height: var(--content-line-height, 1.8);
     }
 
-    /* 빈 <p></p> 및 <p><br></p> 태그도 줄바꿈으로 표시 (에디터 엔터키 반영) */
+    /* 빈 <p></p> 및 <p><br></p> 태그도 줄바꿈으로 표시 (에디터 엔터키 반영).
+       빈 줄 높이도 줄 간격 설정을 따라가 문단감이 일관되게 유지된다. */
     .prose :global(p:empty),
     .prose :global(p:has(> br:only-child)) {
-        min-height: 1.8em;
+        min-height: calc(var(--content-line-height, 1.8) * 1em);
     }
 
     .prose :global(ul),

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -109,11 +109,16 @@ const DEFAULTS: UiSettings = {
     memoColorLabels: {}
 };
 
+// ⛔ normal 은 현재 라이브 하드코딩(markdown .prose p / tiptap p = 1.8)과 **같은 값**이어야 한다.
+//    #13456: 이 설정은 그동안 --content-line-height 를 읽는 CSS 가 0곳이라 죽어 있었다.
+//    이제 markdown/에디터가 var(--content-line-height, 1.8) 로 소비하는데, 만약 기본값을
+//    1.6 으로 두면 설정을 한 번도 안 만진 전 사용자의 본문이 1.8→1.6 으로 좁아지는 대량
+//    회귀가 난다. 그래서 normal=1.8 로 고정하고 나머지만 의미 있게 벌린다.
 const LINE_HEIGHT_VALUES: Record<LineHeight, string> = {
-    compact: '1.4',
-    normal: '1.6',
-    relaxed: '1.8',
-    loose: '2.0'
+    compact: '1.5',
+    normal: '1.8',
+    relaxed: '2.0',
+    loose: '2.3'
 };
 
 const CONTENT_FONT_SIZES: Record<ContentFontSize, string> = {


### PR DESCRIPTION
## 배경 (bug/13456)
설정 → UI 설정 → **본문 줄 높이**를 조정해도 적용이 안 된다는 제보(코파니코피나, 윈11/엣지).

## 근본원인
- `--content-line-height` 를 `<html>` 에 세팅하지만 **이 변수를 읽는 CSS 가 레포 전체에 0곳** — 값만 쓰고 아무도 소비 안 함.
- 본문 문단은 `markdown.svelte .prose p { line-height: 1.8 }` 하드코딩이 지배(글의 91.8%가 한 줄=한 문단). 에디터 `tiptap p` 도 1.8 하드코딩 → 작성 화면도 설정 무시.
- 즉 이 설정은 도입 이래 **죽은 설정**이었다.

## 수정 (web only, 3파일)
- `markdown.svelte`: `.prose` 컨테이너·`p`·빈줄이 `var(--content-line-height, 1.8)` 소비.
- `tiptap-editor.svelte`: 게시 후 렌더와 **동일** 변수 소비(작성=게시 일치, 기존 불변식 유지).
- `ui-settings.svelte.ts`: `LINE_HEIGHT_VALUES` 재매핑 — **normal=1.8(현행 라이브값=무회귀)**, compact 1.5 / relaxed 2.0 / loose 2.3.

## 회귀 방지 핵심
기본값 normal 을 현재 하드코딩값 1.8 에 고정 → 설정 한 번도 안 만진 전 사용자는 그대로. (1.6 으로 두면 전 사용자 본문이 좁아지는 대량 회귀)

## 검증
- [ ] 기존 유닛테스트 green / `pnpm check` 통과 (CI)
- [ ] 설정 compact/relaxed/loose 선택 시 본문·에디터 줄 간격 실제 변화
- [ ] normal(기본) 사용자 본문 1.8 불변