### PR TITLE
ci(web): 카카오톡 공유 JS 앱키 빌드 주입 배관 (#13454)

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -71,9 +71,12 @@ jobs:
         env:
           VITE_GAM_NETWORK_CODE: '23338387889'
           VITE_GAM_SITE_NAME: 'damoang'
+          # 카카오톡 공유 JS 앱키. 비면 Kakao.init("")→"인증 실패"(#13454).
+          VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
         run: |
           echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
           echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
+          echo "VITE_KAKAO_JS_KEY=${VITE_KAKAO_JS_KEY}" >> apps/web/.env
 
           rm -rf apps/web/.svelte-kit apps/web/build apps/web/node_modules/.vite
           pnpm --filter web build

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -85,10 +85,13 @@ jobs:
           VITE_USE_MOCK: 'false'
           VITE_GAM_NETWORK_CODE: '23338387889'
           VITE_GAM_SITE_NAME: 'damoang'
+          # 카카오톡 공유 JS 앱키 (canary). 비면 Kakao.init("")→"인증 실패"(#13454).
+          VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
         run: |
           pnpm --filter "./packages/*" build
           echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
           echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
+          echo "VITE_KAKAO_JS_KEY=${VITE_KAKAO_JS_KEY}" >> apps/web/.env
           pnpm --filter web build
 
       - name: Prepare deploy package

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,12 +164,15 @@ jobs:
           VITE_GAM_NETWORK_CODE: '23338387889'
           VITE_GAM_SITE_NAME: 'damoang'
           VITE_S3_URL: ${{ env.MEDIA_CDN_BASE }}
+          # 카카오톡 공유(sharer.kakao.com) JS 앱키. 비면 Kakao.init("")→"인증 실패"(#13454).
+          VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
           ASSET_BASE_URL: ${{ env.STATIC_ASSET_BASE_ROOT }}/${{ needs.resolve-release.outputs.sha_tag }}
         run: |
           pnpm --filter "./packages/*" build
           echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
           echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
           echo "VITE_S3_URL=${VITE_S3_URL}" >> apps/web/.env
+          echo "VITE_KAKAO_JS_KEY=${VITE_KAKAO_JS_KEY}" >> apps/web/.env
           pnpm --filter web build
 
       - name: Upload immutable assets to R2


### PR DESCRIPTION
## 배경 (bug/13454)
아이폰/사파리에서 게시글 하단 **공유 > 카카오톡** 선택 시 sharer.kakao.com 이
**'요청 실패 / 잘못된 요청으로 인증에 실패하였습니다'** 화면을 띄운다.

## 근본원인 (실측)
prod web 번들에 `window.Kakao.init("")` — **JS 앱키가 빈 문자열**로 빌드됨.
`share.ts` 는 `import.meta.env.VITE_KAKAO_JS_KEY` 를 읽는데, 배포 워크플로의 빌드
env 에 이 변수가 없어서 Vite 가 빈 값을 인라인했다. (`.env` 는 dockerignore 라
무관 — 빌드는 CI 러너에서 `pnpm --filter web build` 로 직접 수행)

## 변경 (배관만)
`deploy.yml` · `deploy-staging.yml` · `deploy-binary.yml` 의 web 빌드 env 에
`VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}` 추가 + `.env` 기록.
기존 `VITE_GAM_*` 와 동일 패턴.

## ⚠️ 이 PR 만으로는 복구되지 않음 (운영자 조치 필요)
1. **GitHub Secret `VITE_KAKAO_JS_KEY`** = 카카오 developers > 내 애플리케이션 > 앱 키 > **JavaScript 키** (로그인용 앱과 동일 앱).
2. **카카오 developers 콘솔**: 플랫폼 > **Web 사이트 도메인에 `https://damoang.net`** (+ `https://canary.damoang.net`) 등록 + **카카오톡 공유 활성화**.
Secret 가 비어 있으면 여전히 `init("")` → 실패. 위 2개가 갖춰진 뒤 재빌드해야 복구된다.

## 검증
- [ ] Secret 설정 + 카카오 콘솔 등록 후 canary 빌드 → 번들에 `Kakao.init("<키>")` 확인
- [ ] canary.damoang.net 에서 공유 > 카카오톡 정상 동작
- [ ] CI 초록