### PR TITLE
feat(공감): 추천 취소 시간잠금 (관리자 설정, 기본 12시간)

### DIFF
--- a/apps/web/src/lib/components/admin/settings/general-settings.svelte
+++ b/apps/web/src/lib/components/admin/settings/general-settings.svelte
@@ -5,6 +5,12 @@
     import { adminSettingsStore } from '$lib/stores/admin-settings-store.svelte.js';
     import Loader2 from '@lucide/svelte/icons/loader-2';
     import Save from '@lucide/svelte/icons/save';
+
+    function setGoodCancelWindowHours(value: string) {
+        // 음수/NaN 은 0(제한 없음)으로 정규화. 소수점은 버림.
+        const n = Math.max(0, Math.floor(Number(value)));
+        adminSettingsStore.settings.general.goodCancelWindowHours = Number.isFinite(n) ? n : 0;
+    }
 </script>
 
 <div class="space-y-6">
@@ -24,6 +30,24 @@
             placeholder="사이트 설명을 입력하세요"
             bind:value={adminSettingsStore.settings.general.siteDescription}
         />
+    </div>
+
+    <div class="space-y-2">
+        <Label for="goodCancelWindowHours">추천(공감) 취소 가능 시간(시간). 0=제한 없음</Label>
+        <Input
+            id="goodCancelWindowHours"
+            type="number"
+            min="0"
+            step="1"
+            placeholder="12"
+            value={String(adminSettingsStore.settings.general.goodCancelWindowHours ?? 12)}
+            oninput={(e: Event) =>
+                setGoodCancelWindowHours((e.currentTarget as HTMLInputElement).value)}
+        />
+        <p class="text-muted-foreground text-xs">
+            추천을 누른 뒤 이 시간이 지나면 취소할 수 없습니다(일방향). 비추천/이모티콘 반응에는
+            적용되지 않습니다.
+        </p>
     </div>
 
     <div class="flex justify-end">

--- a/apps/web/src/lib/types/admin-settings.ts
+++ b/apps/web/src/lib/types/admin-settings.ts
@@ -27,6 +27,12 @@ export interface OAuthProviderMeta {
 export interface GeneralSettings {
     siteName: string;
     siteDescription: string;
+    /**
+     * 추천(공감/good) 취소 가능 시간(단위: 시간).
+     * 추천을 누른 뒤 이 시간이 지나면 취소할 수 없다(레거시 일방향 정책).
+     * 0 = 제한 없음(항상 취소 가능). 비추천/이모티콘 반응에는 적용되지 않는다.
+     */
+    goodCancelWindowHours: number;
 }
 
 /** OAuth 설정 */
@@ -112,7 +118,8 @@ function defaultOAuthProvider(): OAuthProviderConfig {
 export const DEFAULT_SITE_SETTINGS: SiteSettings = {
     general: {
         siteName: '',
-        siteDescription: ''
+        siteDescription: '',
+        goodCancelWindowHours: 12
     },
     oauth: {
         google: defaultOAuthProvider(),

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -15,6 +15,7 @@ import { checkCertification } from '$lib/server/certification';
 import { protectClientIp } from '$lib/server/ip-protection';
 import { isSanctionedPost, SANCTIONED_LOCK_MESSAGE } from '$lib/server/sanctioned-lock';
 import { getRedis } from '$lib/server/redis';
+import { siteSettingsProvider } from '$lib/server/settings/site-settings-provider.js';
 import {
     getPostReactionVersion,
     invalidateReactionCaches,
@@ -23,6 +24,8 @@ import {
 
 interface GoodRow extends RowDataPacket {
     bg_flag: string;
+    /** POST 취소 경로에서만 채워지는 계산 컬럼 (0/1). GET 등 다른 조회에서는 미포함. */
+    good_locked?: number;
 }
 
 interface WriteRow extends RowDataPacket {
@@ -292,6 +295,21 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
     const tableName = `g5_write_${safeBoardId}`;
     const column = action === 'good' ? 'wr_good' : 'wr_nogood';
 
+    // 추천(good) 취소 잠금 시간(시간) — 사이트 설정에서 런타임 조회.
+    // 0 = 제한 없음(항상 취소 가능). nogood/이모티콘 반응에는 적용하지 않는다(good 경로에서만 조회).
+    // 조회는 provider 캐시 경유(mysql=Redis 캐시, json=로컬 파일). nogood 는 조회 자체를 건너뛴다.
+    let goodCancelWindowHours = 0;
+    if (action === 'good') {
+        try {
+            const general = await siteSettingsProvider.get('general');
+            const parsed = Math.floor(Number(general?.goodCancelWindowHours));
+            goodCancelWindowHours = Number.isFinite(parsed) && parsed >= 0 ? parsed : 12;
+        } catch {
+            // 설정 조회 실패 시 기본값(12h)으로 안전하게 동작
+            goodCancelWindowHours = 12;
+        }
+    }
+
     const conn = await pool.getConnection();
     try {
         await conn.beginTransaction();
@@ -316,9 +334,23 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
         }
 
         // 현재 사용자의 기존 추천/비추천 기록 확인
+        // good_locked: 추천(good) 취소 잠금 여부(0/1) 를 DB(KST)에서 계산한다.
+        //   bg_datetime 은 KST 로 저장되므로 현재시각도 CONVERT_TZ 로 KST 로 맞춰 비교한다
+        //   (JS Date.now() 로 비교하면 9시간 어긋난다).
+        //   window(?)=0 이면 항상 0(제한 없음). bg_datetime 이 NULL/'0000-00-00 00:00:00' 이면
+        //   레거시/미상 데이터로 보고 잠그지 않는다(취소 허용).
         const [existingRows] = await conn.query<GoodRow[]>(
-            `SELECT bg_flag FROM g5_board_good WHERE bo_table = ? AND wr_id = ? AND mb_id = ?`,
-            [safeBoardId, safePostId, user.mb_id]
+            `SELECT bg_flag,
+                    CASE
+                        WHEN ? > 0
+                             AND bg_flag = 'good'
+                             AND bg_datetime IS NOT NULL
+                             AND bg_datetime <> '0000-00-00 00:00:00'
+                             AND TIMESTAMPDIFF(HOUR, bg_datetime, CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00')) >= ?
+                        THEN 1 ELSE 0
+                    END AS good_locked
+             FROM g5_board_good WHERE bo_table = ? AND wr_id = ? AND mb_id = ?`,
+            [goodCancelWindowHours, goodCancelWindowHours, safeBoardId, safePostId, user.mb_id]
         );
 
         const existingGood = existingRows.find((r) => r.bg_flag === 'good');
@@ -347,6 +379,20 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
         }
 
         const alreadyExists = action === 'good' ? existingGood : existingNogood;
+
+        // 추천(good) 취소 잠금: 설정된 시간이 지난 추천은 취소를 거부한다(일방향).
+        //   good 취소 경로에서만 적용. INSERT/신규 추천·nogood·이모티콘 반응은 영향 없음.
+        //   window=0(제한 없음)이거나 시간 미경과면 good_locked=0 이라 통과한다.
+        if (action === 'good' && alreadyExists && alreadyExists.good_locked === 1) {
+            await conn.rollback();
+            return json(
+                {
+                    success: false,
+                    message: `추천은 ${goodCancelWindowHours}시간이 지나면 취소할 수 없습니다.`
+                },
+                { status: 403 }
+            );
+        }
 
         let nextLikes = writeRows[0].wr_good;
         let nextDislikes = writeRows[0].wr_nogood;


### PR DESCRIPTION
레거시 nariya 정책 복원: 추천(공감) 후 일정 시간이 지나면 취소 불가(일방향). 마이그레이션에서 빠졌던 것을 되살림.

- 값은 하드코딩 없이 사이트 설정 goodCancelWindowHours(기본 12) — 관리자 설정페이지에서 조정. 0=제한 없음.
- like 엔드포인트가 런타임에 값 읽어 bg_datetime + N시간 경과 시 취소 거부(403). KST 기준(9시간 오프셋 없음), 연결 릴리스 보장.
- 비추천 없음 / 이모지 반응(g5_da_reaction)은 자유 변경 — 손대지 않음.

web-only, DDL 없음. Evaluator SHIP.