### PR TITLE
이용제한 기록: 목록·상세 디자인 정합 + 소명 안내 문구 교정

### DIFF
--- a/apps/web/src/lib/utils/penalty-severity.test.ts
+++ b/apps/web/src/lib/utils/penalty-severity.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { penaltySeverity, SEVERITY_DOT, SEVERITY_TEXT, SEVERITY_BADGE } from './penalty-severity';
+
+describe('penaltySeverity', () => {
+    it('영구(-1)는 permanent', () => {
+        expect(penaltySeverity(-1)).toBe('permanent');
+    });
+
+    it('주의(0)는 notice', () => {
+        expect(penaltySeverity(0)).toBe('notice');
+    });
+
+    it('기간제(1 이상)는 active', () => {
+        expect(penaltySeverity(1)).toBe('active');
+        expect(penaltySeverity(5)).toBe('active');
+        expect(penaltySeverity(365)).toBe('active');
+    });
+
+    it('기간이 만료되면 released', () => {
+        expect(penaltySeverity(5, true)).toBe('released');
+    });
+
+    it('소명 인용 해제도 released — 만료 전이라도 효력이 없다', () => {
+        expect(penaltySeverity(5, false, true)).toBe('released');
+    });
+
+    it('⛔ 영구도 소명 인용되면 released — 빨간 강도로 남으면 안 된다', () => {
+        expect(penaltySeverity(-1, false, true)).toBe('released');
+    });
+
+    it('주의는 해제 개념이 없어도 released 플래그를 존중한다', () => {
+        expect(penaltySeverity(0, true)).toBe('released');
+    });
+});
+
+describe('강도별 색 테이블', () => {
+    it('네 강도 모두 세 테이블에 값이 있다', () => {
+        for (const sev of ['permanent', 'active', 'notice', 'released'] as const) {
+            expect(SEVERITY_DOT[sev]).toBeTruthy();
+            expect(SEVERITY_TEXT[sev]).toBeTruthy();
+            expect(SEVERITY_BADGE[sev]).toBeTruthy();
+        }
+    });
+
+    it('영구와 기간제는 서로 다른 색이어야 구분된다', () => {
+        expect(SEVERITY_DOT.permanent).not.toBe(SEVERITY_DOT.active);
+        expect(SEVERITY_TEXT.permanent).not.toBe(SEVERITY_TEXT.active);
+        expect(SEVERITY_BADGE.permanent).not.toBe(SEVERITY_BADGE.active);
+    });
+});

--- a/apps/web/src/lib/utils/penalty-severity.ts
+++ b/apps/web/src/lib/utils/penalty-severity.ts
@@ -1,0 +1,63 @@
+/**
+ * 이용제한 강도(severity)의 단일 정의.
+ *
+ * 목록(`/disciplinelog`)과 상세(`/disciplinelog/[id]`)가 각자 색을 정하던 탓에
+ * 같은 기록이 화면마다 다른 심각도로 보였다 — 목록에서 빨간 점으로 본 영구 제재가
+ * 상세에서는 기간제와 똑같은 기본 배지로 나왔다. 두 화면이 이 파일 하나만
+ * 바라보게 해서 색 언어가 갈라질 수 없게 한다.
+ *
+ * ⛔ 소명 인용 해제(revoked)는 기간 만료(released)와 원인은 다르지만
+ *    "지금 효력이 없다"는 점에서 같다. 강도 표기는 released 로 합치고,
+ *    구분은 별도의 초록 배지가 맡는다(강도 축에 섞지 않는다).
+ */
+
+/** 이용제한의 심각도. 색·강조는 전부 이 값에서 파생된다. */
+export type PenaltySeverity = 'permanent' | 'active' | 'notice' | 'released';
+
+/**
+ * 제재 일수와 해제 여부로 강도를 판정한다.
+ *
+ * @param period 제재 일수. -1 = 영구, 0 = 주의, 1 이상 = 기간제
+ * @param released 기간 만료 여부 (`getPenaltyDisplay().released`)
+ * @param revoked 소명 인용 해제 여부
+ */
+export function penaltySeverity(
+    period: number,
+    released: boolean = false,
+    revoked: boolean = false
+): PenaltySeverity {
+    if (released || revoked) return 'released';
+    if (period === -1) return 'permanent';
+    if (period === 0) return 'notice';
+    return 'active';
+}
+
+/** 목록 왼쪽 강도 점의 배경색 */
+export const SEVERITY_DOT: Record<PenaltySeverity, string> = {
+    permanent: 'bg-red-500',
+    active: 'bg-amber-500',
+    notice: 'bg-muted-foreground/60',
+    released: 'bg-muted-foreground/40'
+};
+
+/** 강도를 나타내는 짧은 텍스트("영구"·"5일"·"주의")의 색 */
+export const SEVERITY_TEXT: Record<PenaltySeverity, string> = {
+    permanent: 'text-red-600 dark:text-red-400',
+    active: 'text-amber-700 dark:text-amber-500',
+    notice: 'text-muted-foreground',
+    released: 'text-muted-foreground'
+};
+
+/**
+ * 상세 페이지 배지의 색.
+ *
+ * shadcn `variant` 로는 주황(기간제)을 표현할 수 없어 클래스로 통일한다.
+ * 목록의 텍스트 색과 같은 계열을 써서 목록 → 상세 이동 시 인상이 이어지게 한다.
+ */
+export const SEVERITY_BADGE: Record<PenaltySeverity, string> = {
+    permanent:
+        'border-red-300 bg-red-100 text-red-800 dark:border-red-900 dark:bg-red-950 dark:text-red-300',
+    active: 'border-amber-300 bg-amber-100 text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300',
+    notice: 'border-border bg-muted text-muted-foreground',
+    released: 'border-border bg-muted text-muted-foreground'
+};

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -13,6 +13,11 @@
     import Search from '@lucide/svelte/icons/search';
     import X from '@lucide/svelte/icons/x';
     import { getPenaltyDisplay, type DisciplineLogListItem } from '$lib/api/discipline-log.js';
+    import {
+        penaltySeverity,
+        SEVERITY_DOT,
+        SEVERITY_TEXT
+    } from '$lib/utils/penalty-severity.js';
     import BoardFavoriteButton from '$lib/components/features/board/board-favorite-button.svelte';
     import BoardSubscribeButton from '$lib/components/features/board/board-subscribe-button.svelte';
     import type { PageData } from './$types.js';
@@ -87,13 +92,6 @@
     });
 
     /** 제재 강도를 점 하나로. 영구=빨강, 기간제=주황, 주의=회색, 해제=흐리게 */
-    function dotClass(period: number, released: boolean): string {
-        if (released) return 'bg-muted-foreground/40';
-        if (period === -1) return 'bg-red-500';
-        if (period === 0) return 'bg-muted-foreground/60';
-        return 'bg-amber-500';
-    }
-
     function formatGroupDate(dateStr: string): string {
         if (isToday(dateStr)) return `${dateStr} · 오늘`;
         return dateStr;
@@ -184,17 +182,21 @@
                                         log.penalty_period,
                                         log.penalty_date_to
                                     )}
+                                    {@const severity = penaltySeverity(
+                                        log.penalty_period,
+                                        penalty.released,
+                                        log.revoked
+                                    )}
                                     <li>
                                         <a
                                             href="/disciplinelog/{log.id}"
-                                            class="hover:bg-muted/60 focus-visible:ring-ring flex items-center gap-3 rounded-md px-2 py-1.5 leading-tight transition-colors focus-visible:outline-none focus-visible:ring-2"
+                                            class="hover:bg-muted/60 focus-visible:ring-ring flex items-center gap-3 rounded-md px-2 py-1.5 leading-tight transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2"
                                         >
                                             <!-- 강도 점: 영구=빨강 / 기간제=주황 / 주의·해제=회색 -->
                                             <span
-                                                class="h-2 w-2 shrink-0 rounded-full {dotClass(
-                                                    log.penalty_period,
-                                                    penalty.released
-                                                )}"
+                                                class="h-2 w-2 shrink-0 rounded-full {SEVERITY_DOT[
+                                                    severity
+                                                ]}"
                                                 aria-hidden="true"
                                             ></span>
 
@@ -208,13 +210,9 @@
                                                         >{log.member_id}</span
                                                     >
                                                     <span
-                                                        class="text-xs font-medium {penalty.released
-                                                            ? 'text-muted-foreground'
-                                                            : log.penalty_period === -1
-                                                              ? 'text-red-600 dark:text-red-400'
-                                                              : log.penalty_period === 0
-                                                                ? 'text-muted-foreground'
-                                                                : 'text-amber-700 dark:text-amber-500'}"
+                                                        class="text-xs font-medium {SEVERITY_TEXT[
+                                                            severity
+                                                        ]}"
                                                     >
                                                         {penalty.text}
                                                     </span>

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -187,11 +187,11 @@
                                     <li>
                                         <a
                                             href="/disciplinelog/{log.id}"
-                                            class="hover:bg-muted/60 focus-visible:ring-ring flex items-start gap-3 rounded-md px-2 py-1.5 leading-tight transition-colors focus-visible:outline-none focus-visible:ring-2"
+                                            class="hover:bg-muted/60 focus-visible:ring-ring flex items-center gap-3 rounded-md px-2 py-1.5 leading-tight transition-colors focus-visible:outline-none focus-visible:ring-2"
                                         >
                                             <!-- 강도 점: 영구=빨강 / 기간제=주황 / 주의·해제=회색 -->
                                             <span
-                                                class="mt-1 h-2 w-2 shrink-0 rounded-full {dotClass(
+                                                class="h-2 w-2 shrink-0 rounded-full {dotClass(
                                                     log.penalty_period,
                                                     penalty.released
                                                 )}"
@@ -202,6 +202,10 @@
                                                 <span class="flex flex-wrap items-center gap-1.5">
                                                     <span class="truncate font-medium"
                                                         >{log.member_nickname}</span
+                                                    >
+                                                    <span
+                                                        class="text-muted-foreground/70 shrink-0 text-xs"
+                                                        >{log.member_id}</span
                                                     >
                                                     <span
                                                         class="text-xs font-medium {penalty.released
@@ -227,10 +231,6 @@
                                                         >
                                                     {/if}
                                                 </span>
-                                                <span
-                                                    class="text-muted-foreground/70 block truncate text-xs leading-tight"
-                                                    >{log.member_id}</span
-                                                >
                                             </span>
 
                                             <span

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -13,11 +13,7 @@
     import Search from '@lucide/svelte/icons/search';
     import X from '@lucide/svelte/icons/x';
     import { getPenaltyDisplay, type DisciplineLogListItem } from '$lib/api/discipline-log.js';
-    import {
-        penaltySeverity,
-        SEVERITY_DOT,
-        SEVERITY_TEXT
-    } from '$lib/utils/penalty-severity.js';
+    import { penaltySeverity, SEVERITY_DOT, SEVERITY_TEXT } from '$lib/utils/penalty-severity.js';
     import BoardFavoriteButton from '$lib/components/features/board/board-favorite-button.svelte';
     import BoardSubscribeButton from '$lib/components/features/board/board-subscribe-button.svelte';
     import type { PageData } from './$types.js';

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -21,6 +21,7 @@
     } from '$lib/api/discipline-log.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { getReportReasonLabel } from '$lib/utils/report-reasons.js';
+    import { penaltySeverity, SEVERITY_BADGE } from '$lib/utils/penalty-severity.js';
     import type { PageData } from './$types';
 
     let { data }: { data: PageData } = $props();
@@ -30,15 +31,6 @@
     const log = $derived<DisciplineLogDetail | null>(data.log);
     const memberHistory = $derived<DisciplineLogListItem[]>(data.memberHistory ?? []);
     const error = $derived(data.loadError ? '이용제한 기록을 불러오는데 실패했습니다.' : null);
-
-    function getPenaltyBadgeVariant(
-        period: number,
-        released: boolean = false
-    ): 'default' | 'secondary' | 'destructive' | 'outline' {
-        if (released) return 'secondary';
-        if (period === 0) return 'outline';
-        return 'default';
-    }
 
     function formatPeriodRange(log: DisciplineLogDetail): string {
         const penalty = getPenaltyDisplay(log.penalty_period);
@@ -123,11 +115,12 @@
         </Card.Root>
     {:else}
         {@const penalty = getPenaltyDisplay(log.penalty_period, log.penalty_date_to)}
+        {@const severity = penaltySeverity(log.penalty_period, penalty.released, !!log.revoked_at)}
 
         <!-- 소명 인용 해제 배너: revoked_at 있을 때만. 회수 사실만 공개(회수자·사유 비공개). -->
         {#if log.revoked_at}
             <Card.Root
-                class="mb-4 border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/40"
+                class="mb-3 border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/40"
             >
                 <Card.Content class="flex items-start gap-3 py-4">
                     <ShieldCheck
@@ -150,14 +143,14 @@
           기존에는 "기본 정보"와 "제재 기간"이 카드 안에서 라벨·값 쌍으로 흩어져
           정작 중요한 정보를 찾는 데 시선이 여러 번 움직였다.
         -->
-        <div class="mb-4 rounded-lg border p-4">
-            <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                <span class="text-lg font-bold">{log.member_nickname}</span>
-                <span class="text-muted-foreground/70 text-xs">{log.member_id}</span>
-            </div>
-            <div class="mt-2">
-                <div class="flex flex-wrap items-center gap-2">
-                    <Badge variant={getPenaltyBadgeVariant(log.penalty_period, penalty.released)}>
+        <Card.Root class="mb-3">
+            <Card.Content>
+                <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span class="text-lg font-bold">{log.member_nickname}</span>
+                    <span class="text-muted-foreground/70 text-xs">{log.member_id}</span>
+                </div>
+                <div class="mt-2 flex flex-wrap items-center gap-2">
+                    <Badge variant="outline" class={SEVERITY_BADGE[severity]}>
                         {penalty.text}
                     </Badge>
                     {#if log.revoked_at}
@@ -190,38 +183,66 @@
                         {/if}
                     </span>
                 </div>
-            </div>
 
-            <!-- 사유는 요약 헤더 안에 함께 둔다 — 제재의 "무엇 때문에"가 기간과 떨어지면 안 읽힌다 -->
-            {#if log.violation_types.length > 0}
-                <div class="mt-3 space-y-2 border-t pt-3">
-                    {#each log.violation_types as vt}
-                        <div>
-                            <div class="flex items-baseline gap-2">
-                                <AlertTriangle
-                                    class="text-muted-foreground mt-0.5 h-3.5 w-3.5 shrink-0"
-                                />
-                                <span class="text-sm font-medium">{vt.title}</span>
+                <!-- 사유는 요약 헤더 안에 둔다 — 제재의 "무엇 때문에"가 기간과 떨어지면 안 읽힌다 -->
+                {#if log.violation_types.length > 0}
+                    <div class="mt-3 space-y-2 border-t pt-3">
+                        {#each log.violation_types as vt}
+                            <div>
+                                <div class="flex items-baseline gap-2">
+                                    <AlertTriangle
+                                        class="text-muted-foreground mt-0.5 h-3.5 w-3.5 shrink-0"
+                                    />
+                                    <span class="text-sm font-medium">{vt.title}</span>
+                                </div>
+                                <div class="text-muted-foreground mt-0.5 pl-[1.375rem] text-sm">
+                                    {vt.description}
+                                </div>
                             </div>
-                            <div class="text-muted-foreground mt-0.5 pl-[1.375rem] text-sm">
-                                {vt.description}
+                        {/each}
+                    </div>
+                {/if}
+            </Card.Content>
+        </Card.Root>
+
+        <!--
+          소명 액션 — 본인 기록일 때만 요약 바로 아래에 둔다.
+          회원이 이 페이지에 오는 이유의 절반이 "어떻게 푸나"인데, 카드 여러 장 아래에
+          묻혀 있으면 스크롤하지 않은 사람은 소명 경로를 못 본다.
+        -->
+        {#if isAppealablePenalty(log) && isOwnPenalty(log) && !log.claim_post_id}
+            <Card.Root class="border-primary/50 bg-primary/5 mb-3">
+                <Card.Content class="flex flex-wrap items-center justify-between gap-3">
+                    <div class="flex items-start gap-2">
+                        <Calendar class="text-primary mt-0.5 h-4 w-4 shrink-0" />
+                        <div class="text-sm">
+                            <div class="font-medium">이 이용제한에 소명할 수 있습니다</div>
+                            <div class="text-muted-foreground text-xs">
+                                제재일부터 15일 이내에 소명 게시판에서 접수합니다.
                             </div>
                         </div>
-                    {/each}
-                </div>
-            {/if}
-        </div>
+                    </div>
+                    {#if isWithinAppealPeriod(log)}
+                        <Button href="/claim/write?disciplinelog_id={log.id}">소명하기</Button>
+                    {:else}
+                        <span class="text-muted-foreground text-xs"
+                            >소명 가능 기간이 지났습니다</span
+                        >
+                    {/if}
+                </Card.Content>
+            </Card.Root>
+        {/if}
 
         <!-- 기타 사유: 회원 공개용 (운영자가 입력한 경우에만 표시) -->
         {#if log.member_reason && log.member_reason.trim()}
             <Card.Root class="mb-3">
-                <Card.Header>
-                    <Card.Title class="flex items-center gap-2">
-                        <Info class="text-muted-foreground h-5 w-5" />
-                        기타 사유
-                    </Card.Title>
-                </Card.Header>
                 <Card.Content>
+                    <div
+                        class="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-xs font-medium"
+                    >
+                        <Info class="h-3.5 w-3.5" />
+                        기타 사유
+                    </div>
                     <p class="whitespace-pre-line text-sm">{log.member_reason}</p>
                 </Card.Content>
             </Card.Root>
@@ -230,13 +251,13 @@
         <!-- 안내: 회원 공개용 외부 안내문 (운영자가 입력한 경우에만 표시) -->
         {#if log.public_description && log.public_description.trim()}
             <Card.Root class="mb-3">
-                <Card.Header>
-                    <Card.Title class="flex items-center gap-2">
-                        <Megaphone class="text-muted-foreground h-5 w-5" />
-                        안내
-                    </Card.Title>
-                </Card.Header>
                 <Card.Content>
+                    <div
+                        class="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-xs font-medium"
+                    >
+                        <Megaphone class="h-3.5 w-3.5" />
+                        안내
+                    </div>
                     <p class="whitespace-pre-line text-sm">{log.public_description}</p>
                 </Card.Content>
             </Card.Root>
@@ -249,7 +270,7 @@
             <Card.Root class="mb-3">
                 <Card.Header>
                     <Card.Title class="flex items-center gap-2">
-                        <FileText class="h-5 w-5" />
+                        <FileText class="text-muted-foreground h-5 w-5" />
                         신고 접수된 글
                     </Card.Title>
                 </Card.Header>
@@ -300,34 +321,25 @@
             </Card.Root>
         {/if}
 
-        <!-- Appeal Info: 주의(0) 제외, 영구(-1) 및 정지(>=1) 모두 표시 -->
-        {#if isAppealablePenalty(log)}
-            <Card.Root class="border-primary/50 bg-primary/5">
-                <Card.Header>
-                    <Card.Title class="text-primary flex items-center gap-2">
-                        <Calendar class="h-5 w-5" />
-                        소명 안내
-                    </Card.Title>
-                </Card.Header>
+        <!--
+          소명 안내(참고용) — 본인 미소명 건은 위 CTA 가 맡으므로 여기서는 제외한다.
+          남는 경우는 ① 이미 소명글이 있는 건 ② 남의 기록(공개 게시판이라 이쪽이 다수).
+        -->
+        {#if isAppealablePenalty(log) && (log.claim_post_id || !isOwnPenalty(log))}
+            <Card.Root class="border-primary/50 bg-primary/5 mb-3">
                 <Card.Content>
-                    <p class="text-muted-foreground mb-4 text-sm">
+                    <div class="text-primary mb-1.5 flex items-center gap-1.5 text-xs font-medium">
+                        <Calendar class="h-3.5 w-3.5" />
+                        소명 안내
+                    </div>
+                    <p class="text-muted-foreground text-sm">
                         이용제한에 대해 이의가 있으시면 소명 게시판에서 소명하실 수 있습니다. 소명은
-                        제재 시작 후 1일이 지난 시점부터 15일 이내에만 가능합니다.
+                        제재일부터 15일 이내에 가능합니다.
                     </p>
                     {#if log.claim_post_id}
-                        <Button variant="outline" href="/claim/{log.claim_post_id}">
+                        <Button variant="outline" class="mt-3" href="/claim/{log.claim_post_id}">
                             소명글 보기
                         </Button>
-                    {:else if isOwnPenalty(log)}
-                        {#if isWithinAppealPeriod(log)}
-                            <Button variant="outline" href="/claim/write?disciplinelog_id={log.id}">
-                                소명하기
-                            </Button>
-                        {:else}
-                            <p class="text-muted-foreground text-sm">
-                                소명 가능 기간이 아니거나 15일이 지났습니다.
-                            </p>
-                        {/if}
                     {/if}
                 </Card.Content>
             </Card.Root>
@@ -335,10 +347,10 @@
 
         <!-- Member History -->
         {#if memberHistory.length > 0}
-            <Card.Root class="mt-4">
+            <Card.Root class="mb-3">
                 <Card.Header>
                     <Card.Title class="flex items-center gap-2">
-                        <History class="h-5 w-5" />
+                        <History class="text-muted-foreground h-5 w-5" />
                         이 회원의 전체 이용제한 내역
                     </Card.Title>
                 </Card.Header>
@@ -349,26 +361,28 @@
                                 item.penalty_period,
                                 item.penalty_date_to
                             )}
+                            {@const itemSeverity = penaltySeverity(
+                                item.penalty_period,
+                                itemPenalty.released,
+                                item.revoked
+                            )}
                             <a
                                 href="/disciplinelog/{item.id}"
-                                class="hover:bg-muted/50 flex items-center justify-between rounded px-2 py-1.5 text-sm leading-tight transition-colors {item.id ===
+                                class="hover:bg-muted/50 flex items-center justify-between rounded px-2 py-1.5 text-sm leading-tight transition-all duration-200 ease-out {item.id ===
                                 log.id
-                                    ? 'bg-primary/10 border-primary/30 border font-semibold'
+                                    ? 'bg-primary/10 ring-primary/30 font-semibold ring-1'
                                     : ''}"
                             >
                                 <div class="flex items-center gap-3">
                                     <span class="text-muted-foreground"
                                         >{item.penalty_date_from}</span
                                     >
-                                    <Badge
-                                        variant={getPenaltyBadgeVariant(
-                                            item.penalty_period,
-                                            itemPenalty.released
-                                        )}
-                                    >
+                                    <Badge variant="outline" class={SEVERITY_BADGE[itemSeverity]}>
                                         {itemPenalty.text}
                                     </Badge>
-                                    {#if itemPenalty.released}
+                                    {#if item.revoked}
+                                        <Badge variant="secondary" class="text-xs">소명 해제</Badge>
+                                    {:else if itemPenalty.released}
                                         <Badge variant="secondary" class="text-xs">해제</Badge>
                                     {/if}
                                 </div>
@@ -384,7 +398,7 @@
 
         <!-- Meta Info -->
         <div class="text-muted-foreground mt-4 text-center text-xs">
-            작성일: {log.created_at}
+            기록 등록 {log.created_at}
         </div>
     {/if}
 </div>


### PR DESCRIPTION
`docs/design_system.md` 기준으로 목록·상세 두 화면을 대조해 어긋난 것을 고쳤습니다.

## ⛔ 소명 안내 문구 (디자인이 아니라 내용 오류)

| | |
|---|---|
| 기존 안내문 | "제재 시작 후 **1일이 지난 시점부터** 15일 이내" |
| 실제 코드 | `diffDays >= 0` — **제재 당일부터** (#12973에서 고침) |
| 규정 제12~17조 | "**통보 15일 내** 이의신청" — 하한 없음 |

#12973에서 제재 당일 소명을 허용하도록 고칠 때 안내문만 남았습니다. 제재 당일 들어온 회원에게 버튼은 보이는데 안내문은 "내일부터"라고 말했습니다. → **"제재일부터 15일 이내"**

## 심각도 색을 두 화면이 공유

목록은 영구=빨강·기간제=주황으로 구분했으나, 상세는 `getPenaltyBadgeVariant`가 둘을 똑같은 배지로 그렸습니다. 목록에서 빨간 점을 보고 클릭하면 상세에서 기간제와 구분되지 않았습니다.

- `lib/utils/penalty-severity.ts` 신설 — 강도 판정과 색 테이블의 단일 정의
- 목록의 `dotClass`·인라인 삼항 사다리, 상세의 `getPenaltyBadgeVariant` 를 모두 제거해 **두 화면이 갈라질 수 없게** 함
- 소명 인용 해제(`revoked`)를 강도에 반영 — 만료 전이라도 효력이 없는데 목록은 이걸 안 보고 빨간 점을 그대로 뒀습니다

## 표면·간격·아이콘·전환

- 요약 헤더만 `rounded-lg border`(배경·그림자 없음)라 **가장 중요한 블록이 제일 격이 낮아** 보였습니다 → `Card.Root` (§UI Elements)
- 카드 간격 `mb-4`/`mb-3`/없음/`mt-4` 혼재 → `mb-3` 하나로
- FileText·History·Calendar가 색 지정 없이 foreground(≈검정) → 전부 muted (§Iconography "rarely pure black")
- `transition-colors` → `transition-all duration-200 ease-out` (§Motion)
- 회원 이력에서 현재 항목만 `border`를 더해 **그 줄만 1px 밀렸습니다** → `ring`

## 정보 구조

- 소명 CTA를 **본인 기록일 때만** 요약 바로 아래로. 회원이 이 페이지에 오는 이유의 절반이 "어떻게 푸나"인데 카드 네 장 아래에 묻혀 있었습니다. 남의 기록(공개 게시판이라 이쪽이 다수)에서는 기존 위치에 안내만 남깁니다
- 한두 줄짜리 "기타 사유"·"안내"는 `Card.Header`가 본문보다 무거웠습니다 → 라벨 한 줄로 감량
- 목록에서 아이디를 닉네임 옆 한 줄로 (행 높이 절반)
- "작성일" → "기록 등록"

`penalty-severity` 단위 테스트 포함 (영구가 소명 인용되면 빨간 강도로 남지 않는지 등).