### PR TITLE
fix(board): 글자 크기 버튼 인지성 개선 + 목록 배너 정렬

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -217,39 +217,47 @@
 
 <!-- 글자 크기 조절 — 종전에는 본문 바로 위에 전용 줄(34px)을 차지했다. 한 번 맞추면
      다시 건드릴 일이 드문 설정인데 매 게시글마다 고정으로 한 줄을 먹어 작성자 줄로 옮겼다.
-     라벨은 화면 폭에 따라 다르게 쓴다:
-       - md 이상: "작게/보통/크게" (여유 356px, 3버튼 124px)
-       - 모바일:  "가−/가+" (여유 127px, 2버튼 72px). 3버튼은 폭이 안 나온다.
-     +/− 기호만 쓰면 뜻이 안 통한다는 제보가 있어 모바일도 "가" 를 붙여 글자 크기임을 알린다.
-     py-1.5 는 터치 타겟 26px 확보용(WCAG 2.2 AA 최소). -->
+
+     라벨은 화면 폭에 맞춰 다르게 쓴다. 닉네임 줄의 실측 여유는 모바일 45px / PC 356px 이다.
+       - md 이상: "글자크기" 라벨 + 작게·보통·크게 (170px, 여유 안)
+       - 모바일:  작은 "가" / 큰 "가" 두 버튼 (62px). 라벨이나 아이콘을 더 붙이면
+                 101~118px 이 되어 여유를 넘긴다.
+     모바일이 기호(+/−) 대신 글자 크기 차이로 방향을 나타내는 이유: "+/− 는 뜻이 안 통한다"는
+     제보가 있었고, 이 방식은 종전 "가−/가+"(76px)보다 오히려 14px 좁다.
+
+     버튼은 h-[26px] 로 높이를 고정한다. 안쪽 글자 크기가 11px/15px 로 달라도 버튼 높이가
+     흔들리지 않아야 작성자 줄(26px)이 커지지 않는다. 26px 은 터치 타겟 최소치이기도 하다.
+     bg-muted/40 은 옆의 텍스트 메타(닉네임·IP)와 시각 무게를 구분해 "누를 수 있는 것"임을
+     정지 상태에서 알리는 용도다. -->
 {#snippet fontSizeControls()}
     <span class="ml-auto flex shrink-0 items-center gap-1">
+        <span class="text-muted-foreground hidden text-xs md:inline">글자크기</span>
         <button
             type="button"
-            class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-2 py-1.5 text-xs leading-none transition-colors disabled:opacity-30"
+            class="text-muted-foreground hover:text-foreground active:bg-muted border-border bg-muted/40 hover:bg-muted inline-flex h-[26px] min-w-[30px] items-center justify-center rounded border px-2 leading-none transition-colors disabled:opacity-30"
             disabled={currentFontSize === 'small'}
             onclick={() => uiSettingsStore.changeContentFontSize(-1)}
             aria-label="글자 작게"
         >
-            <span class="md:hidden">가−</span>
-            <span class="hidden md:inline">작게</span>
+            <span class="text-[11px] md:hidden">가</span>
+            <span class="hidden text-xs md:inline">작게</span>
         </button>
-        <!-- 기본값 복귀는 md 이상에서만. 모바일은 폭이 없어 가−/가+ 로 오갈 수 있게만 둔다. -->
+        <!-- 기본값 복귀는 md 이상에서만. 모바일은 폭이 없어 작은가/큰가 로 오갈 수 있게만 둔다. -->
         <button
             type="button"
-            class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted hidden rounded border px-2 py-1.5 text-xs leading-none transition-colors md:inline-block"
+            class="text-muted-foreground hover:text-foreground active:bg-muted border-border bg-muted/40 hover:bg-muted hidden h-[26px] items-center justify-center rounded border px-2 text-xs leading-none transition-colors md:inline-flex"
             onclick={() => uiSettingsStore.changeContentFontSize(0)}
             aria-label="글자 기본">보통</button
         >
         <button
             type="button"
-            class="text-muted-foreground hover:text-foreground active:bg-muted border-border hover:bg-muted rounded border px-2 py-1.5 text-xs leading-none transition-colors disabled:opacity-30"
+            class="text-muted-foreground hover:text-foreground active:bg-muted border-border bg-muted/40 hover:bg-muted inline-flex h-[26px] min-w-[30px] items-center justify-center rounded border px-2 leading-none transition-colors disabled:opacity-30"
             disabled={currentFontSize === '3xlarge'}
             onclick={() => uiSettingsStore.changeContentFontSize(1)}
             aria-label="글자 크게"
         >
-            <span class="md:hidden">가+</span>
-            <span class="hidden md:inline">크게</span>
+            <span class="text-[15px] md:hidden">가</span>
+            <span class="hidden text-xs md:inline">크게</span>
         </button>
     </span>
 {/snippet}

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1199,8 +1199,11 @@
             {/if}
 
             <!-- 최상단 자체 배너 (자체 배너 없으면 안 보임) -->
+            <!-- 배너는 아래 목록과 같은 폭을 쓴다. 모바일에서 목록은 -mx-2 로 풀블리드인데
+                 배너만 상위 main 의 px-2 안쪽(8px)에 머물러, 배너가 혼자 들여쓰기된 것처럼 보였다.
+                 md 이상은 목록도 여백을 두므로 종전대로. -->
             {#if widgetLayoutStore.hasEnabledAds}
-                <div class="mb-2">
+                <div class="-mx-2 mb-2 md:mx-0">
                     <PluginSlot name="board-list-banner" />
                 </div>
             {/if}


### PR DESCRIPTION
배포된 화면을 실측·평가해서 나온 두 가지를 다듬는다.

## 1. 글자 크기 버튼 — 무슨 버튼인지 알기 어려웠다

#2080 에서 작성자 줄로 옮긴 뒤, `가−`/`가+` 가 옆의 닉네임·IP 와 **같은 시각 무게**라 기능 버튼으로 읽히지 않았다. `+`/`−` 기호는 뜻이 안 통한다는 제보도 있었다.

| | 종전 | 변경 |
|---|---|---|
| 모바일 | `가−` `가+` (76px) | **작은 `가` / 큰 `가`** (65px) |
| md 이상 | `작게` `보통` `크게` | **`글자크기` 라벨 +** 작게·보통·크게 (170px) |

- 모바일은 기호 대신 **글자 크기 차이로 방향을 나타낸다.** 폭도 11px 줄었다
- 라벨을 모바일에도 붙이면 101~118px 이 되어 닉네임 줄 여유(실측 45px)를 넘긴다. PC 는 여유 356px 라 문제없다
- 버튼에 `bg-muted/40` 을 줘 텍스트 메타와 구분한다
- 버튼 높이를 `h-[26px]` 로 고정 — 안쪽 글자가 11px/15px 로 달라도 작성자 줄(26px)이 커지지 않아야 한다. 26px 은 터치 타겟 최소치이기도 하다

## 2. 목록 배너가 혼자 들여쓰기돼 보였다

모바일에서 목록은 `-mx-2` 로 풀블리드(0~390px)인데 배너만 상위 `main` 의 `px-2` 안쪽(8~382px)에 머물러, 배너만 안으로 밀린 것처럼 보였다.

배너에도 `-mx-2 md:mx-0` 을 줘 폭을 맞춘다. 주입 측정 결과 배너·목록 모두 `left 0 / width 390` 으로 일치.

## 검증

임시 프리뷰 라우트로 실제 컴포넌트를 SSR 렌더해 측정(측정 후 제거, 커밋에 미포함).

- 모바일 390: 컨트롤 **65px**, 버튼 **26px**, 메타 줄 **59px 유지**, 작성자 줄 넘침 **0**
- PC 1440: `글자크기` 라벨 노출, 3버튼 정상
- 목록 배너: 목록과 폭 일치 확인

prettier / svelte-check(0 errors) / unit test 82파일 893개 / production build 전부 로컬 통과.

## 이번에 하지 않은 것

- **`← 자유게시판` 줄 합치기** — 처음엔 "버튼 하나가 한 줄을 쓴다"고 봤으나, 그건 **비로그인 한정**이었다. 로그인하면 `← 자유게시판` + `글쓰기` + 스크랩(작성자면 수정·삭제까지)으로 줄이 찬다. 비로그인만을 위한 조건부 레이아웃은 복잡도 대비 이득이 적다
- **광고 슬롯 충전률** — 글 상세 하단 광고 5개 중 4개가 빈 슬롯(550px)이다. `banner-article` 유닛이 모바일에서 `320×100` 하나만 요청하는 게 원인일 수 있으나, GAM 리포트의 실제 fill rate 없이 지면 크기를 바꾸는 건 추측 배포라 손대지 않았다