### PR TITLE
feat(giving): N-2 참가 조건 UI (설정 폼 + 참가 안내)

### DIFF
--- a/apps/web/src/lib/features/giving/api.ts
+++ b/apps/web/src/lib/features/giving/api.ts
@@ -58,6 +58,15 @@ export interface GivingDetail {
     seed_hash: string | null;
     config_status: string;
     unit_price: number;
+    /**
+     * N-2 참가 조건. 0 이면 제한 없음. 구 응답에는 없으므로 optional.
+     *
+     * entry_point_cost 는 무료 방식에만 적용된다 — 유료(lowest_unique)는 번호당
+     * 단가를 이미 내므로 백엔드가 참가비를 부과하지 않는다.
+     * 차감된 포인트는 전액 소각되며 반환되지 않는다.
+     */
+    entry_min_days?: number;
+    entry_point_cost?: number;
     status: 'active' | 'waiting' | 'paused' | 'ended' | 'no_giving';
     is_paused: boolean;
     is_urgent: boolean;
@@ -109,8 +118,24 @@ export const givingApi = {
 
     config(
         id: number | string,
-        payload: { method: GivingMethod; capacity?: number | null; number_max?: number | null }
-    ): Promise<{ wr_id: number; method: string; seed_hash: string }> {
+        payload: {
+            method: GivingMethod;
+            capacity?: number | null;
+            number_max?: number | null;
+            /**
+             * N-2 참가 조건. 미전송이면 백엔드가 기존 값을 유지한다.
+             * 응모가 1건이라도 있으면 변경 시 409 다.
+             */
+            entry_min_days?: number;
+            entry_point_cost?: number;
+        }
+    ): Promise<{
+        wr_id: number;
+        method: string;
+        seed_hash: string;
+        entry_min_days?: number;
+        entry_point_cost?: number;
+    }> {
         return call(`/config/${id}`, { method: 'POST', body: JSON.stringify(payload) });
     },
 

--- a/apps/web/src/lib/features/giving/giving-participation.svelte
+++ b/apps/web/src/lib/features/giving/giving-participation.svelte
@@ -26,6 +26,9 @@
     let cfgCapacity = $state(1);
     let cfgNumberMax = $state(100);
     let cfgUnit = $state(100);
+    // N-2 참가 조건 (0 = 제한 없음)
+    let cfgEntryMinDays = $state(0);
+    let cfgEntryPointCost = $state(0);
 
     async function load() {
         loadError = null;
@@ -36,6 +39,8 @@
             cfgCapacity = d.capacity ?? 1;
             cfgNumberMax = d.number_max ?? 100;
             cfgUnit = d.unit_price || 100;
+            cfgEntryMinDays = d.entry_min_days ?? 0;
+            cfgEntryPointCost = d.entry_point_cost ?? 0;
         } catch (e) {
             loadError = e instanceof Error ? e.message : '나눔 정보를 불러오지 못했습니다.';
         }
@@ -104,6 +109,14 @@
     const parsedPreview = $derived(numbersInput ? parseBidNumbers(numbersInput) : []);
     const estCost = $derived(parsedPreview.length * (detail?.unit_price ?? 0));
 
+    // N-2 참가 조건. 참가비는 무료 방식에만 부과된다(백엔드와 같은 규칙) —
+    // 유료 방식은 번호당 단가를 이미 내므로 이중 부과가 되지 않게 제외돼 있다.
+    const entryMinDays = $derived(detail?.entry_min_days ?? 0);
+    const entryPointCost = $derived(METHOD_INFO[method].paid ? 0 : (detail?.entry_point_cost ?? 0));
+    const hasEntryCondition = $derived(entryMinDays > 0 || entryPointCost > 0);
+    // 응모가 하나라도 있으면 백엔드가 조건 변경을 409 로 막는다. 화면에서도 미리 잠근다.
+    const hasBids = $derived((detail?.total_bids ?? 0) > 0 || (detail?.participant_count ?? 0) > 0);
+
     function flash(msg: string, isErr = false) {
         if (isErr) {
             actionErr = msg;
@@ -154,7 +167,9 @@
             await givingApi.config(post.id, {
                 method: cfgMethod,
                 capacity: cfgCapacity,
-                number_max: cfgNumberMax
+                number_max: cfgNumberMax,
+                entry_min_days: cfgEntryMinDays,
+                entry_point_cost: cfgEntryPointCost
             });
             showSetup = false;
             flash('나눔 방식을 저장했습니다.');
@@ -298,6 +313,27 @@
 
         <!-- 참가 UI (비주최자, 진행 중, 미개표) -->
         {#if !detail.is_host && isActive && !drawn}
+            <!--
+                N-2 참가 조건 안내. 충족 여부는 백엔드가 판정하므로(가입일은 서버 시각 기준,
+                포인트는 차감 시점 잔액 기준) 화면에서 미리 막지 않고 조건만 명시한다.
+                미충족 시 백엔드가 사유를 담은 403/402 를 주고 guard() 가 그대로 띄운다.
+            -->
+            {#if hasEntryCondition && !detail.my_participation.joined}
+                <div
+                    class="border-border bg-muted/40 text-foreground mb-2 rounded-md border px-3 py-2 text-xs"
+                >
+                    <span class="font-medium">참가 조건</span>
+                    <span class="text-muted-foreground">
+                        {#if entryMinDays > 0}· 가입 {entryMinDays}일 이상{/if}
+                        {#if entryPointCost > 0}· 참가비 {entryPointCost.toLocaleString()}P{/if}
+                    </span>
+                    {#if entryPointCost > 0}
+                        <div class="text-muted-foreground mt-1">
+                            참가비는 응모 시 차감되며 <b>반환되지 않습니다</b>.
+                        </div>
+                    {/if}
+                </div>
+            {/if}
             {#if !authStore.isAuthenticated}
                 <p class="text-muted-foreground text-sm">참가하려면 로그인이 필요합니다.</p>
             {:else if method === 'lowest_unique'}
@@ -337,7 +373,11 @@
                         onclick={joinFree}
                         disabled={busy || detail.my_participation.joined}
                         class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50"
-                        >{detail.my_participation.joined ? '참가 완료' : '참가하기'}</button
+                        >{detail.my_participation.joined
+                            ? '참가 완료'
+                            : entryPointCost > 0
+                              ? `참가하기 (${entryPointCost.toLocaleString()}P)`
+                              : '참가하기'}</button
                     >
                 </div>
             {:else}
@@ -347,7 +387,11 @@
                     onclick={joinFree}
                     disabled={busy || detail.my_participation.joined}
                     class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50"
-                    >{detail.my_participation.joined ? '참가 완료' : '무료 응모하기'}</button
+                    >{detail.my_participation.joined
+                        ? '참가 완료'
+                        : entryPointCost > 0
+                          ? `응모하기 (${entryPointCost.toLocaleString()}P)`
+                          : '무료 응모하기'}</button
                 >
             {/if}
 
@@ -383,6 +427,57 @@
                             ※ 단가는 글 본문(번호 단가)에서 관리됩니다. 방식·정원·최대번호가
                             저장됩니다.
                         </p>
+
+                        <!-- N-2 참가 조건 -->
+                        <div class="border-border mt-3 space-y-2 border-t pt-3">
+                            <div class="text-foreground text-xs font-medium">
+                                참가 조건 <span class="text-muted-foreground font-normal"
+                                    >(0 = 제한 없음)</span
+                                >
+                            </div>
+                            <div class="grid grid-cols-2 gap-2">
+                                <label class="block">
+                                    <span class="text-muted-foreground mb-1 block text-xs"
+                                        >가입 후 경과일</span
+                                    >
+                                    <input
+                                        type="number"
+                                        min="0"
+                                        max="365"
+                                        bind:value={cfgEntryMinDays}
+                                        disabled={hasBids}
+                                        class="border-border bg-background w-full rounded-md border px-2 py-1 text-sm disabled:opacity-50"
+                                    />
+                                </label>
+                                <label class="block">
+                                    <span class="text-muted-foreground mb-1 block text-xs"
+                                        >참가비 (포인트)</span
+                                    >
+                                    <input
+                                        type="number"
+                                        min="0"
+                                        max="100000"
+                                        bind:value={cfgEntryPointCost}
+                                        disabled={hasBids || METHOD_INFO[cfgMethod].paid}
+                                        class="border-border bg-background w-full rounded-md border px-2 py-1 text-sm disabled:opacity-50"
+                                    />
+                                </label>
+                            </div>
+                            {#if METHOD_INFO[cfgMethod].paid}
+                                <p class="text-muted-foreground text-xs">
+                                    이 방식은 번호당 단가를 받으므로 참가비를 따로 받지 않습니다.
+                                </p>
+                            {:else if cfgEntryPointCost > 0}
+                                <p class="text-muted-foreground text-xs">
+                                    참가비는 응모 시 차감되며 <b>반환되지 않습니다</b>(소각).
+                                </p>
+                            {/if}
+                            {#if hasBids}
+                                <p class="text-muted-foreground text-xs">
+                                    이미 응모가 있어 참가 조건은 변경할 수 없습니다.
+                                </p>
+                            {/if}
+                        </div>
                         <button
                             type="button"
                             onclick={saveConfig}


### PR DESCRIPTION
## ⛔ 머지 순서

**be#659 (angple-backend) 승격 후** 머지할 것. 그 전에 올라가면 설정 폼은 보이는데 저장이 무시된다.
be#659 는 다시 **DDL 선행**이 필요하다.

```
DDL(g5_giving_meta 2컬럼) → be#659 머지·승격 → 이 PR 머지·승격
```

응답 필드를 optional 로 뒀기 때문에 순서가 어긋나도 **깨지지는 않는다**(0=제한 없음으로 동작). 다만 기능이 안 먹는다.

## 무엇을

be#659 의 화면 짝.

**설정 폼** (주최자)
- 가입 후 경과일 / 참가비 입력
- 응모가 1건이라도 있으면 **비활성** — 백엔드가 409 로 막으므로 화면에서도 미리 잠근다
- 유료(`lowest_unique`) 선택 시 **참가비 입력 비활성**. 번호당 단가를 이미 받으므로 백엔드가 참가비를 부과하지 않는다.
  입력만 받아두면 저장돼도 무효라 혼란만 준다

**참가 영역** (응모자)
- 조건 칩 표시 (`가입 30일 이상 · 참가비 1,000P`)
- 참가비가 있으면 **`반환되지 않습니다`** 명시 + 버튼 라벨에도 금액 (`참가하기 (1,000P)`)

## 조건 충족 여부는 화면에서 미리 막지 않는다

가입일은 **서버 시각**, 포인트는 **차감 시점 잔액**이 기준이라 클라이언트 판정은 어긋날 수 있다.
미충족 시 백엔드가 사유를 담은 403/402 를 주고 기존 `guard()` 가 그대로 노출한다
(`가입 후 30일이 지나야 참가할 수 있습니다. (현재 12일)`).

> 설계서에는 "403 메시지를 화면 문구로 매핑" 이라고 적었는데, 실제 백엔드 메시지가 현재 상태(현재 N일)를
> 담고 있어 그대로 쓰는 편이 낫다고 판단해 바꿨다.

## 검증

- [ ] 조건 0/0 나눔 → 조건 칩 안 뜨고 종전과 동일
- [ ] 조건 설정 → 저장 후 재조회에 반영
- [ ] 응모 발생 후 조건 입력 비활성 + 사유 표시
- [ ] 유료 방식 선택 시 참가비 입력 비활성
- [ ] 미충족 참가 시도 → 백엔드 사유가 화면에 노출
- [ ] 참가비 있는 나눔에서 버튼 라벨에 금액 표시

be#659: https://github.com/damoang/angple-backend/pull/659