### PR TITLE
fix(cls): 글 상세 하단 광고 높이 예약 — 최근글 목록이 밀리던 문제

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -483,7 +483,9 @@
                 <!-- #12632: infeed 90px 배너가 overflow-y-visible 로 아래 게시물 위까지 수직 침범해
                      클릭을 가로채던 문제(사파리) — 이 슬롯(윙 불필요)만 overflow 클립으로 격리.
                      min-height 유지로 AdSlot 의 반응형 예약 높이를 따라가며, 그 박스를 넘는 spill 만 잘라낸다. -->
-                <div class="py-2" style="min-height: 90px; overflow: hidden; contain: layout;">
+                <!-- 예약 높이는 AdSlot 이 계산하는 값(board-list-infeed = 100px)과 일치시킨다.
+                     90px 로 어긋나 있으면 슬롯이 채워질 때 10px 만큼 아래가 밀린다. -->
+                <div class="py-2" style="min-height: 100px; overflow: hidden; contain: layout;">
                     <AdSlot
                         position="board-list-infeed"
                         height="90px"

--- a/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
+++ b/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
@@ -63,7 +63,7 @@
     }
 </script>
 
-<div class="adsense-multiplex {className}">
+<div class="adsense-multiplex {className}" class:is-reserved={!suppressAds}>
     {#if ready && !suppressAds}
         <ins
             bind:this={insEl}
@@ -79,5 +79,25 @@
 <style>
     .adsense-multiplex {
         overflow: hidden;
+    }
+
+    /*
+     * 높이 예약 — CLS 방지.
+     *
+     * 종전엔 스크립트 로드(`ready`) 전까지 래퍼 높이가 0 이었다가 autorelaxed
+     * 크리에이티브가 들어오면서 수백 px 로 뛰어, 이 아래의 "최근 글" 목록 전체를
+     * 밀어냈다(2026-08-11 감사: 글 상세 CLS 0.111 의 주요 기여분).
+     *
+     * 미충전 시 빈 공백이 남지 않도록 AdSense 가 부여하는
+     * `data-ad-status="unfilled"` 를 만나면 예약을 해제한다.
+     * 광고가 숨겨지는 글(성인/차단 작가)에는 애초에 예약하지 않는다.
+     */
+    .adsense-multiplex.is-reserved {
+        min-height: 300px;
+        contain: layout;
+    }
+
+    .adsense-multiplex.is-reserved:has(ins[data-ad-status='unfilled']) {
+        min-height: 0;
     }
 </style>


### PR DESCRIPTION
## 문제
글 상세 CLS **0.111** ("좋음" 기준 0.1 초과). 최대 단일 시프트 **0.091** 이 하단 최근글 행에서 발생. (2026-08-11 실브라우저 감사)

## 원인 (코드 대조로 특정)
**AdSense Multiplex 래퍼에 높이 예약이 없었다.** 스크립트 로드 전에는 `<ins>` 자체가 없어 높이 0 → autorelaxed 크리에이티브가 들어오며 수백 px 로 확장 → 바로 아래 최근글 목록 전체를 밀어냄.

> 감사 리포트는 인피드 광고 슬롯에 `min-height` 예약이 필요하다고 봤지만, **인피드는 이미 `AdSlot` 이 예약을 자동 주입하고 있었다**(`ad-slot.svelte:158-198`, board-list-infeed=100px). 실제 범인은 예약이 아예 없던 Multiplex 였다.

## 변경
1. `adsense-multiplex.svelte` — 예약 300px + `contain: layout`
   - 미충전 시 빈 공백이 남지 않도록 `data-ad-status="unfilled"` 를 만나면 예약 해제
   - 광고를 숨기는 글(성인·차단 작가)에는 애초에 예약하지 않음
2. `recent-posts.svelte` — 인피드 래퍼 `min-height: 90px` → `100px` (AdSlot 실제 예약과 정렬. 10px 어긋나 밀리던 것)

## 검증
배포 후 동일 페이지에서 layout-shift 재측정 → 0.05 미만 목표. **광고가 실제로 채워진 상태**에서 측정해야 한다.

## 남긴 것 (의도적)
- 프로모션 인라인 2행(`recent-posts.svelte:494`)은 "도착 예정 여부"를 알 수 없어 예약 시 빈 공간이 생길 수 있다 → 이번 변경의 효과를 먼저 측정한 뒤 판단
- `ad-slot-registry.ts` 의 크리에이티브 확장 보정도 동일 이유로 보류