### PR TITLE
fix(poll): 투표 생성이 비관리자 전원 403 나던 문제 (bug/13466)

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -239,8 +239,12 @@ function isExtensionAdminRequest(pathname: string, method: string): boolean {
     }
     // POST /api/plugins = 활성화/비활성화
     if (pathname === '/api/plugins') return !isRead;
-    // DELETE /api/plugins/{id} = 삭제 (같은 깊이의 디스패처보다 이 라우트가 우선한다)
-    if (/^\/api\/plugins\/[^/]+$/.test(pathname)) return !isRead;
+    // DELETE /api/plugins/{id} = 플러그인 삭제. **DELETE 만** 관리자 게이트다.
+    // ⛔ bug/13466: 여기서 !isRead(=쓰기 전부) 로 잡으면 POST /api/plugins/{id} 도 걸린다.
+    //    투표 생성은 POST /api/plugins/poll(=플러그인 디스패처의 회원 기능)인데, 이게
+    //    "poll 플러그인 삭제(관리자)"로 오인돼 비관리자 전원 403 → 투표 생성 불가였다.
+    //    /api/plugins/{id} 깊이의 관리 동작은 삭제(DELETE)뿐이므로 그것만 막는다.
+    if (/^\/api\/plugins\/[^/]+$/.test(pathname)) return method === 'DELETE';
     // PUT /api/plugins/{id}/settings = 설정 변경
     if (/^\/api\/plugins\/[^/]+\/settings$/.test(pathname)) return !isRead;
 


### PR DESCRIPTION
## 근본 원인 (100% 확정)
투표 생성 요청 `POST /api/plugins/poll` 이 `hooks.server.ts` 의 확장 관리 게이트 정규식 **`/^\/api\/plugins\/[^/]+$/`** 에 걸립니다. 이 정규식은 `DELETE /api/plugins/{pluginId}`(플러그인 삭제, 관리자 전용)를 잡으려던 건데, **`POST /api/plugins/poll`(투표 생성)도 같은 depth·같은 패턴**이라 함께 걸려 **'poll 플러그인 삭제(관리자)'로 오인** → 비관리자(=모든 투표 작성자)가 `403 {error:'Unauthorized'}` → 프런트가 generic '잠시 후 다시 시도해 주세요'로 표시.

**검증:** web 파드에서 `POST /api/plugins/poll`(무인증) → **403 Unauthorized**(제보 스크린샷과 일치) / `GET .../by-post/...`(depth 더 깊음) → 200 정상. 백엔드 Create·can_create·경로는 모두 정상(별도 검증). angple_polls에 사용자 생성 투표 ~0건이 이를 뒷받침.

## 수정 (한 줄)
`/api/plugins/{id}` depth의 관리 동작은 **삭제(DELETE)뿐** → 관리자 게이트를 `method === 'DELETE'`로 좁힘. `POST/PUT /api/plugins/{id}`(플러그인 디스패처 회원 기능=투표 생성 등)는 그대로 통과(인증은 백엔드가 강제).

## 영향
- 투표 생성 정상화. 같은 패턴을 쓸 다른 플러그인 회원 POST도 함께 구제.
- 보안 무영향: 통과된 요청은 디스패처/백엔드 JWTAuth가 인증 강제. 플러그인 삭제(DELETE)는 여전히 관리자만.