### PR TITLE
feat(a11y): 글 제목을 h1 으로 — 상세 페이지에 h1 이 없던 문제

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -356,7 +356,7 @@
             {#if desktopExpanded}
                 <CardContent class="grid grid-cols-2 gap-4 pb-2 pt-0">
                     <div>
-                        <h4 class="text-foreground mb-2 text-sm font-semibold">최근 글</h4>
+                        <h2 class="text-foreground mb-2 text-sm font-semibold">최근 글</h2>
                         {#if loading}
                             <div class="flex justify-center py-4">
                                 <Loader2 class="text-muted-foreground h-4 w-4 animate-spin" />
@@ -374,7 +374,7 @@
                         {/if}
                     </div>
                     <div>
-                        <h4 class="text-foreground mb-2 text-sm font-semibold">최근 댓글</h4>
+                        <h2 class="text-foreground mb-2 text-sm font-semibold">최근 댓글</h2>
                         {#if loading}
                             <div class="flex justify-center py-4">
                                 <Loader2 class="text-muted-foreground h-4 w-4 animate-spin" />
@@ -414,7 +414,7 @@
             <div class="grid grid-cols-2 gap-2" transition:slide={{ duration: 200 }}>
                 <Card class="gap-0">
                     <CardHeader class="pb-0 pt-2">
-                        <h4 class="text-foreground text-xs font-semibold">최근 글</h4>
+                        <h2 class="text-foreground text-xs font-semibold">최근 글</h2>
                     </CardHeader>
                     <CardContent class="pb-2 pt-0">
                         {#if loading}
@@ -436,7 +436,7 @@
                 </Card>
                 <Card class="gap-0">
                     <CardHeader class="pb-0 pt-2">
-                        <h4 class="text-foreground text-xs font-semibold">최근 댓글</h4>
+                        <h2 class="text-foreground text-xs font-semibold">최근 댓글</h2>
                     </CardHeader>
                     <CardContent class="pb-2 pt-0">
                         {#if loading}

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -213,7 +213,10 @@
                     </span>
                 </div>
             {/if}
+            <!-- 글 제목이 이 페이지의 주제목이다. 종전엔 CardTitle 이 div 라
+                 상세 페이지에 h1 이 하나도 없었다(SEO·스크린리더 내비게이션 저해). -->
             <CardTitle
+                tag="h1"
                 class="text-foreground flex flex-wrap items-center gap-2 break-words text-xl font-bold sm:text-2xl"
             >
                 {#if isAdmin}

--- a/apps/web/src/lib/components/ui/card/card-title.svelte
+++ b/apps/web/src/lib/components/ui/card/card-title.svelte
@@ -2,19 +2,24 @@
     import type { HTMLAttributes } from 'svelte/elements';
     import { cn, type WithElementRef } from '$lib/utils.js';
 
+    // `tag` 로 시맨틱 요소를 고를 수 있다. 기본값은 종전과 같은 `div` 라
+    // 기존 63개 사용처의 동작은 그대로다. 글 상세처럼 이 제목이 그 페이지의
+    // 주제목인 곳에서만 `tag="h1"` 로 올려 헤딩 계층을 만든다.
     let {
         ref = $bindable(null),
         class: className,
+        tag = 'div',
         children,
         ...restProps
-    }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+    }: WithElementRef<HTMLAttributes<HTMLDivElement>> & { tag?: string } = $props();
 </script>
 
-<div
+<svelte:element
+    this={tag}
     bind:this={ref}
     data-slot="card-title"
     class={cn('font-semibold leading-none', className)}
     {...restProps}
 >
     {@render children?.()}
-</div>
+</svelte:element>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2510,9 +2510,9 @@
             <Card id="comments" class="bg-background rounded-xl px-3 md:px-3">
                 <CardHeader class="flex flex-row items-center justify-between">
                     <div class="flex items-center gap-2">
-                        <h3 class="text-foreground text-lg font-semibold">
+                        <h2 class="text-foreground text-lg font-semibold">
                             댓글 <span class="text-muted-foreground">({commentsTotal})</span>
-                        </h3>
+                        </h2>
                         <button
                             type="button"
                             onclick={refreshComments}


### PR DESCRIPTION
## 문제
글 상세 페이지에 **`<h1>` 이 하나도 없다.** 글 제목이 `CardTitle` 로 렌더되는데 이 컴포넌트가 `<div>` 였다(`card-title.svelte:13`). 헤딩 순서도 h2(드로워) → h4(최근 글) → h3(댓글) 로 뒤집혀 있었다. (2026-08-11 감사 + 코드 확인)

## 변경
| 대상 | 변경 |
|---|---|
| `card-title.svelte` | `tag` prop 추가 (**기본값 `div` — 기존 63개 사용처 무변경**) |
| `view/basic.svelte` | 글 제목만 `tag="h1"` |
| `author-activity-panel.svelte` | "최근 글"·"최근 댓글" h4 → h2 (4곳) |
| `[postId]/+page.svelte` | 댓글 섹션 h3 → h2 |

결과: **h1**(글 제목) → **h2**(작성자 최근 글/댓글, 댓글)

## 남긴 것
헤더 드로워의 h2("추가 메뉴")는 유지했다 — 네비게이션 영역 제목이라 본문 계층과 별개이고, 전 페이지에 영향이 간다.

## 검증
렌더된 HTML 에 h1 정확히 1개 + 계층 h1 → h2. 기존 카드 UI 63곳의 시각적 변화 없음(기본값 div).