### PR TITLE
fix(ui): 모바일 네비 버튼 높이 44px → 36px

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2155,9 +2155,11 @@
         <TagNav />
     </div>
 
-    <!-- 상단 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
+    <!-- 상단 네비게이션 — 모바일 터치 타겟 36px.
+         원래 44px(#12016)였으나 이 네비에만 걸린 값이라 같은 화면의 다른 버튼(32px)과 어긋나
+         유독 커 보였다. 36px = Button 기본 높이(h-9)와 같고 WCAG 2.2 AA 최소(24px)를 상회한다. -->
     <div
-        class="-mx-2 mb-2 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+        class="-mx-2 mb-2 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-9 md:[&_a]:min-h-0 [&_button]:min-h-9 md:[&_button]:min-h-0"
     >
         <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
@@ -2680,9 +2682,9 @@
             </div>
         {/if}
 
-        <!-- 댓글 아래 네비게이션 — 모바일 터치 타겟 44px(#12016) -->
+        <!-- 댓글 아래 네비게이션 — 모바일 터치 타겟 36px (상단 네비와 동일, 사유는 그쪽 주석) -->
         <div
-            class="-mx-2 mt-4 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-11 md:[&_a]:min-h-0 [&_button]:min-h-11 md:[&_button]:min-h-0"
+            class="-mx-2 mt-4 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-9 md:[&_a]:min-h-0 [&_button]:min-h-9 md:[&_button]:min-h-0"
         >
             <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0"
                 >←</Button


### PR DESCRIPTION
## 문제
모바일에서 `목록으로`·`글쓰기`·`수정`·`삭제` 가 유독 크다. 네비 컨테이너의 `[&_button]:min-h-11`·`[&_a]:min-h-11` 이 **모바일에서만 44px 을 강제**하기 때문이다(데스크톱은 `md:min-h-0` 으로 해제 → 32px).

`min-h-11` 은 **사이트 전체 정책이 아니라 이 파일의 네비 2곳에만** 걸린 값이다. 같은 화면의 공감·공유·신고·댓글 액션은 전부 32px 이라, 44px 네비는 위계가 아니라 **불일치**로 읽힌다.

## 변경
`min-h-11`(44px) → `min-h-9`(36px). 상단·하단 네비 두 곳, `a`/`button` 모두.

- 36px = `Button` 기본 높이(`h-9`)와 동일 → 사이트 톤과 일치
- WCAG 2.2 AA 최소 터치 타깃(24×24)을 크게 상회
- `수정`·`삭제` 는 작성자 전용 저빈도 + 파괴적 액션이라, 과하게 크면 오탭 위험이 오히려 커진다

데스크톱은 무변경(32px).

## ⚠️ 알아둘 것
44px 은 "모바일에서 누르기 어렵다"(#12016)로 들어온 값이다. 36px 이면 충분하다고 판단했지만 **실사용 반응은 배포 후에야 알 수 있다** — 불편 제보가 다시 오면 40px(`min-h-10`) 로 조정하는 게 중간값이다.