### PR TITLE
feat(affiliate): 글 조회 시 미변환 제휴 링크 lazy 변환 (배포에 견디는 트리거)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -6,7 +6,8 @@ import {
     applyAffiliateField,
     fetchPostAffiliateLinks,
     findAffiliateFieldRow,
-    renderAffiliateContent
+    renderAffiliateContent,
+    syncPostAffiliateLinks
 } from '$lib/server/affiliate-links.js';
 import { isLinkProcessingPluginEnabled } from '$lib/server/link-processing/runtime.js';
 import { isScraped } from '$lib/server/scrap.js';
@@ -505,6 +506,28 @@ export const load: PageServerLoad = async ({
             const postAffiliateRows = affiliateEnabled
                 ? await fetchPostAffiliateLinks(boardId, Number(postId)).catch(() => [])
                 : [];
+
+            // 제휴 링크 lazy-convert-on-view (배포에 견디는 트리거).
+            // 근본 원인: 지속형 자동 트리거가 배포 시스템 밖(go-service watcher)에 살아
+            // 매 배포마다 죽어, 신규글이 변환되지 않고 매출이 끊겼다(2026-08-08 이후 $0).
+            // 변환된 행이 0개(= 아직 미변환)이고 본문/링크에 외부 링크가 있을 때만
+            // syncPostAffiliateLinks 를 fire-and-forget 로 호출한다. 트리거가 web 이미지
+            // 안에 살아 배포에 견디며, 다음 조회부터 변환 링크가 노출된다.
+            // 값싼 게이트로 링크 없는 글은 걸러 과발화를 막고, 행이 생기면 다시 발화하지 않는다.
+            if (
+                affiliateEnabled &&
+                postAffiliateRows.length === 0 &&
+                (Boolean(post.link1) ||
+                    Boolean(post.link2) ||
+                    (typeof post.content === 'string' && post.content.includes('http')))
+            ) {
+                try {
+                    // await 금지 — SSR 렌더/응답을 절대 블로킹·지연하지 않는다. 에러는 삼킨다.
+                    void syncPostAffiliateLinks(boardId, Number(postId)).catch(() => {});
+                } catch {
+                    // 트리거 실패해도 페이지는 오늘과 동일하게 렌더된다.
+                }
+            }
 
             // link1/link2 제휴 변환 결과 계산 (post 객체는 mutate 하지 않고 별도 payload 로 전달).
             const linkAffiliate: {


### PR DESCRIPTION
## 근본 원인 (제휴 링크 no-trigger)

제휴 링크 변환(kyobobook/yes24/coupang/11st/gmarket/aliexpress/amazon/lotteon → LinkPrice `/go` 리다이렉트, `g5_affiliate_links` 기록)은 **코드로는 건강**하지만, 지속형 자동 트리거가 없습니다. 변환은 내부 API `POST /api/internal/affiliate/sync` 호출 시에만 일어나고, 과거 트리거(go-service watcher)는 **배포되는 시스템 밖**에 살아 매 배포마다 죽었습니다. 그 결과 8/8 이후 신규글이 변환되지 않아 4일간 매출이 끊겼습니다("매 배포마다 깨진다"의 원인).

## 변경 (lazy-convert-on-view · 배포에 견디는 트리거)

글 상세 SSR 로더 `apps/web/src/routes/[boardId]/[postId]/+page.server.ts` 의 제휴 블록에서, 이미 존재 행을 읽어 적용하던 경로에 **미변환 글의 최초 변환**을 얹습니다.

- `affiliateEnabled === true` **그리고** `fetchPostAffiliateLinks` 결과가 **빈 배열**(아직 미변환) **그리고** 값싼 게이트 통과 시에만 `syncPostAffiliateLinks(boardId, postId)` 를 **fire-and-forget** 로 호출합니다.
- 트리거가 배포되는 **web 이미지 안**에 살아 배포에 견딥니다(deploy-proof). 다음 조회부터 변환된 링크가 노출됩니다.

### 값싼 게이트 (과발화 방지)
추가 데이터 조회 없이, 로더에 이미 있는 필드만 사용: `post.link1` 또는 `post.link2` 존재, 또는 `post.content` 에 `http` 포함. 링크 없는 텍스트 글은 걸러냅니다.

### fire-and-forget
`void syncPostAffiliateLinks(...).catch(() => {})` 를 `try/catch` 로 감쌉니다. **절대 await 하지 않으며** SSR 렌더/응답 타이밍·형태에 영향이 없습니다. 무슨 일이 있어도 페이지는 오늘과 동일하게 렌더됩니다.

### 멱등 / 무-스톰
변환 행이 **0개일 때만** 발화합니다. `syncPostAffiliateLinks` 는 백필과 동일 함수로, 대상 행을 DELETE 후 재-INSERT(dedupe)합니다. 최초 sync 후에는 행이 생기므로(unsupported 포함) 재발화하지 않아 스톰이 없습니다. 드문 이중 발화도 무해합니다.

## 범위
web-only. 백엔드 · `write_repo.go` · 읽기/적용 경로 · 페이지네이션 미변경. 댓글 변환은 이번 PR 범위 밖(저위험 유지).

## 성능
핫 경로인 글 상세 SSR을 늦추지 않습니다. 발화 전 `postAffiliateRows`(이미 조회됨)와 로더에 있는 필드만 검사하므로 추가 왕복이 없고, 실제 sync는 await 없이 백그라운드로 흘립니다.
