### PR TITLE
fix(ui): 댓글 액션 버튼 높이 정합 + 터치영역 확보

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1617,10 +1617,10 @@
                                                     size="sm"
                                                     onclick={() => startReply(comment)}
                                                     class={isFeed
-                                                        ? 'h-6 px-1.5'
+                                                        ? 'h-7 min-w-7 px-1.5'
                                                         : commentLayout === 'bordered'
-                                                          ? 'h-6 px-1.5'
-                                                          : 'h-7 px-2'}
+                                                          ? 'h-7 min-w-7 px-1.5'
+                                                          : 'h-8 min-w-8 px-2'}
                                                     disabled={isReplyingTo}
                                                 >
                                                     <Reply class="h-3.5 w-3.5" />
@@ -1636,10 +1636,10 @@
                                                 size="sm"
                                                 onclick={() => copyCommentLink(comment.id)}
                                                 class="comment-action-secondary {isFeed
-                                                    ? 'h-6 px-1.5'
+                                                    ? 'h-7 min-w-7 px-1.5'
                                                     : commentLayout === 'bordered'
-                                                      ? 'h-6 px-1.5'
-                                                      : 'h-7 px-1.5'} opacity-50 transition-opacity hover:opacity-90"
+                                                      ? 'h-7 min-w-7 px-1.5'
+                                                      : 'h-8 min-w-8 px-1.5'} opacity-50 transition-opacity hover:opacity-90"
                                                 title="이 댓글의 링크를 복사합니다"
                                             >
                                                 <Link2 class="h-3.5 w-3.5" />
@@ -1657,10 +1657,10 @@
                                                         size="sm"
                                                         onclick={() => startEdit(comment)}
                                                         class="comment-action-secondary {isFeed
-                                                            ? 'h-6 px-1.5'
+                                                            ? 'h-7 min-w-7 px-1.5'
                                                             : commentLayout === 'bordered'
-                                                              ? 'h-6 px-1.5'
-                                                              : 'h-7 px-2'} opacity-50 transition-opacity hover:opacity-90"
+                                                              ? 'h-7 min-w-7 px-1.5'
+                                                              : 'h-8 min-w-8 px-2'} opacity-50 transition-opacity hover:opacity-90"
                                                         title="수정"
                                                     >
                                                         <Pencil class="h-4 w-4" />
@@ -1672,10 +1672,10 @@
                                                     onclick={() => handleDelete(String(comment.id))}
                                                     disabled={isDeleting === String(comment.id)}
                                                     class="comment-action-secondary text-destructive hover:text-destructive {isFeed
-                                                        ? 'h-6 px-1.5'
+                                                        ? 'h-7 min-w-7 px-1.5'
                                                         : commentLayout === 'bordered'
-                                                          ? 'h-6 px-1.5'
-                                                          : 'h-7 px-2'} opacity-50 transition-opacity hover:opacity-90"
+                                                          ? 'h-7 min-w-7 px-1.5'
+                                                          : 'h-8 min-w-8 px-2'} opacity-50 transition-opacity hover:opacity-90"
                                                 >
                                                     <Trash2 class="h-4 w-4" />
                                                 </Button>
@@ -1687,10 +1687,10 @@
                                                     size="sm"
                                                     onclick={() => startReport(comment)}
                                                     class="comment-action-secondary text-muted-foreground hover:text-destructive {isFeed
-                                                        ? 'h-6 px-1.5'
+                                                        ? 'h-7 min-w-7 px-1.5'
                                                         : commentLayout === 'bordered'
-                                                          ? 'h-6 px-1.5'
-                                                          : 'h-7 px-2'} opacity-50 transition-opacity hover:opacity-90"
+                                                          ? 'h-7 min-w-7 px-1.5'
+                                                          : 'h-8 min-w-8 px-2'} opacity-50 transition-opacity hover:opacity-90"
                                                     title="신고"
                                                 >
                                                     <Flag class="h-4 w-4" />

--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -47,6 +47,21 @@
     let activeCategory = $state('angticon');
     let pickerStyle = $state('');
     let addBtnEl: HTMLButtonElement | undefined = $state();
+    let pickerEl: HTMLDivElement | undefined = $state();
+
+    // Escape 로 피커 닫기.
+    // 종전엔 피커 div 의 onkeydown 만 있었는데, 열 때 focus 를 주지 않아
+    // 키 이벤트가 그 div 에 도달하지 않았다 — 실제로는 닫히지 않았다(2026-08-11 감사).
+    // 포커스 위치와 무관하게 동작하도록 window 에서 듣고, 접근성을 위해 피커에 포커스도 준다.
+    $effect(() => {
+        if (!showPicker) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') showPicker = false;
+        };
+        window.addEventListener('keydown', onKey);
+        pickerEl?.focus({ preventScroll: true });
+        return () => window.removeEventListener('keydown', onKey);
+    });
 
     // target/parent ID 생성 (da_reaction 호환)
     const targetId = $derived(
@@ -322,6 +337,7 @@
 <!-- 이모티콘 피커 (fixed positioning으로 overflow-hidden 부모 탈출) -->
 {#if showPicker}
     <div
+        bind:this={pickerEl}
         class="reaction-picker-fixed bg-popover border-border w-72 overflow-hidden rounded-xl border shadow-xl"
         style={pickerStyle}
         onclick={(e) => e.stopPropagation()}
@@ -366,9 +382,13 @@
                         title={emo.emoji || emo.reaction}
                     >
                         {#if emo.renderType === 'image' && emo.url}
+                            <!-- 첫 오픈 시 탭 전체(앙티콘 44개)가 한꺼번에 내려오던 것을 막는다.
+                                 개별 파일이 최대 679KB 애니 GIF 라 합계 ~2.9MB 였다(2026-08-11 실측). -->
                             <img
                                 src={emo.url}
                                 alt={emo.reaction}
+                                loading="lazy"
+                                decoding="async"
                                 class="h-7 w-7 object-scale-down transition-transform group-hover/emo:z-50 group-hover/emo:scale-[4]"
                             />
                         {:else}


### PR DESCRIPTION
## 문제 (2026-08-11 감사 + 코드 확인)
댓글에서 **좋아요만 4px 크다.** 밀도 설정 3종 모두 동일한 어긋남:

| | 좋아요 | 답글·링크복사·수정·삭제·신고 |
|---|---|---|
| feed | `h-7` | `h-6` |
| bordered | `h-7` | `h-6` |
| 기본 | `h-8` | `h-7` |

아이콘 전용으로 렌더되는 모바일(라벨이 `sm:inline`)에서는 폭이 **26px**(아이콘 14 + `px-1.5` 12)라 터치 타깃도 빠듯했다.

## 변경
낮은 쪽을 좋아요 기준으로 **올린다** — 내리면 터치 타깃이 더 작아진다.

- feed / bordered → `h-7 min-w-7` (28×28)
- 기본 → `h-8 min-w-8` (32×32)

`min-w` 로 아이콘만 보일 때도 정사각 히트영역을 보장한다.

## ⚠️ 하지 않은 것
본문 하단 행(공감 vs 공유·신고)은 감사가 `24px` 로 측정했지만 **코드상 셋 다 32px** 다 — 공감·신고는 `Button size="sm"`(=`h-8`), ShareButton 은 자체 `h-8`. 측정 대상이 버튼이 아닌 내부 요소였던 것으로 보이며, 근거 없이 바꾸면 그쪽이 회귀다.

## 검증
댓글 액션 행이 밀도 3종에서 모두 같은 높이로 정렬되는지, 모바일에서 아이콘 버튼이 눌리는지.