### PR TITLE
perf(seo): og:image 835×626 + 본문 이미지 로딩 힌트

### DIFF
--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -144,6 +144,32 @@
         });
     }
 
+    /**
+     * 본문 이미지에 로딩 힌트를 넣는다.
+     *
+     * 본문은 에디터가 저장한 원본 URL 을 그대로 출력해 왔고 loading/decoding 이
+     * 없었다. 글 하나에 이미지가 여러 장이면 전부 즉시 내려받아 초기 로드를 막는다.
+     *
+     * ⛔ srcset 은 여기서 넣지 않는다. 고정 비율 썸네일(835×626)로 바꾸면 세로로 긴
+     *    이미지가 뭉개져 2026-04-06 에 optimizeMediaHtml 을 끈 전례가 있다.
+     *    비율 유지 썸네일이 준비된 뒤에 별도로 재도입한다.
+     * ⚠️ 첫 이미지는 LCP 후보라 eager 로 남긴다 — lazy 를 걸면 오히려 느려진다.
+     * 작성자가 직접 지정한 loading/decoding 은 존중한다.
+     */
+    function injectImageLoadingHints(html: string): string {
+        if (!html) return html;
+        let seen = 0;
+        return html.replace(/<img\b([^>]*)>/gi, (match, rawAttrs: string) => {
+            const isFirst = seen++ === 0;
+            if (isFirst) return match;
+            const attrs = rawAttrs.replace(/\/\s*$/, '');
+            const loading = /\bloading\s*=/i.test(attrs) ? '' : ' loading="lazy"';
+            const decoding = /\bdecoding\s*=/i.test(attrs) ? '' : ' decoding="async"';
+            if (!loading && !decoding) return match;
+            return `<img${attrs}${loading}${decoding}>`;
+        });
+    }
+
     // DOMPurify 설정
     const PURIFY_CONFIG = {
         ALLOWED_TAGS: [
@@ -277,8 +303,8 @@
         rawHtml = transformEscapedMedia(rawHtml);
         // processEmbeds는 클라이언트 $effect에서만 실행 (SSR 부하 방지)
         // 본문 이미지 src 더블슬래시 collapse + CDN 호스트 정규화 (#12697)
-        return injectYoutubeStart(
-            normalizeHtmlMediaUrls(DOMPurify.sanitize(rawHtml, PURIFY_CONFIG))
+        return injectImageLoadingHints(
+            injectYoutubeStart(normalizeHtmlMediaUrls(DOMPurify.sanitize(rawHtml, PURIFY_CONFIG)))
         );
     }
 
@@ -333,6 +359,7 @@
                 sanitized = normalizeHtmlMediaUrls(sanitized);
                 sanitized = injectYoutubeStart(sanitized);
                 sanitized = addLinkMismatchWarnings(sanitized);
+                sanitized = injectImageLoadingHints(sanitized);
                 renderedHtml = sanitized;
             });
         }

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -53,6 +53,7 @@
     import { doAction } from '$lib/hooks/registry';
     import { page } from '$app/stores';
     import { getAvatarUrl } from '$lib/utils/member-icon.js';
+    import { toThumbnailUrl } from '$lib/utils/thumbnail-url.js';
     import { isEmbeddable } from '$lib/plugins/auto-embed';
     import { embedAsTiptapYoutube } from '$lib/utils/link1-embed';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
@@ -1861,7 +1862,14 @@
         // 본문에 이미지가 없으면 PUBLIC_OG_FALLBACK_IMAGE (운영에서 사이트 로고 URL 설정) 로
         // 대체. fallback 미설정 시 og:image 가 누락되어 크롤러가 페이지 안의 임의 이미지
         // (작성자 프로필, 댓글자 아바타 등) 를 썸네일로 잡아가는 문제 (#12417) 발생.
-        const rawOgImage = data.post.thumbnail || data.post.images?.[0];
+        // 소셜 카드용으로 더 큰 변형본을 쓴다. 백엔드가 주는 thumbnail 은 목록용
+        // 400×225 라 twitter summary_large_image 권장 크기에 한참 못 미쳤다.
+        // Lambda 가 835×626 을 함께 생성하므로 접미사만 바꾸면 된다(2026-08-11 실측:
+        // 최근 글 5건 전부 200). 변환 대상이 아닌 URL 은 toThumbnailUrl 이 원본을 그대로 돌려준다.
+        const rawOgImage = ((): string | undefined => {
+            const src = data.post.thumbnail || data.post.images?.[0];
+            return src ? toThumbnailUrl(src, '835x626') : undefined;
+        })();
         const fallbackOgImage = publicEnv.PUBLIC_OG_FALLBACK_IMAGE || undefined;
         // GSC "image URL 잘못됨" 방지: 상대경로는 siteUrl 기준 절대화, http(s) 외 스킴은 fallback 으로
         let safeOgImage: string | undefined;
@@ -2008,7 +2016,12 @@
                 description: postDescription,
                 type: 'article',
                 url: postUrl,
-                image: ogImageUrl
+                image: ogImageUrl,
+                // 크롤러가 내려받기 전에 카드 크기를 잡을 수 있게 명시한다.
+                // 우리 변형본을 쓸 때만 — fallback 이미지는 크기를 알 수 없다.
+                ...(safeOgImage?.includes('-835x626.webp')
+                    ? { imageWidth: 835, imageHeight: 626 }
+                    : {})
             },
             twitter: {
                 card: safeOgImage ? 'summary_large_image' : 'summary',


### PR DESCRIPTION
## 변경
### 1. og:image 400×225 → 835×626
`data.post.thumbnail` 은 목록용 400×225 라 twitter `summary_large_image` 권장 크기에 못 미쳤다. Lambda 가 835×626 을 함께 생성하므로 `toThumbnailUrl(src, "835x626")` 로 접미사만 바꾼다.

**실측 확인**: 최근 글 5건의 `-835x626.webp` 전부 HTTP 200 (2026-08-11).

`og:image:width/height` 도 채운다 — `meta-helper.ts:71-73` 이 지원하는데 넘기는 곳이 없었다. 우리 변형본일 때만 붙인다(fallback 이미지는 크기를 모름).

### 2. 본문 이미지 `loading="lazy"` + `decoding="async"`
본문은 에디터가 저장한 원본 URL 을 그대로 출력하고 로딩 힌트가 전혀 없었다. SSR·클라이언트 양쪽 렌더 경로에 주입한다.

- ⚠️ **첫 이미지는 eager 로 남긴다** — LCP 후보라 lazy 를 걸면 오히려 느려진다
- 작성자가 직접 지정한 `loading`/`decoding` 은 존중
- 자기닫힘 태그(`<img ... />`) 처리 포함

## ⛔ 하지 않은 것
`srcset` 은 넣지 않았다. 감사 리포트는 "r2 리사이즈 파이프라인을 본문에 적용" 을 P1 로 권고했지만, 그건 **2026-04-06 PR #1089 로 의도적으로 끈 기능**이다(`markdown.svelte:110` `optimizeMediaHtml` 이 정의만 남고 호출이 끊긴 상태). 끈 이유가 **세로로 긴 이미지가 835×626 고정 비율 썸네일에 뭉개짐**이고, 감사가 지적한 이미지(2304×4096)가 정확히 그 케이스다.

재도입 선결 조건: Lambda 비율 유지 썸네일(`-835w.webp`) + 썸네일 부재 시 CDN 301 수정 + `thumbnail-url.ts` 정규식 확장.

## 검증
- 응답 메타에 `-835x626.webp` + width/height
- 본문 2번째 이미지부터 lazy/decoding, 첫 이미지는 없음