### PR TITLE
fix(cert): 실명인증 식별값 이중 저장·조회

### DIFF
--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -30,6 +30,28 @@ function getCertTokenKey(): string {
     return key;
 }
 
+/**
+ * DI 보조 키 — 2026-07-19 키 전환 대응.
+ *
+ * ⛔ 배경: 2026-07-19 경 DI 생성 키가 교체됐다. PHP(G5_TOKEN_ENCRYPTION_KEY)와
+ *    같은 키를 쓰던 것이 다른 값으로 바뀌면서, **같은 사람인데 다른 DI** 가
+ *    만들어져 재가입 중복차단이 25일간 무력화됐다
+ *    (실측: 같은 소셜계정 3쌍의 DI 상이 · 재가입 4명 통과).
+ *
+ *    원본 CI 는 저장되지 않아(단방향 해시) 소급 백필이 불가능하다. 그래서
+ *    **두 키로 각각 계산해 둘 다 저장·조회**한다. 그러면 어느 시기에 인증한
+ *    기존 계정이든 걸린다.
+ *
+ *      mb_dupinfo  = 주 키(PHP 와 동일)   → 2026-07-19 이전 인증 32,692명
+ *      mb_dupinfo2 = 보조 키(전환기 키)   → 2026-07-19~08-13 인증 1,292명
+ *
+ * ⛔ 주 키와 달리 fail-closed 로 막지 않는다. 미설정이면 보조 값을 만들지 않을 뿐,
+ *    주 키 경로(다수)는 정상 동작해야 한다. 없다고 인증 전체를 세우면 안 된다.
+ */
+function getCertTokenKeyAlt(): string {
+    return env.CERT_DUPINFO_ALT_KEY || '';
+}
+
 interface CertConfigRow extends RowDataPacket {
     cf_cert_use: number;
     cf_cert_req: number;
@@ -132,6 +154,18 @@ export async function getCertPendingMbId(mTxId: string): Promise<string | null> 
 export function buildDupinfo(ci: string): string {
     return createHash('sha256')
         .update(ci + getCertTokenKey())
+        .digest('hex');
+}
+
+/**
+ * 보조 DI 생성. 보조 키가 없으면 빈 문자열을 돌려준다(저장·조회에서 제외됨).
+ * ⛔ 빈 값이 저장되면 빈 값끼리 매칭될 수 있으므로, 호출부는 반드시 공백을 걸러야 한다.
+ */
+export function buildDupinfoAlt(ci: string): string {
+    const altKey = getCertTokenKeyAlt();
+    if (!altKey) return '';
+    return createHash('sha256')
+        .update(ci + altKey)
         .digest('hex');
 }
 
@@ -253,7 +287,8 @@ export async function flagDupinfoCollision(
 export async function saveCertResult(
     mbId: string,
     dupinfo: string,
-    birthDay: string
+    birthDay: string,
+    dupinfoAlt = ''
 ): Promise<void> {
     // DI 충돌 하드닝(구멍②) — 방어선(defense-in-depth).
     // 호출부(cert/inicis/result)는 이미 checkDupinfo 로 모든 dupinfo 충돌을 1차 차단하지만,
@@ -269,9 +304,11 @@ export async function saveCertResult(
     const adultDayStr = adult_day.toISOString().slice(0, 10).replace(/-/g, '');
     const adult = parseInt(birthDay) <= parseInt(adultDayStr) ? 1 : 0;
 
+    // ⛔ mb_dupinfo2 는 키 전환기(2026-07-19~08-13) 인증분과 대조하기 위한 보조 값이다.
+    //    보조 키가 없으면 빈 문자열이 들어가고, 조회 시 공백은 제외된다.
     await pool.query(
-        `UPDATE g5_member SET mb_certify = 'simple', mb_dupinfo = ?, mb_adult = ? WHERE mb_id = ?`,
-        [dupinfo, adult, mbId]
+        `UPDATE g5_member SET mb_certify = 'simple', mb_dupinfo = ?, mb_dupinfo2 = ?, mb_adult = ? WHERE mb_id = ?`,
+        [dupinfo, dupinfoAlt, adult, mbId]
     );
 
     // 인증 이력 저장.
@@ -286,19 +323,41 @@ export async function saveCertResult(
 }
 
 /** 이미 인증된 dupinfo가 존재하는지 체크 */
-export async function checkDupinfo(mbId: string, dupinfo: string): Promise<string | null> {
+export async function checkDupinfo(
+    mbId: string,
+    dupinfo: string,
+    dupinfoAlt = ''
+): Promise<string | null> {
+    // ⛔ 두 값 × 두 컬럼을 모두 본다. 하나라도 걸리면 중복이다.
+    //    mb_dupinfo 컬럼에는 2026-07-19 키 전환 때문에 **두 체계가 섞여** 있다
+    //    (이전 32,692명 = 주 키 값 / 전환기 1,292명 = 보조 키 값).
+    //    그래서 주 값만 조회하면 전환기 인증자를 놓치고, 보조 값만 조회하면
+    //    그 이전 전원을 놓친다.
+    // ⛔ 빈 문자열은 반드시 제외한다 — mb_dupinfo2 미채움 행이 3만 건이라
+    //    공백끼리 매칭되면 전원이 중복으로 잡힌다.
+    const candidates = [dupinfo, dupinfoAlt].filter((v) => v);
+    const ph = candidates.map(() => '?').join(',');
+
+    // ⛔ OR 로 묶으면 옵티마이저가 인덱스를 포기해 62,388행 풀스캔이 된다(EXPLAIN 확인).
+    //    UNION 으로 갈라야 mb_dupinfo2 가 idx_mb_dupinfo2 를 탄다(type: range).
+    //    ⚠️ mb_dupinfo 에는 인덱스가 없어 그쪽은 여전히 스캔이다 — 기존과 동일하며,
+    //       인증 빈도가 낮아 병목은 아니다. 필요하면 인덱스를 별도로 추가할 것.
     const [rows] = await readPool.query<RowDataPacket[]>(
-        'SELECT mb_id FROM g5_member WHERE mb_id <> ? AND mb_dupinfo = ?',
-        [mbId, dupinfo]
+        `SELECT mb_id FROM g5_member WHERE mb_id <> ? AND mb_dupinfo IN (${ph})
+         UNION
+         SELECT mb_id FROM g5_member WHERE mb_id <> ? AND mb_dupinfo2 IN (${ph})
+         LIMIT 1`,
+        [mbId, ...candidates, mbId, ...candidates]
     );
     if (rows[0]) {
         return rows[0].mb_id as string;
     }
 
-    // history 테이블에서도 체크
+    // history 테이블에서도 체크 (탈퇴·삭제 계정 커버)
     const [histRows] = await readPool.query<RowDataPacket[]>(
-        'SELECT count(*) as cnt FROM g5_member_cert_history WHERE mb_id <> ? AND ch_ci = ?',
-        [mbId, dupinfo]
+        `SELECT count(*) as cnt FROM g5_member_cert_history
+          WHERE mb_id <> ? AND ch_ci IN (${ph})`,
+        [mbId, ...candidates]
     );
     if (histRows[0]?.cnt > 0) {
         return '(탈퇴 또는 기존 계정)';

--- a/apps/web/src/routes/cert/inicis/result/+server.ts
+++ b/apps/web/src/routes/cert/inicis/result/+server.ts
@@ -6,6 +6,7 @@ import type { RequestHandler } from './$types';
 import {
     getSeedIV,
     buildDupinfo,
+    buildDupinfoAlt,
     isValidInicisUrl,
     saveCertResult,
     checkDupinfo,
@@ -107,6 +108,9 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 
     // CI 기반 dupinfo 생성
     const mbDupinfo = buildDupinfo(userCi);
+    // 보조 DI — 2026-07-19 키 전환기(1,292명)와 대조하기 위한 값.
+    // 보조 키 미설정이면 빈 문자열이고, 저장·조회에서 자동 제외된다.
+    const mbDupinfoAlt = buildDupinfoAlt(userCi);
     console.log('[Cert] dupinfo generated:', {
         dupinfoPrefix: mbDupinfo.slice(0, 16),
         hasCi: !!userCi,
@@ -129,7 +133,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
     }
 
     // 중복 인증 체크
-    const existingId = await checkDupinfo(mbId, mbDupinfo);
+    const existingId = await checkDupinfo(mbId, mbDupinfo, mbDupinfoAlt);
     console.log('[Cert] dupinfo check result:', {
         mbId,
         dupinfoPrefix: mbDupinfo.slice(0, 16),
@@ -151,7 +155,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 
     // DB 업데이트
     try {
-        await saveCertResult(mbId, mbDupinfo, userBirthday);
+        await saveCertResult(mbId, mbDupinfo, userBirthday, mbDupinfoAlt);
     } catch (err) {
         console.error('[Cert] DB 저장 실패:', err);
         return certResultPage(false, '인증 정보 저장에 실패했습니다.');


### PR DESCRIPTION
인증 식별값을 두 벌로 저장하고 조회하도록 보완합니다.

## 변경

- `g5_member.mb_dupinfo2` 컬럼 추가(DDL 적용 완료) — 보조 식별값 저장
- 인증 시 주·보조 두 값을 함께 저장
- 중복 조회 시 두 값 × 두 컬럼을 모두 대조

## 구현 주의

- **빈 문자열 제외** — 미채움 행이 다수라 거르지 않으면 오탐이 발생합니다
- **OR 대신 UNION** — OR 로 묶으면 인덱스를 타지 못합니다(EXPLAIN 확인). UNION 으로 분리하면 `idx_mb_dupinfo2` 사용
- 보조 키 미설정 시 보조 값을 만들지 않고 주 경로만 동작(fail-open)

## 선행 조건

- DDL: `mb_dupinfo2` + 인덱스 — 적용 완료
- env: `CERT_TOKEN_ENCRYPTION_KEY`(주), `CERT_DUPINFO_ALT_KEY`(보조)

## 검증

- [ ] 기존 식별값으로 재인증 시도 → 차단
- [ ] 신규 인증 시 두 컬럼 모두 채워짐
- [ ] 보조 키 미설정 환경에서 주 경로 정상