### PR TITLE
fix(share): 카카오 공유 JS 앱키 런타임(DB) 읽기 (#13454)

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -71,12 +71,9 @@ jobs:
         env:
           VITE_GAM_NETWORK_CODE: '23338387889'
           VITE_GAM_SITE_NAME: 'damoang'
-          # 카카오톡 공유 JS 앱키. 비면 Kakao.init("")→"인증 실패"(#13454).
-          VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
         run: |
           echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
           echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
-          echo "VITE_KAKAO_JS_KEY=${VITE_KAKAO_JS_KEY}" >> apps/web/.env
 
           rm -rf apps/web/.svelte-kit apps/web/build apps/web/node_modules/.vite
           pnpm --filter web build

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -85,13 +85,10 @@ jobs:
           VITE_USE_MOCK: 'false'
           VITE_GAM_NETWORK_CODE: '23338387889'
           VITE_GAM_SITE_NAME: 'damoang'
-          # 카카오톡 공유 JS 앱키 (canary). 비면 Kakao.init("")→"인증 실패"(#13454).
-          VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
         run: |
           pnpm --filter "./packages/*" build
           echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
           echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
-          echo "VITE_KAKAO_JS_KEY=${VITE_KAKAO_JS_KEY}" >> apps/web/.env
           pnpm --filter web build
 
       - name: Prepare deploy package

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,15 +164,12 @@ jobs:
           VITE_GAM_NETWORK_CODE: '23338387889'
           VITE_GAM_SITE_NAME: 'damoang'
           VITE_S3_URL: ${{ env.MEDIA_CDN_BASE }}
-          # 카카오톡 공유(sharer.kakao.com) JS 앱키. 비면 Kakao.init("")→"인증 실패"(#13454).
-          VITE_KAKAO_JS_KEY: ${{ secrets.VITE_KAKAO_JS_KEY }}
           ASSET_BASE_URL: ${{ env.STATIC_ASSET_BASE_ROOT }}/${{ needs.resolve-release.outputs.sha_tag }}
         run: |
           pnpm --filter "./packages/*" build
           echo "VITE_GAM_NETWORK_CODE=23338387889" > apps/web/.env
           echo "VITE_GAM_SITE_NAME=damoang" >> apps/web/.env
           echo "VITE_S3_URL=${VITE_S3_URL}" >> apps/web/.env
-          echo "VITE_KAKAO_JS_KEY=${VITE_KAKAO_JS_KEY}" >> apps/web/.env
           pnpm --filter web build
 
       - name: Upload immutable assets to R2

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -94,5 +94,5 @@ PUBLIC_TURNSTILE_SITE_KEY=
 # --------------------------------------------
 # 외부 서비스 키
 # --------------------------------------------
-# 카카오 공유 JavaScript 키 (공개용 — 카카오 개발자센터에서 발급)
-VITE_KAKAO_JS_KEY=
+# 카카오 공유 JS 앱키는 g5_config.cf_kakao_js_apikey(DB)에서 런타임으로 읽는다(#13454).
+# 로컬에서 DB 대신 env 로 덮어쓰려면 서버 env KAKAO_JS_KEY 사용(oauth/config.ts).

--- a/apps/web/src/lib/server/auth/oauth/config.ts
+++ b/apps/web/src/lib/server/auth/oauth/config.ts
@@ -19,6 +19,8 @@ export interface OAuthKeys {
     naver_secret: string;
     kakao_rest_key: string;
     kakao_client_secret: string;
+    /** 카카오 JS SDK 앱키(공개키). 카카오톡 공유(sharer.kakao.com)에 사용. #13454 */
+    kakao_js_key: string;
     google_clientid: string;
     google_secret: string;
     facebook_appid: string;
@@ -45,7 +47,7 @@ export async function getOAuthKeys(): Promise<OAuthKeys> {
     }
 
     const [rows] = await pool.query<RowDataPacket[]>(
-        `SELECT cf_naver_clientid, cf_naver_secret, cf_kakao_rest_key, cf_kakao_client_secret,
+        `SELECT cf_naver_clientid, cf_naver_secret, cf_kakao_rest_key, cf_kakao_client_secret, cf_kakao_js_apikey,
 		        cf_google_clientid, cf_google_secret, cf_facebook_appid, cf_facebook_secret,
 		        cf_twitter_key, cf_twitter_secret, cf_payco_clientid, cf_payco_secret,
 		        cf_apple_bundle_id, cf_apple_team_id, cf_apple_key_id, cf_apple_key_file
@@ -62,6 +64,7 @@ export async function getOAuthKeys(): Promise<OAuthKeys> {
         naver_secret: env.NAVER_CLIENT_SECRET || row.cf_naver_secret || '',
         kakao_rest_key: env.KAKAO_REST_KEY || row.cf_kakao_rest_key || '',
         kakao_client_secret: env.KAKAO_CLIENT_SECRET || row.cf_kakao_client_secret || '',
+        kakao_js_key: env.KAKAO_JS_KEY || row.cf_kakao_js_apikey || '',
         google_clientid: env.GOOGLE_CLIENT_ID || row.cf_google_clientid || '',
         google_secret: env.GOOGLE_CLIENT_SECRET || row.cf_google_secret || '',
         facebook_appid: env.FACEBOOK_APP_ID || row.cf_facebook_appid || '',

--- a/apps/web/src/lib/utils/share.ts
+++ b/apps/web/src/lib/utils/share.ts
@@ -75,14 +75,16 @@ declare global {
 /** 카카오 JS 앱키를 런타임으로 1회 조회(모듈 캐시). 없으면 빈 문자열. */
 async function fetchKakaoKey(): Promise<string> {
     if (cachedKakaoKey !== null) return cachedKakaoKey;
+    let key = '';
     try {
         const res = await fetch('/api/config/kakao-share-key');
         const data = res.ok ? await res.json() : null;
-        cachedKakaoKey = typeof data?.key === 'string' ? data.key : '';
+        key = typeof data?.key === 'string' ? data.key : '';
     } catch {
-        cachedKakaoKey = '';
+        key = '';
     }
-    return cachedKakaoKey;
+    cachedKakaoKey = key;
+    return key;
 }
 
 /** 카카오 SDK 스크립트를 한 번만 로드 */

--- a/apps/web/src/lib/utils/share.ts
+++ b/apps/web/src/lib/utils/share.ts
@@ -54,8 +54,11 @@ export function shareToTumblr(url: string) {
     );
 }
 
-let kakaoLoading = false;
-let kakaoLoaded = false;
+// 카카오 JS 앱키는 g5_config 에 있고 /api/config/kakao-share-key 로 런타임 조회한다(#13454).
+// 예전엔 빌드타임 VITE_KAKAO_JS_KEY 를 읽어, 그 값이 비어 Kakao.init("") 로 빌드되면서
+// 공유가 sharer.kakao.com "인증 실패" 였다. 이제 DB(SoT)에서 런타임으로 받는다.
+let cachedKakaoKey: string | null = null;
+let scriptPromise: Promise<boolean> | null = null;
 
 declare global {
     interface Window {
@@ -69,43 +72,51 @@ declare global {
     }
 }
 
-async function loadKakaoSdk(): Promise<boolean> {
-    if (kakaoLoaded && window.Kakao?.isInitialized()) return true;
-    if (kakaoLoading) {
-        // 이미 로딩 중이면 대기
-        return new Promise((resolve) => {
-            const check = setInterval(() => {
-                if (kakaoLoaded) {
-                    clearInterval(check);
-                    resolve(true);
-                }
-            }, 100);
-            setTimeout(() => {
-                clearInterval(check);
-                resolve(false);
-            }, 5000);
-        });
+/** 카카오 JS 앱키를 런타임으로 1회 조회(모듈 캐시). 없으면 빈 문자열. */
+async function fetchKakaoKey(): Promise<string> {
+    if (cachedKakaoKey !== null) return cachedKakaoKey;
+    try {
+        const res = await fetch('/api/config/kakao-share-key');
+        const data = res.ok ? await res.json() : null;
+        cachedKakaoKey = typeof data?.key === 'string' ? data.key : '';
+    } catch {
+        cachedKakaoKey = '';
     }
+    return cachedKakaoKey;
+}
 
-    kakaoLoading = true;
-    return new Promise((resolve) => {
+/** 카카오 SDK 스크립트를 한 번만 로드 */
+function ensureKakaoScript(): Promise<boolean> {
+    if (scriptPromise) return scriptPromise;
+    scriptPromise = new Promise((resolve) => {
         const script = document.createElement('script');
         script.src = 'https://t1.kakaocdn.net/kakao_js_sdk/v1/kakao.min.js';
-        script.onload = () => {
-            const key = import.meta.env.VITE_KAKAO_JS_KEY || '';
-            if (window.Kakao && !window.Kakao.isInitialized()) {
-                window.Kakao.init(key);
-            }
-            kakaoLoaded = true;
-            kakaoLoading = false;
-            resolve(true);
-        };
+        script.onload = () => resolve(true);
         script.onerror = () => {
-            kakaoLoading = false;
+            scriptPromise = null; // 실패 시 다음 시도에서 재로드 허용
             resolve(false);
         };
         document.head.appendChild(script);
     });
+    return scriptPromise;
+}
+
+async function loadKakaoSdk(): Promise<boolean> {
+    if (typeof window === 'undefined') return false;
+    if (window.Kakao?.isInitialized()) return true;
+
+    // 키가 없으면 SDK 를 붙여도 init 이 실패하므로 먼저 확인한다.
+    const key = await fetchKakaoKey();
+    if (!key) return false;
+
+    if (!window.Kakao) {
+        const loaded = await ensureKakaoScript();
+        if (!loaded || !window.Kakao) return false;
+    }
+    if (!window.Kakao.isInitialized()) {
+        window.Kakao.init(key);
+    }
+    return window.Kakao.isInitialized();
 }
 
 export async function shareToKakao(title: string, url: string, imageUrl?: string) {

--- a/apps/web/src/routes/api/config/kakao-share-key/+server.ts
+++ b/apps/web/src/routes/api/config/kakao-share-key/+server.ts
@@ -1,0 +1,35 @@
+/**
+ * GET /api/config/kakao-share-key
+ *
+ * 카카오톡 공유(share.ts)가 클릭 시점에 1회 호출하는 지연 엔드포인트.
+ * 카카오 JS SDK 앱키(=공개키)를 g5_config(cf_kakao_js_apikey, OAuth 키와 같은 SoT)에서
+ * 읽어 내려준다. #13454 — 예전엔 빌드타임 VITE_KAKAO_JS_KEY 를 읽었는데 그 값이 비어
+ * Kakao.init("") 로 빌드돼 공유가 "인증 실패"였다. 이제 DB 값을 런타임으로 읽어
+ * 시크릿 복제·재빌드 없이 동작한다.
+ *
+ * ⛔ JS 앱키는 원래 클라이언트에 노출되는 공개키다. 이 라우트는 **JS 키만** 반환하며
+ *    REST 키·client_secret 등 비공개 값은 절대 내려주지 않는다.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getOAuthKeys } from '$lib/server/auth/oauth/config';
+
+export const GET: RequestHandler = async () => {
+    let key = '';
+    try {
+        key = (await getOAuthKeys()).kakao_js_key || '';
+    } catch {
+        // g5_config 조회 실패 시 빈 키 — share.ts 가 false 반환 후 안내 토스트
+        key = '';
+    }
+
+    return json(
+        { key },
+        {
+            headers: {
+                // 앱키는 거의 안 바뀌므로 넉넉히 캐시. getOAuthKeys 자체도 5분 메모리 캐시.
+                'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400, max-age=600'
+            }
+        }
+    );
+};


### PR DESCRIPTION
## 근본원인 (bug/13454)
카카오톡 공유 시 sharer.kakao.com **'잘못된 요청으로 인증 실패'**. prod 번들에 `Kakao.init("")` — **빈 앱키**로 빌드됨. `share.ts` 가 빌드타임 `VITE_KAKAO_JS_KEY` 를 읽는데 그 값이 비어 있었기 때문. 정작 JS 앱키는 `g5_config.cf_kakao_js_apikey` (카카오 로그인과 같은 SoT)에 **줄곧 있었고**, 웹만 그걸 안 읽고 있었다.

## 해결 — 모범사례(SoT=DB, 런타임 읽기)
빌드 시크릿으로 키를 **복제**하는 대신, 로그인과 동일하게 DB에서 읽는다:
- `oauth/config.ts` `getOAuthKeys()`: `cf_kakao_js_apikey` 추가 (소셜키 정본 로더, 5분 캐시).
- 신규 `GET /api/config/kakao-share-key`: **공개 JS키만** 반환(REST키·client_secret 등 비공개값 미노출), edge 캐시.
- `share.ts`: 클릭 시점에 이 엔드포인트를 런타임 fetch. **키 없으면 init 안 하고 false 반환** → 공유 버튼이 안내 토스트. SDK 스크립트 로드도 promise 단일화로 정리.
- 죽은 배관 제거: `deploy*.yml` 의 `VITE_KAKAO_JS_KEY`(fe#2031) + `.env.example` 항목.

## 이점
- 키 회전 = DB만 수정(재빌드·시크릿 불필요). JS 앱키는 원래 공개키라 클라 노출 안전.
- 크리덴셜 이중관리 제거(SoT 1곳).

## 남은 관문 (canary 실측)
빈 키 → 실제 키로 바뀌어도, **카카오 콘솔 Web 플랫폼에 damoang.net 도메인 미등록**이면 여전히 인증 실패 가능(로그인은 REST redirect라 별개 설정). canary 에서 실제 공유 눌러 확인 → 필요 시 도메인 등록 안내.

## 검증
- [ ] `pnpm check` (CI)
- [ ] canary: 번들에 init("") 아닌 런타임 fetch 경로 / GET /api/config/kakao-share-key 가 키 반환 / 공유>카카오톡 실제 동작
- [ ] 엔드포인트가 REST키·secret 미노출(JS키만)