### PR TITLE
fix(reaction): 실제 렌더 경로도 썸네일로 — #2102 누락분

### DIFF
--- a/apps/web/src/lib/types/reaction.ts
+++ b/apps/web/src/lib/types/reaction.ts
@@ -103,9 +103,18 @@ export function getReactionDisplay(reaction: string): {
                 label: hexToEmoji(reactionId)
             };
         case 'angticon':
+            // 정지 썸네일을 쓴다. 리액션바는 20×20(h-5 w-5)으로 그리는데 원본 GIF 는
+            // 최대 152,924B 이고 같은 파일의 _thumb.webp 는 1,142B 다(134배).
+            //
+            // ⛔ 여기가 **실제로 화면에 그려지는 경로**다. reaction-config.ts 의 ANGTICONS 는
+            //    피커에 "고를 수 있는 목록"을 만들 뿐, 이미 달린 리액션은 이 함수를 탄다.
+            //    2026-08-17 에 config 만 고치고 이 줄을 놓쳐서 번들에 .gif 가 남았었다.
+            //    앙티콘 URL 을 바꿀 때는 **두 곳을 같이** 바꿔야 한다.
+            // ⛔ 썸네일이 없는 앙티콘은 404 로 깨진다. scripts/make-reaction-thumbs.py 로
+            //    _thumb.webp 를 먼저 만들고 호스트에 동기화한 뒤 바꿀 것(파일 먼저·코드 나중).
             return {
                 renderType: 'image',
-                url: `/api/emoticons/nariya/damoang-${reactionId}.gif`,
+                url: `/api/emoticons/nariya/damoang-${reactionId}_thumb.webp`,
                 label: `앙티콘 ${reactionId}`
             };
         case 'noto-animoji': {


### PR DESCRIPTION
## #2102 가 절반만 고쳤다

카나리 번들을 확인해보니 `.gif` 가 그대로 남아 있었다.

```
emoticons/nariya/damoang-${reactionId}.gif   ← 남아 있던 것
```

앙티콘 URL 을 만드는 곳이 **두 군데**인데 하나만 바꿨다.

| 파일 | 역할 | #2102 |
|---|---|---|
| `reaction-config.ts` ANGTICONS | 피커에 **고를 수 있는 목록**을 만든다 | 바꿈 |
| `types/reaction.ts` `getReactionDisplay()` | **이미 달린 리액션을 화면에 그린다** | **놓침** |

리액션바(`reaction-bar.svelte:273`)는 `getReactionDisplay()` 를 쓴다.
즉 실측에서 **138KB × 32개**가 나온 경로가 이쪽이고, #2102 만으로는 효과가 없었다.

## 안전 확인 (커버리지)

썸네일이 없는 앙티콘이 하나라도 쓰이면 404 로 깨지므로 **DB 실사용 기준으로 전수 확인**했다.

```
DB 실사용 앙티콘        44종
그중 _thumb.webp 보유   44종 (누락 0)
피커 목록 밖 사용        0종
호스트 서빙 확인        44/44 → 200
```

## 재발 방지

두 파일 모두에 **"앙티콘 URL 을 바꿀 때는 두 곳을 같이 바꿔라"** 주석을 남겼다.

## 검증

- [ ] 카나리 번들에서 `nariya/damoang-*.gif` **0종** / `_thumb.webp` 참조 확인
- [ ] 승격 후 리액션바 이미지 합계 **1,602KB → 200KB 미만**
- [ ] 리액션 아이콘 깨짐 0 (실사용 44종)

선행: #2102 (썸네일 6개 생성 + 호스트 동기화 완료)