### PR TITLE
이용제한 확정 글에 추천·댓글·수정 차단

### DIFF
--- a/apps/web/src/lib/server/sanctioned-lock.ts
+++ b/apps/web/src/lib/server/sanctioned-lock.ts
@@ -1,0 +1,57 @@
+/**
+ * 이용제한 처분이 확정된 글의 잠금.
+ *
+ * 제재 근거로 확정된 글에 추천이 더 쌓이거나 댓글로 논쟁이 이어지면 처분의 취지가 무너진다.
+ * 작성자가 본문을 고치면 근거 자체가 바뀐다.
+ *
+ * 실측(2026-08-11) — 제재가 확정된 뒤에 붙은 것들:
+ *   추천 517건(95글) · 댓글 288건(78글) · 본문 수정 23건(19글)
+ *
+ * ⛔ 화면에서 버튼만 숨기지 않는다. 버튼은 우회할 수 있으므로 서버에서 거절한다.
+ * ⛔ 이미 달린 추천·댓글은 지우지 않는다. 소급 삭제는 "몰래 지웠다"가 되고, 남아 있는
+ *    것 자체가 당시 상황의 기록이다.
+ */
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+/** 잠금 사유 — 화면에 그대로 보여준다. 조용히 실패하면 고장으로 읽힌다. */
+export const SANCTIONED_LOCK_MESSAGE = '이용제한 처분이 확정된 글이라 더 이상 참여할 수 없습니다.';
+
+/**
+ * 이 글이 제재 근거로 확정됐는지.
+ *
+ * 판정 기준은 `g5_na_singo` 의 처분 완료 행이다. 별도 플래그를 쓰지 않는 이유는,
+ * 플래그 방식이면 집행 경로(화면·크론·SQL)마다 갱신을 빠뜨릴 수 있고 과거분 백필도
+ * 필요하기 때문이다. `idx_table_id_time` 이 걸려 조회는 2행 수준이다.
+ */
+export async function isSanctionedPost(boardId: string, wrId: number): Promise<boolean> {
+    if (!boardId || !wrId) return false;
+    try {
+        const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT 1 AS hit FROM g5_na_singo
+              WHERE sg_table = ? AND sg_id = ?
+                AND processed = 1 AND admin_approved = 1 AND discipline_log_id > 0
+              LIMIT 1`,
+            [boardId, wrId]
+        );
+        return rows.length > 0;
+    } catch {
+        // ⛔ 조회가 실패하면 잠그지 않는다. 판정 불가를 이유로 정상 이용을 막으면
+        //    장애가 곧바로 서비스 중단으로 번진다.
+        return false;
+    }
+}
+
+/**
+ * 댓글이 달릴 대상(글)이 잠겼는지. 댓글 신고로 제재된 경우 그 댓글 자체도 잠근다.
+ * 글 번호와 댓글 번호를 함께 받아 둘 중 하나라도 확정 처분이면 true.
+ */
+export async function isSanctionedTarget(
+    boardId: string,
+    postId: number,
+    commentId?: number
+): Promise<boolean> {
+    if (await isSanctionedPost(boardId, postId)) return true;
+    if (commentId && (await isSanctionedPost(boardId, commentId))) return true;
+    return false;
+}

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -13,6 +13,7 @@ import { buildGradeDeniedMessage } from '$lib/utils/board-permissions';
 import { canRestrictedUserReactToBoard, getAuthUser, isRestrictedUser } from '$lib/server/auth';
 import { checkCertification } from '$lib/server/certification';
 import { protectClientIp } from '$lib/server/ip-protection';
+import { isSanctionedPost, SANCTIONED_LOCK_MESSAGE } from '$lib/server/sanctioned-lock';
 import { getRedis } from '$lib/server/redis';
 import {
     getPostReactionVersion,
@@ -237,6 +238,12 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
             { success: false, message: '이용제한 중에는 추천/비추천을 할 수 없습니다.' },
             { status: 403 }
         );
+    }
+
+    // ⛔ 제재 근거로 확정된 글에는 추천이 더 붙지 않게 한다.
+    //    실측(2026-08-11) 확정 이후에 붙은 추천이 517건(95글)이었다 — 처분 취지가 무너진다.
+    if (await isSanctionedPost(boardId, Number(postId))) {
+        return json({ success: false, message: SANCTIONED_LOCK_MESSAGE }, { status: 403 });
     }
 
     // 레벨 체크 (레벨 3 미만은 추천/비추천 불가)

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from './$types';
+import { isSanctionedPost, SANCTIONED_LOCK_MESSAGE } from '$lib/server/sanctioned-lock';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import pool from '$lib/server/db';
@@ -377,6 +378,18 @@ async function linkAngttOnEdit(path: string): Promise<void> {
 }
 
 // 공통 프록시 로직
+/**
+ * 프록시 경로가 "확정 처분된 글에 손대는" 요청인지 판정한다.
+ *   댓글 달기  boards/{board}/posts/{id}/comments
+ *   본문 수정  boards/{board}/posts/{id}
+ * 둘 다 대상 글 번호가 경로에 있으므로 그 글의 처분 여부만 보면 된다.
+ */
+async function sanctionedLockTarget(path: string): Promise<boolean> {
+    const m = path.match(/^boards\/([a-zA-Z0-9_-]+)\/posts\/(\d+)(?:\/comments)?\/?$/);
+    if (!m) return false;
+    return isSanctionedPost(m[1], Number(m[2]));
+}
+
 async function proxyRequest(
     method: string,
     params: { path: string },
@@ -397,6 +410,20 @@ async function proxyRequest(
     ) {
         if (!isInternalRequest) {
             return internalOnlyErrorResponse();
+        }
+    }
+
+    // ⛔ 이용제한 처분이 확정된 글은 더 손대지 못하게 한다 — 댓글 달기·본문 수정.
+    //    추천은 web 이 직접 처리하므로 like/+server.ts 에서 따로 막는다.
+    //    실측(2026-08-11): 확정 이후 댓글 288건(78글) · 본문 수정 23건(19글)이 붙었다.
+    //    ⛔ DELETE 는 막지 않는다 — 운영자 삭제와 작성자 자진 삭제는 계속 가능해야 한다.
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+        const locked = await sanctionedLockTarget(path);
+        if (locked) {
+            return new Response(
+                JSON.stringify({ success: false, message: SANCTIONED_LOCK_MESSAGE }),
+                { status: 403, headers: { 'Content-Type': 'application/json' } }
+            );
         }
     }
 


### PR DESCRIPTION
제재 근거로 확정된 글에 추천이 더 쌓이거나 댓글로 논쟁이 이어지면 처분의 취지가 무너집니다. 작성자가 본문을 고치면 근거 자체가 바뀝니다.

## 실측 — 처분 확정 **이후에** 붙은 것들

| | 건수 | 글 수 |
|---|---|---|
| 추천 | **517** | 95 |
| 댓글 | **288** | 78 |
| 본문 수정 | 23 | 19 |

## 구현

- `lib/server/sanctioned-lock.ts` 신설. 판정은 `g5_na_singo` 의 처분 완료 행(`processed=1 AND admin_approved=1 AND discipline_log_id>0`). **별도 플래그를 쓰지 않은 이유**: 집행 경로(화면·크론·SQL)마다 갱신을 빠뜨릴 수 있고 과거 3,155건 백필도 필요합니다. `idx_table_id_time` 이 걸려 조회는 2행 수준입니다.
- **추천**: web 이 직접 처리하므로 `like/+server.ts` 에서 거절
- **댓글·수정**: 둘 다 `api/v1` 프록시를 거치므로 `proxyRequest` 한 곳에서 거절

## ⛔ 지킨 것

- 버튼만 숨기지 않고 **서버에서 거절**합니다
- **DELETE 는 막지 않습니다** — 운영자 삭제·작성자 자진 삭제는 계속 가능해야 합니다
- **이미 달린 추천·댓글은 지우지 않습니다.** 소급 삭제는 '몰래 지웠다'가 되고, 남아 있는 것 자체가 당시 상황의 기록입니다
- **판정 조회가 실패하면 잠그지 않습니다.** 판정 불가를 이유로 정상 이용을 막으면 장애가 곧바로 서비스 중단으로 번집니다
- 거절 사유를 응답 메시지로 돌려줍니다