### PR TITLE
feat(report): 운영 현황에 「선택된 사유」 카드 추가

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -147,6 +147,11 @@
         total_cases?: number;
         total_month_cases?: number;
         total_reports?: number;
+        /**
+         * 선택된 사유 수. 신고 1건에 사유를 여러 개 고르면 각각 센다 —
+         * total_reports(신고 건수)와 다른 지표다. 예전 보고서엔 없으므로 optional.
+         */
+        reason_selections?: number;
         completed_reports?: number;
         report_count?: number;
         claim_reports?: number;
@@ -196,6 +201,7 @@
             posts?: number;
             comments?: number;
             total_reports?: number;
+            reason_selections?: number;
             report_count?: number;
             report_month?: number;
             reporter_count?: number;
@@ -314,6 +320,16 @@
             icon: Shield,
             color: 'text-purple-600 dark:text-purple-400',
             bg: 'bg-purple-50 dark:bg-purple-950/30'
+        },
+        // 「신고 접수」 바로 옆에 둔다 — 두 숫자가 왜 다른지가 나란히 보여야 오해가 없다.
+        // 신고 1건에 사유를 여러 개 고르면 각각 세므로 접수 건수보다 크다(2026-08-15: 352 vs 738).
+        {
+            label: '선택된 사유',
+            value: stats.reason_selections ?? 0,
+            prev: stats.prev_day?.reason_selections,
+            icon: Shield,
+            color: 'text-violet-600 dark:text-violet-400',
+            bg: 'bg-violet-50 dark:bg-violet-950/30'
         },
         {
             label: '신고된 글',


### PR DESCRIPTION
## 배경

일일 「운영 현황」의 **신고 접수** 카드가 `g5_na_singo` 를 **행 단위**로 세고 있었다.
신고 1건에 사유를 여러 개 고르면 **사유마다 1행**이 저장되므로(평균 2.1개) 2배 넘게 부풀었다.

담당자 제보 — *"느낌상 많아야 300건인데 738건이나…"*. 실제는 **352건**이었다.

집계는 별도로 바로잡았고(`triage/tools/daily_report_gen.py`·`report_publish.py`, 과거 8건 재계산 완료),
이 PR 은 **두 지표를 구분해 보여주는** 화면 변경이다.

## 변경

「신고 접수」 **바로 옆에** 「선택된 사유」 카드를 추가한다.

| 카드 | 8/15 | 뜻 |
|---|---|---|
| 신고 접수 | **352** | 같은 회원이 같은 게시물을 신고 = 1건 |
| **선택된 사유** | **738** | 사유를 여러 개 고르면 각각 카운트 |

나란히 두는 것이 요점이다 — 두 숫자가 왜 다른지가 한 화면에 있어야
"예전엔 738이었는데?" 가 안 나온다.

- `reason_selections` 필드 추가. **구 보고서에는 없으므로 optional** — 없으면 `?? 0`
- `prev_day` 에도 추가해 전일 대비 증감 표시

## 검증

- prettier · Svelte 파일 단위 컴파일 (**수정 전 대조군 포함**) 통과
- 백엔드 실측: 8/15 → 접수 352 / 사유 738, 전일(8/14) 사유 687 정상 산출
- 과거 발행분은 필드가 없어 0 으로 표시된다(깨지지 않음)