### PR TITLE
feat(disciplinelog): 목록·상세 여백 정리와 상세 요약 헤더

### DIFF
--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -178,7 +178,7 @@
                                 >
                             </div>
 
-                            <ul class="space-y-0.5">
+                            <ul>
                                 {#each group.items as log (log.id)}
                                     {@const penalty = getPenaltyDisplay(
                                         log.penalty_period,
@@ -187,11 +187,11 @@
                                     <li>
                                         <a
                                             href="/disciplinelog/{log.id}"
-                                            class="hover:bg-muted/60 focus-visible:ring-ring flex items-start gap-3 rounded-md px-2 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2"
+                                            class="hover:bg-muted/60 focus-visible:ring-ring flex items-start gap-3 rounded-md px-2 py-1.5 leading-tight transition-colors focus-visible:outline-none focus-visible:ring-2"
                                         >
                                             <!-- 강도 점: 영구=빨강 / 기간제=주황 / 주의·해제=회색 -->
                                             <span
-                                                class="mt-1.5 h-2 w-2 shrink-0 rounded-full {dotClass(
+                                                class="mt-1 h-2 w-2 shrink-0 rounded-full {dotClass(
                                                     log.penalty_period,
                                                     penalty.released
                                                 )}"
@@ -228,7 +228,7 @@
                                                     {/if}
                                                 </span>
                                                 <span
-                                                    class="text-muted-foreground/70 block truncate text-xs"
+                                                    class="text-muted-foreground/70 block truncate text-xs leading-tight"
                                                     >{log.member_id}</span
                                                 >
                                             </span>

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -8,7 +8,6 @@
     import ArrowLeft from '@lucide/svelte/icons/arrow-left';
     import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
     import Calendar from '@lucide/svelte/icons/calendar';
-    import User from '@lucide/svelte/icons/user';
     import FileText from '@lucide/svelte/icons/file-text';
     import Info from '@lucide/svelte/icons/info';
     import Megaphone from '@lucide/svelte/icons/megaphone';
@@ -146,28 +145,18 @@
             </Card.Root>
         {/if}
 
-        <!-- Basic Info -->
-        <Card.Root class="mb-4">
-            <Card.Header>
-                <Card.Title class="flex items-center gap-2">
-                    <User class="h-5 w-5" />
-                    기본 정보
-                </Card.Title>
-            </Card.Header>
-            <Card.Content class="space-y-4">
-                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                    <div>
-                        <div class="text-muted-foreground mb-1 text-sm">닉네임</div>
-                        <div class="font-medium">{log.member_nickname}</div>
-                    </div>
-                    <div>
-                        <div class="text-muted-foreground mb-1 text-sm">아이디</div>
-                        <div class="font-medium">{log.member_id}</div>
-                    </div>
-                </div>
-                <div>
-                    <div class="text-muted-foreground mb-1 text-sm">제재 기간</div>
-                    <div class="flex items-center gap-2">
+        <!--
+          요약 헤더 — 누가·얼마나·언제를 한 블록에 모은다.
+          기존에는 "기본 정보"와 "제재 기간"이 카드 안에서 라벨·값 쌍으로 흩어져
+          정작 중요한 정보를 찾는 데 시선이 여러 번 움직였다.
+        -->
+        <div class="mb-4 rounded-lg border p-4">
+            <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span class="text-lg font-bold">{log.member_nickname}</span>
+                <span class="text-muted-foreground/70 text-xs">{log.member_id}</span>
+            </div>
+            <div class="mt-2">
+                    <div class="flex flex-wrap items-center gap-2">
                         <Badge
                             variant={getPenaltyBadgeVariant(log.penalty_period, penalty.released)}
                         >
@@ -203,33 +192,31 @@
                             {/if}
                         </span>
                     </div>
-                </div>
-            </Card.Content>
-        </Card.Root>
+            </div>
 
-        <!-- Violation Types -->
-        <Card.Root class="mb-4">
-            <Card.Header>
-                <Card.Title class="flex items-center gap-2">
-                    <AlertTriangle class="text-muted-foreground h-5 w-5" />
-                    제재 사유
-                </Card.Title>
-            </Card.Header>
-            <Card.Content>
-                <div class="space-y-3">
+            <!-- 사유는 요약 헤더 안에 함께 둔다 — 제재의 "무엇 때문에"가 기간과 떨어지면 안 읽힌다 -->
+            {#if log.violation_types.length > 0}
+                <div class="mt-3 space-y-2 border-t pt-3">
                     {#each log.violation_types as vt}
-                        <div class="bg-muted/50 rounded-lg p-3">
-                            <div class="text-sm font-medium">{vt.title}</div>
-                            <div class="text-muted-foreground mt-1 text-sm">{vt.description}</div>
+                        <div>
+                            <div class="flex items-baseline gap-2">
+                                <AlertTriangle
+                                    class="text-muted-foreground mt-0.5 h-3.5 w-3.5 shrink-0"
+                                />
+                                <span class="text-sm font-medium">{vt.title}</span>
+                            </div>
+                            <div class="text-muted-foreground mt-0.5 pl-[1.375rem] text-sm">
+                                {vt.description}
+                            </div>
                         </div>
                     {/each}
                 </div>
-            </Card.Content>
-        </Card.Root>
+            {/if}
+        </div>
 
         <!-- 기타 사유: 회원 공개용 (운영자가 입력한 경우에만 표시) -->
         {#if log.member_reason && log.member_reason.trim()}
-            <Card.Root class="mb-4">
+            <Card.Root class="mb-3">
                 <Card.Header>
                     <Card.Title class="flex items-center gap-2">
                         <Info class="text-muted-foreground h-5 w-5" />
@@ -244,7 +231,7 @@
 
         <!-- 안내: 회원 공개용 외부 안내문 (운영자가 입력한 경우에만 표시) -->
         {#if log.public_description && log.public_description.trim()}
-            <Card.Root class="mb-4">
+            <Card.Root class="mb-3">
                 <Card.Header>
                     <Card.Title class="flex items-center gap-2">
                         <Megaphone class="text-muted-foreground h-5 w-5" />
@@ -261,7 +248,7 @@
 
         <!-- Reported Items -->
         {#if log.reported_items && log.reported_items.length > 0}
-            <Card.Root class="mb-4">
+            <Card.Root class="mb-3">
                 <Card.Header>
                     <Card.Title class="flex items-center gap-2">
                         <FileText class="h-5 w-5" />
@@ -358,7 +345,7 @@
                     </Card.Title>
                 </Card.Header>
                 <Card.Content>
-                    <div class="space-y-2">
+                    <div class="space-y-0.5">
                         {#each memberHistory as item}
                             {@const itemPenalty = getPenaltyDisplay(
                                 item.penalty_period,
@@ -366,7 +353,7 @@
                             )}
                             <a
                                 href="/disciplinelog/{item.id}"
-                                class="hover:bg-muted/50 flex items-center justify-between rounded p-2 text-sm transition-all duration-200 ease-out {item.id ===
+                                class="hover:bg-muted/50 flex items-center justify-between rounded px-2 py-1.5 text-sm leading-tight transition-colors {item.id ===
                                 log.id
                                     ? 'bg-primary/10 border-primary/30 border font-semibold'
                                     : ''}"

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -156,42 +156,40 @@
                 <span class="text-muted-foreground/70 text-xs">{log.member_id}</span>
             </div>
             <div class="mt-2">
-                    <div class="flex flex-wrap items-center gap-2">
+                <div class="flex flex-wrap items-center gap-2">
+                    <Badge variant={getPenaltyBadgeVariant(log.penalty_period, penalty.released)}>
+                        {penalty.text}
+                    </Badge>
+                    {#if log.revoked_at}
                         <Badge
-                            variant={getPenaltyBadgeVariant(log.penalty_period, penalty.released)}
+                            variant="secondary"
+                            class="border-emerald-300 bg-emerald-100 text-xs text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
                         >
-                            {penalty.text}
+                            소명 해제
                         </Badge>
+                    {:else if penalty.released}
+                        <Badge variant="secondary" class="text-xs">해제</Badge>
+                    {/if}
+                    <span class="text-muted-foreground text-sm">
                         {#if log.revoked_at}
-                            <Badge
-                                variant="secondary"
-                                class="border-emerald-300 bg-emerald-100 text-xs text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
-                            >
-                                소명 해제
-                            </Badge>
-                        {:else if penalty.released}
-                            <Badge variant="secondary" class="text-xs">해제</Badge>
-                        {/if}
-                        <span class="text-muted-foreground text-sm">
-                            {#if log.revoked_at}
-                                <!-- 회수된 제재: 원래 종료일에 취소선 + 조기 해제 표기.
-                                     (기간이 만료된 게 아니라 소명 인용으로 중간에 풀렸음을 명확히) -->
-                                ({log.penalty_date_from} 시작 ·
-                                {#if log.penalty_period !== 0}
-                                    <s class="opacity-60"
-                                        >{log.penalty_period === -1
-                                            ? '영구'
-                                            : log.penalty_date_to || ''}</s
-                                    > ·
-                                {/if}
-                                <span class="text-emerald-700 dark:text-emerald-400"
-                                    >{log.revoked_at} 소명 인용으로 해제</span
-                                >)
-                            {:else}
-                                ({formatPeriodRange(log)})
+                            <!-- 회수된 제재: 원래 종료일에 취소선 + 조기 해제 표기.
+                                 (기간이 만료된 게 아니라 소명 인용으로 중간에 풀렸음을 명확히) -->
+                            ({log.penalty_date_from} 시작 ·
+                            {#if log.penalty_period !== 0}
+                                <s class="opacity-60"
+                                    >{log.penalty_period === -1
+                                        ? '영구'
+                                        : log.penalty_date_to || ''}</s
+                                > ·
                             {/if}
-                        </span>
-                    </div>
+                            <span class="text-emerald-700 dark:text-emerald-400"
+                                >{log.revoked_at} 소명 인용으로 해제</span
+                            >)
+                        {:else}
+                            ({formatPeriodRange(log)})
+                        {/if}
+                    </span>
+                </div>
             </div>
 
             <!-- 사유는 요약 헤더 안에 함께 둔다 — 제재의 "무엇 때문에"가 기간과 떨어지면 안 읽힌다 -->


### PR DESCRIPTION
카나리 확인 피드백 반영 + 상세 페이지까지.

## 목록 — 행이 성글었다

> "아이디와 아이디 간 상하 간격이 좀 더 컴팩트했으면"

- 행 사이 `space-y-0.5` 제거
- 행 상하 패딩 `py-2` → `py-1.5`, `leading-tight` 추가
- 강도 점 위치를 좁아진 행에 맞춤(`mt-1.5` → `mt-1`)

## 상세 — 카드 7개로 쪼개져 세로로 길었다

**"누가·얼마나·왜"가 서로 다른 카드에 흩어져** 있어 시선이 여러 번 움직였다. 기본 정보는 라벨·값 쌍이 2열 그리드로 배치돼 정작 중요한 값을 찾기 어려웠다.

**바뀐 모습**

```
┌────────────────────────────────────────┐
│ 딴지난민  naver_8f7c08c0               │
│ [영구]  (2026-08-11 ~ 영구)            │
│ ────────────────────────────────────── │
│ ⚠ 다중이                               │
│   다중계정 또는 징계회피목적으로…       │
│ ⚠ 예의없음                             │
│   반말 등 예의를 갖추지 않은 행위       │
└────────────────────────────────────────┘
```

- **기본 정보 + 제재 사유를 하나의 요약 헤더로 통합** — 닉네임·아이디를 한 줄에, 그 아래 기간, 구분선 뒤 사유
- **회원 이력 행을 목록과 같은 컴팩트 스타일로** 통일(`py-1.5`·`space-y-0.5`)
- 카드 간격 `mb-4` → `mb-3`, 미사용 `User` 아이콘 제거

## 동작 변경 없음

소명 해제 배너·취소선 표기·근거글 링크·소명 안내·메타 정보는 **그대로**입니다. 레이아웃만 바뀌었습니다.

## 검증

- [ ] 목록에서 행 간격이 좁아졌는지, 날짜 그룹은 그대로인지
- [ ] 상세에서 닉네임·아이디·기간·사유가 한 블록에 보이는지
- [ ] 소명 해제된 건에서 취소선·해제일이 정상 표기되는지
- [ ] 회원 이력에서 현재 보고 있는 건이 강조되는지
- [ ] 모바일에서 안 깨지는지