### PR TITLE
fix(ci): 이모티콘 WebP 워크플로가 PR 을 만들지 못하던 가드 수정

### DIFF
--- a/.github/workflows/emoticons-to-webp.yml
+++ b/.github/workflows/emoticons-to-webp.yml
@@ -101,7 +101,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if git diff --quiet; then
+          # ⛔ `git diff --quiet` 는 **추적 중인 파일의 변경만** 본다. 이 워크플로가 만드는
+          # .webp 는 전부 신규(untracked) 라, 변환이 성공해도 항상 "변경 없음" 으로 빠져나가
+          # PR 이 만들어지지 않았다(2026-08-11 실측: 47MB→11MB 변환 성공했는데 PR 0건).
+          # untracked 를 포함해 판정한다.
+          if [ -z "$(git status --porcelain apps/web/static/emoticons)" ]; then
             echo "변경 없음 — PR 생략"; exit 0
           fi
           AFTER=$(du -sb apps/web/static/emoticons | cut -f1)

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1617,10 +1617,10 @@
                                                     size="sm"
                                                     onclick={() => startReply(comment)}
                                                     class={isFeed
-                                                        ? 'h-6 px-1.5'
+                                                        ? 'h-7 min-w-7 px-1.5'
                                                         : commentLayout === 'bordered'
-                                                          ? 'h-6 px-1.5'
-                                                          : 'h-7 px-2'}
+                                                          ? 'h-7 min-w-7 px-1.5'
+                                                          : 'h-8 min-w-8 px-2'}
                                                     disabled={isReplyingTo}
                                                 >
                                                     <Reply class="h-3.5 w-3.5" />
@@ -1636,10 +1636,10 @@
                                                 size="sm"
                                                 onclick={() => copyCommentLink(comment.id)}
                                                 class="comment-action-secondary {isFeed
-                                                    ? 'h-6 px-1.5'
+                                                    ? 'h-7 min-w-7 px-1.5'
                                                     : commentLayout === 'bordered'
-                                                      ? 'h-6 px-1.5'
-                                                      : 'h-7 px-1.5'} opacity-50 transition-opacity hover:opacity-90"
+                                                      ? 'h-7 min-w-7 px-1.5'
+                                                      : 'h-8 min-w-8 px-1.5'} opacity-50 transition-opacity hover:opacity-90"
                                                 title="이 댓글의 링크를 복사합니다"
                                             >
                                                 <Link2 class="h-3.5 w-3.5" />
@@ -1657,10 +1657,10 @@
                                                         size="sm"
                                                         onclick={() => startEdit(comment)}
                                                         class="comment-action-secondary {isFeed
-                                                            ? 'h-6 px-1.5'
+                                                            ? 'h-7 min-w-7 px-1.5'
                                                             : commentLayout === 'bordered'
-                                                              ? 'h-6 px-1.5'
-                                                              : 'h-7 px-2'} opacity-50 transition-opacity hover:opacity-90"
+                                                              ? 'h-7 min-w-7 px-1.5'
+                                                              : 'h-8 min-w-8 px-2'} opacity-50 transition-opacity hover:opacity-90"
                                                         title="수정"
                                                     >
                                                         <Pencil class="h-4 w-4" />
@@ -1672,10 +1672,10 @@
                                                     onclick={() => handleDelete(String(comment.id))}
                                                     disabled={isDeleting === String(comment.id)}
                                                     class="comment-action-secondary text-destructive hover:text-destructive {isFeed
-                                                        ? 'h-6 px-1.5'
+                                                        ? 'h-7 min-w-7 px-1.5'
                                                         : commentLayout === 'bordered'
-                                                          ? 'h-6 px-1.5'
-                                                          : 'h-7 px-2'} opacity-50 transition-opacity hover:opacity-90"
+                                                          ? 'h-7 min-w-7 px-1.5'
+                                                          : 'h-8 min-w-8 px-2'} opacity-50 transition-opacity hover:opacity-90"
                                                 >
                                                     <Trash2 class="h-4 w-4" />
                                                 </Button>
@@ -1687,10 +1687,10 @@
                                                     size="sm"
                                                     onclick={() => startReport(comment)}
                                                     class="comment-action-secondary text-muted-foreground hover:text-destructive {isFeed
-                                                        ? 'h-6 px-1.5'
+                                                        ? 'h-7 min-w-7 px-1.5'
                                                         : commentLayout === 'bordered'
-                                                          ? 'h-6 px-1.5'
-                                                          : 'h-7 px-2'} opacity-50 transition-opacity hover:opacity-90"
+                                                          ? 'h-7 min-w-7 px-1.5'
+                                                          : 'h-8 min-w-8 px-2'} opacity-50 transition-opacity hover:opacity-90"
                                                     title="신고"
                                                 >
                                                     <Flag class="h-4 w-4" />

--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -47,6 +47,21 @@
     let activeCategory = $state('angticon');
     let pickerStyle = $state('');
     let addBtnEl: HTMLButtonElement | undefined = $state();
+    let pickerEl: HTMLDivElement | undefined = $state();
+
+    // Escape 로 피커 닫기.
+    // 종전엔 피커 div 의 onkeydown 만 있었는데, 열 때 focus 를 주지 않아
+    // 키 이벤트가 그 div 에 도달하지 않았다 — 실제로는 닫히지 않았다(2026-08-11 감사).
+    // 포커스 위치와 무관하게 동작하도록 window 에서 듣고, 접근성을 위해 피커에 포커스도 준다.
+    $effect(() => {
+        if (!showPicker) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') showPicker = false;
+        };
+        window.addEventListener('keydown', onKey);
+        pickerEl?.focus({ preventScroll: true });
+        return () => window.removeEventListener('keydown', onKey);
+    });
 
     // target/parent ID 생성 (da_reaction 호환)
     const targetId = $derived(
@@ -322,6 +337,7 @@
 <!-- 이모티콘 피커 (fixed positioning으로 overflow-hidden 부모 탈출) -->
 {#if showPicker}
     <div
+        bind:this={pickerEl}
         class="reaction-picker-fixed bg-popover border-border w-72 overflow-hidden rounded-xl border shadow-xl"
         style={pickerStyle}
         onclick={(e) => e.stopPropagation()}
@@ -366,9 +382,13 @@
                         title={emo.emoji || emo.reaction}
                     >
                         {#if emo.renderType === 'image' && emo.url}
+                            <!-- 첫 오픈 시 탭 전체(앙티콘 44개)가 한꺼번에 내려오던 것을 막는다.
+                                 개별 파일이 최대 679KB 애니 GIF 라 합계 ~2.9MB 였다(2026-08-11 실측). -->
                             <img
                                 src={emo.url}
                                 alt={emo.reaction}
+                                loading="lazy"
+                                decoding="async"
                                 class="h-7 w-7 object-scale-down transition-transform group-hover/emo:z-50 group-hover/emo:scale-[4]"
                             />
                         {:else}


### PR DESCRIPTION
## 문제
`Emoticons to Animated WebP` 를 `apply=true` 로 돌려도 **PR 이 생성되지 않는다.**

변환 자체는 성공한다 — 2026-08-11 실행 로그에 `채택분 절감: 47MB → 11MB (36.4MB)` 가 찍혔다. 그런데 Open PR 스텝이 `변경 없음 — PR 생략` 으로 종료됐다.

## 원인
```bash
if git diff --quiet; then   # ← 추적 중인 파일의 변경만 본다
```
이 워크플로가 만드는 `.webp` 는 **전부 신규(untracked)** 라 `git diff` 에 잡히지 않는다. 바로 다음 줄의 `git add apps/web/static/emoticons` 는 정상이므로, 가드만 통과하면 나머지 흐름은 그대로 동작한다.

## 수정
`git status --porcelain apps/web/static/emoticons` 로 untracked 포함 판정.

## 영향
8/9 에 이 워크플로를 만든 이후 **한 번도 산출 PR 이 나올 수 없는 상태**였다. "매니페스트가 비어 있어 무변화" 로 남아 있던 이유이기도 하다. 수정 후 재실행하면 변환 파일 PR 이 생성된다(머지는 눈으로 확인 후).