### PR TITLE
fix(recommended): 홈 추천글·모아보기·위젯에서 이용제한 근거 글 제외

### DIFF
--- a/apps/web/src/lib/server/explore-loader.ts
+++ b/apps/web/src/lib/server/explore-loader.ts
@@ -8,7 +8,8 @@
 import { readFile } from 'node:fs/promises';
 import { rewriteImageHosts } from '$lib/server/cdn-rewrite';
 import { existsSync } from 'node:fs';
-import type { ExploreData, ExploreModeData } from '$lib/api/types';
+import type { ExploreData, ExploreModeData, ExplorePost, ExploreComment } from '$lib/api/types';
+import { findDisciplinedIds } from '$lib/server/discipline-mask';
 import { env } from '$env/dynamic/private';
 
 const CACHE_DIR = env.RECOMMENDED_CACHE_DIR || '/home/damoang/www/data/cache/recommended';
@@ -37,9 +38,106 @@ function trimExploreModeData(mode: ExploreModeData, topOnly = false): ExploreMod
 }
 
 /**
- * explore.json 캐시 파일을 읽어 반환
+ * 모아보기 목록에서 **이용제한 근거 글**(g5_na_singo.discipline_log_id)을 제거한다.
+ *
+ * 추천글·공감글과 동일하게 explore.json 은 cron 스냅샷이라, 생성 후 신고→징계된 글이
+ * 원제목(댓글은 parent_title)으로 그대로 노출된다. 마스킹 대신 목록에서 제외한다.
+ * mode(hot/new/rising/top) × {posts, periods.24h/7d/30d, comments, comment_periods.*}
+ * 를 모두 훑어 글(id)과 댓글의 부모글(parent_id)까지 판정 대상으로 삼는다.
+ *
+ * ⛔ 읽기 시점 매번 판정(스냅샷 생성 후 징계 즉시 반영). 판정 실패 시 로깅만 하고
+ *    원본 통과(fail-open, 다른 마스킹 표면과 동일).
+ */
+async function filterDisciplinedExplore(data: ExploreData): Promise<ExploreData> {
+    const modes = data.modes;
+    if (!modes) return data;
+    const modeList = [modes.hot, modes.new, modes.rising, modes.top].filter(Boolean);
+
+    // 1) board별 판정 대상 id 수집 (글 id + 댓글 자신 id + 댓글 부모 parent_id)
+    const byBoard = new Map<string, Set<number>>();
+    const add = (board: string | undefined, id: number | undefined) => {
+        if (!board || !id) return;
+        let set = byBoard.get(board);
+        if (!set) byBoard.set(board, (set = new Set()));
+        set.add(id);
+    };
+    const eachPost = (arr: ExplorePost[] | undefined) => arr?.forEach((p) => add(p.board, p.id));
+    const eachComment = (arr: ExploreComment[] | undefined) =>
+        arr?.forEach((c) => {
+            add(c.board, c.id);
+            add(c.board, c.parent_id);
+        });
+    for (const m of modeList) {
+        eachPost(m.posts);
+        eachPost(m.periods?.['24h']);
+        eachPost(m.periods?.['7d']);
+        eachPost(m.periods?.['30d']);
+        eachComment(m.comments);
+        eachComment(m.comment_periods?.['24h']);
+        eachComment(m.comment_periods?.['7d']);
+        eachComment(m.comment_periods?.['30d']);
+    }
+    if (byBoard.size === 0) return data;
+
+    const disciplined = new Map<string, Set<number>>();
+    await Promise.all(
+        [...byBoard].map(async ([board, ids]) => {
+            disciplined.set(board, await findDisciplinedIds(board, [...ids]));
+        })
+    );
+    const isDisc = (board: string, id: number) => disciplined.get(board)?.has(id) === true;
+
+    // 2) 사본을 만들며 제외
+    const keepPosts = (arr: ExplorePost[] | undefined): ExplorePost[] | undefined =>
+        arr?.filter((p) => !isDisc(p.board, p.id));
+    const keepComments = (arr: ExploreComment[] | undefined): ExploreComment[] | undefined =>
+        arr?.filter((c) => !isDisc(c.board, c.id) && !isDisc(c.board, c.parent_id));
+    const filterMode = (m: ExploreModeData): ExploreModeData => ({
+        ...m,
+        posts: keepPosts(m.posts) ?? m.posts,
+        periods: m.periods
+            ? {
+                  '24h': keepPosts(m.periods['24h']) ?? [],
+                  '7d': keepPosts(m.periods['7d']) ?? [],
+                  '30d': keepPosts(m.periods['30d']) ?? []
+              }
+            : m.periods,
+        comments: keepComments(m.comments) ?? m.comments,
+        comment_periods: m.comment_periods
+            ? {
+                  '24h': keepComments(m.comment_periods['24h']) ?? [],
+                  '7d': keepComments(m.comment_periods['7d']) ?? [],
+                  '30d': keepComments(m.comment_periods['30d']) ?? []
+              }
+            : m.comment_periods
+    });
+
+    return {
+        ...data,
+        modes: {
+            hot: filterMode(modes.hot),
+            new: filterMode(modes.new),
+            rising: filterMode(modes.rising),
+            top: filterMode(modes.top)
+        }
+    };
+}
+
+/**
+ * explore.json 캐시 파일을 읽어 반환 (이용제한 글 제외)
  */
 export async function loadExploreData(): Promise<ExploreData | null> {
+    const raw = await loadExploreDataRaw();
+    if (!raw) return null;
+    try {
+        return await filterDisciplinedExplore(raw);
+    } catch (err) {
+        console.error('[explore-loader] 징계 필터 실패:', err);
+        return raw;
+    }
+}
+
+async function loadExploreDataRaw(): Promise<ExploreData | null> {
     if (cache && Date.now() - cache.timestamp < CACHE_TTL_MS) {
         return cache.data;
     }

--- a/apps/web/src/lib/server/index-widgets-builder.ts
+++ b/apps/web/src/lib/server/index-widgets-builder.ts
@@ -8,6 +8,7 @@
 import { readFile } from 'fs/promises';
 import { rewriteImageHosts } from '$lib/server/cdn-rewrite';
 import { env } from '$env/dynamic/private';
+import { findDisciplinedIds } from '$lib/server/discipline-mask';
 import type {
     IndexWidgetsData,
     NewsPost,
@@ -60,9 +61,74 @@ const EMPTY_RESULT: IndexWidgetsData = {
 let cachedWidgets: IndexWidgetsData | null = null;
 let cacheTimestamp = 0;
 
+/** board+id 를 실은 위젯 글의 최소 형태 */
+interface BoardIdItem {
+    board?: string;
+    id?: number;
+}
+
 /**
- * index-widgets.json 파일을 읽어 IndexWidgetsData를 반환
- * 30초 인메모리 캐시로 파일 I/O 최소화
+ * 홈 위젯 목록에서 **이용제한 근거 글**(g5_na_singo.discipline_log_id)을 제거한다.
+ *
+ * news/economy/gallery/group 탭·emoji_awards 모두 board+id 를 실어 나르고,
+ * index-widgets.json 은 5분마다 갱신되는 cron 스냅샷이라 생성 후 신고→징계된 글이
+ * 홈 하이라이트로 그대로 노출된다(추천글·공감글·모아보기와 동일 클래스). 마스킹 대신
+ * 목록에서 제외한다. 판정 실패 시 로깅만 하고 원본 통과(fail-open).
+ *
+ * ⚠️ 홈은 최다 트래픽 경로라 필터된 결과를 60초 캐시(스냅샷 자체가 5분 주기라 무해)해
+ *    호출당 DB 조회를 파드/분당 1회로 억제한다.
+ */
+async function filterDisciplinedWidgets(data: IndexWidgetsData): Promise<IndexWidgetsData> {
+    const g = data.group_tabs ?? EMPTY_RESULT.group_tabs;
+    const groupArrays = [g.all, g['24h'], g.week, g.month];
+    const allArrays: BoardIdItem[][] = [
+        data.news_tabs,
+        data.economy_tabs,
+        data.gallery,
+        data.emoji_awards as BoardIdItem[],
+        ...groupArrays
+    ].filter(Boolean) as BoardIdItem[][];
+
+    const byBoard = new Map<string, Set<number>>();
+    for (const arr of allArrays) {
+        for (const p of arr) {
+            if (!p?.board || !p?.id) continue;
+            let set = byBoard.get(p.board);
+            if (!set) byBoard.set(p.board, (set = new Set()));
+            set.add(p.id);
+        }
+    }
+    if (byBoard.size === 0) return data;
+
+    const disciplined = new Map<string, Set<number>>();
+    await Promise.all(
+        [...byBoard].map(async ([board, ids]) => {
+            disciplined.set(board, await findDisciplinedIds(board, [...ids]));
+        })
+    );
+    const isDisc = (p: BoardIdItem) =>
+        !!p.board && !!p.id && disciplined.get(p.board)?.has(p.id) === true;
+    const keep = <T extends BoardIdItem>(arr: T[] | undefined): T[] =>
+        (arr ?? []).filter((p) => !isDisc(p));
+
+    return {
+        ...data,
+        news_tabs: keep(data.news_tabs),
+        economy_tabs: keep(data.economy_tabs),
+        gallery: keep(data.gallery),
+        group_tabs: {
+            all: keep(g.all),
+            '24h': keep(g['24h']),
+            week: keep(g.week),
+            month: keep(g.month)
+        },
+        emoji_awards: keep(data.emoji_awards as BoardIdItem[]) as IndexWidgetsData['emoji_awards']
+    };
+}
+
+/**
+ * index-widgets.json 파일을 읽어 IndexWidgetsData를 반환 (이용제한 글 제외)
+ * 60초 인메모리 캐시로 파일 I/O + 징계 판정 최소화 (스냅샷은 5분 주기)
  */
 export async function buildIndexWidgets(_backendUrl: string): Promise<IndexWidgetsData> {
     const now = Date.now();
@@ -74,7 +140,7 @@ export async function buildIndexWidgets(_backendUrl: string): Promise<IndexWidge
         const raw = await readFile(JSON_PATH, 'utf-8');
         const json = JSON.parse(rewriteImageHosts(raw));
 
-        const result: IndexWidgetsData = {
+        const rawResult: IndexWidgetsData = {
             news_tabs: (json.news_tabs ?? []) as NewsPost[],
             economy_tabs: (json.economy_tabs ?? []) as EconomyPost[],
             gallery: (json.gallery ?? []) as GalleryPost[],
@@ -82,7 +148,14 @@ export async function buildIndexWidgets(_backendUrl: string): Promise<IndexWidge
             emoji_awards: (json.emoji_awards ?? []) as IndexWidgetsData['emoji_awards']
         };
 
-        // 데이터가 있을 때만 캐시
+        let result = rawResult;
+        try {
+            result = await filterDisciplinedWidgets(rawResult);
+        } catch (err) {
+            console.error('[index-widgets-builder] 징계 필터 실패:', err);
+        }
+
+        // 데이터가 있을 때만 캐시 (필터된 결과를 캐시)
         if (
             result.news_tabs.length > 0 ||
             result.economy_tabs.length > 0 ||

--- a/apps/web/src/lib/server/recommended-loader.ts
+++ b/apps/web/src/lib/server/recommended-loader.ts
@@ -8,7 +8,8 @@
 import { readFile } from 'node:fs/promises';
 import { rewriteImageHosts } from '$lib/server/cdn-rewrite';
 import { existsSync, statSync } from 'node:fs';
-import type { RecommendedDataWithAI, RecommendedPeriod } from '$lib/api/types';
+import type { RecommendedDataWithAI, RecommendedPeriod, RecommendedSection } from '$lib/api/types';
+import { findDisciplinedIds } from '$lib/server/discipline-mask';
 import { env } from '$env/dynamic/private';
 
 const RECOMMENDED_CACHE_DIR =
@@ -46,9 +47,76 @@ export function getDefaultPeriod(): RecommendedPeriod {
 }
 
 /**
- * 추천글 캐시 파일을 읽어 반환
+ * 추천글 목록에서 **이용제한 근거 글**(g5_na_singo.discipline_log_id)을 제거한다.
+ *
+ * 메인 페이지 추천글도 날짜별 공감글과 동일하게 cron 스냅샷을 읽어 서빙하므로,
+ * 스냅샷 생성 후 신고→징계된 글이 원제목으로 그대로 노출된다(콘텐츠 재노출 사고).
+ * 추천 피드이므로 마스킹(제목 치환)보다 **목록에서 제외**가 맞다. 원본 캐시는
+ * 건드리지 않고 사본을 반환한다.
+ *
+ * ⛔ 읽기 시점에 매번 판정한다(스냅샷 생성 후 징계돼도 즉시 반영). 판정 실패 시엔
+ *    로깅만 하고 원본을 통과시킨다 — 판정이 드물게 실패해도 추천글이 통째로 비지
+ *    않도록(fail-open, daily-recommended-loader 와 동일 정책).
+ */
+async function filterDisciplinedRecommended(
+    data: RecommendedDataWithAI
+): Promise<RecommendedDataWithAI> {
+    const sections = data.sections;
+    if (!sections) return data;
+
+    const byBoard = new Map<string, Set<number>>();
+    for (const key of ['community', 'group', 'info'] as const) {
+        for (const p of sections[key]?.posts ?? []) {
+            if (!p.board || !p.id) continue;
+            let set = byBoard.get(p.board);
+            if (!set) byBoard.set(p.board, (set = new Set()));
+            set.add(p.id);
+        }
+    }
+    if (byBoard.size === 0) return data;
+
+    const disciplined = new Map<string, Set<number>>();
+    await Promise.all(
+        [...byBoard].map(async ([board, ids]) => {
+            disciplined.set(board, await findDisciplinedIds(board, [...ids]));
+        })
+    );
+
+    const isDisc = (board: string, id: number) => disciplined.get(board)?.has(id) === true;
+    const filterSection = (sec: RecommendedSection): RecommendedSection => {
+        if (!sec?.posts) return sec;
+        const kept = sec.posts.filter((p) => !isDisc(p.board, p.id));
+        return kept.length === sec.posts.length ? sec : { ...sec, posts: kept, count: kept.length };
+    };
+
+    return {
+        ...data,
+        sections: {
+            community: filterSection(sections.community),
+            group: filterSection(sections.group),
+            info: filterSection(sections.info)
+        }
+    };
+}
+
+/**
+ * 추천글 캐시 파일을 읽어 반환 (이용제한 글 제외)
  */
 export async function loadRecommendedData(
+    period: RecommendedPeriod
+): Promise<RecommendedDataWithAI | null> {
+    const raw = await loadRecommendedDataRaw(period);
+    if (!raw) return null;
+
+    try {
+        return await filterDisciplinedRecommended(raw);
+    } catch (err) {
+        console.error('[recommended-loader] 징계 필터 실패:', err);
+        return raw;
+    }
+}
+
+async function loadRecommendedDataRaw(
     period: RecommendedPeriod
 ): Promise<RecommendedDataWithAI | null> {
     // 인메모리 캐시 확인


### PR DESCRIPTION
## 배경
공감글(날짜별 `daily-recommended-loader`)에는 fe#2049로 `findDisciplinedIds` 필터가 배선됐으나, **같은 cron 스냅샷 계열의 나머지 홈 피드 3개**에는 없어 이용제한 근거 글(신고→징계, `g5_na_singo.discipline_log_id IS NOT NULL`)이 원제목으로 재노출되는 동일 누수 클래스가 남아 있었다.

**실측: 모아보기(explore) `new.posts`에 free/6977597 실시간 1건 누수 확인** (+ `top.30d` 댓글 부모글 free/6834581 parent_title 누수). 홈 추천글/index-widgets는 현재 0건이나 잠재 노출.

## 변경 (전부 web 서버 로더, 백엔드 무변)
- `recommended-loader.ts` — 홈 추천글 위젯 `sections.{community,group,info}.posts`
- `explore-loader.ts` — 모아보기 mode(hot/new/rising/top) × {posts, periods.24h/7d/30d, comments, comment_periods.*}, 댓글은 부모글(parent_id)까지 판정
- `index-widgets-builder.ts` — news/economy/gallery/group/emoji_awards. 홈 최다 트래픽이라 **필터된 결과 60초 캐시**(스냅샷 5분 주기라 무해)

## 정책 (기존 공감글 필터와 동일)
- 읽기 시점 매번 판정 → 스냅샷 생성 후 징계돼도 즉시 반영
- 원본 인메모리 캐시 무변(사본 반환)
- 판정 실패 시 로깅만·원본 통과(fail-open — 피드 통째 비는 것 방지)
- board별 1쿼리(N+1 없음)