### PR TITLE
fix(board): 글 상세 상단 여백 축소 — 작성자 메타 2줄 고정

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -203,7 +203,7 @@
 </script>
 
 <!-- 게시글 카드 -->
-<Card class="bg-background mb-6 rounded-xl px-3 pb-5 pt-4 md:px-3">
+<Card class="bg-background mb-6 rounded-xl px-3 pb-5 pt-3 md:px-3">
     <CardHeader class="space-y-3">
         <div>
             {#if post.category}

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -23,6 +23,8 @@
     import Paperclip from '@lucide/svelte/icons/paperclip';
     import Video from '@lucide/svelte/icons/video';
     import { deriveVideoPoster } from '$lib/utils/video-poster.js';
+    // formatDate 는 prop 으로 주입되지만, 모바일 축약 표기는 이 레이아웃에서만 쓰므로 직접 가져온다.
+    import { formatDateTime } from '$lib/utils/format-date.js';
     import Heart from '@lucide/svelte/icons/heart';
     import ThumbsDown from '@lucide/svelte/icons/thumbs-down';
     import Users from '@lucide/svelte/icons/users';
@@ -59,6 +61,17 @@
     };
 
     const currentFontSize = $derived(uiSettingsStore.contentFontSize);
+
+    // 모바일 메타 줄은 폭이 곧 줄 수다. 날짜(111px) + 조회·공감·댓글(175px)이 컬럼 폭을
+    // 넘으면 줄바꿈되어 한 줄이 통째로 더 붙는다. 올해 글은 연도를 빼 "08.13 21:58"(78px)로
+    // 줄여 한 줄에 담고, 작년 이전 글만 연도를 유지한다(그때도 대개 들어간다).
+    const createdShort = $derived.by(() => {
+        const full = formatDateTime(post.created_at); // "2026.08.13 21:58"
+        const thisYear = new Date()
+            .toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' })
+            .slice(0, 4);
+        return full.startsWith(`${thisYear}.`) ? full.slice(5) : full;
+    });
 
     import { toast } from 'svelte-sonner';
     import { trackFileDownload } from '$lib/services/ga4.js';
@@ -202,12 +215,34 @@
     }
 </script>
 
+<!-- 조회/공감/댓글 — 모바일에서는 작성자 날짜 옆으로, md 이상은 메타 줄 우측으로
+     같은 마크업을 두 위치에 렌더한다(둘 중 하나만 보이므로 중복 노출은 없다). -->
+{#snippet metaCounts()}
+    <div class="text-secondary-foreground flex gap-2 sm:gap-4" style="font-size: 0.85em;">
+        <span>조회 {post.views.toLocaleString()}</span>
+        <span>공감 {likeCount.toLocaleString()}</span>
+        <!-- bug/13376: 옆의 조회·공감과 똑같이 생겨서 누를 수 있는 줄 몰랐다는
+             제보. hover 만으로는 터치 기기에서 아무 단서가 되지 못한다.
+             테두리와 아래 화살표로 "눌러서 아래로 간다"를 정지 상태에서 보인다. -->
+        <button
+            type="button"
+            class="border-border hover:bg-muted hover:text-foreground -my-0.5 inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0.5 transition-colors"
+            aria-label="댓글 {post.comments_count}개로 이동"
+            onclick={() =>
+                document.getElementById('comments')?.scrollIntoView({ behavior: 'smooth' })}
+        >
+            댓글 {post.comments_count.toLocaleString()}
+            <ChevronDown class="h-3 w-3" aria-hidden="true" />
+        </button>
+    </div>
+{/snippet}
+
 <!-- 게시글 카드 -->
-<Card class="bg-background mb-6 rounded-xl px-3 pb-5 pt-3 md:px-3">
+<Card class="bg-background mb-6 gap-3 rounded-xl px-3 pb-5 pt-3 md:px-3">
     <CardHeader class="space-y-3">
         <div>
             {#if post.category}
-                <div class="mb-3 flex flex-wrap gap-1.5">
+                <div class="mb-2 flex flex-wrap gap-1.5">
                     <span
                         class="bg-primary/10 text-primary rounded-md px-2 py-0.5 text-[13px] font-medium"
                     >
@@ -279,27 +314,35 @@
             {/if}
         </div>
 
-        <div class="border-border flex flex-wrap items-center gap-4 border-t pt-4">
+        <!-- 작성자/메타 — 모바일(390px)에서 작성자 블록(239px)과 조회·공감·댓글(175px)이
+             한 줄에 안 들어가 줄바꿈되고, 그때 gap-4 의 행간 16px 까지 붙어 106px 이 됐다.
+             상단 chrome 전체에서 가장 큰 단일 항목이었다(#상단여백).
+             모바일은 카운트를 날짜 옆으로 접고 아바타를 size-7 로 줄여 2줄에 고정한다.
+             md 이상은 한 줄에 들어가므로 종전 레이아웃(우측 정렬) 그대로. -->
+        <div
+            class="border-border flex flex-wrap items-center gap-x-3 gap-y-1 border-t pt-2 md:gap-4 md:pt-4"
+        >
             {#if post.deleted_at}
-                <div class="flex items-center gap-2">
+                <div class="flex min-w-0 flex-1 items-center gap-2">
                     <div
-                        class="bg-muted text-muted-foreground flex size-10 items-center justify-center rounded-full"
+                        class="bg-muted text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded-full md:size-10"
                     >
                         ?
                     </div>
-                    <div>
+                    <div class="min-w-0 flex-1">
                         <p class="text-muted-foreground font-medium">작성자 정보 비공개</p>
+                        <div class="mt-0.5 md:hidden">{@render metaCounts()}</div>
                     </div>
                 </div>
             {:else}
-                <div class="flex items-center gap-2">
+                <div class="flex min-w-0 flex-1 items-center gap-2">
                     {#if getAvatarUrl(post.author_image, post.author_image_updated_at)}
                         <img
                             src={getAvatarUrl(post.author_image, post.author_image_updated_at)}
                             alt={post.author}
                             loading="lazy"
                             decoding="async"
-                            class="size-10 rounded-full object-cover"
+                            class="size-7 shrink-0 rounded-full object-cover md:size-10"
                             onerror={(e) => {
                                 const img = e.currentTarget as HTMLImageElement;
                                 img.style.display = 'none';
@@ -308,18 +351,18 @@
                             }}
                         />
                         <div
-                            class="bg-primary text-primary-foreground hidden size-10 items-center justify-center rounded-full"
+                            class="bg-primary text-primary-foreground hidden size-7 shrink-0 items-center justify-center rounded-full md:size-10"
                         >
                             {post.author.charAt(0).toUpperCase()}
                         </div>
                     {:else}
                         <div
-                            class="bg-primary text-primary-foreground flex size-10 items-center justify-center rounded-full"
+                            class="bg-primary text-primary-foreground flex size-7 shrink-0 items-center justify-center rounded-full md:size-10"
                         >
                             {post.author.charAt(0).toUpperCase()}
                         </div>
                     {/if}
-                    <div>
+                    <div class="min-w-0 flex-1">
                         <p class="text-foreground flex items-center gap-1.5 font-medium">
                             <LevelBadge level={memberLevelStore.getLevel(post.author_id)} />
                             <AuthorLink
@@ -340,55 +383,42 @@
                                 >
                             {/if}
                         </p>
-                        <p class="text-secondary-foreground" style="font-size: 0.9em;">
-                            {formatDate(post.created_at)}
-                            <!-- 수정 배지: 리비전 기반 edit_count/last_edited_at (백엔드 주입) 사용.
+                        <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                            <p class="text-secondary-foreground" style="font-size: 0.9em;">
+                                <!-- 모바일은 폭 절약형(올해 글이면 연도 생략),
+                                     md 이상은 종전의 읽기 좋은 상대형 표기를 유지한다. -->
+                                <span class="md:hidden">{createdShort}</span>
+                                <span class="hidden md:inline">{formatDate(post.created_at)}</span>
+                                <!-- 수정 배지: 리비전 기반 edit_count/last_edited_at (백엔드 주입) 사용.
                                  게시글 수정 시 wr_last 미갱신이라 post.updated_at 대신 이 값을 쓴다.
                                  ⛔ 5분 grace 숨김은 2026-08-05 제거했다. 실측상 그 게이트가
                                     글 수정의 67.3%, 댓글 수정의 88.2%를 화면에서 지웠다.
                                     특히 신고 직후 5분 안에 문제 표현을 순화하면 기록만 남고
                                     화면엔 흔적이 없어 판정 근거가 사라졌다. 수정은 수정이다. -->
-                            {#if post.edit_count && post.edit_count > 0 && post.last_edited_at && formatTimeShort}
-                                <span class="text-muted-foreground/70"
-                                    >· 수정 {post.edit_count}회({formatTimeShort(
-                                        post.last_edited_at,
-                                        post.created_at
-                                    )})</span
-                                >
-                            {/if}
-                            {#if post.deleted_at && formatTimeShort}
-                                <span class="text-red-500/70"
-                                    >· 삭제됨 {formatTimeShort(
-                                        post.deleted_at,
-                                        post.created_at
-                                    )}</span
-                                >
-                            {/if}
-                        </p>
+                                {#if post.edit_count && post.edit_count > 0 && post.last_edited_at && formatTimeShort}
+                                    <span class="text-muted-foreground/70"
+                                        >· 수정 {post.edit_count}회({formatTimeShort(
+                                            post.last_edited_at,
+                                            post.created_at
+                                        )})</span
+                                    >
+                                {/if}
+                                {#if post.deleted_at && formatTimeShort}
+                                    <span class="text-red-500/70"
+                                        >· 삭제됨 {formatTimeShort(
+                                            post.deleted_at,
+                                            post.created_at
+                                        )}</span
+                                    >
+                                {/if}
+                            </p>
+                            <div class="md:hidden">{@render metaCounts()}</div>
+                        </div>
                     </div>
                 </div>
             {/if}
 
-            <div
-                class="text-secondary-foreground ml-auto flex gap-2 sm:gap-4"
-                style="font-size: 0.85em;"
-            >
-                <span>조회 {post.views.toLocaleString()}</span>
-                <span>공감 {likeCount.toLocaleString()}</span>
-                <!-- bug/13376: 옆의 조회·공감과 똑같이 생겨서 누를 수 있는 줄 몰랐다는
-                     제보. hover 만으로는 터치 기기에서 아무 단서가 되지 못한다.
-                     테두리와 아래 화살표로 "눌러서 아래로 간다"를 정지 상태에서 보인다. -->
-                <button
-                    type="button"
-                    class="border-border hover:bg-muted hover:text-foreground -my-0.5 inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0.5 transition-colors"
-                    aria-label="댓글 {post.comments_count}개로 이동"
-                    onclick={() =>
-                        document.getElementById('comments')?.scrollIntoView({ behavior: 'smooth' })}
-                >
-                    댓글 {post.comments_count.toLocaleString()}
-                    <ChevronDown class="h-3 w-3" aria-hidden="true" />
-                </button>
-            </div>
+            <div class="ml-auto hidden md:flex">{@render metaCounts()}</div>
         </div>
 
         <!-- 별점 위젯 (앙티티 Phase 0): features.rating 보드에서만 백엔드가

--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -39,7 +39,7 @@
 {#if celebrations.length > 0}
     <a
         href={getLink(celebrations[currentIndex])}
-        class="border-border bg-background hover:bg-accent flex h-6 items-center gap-2 overflow-hidden rounded-lg border px-3 transition-colors {className}"
+        class="border-border bg-background hover:bg-accent flex h-7 items-center gap-2 overflow-hidden rounded-lg border px-3 transition-colors {className}"
     >
         {#if showAvatar}
             <div class="relative h-5 w-5 shrink-0 overflow-hidden rounded-full">
@@ -60,7 +60,7 @@
             </div>
         {/if}
 
-        <div class="relative h-5 min-w-0 flex-1 overflow-hidden">
+        <div class="relative h-6 min-w-0 flex-1 overflow-hidden">
             {#each celebrations as banner, i (banner.id)}
                 <span
                     class="absolute inset-0 flex items-center gap-1.5 truncate text-sm transition-all duration-500 ease-in-out
@@ -81,7 +81,7 @@
     </a>
 {:else if ready}
     <div
-        class="border-border bg-background flex h-6 items-center justify-center rounded-lg border px-3 {className}"
+        class="border-border bg-background flex h-7 items-center justify-center rounded-lg border px-3 {className}"
     >
         <a
             href="/message"
@@ -90,5 +90,5 @@
         >
     </div>
 {:else}
-    <div aria-hidden="true" class="pointer-events-none invisible h-6 {className}"></div>
+    <div aria-hidden="true" class="pointer-events-none invisible h-7 {className}"></div>
 {/if}

--- a/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
+++ b/apps/web/src/lib/components/ui/celebration-rolling/celebration-rolling.svelte
@@ -39,16 +39,16 @@
 {#if celebrations.length > 0}
     <a
         href={getLink(celebrations[currentIndex])}
-        class="border-border bg-background hover:bg-accent flex h-9 items-center gap-2 overflow-hidden rounded-lg border px-3 transition-colors {className}"
+        class="border-border bg-background hover:bg-accent flex h-6 items-center gap-2 overflow-hidden rounded-lg border px-3 transition-colors {className}"
     >
         {#if showAvatar}
-            <div class="relative h-6 w-6 shrink-0 overflow-hidden rounded-full">
+            <div class="relative h-5 w-5 shrink-0 overflow-hidden rounded-full">
                 {#each celebrations as banner, i (banner.id)}
                     {#if banner.target_member_photo}
                         <img
                             src={banner.target_member_photo}
                             alt=""
-                            class="absolute inset-0 h-6 w-6 rounded-full object-cover transition-all duration-500 ease-in-out
+                            class="absolute inset-0 h-5 w-5 rounded-full object-cover transition-all duration-500 ease-in-out
                                 {i === currentIndex
                                 ? 'translate-y-0 opacity-100'
                                 : i < currentIndex
@@ -60,7 +60,7 @@
             </div>
         {/if}
 
-        <div class="relative h-7 min-w-0 flex-1 overflow-hidden">
+        <div class="relative h-5 min-w-0 flex-1 overflow-hidden">
             {#each celebrations as banner, i (banner.id)}
                 <span
                     class="absolute inset-0 flex items-center gap-1.5 truncate text-sm transition-all duration-500 ease-in-out
@@ -81,7 +81,7 @@
     </a>
 {:else if ready}
     <div
-        class="border-border bg-background flex h-9 items-center justify-center rounded-lg border px-3 {className}"
+        class="border-border bg-background flex h-6 items-center justify-center rounded-lg border px-3 {className}"
     >
         <a
             href="/message"
@@ -90,5 +90,5 @@
         >
     </div>
 {:else}
-    <div aria-hidden="true" class="pointer-events-none invisible h-9 {className}"></div>
+    <div aria-hidden="true" class="pointer-events-none invisible h-6 {className}"></div>
 {/if}

--- a/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
+++ b/apps/web/src/lib/components/ui/tag-nav/tag-nav.svelte
@@ -36,7 +36,7 @@
 </script>
 
 {#if visibleMenus.length > 0}
-    <nav class="tag-nav flex gap-1.5 overflow-x-auto {className}" aria-label="빠른 이동">
+    <nav class="tag-nav flex gap-1 overflow-x-auto {className}" aria-label="빠른 이동">
         {#each visibleMenus as menu (menu.key)}
             <a
                 href={menu.url}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2125,20 +2125,22 @@
      동일 선언에 hidden 폴백을 먼저 두고 clip 으로 덮는 방식으로 cascade 처리:
      - clip 미지원 브라우저: hidden 적용 (이 wrapper 내부에는 position:sticky 가 없어 안전)
      - clip 지원 브라우저: clip 이 hidden 을 덮어 기존 동작 유지 -->
-<div class="mx-auto pt-2" style="overflow-x: hidden; overflow-x: clip;">
+<div class="mx-auto pt-1" style="overflow-x: hidden; overflow-x: clip;">
     <!-- 플러그인 슬롯: 글 상세 페이지 시작 — Slot Catalog Sprint 2c -->
     <PluginSlot name="post-detail-before" {boardId} postId={data.post.id} />
 
     <!-- 최상단 자체 배너 (없으면 GAM 폴백) -->
     {#if widgetLayoutStore.hasEnabledAds && !data.post.deleted_at}
-        <div class="mb-3">
+        <div class="mb-2">
             <PluginSlot name="board-view-banner" />
         </div>
     {/if}
 
-    <!-- 브레드크럼 -->
+    <!-- 브레드크럼 — 모바일에서는 숨긴다. 마지막 항목이 글 제목이라 바로 아래 h1 과
+         글자 그대로 중복이고, 앞의 "홈 / 게시판"은 아래 목록 버튼(← 게시판명)이
+         대신한다. 줄 하나(24px)를 통째로 아끼면서 잃는 정보가 없다. -->
     <nav
-        class="text-muted-foreground -mx-2 mb-1 flex items-center gap-1 px-2 text-sm md:mx-0 md:px-0"
+        class="text-muted-foreground -mx-2 mb-1 hidden items-center gap-1 px-2 text-sm md:mx-0 md:flex md:px-0"
         aria-label="breadcrumb"
     >
         <a href="/" class="hover:text-foreground transition-colors">홈</a>
@@ -2151,7 +2153,7 @@
     </nav>
 
     <!-- 빠른 이동(tag-nav) — 목록 페이지와 동일. 메뉴는 admin 설정/DEFAULT_MENUS 공유 -->
-    <div class="mb-2">
+    <div class="mb-1">
         <TagNav />
     </div>
 
@@ -2159,10 +2161,14 @@
          원래 44px(#12016)였으나 이 네비에만 걸린 값이라 같은 화면의 다른 버튼(32px)과 어긋나
          유독 커 보였다. 36px = Button 기본 높이(h-9)와 같고 WCAG 2.2 AA 최소(24px)를 상회한다. -->
     <div
-        class="-mx-2 mb-1 flex flex-wrap items-center gap-2 px-2 py-1 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-9 md:[&_a]:min-h-0 [&_button]:min-h-9 md:[&_button]:min-h-0"
+        class="-mx-2 mb-1 flex flex-wrap items-center gap-1.5 px-2 py-0 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-9 md:[&_a]:min-h-0 [&_button]:min-h-9 md:[&_button]:min-h-0"
     >
-        <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
-        <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>
+        <!-- 목록 버튼이 현재 위치도 겸한다. 종전의 별도 ← 버튼은 이 버튼과 목적지가
+             같아 중복이었고, 라벨이 "목록으로"라 어느 게시판으로 가는지 말해주지 않았다.
+             게시판명을 넣으면 모바일에서 브레드크럼을 숨겨도 현재 위치가 유지된다. -->
+        <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">
+            ← {boardTitle}
+        </Button>
 
         <!-- 상단에도 글쓰기 버튼 (하단 네비와 동일 권한/실명인증 로직) -->
         {#if authStore.isAuthenticated && checkPermission(data.board, 'can_write', authStore.user ?? null)}
@@ -2284,7 +2290,7 @@
     </div>
 
     <!-- 축하 메시지 롤링 (슬롯 기반) -->
-    <div class="mb-4">
+    <div class="mb-2">
         <PluginSlot name="board-view-rolling" />
     </div>
 

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -301,6 +301,11 @@
     const fromBoard = $derived(sanitizeFromBoard($page.url.searchParams.get('from')));
     const boardTitle = $derived(data.board?.subject || data.board?.name || boardId);
 
+    // 브레드크럼 표시 여부. 목록 버튼이 "← {게시판명}" 으로 현재 위치를 겸하게 되면서
+    // 담고 있던 정보(홈/게시판/글 제목)가 전부 화면에 중복으로 남아 잠시 꺼둔다.
+    // 되살릴 일이 있을 수 있어 마크업은 남겨두고 이 플래그만 true 로 바꾸면 된다.
+    const SHOW_BREADCRUMB = false;
+
     // #12920: 이용제한 근거 콘텐츠 공개 워터마크용 열람자 정보를 스토어에 동기화.
     // 스토어가 모듈 싱글톤이라 teardown 에서 반드시 정리해 페이지 이탈 후 잔존을 방지.
     $effect(() => {
@@ -2136,21 +2141,28 @@
         </div>
     {/if}
 
-    <!-- 브레드크럼 — 모바일에서는 숨긴다. 마지막 항목이 글 제목이라 바로 아래 h1 과
-         글자 그대로 중복이고, 앞의 "홈 / 게시판"은 아래 목록 버튼(← 게시판명)이
-         대신한다. 줄 하나(24px)를 통째로 아끼면서 잃는 정보가 없다. -->
-    <nav
-        class="text-muted-foreground -mx-2 mb-1 hidden items-center gap-1 px-2 text-sm md:mx-0 md:flex md:px-0"
-        aria-label="breadcrumb"
-    >
-        <a href="/" class="hover:text-foreground transition-colors">홈</a>
-        <span class="text-muted-foreground/50">/</span>
-        <a href="/{data.boardId}" class="hover:text-foreground transition-colors">{boardTitle}</a>
-        <span class="text-muted-foreground/50">/</span>
-        <span class="text-foreground min-w-0 break-words" title={data.post.title}
-            >{data.post.title}</span
+    <!-- 브레드크럼 — 현재 꺼둔 상태(SHOW_BREADCRUMB=false). 담고 있던 정보가 전부
+         화면 어딘가에 이미 있다: "홈 / 게시판"은 아래 목록 버튼(← 게시판명)이,
+         글 제목은 바로 아래 h1 이 글자 그대로 보여준다. 모바일·PC 각각 줄 하나(24px)를
+         통째로 아끼면서 잃는 정보가 없다.
+         되살리려면 SHOW_BREADCRUMB 를 true 로. 그 경우 모바일에서는 계속 숨고
+         md 이상에서만 나온다(hidden md:flex). -->
+    {#if SHOW_BREADCRUMB}
+        <nav
+            class="text-muted-foreground -mx-2 mb-1 hidden items-center gap-1 px-2 text-sm md:mx-0 md:flex md:px-0"
+            aria-label="breadcrumb"
         >
-    </nav>
+            <a href="/" class="hover:text-foreground transition-colors">홈</a>
+            <span class="text-muted-foreground/50">/</span>
+            <a href="/{data.boardId}" class="hover:text-foreground transition-colors"
+                >{boardTitle}</a
+            >
+            <span class="text-muted-foreground/50">/</span>
+            <span class="text-foreground min-w-0 break-words" title={data.post.title}
+                >{data.post.title}</span
+            >
+        </nav>
+    {/if}
 
     <!-- 빠른 이동(tag-nav) — 목록 페이지와 동일. 메뉴는 admin 설정/DEFAULT_MENUS 공유 -->
     <div class="mb-1">

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2151,7 +2151,7 @@
     </nav>
 
     <!-- 빠른 이동(tag-nav) — 목록 페이지와 동일. 메뉴는 admin 설정/DEFAULT_MENUS 공유 -->
-    <div class="mb-3">
+    <div class="mb-2">
         <TagNav />
     </div>
 
@@ -2159,7 +2159,7 @@
          원래 44px(#12016)였으나 이 네비에만 걸린 값이라 같은 화면의 다른 버튼(32px)과 어긋나
          유독 커 보였다. 36px = Button 기본 높이(h-9)와 같고 WCAG 2.2 AA 최소(24px)를 상회한다. -->
     <div
-        class="-mx-2 mb-2 flex flex-wrap items-center gap-2 px-2 py-2 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-9 md:[&_a]:min-h-0 [&_button]:min-h-9 md:[&_button]:min-h-0"
+        class="-mx-2 mb-1 flex flex-wrap items-center gap-2 px-2 py-1 md:mx-0 md:flex-nowrap md:gap-2 md:px-0 [&_a]:min-h-9 md:[&_a]:min-h-0 [&_button]:min-h-9 md:[&_button]:min-h-0"
     >
         <Button variant="ghost" size="sm" onclick={() => history.back()} class="shrink-0">←</Button>
         <Button variant="outline" size="sm" onclick={goBack} class="shrink-0">목록으로</Button>


### PR DESCRIPTION
## 배경

게시글 상세에서 본문이 보이기까지 화면을 과하게 소모한다. 모바일 390x844 에서 첫 화면 844px 중 본문 시작이 546px(65%).

전수 측정 결과 **진짜 원인은 여백이 아니라 작성자 메타 줄(106px)** 이었다. 작성자 블록(239px)과 조회·공감·댓글(175px)이 350px 폭에 안 들어가 줄바꿈되고, 그때 `gap-4` 의 행간 16px 까지 붙는다. `pt-4` 포함 122px 로 상단 chrome 최대 단일 항목.

## 변경

### 1. 메타 줄 — 실측 106 → 59px (`view/basic.svelte`)

- 모바일은 조회·공감·댓글을 날짜 옆으로 접어 **2줄 고정**, md 이상은 종전대로 우측 정렬. 같은 마크업을 snippet 으로 두 위치에 렌더(둘 중 하나만 보이므로 중복 노출 없음)
- 아바타 `size-10` → `size-7` (md 이상 `size-10` 유지)
- 모바일 날짜는 올해 글이면 연도 생략 — `08.13 21:58`(74px). 연도까지 쓰면 날짜 111 + 카운트 175 가 컬럼(282px)을 넘겨 다시 줄바꿈된다
- `border-t pt-4` → `pt-2`, `gap-4` → `gap-x-3 gap-y-1` (md 이상 종전값)

### 2. 현재 위치를 목록 버튼으로 통합 (`+page.svelte`)

- 목적지가 같아 중복이던 별도 `←` 버튼을 없애고, 목록 버튼 라벨을 `← {게시판명}` 으로. 줄을 더 쓰지 않고 모든 게시판에서 정확하다
  - tag-nav 활성 pill 로 대체하는 안은 갤러리·중고장터처럼 tag-nav 메뉴에 없는 게시판에서 현재 위치가 사라져 채택하지 않음
- **브레드크럼은 잠시 비활성화** (모바일·PC 모두). 담고 있던 정보가 전부 화면에 중복으로 남았다 — `홈 / 게시판`은 목록 버튼이, 글 제목은 바로 아래 h1 이 글자 그대로 보여준다
  - 되살릴 수 있게 마크업은 남기고 `SHOW_BREADCRUMB` 플래그로만 끈다. `true` 로 바꾸면 종전대로 md 이상에서만 노출

### 3. 여백

| 위치 | 변경 |
|---|---|
| `main` | `pt-2` → `pt-1` |
| 배너 래퍼 | `mb-3` → `mb-2` |
| tag-nav 래퍼 / pill | `mb-3` → `mb-1` / `gap-1.5` → `gap-1` |
| 버튼줄 | `py-2` → `py-0`, `mb-2` → `mb-1`, `gap-2` → `gap-1.5` |
| 카드 | `pt-4` → `pt-3`, `gap-6` → `gap-3` |
| 카테고리 칩 | `mb-3` → `mb-2` |
| 마음메시지 | 박스 `h-9` → `h-7`, 래퍼 `mb-4` → `mb-2` |

버튼 높이는 `[&_a]:min-h-9` / `[&_button]:min-h-9` 가 유지 → 모바일 터치 타겟 36px 그대로(WCAG 2.2 AA 최소 24px 상회).

마음메시지는 한 번 24px(`h-6`)까지 줄였다가 되돌렸다. 본문 텍스트가 14px 인데 박스가 24px 이면 위아래 여백이 5px 뿐이고 아바타도 18px 까지 줄어야 해서, 이모지가 섞인 메시지에서 눌린다. 28px 은 여백 7px·아바타 20px 로 종전(36px) 대비 슬림하면서 눌린 느낌이 없다. 24px 대비 손해는 4px.

## 측정

**실측** — 임시 프리뷰 라우트로 실제 컴포넌트를 SSR 렌더해 측정(측정 후 제거)

- 모바일 390: 메타 줄 **106 → 59px**
- PC 1440: 아바타 40px·카운트 우측 정렬로 종전 동작 유지 확인

**개별 델타 합산 추정** (전체 페이지 렌더는 아래 "검증 한계" 참고)

| | 제목 top | 본문 top |
|---|---|---|
| 모바일 390 | 308 → 약 228 | 546 → 약 407 |
| PC 1440 | 383 → 약 303 | 557 → 약 465 |

## 하지 않은 것

- **마음메시지 제거** — 유지하기로 결정. 박스·여백만 52 → 36px 로 축소
- **폰트조절 줄(-34px)** — 우하단 플로팅 메뉴로 옮기는 안이 있으나 목적지 확정 전이라 보류
- **`CardContent` 의 `space-y-6`** — 확인해보니 이 유틸이 실제로 아무 margin 도 만들지 않는다. Tailwind v4 의 `space-y-*` 는 `:where(& > :not(:last-child))` 라 specificity 가 0 이고 첫 자식의 자기 `mb-1` 에 밀리며, 둘째 자식은 `:last-child` 라 대상 밖. 자식 2개인 일반 게시글에선 완전 no-op. 별건 정리 대상

## 검증 한계

로컬 풀스택 렌더는 angple MySQL(3306)이 없어 불가. 임시 프리뷰 라우트로 컴포넌트를 직접 SSR 렌더해 측정했고, 해당 라우트와 임시 env 는 커밋에 포함되지 않는다. **전체 페이지 기준 수치는 개별 델타 합산 추정이므로 배포 전 실환경 확인을 권한다** — 실제로 첫 구현에서 메타가 의도와 달리 3줄로 나온 것(날짜 연도 때문에 16px 초과 → 줄바꿈)도 이 렌더 검증에서 잡았다.

변경 파일 기준 Prettier / ESLint / svelte-check(0 errors) 통과. 리포 전체 lint 실패와 `overflow-x` 중복 error 는 main 에도 있는 기존 이슈.