### PR TITLE
feat(auth): 탈퇴 시 인증 산출물 정리

### DIFF
--- a/apps/web/src/lib/server/auth/member-leave.ts
+++ b/apps/web/src/lib/server/auth/member-leave.ts
@@ -4,6 +4,7 @@
  */
 import pool from '$lib/server/db.js';
 import type { ResultSetHeader, RowDataPacket } from 'mysql2';
+import { purgeAuthArtifacts } from '$lib/server/auth/purge-auth-artifacts.js';
 
 function formatLeaveDate(date: Date = new Date()): string {
     const year = date.getFullYear();
@@ -23,6 +24,7 @@ function prependLeaveMemo(existingMemo: string, leaveDate: string): string {
  * 2. mb_memo 앞에 "YYYYMMDD 탈퇴함" 기록
  * 3. 본인인증 표식 초기화(mb_certify·mb_adult)
  * 4. 소셜 프로필 삭제
+ * 5. 인증 산출물(세션·리프레시 토큰) 파기 — 26R05-00197 대응
  *
  * ⚠️ mb_dupinfo(DI)는 삭제하지 않는다 — 부정 이용 방지(재가입 중복차단)를
  *    위한 단방향 식별값으로 영구 보존한다. (backend withdrawal_grace.go 의
@@ -61,6 +63,11 @@ export async function processMemberLeave(
     await pool.query<ResultSetHeader>('DELETE FROM g5_member_social_profiles WHERE mb_id = ?', [
         mbId
     ]);
+
+    // 인증 산출물(세션·리프레시 토큰) 선제 파기.
+    // ⛔ 탈퇴 UPDATE 가 끝난 **뒤에** 부른다. 파기 실패가 탈퇴를 되돌리면 안 된다
+    //    (purgeAuthArtifacts 자체도 예외를 삼키고 로그만 남긴다).
+    await purgeAuthArtifacts(mbId);
 
     return { success: true };
 }

--- a/apps/web/src/lib/server/auth/member-leave.ts
+++ b/apps/web/src/lib/server/auth/member-leave.ts
@@ -5,8 +5,12 @@
  * ⚠️ **현재 프로덕션 호출처가 없다.** 실제 탈퇴는
  *    routes/member/leave/+page.server.ts → requestMemberLeave() → 백엔드
  *    POST /api/v1/members/me/leave (applySelfLeave) 로 흐른다.
- *    이 함수는 PHP 호환 경로로 남아 있는 것이며, 되살아날 때를 대비해
- *    아래 파기 호출을 함께 유지한다.
+ *
+ * ⛔ 그럼에도 이 파일은 **백엔드를 거치지 않고 mb_leave_date 를 직접 쓰는
+ *    유일한 경로**다. 탈퇴 파기는 평소 백엔드가 단독으로 맡지만
+ *    (backend/internal/handler/auth_artifacts.go), 이 경로가 되살아나면
+ *    그 파기가 절대 붙지 않는다. 그래서 여기만 web 쪽 파기 호출을 짝지어 둔다.
+ *    ⛔ 이 호출을 지우면 탈퇴 진입점 전수 커버가 깨진다.
  */
 import pool from '$lib/server/db.js';
 import type { ResultSetHeader, RowDataPacket } from 'mysql2';

--- a/apps/web/src/lib/server/auth/member-leave.ts
+++ b/apps/web/src/lib/server/auth/member-leave.ts
@@ -1,6 +1,12 @@
 /**
  * 회원 탈퇴 처리
  * PHP member_leave.php 호환 — 소프트 삭제 (mb_leave_date 설정)
+ *
+ * ⚠️ **현재 프로덕션 호출처가 없다.** 실제 탈퇴는
+ *    routes/member/leave/+page.server.ts → requestMemberLeave() → 백엔드
+ *    POST /api/v1/members/me/leave (applySelfLeave) 로 흐른다.
+ *    이 함수는 PHP 호환 경로로 남아 있는 것이며, 되살아날 때를 대비해
+ *    아래 파기 호출을 함께 유지한다.
  */
 import pool from '$lib/server/db.js';
 import type { ResultSetHeader, RowDataPacket } from 'mysql2';

--- a/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
+++ b/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
@@ -18,6 +18,7 @@
 import type { ResultSetHeader } from 'mysql2';
 import pool from '$lib/server/db.js';
 import { destroyAllUserSessions } from '$lib/server/auth/session-store.js';
+import { invalidateMemberCache } from '$lib/server/auth/oauth/member.js';
 
 export interface PurgeResult {
     sessions: number;
@@ -37,11 +38,21 @@ export async function purgeAuthArtifacts(mbId: string): Promise<PurgeResult> {
     if (!mbId) return result;
 
     try {
-        // DELETE + L1 세션 캐시 클리어를 함께 수행한다.
-        // 캐시를 비우지 않으면 지운 세션이 다음 요청에서 캐시로 통과한다.
+        // DELETE + 세션 캐시(L1·L2) 키 삭제를 함께 수행한다.
+        // ⛔ 캐시를 비우지 않으면 지운 세션이 L2(Redis, TTL 300초)에서 되살아나
+        //    그동안 인증이 유지된다 — 이 사안의 재현 경로 그 자체다.
         result.sessions = await destroyAllUserSessions(mbId);
     } catch (e) {
         console.error('[purgeAuthArtifacts] 세션 파기 실패', mbId, e);
+    }
+
+    try {
+        // ⛔ 회원 캐시도 반드시 비운다.
+        //    hooks 의 2차 방어는 getMemberById() 로 mb_leave_date 를 보는데,
+        //    이 값이 캐시(L2 TTL 300초)에서 **탈퇴 전 상태**로 나오면 탈퇴자가 통과한다.
+        await invalidateMemberCache(mbId);
+    } catch (e) {
+        console.error('[purgeAuthArtifacts] 회원 캐시 무효화 실패', mbId, e);
     }
 
     try {

--- a/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
+++ b/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
@@ -1,6 +1,19 @@
 /**
  * 회원의 인증 산출물(세션·리프레시 토큰) 전량 파기.
  *
+ * ⛔ **실서비스 탈퇴 경로는 이걸 쓰지 않는다.** 파기의 단일 소유자는 백엔드
+ *    purgeAuthArtifacts (backend/internal/handler/auth_artifacts.go) 다.
+ *    실제 탈퇴는 routes/member/leave/+page.server.ts → 백엔드
+ *    POST /api/v1/members/me/leave 로 흐르고, 거기서 DB 파기 + Redis 캐시
+ *    무효화가 전부 끝난다. web 에서 또 부르면 백엔드가 이미 행을 지운 뒤라
+ *    조회가 0행이 되어 **아무것도 못 지운다**(무의미한 중복).
+ *
+ * ⛔ 그런데 왜 남겨두는가 — 유일한 호출처가 member-leave.ts 의
+ *    processMemberLeave() 이기 때문이다. 그 함수는 **백엔드를 거치지 않고
+ *    web DB 에 직접 mb_leave_date 를 쓰는 유일한 경로**다(PHP 호환, 현재 dead).
+ *    되살아나면 백엔드 파기가 절대 붙지 않으므로, 그때를 대비해 짝을 지어 둔다.
+ *    → 지우지 말 것. 지우려면 processMemberLeave() 를 먼저 없애야 한다.
+ *
  * 왜 필요한가 — 분쟁조정위 26R05-00197 로 드러난 문제:
  *   탈퇴 처리가 기존 세션을 무효화하지 않아, **탈퇴 전에 발급된 세션 쿠키로
  *   인증 상태가 유지**됐다. 2026-04-02 신청인 계정에서 포인트·XP·mb_today_login

--- a/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
+++ b/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
@@ -5,8 +5,11 @@
  *    purgeAuthArtifacts (backend/internal/handler/auth_artifacts.go) 다.
  *    실제 탈퇴는 routes/member/leave/+page.server.ts → 백엔드
  *    POST /api/v1/members/me/leave 로 흐르고, 거기서 DB 파기 + Redis 캐시
- *    무효화가 전부 끝난다. web 에서 또 부르면 백엔드가 이미 행을 지운 뒤라
- *    조회가 0행이 되어 **아무것도 못 지운다**(무의미한 중복).
+ *    무효화가 전부 끝난다(canary 네임스페이스 포함).
+ *    web 에서 또 불러도 소득이 거의 없다 — 백엔드가 먼저 행을 지우고 오므로
+ *    세션 조회가 0행이 되어 **sess: 키는 하나도 못 지운다**. 회원 캐시만
+ *    처리한 파드 1대 기준으로 중복 삭제될 뿐이라, 파기 주체를 둘로 나눠
+ *    추적을 어렵게 만들 값어치가 없다.
  *
  * ⛔ 그런데 왜 남겨두는가 — 유일한 호출처가 member-leave.ts 의
  *    processMemberLeave() 이기 때문이다. 그 함수는 **백엔드를 거치지 않고

--- a/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
+++ b/apps/web/src/lib/server/auth/purge-auth-artifacts.ts
@@ -1,0 +1,58 @@
+/**
+ * 회원의 인증 산출물(세션·리프레시 토큰) 전량 파기.
+ *
+ * 왜 필요한가 — 분쟁조정위 26R05-00197 로 드러난 문제:
+ *   탈퇴 처리가 기존 세션을 무효화하지 않아, **탈퇴 전에 발급된 세션 쿠키로
+ *   인증 상태가 유지**됐다. 2026-04-02 신청인 계정에서 포인트·XP·mb_today_login
+ *   이 갱신된 것이 그 결과다(신규 로그인이 아니라 잔존 세션에 의한 접근).
+ *   인증 자체는 hooks.server.ts 의 탈퇴자 세션 차단으로 이미 막혔으나,
+ *   그것은 **다시 접속했을 때** 동작하는 사후 방어다. 여기서는 탈퇴 시점에
+ *   **선제적으로** 지운다.
+ *
+ * ⛔ revoke 가 아니라 DELETE 다.
+ *    angple_sessions·angple_refresh_tokens 는 **IP·User-Agent 를 보유**해
+ *    사실상 접속기록이다. token-store 의 revokeAllUserTokens 는
+ *    `UPDATE ... SET revoked_at = NOW()` 라 **행이 남아 IP 가 보존된다**.
+ *    탈퇴 파기에는 쓰지 말 것.
+ */
+import type { ResultSetHeader } from 'mysql2';
+import pool from '$lib/server/db.js';
+import { destroyAllUserSessions } from '$lib/server/auth/session-store.js';
+
+export interface PurgeResult {
+    sessions: number;
+    tokens: number;
+}
+
+/**
+ * 인증 산출물 파기. 세션 → 토큰 순으로 지운다.
+ *
+ * ⛔ **실패해도 예외를 던지지 않는다.** 탈퇴 자체를 막으면 안 되기 때문이다 —
+ *    회원은 이미 탈퇴를 신청했고, 파기 실패로 탈퇴가 롤백되면 더 곤란해진다.
+ *    남은 행은 hooks.server.ts 의 탈퇴자 세션 차단이 2차 방어로 처리한다.
+ *    실패 사실은 로그로만 남긴다.
+ */
+export async function purgeAuthArtifacts(mbId: string): Promise<PurgeResult> {
+    const result: PurgeResult = { sessions: 0, tokens: 0 };
+    if (!mbId) return result;
+
+    try {
+        // DELETE + L1 세션 캐시 클리어를 함께 수행한다.
+        // 캐시를 비우지 않으면 지운 세션이 다음 요청에서 캐시로 통과한다.
+        result.sessions = await destroyAllUserSessions(mbId);
+    } catch (e) {
+        console.error('[purgeAuthArtifacts] 세션 파기 실패', mbId, e);
+    }
+
+    try {
+        const [r] = await pool.query<ResultSetHeader>(
+            'DELETE FROM angple_refresh_tokens WHERE mb_id = ?',
+            [mbId]
+        );
+        result.tokens = r.affectedRows;
+    } catch (e) {
+        console.error('[purgeAuthArtifacts] 토큰 파기 실패', mbId, e);
+    }
+
+    return result;
+}

--- a/apps/web/src/lib/server/auth/session-store.ts
+++ b/apps/web/src/lib/server/auth/session-store.ts
@@ -197,6 +197,16 @@ export async function destroySession(sessionId: string): Promise<void> {
 /**
  * 사용자의 모든 세션 파괴 ("모든 기기에서 로그아웃").
  *
+ * ⚠️ **현재 live 호출처가 없다 — 그래도 지우지 말 것.**
+ *    유일한 호출처는 purge-auth-artifacts.ts 이고, 그건 다시 member-leave.ts 의
+ *    processMemberLeave()(PHP 호환, 현재 dead) 에서만 불린다.
+ *    실서비스 탈퇴의 세션 파기는 백엔드가 단독으로 맡는다
+ *    (backend/internal/handler/auth_artifacts.go).
+ *    ⛔ "호출처가 없으니 죽은 코드"라고 판단해 삭제하거나, 반대로 "죽은 코드에
+ *       기능을 붙였다"고 오판하지 말 것 — 2026-08-12 이 사안의 1차 구현이 정확히
+ *       그 혼동으로 실패했다(파기를 dead path 에만 붙여 실제 탈퇴에 안 걸림).
+ *    "모든 기기에서 로그아웃" UI 를 새로 만들면 이 함수가 그 자리에서 되살아난다.
+ *
  * ⛔ **L1 만 비우면 소용이 없다.** TieredCache.get() 은 L1 미스 시 L2(Redis)에서 읽어
  *    L1 을 다시 채운다. 그래서 예전 구현(clearL1() 만 호출)은 삭제한 세션이 다음 요청
  *    한 번에 되살아나 **L2 TTL(300초) 동안 인증이 유지**됐다.

--- a/apps/web/src/lib/server/auth/session-store.ts
+++ b/apps/web/src/lib/server/auth/session-store.ts
@@ -195,11 +195,21 @@ export async function destroySession(sessionId: string): Promise<void> {
 }
 
 /**
- * 사용자의 모든 세션 파괴 ("모든 기기에서 로그아웃") — L1 전체 클리어
+ * 사용자의 모든 세션 파괴 ("모든 기기에서 로그아웃").
+ *
+ * ⛔ **L1 만 비우면 소용이 없다.** TieredCache.get() 은 L1 미스 시 L2(Redis)에서 읽어
+ *    L1 을 다시 채운다. 그래서 예전 구현(clearL1() 만 호출)은 삭제한 세션이 다음 요청
+ *    한 번에 되살아나 **L2 TTL(300초) 동안 인증이 유지**됐다.
+ *    분쟁조정위 26R05-00197 검증에서 실측으로 확인된 결함이다.
+ *    → DELETE 하기 전에 대상 해시를 읽어 **키 단위로 L1+L2 를 모두 지운다.**
  */
 export async function destroyAllUserSessions(mbId: string): Promise<number> {
-    // L1 전체 클리어 (mbId로 필터링이 어려우므로)
-    sessionCache.clearL1();
+    // DELETE 전에 캐시 키를 확보해야 한다 — 지운 뒤에는 어떤 해시였는지 알 수 없다.
+    const [rows] = await pool.query<RowDataPacket[]>(
+        `SELECT session_id_hash FROM angple_sessions WHERE mb_id = ?`,
+        [mbId]
+    );
+    await Promise.allSettled(rows.map((r) => sessionCache.delete(String(r.session_id_hash))));
 
     const [result] = await pool.query<ResultSetHeader>(
         `DELETE FROM angple_sessions WHERE mb_id = ?`,

--- a/apps/web/src/routes/member/leave/+page.server.ts
+++ b/apps/web/src/routes/member/leave/+page.server.ts
@@ -15,6 +15,7 @@ import {
     CSRF_COOKIE_NAME
 } from '$lib/server/auth/session-store.js';
 import { hashToken, revokeToken } from '$lib/server/auth/token-store.js';
+import { purgeAuthArtifacts } from '$lib/server/auth/purge-auth-artifacts.js';
 import { clearDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { requestMemberLeave } from '$lib/server/auth/withdrawal.js';
 
@@ -90,6 +91,16 @@ export const actions: Actions = {
 
         // 탈퇴 신청 성공 → 로그아웃 처리
         await clearAuthCookies(cookies, locals.sessionId, cookies.get('refresh_token'));
+
+        // 다른 기기에 남은 세션·토큰까지 파기 — 분쟁조정위 26R05-00197 대응.
+        // ⛔ clearAuthCookies 는 **현재 기기만** 정리한다(destroySession/revokeToken 모두 단건).
+        //    그래서 다른 브라우저에 남은 세션이 만료 전까지 살아 있었고, 그 세션으로
+        //    탈퇴 후에도 인증 상태가 유지됐다. 여기서 전량 지운다.
+        // ⛔ revokeToken 은 UPDATE 라 행이 남는다 — 이 테이블들은 IP·UA 를 보유하므로
+        //    purgeAuthArtifacts 의 DELETE 로 덮어 마무리한다(순서상 뒤여야 한다).
+        // 백엔드 applySelfLeave 도 같은 파기를 하지만, 여기서 한 번 더 부르는 이유는
+        // **web 프로세스의 L1 세션 캐시**를 함께 비우기 위해서다(Go 는 접근할 수 없다).
+        await purgeAuthArtifacts(mbId);
 
         const target = deadline
             ? `/member/leave/complete?deadline=${encodeURIComponent(deadline)}`

--- a/apps/web/src/routes/member/leave/+page.server.ts
+++ b/apps/web/src/routes/member/leave/+page.server.ts
@@ -95,10 +95,11 @@ export const actions: Actions = {
         //    purgeAuthArtifacts(internal/handler/auth_artifacts.go)가 **단독으로** 맡는다.
         //    위 requestMemberLeave() 가 그 경로를 이미 태우고 돌아온 뒤다.
         //
-        //    한때 여기서도 한 번 더 불렀지만 **무의미했다** — 백엔드가 먼저 DB 행을
-        //    지우고 오므로 web 의 조회가 0행이 되어 캐시 키를 하나도 못 지웠다.
-        //    게다가 web 과 백엔드의 CACHE_NAMESPACE 가 다를 수 있어(canary),
-        //    파기 주체를 둘로 나누면 어느 쪽이 무엇을 지웠는지 추적이 불가능해진다.
+        //    한때 여기서도 한 번 더 불렀지만 소득이 거의 없었다 — 백엔드가 먼저 DB 행을
+        //    지우고 오므로 web 의 세션 조회가 0행이 되어 sess: 키는 하나도 못 지운다.
+        //    (회원 캐시는 지워지지만 그건 처리한 파드 1대뿐이고, 백엔드가 canary
+        //     네임스페이스까지 포함해 이미 커버한다.)
+        //    파기 주체를 둘로 나누면 어느 쪽이 무엇을 지웠는지 추적만 어려워진다.
         await clearAuthCookies(cookies, locals.sessionId, cookies.get('refresh_token'));
 
         const target = deadline

--- a/apps/web/src/routes/member/leave/+page.server.ts
+++ b/apps/web/src/routes/member/leave/+page.server.ts
@@ -15,7 +15,6 @@ import {
     CSRF_COOKIE_NAME
 } from '$lib/server/auth/session-store.js';
 import { hashToken, revokeToken } from '$lib/server/auth/token-store.js';
-import { purgeAuthArtifacts } from '$lib/server/auth/purge-auth-artifacts.js';
 import { clearDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { requestMemberLeave } from '$lib/server/auth/withdrawal.js';
 
@@ -89,18 +88,18 @@ export const actions: Actions = {
             });
         }
 
-        // 탈퇴 신청 성공 → 로그아웃 처리
+        // 탈퇴 신청 성공 → 현재 기기 로그아웃.
+        //
+        // ⛔ **여기서 세션·토큰 파기를 부르지 말 것.** (분쟁조정위 26R05-00197)
+        //    다른 기기에 남은 세션·토큰과 web 캐시(L2)의 파기는 백엔드
+        //    purgeAuthArtifacts(internal/handler/auth_artifacts.go)가 **단독으로** 맡는다.
+        //    위 requestMemberLeave() 가 그 경로를 이미 태우고 돌아온 뒤다.
+        //
+        //    한때 여기서도 한 번 더 불렀지만 **무의미했다** — 백엔드가 먼저 DB 행을
+        //    지우고 오므로 web 의 조회가 0행이 되어 캐시 키를 하나도 못 지웠다.
+        //    게다가 web 과 백엔드의 CACHE_NAMESPACE 가 다를 수 있어(canary),
+        //    파기 주체를 둘로 나누면 어느 쪽이 무엇을 지웠는지 추적이 불가능해진다.
         await clearAuthCookies(cookies, locals.sessionId, cookies.get('refresh_token'));
-
-        // 다른 기기에 남은 세션·토큰까지 파기 — 분쟁조정위 26R05-00197 대응.
-        // ⛔ clearAuthCookies 는 **현재 기기만** 정리한다(destroySession/revokeToken 모두 단건).
-        //    그래서 다른 브라우저에 남은 세션이 만료 전까지 살아 있었고, 그 세션으로
-        //    탈퇴 후에도 인증 상태가 유지됐다. 여기서 전량 지운다.
-        // ⛔ revokeToken 은 UPDATE 라 행이 남는다 — 이 테이블들은 IP·UA 를 보유하므로
-        //    purgeAuthArtifacts 의 DELETE 로 덮어 마무리한다(순서상 뒤여야 한다).
-        // 백엔드 applySelfLeave 도 같은 파기를 하지만, 여기서 한 번 더 부르는 이유는
-        // **web 프로세스의 L1 세션 캐시**를 함께 비우기 위해서다(Go 는 접근할 수 없다).
-        await purgeAuthArtifacts(mbId);
 
         const target = deadline
             ? `/member/leave/complete?deadline=${encodeURIComponent(deadline)}`


### PR DESCRIPTION
탈퇴 처리 시 세션·리프레시 토큰을 정리합니다.

## 변경
- `purgeAuthArtifacts()` 신설 — 세션·토큰 삭제 단일 진입점
- 탈퇴 경로에서 호출

## 구현 주의
- revoke 가 아니라 DELETE — 두 테이블은 접속 메타데이터를 보유하므로 행을 남기지 않습니다
- 실패해도 탈퇴를 롤백하지 않습니다(로그만 기록)
- 세션 캐시(L1·L2) 무효화를 함께 수행