### PR TITLE
fix(angtt): 앙티티 게시판 리뷰를 role='review'로 연결 (후기 인식 회귀)

### DIFF
--- a/apps/web/src/lib/server/angtt-auto-link.ts
+++ b/apps/web/src/lib/server/angtt-auto-link.ts
@@ -25,6 +25,13 @@ import {
 /** 자동 연결을 적용할 게시판 */
 const AUTO_LINK_BOARDS = new Set(['free', 'angtt']);
 
+/**
+ * 후기 게시판 — 이 게시판의 글은 그 자체가 작품 후기(review)다.
+ * free 등 다른 게시판의 글은 작품을 "언급(mention/auto)"할 뿐이지만,
+ * angtt 게시판 글은 작품 페이지에서 「후기」로 최상단에 노출돼야 한다.
+ */
+const REVIEW_BOARD = 'angtt';
+
 /** 시스템 태그 작성자 — 관리자/작성자와 구분 */
 const SYSTEM_TAG_MB_ID = 'ai';
 
@@ -157,11 +164,45 @@ export async function detectEntityFromTitle(title: string): Promise<AngttDetectM
 }
 
 /**
+ * entity_posts 링크 1건을 기록한다. 게시판에 따라 역할이 갈린다.
+ *
+ * - angtt(REVIEW_BOARD): 글 자체가 후기이므로 role='review'.
+ *   이미 auto/mention 으로 잘못 링크된 행이 있으면 review 로 **승격**한다
+ *   (ON DUPLICATE KEY UPDATE). 후기가 auto/mention 으로 남아 작품 페이지에서
+ *   「후기」로 안 뜨던 회귀를 여기서 바로잡는다.
+ * - free 등: 기존과 동일하게 `otherRole`(auto/mention)로 INSERT IGNORE —
+ *   이미 어떤 행이든 있으면 무변화(PK: bo_table, wr_id, entity_id). 언급 경로는 그대로다.
+ *
+ * ⛔ review 승격은 angtt 게시판에만 적용된다. free 글의 auto/mention 은 절대 덮지 않는다.
+ */
+async function upsertEntityLink(
+    entityId: number,
+    boardId: string,
+    wrId: number,
+    otherRole: 'auto' | 'mention'
+): Promise<void> {
+    if (boardId === REVIEW_BOARD) {
+        await pool.execute(
+            `INSERT INTO angple_entity_posts (entity_id, bo_table, wr_id, role, created_at)
+             VALUES (?, ?, ?, 'review', NOW(3))
+             ON DUPLICATE KEY UPDATE role = 'review'`,
+            [entityId, boardId, wrId]
+        );
+        return;
+    }
+    await pool.execute(
+        `INSERT IGNORE INTO angple_entity_posts (entity_id, bo_table, wr_id, role, created_at)
+         VALUES (?, ?, ?, ?, NOW(3))`,
+        [entityId, boardId, wrId, otherRole]
+    );
+}
+
+/**
  * 글의 태그(작성자가 확정한 것)를 보고 작품 링크를 만든다.
  *
- * 「앙티티」+ 별칭 정확 일치 태그가 있으면 entity_posts 에 role='mention' 을
- * INSERT IGNORE 한다 — 이미 auto/review/mention 행이 있으면 무변화(PK: bo_table,
- * wr_id, entity_id). 태그는 건드리지 않고(작성자 소유) 링크만 **추가**한다.
+ * 「앙티티」+ 별칭 정확 일치 태그가 있으면 entity_posts 에 링크를 남긴다.
+ * angtt 게시판이면 role='review'(후기 본체), 그 외 게시판이면 role='mention'.
+ * 태그는 건드리지 않고(작성자 소유) 링크만 **추가**한다.
  * 제안 칩 [연결]·수동 태그 입력 양쪽이 이 경로로 작품페이지에 연결된다.
  *
  * @returns 링크한 작품 slug, 대상 아니면 null
@@ -186,11 +227,7 @@ export async function linkEntityFromTags(boardId: string, wrId: number): Promise
     const info = slugToInfo.get(hit.entitySlug);
     if (!info) return null;
 
-    await pool.execute(
-        `INSERT IGNORE INTO angple_entity_posts (entity_id, bo_table, wr_id, role, created_at)
-         VALUES (?, ?, ?, 'mention', NOW(3))`,
-        [info.id, boardId, wrId]
-    );
+    await upsertEntityLink(info.id, boardId, wrId, 'mention');
 
     return hit.entitySlug;
 }
@@ -288,7 +325,8 @@ export async function isAutoLinkSuspended(): Promise<boolean> {
 
 /**
  * 새 글의 제목을 보고 작품에 자동 연결한다.
- * 연결 시 「앙티티」 + 작품명 태그를 달고 angple_entity_posts 에 role='auto' 링크를 남긴다.
+ * 연결 시 「앙티티」 + 작품명 태그를 달고 angple_entity_posts 에 링크를 남긴다 —
+ * angtt 게시판이면 role='review'(후기 본체), 그 외 게시판이면 role='auto'.
  *
  * @returns 연결한 작품 slug, 연결 안 했으면 null
  */
@@ -318,11 +356,7 @@ export async function autoLinkAngttEntity(
     await attachTag(boardId, wrId, ANGTT_TAG);
     await attachTag(boardId, wrId, hit.entitySlug);
 
-    await pool.execute(
-        `INSERT IGNORE INTO angple_entity_posts (entity_id, bo_table, wr_id, role, created_at)
-         VALUES (?, ?, ?, 'auto', NOW(3))`,
-        [entityId, boardId, wrId]
-    );
+    await upsertEntityLink(entityId, boardId, wrId, 'auto');
 
     return hit.entitySlug;
 }


### PR DESCRIPTION
## 배경
angtt(앙티티) 게시판의 리뷰 글이 엔티티에 `role='auto'`/`'mention'`으로 연결돼(원래 'review'여야) 앙티티 작품페이지에서 **후기로 인식·정렬되지 않던** 문제. 예: 오디세이(엔티티5)의 리뷰 angtt/7361이 'auto'로 연결돼 후기 미인식.

## 근본원인
`role='review'` write 경로가 코드에 **아예 없었음**(#1811이 read/sort 마커로만 도입, linker는 항상 'auto'/'mention' write). 초기 2건(7297·7330)만 수동 시드돼 있어 정상처럼 보였고, 이후 angtt 리뷰는 전부 `autoLinkAngttEntity`(role='auto')로 흘러 후기 미인식.

## 수정 (angtt-auto-link.ts 1파일)
- `REVIEW_BOARD='angtt'` + `upsertEntityLink()` 도입: **angtt 보드 글 → role='review'** (INSERT … ON DUPLICATE KEY UPDATE role='review' — 기존 stale 'auto'도 재링크 시 자가치유).
- **free 등 그 외 보드는 기존 그대로** ('auto'/'mention', INSERT IGNORE). 리뷰 분기는 boardId==='angtt'로만 게이트 → free 무영향.

## 검증
- Evaluator(독립) 8항목 전부 PASS, **SHIP**. free 경로 무회귀(bo_table 키), 카드 무영향(angtt는 카드 미생성 + 카드는 role 미참조) 확인.
- 데이터 백필은 별도 집행(기존 angtt 'auto'→'review', 7361·7381 완료).
- prettier 통과. 백엔드/DDL 무변.

## 카드 증상은 별개
사용자 제보의 '평점+첫등록 동시' 카드 증상은 role이 아닌 resolveAngttMatch 엔티티-인덱스 폴백(dictionary.ts) 소관이라 본 PR과 무관 — 별도 확인 필요.