### PR TITLE
소명게시판 직접 글쓰기에도 제목·본문 자동 채움

### DIFF
--- a/apps/web/src/lib/server/appealable-discipline.ts
+++ b/apps/web/src/lib/server/appealable-discipline.ts
@@ -1,0 +1,77 @@
+/**
+ * 소명 가능한 최근 이용제한 기록 찾기.
+ *
+ * 소명 글쓰기 화면은 `?disciplinelog_id=` 가 붙어 있을 때만 제목·본문을 채운다.
+ * 그런데 회원이 소명게시판에서 **직접 글쓰기**로 들어오면 그 값이 없어 제목이 빈 채로
+ * 남는다. 실제로 claim/1733 이 그렇게 작성돼 최근 10건 중 혼자만 제목 형식이 달랐다
+ * (나머지는 전부 "이용제한 NNNN번에 대한 소명").
+ *
+ * 운영 입장에서도 제목만 보고 어느 처분에 대한 소명인지 알 수 있어야 처리가 빠르다.
+ * 그래서 값이 없으면 **본인의 소명 가능한 최근 기록**을 찾아 채운다.
+ */
+import type { RowDataPacket } from 'mysql2';
+import pool from '$lib/server/db';
+
+export interface AppealableDiscipline {
+    id: number;
+    /** 'YYYY-MM-DD' */
+    penaltyDateFrom: string;
+    /** -1=영구 · 0=주의 · 1 이상=기간제 */
+    penaltyPeriod: number;
+}
+
+/**
+ * 이 회원이 지금 소명할 수 있는 가장 최근 이용제한.
+ *
+ * 조건 — 이용제한 기록 상세의 소명 버튼과 같은 기준을 쓴다:
+ * - ⛔ **주의(0일)는 제외.** 운영 관행상 소명 대상이 아니다
+ * - 제재일부터 **15일 이내**(제12~17조). 제재 당일(0일차)도 포함한다
+ * - 이미 소명글을 낸 건은 제외 — 같은 처분에 두 번 쓰게 하지 않는다
+ *
+ * ⛔ 조회가 실패하면 null 을 돌려 **아무것도 채우지 않는다.** 자동 채움은 편의이지
+ *    필수가 아니므로, 실패를 이유로 글쓰기를 막지 않는다.
+ */
+export async function findAppealableDiscipline(mbId: string): Promise<AppealableDiscipline | null> {
+    if (!mbId) return null;
+    try {
+        // ⛔ wr_content 에 JSON 이 아닌 행이 섞여 있다(빈 문자열 2건 확인).
+        //    WHERE 절에서 JSON_EXTRACT 를 바로 쓰면 "Invalid JSON text" 로 쿼리 전체가 죽는다.
+        //    회원 식별은 STORED GENERATED 컬럼 `penalty_mb_id`(인덱스 있음)로 하고,
+        //    JSON 은 유효한 행에서만 JSON_VALID 가드를 통과한 뒤 읽는다.
+        const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT id, from_at, period FROM (
+                 SELECT d.wr_id AS id,
+                        CASE WHEN JSON_VALID(d.wr_content)
+                             THEN JSON_UNQUOTE(JSON_EXTRACT(d.wr_content, '$.penalty_date_from'))
+                        END AS from_at,
+                        CASE WHEN JSON_VALID(d.wr_content)
+                             THEN CAST(JSON_UNQUOTE(JSON_EXTRACT(d.wr_content, '$.penalty_period')) AS SIGNED)
+                        END AS period
+                   FROM g5_write_disciplinelog d
+                  WHERE d.wr_is_comment = 0
+                    AND d.penalty_mb_id = ?
+                    AND d.wr_datetime >= DATE_SUB(NOW(), INTERVAL 15 DAY)
+                    AND NOT EXISTS (
+                          SELECT 1 FROM g5_write_claim c
+                           WHERE c.wr_is_comment = 0
+                             AND c.mb_id = ?
+                             AND c.wr_content LIKE CONCAT('%disciplinelog/', d.wr_id, '%')
+                        )
+               ) t
+              WHERE t.period IS NOT NULL AND t.period <> 0
+              ORDER BY t.id DESC
+              LIMIT 1`,
+            [mbId, mbId]
+        );
+        if (rows.length === 0) return null;
+        const r = rows[0];
+        return {
+            id: Number(r.id),
+            penaltyDateFrom: String(r.from_at ?? '').slice(0, 10),
+            penaltyPeriod: Number(r.period ?? 0)
+        };
+    } catch {
+        // 자동 채움은 편의 기능이다 — 실패해도 글쓰기를 막지 않는다
+        return null;
+    }
+}

--- a/apps/web/src/routes/[boardId]/write/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/write/+page.server.ts
@@ -4,6 +4,7 @@ import type { Board } from '$lib/api/types.js';
 import { backendFetch, createAuthHeaders } from '$lib/server/backend-fetch.js';
 import { checkCertification } from '$lib/server/certification.js';
 import { resolveCanonicalBoardId } from '$lib/server/board-cache.js';
+import { findAppealableDiscipline } from '$lib/server/appealable-discipline';
 
 /**
  * 글쓰기 페이지 서버 로드
@@ -80,6 +81,15 @@ export const load: PageServerLoad = async ({ locals, params }) => {
             throw err;
         }
         // 게시판 정보 조회 실패는 무시 (CSR에서 재확인)
+    }
+
+    // 소명게시판에 **직접** 글쓰기로 들어온 경우 — ?disciplinelog_id= 가 없으면
+    // 본인의 소명 가능한 최근 기록을 찾아 화면이 제목·본문을 채우게 한다.
+    // 그 값이 없으면 제목이 빈 채로 남아 목록에서 어느 처분에 대한 소명인지 안 보인다
+    // (claim/1733 이 그렇게 작성됐다).
+    if (boardId === 'claim' && locals.user?.id) {
+        const recent = await findAppealableDiscipline(locals.user.id);
+        if (recent) return { appealableDiscipline: recent };
     }
 
     return {};

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -27,7 +27,15 @@
     let { data }: { data: PageData } = $props();
 
     // 소명 연동: disciplinelog_id 쿼리파라미터 처리
-    const disciplinelogId = $derived($page.url.searchParams.get('disciplinelog_id') ?? '');
+    //
+    // ⛔ 쿼리파라미터가 없으면(소명게시판에서 직접 글쓰기) 제목이 빈 채로 남아,
+    //    목록에서 어느 처분에 대한 소명인지 보이지 않는다. 실제로 claim/1733 이
+    //    그렇게 작성돼 최근 10건 중 혼자만 제목 형식이 달랐다.
+    //    그래서 서버가 찾아준 **소명 가능한 최근 기록**으로 대신 채운다.
+    const disciplinelogId = $derived(
+        $page.url.searchParams.get('disciplinelog_id') ??
+            (data.appealableDiscipline ? String(data.appealableDiscipline.id) : '')
+    );
     const claimInitialTitle = $derived(
         disciplinelogId ? `이용제한 ${disciplinelogId}번에 대한 소명` : ''
     );


### PR DESCRIPTION
소명 글쓰기 화면은 `?disciplinelog_id=` 가 붙어 있을 때만 제목을 채웁니다("이용제한 NNNN번에 대한 소명"). 회원이 소명게시판에서 **직접 글쓰기**로 들어오면 그 값이 없어 **제목이 빈 채로** 남습니다.

실제로 `claim/1733` 이 그렇게 작성돼 **최근 10건 중 혼자만 제목 형식이 달랐습니다**(나머지 9건은 전부 자동 형식). 운영 입장에서도 제목만 보고 어느 처분에 대한 소명인지 알 수 있어야 처리가 빠릅니다.

## 판정 기준 (이용제한 기록 상세의 소명 버튼과 동일)

- ⛔ **주의(0일) 제외** — 운영 관행상 소명 대상이 아닙니다
- 제재일부터 **15일 이내**
- **이미 소명글을 낸 건은 제외** — 같은 처분에 두 번 쓰게 하지 않습니다

## ⛔ 쿼리 함정

`wr_content` 에 **JSON 이 아닌 행이 섞여 있습니다**(빈 문자열 2건). WHERE 에서 `JSON_EXTRACT` 를 바로 쓰면 *"Invalid JSON text"* 로 쿼리 전체가 죽습니다.

→ 회원 식별은 **STORED GENERATED 컬럼 `penalty_mb_id`**(인덱스 보유)로 하고, JSON 은 `JSON_VALID` 가드를 통과한 행에서만 읽습니다.

조회 실패 시 `null` — 자동 채움은 편의이지 필수가 아니므로 글쓰기를 막지 않습니다.

## 실측 검증

| 회원 | 상황 | 결과 |
|---|---|---|
| LALA | 영구 + 소명 이미 냄 | `null` ✅ |
| 하우디 | 5일, 소명 안 냄 | **4241** ✅ |
| 뽈뽈이 | 주의(0일) | `null` ✅ |
| 노사모준 | 5일, 소명 안 냄 | **4245** ✅ |