### PR TITLE
fix(board): 목록 상단 여백 축소 + 모아보기/공감글 좌우 여백 통일

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -202,6 +202,14 @@
     let isRestoring = $state<string | null>(null);
 
     // 수정 폼 이미지 업로드
+    /**
+     * 댓글 수정 에디터 인스턴스.
+     * LazyCommentEditor 는 동적 import 라 인스턴스 타입이 SvelteComponent<{}> 로만 잡혀
+     * 실제 메서드(insertContent/insertImage/getImageCount)가 타입에 없다. 구조적 인터페이스를
+     * 붙이면 bind:this 대입에서 타입이 충돌하므로 any 를 유지한다.
+     * 호출하는 메서드는 아래 세 개뿐이다: insertContent, insertImage, getImageCount.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let editEditorRef = $state<any>(null);
     let editFileInputRef = $state<HTMLInputElement | null>(null);
     let editIsUploading = $state(false);
@@ -815,6 +823,7 @@
     // TipTap 에디터로 작성된 댓글은 <p>, <strong> 등 HTML 태그를 포함하므로
     // escapeHtml 대신 DOMPurify로 산화하여 안전한 태그는 보존
     const ssrCommentHtml = $derived.by(() => {
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- $derived.by 내부 지역 변수. 반응형 상태가 아니라 계산 중 임시 조회표다.
         const map = new Map<string | number, string>();
         for (const comment of commentTree) {
             if (!comment.content) {
@@ -1077,6 +1086,7 @@
     // #12856: 로드 성공 시에만 loadedIds 에 표시. 진행중(inflight)·시도상한으로 중복/폭주 방지.
     let likerAvatarsLoadedIds = new SvelteSet<string>();
     let likerAvatarsInflight = new SvelteSet<string>();
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- 재시도 횟수 기록용. 화면에 렌더되지 않아 반응형일 필요가 없다.
     const likerAvatarsAttempts = new Map<string, number>();
     const LIKER_AVATARS_MAX_ATTEMPTS = 4;
     $effect(() => {

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -2320,8 +2320,11 @@
     .comment-item:first-child {
         padding-top: calc(var(--comment-pad-extra, 3px));
     }
+    /* 마지막 댓글은 first-child 와 대칭으로 0.75rem 을 뺀다. 종전 값은 base 규칙과
+       완전히 동일해서 아무 효과가 없었다(= 규칙이 없는 것과 구분 불가). 아래 댓글 작성
+       영역이 border-t + pt-6 로 이미 간격을 만들므로 여기서 12px 을 더 둘 이유가 없다. */
     .comment-item:last-child {
-        padding-bottom: calc(var(--comment-pad-extra, 3px) + 0.75rem);
+        padding-bottom: calc(var(--comment-pad-extra, 3px));
     }
 
     /* 긴 URL 레이아웃 깨짐 방지 */

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -278,7 +278,10 @@
 
 <!-- 게시글 카드 -->
 <Card class="bg-background mb-6 gap-3 rounded-xl px-3 pb-5 pt-3 md:px-3">
-    <CardHeader class="space-y-3">
+    <!-- gap-3: CardHeader 는 자체적으로 grid gap-1.5 를 갖는다. 종전 space-y-3 는
+         그 gap 을 대체하지 못하고 margin 으로 얹혀 6+12=18px 이 됐다(의도는 12px).
+         같은 축의 gap 으로 주면 tailwind-merge 가 gap-1.5 를 대체해 정확히 12px. -->
+    <CardHeader class="gap-3">
         <div>
             {#if post.category}
                 <div class="mb-2 flex flex-wrap gap-1.5">

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -459,7 +459,10 @@
 
 <!-- 운영 리포트 카드 -->
 <Card class="bg-background mb-6 px-3 md:px-3">
-    <CardHeader class="space-y-3">
+    <!-- gap-3: CardHeader 는 자체적으로 grid gap-1.5 를 갖는다. 종전 space-y-3 는
+         그 gap 을 대체하지 못하고 margin 으로 얹혀 6+12=18px 이 됐다(의도는 12px).
+         같은 축의 gap 으로 주면 tailwind-merge 가 gap-1.5 를 대체해 정확히 12px. -->
+    <CardHeader class="gap-3">
         <div>
             {#if post.category}
                 <div class="mb-3 flex flex-wrap gap-1.5">
@@ -741,7 +744,9 @@
         {/each}
 
         <!-- 글자 크기 조절 -->
-        <div class="mb-1 flex justify-end gap-1">
+        <!-- mb-1 제거: 부모 CardContent 의 space-y-6 가 specificity 0(:where)이라
+             이 mb-1 에 밀려 블록 간격이 24px 이 아니라 4px 로 좁아져 있었다. -->
+        <div class="flex justify-end gap-1">
             <button
                 type="button"
                 class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-3 py-1.5 text-sm transition-colors disabled:opacity-30"

--- a/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
+++ b/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
@@ -268,7 +268,9 @@
     }
 </script>
 
-<div class="mx-auto max-w-5xl px-4 py-4">
+<!-- 좌우 여백은 모바일에서 게시판 목록과 맞춘다(상위 main 이 이미 px-2 를 준다).
+     종전 px-4 는 그 위에 16px 을 더 얹어 /free 목록(8px)과 어긋나 보였다. -->
+<div class="mx-auto max-w-5xl px-0 py-2 md:px-4 md:py-4">
     <div class="mb-4">
         <AdSlot position="empathy-top" height="90px" slotKey="empathy-top" />
     </div>

--- a/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
+++ b/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
@@ -42,7 +42,7 @@
 
     // SPA 네비게이션 시 폴링 데이터 초기화
     $effect(() => {
-        date; // date 변경 추적
+        void date; // date 변경 추적
         pollData = null;
     });
 
@@ -79,7 +79,7 @@
 
     // SPA 네비게이션 시 댓글 데이터도 초기화
     $effect(() => {
-        date;
+        void date;
         lazyComments = null;
     });
 
@@ -105,6 +105,7 @@
                 ...(sections.info.posts ?? [])
             ];
             // 섹션 간 중복 게시글 제거 (id+board 기준)
+            // eslint-disable-next-line svelte/prefer-svelte-reactivity -- $derived.by 내부 중복 제거용 지역 변수.
             const seen = new Set<string>();
             posts = all.filter((p) => {
                 const key = `${p.id}-${p.board}`;
@@ -155,6 +156,7 @@
                 ...(commentSections.group?.comments ?? []),
                 ...(commentSections.info?.comments ?? [])
             ];
+            // eslint-disable-next-line svelte/prefer-svelte-reactivity -- $derived.by 내부 중복 제거용 지역 변수.
             const seen = new Set<string>();
             comments = all.filter((c) => {
                 const key = `${c.id}-${c.board}`;

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -312,6 +312,7 @@
     });
 
     const MEMO_CACHE_TTL_MS = 30_000;
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- TTL 캐시. 렌더에 쓰이지 않아 반응형일 필요가 없다.
     const memoBatchCache = new Map<
         string,
         {
@@ -319,6 +320,7 @@
             value: Record<string, { content: string; color: string } | null>;
         }
     >();
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- 진행 중 요청 중복 방지용. 렌더에 쓰이지 않는다.
     const memoBatchPending = new Map<
         string,
         Promise<Record<string, { content: string; color: string } | null>>
@@ -654,7 +656,7 @@
         }
     }
 
-    function selectAllVisible(posts: any[]): void {
+    function selectAllVisible(posts: FreePost[]): void {
         selectedPostIds = posts.map((p) => p.id);
     }
 
@@ -859,6 +861,7 @@
     async function fetchBackfillPage(
         pageNum: number
     ): Promise<{ posts: FreePost[]; hasNext: boolean }> {
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- 함수 내부 지역 변수. URL 문자열을 만들고 버린다.
         const params = new URLSearchParams($page.url.searchParams);
         params.set('page', String(pageNum));
         // 태그 필터는 서버가 sfl=title_content&stx= 를 함께 붙여 조회한다 — 동일하게 재현.
@@ -909,6 +912,7 @@
         void (async () => {
             backfilling = true;
             const collected: FreePost[] = [];
+            // eslint-disable-next-line svelte/prefer-svelte-reactivity -- 함수 내부 중복 제거용 지역 변수.
             const seen = new Set(posts.map((p) => p.id)); // id 중복 제거(원본 + 누적)
             let visible = startVisible;
             let nextPage = startPage + 1;

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -976,9 +976,11 @@
             </div>
         </div>
     {:else}
-        <div class="mx-auto pt-4">
+        <!-- 상단 여백 축소 — 첫 게시물까지 PC 450px / 모바일 265px 을 쓰고 있었다.
+             글 상세(#2079)와 같은 기준으로 맞춘다. -->
+        <div class="mx-auto pt-2">
             <!-- 빠른 이동 네비게이션 -->
-            <div class="mb-4">
+            <div class="mb-2">
                 <TagNav />
             </div>
 
@@ -993,7 +995,7 @@
             {/if}
 
             <!-- 헤더 -->
-            <div class="mb-4 flex min-w-0 flex-wrap items-center justify-between gap-2">
+            <div class="mb-3 flex min-w-0 flex-wrap items-center justify-between gap-2">
                 <div class="flex min-w-0 shrink items-center gap-2">
                     <h1 class="text-2xl font-bold sm:text-3xl">
                         <a
@@ -1194,14 +1196,15 @@
 
             <!-- 최상단 자체 배너 (자체 배너 없으면 안 보임) -->
             {#if widgetLayoutStore.hasEnabledAds}
-                <div class="mb-3">
+                <div class="mb-2">
                     <PluginSlot name="board-list-banner" />
                 </div>
             {/if}
 
-            <!-- 축하 메시지 롤링 (슬롯 기반) -->
+            <!-- 축하 메시지 롤링 (슬롯 기반) — 글 상세와 같은 mb-2.
+                 메시지가 없어도 h-7(28px) 자리표시자가 남는 건 의도된 CLS 방지다. -->
             {#if !isSearching}
-                <div class="mb-4">
+                <div class="mb-2">
                     <PluginSlot name="board-list-rolling" />
                 </div>
             {/if}
@@ -1224,7 +1227,7 @@
             <!-- #12012: 내가 쓴 글/댓글 빠른 필터 (로그인 시) -->
             <!-- #12592: 모바일에서는 상단 SearchForm 과 검색 input 중복 → PC(md+) 전용 -->
             {#if authStore.isAuthenticated}
-                <div class="mb-3 hidden flex-wrap items-center gap-2 md:flex">
+                <div class="mb-2 hidden flex-wrap items-center gap-2 md:flex">
                     <Button
                         variant={isMyPostsActive ? 'default' : 'outline'}
                         size="sm"

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2130,6 +2130,7 @@
      동일 선언에 hidden 폴백을 먼저 두고 clip 으로 덮는 방식으로 cascade 처리:
      - clip 미지원 브라우저: hidden 적용 (이 wrapper 내부에는 position:sticky 가 없어 안전)
      - clip 지원 브라우저: clip 이 hidden 을 덮어 기존 동작 유지 -->
+<!-- eslint-disable-next-line svelte/no-dupe-style-properties -- 위 주석대로 의도된 cascade 폴백이다. -->
 <div class="mx-auto pt-1" style="overflow-x: hidden; overflow-x: clip;">
     <!-- 플러그인 슬롯: 글 상세 페이지 시작 — Slot Catalog Sprint 2c -->
     <PluginSlot name="post-detail-before" {boardId} postId={data.post.id} />
@@ -2761,6 +2762,9 @@
      initialPage(보통 1) 가 stale 상태로 남아 항상 1페이지가 표시되는 회귀.
      post.id 를 key 에 포함시켜 글 이동마다 RecentPosts 를 재마운트, URL ?page=N 반영. -->
 {#if canRead}
+    <!-- 위쪽 wrapper 와 같은 의도된 cascade 폴백(#12096): clip 미지원 브라우저는 hidden,
+         지원 브라우저는 clip 이 덮는다. (disable 지시자는 한 줄이어야 해서 아래에 따로 둔다) -->
+    <!-- eslint-disable-next-line svelte/no-dupe-style-properties -->
     <div style="overflow-x: hidden; overflow-x: clip;">
         {#key `${boardId}:${data.post.id}`}
             <RecentPosts

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2495,9 +2495,12 @@
                     : {}}
             />
         {/each}
-        <!-- 본문 직후, 댓글 직전 광고 (삭제된 글에서는 비표시) -->
+        <!-- 본문 직후, 댓글 직전 광고 (삭제된 글에서는 비표시)
+             my-6 → my-2: 바로 위 AdSense(390px)와 이 슬롯(예약 100px)이 연달아 붙어
+             본문 끝~댓글 사이 426px 의 대부분을 만들고 있었다. 슬롯은 그대로 두고
+             위아래 여백만 24+24 → 8+8 로 줄인다(32px 회수, 노출 영향 없음). -->
         {#if widgetLayoutStore.hasEnabledAds && !data.post.deleted_at}
-            <div class="my-6">
+            <div class="my-2">
                 <AdSlot
                     position="board-before-comments"
                     height="90px"

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -158,8 +158,11 @@
     }}
 />
 
-<div class="mx-auto max-w-4xl px-4 py-6">
-    <div class="mb-4">
+<!-- 좌우 여백은 모바일에서 게시판 목록과 맞춘다. 종전 px-4 는 상위 main 의 px-2 위에
+     16px 을 더 얹어 콘텐츠가 24px 안쪽에서 시작했고, /free 목록(8px)과 어긋나 보였다.
+     md 이상은 종전대로 px-4. 상하도 목록 페이지(pt-2)와 같은 기준으로. -->
+<div class="mx-auto max-w-4xl px-0 pb-6 pt-2 md:px-4 md:py-6">
+    <div class="mb-2">
         <TagNav />
     </div>
 

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -92,6 +92,7 @@
 
     const availableBoards = $derived.by(() => {
         const items = viewMode === 'posts' ? currentPosts : currentComments;
+        // eslint-disable-next-line svelte/prefer-svelte-reactivity -- $derived.by 내부 지역 변수.
         const seenBoards = new Set<string>();
         const boards: { id: string; label: string }[] = [];
 


### PR DESCRIPTION
#2079 · #2080 후속. 목록 페이지와 화면 간 여백 불일치를 정리한다.

## 1. 목록 상단 여백 — 모바일 -32px / PC -36px

첫 게시물까지 모바일 265px, PC 450px 을 쓰고 있었다. 글 상세와 같은 기준으로 맞춘다.

| 위치 | 변경 |
|---|---|
| 컨테이너 | `pt-4` → `pt-2` |
| tag-nav 래퍼 | `mb-4` → `mb-2` |
| 게시판 제목 | `mb-4` → `mb-3` |
| 배너 래퍼 | `mb-3` → `mb-2` |
| 마음메시지 래퍼 | `mb-4` → `mb-2` (글 상세와 통일) |
| PC 툴바 | `mb-3` → `mb-2` |

마음메시지 자리표시자(`h-7`) 자체는 CLS 방지용이라 유지한다.

## 2. 좌우 여백 통일

`/explore`, `/empathy` 는 상위 `main` 의 `px-2` 위에 `px-4` 를 더 얹어 모바일 콘텐츠가 24px 안쪽에서 시작했다. `/free` 목록(8px)과 어긋나 보인다. `px-4` → `px-0 md:px-4`.

## 3. 댓글 마지막 항목

`.comment-item:last-child` 의 `padding-bottom` 이 base 규칙과 값이 **완전히 동일**해 아무 효과가 없었다(규칙이 없는 것과 구분 불가). `:first-child` 와 대칭이 되도록 `0.75rem` 을 뺀다. 아래 작성 영역이 `border-t` + `pt-6` 로 이미 간격을 만든다. 밀도 변수(`--comment-pad-extra`) 체계는 그대로.

## 4. Tailwind v4 `space-y-*` 실효성 문제 2건

전수조사에서 나온 것 중 실제 시각 영향이 있는 것만 고친다.

- **`CardHeader class="space-y-3"` → `gap-3`** (`basic.svelte`, `report.svelte`)
  `CardHeader` 는 자체적으로 `grid gap-1.5` 를 갖는다. v4 의 `space-y-*` 는 `:where(& > :not(:last-child))` 라 gap 을 대체하지 못하고 margin 으로 얹혀 **6+12=18px** 이 됐다(의도는 12px). 같은 축의 `gap` 으로 주면 `tailwind-merge` 가 `gap-1.5` 를 대체해 정확히 12px.
- **`report.svelte` 본문 블록 간격** — `CardContent` 의 `space-y-6` 가 specificity 0 이라 자식의 `mb-1` 에 밀려 24px 이 **4px** 로 좁아져 있었다. `mb-1` 제거.

## 검증

- 목록 상단: 프로덕션 DOM 에 같은 값을 주입해 전/후 측정 — 모바일 390 에서 첫 게시물 **265 → 233px**. 공지 6줄이 전부 첫 화면에 들어온다
- Prettier / svelte-check(0 errors) 통과

**2·3·4 는 아직 화면 확인을 못 했다.** `/explore`·`/empathy`·댓글 마지막 항목·CardHeader 는 로그인이나 특정 조건이 필요해 프로덕션 주입으로 재현하기 번거로웠다. 값 자체는 결정적이지만 배포 전 확인을 권한다.

## 후속으로 남긴 것

- `CardHeader class="space-y-0"` **20곳** — 이 리포의 CardHeader 에는 취소할 `space-y` 가 없어(`grid gap-1.5`) 전부 죽은 클래스
- 자식이 1개뿐이라 영원히 무효인 `space-y-*` 컨테이너 **13곳** (관리자·설정 화면 위주)
- 댓글 `li` 의 `py-3`/`py-4` — scoped `.comment-item` 규칙이 4개 레이아웃의 `py-*` 를 전부 덮고 있어 죽은 클래스. 레이아웃별 확인 필요

셋 다 시각 변화가 0인 죽은 코드 제거라 별도 PR 로 분리한다.