### PR TITLE
소명으로 정정된 사유를 회원 화면에 표시

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -79,6 +79,18 @@ export interface DisciplineLogListItem {
     revoked?: boolean; // 소명 인용 등으로 회수된 제재 (목록 배지용)
 }
 
+/**
+ * 사유 정정 한 건 (소명 인용 등으로 사유가 빠지거나 더해진 경우).
+ *
+ * ⛔ 운영자 ID·내부 메모는 응답에 없다. 회수(revoked_at)와 같은 기준이다.
+ */
+export interface ReasonCorrection {
+    at: string;
+    removed?: string[];
+    added?: string[];
+    claim_id?: number;
+}
+
 export interface DisciplineLogDetail {
     id: number;
     member_id: string;
@@ -96,6 +108,7 @@ export interface DisciplineLogDetail {
     status: 'pending' | 'approved' | 'rejected';
     claim_post_id?: number;
     revoked_at?: string; // 소명 인용 등으로 회수된 경우 해제일 (revoked_by·admin_memo는 미노출)
+    reason_corrections?: ReasonCorrection[]; // 사유 정정 이력 (없으면 키 자체가 없다)
 }
 
 export interface DisciplineLogListResponse {

--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -48,7 +48,10 @@ export const VIOLATION_TYPES: Record<number, { title: string; desc: string }> = 
     38: { title: '기타사유', desc: '기타 전항 각호에 준하는 사유' },
     // 추가 유형 (39-40)
     39: { title: '뉴스펌글누락', desc: '뉴스 펌글 작성 시 필수 사항(스크린샷, 출처, 의견) 누락' },
-    40: { title: '뉴스전문전재', desc: '뉴스 전문을 허가 없이 전재하는 행위' }
+    40: { title: '뉴스전문전재', desc: '뉴스 전문을 허가 없이 전재하는 행위' },
+    // ⛔ 41 은 운영 콘솔이 선택지로 제공하는데 이 표에 없었다 — 이 사유로 받은
+    //    제재가 회원 화면에서 이름 없이 사라진다.
+    41: { title: '부적절한 닉네임', desc: '부적절한 닉네임을 사용하는 행위' }
 };
 
 export interface ReportedItem {

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -220,6 +220,49 @@
                         {/each}
                     </div>
                 {/if}
+
+                <!--
+                  사유 정정 — 소명이 인용돼 사유가 빠지면 위 목록에서 조용히 사라진다.
+                  그러면 회원은 소명이 반영됐는지 알 수 없다. 무엇이 빠졌는지 남긴다.
+                  ⛔ 정정한 운영자·내부 메모는 응답에 없다(회수 배너와 같은 기준).
+                -->
+                {#if log.reason_corrections?.length}
+                    <div class="mt-3 border-t pt-3">
+                        <div
+                            class="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-xs font-medium"
+                        >
+                            <Info class="h-3.5 w-3.5" />
+                            사유 정정
+                        </div>
+                        <ul class="space-y-1.5">
+                            {#each log.reason_corrections as c, i (i)}
+                                <li class="text-sm">
+                                    {#if c.removed?.length}
+                                        <span class="text-emerald-700 dark:text-emerald-400"
+                                            >제외 — {c.removed.join(', ')}</span
+                                        >
+                                    {/if}
+                                    {#if c.added?.length}
+                                        <span class="text-muted-foreground"
+                                            >{c.removed?.length ? ' · ' : ''}추가 — {c.added.join(
+                                                ', '
+                                            )}</span
+                                        >
+                                    {/if}
+                                    <span class="text-muted-foreground/70 ml-1 text-xs">
+                                        {c.at.slice(0, 10)}
+                                        {#if c.claim_id}
+                                            · <a
+                                                href="/claim/{c.claim_id}"
+                                                class="underline underline-offset-2">소명 보기</a
+                                            >
+                                        {/if}
+                                    </span>
+                                </li>
+                            {/each}
+                        </ul>
+                    </div>
+                {/if}
             </Card.Content>
         </Card.Root>
 


### PR DESCRIPTION
소명이 인용돼 사유 하나가 빠지면 사유 목록에서 **조용히 사라집니다.** 회원 입장에서는 소명이 반영된 것인지, 애초에 그런 사유가 없었던 것인지 알 방법이 없습니다.

사유 목록 아래에 "사유 정정"을 붙입니다.

```
사유 정정
  제외 — 운영정책부정          2026-08-13 · 소명 보기
  추가 — 분란유도/갈등조장
```

## 운영자·내부 메모는 표시하지 않습니다

해제 배너가 회수자·회수사유를 감추는 것과 같은 기준입니다. 판단 근거는 소명 답변으로 전달되므로, 링크로 그쪽을 가리킵니다.

`reason_corrections` 가 없는 기존 기록은 블록 자체가 렌더되지 않습니다.

## 배포 순서

**angple-backend#661 이 먼저입니다.** 그 전에는 `reason_corrections` 가 내려오지 않아 아무것도 보이지 않습니다(깨지지는 않습니다).
