### PR TITLE
fix(post): 에디터 이미지 드래그 업로드(13471) + 하단 스크랩 버튼 복원(13468)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/types.ts
+++ b/apps/web/src/lib/components/features/board/layouts/types.ts
@@ -69,6 +69,9 @@ export interface ViewLayoutProps {
     canViewSecret: boolean;
     promotionExpired?: boolean;
 
+    /** 스크랩(보존) 여부 — 하단 액션바 스크랩 버튼 초기 표시용(bug/13468). */
+    initialScrapped?: boolean;
+
     // 추천/비추천 상태
     likeCount: number;
     dislikeCount: number;

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -44,6 +44,7 @@
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import Pin from '@lucide/svelte/icons/pin';
     import ShareButton from '$lib/components/post/share-button.svelte';
+    import ScrapButton from '$lib/components/post/scrap-button.svelte';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import PostRatingWidget from '../../post-rating.svelte';
     import type { ViewLayoutProps } from '../types.js';
@@ -77,6 +78,7 @@
         isAuthor,
         isAdmin,
         canViewSecret,
+        initialScrapped = false,
         likeCount,
         dislikeCount,
         isLiked,
@@ -759,10 +761,15 @@
                     {/if}
                 {/if}
 
-                <!-- 공유 + 신고 (우측 정렬) — 스크랩(보존) 버튼은 상단 툴바에 있어 여기선 제외한다.
-                     (bug/13447: #11666 이 하단에 스크랩을 중복 추가해 두 개로 보였고, 하단본은
-                      initialScrapped 상태도 안 받아 표시가 부정확했다. 상태가 올바른 상단본만 유지) -->
+                <!-- 스크랩 + 공유 + 신고 (우측 정렬).
+                     bug/13447: 예전엔 상단 툴바(#238)와 하단(#11666) 두 곳에 스크랩이 있었고
+                     하단본이 initialScrapped 를 안 받아 표시가 부정확했다. bug/13468: 하단본을
+                     통째로 제거했더니 사용자가 글 읽고 누르던 위치의 스크랩이 사라졌다는 제보.
+                     → 하단본을 initialScrapped 와 함께 복원(정확 표시 + 익숙한 위치 둘 다 충족). -->
                 <div class="ml-auto flex items-center gap-1">
+                    {#if authStore.isAuthenticated}
+                        <ScrapButton {boardId} postId={post.id} {initialScrapped} />
+                    {/if}
                     {#if board?.use_sns}
                         <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2365,6 +2365,7 @@
                 isAdmin={authStore.user?.mb_id === 'admin' || data.canManageBoard === true}
                 {canViewSecret}
                 {promotionExpired}
+                initialScrapped={isScrapped}
                 {likeCount}
                 {dislikeCount}
                 {isLiked}

--- a/apps/web/src/routes/api/media/images/+server.ts
+++ b/apps/web/src/routes/api/media/images/+server.ts
@@ -68,6 +68,46 @@ function getExt(filename: string): string {
     return dot >= 0 ? filename.slice(dot).toLowerCase() : '';
 }
 
+/**
+ * MIME 타입 → 표준 확장자.
+ *
+ * 에디터 내에서 이미지를 드래그하면 브라우저가 파일명을 `download`(확장자 없음)로 주는데,
+ * `file.type`(예: image/png)은 유효하다. 확장자 검증만 하면 이런 파일이 거부되므로
+ * (bug/13471), 확장자가 없거나 미허용일 때 MIME 으로 확장자를 복구한다. 지원 MIME 이
+ * 아니면 '' 를 반환해 호출부가 400 을 유지하도록 한다.
+ */
+function mimeToExt(mime: string): string {
+    switch ((mime || '').split(';')[0].trim().toLowerCase()) {
+        case 'image/jpeg':
+        case 'image/jpg':
+            return '.jpg';
+        case 'image/png':
+            return '.png';
+        case 'image/gif':
+            return '.gif';
+        case 'image/webp':
+            return '.webp';
+        case 'image/svg+xml':
+            return '.svg';
+        case 'image/heic':
+            return '.heic';
+        case 'image/heif':
+            return '.heif';
+        case 'video/mp4':
+            return '.mp4';
+        case 'video/webm':
+            return '.webm';
+        case 'video/quicktime':
+            return '.mov';
+        case 'video/x-msvideo':
+            return '.avi';
+        case 'video/x-matroska':
+            return '.mkv';
+        default:
+            return '';
+    }
+}
+
 function sanitize(filename: string): string {
     const ext = getExt(filename);
     const base = filename
@@ -76,11 +116,10 @@ function sanitize(filename: string): string {
     return (base || 'file') + ext;
 }
 
-function generateKey(filename: string): string {
+function generateKey(ext: string): string {
     const now = new Date();
     const yy = String(now.getFullYear()).slice(2);
     const mm = String(now.getMonth() + 1).padStart(2, '0');
-    const ext = getExt(filename);
     // 7자리 해시 (PHP S3Uploader와 동일 방식)
     const hash = crypto
         .createHash('md5')
@@ -153,10 +192,12 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
         error(400, '파일이 필요합니다.');
     }
 
-    // 확장자 검증
-    const ext = getExt(file.name);
-    if (!ALLOWED_EXTENSIONS.has(ext)) {
-        error(400, `지원하지 않는 파일 형식입니다: ${ext}`);
+    // 형식 검증: 확장자 우선, 없거나 미허용이면 MIME 으로 복구(bug/13471: 에디터에서
+    // 드래그한 이미지는 파일명이 `download`(확장자 없음)이지만 file.type 은 유효하다).
+    const rawExt = getExt(file.name);
+    const ext = ALLOWED_EXTENSIONS.has(rawExt) ? rawExt : mimeToExt(file.type);
+    if (!ext) {
+        error(400, `지원하지 않는 파일 형식입니다: ${rawExt || file.type || file.name}`);
     }
 
     // 크기 검증
@@ -172,7 +213,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
         error(400, `파일 크기가 너무 큽니다 (최대 ${Math.floor(sizeLimit / 1024 / 1024)}MB)`);
     }
 
-    const rawKey = generateKey(file.name);
+    const rawKey = generateKey(ext);
     const finalKey = rawKeyToFinalKey(rawKey);
     const contentType = file.type || 'application/octet-stream';
 


### PR DESCRIPTION
## bug/13471 — 에디터 이미지 드래그 시 '지원하지 않는 파일 형식' 경고
`api/media/images/+server.ts` 형식검증이 **확장자에만 의존**. 에디터 내에서 이미지를 드래그하면 브라우저가 파일명을 `download`(확장자 없음)로 주는데 `file.type='image/png'`은 유효한데도 거부됐다(경고: `download — 지원하지 않는 파일 형식입니다:`).
- `mimeToExt(mime)` 추가 → 확장자 없거나 미허용이면 **MIME으로 복구**. 그 ext로 S3 키 생성(`generateKey(ext)`). 진짜 미지원 MIME은 400 유지.

## bug/13468 — 자유게시판 스크랩 버튼 사라짐 (fe#2029 회귀)
13447(보존버튼 2개) 처리 때 **하단 액션바 스크랩을 통째로 제거**했으나, 그게 사용자가 글 읽고 누르던 위치였다(혈압요정 제보 22:50, 배포 직후).
- 하단본을 **`initialScrapped`와 함께 복원** → 13447의 실제 문제(상태 부정확)와 13468(익숙한 위치)을 동시 해결.
- `ViewLayoutProps.initialScrapped` 추가 → `+page.svelte`가 `isScrapped`를 레이아웃에 전달. 상단본(글쓰기/수정/삭제 툴바)은 그대로 — 이제 상단·하단 둘 다 정확한 상태.

## 검증
- [ ] 확장자 없는 이미지(download/image/png) 정상 업로드(.png) / 미지원은 400
- [ ] 로그인 사용자에게 하단 스크랩 버튼 표시 + 정확한 스크랩됨 상태 + 토글 동작
- [ ] pnpm check(svelte-check) 통과

범위 밖: bug/13473(키워드 차단 시 게시물 수 일정) = 기능제안, 별도.