### PR TITLE
fix(layout): 사이드바 메뉴를 SSR 시점에도 렌더해 CLS 제거

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -11,6 +11,7 @@
     import { cn } from '$lib/utils';
     import { handleBoardLinkClick } from '$lib/utils/board-nav.js';
     import { menuStore } from '$lib/stores/menu.svelte';
+    import type { MenuItem } from '$lib/api/types';
 
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
     import { getIcon } from '$lib/utils/icon-map';
@@ -33,8 +34,15 @@
 
     let isCollapsed = $state(false);
 
-    // 메뉴 데이터는 SSR에서 초기화된 스토어에서 가져옴
-    const menuData = $derived(menuStore.menus.filter((m) => m.show_in_sidebar !== false));
+    // 메뉴 데이터는 SSR에서 초기화된 스토어에서 가져옴.
+    // ⛔ 단 스토어를 채우는 +layout.svelte 의 initFromServer 는 $effect 안에 있고,
+    //    $effect 는 서버에서 실행되지 않는다 → SSR 렌더 시점의 스토어는 항상 비어 있다.
+    //    그대로 두면 서버 HTML 의 사이드바가 빈 채로 나가고, 하이드레이션 직후 메뉴
+    //    610px 이 한꺼번에 생기며 아래를 전부 밀어낸다(2026-08-12 실측 CLS 0.1045).
+    //    스토어가 비어 있는 동안에는 SSR 로 이미 내려와 있는 page.data.menus 를 직접 읽는다.
+    const ssrMenus = $derived(($page.data?.menus ?? []) as MenuItem[]);
+    const sourceMenus = $derived(menuStore.menus.length > 0 ? menuStore.menus : ssrMenus);
+    const menuData = $derived(sourceMenus.filter((m) => m.show_in_sidebar !== false));
 
     // 빠른 바로가기: DB 메뉴 그룹(센티넬 URL)의 자식을 즐겨찾기 아래 2열 그리드로 렌더한다.
     // 라벨/URL/아이콘은 전부 DB(menus 테이블)에서 오며(하드코딩 없음), 관리자가 그룹의


### PR DESCRIPTION
## 배경

8/11 감사 대응으로 넣은 fe#2040(AdSense Multiplex 300px 예약)이 **CLS 를 거의 줄이지 못했다**는 것이 재측정으로 드러났다.

| 뷰포트 | CLS | |
|---|---|---|
| 데스크톱 1491×825 | **0.1045** | 감사 당시 0.111에서 거의 그대로 |
| 모바일 390×844 | 0.0017 | 정상 |

데스크톱에만 발생하고 모바일은 멀쩡하다는 것이 열쇠였다 — 모바일엔 사이드바가 없다.
shift 상위 3건이 전체의 **96%** 이고 전부 사이드바다.

## 원인

`+layout.svelte:232` 가 `$effect` 안에서 스토어를 초기화한다.

```js
// SSR에서 받은 테마/메뉴로 스토어 초기화 (깜박임 방지!)   ← 의도와 반대로 동작
$effect(() => {
    if (menus.length > 0) menuStore.initFromServer(menus);
});
```

**`$effect` 는 서버에서 실행되지 않는다.** 따라서

1. `+layout.server.ts:166` 이 `menus` 를 정상적으로 내려준다 ✅
2. 그런데 SSR 렌더 시점의 `menuStore.menus` 는 `[]` → **서버 HTML 의 사이드바가 비어 있다**
3. `loading` 초기값도 `false` 라 스켈레톤조차 안 나온다
4. 하이드레이션 후 $effect 발화 → 메뉴 **610~682px** 가 갑자기 생성 → 아래 전부 밀림

## 변경

`sidebar.svelte` 에서 스토어가 비어 있는 동안에는 SSR 로 이미 내려와 있는 `page.data.menus` 를 직접 읽는다.
`page` 는 이 파일에서 이미 쓰고 있어 신규 의존이 없다.

스토어가 채워진 뒤 동작은 종전과 동일하므로 **관리자 메뉴 갱신 경로는 영향받지 않는다.**

⛔ 전역 스토어를 SSR 에서 채우는 방식은 쓰지 않았다 — 모듈 스코프 스토어는 서버에서 요청 간 공유되어 오염 위험이 있다.

## 검증 (승격 후 Evaluator 가 수행)

- [ ] 데스크톱 CLS **< 0.05** (동일 Playwright 스크립트로 재측정)
- [ ] SSR HTML(curl, JS 미실행)에 좌측 메뉴 항목이 **포함**될 것 — 현재는 없다
- [ ] 모바일 CLS 가 0.0017 에서 나빠지지 않을 것
- [ ] 관리자 메뉴 수정 → 사이드바 즉시 반영 / 로그인·비로그인 동일 동작

## 범위 밖

- 우측 `Panel` 위젯 shift(0.0638) — 동일 원인으로 추정되나 `WidgetRenderer` 구조 미확인. **이 PR 배포 후 실측하여 판단**
- Multiplex 가 `unfilled` 인데 300px 점유하는 문제 — 빈 공간 낭비이지 CLS 원인은 아님

설계서: `/home/damoang/docs/2026-08-12-cls-sidebar-sprint-contract.html`