### PR TITLE
운영자 답변이 달린 소명글은 원문 수정 차단

### DIFF
--- a/apps/web/src/lib/server/sanctioned-lock.ts
+++ b/apps/web/src/lib/server/sanctioned-lock.ts
@@ -55,3 +55,36 @@ export async function isSanctionedTarget(
     if (commentId && (await isSanctionedPost(boardId, commentId))) return true;
     return false;
 }
+
+/** 소명글 잠금 사유. */
+export const CLAIM_ANSWERED_LOCK_MESSAGE =
+    '운영자 답변이 등록된 소명글은 수정할 수 없습니다. 추가로 하실 말씀은 댓글로 남겨 주세요.';
+
+/**
+ * 운영자 답변이 달린 소명글인지.
+ *
+ * 답변이 나간 뒤 원문이 바뀌면 대화 기록이 어긋난다 — 운영 답변이 존재하지 않는 주장에
+ * 답하는 모양이 되고, 답변 근거로 인용한 문장이 사라질 수도 있다(2026-08-11 claim/1733:
+ * 접수 후 5회 수정, 3,611 → 5,034자).
+ *
+ * ⛔ **접수 자동 답변(mb_id='cs')은 답변으로 치지 않는다.** 그건 글을 올리면 곧바로 달리므로,
+ *    그걸 기준으로 잠그면 소명을 보충할 기회 자체가 사라진다. 보충은 소명권의 일부다.
+ * ⛔ **삭제는 막지 않는다**(DELETE 는 이 가드를 타지 않는다). 제재는 잊힐 권리가 있다.
+ * ⛔ **댓글도 막지 않는다.** 회원이 답변에 반응할 수 있어야 한다 — 막히는 것은 원문 수정뿐.
+ */
+export async function isClaimAnswered(wrId: number): Promise<boolean> {
+    if (!wrId) return false;
+    try {
+        const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT 1 AS hit FROM g5_write_claim
+              WHERE wr_parent = ? AND wr_is_comment = 1
+                AND mb_id IN ('ai', 'admin', 'police', 'appeal')
+              LIMIT 1`,
+            [wrId]
+        );
+        return rows.length > 0;
+    } catch {
+        // 판정 불가를 이유로 정상 수정을 막지 않는다
+        return false;
+    }
+}

--- a/apps/web/src/routes/api/v1/[...path]/+server.ts
+++ b/apps/web/src/routes/api/v1/[...path]/+server.ts
@@ -1,5 +1,10 @@
 import type { RequestHandler } from './$types';
-import { isSanctionedPost, SANCTIONED_LOCK_MESSAGE } from '$lib/server/sanctioned-lock';
+import {
+    isSanctionedPost,
+    isClaimAnswered,
+    SANCTIONED_LOCK_MESSAGE,
+    CLAIM_ANSWERED_LOCK_MESSAGE
+} from '$lib/server/sanctioned-lock';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import pool from '$lib/server/db';
@@ -417,6 +422,18 @@ async function proxyRequest(
     //    추천은 web 이 직접 처리하므로 like/+server.ts 에서 따로 막는다.
     //    실측(2026-08-11): 확정 이후 댓글 288건(78글) · 본문 수정 23건(19글)이 붙었다.
     //    ⛔ DELETE 는 막지 않는다 — 운영자 삭제와 작성자 자진 삭제는 계속 가능해야 한다.
+    // ⛔ 운영자 답변이 달린 소명글은 원문 수정을 막는다(댓글·삭제는 허용).
+    //    답변 후 원문이 바뀌면 대화 기록이 어긋나고, 답변이 인용한 문장이 사라질 수 있다.
+    if (method === 'PUT' || method === 'PATCH') {
+        const claimMatch = path.match(/^boards\/claim\/posts\/(\d+)\/?$/);
+        if (claimMatch && (await isClaimAnswered(Number(claimMatch[1])))) {
+            return new Response(
+                JSON.stringify({ success: false, message: CLAIM_ANSWERED_LOCK_MESSAGE }),
+                { status: 403, headers: { 'Content-Type': 'application/json' } }
+            );
+        }
+    }
+
     if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
         const locked = await sanctionedLockTarget(path);
         if (locked) {


### PR DESCRIPTION
답변이 나간 뒤 원문이 바뀌면 대화 기록이 어긋납니다. 운영 답변이 존재하지 않는 주장에 답하는 모양이 되고, **답변 근거로 인용한 문장이 사라질 수도** 있습니다.

실측(2026-08-11 `claim/1733`): 접수 후 **5회 수정**, 3,611 → 5,034자. 전부 덧붙이기였고 인용 문장도 남아 있었으나, 언제든 지울 수 있는 상태였습니다.

## 판정 기준

운영자 계정(`ai`·`admin`·`police`·`appeal`)의 댓글이 있으면 잠급니다.

⛔ **접수 자동 답변(`cs`)은 답변으로 치지 않습니다.** 글을 올리면 곧바로 달리므로, 그걸 기준으로 잠그면 **소명을 보충할 기회 자체가 사라집니다.** 보충은 소명권의 일부입니다.

## ⛔ 막지 않는 것

| | 이유 |
|---|---|
| **삭제** | **제재는 잊힐 권리가 있습니다** (DELETE 는 이 가드를 타지 않습니다) |
| **댓글** | 회원이 답변에 반응할 수 있어야 합니다. 막히는 것은 원문 수정(PUT/PATCH)뿐 |
| 판정 실패 시 | 잠그지 않습니다 |

## 실측 검증

| 소명글 | 댓글 작성자 | 판정 |
|---|---|---|
| 1730 (운영 답변 게시함) | `ai`, `cs` | 🔒 수정 잠김 |
| 1733 (자동 답변만) | `cs` | ✏️ 수정 가능 |