### PR TITLE
글마다 사유가 다르면 상단에 나열하지 않는다

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -80,6 +80,8 @@ export interface DisciplineLogListItem {
     violation_titles: string[];
     memo?: string;
     revoked?: boolean; // 소명 인용 등으로 회수된 제재 (목록 배지용)
+    /** 글마다 적용 사유가 다름 — violation_titles(합집합) 대신 배지로 대체한다 */
+    reasons_differ_by_item?: boolean;
 }
 
 /**
@@ -112,6 +114,13 @@ export interface DisciplineLogDetail {
     claim_post_id?: number;
     revoked_at?: string; // 소명 인용 등으로 회수된 경우 해제일 (revoked_by·admin_memo는 미노출)
     reason_corrections?: ReasonCorrection[]; // 사유 정정 이력 (없으면 키 자체가 없다)
+    /**
+     * 글마다 적용 사유가 다른 경우.
+     *
+     * ⛔ `violation_types` 는 항목별 사유의 **합집합**이다. 참일 때 그대로 나열하면
+     *    한 글에만 적용한 사유가 전건에 적용된 것처럼 읽힌다.
+     */
+    reasons_differ_by_item?: boolean;
 }
 
 export interface DisciplineLogListResponse {

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -230,15 +230,27 @@
                                             <span
                                                 class="hidden max-w-[45%] flex-wrap justify-end gap-1 sm:flex"
                                             >
-                                                {#each log.violation_titles.slice(0, 2) as title}
+                                                <!--
+                                                  ⛔ violation_titles 는 글별 사유의 **합집합**이다.
+                                                     글마다 다르면 나열하지 않는다 — 한 글에만
+                                                     적용한 사유가 전건에 붙은 것처럼 읽힌다.
+                                                -->
+                                                {#if log.reasons_differ_by_item}
                                                     <Badge variant="outline" class="text-[10px]"
-                                                        >{title}</Badge
+                                                        >사유 여러 건</Badge
                                                     >
-                                                {/each}
-                                                {#if log.violation_titles.length > 2}
-                                                    <Badge variant="outline" class="text-[10px]"
-                                                        >+{log.violation_titles.length - 2}</Badge
-                                                    >
+                                                {:else}
+                                                    {#each log.violation_titles.slice(0, 2) as title}
+                                                        <Badge variant="outline" class="text-[10px]"
+                                                            >{title}</Badge
+                                                        >
+                                                    {/each}
+                                                    {#if log.violation_titles.length > 2}
+                                                        <Badge variant="outline" class="text-[10px]"
+                                                            >+{log.violation_titles.length -
+                                                                2}</Badge
+                                                        >
+                                                    {/if}
                                                 {/if}
                                             </span>
                                         </a>

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -202,8 +202,23 @@
                     </span>
                 </div>
 
-                <!-- 사유는 요약 헤더 안에 둔다 — 제재의 "무엇 때문에"가 기간과 떨어지면 안 읽힌다 -->
-                {#if log.violation_types.length > 0}
+                <!--
+                  사유는 요약 헤더 안에 둔다 — 제재의 "무엇 때문에"가 기간과 떨어지면 안 읽힌다.
+
+                  ⛔ 단, **글마다 사유가 다르면 여기에 나열하지 않는다.**
+                     상단 사유는 항목별 사유의 합집합이라, 다섯 글이 A·B 이고 한 글만 C·D 여도
+                     A·B·C·D 가 전부 뜬다. 회원은 네 가지 사유로 제한받았다고 읽는다.
+                     사람은 큰 글씨를 먼저 읽어서, 아래 글별 목록을 봐도 오해가 풀리지 않는다.
+                     그런 건은 안내 한 줄로 대체하고 사유는 글별 목록에서만 읽게 한다.
+                -->
+                {#if log.reasons_differ_by_item}
+                    <div class="mt-3 flex items-baseline gap-2 border-t pt-3">
+                        <AlertTriangle class="text-muted-foreground mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        <span class="text-muted-foreground text-sm">
+                            적용 사유는 글마다 다릅니다 — 아래 목록에서 확인하세요
+                        </span>
+                    </div>
+                {:else if log.violation_types.length > 0}
                     <div class="mt-3 space-y-2 border-t pt-3">
                         {#each log.violation_types as vt}
                             <div>


### PR DESCRIPTION
묶음 처분의 상단 사유는 항목별 사유의 **합집합**입니다. 다섯 글이 A·B 이고 한 글만 C·D 여도 상단에는 A·B·C·D 가 전부 뜹니다. **8/13·8/14 소명에서 이걸 해명해야 했습니다.**

| 화면 | 글마다 사유가 다를 때 |
|---|---|
| 상세 | 사유 나열 대신 한 줄 — *"적용 사유는 글마다 다릅니다 — 아래 목록에서 확인하세요"* |
| 목록 | `사유 여러 건` 배지로 대체 |

사유는 아래 **"신고된 글"** 목록에서 글별로 읽습니다. 이미 렌더되고 있어 추가 배선은 없습니다.

```
이용제한 10일
  적용 사유는 글마다 다릅니다 — 아래 목록에서 확인하세요

신고된 글
· 다음 주 김민석의 발언…   [예의없음] [운영정책부정] [10일]
· 김석열의 과거            [분란유도/갈등조장] [부적절한 표현] [10일]
```

## 절충안을 택하지 않은 이유

⛔ 합집합을 남기고 안내만 덧붙이는 안은 배제했습니다. **사람은 큰 글씨를 먼저 읽습니다.** 상단에 네 개가 보이는 한, 아래 목록을 봐도 *"전부 적용됐는데 글마다 나눠 적었구나"* 로 읽힙니다.

## 범위

- 사유가 전부 같은 건(대부분)은 **지금 그대로**입니다.
- 판정은 백엔드가 내립니다(`reasons_differ_by_item`) — **angple-backend 가 먼저 배포**되어야 합니다. 그 전에는 `undefined` 라 지금 화면이 그대로 나옵니다(깨지지 않습니다).
- 항목 정보가 없는 옛 기록은 거짓이라 표시가 유지됩니다.
- 과거 기록도 **소급해서 정확해집니다**(2026년 71건).

⛔ svelte 컴파일러로 두 파일 모두 파일 단위 검증했습니다.
