### PR TITLE
feat(board): 신고 누적 자동잠금(A형) 글의 추가 신고 재개방

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/types.ts
+++ b/apps/web/src/lib/components/features/board/layouts/types.ts
@@ -129,6 +129,12 @@ export interface ViewLayoutProps {
     /** 게시글 신고 횟수 (관리자만, wr_7 값) */
     postReportCount?: number | string | null;
 
+    /**
+     * 관리자 제재가 확정된 신고잠금 글(B형)인지. true 면 신고 버튼을 숨긴다.
+     * A형(신고 누적 자동잠금)은 false → 추가 신고 버튼 노출. isLockedPost(가림/배지)와 독립된 게이트.
+     */
+    isSanctioned?: boolean;
+
     /** 잠긴 게시글의 진실의방 참조 글 ID */
     truthroomPostId?: number | null;
 

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -122,6 +122,7 @@
         promotionExpired = false,
         postReactions,
         postReportCount,
+        isSanctioned = false,
         truthroomPostId,
         originalPostLink
     }: ViewLayoutProps = $props();
@@ -848,8 +849,11 @@
                     {#if board?.use_sns}
                         <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}
-                    {#if !isAuthor && !isLockedPost}
-                        <!-- #12420: 이미 신고 누적으로 잠긴 글은 추가 신고 불가 -->
+                    {#if !isAuthor && !isSanctioned}
+                        <!-- #12420: 신고잠금 글의 추가 신고 게이트.
+                             제재 확정(B형)만 숨긴다 — 재신고 시 백엔드 409+트리거로 차단되기 때문.
+                             신고 누적 자동잠금(A형)은 다시 열어 추가 신고를 허용한다(백엔드가 계속 accept).
+                             ⛔ isLockedPost(가림/배지/워터마크)는 그대로 유지 — 게이트만 isSanctioned 로 분리. -->
                         <Button
                             variant="ghost"
                             size="sm"

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -21,6 +21,7 @@ import {
 } from '$lib/server/viewcount.js';
 import { addReadPost } from '$lib/server/read-posts.js';
 import { fetchPostReportCount } from '$lib/server/report-count.js';
+import { isSanctionedPost } from '$lib/server/sanctioned-lock.js';
 import { fetchReactionsByParentId } from '$lib/server/reactions.js';
 import { fetchMemberImagesWithTimestamp } from '$lib/server/member-images.js';
 import { fetchCommentLikeStatuses } from '$lib/server/comment-likes.js';
@@ -739,6 +740,18 @@ export const load: PageServerLoad = async ({
         // 신고잠금(wr_7='lock') 동기 신호 — post.extra_7 은 백엔드 상세 응답에 없어 항상
         // undefined 이므로, 확실한 lock 신호인 신고 횟수 조회 결과를 워터마크 판정에 사용한다.
         const postReportLock = (await postReportCountPromise) === 'lock';
+
+        // 신고잠금(wr_7='lock') 2형 구분 — 신고 버튼 게이트 전용.
+        //  A형: 신고 누적 자동잠금(미제재). 백엔드가 신고를 계속 accept 하므로 추가 신고를 다시 연다.
+        //  B형: 관리자 제재 확정(g5_na_singo processed=1 AND admin_approved=1 AND discipline_log_id>0).
+        //       백엔드가 409(제재 확정)+DB 트리거로 재신고를 막으므로 버튼은 계속 숨긴다.
+        // B형은 정의상 wr_7='lock' 이므로 잠긴 글에서만 조회한다(비잠금 글엔 불필요한 DB 왕복 회피).
+        // isSanctionedPost 는 내부 try/catch 로 실패 시 false 수렴 — 판정 불가가 신고 차단이 되지 않는다.
+        const isSanctioned =
+            postReportLock || post.extra_7 === 'lock'
+                ? await isSanctionedPost(boardId, Number(postId))
+                : false;
+
         let watermark: { nickname: string; userId: string; clientIp: string } | null = null;
         // ⛔ locals.user 가드 필수 — 익명 SSR 응답은 CDN 캐시라 워터마크에 요청자 IP 가
         //    박히면 첫 익명 방문자 IP 가 이후 모두에게 노출된다(#12920, 아래 disciplineViewer 와 동일 이유).
@@ -871,6 +884,11 @@ export const load: PageServerLoad = async ({
             promotionExpired,
             watermark,
             disciplineViewer,
+            /**
+             * 신고잠금 글이 관리자 제재 확정(B형)인지. true 면 신고 버튼을 계속 숨긴다.
+             * A형(신고 누적 자동잠금)은 false → 추가 신고 버튼을 다시 노출. isLockedPost(가림/배지)와 독립.
+             */
+            isSanctioned,
             truthroomPostId,
             originalPostLink,
             recentPosts,

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2417,6 +2417,7 @@
                 pageData={data}
                 {postReactions}
                 {postReportCount}
+                isSanctioned={data.isSanctioned}
                 truthroomPostId={data.truthroomPostId}
                 originalPostLink={data.originalPostLink}
             />


### PR DESCRIPTION
## 배경

신고잠금(`wr_7='lock'`)은 두 형태로 발생한다.

| 형태 | 발생 조건 | 백엔드 동작 |
|------|-----------|-------------|
| **A형** 자동잠금 | 신고 누적(미제재) | 신고를 **계속 accept** |
| **B형** 제재확정 | 관리자 처분 확정(`g5_na_singo` `processed=1 AND admin_approved=1 AND discipline_log_id>0`) | 재신고 시 **409 + DB 트리거로 차단** |

프론트는 `wr_7='lock'` 만 알아 A/B 를 구분하지 못하고, 두 형태 모두 신고 버튼을 숨겨왔다. 그 결과 백엔드가 신고를 여전히 받는 **A형 글에서도 추가 신고가 막혀** 있었다.

## 변경

신고 버튼 게이트를 `isLockedPost`(A·B 공통) → **`isSanctioned`(B형 전용)** 로 분리한다.

- **A형**: 신고 버튼 다시 노출 → 추가 신고 허용
- **B형**: 계속 숨김 (재신고 시 어차피 백엔드 409)

### SSR 신호 확보
- `+page.server.ts`: 잠긴 글일 때만 `isSanctionedPost(boardId, postId)` 조회(비잠금 글엔 불필요한 DB 왕복 없음), `isSanctioned` 를 page data 로 전달.
- 판정 조회 실패 시 `false` 수렴 — 판정 불가가 정상 이용(신고) 차단으로 번지지 않음.

### 무변경 (신고 버튼 게이트와 독립)
- 본문 가림(blur) · 신고잠금 배지 · 워터마크 → `isLockedPost` 그대로 유지
- 댓글 · truthroom 이동 · `isLockedPost` 자체 로직
- 백엔드(report_service / repo / DB 트리거)

### 409 graceful
`ReportDialog` 는 기존대로 409 를 파괴적 오류가 아닌 **중립 안내**로 표시한다(조용한 실패 아님). B형 경쟁상황(제출 직전 제재 확정)에서도 같은 경로로 안내된다.

## 변경 파일
- `apps/web/src/routes/[boardId]/[postId]/+page.server.ts` — `isSanctioned` SSR 조회·전달
- `apps/web/src/lib/components/features/board/layouts/types.ts` — `isSanctioned` prop 타입
- `apps/web/src/lib/components/features/board/layouts/view/basic.svelte` — 신고 버튼 게이트 교체
- `apps/web/src/routes/[boardId]/[postId]/+page.svelte` — 레이아웃에 `isSanctioned` 전달