### PR TITLE
fix(block): 차단 확인을 인-DOM 다이얼로그로 (bug/13526, iOS 사파리 첫 클릭 무반응)

### DIFF
--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
     import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
+    import * as Dialog from '$lib/components/ui/dialog/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { toast } from 'svelte-sonner';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { goto } from '$app/navigation';
     import { page } from '$app/stores';
@@ -89,30 +92,50 @@
     }
 
     let blockLoading = $state(false);
+    // #13526: iOS Safari 는 portal 된 드롭다운 항목 첫 탭에서 네이티브 confirm() 이
+    // user-activation 밖으로 밀려 무반응/새로고침 후에야 뜨는 문제가 있다. 네이티브
+    // confirm/alert 을 인앱 Dialog(+toast) 로 대체해 user-activation 의존을 제거한다.
+    let blockDialogOpen = $state(false);
+    let pendingScope = $state<'all' | 'message'>('all');
 
-    async function handleBlock(scope: 'all' | 'message' = 'all'): Promise<void> {
+    const blockConfirmMsg = $derived(
+        pendingScope === 'message'
+            ? `${authorName}님의 쪽지만 차단하시겠습니까? (게시글·댓글은 그대로 표시됩니다)`
+            : `${authorName}님을 차단하시겠습니까?`
+    );
+
+    // 드롭다운 항목 선택 시: 인증 확인 후 인앱 확인 다이얼로그를 연다.
+    // 드롭다운이 닫히는 같은 이벤트에서 다이얼로그를 동기로 열면 bits-ui 의
+    // interact-outside 처리와 충돌해 즉시 닫힐 수 있어, 다음 태스크로 미룬다.
+    function requestBlock(scope: 'all' | 'message' = 'all'): void {
         if (!authStore.isAuthenticated) {
             authStore.redirectToLogin();
             return;
         }
         if (blockLoading) return;
-        const confirmMsg =
-            scope === 'message'
-                ? `${authorName}님의 쪽지만 차단하시겠습니까? (게시글·댓글은 그대로 표시됩니다)`
-                : `${authorName}님을 차단하시겠습니까?`;
-        if (!confirm(confirmMsg)) return;
+        pendingScope = scope;
+        setTimeout(() => {
+            blockDialogOpen = true;
+        }, 0);
+    }
+
+    // 다이얼로그 확인 시에만 실제 차단 API 호출.
+    async function confirmBlock(): Promise<void> {
+        if (blockLoading) return;
+        const scope = pendingScope;
         blockLoading = true;
         try {
             await apiClient.blockMember(authorId, scope);
             blockedUsersStore.add(authorId, scope);
-            alert(
+            toast.success(
                 scope === 'message'
                     ? `${authorName}님의 쪽지를 차단했습니다.`
                     : `${authorName}님을 차단했습니다.`
             );
+            blockDialogOpen = false;
         } catch (err) {
             console.error('[Block] Failed:', authorId, err);
-            alert('차단 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+            toast.error('차단 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.');
         } finally {
             blockLoading = false;
         }
@@ -264,7 +287,7 @@
                     </DropdownMenu.Item>
                     <DropdownMenu.Item
                         class="cursor-pointer gap-2"
-                        onclick={() => handleBlock('message')}
+                        onSelect={() => requestBlock('message')}
                         disabled={blockLoading}
                     >
                         <Ban class="h-3.5 w-3.5" />
@@ -272,7 +295,7 @@
                     </DropdownMenu.Item>
                     <DropdownMenu.Item
                         class="text-destructive cursor-pointer gap-2"
-                        onclick={() => handleBlock('all')}
+                        onSelect={() => requestBlock('all')}
                         disabled={blockLoading}
                     >
                         <Ban class="h-3.5 w-3.5" />
@@ -282,4 +305,26 @@
             </DropdownMenu.Content>
         </DropdownMenu.Root>
     </span>
+
+    <!-- #13526: 네이티브 confirm() 대체 인앱 차단 확인 다이얼로그 (portal → body, user-activation 무관) -->
+    <Dialog.Root bind:open={blockDialogOpen}>
+        <Dialog.Content class="sm:max-w-sm">
+            <Dialog.Header>
+                <Dialog.Title>차단 확인</Dialog.Title>
+                <Dialog.Description>{blockConfirmMsg}</Dialog.Description>
+            </Dialog.Header>
+            <Dialog.Footer>
+                <Button
+                    variant="outline"
+                    onclick={() => (blockDialogOpen = false)}
+                    disabled={blockLoading}
+                >
+                    취소
+                </Button>
+                <Button variant="destructive" onclick={confirmBlock} disabled={blockLoading}>
+                    {blockLoading ? '처리 중...' : '차단'}
+                </Button>
+            </Dialog.Footer>
+        </Dialog.Content>
+    </Dialog.Root>
 {/if}

--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
+    import * as Dialog from '$lib/components/ui/dialog/index.js';
+    import { toast } from 'svelte-sonner';
     import { Badge } from '$lib/components/ui/badge/index.js';
     import { Progress } from '$lib/components/ui/progress/index.js';
     import * as Tabs from '$lib/components/ui/tabs/index.js';
@@ -134,6 +136,8 @@
     // 차단 상태
     let isBlocking = $state(false);
     let isBlocked = $state(false);
+    // #13526: iOS Safari 네이티브 confirm() 미동작 대응 — 인앱 확인 다이얼로그
+    let blockDialogOpen = $state(false);
 
     // 탭 데이터 (lazy load)
     interface RecentPost {
@@ -296,32 +300,37 @@
         followLoading = false;
     }
 
-    // 차단
+    // 차단 버튼: 이미 차단이면 즉시 해제, 아니면 인앱 확인 다이얼로그 표시 (#13526)
     async function handleBlock(): Promise<void> {
         if (!p || !authStore.isAuthenticated) return;
-        isBlocking = true;
-        try {
-            if (isBlocked) {
+        if (isBlocked) {
+            isBlocking = true;
+            try {
                 await apiClient.unblockMember(p.mb_id);
                 blockedUsersStore.remove(p.mb_id);
                 isBlocked = false;
-            } else {
-                if (!confirm(`${p.mb_name}님을 차단하시겠습니까?`)) {
-                    isBlocking = false;
-                    return;
-                }
-                try {
-                    await apiClient.blockMember(p.mb_id);
-                } catch {
-                    // 이미 차단된 경우(409) 등 → 무시하고 차단 상태로 처리
-                }
-                blockedUsersStore.add(p.mb_id);
-                isBlocked = true;
+            } catch {
+                toast.error('차단 처리에 실패했습니다.');
             }
-        } catch {
-            alert('차단 처리에 실패했습니다.');
+            isBlocking = false;
+            return;
         }
+        blockDialogOpen = true;
+    }
+
+    // 다이얼로그 확인 시에만 실제 차단 API 호출
+    async function confirmBlock(): Promise<void> {
+        if (!p || isBlocking) return;
+        isBlocking = true;
+        try {
+            await apiClient.blockMember(p.mb_id);
+        } catch {
+            // 이미 차단된 경우(409) 등 → 무시하고 차단 상태로 처리
+        }
+        blockedUsersStore.add(p.mb_id);
+        isBlocked = true;
         isBlocking = false;
+        blockDialogOpen = false;
     }
 
     // 상대 시간
@@ -1091,4 +1100,26 @@
             followDialogOpen = false;
         }}
     />
+
+    <!-- #13526: 네이티브 confirm() 대체 인앱 차단 확인 다이얼로그 -->
+    <Dialog.Root bind:open={blockDialogOpen}>
+        <Dialog.Content class="sm:max-w-sm">
+            <Dialog.Header>
+                <Dialog.Title>차단 확인</Dialog.Title>
+                <Dialog.Description>{p.mb_name}님을 차단하시겠습니까?</Dialog.Description>
+            </Dialog.Header>
+            <Dialog.Footer>
+                <Button
+                    variant="outline"
+                    onclick={() => (blockDialogOpen = false)}
+                    disabled={isBlocking}
+                >
+                    취소
+                </Button>
+                <Button variant="destructive" onclick={confirmBlock} disabled={isBlocking}>
+                    {isBlocking ? '처리 중...' : '차단'}
+                </Button>
+            </Dialog.Footer>
+        </Dialog.Content>
+    </Dialog.Root>
 {/if}


### PR DESCRIPTION
아이폰 사파리에서 차단하기 첫 클릭 무반응(새로고침 후에야 확인 팝업). 원인=iOS 사파리 ↔ bits-ui 포털 드롭다운 ↔ 네이티브 confirm() 상호작용(제스처창 밖 confirm 억제 or 포털 첫 탭 드롭).

수정(메커니즘 무관): 차단 흐름의 네이티브 confirm/alert→앱 인-DOM 다이얼로그(delete-confirm-dialog 선례)+토스트. 드롭다운 항목 onclick→bits-ui onSelect(포털 첫 탭 유실 방지). author-link + member/[id] 두 표면. 차단 API·이미지 flow 무변.

Evaluator SHIP(저위험). ⚠️ iOS 사파리 실기기 최종 확인 권장(다이얼로그 뜨고 유지되는지). web-only.