### PR TITLE
fix(auth): 초대·앱 경로에도 이용제한 계정 재가입 차단 (F3 §4-②)

### DIFF
--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -39,6 +39,7 @@ import { runSocialLoginPostProcess } from '$lib/server/auth/social-login-postpro
 import {
     generateSocialMbId,
     appendMbIdSuffix,
+    inspectSocialMbIdOccupant,
     isMbIdTaken,
     isNicknameTaken,
     createMember,
@@ -271,6 +272,14 @@ async function handleCallback(
                     // 이전 초대 시도에서 생성된 임시 계정 재사용 (중복 방지)
                     mbId = existingTemp.mb_id;
                 } else {
+                    // ⛔ 이용제한 중인 계정이 점유한 mb_id 면 새 계정을 만들지 않는다(F3 §4-②).
+                    const occupant = await inspectSocialMbIdOccupant(
+                        providerName,
+                        profile.identifier
+                    );
+                    if (occupant.kind === 'blocked') {
+                        redirect(302, '/login?error=account_blocked');
+                    }
                     const nickname = await generateInviteTempNickname(providerName);
                     mbId = baseMbId;
                     if (await isMbIdTaken(mbId)) {
@@ -334,6 +343,14 @@ async function handleCallback(
                 if (existingTemp) {
                     mbId = existingTemp.mb_id;
                 } else {
+                    // ⛔ 이용제한 중인 계정이 점유한 mb_id 면 새 계정을 만들지 않는다(F3 §4-②).
+                    const occupant = await inspectSocialMbIdOccupant(
+                        providerName,
+                        profile.identifier
+                    );
+                    if (occupant.kind === 'blocked') {
+                        redirect(302, '/login?error=account_blocked');
+                    }
                     const nickname = await generateInviteTempNickname(providerName);
                     mbId = baseMbId;
                     if (await isMbIdTaken(mbId)) {

--- a/apps/web/src/routes/auth/native/apple/+server.ts
+++ b/apps/web/src/routes/auth/native/apple/+server.ts
@@ -23,6 +23,7 @@ import { getMemberById, findMemberByEmail, isMemberActive } from '$lib/server/au
 import {
     generateSocialMbId,
     appendMbIdSuffix,
+    inspectSocialMbIdOccupant,
     isMbIdTaken,
     isNicknameTaken,
     createMember,
@@ -148,6 +149,13 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
             if (existingTemp) {
                 mbId = existingTemp.mb_id;
             } else {
+                // ⛔ 이용제한 중인 계정이 점유한 mb_id 면 새 계정을 만들지 않는다.
+                //    generateSocialMbId 는 결정적이라 충돌 = 같은 소셜 계정 = 동일인이다.
+                //    접미사를 붙여 우회시키면 영구정지가 앱 경로로 뚫린다(F3 §4-②).
+                const occupant = await inspectSocialMbIdOccupant('apple', identifier);
+                if (occupant.kind === 'blocked') {
+                    return json({ success: false, error: 'account_blocked' }, { status: 403 });
+                }
                 const nickname = await generateUniqueTempNickname();
                 mbId = baseMbId;
                 if (await isMbIdTaken(mbId)) {

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -11,6 +11,9 @@
     const oauthErrorMessages: Record<string, string> = {
         no_account: '연결된 계정이 없습니다. 소셜 로그인으로 회원가입을 진행해주세요.',
         account_inactive: '탈퇴했거나 이용이 제한된 계정입니다.',
+        // 이용제한 중인 계정이 점유한 소셜 계정으로 새 계정을 만들려 한 경우.
+        // 제재 사유·기간은 노출하지 않는다(F3 §4-②).
+        account_blocked: '이용이 제한된 계정입니다. 자세한 내용은 고객센터로 문의해주세요.',
         invalid_state: '인증 세션이 만료되었습니다. 다시 시도해주세요.',
         invalid_provider: '지원하지 않는 로그인 방식입니다.',
         provider_mismatch: '인증 정보가 일치하지 않습니다. 다시 시도해주세요.',


### PR DESCRIPTION
## 무엇이 새고 있었나

일반 가입 경로는 `inspectSocialMbIdOccupant()` 로 `blocked` 를 이미 막고 있다. 그런데 **초대 플로우와 애플 앱 경로는 여전히** `isMbIdTaken` → `appendMbIdSuffix` 로 접미사 계정을 만든다.

`generateSocialMbId` 는 **결정적**이라 mb_id 충돌은 곧 **같은 소셜 계정 = 동일인**이라는 뜻이다. 여기서 접미사를 붙여 우회시키면 **영구정지가 그 경로로 뚫린다.**

## 실측 (운영 DB)

| | |
|---|---|
| 접미사 계정 총계 | 113 |
| 그중 **원본이 영구정지** | **10** |
| F3 Contract 작성(2026-07-23) **이후** 생성 | **7건** (최근 2026-08-04) |

7/23 이후 7건의 원본 상태는 차단 0 · **탈퇴 4** · 활성 3 이다. 즉 제재 회피는 (일반 경로에서) 막히고 있으나, 닉네임이 `tmp_google_f16190`·`tmp_kakao_6a44dd` 인 건들이 **초대·앱 임시계정 경로가 살아 있음**을 보여준다.

## 변경

| 파일 | 처리 |
|---|---|
| `auth/native/apple/+server.ts` | `blocked` → `account_blocked` **403**, 계정 생성 안 함 |
| `auth/callback/[provider]/+server.ts` (2곳) | `blocked` → `/login?error=account_blocked` |
| `login/+page.svelte` | `account_blocked` 문구 추가 |

안내 문구는 **제재 사유·기간을 노출하지 않는다**(F3 §4-② 원칙):
> 이용이 제한된 계정입니다. 자세한 내용은 고객센터로 문의해주세요.

## 이번 범위 밖

- **`recoverable`(탈퇴/활성 점유)** — 초대·앱 플로우에는 복구 확인 UI 가 없어 현행 동작을 유지했다. 복구 경로 통합은 별건(F3 §4-③)
- **기존 접미사 계정 8건** — 원본이 차단됐는데 살아 있는 파생 계정들. 전부 활동 0 이라 별도 판단 사항
- **기록관 발행**(F3 §6-2 승인 큐) — 차단만 하고 기록은 남기지 않았다

## 검증

- [ ] 영구정지 계정의 소셜로 **앱 로그인** → `account_blocked`, `g5_member` 신규 행 0
- [ ] 같은 조건 **초대 링크** 진입 → 로그인 화면에 안내 문구
- [ ] **만료된** 제재(과거 날짜)는 차단되지 않고 기존 흐름 유지
- [ ] 초대 플로우 정상 케이스 회귀 없음
- [ ] 일반 가입 경로 무변