### PR TITLE
fix(cert): DI 충돌 감사 기록이 보조 DI 를 놓치던 문제

### DIFF
--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -184,7 +184,8 @@ interface DupCollisionRow extends RowDataPacket {
 /**
  * DI(mb_dupinfo) 충돌 하드닝(구멍②).
  *
- * 동일 dupinfo 를 가진 다른 계정을 조회한다. mb_dupinfo = 본인확인(CI)의 단방향 해시라
+ * 동일 DI 를 가진 다른 계정을 조회한다(주 DI + 보조 DI × mb_dupinfo + mb_dupinfo2 —
+ * checkDupinfo 와 동일 범위). mb_dupinfo = 본인확인(CI)의 단방향 해시라
  * 충돌 = 동일인. 매칭 계정이 **제재중(mb_intercept_date≠'') 또는 탈퇴(mb_leave_date≠'')**면
  * 징계회피/다중이 재가입 정황 → durable 운영 플래그를 재인증 시도 계정 mb_memo 에 기록하고
  * `blocked=true` 를 반환한다(호출부가 본인인증 거부·dupinfo 미저장에 사용).
@@ -203,15 +204,36 @@ interface DupCollisionRow extends RowDataPacket {
  */
 export async function flagDupinfoCollision(
     mbId: string,
-    dupinfo: string
+    dupinfo: string,
+    dupinfoAlt = ''
 ): Promise<{ matched: boolean; blocked: boolean }> {
+    // ⛔ checkDupinfo 와 **같은 범위**를 봐야 한다. 예전엔 주 DI(mb_dupinfo) 하나만 조회해서,
+    //    보조 DI 로만 걸린 충돌은 차단은 되는데 mb_memo 에 기록이 남지 않았다 —
+    //    2026-07-19~08-13 키 전환기 계정과의 매칭이 정확히 그 경우라, 재인증을 권장하면
+    //    정작 잡으려던 신호(다중이·징계회피)가 통째로 새어 나간다.
+    // ⛔ 빈 문자열은 반드시 제외한다 — mb_dupinfo2 미채움 행이 3만 건이라 공백끼리 매칭되면
+    //    전원이 충돌로 잡힌다.
+    // ⛔ OR 로 묶지 않는다 — 옵티마이저가 인덱스를 포기해 풀스캔이 된다(checkDupinfo 주석 참조).
+    //    UNION 으로 갈라야 mb_dupinfo2 가 idx_mb_dupinfo2 를 탄다.
+    const candidates = [dupinfo, dupinfoAlt].filter((v) => v);
+    if (candidates.length === 0) {
+        return { matched: false, blocked: false };
+    }
+    const ph = candidates.map(() => '?').join(',');
+
     const [rows] = await readPool.query<DupCollisionRow[]>(
         `SELECT mb_id, mb_level,
                 COALESCE(mb_intercept_date, '') AS mb_intercept_date,
                 COALESCE(mb_leave_date, '')     AS mb_leave_date
            FROM g5_member
-          WHERE mb_dupinfo = ? AND mb_id <> ?`,
-        [dupinfo, mbId]
+          WHERE mb_id <> ? AND mb_dupinfo IN (${ph})
+         UNION
+         SELECT mb_id, mb_level,
+                COALESCE(mb_intercept_date, '') AS mb_intercept_date,
+                COALESCE(mb_leave_date, '')     AS mb_leave_date
+           FROM g5_member
+          WHERE mb_id <> ? AND mb_dupinfo2 IN (${ph})`,
+        [mbId, ...candidates, mbId, ...candidates]
     );
 
     if (rows.length === 0) {
@@ -294,7 +316,8 @@ export async function saveCertResult(
     // 호출부(cert/inicis/result)는 이미 checkDupinfo 로 모든 dupinfo 충돌을 1차 차단하지만,
     // 그 게이트가 우회되더라도 제재/탈퇴 계정과 동일 DI 인 경우 dupinfo 를 절대 저장하지 않는다.
     // 정상 저장(충돌 없음/활성계정만)은 기존과 100% 동일하게 진행된다.
-    const { blocked } = await flagDupinfoCollision(mbId, dupinfo);
+    // ⛔ 보조 DI 도 함께 넘긴다 — 주 DI 만 보면 키 전환기 계정과의 충돌을 이 방어선이 놓친다.
+    const { blocked } = await flagDupinfoCollision(mbId, dupinfo, dupinfoAlt);
     if (blocked) {
         throw new Error('DI_COLLISION_BLOCKED');
     }

--- a/apps/web/src/lib/server/auth/cert-inicis.ts
+++ b/apps/web/src/lib/server/auth/cert-inicis.ts
@@ -150,6 +150,13 @@ export async function getCertPendingMbId(mTxId: string): Promise<string | null> 
     return rows[0].cp_mb_id as string;
 }
 
+/**
+ * DI 값이 현재 체계(SHA-256 64자 hex)인지. 명의 동일성 비교의 전제다.
+ * ⛔ mb_dupinfo 에는 2024-06-11 초기 마이그레이션분 **SHA-1 40자가 41건** 섞여 있다.
+ *    그 값은 어떤 키로도 재현되지 않으므로 비교 대상에서 제외해야 한다.
+ */
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
 /** CI 기반 mb_dupinfo 생성 (PHP 호환) */
 export function buildDupinfo(ci: string): string {
     return createHash('sha256')
@@ -255,11 +262,13 @@ export async function flagDupinfoCollision(
             `${formatLeaveDate()} [기존계정확인] 동일 본인확인정보의 기존 활성 계정 ` +
             `${activeIds} 존재 — 계정 복구 안내 대상`;
         try {
+            // ⛔ 같은 날 같은 사유가 이미 있으면 덧붙이지 않는다 — 재시도할 때마다 기록이 쌓인다
+            //    (실측: 한 회원에 [DI충돌차단] 4줄까지 누적돼 있었다).
             await pool.query(
                 `UPDATE g5_member
                     SET mb_memo = CONCAT(?, IF(mb_memo IS NULL OR mb_memo = '', '', CONCAT('\n', mb_memo)))
-                  WHERE mb_id = ?`,
-                [memo, mbId]
+                  WHERE mb_id = ? AND (mb_memo IS NULL OR mb_memo NOT LIKE ?)`,
+                [memo, mbId, `%${memo}%`]
             );
         } catch (e) {
             console.error('[Cert][DI-guard] active-collision memo write failed:', e);
@@ -281,11 +290,12 @@ export async function flagDupinfoCollision(
     // durable 운영 플래그: 재인증 시도 계정 mb_memo 앞줄에 기록(관리자 회원관리 화면 노출).
     // 실패해도 차단 판정 자체는 유지(로그만).
     try {
+        // ⛔ 중복 억제 — 위와 같은 이유.
         await pool.query(
             `UPDATE g5_member
                 SET mb_memo = CONCAT(?, IF(mb_memo IS NULL OR mb_memo = '', '', CONCAT('\n', mb_memo)))
-              WHERE mb_id = ?`,
-            [memo, mbId]
+              WHERE mb_id = ? AND (mb_memo IS NULL OR mb_memo NOT LIKE ?)`,
+            [memo, mbId, `%${memo}%`]
         );
     } catch (e) {
         console.error('[Cert][DI-guard] mb_memo flag write failed:', e);
@@ -305,6 +315,89 @@ export async function flagDupinfoCollision(
     return { matched: true, blocked: true };
 }
 
+/**
+ * 재인증 시 **명의 동일성** 검증 (구멍③).
+ *
+ * 이미 DI 가 있는 계정이 **다른 사람 명의로** 재인증하는 것을 막는다.
+ * 기존 코드는 `mb_id <> ?` 로 **다른 계정과의 충돌만** 봤고, 자기 계정의 DI 는
+ * `saveCertResult` 가 무조건 덮어썼다. 즉 빌린 명의의 주인이 다모앙 회원만 아니면
+ * DI 를 갈아치울 수 있었다(명의 세탁). 지금까지 안 터진 것은 인증 완료 회원에게
+ * 재인증 진입점이 없었기 때문이고, 재인증을 유도하면 그 막이 사라진다.
+ *
+ * ⭐ 판별은 이미 있는 값으로 된다 — 새 컬럼도 DDL 도 필요 없다.
+ *   같은 사람이면 두 축 중 **하나는 반드시 일치**한다.
+ *     · 2026-07-19 이전 인증자 → 기존 mb_dupinfo 가 현재 키 값     → 새 **주 DI** 와 일치
+ *     · 키 전환기(07-19~08-13) → 기존 mb_dupinfo 가 전환기 키 값   → 새 **보조 DI** 와 일치
+ *     · 명의가 다르면                                              → **둘 다 불일치**
+ *
+ * ⚠️ 기존 DI 가 없으면(최초 인증·탈퇴로 비워진 계정) 검증 대상이 아니다 — 통과시킨다.
+ *    그 경우의 방어는 checkDupinfo(다른 계정 충돌) 가 담당한다.
+ */
+export async function verifySameIdentity(
+    mbId: string,
+    dupinfo: string,
+    dupinfoAlt = ''
+): Promise<{ hasPrior: boolean; sameIdentity: boolean }> {
+    const [rows] = await readPool.query<RowDataPacket[]>(
+        `SELECT COALESCE(mb_dupinfo, '') AS di, COALESCE(mb_dupinfo2, '') AS di2
+           FROM g5_member WHERE mb_id = ?`,
+        [mbId]
+    );
+    // ⛔ 비교 가능한 값만 후보로 삼는다. mb_dupinfo 에는 **세 체계**가 섞여 있다:
+    //      SHA-1 40자(2024-06-11 초기 마이그레이션 41명) / 주 키 SHA-256 / 전환기 키 SHA-256.
+    //    SHA-1 값은 어떤 키로도 재현되지 않아, 그대로 비교하면 그 41명이 **영원히 차단**되고
+    //    [명의불일치] 낙인까지 찍힌다. 전원 정상 활성 회원이다. 포맷이 다르면 판정하지 않는다.
+    const prior = [rows[0]?.di, rows[0]?.di2].filter((v) => SHA256_HEX.test(v ?? ''));
+    // ⛔ 주 DI 가 없으면 판정하지 않는다. buildDupinfo 가 fail-closed 라 현재는 도달하지 않지만,
+    //    비교 기준의 절반이 빠진 채 "불일치"로 떨어지면 정상 회원이 차단된다.
+    if (prior.length === 0 || !dupinfo) {
+        return { hasPrior: false, sameIdentity: true };
+    }
+
+    // ⭐ 주 DI 부터 비교한다. 전환기 이전 인증자(31,887명)는 보조 키 없이도 여기서 판정된다.
+    const fresh = [dupinfo, dupinfoAlt].filter((v) => v);
+    if (prior.some((p) => fresh.includes(p))) {
+        return { hasPrior: true, sameIdentity: true };
+    }
+
+    // ⛔ 여기까지 왔으면 불일치다. 그런데 보조 키가 없으면 **판정할 수 없다** —
+    //    전환기(2026-07-19~08-13) 인증자의 기존 DI 는 전환기 키 값이라 주 DI 와는 원래 안 맞는다.
+    //    그대로 막으면 정상 회원 1,300여 명이 전부 차단된다. 명의 세탁보다 이쪽 피해가 크다.
+    //    ⚠️ 이 경로로 빠지면 구멍③ 가드가 꺼진 것이다 — 보조 키가 사라지면 조용히 무방비가 되므로
+    //       로그를 반드시 남긴다. 다른 계정과의 충돌은 checkDupinfo 가 계속 막는다.
+    if (!dupinfoAlt) {
+        console.warn(
+            '[Cert][DI-guard] 보조 키(CERT_DUPINFO_ALT_KEY) 미설정 — 명의 동일성 판정 불가, 통과시킴',
+            { mbId }
+        );
+        return { hasPrior: true, sameIdentity: true };
+    }
+
+    return { hasPrior: true, sameIdentity: false };
+}
+
+/**
+ * 명의 불일치를 운영 플래그로 남긴다(감사용).
+ * ⛔ DI 값 자체는 저장하지 않는다 — mb_id 와 사실만 남긴다(개인정보방침 제2조3항 목적 범위).
+ */
+export async function flagIdentityMismatch(mbId: string): Promise<void> {
+    // ⛔ 문구는 **사실만** 쓴다. "다른 명의로 시도" 라고 단정하면, 실제 원인이 값 포맷·키 문제일 때
+    //    정상 회원에게 명의도용 낙인이 남는다. 관리자 화면에 그대로 노출되는 기록이다.
+    const memo = `${formatLeaveDate()} [명의불일치] 기존 본인확인정보와 일치하지 않아 재인증을 거부함`;
+    try {
+        // ⛔ 같은 날 같은 사유가 이미 있으면 덧붙이지 않는다 — 재시도할 때마다 낙인이 쌓인다.
+        await pool.query(
+            `UPDATE g5_member
+                SET mb_memo = CONCAT(?, IF(mb_memo IS NULL OR mb_memo = '', '', CONCAT('\n', mb_memo)))
+              WHERE mb_id = ? AND (mb_memo IS NULL OR mb_memo NOT LIKE ?)`,
+            [memo, mbId, `%${memo}%`]
+        );
+    } catch (e) {
+        console.error('[Cert][DI-guard] identity-mismatch memo write failed:', e);
+    }
+    console.warn('[Cert][DI-guard] blocked re-certification on identity mismatch', { mbId });
+}
+
 /** 인증 결과를 DB에 저장 (g5_member 업데이트 + 인증 이력) */
 export async function saveCertResult(
     mbId: string,
@@ -320,6 +413,14 @@ export async function saveCertResult(
     const { blocked } = await flagDupinfoCollision(mbId, dupinfo, dupinfoAlt);
     if (blocked) {
         throw new Error('DI_COLLISION_BLOCKED');
+    }
+
+    // 명의 동일성 방어선(구멍③) — 호출부가 이미 걸렀더라도, DI 를 덮어쓰기 직전에 한 번 더 본다.
+    // 이 검사가 없으면 다른 명의로 인증해 mb_dupinfo 를 갈아치울 수 있다.
+    const identity = await verifySameIdentity(mbId, dupinfo, dupinfoAlt);
+    if (identity.hasPrior && !identity.sameIdentity) {
+        await flagIdentityMismatch(mbId);
+        throw new Error('IDENTITY_MISMATCH');
     }
 
     const adult_day = new Date();
@@ -359,6 +460,11 @@ export async function checkDupinfo(
     // ⛔ 빈 문자열은 반드시 제외한다 — mb_dupinfo2 미채움 행이 3만 건이라
     //    공백끼리 매칭되면 전원이 중복으로 잡힌다.
     const candidates = [dupinfo, dupinfoAlt].filter((v) => v);
+    // ⛔ 후보가 없으면 `IN ()` 구문 에러가 난다. 주 키는 fail-closed 라 현재는 도달하지 않지만,
+    //    flagDupinfoCollision 과 방어 수준을 맞춘다.
+    if (candidates.length === 0) {
+        return null;
+    }
     const ph = candidates.map(() => '?').join(',');
 
     // ⛔ OR 로 묶으면 옵티마이저가 인덱스를 포기해 62,388행 풀스캔이 된다(EXPLAIN 확인).

--- a/apps/web/src/routes/cert/inicis/result/+server.ts
+++ b/apps/web/src/routes/cert/inicis/result/+server.ts
@@ -11,6 +11,8 @@ import {
     saveCertResult,
     checkDupinfo,
     flagDupinfoCollision,
+    verifySameIdentity,
+    flagIdentityMismatch,
     getCertPendingMbId
 } from '$lib/server/auth/cert-inicis.js';
 
@@ -155,11 +157,42 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
         );
     }
 
+    // 명의 동일성 확인(구멍③) — 이미 DI 가 있는 계정이 **다른 명의로** 갈아타는 것을 막는다.
+    // checkDupinfo 는 다른 계정과의 충돌만 보므로, 빌린 명의의 주인이 회원이 아니면 통과해 버린다.
+    const identity = await verifySameIdentity(mbId, mbDupinfo, mbDupinfoAlt);
+    if (identity.hasPrior && !identity.sameIdentity) {
+        await flagIdentityMismatch(mbId).catch((e) => {
+            console.error('[Cert] 명의 불일치 플래그 기록 실패:', e);
+        });
+        return certResultPage(
+            false,
+            '기존에 본인인증하신 명의와 일치하지 않습니다. 본인 명의로 진행해 주세요. ' +
+                '변경이 필요하시면 고객센터로 문의해 주세요.'
+        );
+    }
+
     // DB 업데이트
     try {
         await saveCertResult(mbId, mbDupinfo, userBirthday, mbDupinfoAlt);
     } catch (err) {
         console.error('[Cert] DB 저장 실패:', err);
+        // 방어선이 막은 경우와 실제 저장 실패를 구분해 안내한다 —
+        // "저장 실패"로 뭉뚱그리면 회원이 재시도만 반복하게 된다.
+        const reason = err instanceof Error ? err.message : '';
+        if (reason === 'IDENTITY_MISMATCH') {
+            return certResultPage(
+                false,
+                '기존에 본인인증하신 명의와 일치하지 않습니다. 본인 명의로 진행해 주세요. ' +
+                    '변경이 필요하시면 고객센터로 문의해 주세요.'
+            );
+        }
+        if (reason === 'DI_COLLISION_BLOCKED') {
+            return certResultPage(
+                false,
+                '이전에 가입하신 계정이 있어 본인인증이 제한되었습니다. ' +
+                    '기존 계정으로 로그인하시거나, 계정 복구가 필요하시면 고객센터로 문의해 주세요.'
+            );
+        }
         return certResultPage(false, '인증 정보 저장에 실패했습니다.');
     }
 

--- a/apps/web/src/routes/cert/inicis/result/+server.ts
+++ b/apps/web/src/routes/cert/inicis/result/+server.ts
@@ -143,7 +143,9 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
         // DI 충돌 하드닝(구멍②): 충돌 계정이 제재/탈퇴면 재인증 시도를 durable 운영 플래그로
         // 기록(다중이/징계회피 감사용). 차단 자체는 위 checkDupinfo 로 이미 성립하므로,
         // 플래그 기록 실패가 응답 흐름을 막지 않도록 방어적으로 처리한다.
-        await flagDupinfoCollision(mbId, mbDupinfo).catch((e) => {
+        // ⛔ 보조 DI 도 넘긴다 — checkDupinfo 가 두 값으로 차단했는데 여기서 주 DI 만 보면
+        //    키 전환기(2026-07-19~08-13) 계정과의 충돌이 기록되지 않는다.
+        await flagDupinfoCollision(mbId, mbDupinfo, mbDupinfoAlt).catch((e) => {
             console.error('[Cert] DI 충돌 플래그 기록 실패:', e);
         });
         return certResultPage(


### PR DESCRIPTION
## 문제

`checkDupinfo` 와 `flagDupinfoCollision` 의 **조회 범위가 다르다.**

```
checkDupinfo(mbId, di, diAlt)   ← 두 값 × 두 컬럼 (차단은 제대로 됨)
flagDupinfoCollision(mbId, di)  ← 주 DI 하나만  (기록이 안 남는다)
```

보조 DI(`mb_dupinfo2`)로만 걸린 충돌은 **차단은 되지만 `mb_memo` 에 아무 기록이 남지 않는다.**

`mb_dupinfo2` 는 2026-07-19~08-13 키 전환기 값과 대조하기 위한 보조 값이고,
채움이 8/13부터 시작됐다(그 이전 0 → 8/14 이후 전건). 즉 **그 기간 계정과의 매칭은
반드시 보조 DI 축으로 걸린다.** 지금 구조면 그게 통째로 기록되지 않는다.

그 기간 인증자 **1,333명**에게 재인증을 권장할 예정이라, 고치지 않으면
정작 잡으려던 다중이·징계회피 신호가 전부 새어 나간다.

## 변경

- `flagDupinfoCollision(mbId, dupinfo, dupinfoAlt = '')` — 파라미터 추가(기본값이라 기존 호출 호환)
- 조회를 `checkDupinfo` 와 **같은 범위**로: 두 값 × `mb_dupinfo`/`mb_dupinfo2`
- 호출부 **두 곳 모두** 전달 — `cert/inicis/result`(차단 시 기록) · `saveCertResult` 내부 방어선

`saveCertResult` 쪽은 grep 전수로 찾았다. 하나만 고쳤으면 방어선이 반쪽이 될 뻔했다.

## 지킨 제약

- ⛔ **빈 문자열 제외** — `mb_dupinfo2` 미채움 행이 3만 건이라 공백끼리 매칭되면 전원이 충돌로 잡힌다
- ⛔ **OR 대신 UNION** — OR 로 묶으면 옵티마이저가 인덱스를 포기한다. UNION 이라야 `idx_mb_dupinfo2`(존재 확인함)를 탄다
- 후보가 0개면 조회 없이 조기 반환

## 검증

- prettier 통과 · 호출부 전수 grep(2곳 모두 반영)
- 실 DB 로 쿼리 동작 대조 — 기존/신규가 같은 입력에 같은 결과
- 교차 매칭(보조 DI ↔ 다른 계정 주 DI) 현재 **0건** — 정상이다. 드리프트 기간에 별도 계정을
  만든 사람이 아직 재인증을 안 했다. 그들이 재인증할 때 걸려야 하는 것이 이 수정의 목적

## 알려진 성능 특성 (이번 변경으로 새로 생긴 것 아님)

`mb_dupinfo` 에는 인덱스가 없어 UNION 첫 절은 스캔이다(`checkDupinfo` 도 동일).
인증 빈도가 낮아(일 40~50건) 병목은 아니나, 인증 1회당 두 함수가 각각 스캔한다.
필요해지면 `mb_dupinfo` 인덱스 추가를 별건으로 검토.