### PR TITLE
fix(widgets): 사이드바 위젯 스켈레톤을 실제 목록과 정합 (CLS)

### DIFF
--- a/widgets/giving/index.svelte
+++ b/widgets/giving/index.svelte
@@ -18,6 +18,12 @@
         is_urgent: boolean;
     }
 
+    /**
+     * 목록 개수. fetch 의 limit 과 로딩 스켈레톤 개수를 한 값으로 묶는다 —
+     * 둘이 어긋나면 하이드레이션 직후 높이가 바뀌어 그대로 CLS 가 된다.
+     */
+    const GIVING_WIDGET_LIMIT = 5;
+
     let items = $state<GivingItem[]>([]);
     let loading = $state(true);
     let error = $state(false);
@@ -34,8 +40,10 @@
     onMount(async () => {
         try {
             // timedFetch: 12s timeout + 1회 retry. (audit 2026-05-01 §3-1)
-            const res = await timedFetch(// tab=all: 진행중(임박순) 우선 + 최신 글 채움 — premium 포크와 동일 정책 (be#605 세트)
-                '/api/plugins/giving/list?tab=all&limit=5&sort=urgent');
+            const res = await timedFetch(
+                // tab=all: 진행중(임박순) 우선 + 최신 글 채움 — premium 포크와 동일 정책 (be#605 세트)
+                `/api/plugins/giving/list?tab=all&limit=${GIVING_WIDGET_LIMIT}&sort=urgent`
+            );
             if (res.ok) {
                 const data = await res.json();
                 if (data.success) {
@@ -78,13 +86,30 @@
     </h3>
 
     {#if loading}
-        <ul class="space-y-2">
-            {#each Array(3) as _}
-                <li class="bg-muted h-4 animate-pulse rounded"></li>
+        <!--
+            스켈레톤은 실제 목록과 **같은 개수·같은 구조**여야 한다.
+            onMount 는 SSR 에서 실행되지 않으므로 서버 HTML 에는 항상 이 블록이 나가고,
+            하이드레이션 후 실제 목록으로 교체되며 그 높이 차이가 그대로 CLS 가 된다.
+            개수는 위 fetch 의 limit(=5)과 맞춘다 — 바꾸면 여기도 같이 바꿔야 한다.
+            (2026-08-12 실측: 3개짜리 스켈레톤이 데스크톱 CLS 0.066 의 주범이었다)
+        -->
+        <ul class="text-muted-foreground space-y-2 text-xs">
+            {#each Array(GIVING_WIDGET_LIMIT) as _}
+                <li class="flex items-center gap-1.5">
+                    <span class="bg-muted h-4 min-w-0 flex-1 animate-pulse rounded"></span>
+                    <span class="bg-muted h-4 w-12 shrink-0 animate-pulse rounded"></span>
+                </li>
             {/each}
         </ul>
     {:else if error || items.length === 0}
-        <p class="text-muted-foreground py-2 text-center text-xs">진행중인 나눔이 없어요</p>
+        <!-- 빈 상태도 목록과 높이를 맞춰 축소 shift 를 막는다 -->
+        <div
+            class="text-muted-foreground flex items-center justify-center text-center text-xs"
+            style="min-height: calc({GIVING_WIDGET_LIMIT} * 1rem + {GIVING_WIDGET_LIMIT -
+                1} * 0.5rem)"
+        >
+            진행중인 나눔이 없어요
+        </div>
     {:else}
         <ul class="text-muted-foreground space-y-2 text-xs">
             {#each items as item (item.id)}

--- a/widgets/notice/index.svelte
+++ b/widgets/notice/index.svelte
@@ -22,6 +22,12 @@
     // ~50 MiB/h 누적. apiClient 가 이제 AbortSignal 을 받으므로
     // AbortController 로 timeout + unmount 통합 abort.
     const FETCH_TIMEOUT_MS = 12_000;
+
+    /**
+     * 표시 개수. 목록 slice 와 로딩 스켈레톤 개수를 한 값으로 묶는다 —
+     * 둘이 어긋나면 하이드레이션 직후 높이가 바뀌어 그대로 CLS 가 된다.
+     */
+    const NOTICE_WIDGET_LIMIT = 5;
     let controller: AbortController | null = null;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -45,7 +51,7 @@
                     return null;
                 })
             ]);
-            notices = noticesData.slice(0, 5);
+            notices = noticesData.slice(0, NOTICE_WIDGET_LIMIT);
             if (latestData?.items?.length) {
                 latestNotice = latestData.items[0];
             }
@@ -80,13 +86,27 @@
     </h3>
 
     {#if loading}
-        <ul class="space-y-2">
-            {#each Array(3) as _}
-                <li class="bg-muted h-4 animate-pulse rounded"></li>
+        <!--
+            스켈레톤 개수는 실제 목록(slice 0..NOTICE_WIDGET_LIMIT)과 맞춰야 한다.
+            onMount 는 SSR 에서 실행되지 않아 서버 HTML 에는 항상 이 블록이 나가고,
+            하이드레이션 후 실제 목록으로 교체되며 높이 차이가 그대로 CLS 가 된다.
+        -->
+        <ul class="text-muted-foreground space-y-2 text-xs">
+            {#each Array(NOTICE_WIDGET_LIMIT) as _}
+                <li class="flex items-center gap-1">
+                    <span class="bg-muted h-4 min-w-0 flex-1 animate-pulse rounded"></span>
+                </li>
             {/each}
         </ul>
     {:else if error || notices.length === 0}
-        <p class="text-muted-foreground py-2 text-center text-xs">아직 공지사항이 없어요</p>
+        <!-- 빈 상태도 목록과 높이를 맞춰 축소 shift 를 막는다 -->
+        <div
+            class="text-muted-foreground flex items-center justify-center text-center text-xs"
+            style="min-height: calc({NOTICE_WIDGET_LIMIT} * 1rem + {NOTICE_WIDGET_LIMIT -
+                1} * 0.5rem)"
+        >
+            아직 공지사항이 없어요
+        </div>
     {:else}
         <ul class="text-muted-foreground space-y-2 text-xs">
             {#each notices as notice (notice.id)}


### PR DESCRIPTION
## 배경

fe#2068(사이드바 SSR)로 데스크톱 CLS 가 **0.1045 → 0.0782** 로 내려갔다.
남은 shift 의 대부분(**0.066**)이 우측 사이드바 위젯이었다.

## 원인 — 좌측과 다르다

좌측은 `$effect` 안의 스토어 초기화가 SSR 에서 안 도는 문제였다.
우측은 위젯이 **각자 `onMount` 에서 fetch** 하는데, `onMount` 도 SSR 에서 실행되지 않는다.
그래서 서버 HTML 에는 **항상 로딩 스켈레톤**이 나가고, 하이드레이션 직후 실제 목록으로 교체되며
그 높이 차이가 그대로 CLS 가 된다.

그런데 **스켈레톤이 실제와 안 맞았다.**

| 위젯 | 실제 개수 | 스켈레톤 |
|---|---|---|
| giving | `limit=5` | **3개** |
| notice | `slice(0,5)` | **3개** |

## 수정

- 스켈레톤을 실제 목록과 **같은 개수·같은 마크업**으로 (`flex items-center gap-1.5` + 같은 텍스트 크기)
- 개수를 **상수 하나로 묶어** fetch limit 과 스켈레톤이 다시 어긋나지 않게 (`GIVING_WIDGET_LIMIT`, `NOTICE_WIDGET_LIMIT`)
- **빈 상태도 같은 높이 확보** — 종전에는 `진행중인 나눔이 없어요` 가 1줄이라 데이터가 없을 때 오히려 축소 shift 가 났다

## fe#2040(Multiplex 300px)과 무엇이 다른가

그쪽은 AdSense 크리에이티브 높이를 **알 수 없어 추정**이었고, 실제로 CLS 를 못 줄였다.
여기는 개수가 `limit` 으로 **고정**이라 정확히 맞출 수 있다. 추정이 아니다.

## 범위 밖 (측정 후 판단)

- `celebration`, `trending-groups` — 로딩 스켈레톤이 **아예 없다**. 구조가 달라 별도 확인 필요
- `image-text-banner` — `limit=4` / 스켈레톤 4개로 **이미 일치**. 손대지 않음

## 검증

- [ ] 승격 후 데스크톱 CLS **< 0.05** (Playwright 재측정)
- [ ] 모바일 CLS 0.0017 에서 나빠지지 않을 것
- [ ] 나눔·공지 위젯이 로딩 중/도착 후 **같은 높이**
- [ ] 나눔 0건일 때도 높이 유지