### PR TITLE
fix(scroll): 뒤로가기 복원 루프 teardown (#13239·#13221)

### DIFF
--- a/apps/web/src/lib/utils/scroll-restore.test.ts
+++ b/apps/web/src/lib/utils/scroll-restore.test.ts
@@ -134,4 +134,39 @@ describe('createScrollSnapshot', () => {
         resizeCallbacks.forEach((cb) => cb());
         expect(scrollTo.mock.calls.length).toBe(callsAfterRestore);
     });
+
+    it('⛔ capture 는 진행 중인 복원 루프를 취소한다 (라우트 넘어 누수 방지 · #13239)', () => {
+        const snap = createScrollSnapshot();
+        scrollHeight = 900; // 아직 문서가 짧아 복원 대기 중
+        snap.restore({ scrollY: 5000 });
+        drainFrames(3);
+        expect(scrollTo).not.toHaveBeenCalled();
+
+        // 이 페이지를 떠난다 → 복원 루프가 종료돼야 한다
+        snap.capture();
+
+        // 다음 라우트에서 문서가 길어지고 리사이즈가 나도 옛 target 으로 스크롤하면 안 된다
+        scrollHeight = 6000;
+        drainFrames(70);
+        resizeCallbacks.forEach((cb) => cb());
+
+        expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('새 restore 는 이전 루프를 취소하고 새 target 으로만 복원한다', () => {
+        const snap = createScrollSnapshot();
+        scrollHeight = 900;
+        snap.restore({ scrollY: 5000 }); // 루프 A (대기)
+        drainFrames(3);
+
+        snap.restore({ scrollY: 1000 }); // 루프 B — A 를 취소
+
+        scrollHeight = 6000; // 두 target 모두 도달 가능한 높이
+        drainFrames(3);
+        resizeCallbacks.forEach((cb) => cb());
+
+        expect(scrollTo).toHaveBeenCalledWith(0, 1000);
+        expect(scrollTo).not.toHaveBeenCalledWith(0, 5000);
+        expect(scrollY).toBe(1000);
+    });
 });

--- a/apps/web/src/lib/utils/scroll-restore.ts
+++ b/apps/web/src/lib/utils/scroll-restore.ts
@@ -11,6 +11,14 @@
  *   - rAF 최대 60프레임(~1s)
  *   - 그 뒤는 ResizeObserver 로 문서 높이 변화마다 재시도 (3초 상한)
  *
+ * ⛔ **복원 루프는 반드시 취소 가능해야 한다.**
+ *    `window`·`document.documentElement(<html>)` 은 SPA 네비게이션에서 교체되지 않는다.
+ *    한 라우트에서 시작한 rAF/ResizeObserver 루프가 취소되지 않으면, 뒤로가기로
+ *    다른 페이지가 마운트된 뒤에도 살아남아 **새 페이지를 옛 target 으로 다시 스크롤**한다
+ *    (#13239: 목록이 본문에서 내려간 만큼 내려가 있음, #13221: 스와이프백 시 바닥 착지).
+ *    그래서 이 스냅샷은 활성 루프를 하나만 유지하고, 페이지를 떠날 때(capture)와 새 복원을
+ *    시작할 때(restore) 이전 루프를 확실히 종료한다.
+ *
  * ⛔ 이 로직을 페이지마다 복붙하지 말 것. 2026-03 에 목록만 고치고 상세를 빠뜨려
  *    같은 증상이 5개월 더 남아 있었다. 스크롤 복원이 필요한 페이지는 이 유틸을 쓴다.
  */
@@ -28,6 +36,7 @@ export interface ScrollSnapshotValue {
 
 /**
  * SvelteKit `snapshot` 으로 그대로 쓸 수 있는 객체를 만든다.
+ * 라우트(모듈)마다 한 번 호출 → 각자 독립된 클로저(=독립 활성 루프)를 갖는다.
  *
  * ```svelte
  * <script lang="ts" module>
@@ -39,16 +48,44 @@ export function createScrollSnapshot(): {
     capture: () => ScrollSnapshotValue;
     restore: (value: ScrollSnapshotValue) => void;
 } {
+    // 진행 중인 복원 루프를 종료하는 핸들. 이 스냅샷당 하나만 산다.
+    // 다음 restore 진입 시(중복 루프 방지)와 capture 시(페이지 떠남) 호출한다.
+    let cancelActive: (() => void) | null = null;
+
     return {
-        capture: () => ({ scrollY: window.scrollY }),
+        capture: () => {
+            // 이 페이지를 떠난다 — 남아있는 복원 루프가 다음 라우트를 스크롤하지 못하게 끊는다.
+            cancelActive?.();
+            return { scrollY: window.scrollY };
+        },
 
         restore: (value: ScrollSnapshotValue) => {
+            // 새 복원을 시작하기 전에 이전 루프를 반드시 취소한다.
+            cancelActive?.();
+
             const target = value?.scrollY ?? 0;
             // 맨 위였으면 복원할 것이 없다. 굳이 건드리면 스와이프 제스처와 충돌만 난다.
             if (target <= 0) return;
 
-            let tries = 0;
             let done = false;
+            let rafId = 0;
+            let ro: ResizeObserver | null = null;
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+            /** rAF·ResizeObserver·timeout 을 모두 정리하고 활성 핸들을 비운다 */
+            const cleanup = () => {
+                done = true;
+                if (rafId && typeof cancelAnimationFrame !== 'undefined')
+                    cancelAnimationFrame(rafId);
+                rafId = 0;
+                ro?.disconnect();
+                ro = null;
+                if (timeoutId !== undefined) clearTimeout(timeoutId);
+                timeoutId = undefined;
+                // 다른 복원이 이미 활성 핸들을 가져갔다면 그것까지 지우지 않는다.
+                if (cancelActive === cleanup) cancelActive = null;
+            };
+            cancelActive = cleanup;
 
             /** 문서가 목표에 닿았을 때만 스크롤한다 — clamp 방지의 핵심 */
             const tryScroll = () => {
@@ -59,28 +96,32 @@ export function createScrollSnapshot(): {
                 }
             };
 
+            let tries = 0;
             const attempt = () => {
                 if (done) return;
                 tryScroll();
                 tries++;
-                if (!done && tries < MAX_FRAMES) requestAnimationFrame(attempt);
+                if (done) {
+                    cleanup();
+                    return;
+                }
+                if (tries < MAX_FRAMES) rafId = requestAnimationFrame(attempt);
             };
-            requestAnimationFrame(attempt);
+            rafId = requestAnimationFrame(attempt);
 
             // 이미지·광고가 로드돼 문서 높이가 바뀔 때마다 재시도
             if (typeof ResizeObserver !== 'undefined') {
-                const ro = new ResizeObserver(() => {
+                ro = new ResizeObserver(() => {
                     if (done) {
-                        ro.disconnect();
+                        cleanup();
                         return;
                     }
                     tryScroll();
-                    if (done) ro.disconnect();
+                    if (done) cleanup();
                 });
                 ro.observe(document.documentElement);
-                setTimeout(() => {
-                    done = true;
-                    ro.disconnect();
+                timeoutId = setTimeout(() => {
+                    cleanup();
                 }, OBSERVE_TIMEOUT_MS);
             }
         }


### PR DESCRIPTION
## 배경 (bug/13239 매번·모바일, bug/13221 간헐·iOS 스와이프백)
목록→상세→뒤로가기 시 **목록이 본문에서 내려간 만큼 내려가 있음**(13239), iOS 스와이프백 시 **바닥 착지**(13221).

## 근본원인 (Explore 확정)
리더 가설('목록에 스냅샷 없음')은 **틀림** — 목록·상세 둘 다 `createScrollSnapshot()` 스냅샷 보유, 유틸도 유닛테스트됨. 진짜 원인은 **`scroll-restore.ts` 의 `restore` 루프가 취소 불가**라는 것. rAF(최대 60프레임)·ResizeObserver(최대 3s)가 `window`·`<html>`(SPA에서 미교체 전역)을 대상으로 도는데, 한 라우트에서 시작한 루프가 뒤로가기 후에도 살아남아 **새로 마운트된 페이지를 옛 target 으로 다시 스크롤**한다.

## 수정 (파일 1개, 호출부 무변경)
`apps/web/src/lib/utils/scroll-restore.ts`:
- 스냅샷 클로저에 활성 루프 취소 핸들 `cancelActive` 1개 유지.
- `restore`: 시작 전 이전 루프 취소(중복 루프 방지) 후 새 루프 등록.
- `capture`: 페이지 이탈 시(SvelteKit 이 이탈 직전 호출) 활성 복원 루프 종료 → 루프가 라우트를 넘지 못함.
- `cleanup` 이 rAF·ResizeObserver·timeout 전부 정리, `cancelActive === cleanup` 가드로 타 복원 핸들 미침범.
- **기존 clamp-방지 계약(문서 높이 도달 전 scrollTo 금지)은 100% 유지.**

## 설계 판단
Explore 가 제안한 '두 호출부에 beforeNavigate/onDestroy 배선'은 파일 3개·blast radius 넓음 → **기각**. capture 가 이탈 신호이므로 유틸 1파일로 동일 효과. line 48 조기리턴을 강제 scroll-to-0 으로 바꾸는 안도 **기각**(제스처 충돌 주석 존재).

## 검증
- [ ] 기존 유닛테스트 5 + 신규 2(capture 취소 / 재-restore 취소) green
- [ ] `pnpm check` 통과 (CI)
- [ ] prod: 목록→상세→뒤로 시 목록 원위치, iOS 스와이프백 바닥 안 떨어짐