### PR TITLE
feat(angmap): 지도에 앙님 별점 노출 + 내 주변 (Phase 2)

### DIFF
--- a/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
+++ b/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
@@ -250,12 +250,19 @@
     function locateMe(): void {
         if (!browser || !map || typeof navigator === 'undefined' || !navigator.geolocation) return;
         locating = true;
+        // 권한 프롬프트를 무시하면 두 콜백 다 안 와 스피너가 고착될 수 있다(브라우저가
+        // 프롬프트 표시 중엔 timeout 타이머를 멈춘다) → 독립 안전 리셋.
+        const safety = setTimeout(() => {
+            locating = false;
+        }, 12_000);
         navigator.geolocation.getCurrentPosition(
             (pos) => {
+                clearTimeout(safety);
                 locating = false;
                 map?.setView([pos.coords.latitude, pos.coords.longitude], 14);
             },
             () => {
+                clearTimeout(safety);
                 locating = false;
             },
             { enableHighAccuracy: false, timeout: 8000, maximumAge: 60_000 }

--- a/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
+++ b/apps/web/src/lib/components/features/board/angmap-pin-map.svelte
@@ -10,6 +10,7 @@
     import MapPin from '@lucide/svelte/icons/map-pin';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ExternalLink from '@lucide/svelte/icons/external-link';
+    import LocateFixed from '@lucide/svelte/icons/locate-fixed';
     import type { Map as LeafletMap } from 'leaflet';
     import {
         ANGMAP_TILE_PROVIDER,
@@ -17,6 +18,8 @@
         ANGMAP_DEFAULT_CENTER,
         ANGMAP_DEFAULT_ZOOM
     } from './angmap-map-provider.js';
+    // 별점 표시 규약 공유 유틸(n<3='앙님 N명 평가', n>=3='★avg · N명') — Phase 1과 동일 소스
+    import { formatRatingSummary } from './rating-display.js';
 
     interface AngmapPin {
         id: number;
@@ -26,6 +29,8 @@
         lng: number;
         provider: string;
         region: string | null;
+        ratingAvg: number | null;
+        ratingCount: number;
     }
 
     const STORAGE_KEY = 'angmap_pinmap_expanded';
@@ -154,18 +159,23 @@
     ): void {
         const label = escapeHtml(pin.name || pin.title);
         const title = escapeHtml(pin.title);
-        L.circleMarker([pin.lat, pin.lng], {
-            radius: 7,
-            weight: 2,
-            color: '#be123c',
-            fillColor: '#f43f5e',
-            fillOpacity: 0.75
-        })
+        const rated = pin.ratingCount > 0;
+        // makeang/84: 앙님 별점이 있는 장소는 지도에서 바로 눈에 띄게(금색). 없으면 기존 로즈색.
+        const style = rated
+            ? { radius: 8, weight: 2, color: '#b45309', fillColor: '#f59e0b', fillOpacity: 0.9 }
+            : { radius: 7, weight: 2, color: '#be123c', fillColor: '#f43f5e', fillOpacity: 0.75 };
+        const ratingLine = rated
+            ? `<br><span style="font-size:12px;color:#b45309;font-weight:600">${escapeHtml(
+                  formatRatingSummary(pin.ratingAvg ?? 0, pin.ratingCount)
+              )}</span>`
+            : '';
+        L.circleMarker([pin.lat, pin.lng], style)
             .bindPopup(
                 `<a href="/angmap/${pin.id}" style="font-weight:600">${label}</a>` +
                     (pin.name && pin.name !== pin.title
                         ? `<br><span style="font-size:12px;color:#666">${title}</span>`
-                        : '')
+                        : '') +
+                    ratingLine
             )
             .addTo(layer);
     }
@@ -230,6 +240,26 @@
         if (data.length > 0) {
             map.fitBounds(initialBounds(leafletMod, data).pad(0.15), { maxZoom: 15 });
         }
+    }
+
+    let locating = $state(false);
+    /**
+     * 내 주변 — 클라이언트 geolocation 으로 지도만 이동(서버 왕복 0, makeang/84 서버부담 최소).
+     * ⛔ 국가 가정 없음: 좌표 그대로 setView. 권한 거부/미지원이면 조용히 무시.
+     */
+    function locateMe(): void {
+        if (!browser || !map || typeof navigator === 'undefined' || !navigator.geolocation) return;
+        locating = true;
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                locating = false;
+                map?.setView([pos.coords.latitude, pos.coords.longitude], 14);
+            },
+            () => {
+                locating = false;
+            },
+            { enableHighAccuracy: false, timeout: 8000, maximumAge: 60_000 }
+        );
     }
 
     function initMap(leaflet: typeof import('leaflet'), pinData: AngmapPin[]): void {
@@ -364,6 +394,19 @@
                     </button>
                 </div>
             {:else}
+                <!-- 내 주변 + 별점 범례 (makeang/84: 지도를 맛집 발견 입구로) -->
+                <div class="mb-2 flex items-center gap-2">
+                    <button
+                        type="button"
+                        onclick={locateMe}
+                        disabled={locating}
+                        class="text-muted-foreground hover:bg-muted inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs transition-colors disabled:opacity-50"
+                    >
+                        <LocateFixed class="h-3.5 w-3.5" />
+                        {locating ? '위치 찾는 중…' : '내 주변'}
+                    </button>
+                    <span class="text-muted-foreground text-xs">🟡 앙님 별점 있는 곳</span>
+                </div>
                 {#if regions.length > 1}
                     <!-- 지역 필터 칩 (ca_name) — 선택 시 해당 지역만 그리고 뷰를 맞춘다 -->
                     <div class="mb-2 flex flex-wrap gap-1.5">

--- a/apps/web/src/routes/api/angmap/pins/+server.ts
+++ b/apps/web/src/routes/api/angmap/pins/+server.ts
@@ -22,6 +22,10 @@ interface AngmapPin {
     provider: string;
     /** 글 카테고리(ca_name) = 지역명(경기·서울…). 지도 필터 칩용 (M-1b) */
     region: string | null;
+    /** 앙님 별점 평균(평가 없으면 null). angple_post_ratings(bo_table=angmap) 집계 (Phase 2) */
+    ratingAvg: number | null;
+    /** 별점 참여 인원(n). 표시 규약은 rating-display 유틸이 판단 */
+    ratingCount: number;
 }
 
 interface PinRow extends RowDataPacket {
@@ -32,6 +36,8 @@ interface PinRow extends RowDataPacket {
     lng: string | number;
     provider: string;
     ca_name: string | null;
+    avg_rating: string | number | null;
+    rating_count: string | number | null;
 }
 
 const pinsCache = createCache<AngmapPin[]>({ ttl: 60_000, maxSize: 4 });
@@ -63,10 +69,19 @@ function isPlottable(p: AngmapPin): boolean {
 
 async function loadPins(): Promise<AngmapPin[]> {
     const [rows] = await readPool.query<PinRow[]>(
-        `SELECT p.wr_id, p.name, p.lat, p.lng, p.provider, w.wr_subject, w.ca_name
+        // 별점 집계는 angmap 한정 GROUP BY 서브쿼리 1회(현재 수십 행 규모) + 60초 캐시.
+        // makeang/84 서버부담 최소 원칙 — pins 응답에 얹어 추가 왕복 0.
+        `SELECT p.wr_id, p.name, p.lat, p.lng, p.provider, w.wr_subject, w.ca_name,
+                r.avg_rating, r.rating_count
          FROM angmap_places p
          INNER JOIN g5_write_angmap w
              ON w.wr_id = p.wr_id AND w.wr_is_comment = 0
+         LEFT JOIN (
+             SELECT wr_id, AVG(rating) AS avg_rating, COUNT(*) AS rating_count
+             FROM angple_post_ratings
+             WHERE bo_table = 'angmap'
+             GROUP BY wr_id
+         ) r ON r.wr_id = p.wr_id
          WHERE p.resolve_status = 'ok'
            AND w.wr_option NOT LIKE '%secret%'`
     );
@@ -78,7 +93,9 @@ async function loadPins(): Promise<AngmapPin[]> {
             lat: Number(r.lat),
             lng: Number(r.lng),
             provider: r.provider,
-            region: r.ca_name || null
+            region: r.ca_name || null,
+            ratingAvg: r.avg_rating != null ? Number(r.avg_rating) : null,
+            ratingCount: Number(r.rating_count) || 0
         }))
         .filter(isPlottable);
 }


### PR DESCRIPTION
## 배경 (task#6 Phase 2, makeang/84 완성)
앙지도를 '남의 링크 위치 모음'에서 **앙님 별점이 붙은 맛집 발견 지도**로. Phase 1으로 상세 별점이 이미 수집 중(angmap 9개 장소에 별점 有). 그 별점을 지도에 얹는다.

> makeang/84: "지도에서 위치만 말고 후기·별점을 보고 싶다. 지도는 입구, 읽기는 다모앙, 서버부담 최소."

## 변경 (web only, 2파일, DDL 0)
- **`/api/angmap/pins`**: `angple_post_ratings`(bo_table=angmap) 집계 LEFT JOIN → `ratingAvg`·`ratingCount` 추가. 소규모 GROUP BY 1회 + 기존 60초 캐시 = **추가 왕복 0**(서버부담 최소).
- **핀맵**: 별점 있는 장소 **금색 강조**(없으면 기존 로즈), 팝업에 별점 요약(**`rating-display` 공유 유틸** — n<3 '앙님 N명 평가', n≥3 '★avg · N명').
- **'내 주변'**: 클라 geolocation 지도 이동(서버 왕복 0). 권한 거부/미지원 조용히 무시. ⛔국가 가정 없음.
- 핀 클릭 → 원문 이동 그대로(지도=입구).

## 실측
pins 쿼리: **9 rated / 1504 pins**, avg·count 정상(황성노마 ★5.0 등).

## 검증
- [ ] pins 응답에 ratingAvg/ratingCount 포함, 캐시 유지
- [ ] 별점 있는 핀 금색 + 팝업 별점 요약(n 규약)
- [ ] 내 주변 버튼: 권한 허용 시 이동, 거부 시 무해
- [ ] 별점 없는 핀·해외 핀 정상, 클러스터 회귀 0
- [ ] pnpm check 통과