### PR TITLE
fix(ui): 글 상세 네비 버튼 간격 12px → 8px (데스크톱)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2157,7 +2157,7 @@
 
     <!-- 상단 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
     <div
-        class="-mx-2 mb-2 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-3 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+        class="-mx-2 mb-2 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
     >
         <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
@@ -2682,7 +2682,7 @@
 
         <!-- 댓글 아래 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
         <div
-            class="-mx-2 mt-4 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-3 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+            class="-mx-2 mt-4 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
         >
             <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0"
                 >←</Button


### PR DESCRIPTION
## 문제
글 상세에서 `←` · `목록으로` · `글쓰기` 버튼 사이가 유독 넓다. 같은 페이지 안에서 **3배 차이**:

| 위치 | 데스크톱 간격 |
|---|---|
| 상단/하단 네비 | **12px** (`md:gap-3`) |
| 본문 하단 액션(공감·공유·신고) | 4px (`gap-1`) |
| 댓글 액션 | 4px (`gap-1`) |

## 변경
데스크톱만 `md:gap-3` → `md:gap-2`(8px). 상단·하단 네비 두 곳 동일 패턴이라 함께 적용.

네비는 주요 액션이라 본문(4px)보다 약간 넓게 두는 게 자연스러워 4px 까지 좁히지는 않았다.

## 건드리지 않은 것
모바일 `gap-2` + `min-h-11`(44px 터치 타깃, #12016) 은 그대로 둔다.