### PR TITLE
fix(신고잠금): 열람 시 캡처방지 워터마크 배선 (bug/13548)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -711,9 +711,21 @@ export const load: PageServerLoad = async ({
             };
         })();
 
-        // 워터마크 대상 게시판: 열람자 정보 전달
+        // 워터마크 대상: 열람자 정보 전달
+        // bug/13548: 진실의방 외에도 신고잠금(report-lock) 글/댓글을 [보기]로 열람할 때 캡처방지
+        // (Watermark 전체화면 오버레이)를 진실의방과 동일하게 적용한다. 기존엔 truthroom 만 채워
+        // 일반 보드(free 등)의 신고잠금 글은 ContentBlur 로 열려도 캡처방지가 없었다.
+        // - 글 잠금 신호: post.extra_7 === 'lock' (= wr_7. fetchPostReportCount 와 동일 컬럼이라
+        //   postReportCount === 'lock' 과 동치이며, 기존 line 749 도 이 신호를 신뢰한다)
+        // - 댓글 잠금 신호: SSR 스레드 댓글 중 report_count === 'lock' 존재 (line 635 필터와 동일 소스)
+        // 페이지의 단일 {#if data.watermark} 가 그대로 발동해 글·댓글을 한 오버레이로 커버하고,
+        // clientIp 는 SSR(getClientAddress)에서만 확정된다. always-on-when-locked.
+        const hasLockedComment =
+            commentsData?.comments?.items?.some(
+                (c: { report_count?: string | number }) => c.report_count === 'lock'
+            ) ?? false;
         let watermark: { nickname: string; userId: string; clientIp: string } | null = null;
-        if (boardId === 'truthroom') {
+        if (boardId === 'truthroom' || post.extra_7 === 'lock' || hasLockedComment) {
             let clientIp = '';
             try {
                 clientIp = getClientAddress();

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -725,7 +725,12 @@ export const load: PageServerLoad = async ({
                 (c: { report_count?: string | number }) => c.report_count === 'lock'
             ) ?? false;
         let watermark: { nickname: string; userId: string; clientIp: string } | null = null;
-        if (boardId === 'truthroom' || post.extra_7 === 'lock' || hasLockedComment) {
+        // ⛔ locals.user 가드 필수 — 익명 SSR 응답은 CDN 캐시라 워터마크에 요청자 IP 가
+        //    박히면 첫 익명 방문자 IP 가 이후 모두에게 노출된다(#12920, 아래 disciplineViewer 와 동일 이유).
+        if (
+            (boardId === 'truthroom' || post.extra_7 === 'lock' || hasLockedComment) &&
+            locals.user
+        ) {
             let clientIp = '';
             try {
                 clientIp = getClientAddress();


### PR DESCRIPTION
신고잠금(report-lock) 글·댓글을 클릭해 열람할 때 캡처방지(Watermark)가 truthroom에만 적용돼 일반 보드에선 누락되던 문제.

- 서버 [boardId]/[postId]/+page.server.ts: 워터마크 채움 조건을 truthroom → 신고잠금 글(extra_7==='lock')·신고잠금 댓글(report_count==='lock')까지 확장. 페이지 렌더 무변(기존 {#if data.watermark}).
- ⛔ locals.user 가드 필수: 익명 SSR 응답은 CDN 캐시라 워터마크에 요청자 IP가 박히면 첫 익명 방문자 IP가 이후 모두에게 노출됨 → 로그인 사용자에게만(disciplineViewer와 동일 가드, #12920). Evaluator가 잡은 회귀.

web-only, 백엔드/DDL 무변. 설계=docs/2026-08-15-13548-anti-capture-report-lock-sprint-contract.html. Evaluator 검증(가드 반영).