### PR TITLE
fix(ui): 마음메시지 회전 감속 + 글 제목 WebKit 잘림 (bug/13237, bug/13516)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -320,8 +320,12 @@
                 {/if}
                 <!-- bug/13388: 맨몸 텍스트는 익명 flex item 이 되어 min-width/줄바꿈을
                      제어할 수 없고, iOS WebKit 에서 줄바꿈 폭 오계산 → 1행 넘침이
-                     조상 overflow-x:hidden 에 잘려 글자가 소실된다. 실요소로 감싼다. -->
-                <span class="min-w-0 [overflow-wrap:anywhere]">
+                     조상 overflow-x:hidden 에 잘려 글자가 소실된다. 실요소로 감싼다.
+                     bug/13516: flex-basis:auto(기본) 이면 WebKit 계열이 이 flex item 을
+                     콘텐츠(max-content) 폭으로 잡아 min-w-0·overflow-wrap 만으론 여전히
+                     한 글자 넘쳐 잘렸다(Android/WebKit 계열 재현). flex-1(=flex:1 1 0%)로
+                     basis 를 0 으로 두면 남는 폭 기준으로 감싸 넘침이 사라진다. Chromium 동작 불변. -->
+                <span class="min-w-0 flex-1 [overflow-wrap:anywhere]">
                     {#if post.is_discipline_related}
                         <DisciplinedContent
                             inline

--- a/apps/web/src/lib/stores/celebration.svelte.ts
+++ b/apps/web/src/lib/stores/celebration.svelte.ts
@@ -42,8 +42,10 @@ let intervalId: ReturnType<typeof setInterval> | null = null;
 let loadedDateKST = '';
 // visibilitychange 리스너 중복 등록 방지 (스토어는 앱 수명 동안 단일 인스턴스).
 let visibilityBound = false;
-// 롤링 주기. 사용자 요청으로 3s → 2s 로 추가 단축 (메시지 6개 기준 한 바퀴 12s).
-const CELEBRATION_ROTATION_INTERVAL_MS = 2_000;
+// 롤링 주기. bug/13237: 마음메시지가 2개 이상일 때 너무 빨리 바뀌어 긴 문구를 다 못 읽는다는
+// 요청으로 2s → 5s 로 늘렸다(약 2.5배). 전환 애니메이션 500ms 를 빼도 정지 노출이 ~4.5s 라
+// 긴 문구도 편히 읽힌다.
+const CELEBRATION_ROTATION_INTERVAL_MS = 5_000;
 
 /**
  * KST(Asia/Seoul) 기준 오늘 YYYY-MM-DD.


### PR DESCRIPTION
bug/13237 — 마음메시지(축하 배너/롤러)가 2초마다 바뀌어 너무 빨랐음. 회전 간격 2s→5s.
bug/13516 — 게시글 상세 제목이 iOS/WebKit 계열에서 줄바꿈 폭 오계산으로 우측 잘림. 제목 span에 flex-1(flex-basis:0) 부여해 WebKit이 내부 줄바꿈하도록. 형제 배지는 전부 shrink-0라 무영향(Chromium 비회귀 확인).

bug/13119(앙파일럿 상단바 가림)은 코드 밖(구글 AdSense Auto Ads 앵커광고)이라 이 PR에 미포함.

web-only, DDL 없음.