### PR TITLE
fix(ci): 크기 가드가 애니 WebP 를 정지 이미지로 오판하던 문제

### DIFF
--- a/scripts/check-emoticon-size.py
+++ b/scripts/check-emoticon-size.py
@@ -7,7 +7,12 @@
 또 들어오는 걸 방지한다(렌더 느림의 근본 원인).
 
 - 기존 대형 파일은 건드리지 않는다 — PR diff 로 **변경된 파일만** 검사한다.
-- GIF 는 애니라 조금 크게(GIF_MAX), 그 외 정지 이미지는 작게(STILL_MAX).
+- 애니(GIF·애니 WebP)는 조금 크게(ANIM_MAX), 정지 이미지는 작게(STILL_MAX).
+
+⛔ WebP 를 확장자만 보고 "정지" 로 판정하면 안 된다 — emoticons-to-webp 워크플로가
+   만드는 산출물이 바로 **애니 WebP** 라, 그렇게 하면 이 가드가 우리 변환 PR 을
+   막아버린다(2026-08-11 실측: 40개 중 5개가 512KB 상한에 걸려 CI 실패).
+   RIFF 헤더의 ANIM 청크로 애니 여부를 판별한다(외부 의존 없음).
 사용: check-emoticon-size.py <base_ref>
 """
 import subprocess
@@ -15,8 +20,22 @@ import sys
 import os
 
 EMO_DIR = "apps/web/static/emoticons"
-GIF_MAX = 2 * 1024 * 1024       # 애니 GIF 2MB
+ANIM_MAX = 2 * 1024 * 1024      # 애니 GIF / 애니 WebP 2MB
 STILL_MAX = 512 * 1024          # png/jpg/webp(정지) 512KB
+
+
+def is_animated_webp(path):
+    """WebP 컨테이너에 ANIM 청크가 있으면 애니메이션.
+
+    확장 WebP 는 `RIFF....WEBPVP8X` 뒤에 ANIM/ANMF 청크가 온다. 파일 앞부분만
+    읽으면 충분하고 Pillow 같은 의존성이 필요 없다.
+    """
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(1024)
+    except OSError:
+        return False
+    return head[:4] == b"RIFF" and head[8:12] == b"WEBP" and b"ANIM" in head
 
 
 def changed_files(base_ref):
@@ -35,7 +54,8 @@ def main():
             continue
         size = os.path.getsize(f)
         ext = f.rsplit(".", 1)[-1].lower()
-        limit = GIF_MAX if ext == "gif" else STILL_MAX
+        animated = ext == "gif" or (ext == "webp" and is_animated_webp(f))
+        limit = ANIM_MAX if animated else STILL_MAX
         if size > limit:
             over.append((f, size, limit))
     if over:


### PR DESCRIPTION
## 문제
`Emoticons to Animated WebP` 워크플로가 만든 PR(#2048)이 **우리가 만든 크기 가드에 막혔다.**

```
❌ 크기 상한 초과 이모티콘
  damoang-meme-008.webp: 2318KB (상한 512KB)
  damoang-meme-019.webp:  752KB (상한 512KB)
  ... 총 5건
```

가드가 확장자만 보고 `webp = 정지 이미지`로 판정해 512KB 상한을 걸었는데, 이 워크플로 산출물은 **애니 WebP** 다. 8/9 에 만든 두 도구가 서로를 막고 있었다.

## 수정
RIFF 컨테이너의 `ANIM` 청크로 애니 여부를 판별한다(파일 앞 1KB 만 읽음, 외부 의존성 없음). 애니면 GIF 와 동일한 2MB 상한.

## 검증
변환 산출물 40개에 적용: **애니 35 / 정지 5** 로 정확히 분류. 초과는 `damoang-meme-008`(2318KB, 원본 6.7MB) 1건만 남는다 — 이 파일은 #2048 에서 제외하고 추후 품질을 낮춰 재변환한다.