### PR TITLE
fix(search): 검색 폼 점진적 향상 — JS 죽어도 검색되게 (bug/13503)

### DIFF
--- a/apps/web/src/lib/components/features/search/search-autocomplete.svelte
+++ b/apps/web/src/lib/components/features/search/search-autocomplete.svelte
@@ -9,9 +9,16 @@
         placeholder?: string;
         initialQuery?: string;
         onSearch?: (query: string) => void;
+        /** 네이티브 폼 제출용 input name (JS 죽어도 검색되게, bug/13503) */
+        name?: string;
     }
 
-    let { placeholder = '검색어를 입력하세요', initialQuery = '', onSearch }: Props = $props();
+    let {
+        placeholder = '검색어를 입력하세요',
+        initialQuery = '',
+        onSearch,
+        name
+    }: Props = $props();
 
     let query = $state(initialQuery);
     let results = $state<GlobalSearchResult[]>([]);
@@ -110,6 +117,7 @@
         <input
             bind:this={inputEl}
             type="text"
+            {name}
             value={query}
             oninput={handleInput}
             onkeydown={handleKeydown}

--- a/apps/web/src/routes/search/+page.svelte
+++ b/apps/web/src/routes/search/+page.svelte
@@ -188,7 +188,19 @@
         <h1 class="text-foreground mb-4 text-3xl font-bold">검색</h1>
 
         <!-- 검색 폼 -->
-        <form onsubmit={handleSearch} class="flex flex-wrap items-center gap-2">
+        <!-- bug/13503: method/action 을 명시해 JS(하이드레이션)가 죽어도 네이티브 제출로 검색된다.
+             기존엔 action·name 이 없어, 광고차단기·삼성브라우저에서 스크립트가 막혀 handleSearch 가
+             안 붙으면 빈 /search 로 되돌아가 오류 없이 아무것도 안 나왔다(제보와 일치).
+             JS 살아있으면 handleSearch 가 preventDefault 후 goto(); 죽어있으면 브라우저가
+             /search?q=…&sfl=… 로 네이티브 이동한다. +page.ts 가 이미 q/sfl 을 읽으므로 서버 무변. -->
+        <form
+            method="GET"
+            action="/search"
+            onsubmit={handleSearch}
+            class="flex flex-wrap items-center gap-2"
+        >
+            <!-- JS 없을 때 검색 필드도 함께 제출(Select 는 JS 전용이라 기본값이 나간다) -->
+            <input type="hidden" name="sfl" value={searchField} />
             <!-- 검색 필드 선택 -->
             <Select.Root type="single" value={searchField} onValueChange={handleFieldChange}>
                 <Select.Trigger class="w-[120px]">
@@ -204,6 +216,7 @@
             <!-- 검색어 입력 (자동완성) -->
             <div class="relative min-w-[250px] flex-1">
                 <SearchAutocomplete
+                    name="q"
                     initialQuery={searchQuery}
                     placeholder="검색어를 입력하세요"
                     onSearch={(q) => {


### PR DESCRIPTION
## 배경 (bug/13503)
갤럭시S24/삼성브라우저/유니콘 광고차단 환경에서 검색해도 결과가 안 나오고 오류도 없음. API·페이지·비로그인 안내는 모두 정상 → 서버 아님.

## 근본원인
검색 폼이 **JS 100% 의존**. `<form onsubmit={handleSearch}>`에 action·method가 없고 SearchAutocomplete input에 name이 없어, 하이드레이션이 실패(차단기가 스크립트 차단/삼성브라우저 JS오류)하면 네이티브 제출이 **쿼리 없이 /search로 되돌아가** 빈 결과를 오류 없이 표시했다. 제보 문구와 정확히 일치.

## 수정 (점진적 향상, 웹 2파일)
- `search-autocomplete.svelte`: `name?` prop 추가 → 실제 input에 적용.
- `search/+page.svelte`: form에 `method=GET action=/search` + hidden `sfl` + SearchAutocomplete `name=q`.
- `+page.ts`는 이미 `url.searchParams`에서 q/sfl을 읽음(파라미터명 일치 확인) → **서버 무변**.

JS 살아있으면 기존대로 `goto()` SPA, 죽어있으면 브라우저가 `/search?q=…&sfl=…` 네이티브 이동 → **차단기·하이드레이션 실패에도 검색 동작**.

## 검증
- Evaluator(독립) 8항목 전부 PASS, **SHIP**. q/sfl 파라미터 일치·name이 실제 타이핑 input·svelte-check 무파손·JS경로 무회귀 확인.
- prettier 통과. 백엔드/DDL 무변.