### PR TITLE
chore(ui): 동작하지 않는 space-y-0 20곳 제거 (CardHeader)

### DIFF
--- a/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
+++ b/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
@@ -278,7 +278,7 @@
     </div>
 
     <Card class="gap-0 overflow-hidden">
-        <CardHeader class="space-y-0 pb-0">
+        <CardHeader class="pb-0">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div class="flex items-center gap-2">
                     <Compass class="text-primary h-5 w-5" />

--- a/apps/web/src/lib/components/features/economy/economy-tabs.svelte
+++ b/apps/web/src/lib/components/features/economy/economy-tabs.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <Card class="gap-0">
-    <CardHeader class="flex flex-row items-center justify-between space-y-0 py-3">
+    <CardHeader class="flex flex-row items-center justify-between py-3">
         <a href="/economy" class="hover:text-foreground flex items-center gap-2 transition-colors">
             <div
                 class="flex h-7 w-7 items-center justify-center rounded-lg bg-green-100 dark:bg-green-900/30"

--- a/apps/web/src/lib/components/features/explore/explore-preview.svelte
+++ b/apps/web/src/lib/components/features/explore/explore-preview.svelte
@@ -173,7 +173,7 @@
 
 <div bind:this={rootEl}>
     <Card class="gap-0">
-        <CardHeader class="flex flex-row items-center justify-between gap-2 space-y-0 py-3">
+        <CardHeader class="flex flex-row items-center justify-between gap-2 py-3">
             <a
                 href="/explore"
                 class="hover:text-foreground flex shrink-0 items-center gap-2 transition-colors"

--- a/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
+++ b/apps/web/src/lib/components/features/gallery/gallery-grid.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Card class="gap-0">
-    <CardHeader class="flex flex-row flex-nowrap items-center space-y-0 py-3">
+    <CardHeader class="flex flex-row flex-nowrap items-center py-3">
         <a href="/gallery" class="hover:text-foreground flex items-center gap-2 transition-colors">
             <div
                 class="flex h-7 w-7 items-center justify-center rounded-lg bg-purple-100 dark:bg-purple-900/30"

--- a/apps/web/src/lib/components/features/group/group-tabs.svelte
+++ b/apps/web/src/lib/components/features/group/group-tabs.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <Card class="gap-0">
-    <CardHeader class="flex flex-row items-center justify-between space-y-0 py-3">
+    <CardHeader class="flex flex-row items-center justify-between py-3">
         <GroupHeader />
         <GroupTabs bind:activeTab onTabChange={handleTabChange} />
     </CardHeader>

--- a/apps/web/src/lib/components/features/new-board/new-board.svelte
+++ b/apps/web/src/lib/components/features/new-board/new-board.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <Card class="gap-0">
-    <CardHeader class="flex flex-row items-center justify-between gap-2 space-y-0 py-3">
+    <CardHeader class="flex flex-row items-center justify-between gap-2 py-3">
         <a
             href="/new"
             class="hover:text-foreground flex shrink-0 items-center gap-2 transition-colors"

--- a/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
+++ b/apps/web/src/lib/components/features/recommended/recommended-posts.svelte
@@ -169,7 +169,7 @@
 </script>
 
 <Card class="gap-0">
-    <CardHeader class="flex flex-row items-center justify-between gap-2 space-y-0 py-3">
+    <CardHeader class="flex flex-row items-center justify-between gap-2 py-3">
         <RecommendedHeader />
         <RecommendedTabs bind:activeTab onTabChange={handleTabChange} />
     </CardHeader>

--- a/apps/web/src/routes/admin/commerce/+page.svelte
+++ b/apps/web/src/routes/admin/commerce/+page.svelte
@@ -162,7 +162,7 @@
         <!-- 통계 카드 -->
         <div class="mb-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <Card>
-                <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardHeader class="flex flex-row items-center justify-between pb-2">
                     <CardTitle class="text-sm font-medium">총 상품</CardTitle>
                     <Package class="text-muted-foreground h-4 w-4" />
                 </CardHeader>
@@ -175,7 +175,7 @@
             </Card>
 
             <Card>
-                <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardHeader class="flex flex-row items-center justify-between pb-2">
                     <CardTitle class="text-sm font-medium">총 주문</CardTitle>
                     <ShoppingCart class="text-muted-foreground h-4 w-4" />
                 </CardHeader>
@@ -188,7 +188,7 @@
             </Card>
 
             <Card>
-                <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardHeader class="flex flex-row items-center justify-between pb-2">
                     <CardTitle class="text-sm font-medium">총 매출</CardTitle>
                     <DollarSign class="text-muted-foreground h-4 w-4" />
                 </CardHeader>
@@ -202,7 +202,7 @@
             </Card>
 
             <Card>
-                <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardHeader class="flex flex-row items-center justify-between pb-2">
                     <CardTitle class="text-sm font-medium">정산 대기</CardTitle>
                     <ClipboardList class="text-muted-foreground h-4 w-4" />
                 </CardHeader>

--- a/apps/web/src/routes/admin/commerce/reviews/+page.svelte
+++ b/apps/web/src/routes/admin/commerce/reviews/+page.svelte
@@ -213,7 +213,7 @@
     <!-- 요약 카드 -->
     <div class="mb-6 grid gap-4 md:grid-cols-3">
         <Card>
-            <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader class="flex flex-row items-center justify-between pb-2">
                 <CardTitle class="text-sm font-medium">검토 대기</CardTitle>
                 <Star class="text-muted-foreground h-4 w-4" />
             </CardHeader>
@@ -226,7 +226,7 @@
         </Card>
 
         <Card>
-            <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader class="flex flex-row items-center justify-between pb-2">
                 <CardTitle class="text-sm font-medium">승인된 리뷰</CardTitle>
                 <Check class="text-muted-foreground h-4 w-4" />
             </CardHeader>
@@ -238,7 +238,7 @@
         </Card>
 
         <Card>
-            <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader class="flex flex-row items-center justify-between pb-2">
                 <CardTitle class="text-sm font-medium">평균 평점</CardTitle>
                 <Star class="text-muted-foreground h-4 w-4" />
             </CardHeader>

--- a/apps/web/src/routes/admin/commerce/settlements/+page.svelte
+++ b/apps/web/src/routes/admin/commerce/settlements/+page.svelte
@@ -145,7 +145,7 @@
     <!-- 요약 카드 -->
     <div class="mb-6 grid gap-4 md:grid-cols-3">
         <Card>
-            <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader class="flex flex-row items-center justify-between pb-2">
                 <CardTitle class="text-sm font-medium">정산 대기</CardTitle>
                 <Clock class="text-muted-foreground h-4 w-4" />
             </CardHeader>
@@ -158,7 +158,7 @@
         </Card>
 
         <Card>
-            <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader class="flex flex-row items-center justify-between pb-2">
                 <CardTitle class="text-sm font-medium">처리 중</CardTitle>
                 <Clock class="text-muted-foreground h-4 w-4" />
             </CardHeader>
@@ -170,7 +170,7 @@
         </Card>
 
         <Card>
-            <CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader class="flex flex-row items-center justify-between pb-2">
                 <CardTitle class="text-sm font-medium">이번 달 완료</CardTitle>
                 <Check class="text-muted-foreground h-4 w-4" />
             </CardHeader>

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -172,7 +172,7 @@
     </div>
 
     <Card class="gap-0">
-        <CardHeader class="space-y-0 pb-0">
+        <CardHeader class="pb-0">
             <!-- 헤더 + 탭 한 줄 -->
             <div class="flex items-center justify-between gap-3">
                 <div class="flex items-center gap-2">

--- a/apps/web/src/routes/groups/+page.svelte
+++ b/apps/web/src/routes/groups/+page.svelte
@@ -129,7 +129,7 @@
 
 <div class="mx-auto max-w-5xl px-4 py-8">
     <Card class="gap-0">
-        <CardHeader class="space-y-0 pb-0">
+        <CardHeader class="pb-0">
             <!-- 헤더 -->
             <div class="mb-4 flex items-center gap-3">
                 <Users class="text-primary h-7 w-7" />

--- a/widgets/celebration/index.svelte
+++ b/widgets/celebration/index.svelte
@@ -48,7 +48,7 @@
 
 {#if celebrations.length > 0}
     <Card class="w-full gap-0 overflow-hidden">
-        <CardHeader class="flex flex-row items-center justify-between space-y-0 px-3 pb-2 pt-0">
+        <CardHeader class="flex flex-row items-center justify-between px-3 pb-2 pt-0">
             <div class="flex items-center gap-1.5">
                 <PartyPopper class="text-primary h-4 w-4" />
                 <h3 class="text-sm font-semibold">마음메시지</h3>


### PR DESCRIPTION
#2081 후속. 전수조사에서 나온 죽은 클래스 중 **절대 동작할 수 없는 것만** 제거한다. 시각 변화 0.

## 왜 죽은 클래스인가

Tailwind v4 는 `space-y-0` 을 이렇게 생성한다.

```css
.space-y-0 { :where(& > :not(:last-child)) { margin-block-end: calc(0 * ...) } }
```

- `:where()` 가 선택자 전체를 감싸 **specificity 0**
- preflight 가 이미 `*{margin:0}` 이므로, 0 을 다시 0 으로 덮는 셈
- 자식이 자기 `mb-*`(0,1,0)를 가지면 그쪽이 무조건 이긴다

즉 **어떤 경우에도 상태를 바꾸지 못한다.**

## 왜 20곳 전부 CardHeader 인가

shadcn 구버전 `CardHeader` 의 기본값 `space-y-1.5` 를 취소하려는 관용구다. 그런데 이 리포의 `card-header.svelte` 는 이미 grid 변형이다.

```
'@container/card-header ... grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5'
```

취소할 `space-y` 가 없고, `space-y-0` 으로는 `gap-1.5` 도 취소되지 않는다. 헤더 간격을 죽이려고 이 클래스를 쓴 사람은 원하는 결과를 얻지 못한다.

## 남겨둔 것

- **반응형 취소용 `md:space-y-0` 3곳** — `layouts/list/classic.svelte:191`, `layouts/list/archive.svelte:80`, `comment-list.svelte:1119`. 같은 요소의 base `space-y-1` 을 실제로 취소하므로 유효하다 (같은 specificity, 소스 순서로 md 가 이김)
- **`space-y-0.5`** — 값이 있는 유틸이라 대상 아님

## 이번에 제거하지 않은 것과 그 이유

전수조사에서 함께 나온 두 부류는 **제거하지 않는 편이 낫다고 판단**했다.

**INERT `space-y-*` 13곳** (자식이 1개뿐이라 현재 무효)
`space-y-0` 과 달리 이것들은 **조건부로 옳다.** 지금은 자식이 하나라 아무 일도 안 하지만, 나중에 형제가 추가되면 의도한 간격이 살아난다. 지우면 그때 간격이 조용히 0 이 되는 잠재 회귀를 만든다. 대부분 `{#if}` 분기 안이라 형제 추가가 충분히 있을 법한 자리다.

**댓글 `li` 의 `py-3`/`py-4`**
scoped `.comment-item` 규칙(specificity 0,2,0)이 이들을 덮는 건 맞지만, muzia/chat/discussion/feed 4개 레이아웃이 각각 다른 `py-*` 를 쓰고 있다. scoped 규칙이 바뀌면 되살아나야 하는 값들이라, 레이아웃별 확인 없이 지우면 위험하다.

## 검증

Prettier / svelte-check(0 errors) / unit test 82파일 893개 / production build 전부 로컬 통과.