### PR TITLE
fix(board): 글 상세 메타 줄 타이포/정렬 규칙 정리 (bug/13536)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -230,7 +230,9 @@
      bg-muted/40 은 옆의 텍스트 메타(닉네임·IP)와 시각 무게를 구분해 "누를 수 있는 것"임을
      정지 상태에서 알리는 용도다. -->
 {#snippet fontSizeControls()}
-    <span class="ml-auto flex shrink-0 items-center gap-1">
+    <!-- self-center: 부모 줄이 items-baseline 이라 그대로 두면 버튼 박스가 밑선에 매달려
+         줄 높이를 밀어낸다. 이 그룹만 세로 중앙으로 되돌린다 (bug/13536). -->
+    <span class="ml-auto flex shrink-0 items-center gap-1 self-center">
         <span class="text-muted-foreground hidden text-xs md:inline">글자크기</span>
         <button
             type="button"
@@ -265,15 +267,20 @@
 <!-- 조회/공감/댓글 — 모바일에서는 작성자 날짜 옆으로, md 이상은 메타 줄 우측으로
      같은 마크업을 두 위치에 렌더한다(둘 중 하나만 보이므로 중복 노출은 없다). -->
 {#snippet metaCounts()}
-    <div class="text-secondary-foreground flex gap-2 sm:gap-4" style="font-size: 0.85em;">
+    <!-- text-xs: 메타 보조 정보는 14px 한 값으로 통일한다(bug/13536). 종전 0.85em 은
+         부모 폰트에 따라 값이 흔들리고, 옆의 날짜(0.9em)와 크기가 달라 같은 줄에서
+         기준선이 어긋났다. items-baseline 과 함께 써야 효과가 있다. -->
+    <div class="text-secondary-foreground flex items-baseline gap-2 text-sm sm:gap-4">
         <span>조회 {post.views.toLocaleString()}</span>
         <span>공감 {likeCount.toLocaleString()}</span>
         <!-- bug/13376: 옆의 조회·공감과 똑같이 생겨서 누를 수 있는 줄 몰랐다는
              제보. hover 만으로는 터치 기기에서 아무 단서가 되지 못한다.
-             테두리와 아래 화살표로 "눌러서 아래로 간다"를 정지 상태에서 보인다. -->
+             테두리와 아래 화살표로 "눌러서 아래로 간다"를 정지 상태에서 보인다.
+             bug/13536: 종전 -my-0.5 가 배지를 줄 밖으로 4px 밀어내 "붕 떠 보인다"는
+             제보로 이어졌다. 음수 마진을 없애고 줄 안에 들어오게 한다. -->
         <button
             type="button"
-            class="border-border hover:bg-muted hover:text-foreground -my-0.5 inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0.5 transition-colors"
+            class="border-border hover:bg-muted hover:text-foreground inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0 leading-5 transition-colors"
             aria-label="댓글 {post.comments_count}개로 이동"
             onclick={() =>
                 document.getElementById('comments')?.scrollIntoView({ behavior: 'smooth' })}
@@ -416,7 +423,11 @@
                         </div>
                     {/if}
                     <div class="min-w-0 flex-1">
-                        <p class="text-foreground flex items-center gap-1.5 font-medium">
+                        <!-- 닉네임(16px)·IP(12px)가 한 줄에 서므로 밑선 정렬한다.
+                             종전 items-center 조합에서 기준선이 3px 어긋났다 (bug/13536).
+                             닉네임 크기는 줄이지 않는다 — 이 줄의 주 정보이고, 줄이면 메타 블록이
+                             2px 더 좁아져 "답답하다"는 같은 제보의 다른 지적과 충돌한다. -->
+                        <p class="text-foreground flex items-baseline gap-1.5 font-medium">
                             <LevelBadge level={memberLevelStore.getLevel(post.author_id)} />
                             <AuthorLink
                                 authorId={post.author_id}
@@ -437,8 +448,12 @@
                             {/if}
                             {@render fontSizeControls()}
                         </p>
-                        <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-                            <p class="text-secondary-foreground" style="font-size: 0.9em;">
+                        <!-- items-baseline: 크기가 다른 요소를 items-center 로 묶으면 글자 밑선이
+                             어긋난다. 한글 폰트는 ascent/descent 비율이 OS 마다 달라(iOS Apple SD
+                             Gothic Neo vs Android Noto Sans KR) 어긋나는 정도도 기기별로 달라진다.
+                             밑선 정렬은 폰트 metrics 에 영향받지 않는다 (bug/13536). -->
+                        <div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                            <p class="text-secondary-foreground text-sm">
                                 <!-- 모바일은 폭 절약형(올해 글이면 연도 생략),
                                      md 이상은 종전의 읽기 좋은 상대형 표기를 유지한다. -->
                                 <span class="md:hidden">{createdShort}</span>

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -503,7 +503,8 @@
             {/if}
         </div>
 
-        <div class="border-border flex flex-wrap items-center gap-4 border-t pt-4">
+        <!-- items-baseline: 크기가 다른 메타 요소의 글자 밑선을 맞춘다 (bug/13536, basic.svelte 와 동일 규칙) -->
+        <div class="border-border flex flex-wrap items-baseline gap-4 border-t pt-4">
             <div class="flex items-center gap-2">
                 {#if getAvatarUrl(post.author_image, post.author_image_updated_at)}
                     <img
@@ -532,7 +533,7 @@
                     </div>
                 {/if}
                 <div>
-                    <p class="text-foreground flex items-center gap-1.5 font-medium">
+                    <p class="text-foreground flex items-baseline gap-1.5 font-medium">
                         <LevelBadge level={memberLevelStore.getLevel(post.author_id)} />
                         <AuthorLink
                             authorId={post.author_id}
@@ -547,7 +548,7 @@
                             />
                         {/if}
                     </p>
-                    <p class="text-secondary-foreground" style="font-size: 0.9em;">
+                    <p class="text-secondary-foreground text-sm">
                         {formatDate(post.created_at)}
                         <!-- 수정 배지: 리비전 기반 edit_count/last_edited_at(백엔드 주입). 게시글은
                              wr_last 미갱신이라 post.updated_at 대신 사용.
@@ -569,16 +570,16 @@
                 </div>
             </div>
 
+            <!-- text-xs: 메타 보조 정보는 14px 로 통일 (bug/13536) -->
             <div
-                class="text-secondary-foreground ml-auto flex gap-2 sm:gap-4"
-                style="font-size: 0.85em;"
+                class="text-secondary-foreground ml-auto flex items-baseline gap-2 text-sm sm:gap-4"
             >
                 <span>조회 {post.views.toLocaleString()}</span>
                 <span>공감 {likeCount.toLocaleString()}</span>
                 <!-- bug/13376 — basic.svelte 와 같은 이유로 같은 모양을 쓴다. -->
                 <button
                     type="button"
-                    class="border-border hover:bg-muted hover:text-foreground -my-0.5 inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0.5 transition-colors"
+                    class="border-border hover:bg-muted hover:text-foreground inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0 leading-5 transition-colors"
                     aria-label="댓글 {post.comments_count}개로 이동"
                     onclick={() =>
                         document.getElementById('comments')?.scrollIntoView({ behavior: 'smooth' })}


### PR DESCRIPTION
## 제보

> 글자와 숫자들의 **아랫바닥 기준선이 일직선상에 놓이지 않고 들쑥날쑥**해서 보기 불편합니다. 댓글 바로가기 아이콘은 좋으나 **기준선에서 어긋나 붕 떠있는** 느낌입니다.

증상 3개를 때우는 대신 계통을 봤다.

## 진단 — 메타가 나오는 세 위치 실측 (모바일 390)

| 위치 | 정렬 | 폰트 종류 | 기준선 편차 |
|---|---|---|---|
| 목록 행 | items-center | **13.6px 1종** | **0px** |
| 글 상세 1행 | items-center | 16 / 15 / 12 / 11px **4종** | **3.0px** |
| 글 상세 2행 | items-center | 14.4 / 13.6px **2종** | **1.4px** |

목록은 `var(--list-font-size)` **단일 토큰**이라 편차가 0이다. 글 상세만 `0.9em` / `0.85em` 하드코딩 + Tailwind 유틸 + 상속이 뒤섞여 **한 블록에 6종**이 됐다. **규칙이 없던 게 원인**이다.

## 규칙

**1. 메타 보조 정보는 한 값으로** — 날짜·조회·공감·댓글을 `text-sm`(14px) 하나로 통일. `em` 은 부모에 따라 값이 변해 예측이 안 되고, `0.9em`과 `0.85em`이 서로 다른 크기를 만들고 있었다.

12px 도 후보였으나 종전(13.6~14.4px)보다 작아져 가독성이 떨어지고 블록이 더 좁아진다. 같은 제보의 "답답하다"와 충돌해 14px 로 정했다.

**2. 텍스트는 밑선 정렬** — `items-center` → `items-baseline`.

한글 폰트는 ascent/descent 비율이 OS 마다 다르다(iOS Apple SD Gothic Neo vs Android Noto Sans KR). `items-center` 에서는 **어긋나는 정도가 기기별로 달라진다** — 제보자(안드로이드)에겐 보이고 운영자(iOS)에겐 안 보이던 이유다. 밑선 정렬은 폰트 metrics 에 영향받지 않는다.

**3. 박스는 줄 높이를 넘지 않는다** — 댓글 배지의 `-my-0.5` 제거. 줄(22px)보다 **4px 크게 삐져나와** 있었다. 이게 "붕 떠 보인다"의 정체다.

**예외** — 글자크기 버튼(`가`/`가`)의 11px/15px 대비는 방향을 알리는 affordance 라 유지. 부모가 `items-baseline` 이 되면 버튼 박스가 밑선에 매달리므로 `self-center` 로 되돌린다.

`report.svelte` 도 같은 패턴이라 함께 고쳤다. **한쪽만 고치면 재발한다.**

## 검증

임시 프리뷰 라우트로 실제 컴포넌트를 SSR 렌더해 측정(측정 후 제거, 커밋 미포함).

| | 종전 | 변경 |
|---|---|---|
| 2행 폰트 종류 | 2종 | **1종 (14px)** |
| 2행 기준선 편차 | 1.4px | **0px** |
| 1행 기준선 편차 | 3.0px | **1.0px** |
| 댓글 배지 높이 | 28px (줄 24px) | **22px = 줄 22px** |

prettier / svelte-check(0 errors) / unit test 82파일 893개 / production build 전부 로컬 통과.

## 남은 것 · 한계

- **1행 편차 1.0px** — 닉네임 16px 과 IP 12px 의 폰트 metrics 차이라 밑선 정렬로도 완전히 0 이 되진 않는다. 종전 3.0px 에서 줄었다
- **메타 블록 59 → 57px** — 2행 폰트가 14.4 → 14px 로 정규화된 결과다. 2px 좁아졌다
- **"답답하다"** 는 지적은 이번 범위에 넣지 않았다. 정렬과 원인이 다르고(여백 축소), 되돌릴지는 취향이 아니라 운영 판단이라 제보가 더 쌓이는지 보고 별도로 다루는 게 맞다고 본다
- **안드로이드 실기기 확인은 못 했다.** 세 규칙 모두 구조적 수정이라 iOS 에서 나빠질 위험은 낮지만, 제보자 체감까지 해결되는지는 카나리에서 확인이 필요하다