### PR TITLE
fix(emoticon): 머지해도 서빙되지 않던 간극 — 호스트 동기화 정식화

### DIFF
--- a/.github/workflows/emoticons-to-webp.yml
+++ b/.github/workflows/emoticons-to-webp.yml
@@ -123,9 +123,27 @@ jobs:
           {
             echo "emoticons-to-webp 워크플로 산출. GIF 원본은 유지, 애니 WebP 를 추가."
             echo ""
-            echo "⛔ 머지 전 눈으로 확인. 머지 후 premium webp-manifest.json 의 names 에"
-            echo "위 목록(step summary / webp-manifest.names.json)을 반영해야 렌더가 WebP 로"
-            echo "전환됩니다(파일 먼저, 파서 나중)."
+            echo "## ⛔ 머지만으로는 서빙되지 않는다"
+            echo ""
+            echo "이모티콘은 **nginx 가 호스트 파일을 직접 서빙**한다(컨테이너 이미지가 아님)."
+            echo '  `location ^~ /emoticons/` → `alias /home/damoang/legacy-data/emoticons/`'
+            echo '  `location ^~ /api/emoticons/nariya/` → 같은 경로 (리액션 피커)'
+            echo ""
+            echo "2026-08-11 에 이 PR 계열을 머지·승격했는데 운영에서 **전부 404** 였다."
+            echo "파일이 컨테이너에만 들어갔기 때문이다. 머지 후 호스트 동기화가 반드시 필요하다."
+            echo ""
+            echo "### 반영 순서"
+            echo '1. 이 PR 머지 (저장소=SoT 갱신)'
+            echo '2. 운영 호스트에서 동기화:'
+            echo '   ```'
+            echo '   bash scripts/sync-emoticons-to-host.sh              # dry-run'
+            echo '   sudo bash scripts/sync-emoticons-to-host.sh --apply'
+            echo '   ```'
+            echo '3. 검증: `curl -sI https://damoang.net/emoticons/<파일>.webp | head -1` → 200'
+            echo '4. 그 다음에야 premium `webp-manifest.json` 의 names 에 아래 목록 반영'
+            echo '   (**파일 먼저, 파서 나중** — 역순이면 404)'
+            echo ""
+            echo "⛔ 머지 전 눈으로 확인할 것. 변환이 프레임을 떨어뜨렸을 수 있다."
           } > pr-body.md
           gh pr create --base main --head "$BRANCH" \
             --title "chore: 이모티콘 애니 WebP 생성 (A안 PR-B)" \

--- a/scripts/sync-emoticons-to-host.sh
+++ b/scripts/sync-emoticons-to-host.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# 이모티콘을 저장소(SoT) → 운영 서빙 디렉토리로 동기화한다.
+#
+# ⛔ 왜 이 스크립트가 필요한가
+#   이모티콘은 **nginx 가 호스트 파일을 직접 서빙**한다. 컨테이너 이미지에 넣어도 나가지 않는다.
+#     /etc/nginx/conf.d/damoang.net.conf
+#       location ^~ /emoticons/            alias /home/damoang/legacy-data/emoticons/;
+#       location ^~ /api/emoticons/nariya/ alias /home/damoang/legacy-data/emoticons/;  (리액션 피커)
+#   저장소 apps/web/static/emoticons 는 SoT 이자 빌드 사본이고, 서빙본은 위 호스트 경로다.
+#   2026-08-11: emoticons-to-webp 워크플로 산출물 40개를 머지·승격했는데 운영에서 전부 404 였다.
+#   파일이 컨테이너에만 들어갔기 때문이다. 그 간극을 메우는 게 이 스크립트다.
+#
+# 사용:
+#   bash scripts/sync-emoticons-to-host.sh              # dry-run (기본) — 무엇이 바뀔지만 출력
+#   sudo bash scripts/sync-emoticons-to-host.sh --apply # 실제 반영 (서빙 디렉토리가 damoang 소유)
+#
+# 기본은 **추가만** 한다. 기존 파일 내용이 다르면 건드리지 않고 목록만 알린다
+# (덮어쓰기는 --overwrite 를 명시할 때만, 항상 백업 후).
+set -euo pipefail
+
+DEST="${EMOTICON_DEST:-/home/damoang/legacy-data/emoticons}"
+APPLY=0
+OVERWRITE=0
+for a in "$@"; do
+    case "$a" in
+        --apply) APPLY=1 ;;
+        --overwrite) OVERWRITE=1 ;;
+        -h|--help) sed -n '2,25p' "$0"; exit 0 ;;
+        *) echo "알 수 없는 인자: $a" >&2; exit 2 ;;
+    esac
+done
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$ROOT" ]; then
+    echo "⛔ git 저장소 안에서 실행해야 한다(소스가 저장소의 static 이므로)." >&2
+    exit 1
+fi
+SRC="$ROOT/apps/web/static/emoticons"
+[ -d "$SRC" ] || { echo "⛔ 소스 없음: $SRC" >&2; exit 1; }
+[ -d "$DEST" ] || { echo "⛔ 서빙 디렉토리 없음: $DEST" >&2; exit 1; }
+
+# ⛔ stale checkout 방지 — 서빙본을 옛 트리로 되돌리는 사고가 제일 무섭다.
+git -C "$ROOT" fetch origin main --quiet 2>/dev/null || true
+LOCAL=$(git -C "$ROOT" rev-parse HEAD)
+REMOTE=$(git -C "$ROOT" rev-parse origin/main 2>/dev/null || echo "")
+if [ -n "$REMOTE" ] && [ "$LOCAL" != "$REMOTE" ]; then
+    if ! git -C "$ROOT" merge-base --is-ancestor "$REMOTE" "$LOCAL" 2>/dev/null; then
+        echo "⛔ 이 체크아웃은 origin/main 보다 뒤처져 있다 (HEAD=${LOCAL:0:7}, origin/main=${REMOTE:0:7})."
+        echo "   옛 파일을 서빙본에 덮어쓸 수 있으니 먼저 최신화할 것."
+        exit 1
+    fi
+fi
+
+added=(); differs=()
+shopt -s nullglob
+for f in "$SRC"/*.{gif,webp,png,jpg,jpeg}; do
+    n=$(basename "$f")
+    if [ ! -e "$DEST/$n" ]; then
+        added+=("$n")
+    elif ! cmp -s "$f" "$DEST/$n"; then
+        differs+=("$n")
+    fi
+done
+shopt -u nullglob
+
+echo "소스 : $SRC (HEAD ${LOCAL:0:7})"
+echo "대상 : $DEST"
+echo "신규 : ${#added[@]}개 / 내용 다름: ${#differs[@]}개"
+[ ${#added[@]} -gt 0 ] && printf '  + %s\n' "${added[@]:0:20}"
+[ ${#added[@]} -gt 20 ] && echo "  ... 외 $(( ${#added[@]} - 20 ))개"
+if [ ${#differs[@]} -gt 0 ]; then
+    echo "  ⚠️ 내용이 다른 파일(기본은 건드리지 않음, --overwrite 필요):"
+    printf '     ~ %s\n' "${differs[@]:0:10}"
+fi
+
+if [ "$APPLY" != "1" ]; then
+    echo ""
+    echo "dry-run — 반영하려면: sudo bash scripts/sync-emoticons-to-host.sh --apply"
+    exit 0
+fi
+
+TS=$(date +%Y%m%d-%H%M%S)
+BACKUP="$DEST/_backup_$TS"
+copied=0
+if [ ${#added[@]} -gt 0 ]; then
+    for n in "${added[@]}"; do
+        cp -p "$SRC/$n" "$DEST/$n"
+        copied=$((copied + 1))
+    done
+fi
+if [ "$OVERWRITE" = "1" ] && [ ${#differs[@]} -gt 0 ]; then
+    mkdir -p "$BACKUP"
+    for n in "${differs[@]}"; do
+        cp -p "$DEST/$n" "$BACKUP/$n"
+        cp -p "$SRC/$n" "$DEST/$n"
+        copied=$((copied + 1))
+    done
+    echo "덮어쓴 파일 백업: $BACKUP"
+fi
+echo "✅ 반영 $copied 개"
+echo "검증: curl -sI https://damoang.net/emoticons/<파일명> | head -1   # 200 이어야 한다"


### PR DESCRIPTION
## 문제
어제 애니 WebP 40개를 머지하고 **운영 승격까지 했는데 전부 404** 였다.

```
GET https://damoang.net/emoticons/damoang-emo-036.webp   → 404
GET https://damoang.net/api/emoticons/nariya/…webp       → 404
```

이모티콘은 **nginx 가 호스트 파일을 직접 서빙**한다 — 컨테이너 이미지가 아니다.

| | 경로 | 상태 |
|---|---|---|
| 워크플로가 넣는 곳 | 저장소 `apps/web/static/emoticons/` → 컨테이너 | 파일 들어감 |
| nginx 가 읽는 곳 | 호스트 `/home/damoang/legacy-data/emoticons/` (alias) | **비어 있음** |

저장소와 호스트는 1246개가 해시까지 동일한 사본 관계인데, **동기화가 수동**이었고 워크플로에 그 단계가 없었다. 8/9 에 이 트랙을 만든 이후 계속 있던 간극이다.

## 변경
### 1. `scripts/sync-emoticons-to-host.sh` 신설
- dry-run 기본. `--apply` 로만 반영
- **추가만** 한다. 내용이 다른 파일은 건드리지 않고 목록만 알림(`--overwrite` 시에만, 항상 백업)
- ⛔ **stale checkout 가드** — `origin/main` 보다 뒤처진 트리면 거부한다. 옛 파일로 서빙본을 되돌리는 게 가장 위험하다
- 실측 검증: 현 상태에서 `신규 39 / 내용 다름 0` 정확히 판정. 가드도 실제로 걸리는 것 확인(HEAD 뒤처졌을 때 중단)

### 2. 워크플로 PR 본문에 반영 순서 명시
"머지만으로는 서빙되지 않는다" + 4단계(머지 → 호스트 동기화 → curl 200 검증 → premium 매니페스트).

## 반영 순서 (이 PR 머지 후)
```bash
bash scripts/sync-emoticons-to-host.sh              # dry-run
sudo bash scripts/sync-emoticons-to-host.sh --apply # 운영 반영
curl -sI https://damoang.net/emoticons/damoang-emo-036.webp | head -1   # 200 확인
```
그 다음에야 premium `webp-manifest.json` 반영(**파일 먼저, 파서 나중**).