### PR TITLE
feat(plugins): 활성상태 SoT MySQL 이관 + pub/sub 무효화 + CDN 분리

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -25,6 +25,7 @@ import { generateAccessToken } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { parseUserBasicCookie, issueUserBasicCookie } from '$lib/server/auth/user-basic.js';
 import { loadAllPluginServerHooks } from '$lib/server/plugin-server-loader.js';
+import { initPluginInvalidationSubscriber } from '$lib/server/plugins/invalidation-subscriber.js';
 import { CompositeSiteResolver } from '$lib/server/site-resolver/composite.js';
 import { ConfigSiteResolver } from '$lib/server/site-resolver/config.js';
 import { DbSiteResolver } from '$lib/server/site-resolver/db.js';
@@ -33,6 +34,10 @@ import { DbSiteResolver } from '$lib/server/site-resolver/db.js';
 // Fire-and-forget: load 실패해도 앱 전체가 멈추지 않음.
 // 모듈 load 시점 1회 실행 (최초 요청 전 ready).
 void loadAllPluginServerHooks();
+
+// 플러그인 캐시 무효화 pub/sub 구독 시작 (Option C 2단계).
+// 다른 파드의 플러그인 토글/설정변경을 수신해 이 파드의 로컬 캐시를 비운다. 멱등·best-effort.
+initPluginInvalidationSubscriber();
 
 // Phase 1 (multisite domain → theme/SEO resolver) — Strategy 패턴.
 // 부팅 시 1회 ConfigSiteResolver 가 host-overrides JSON 로드. miss 시 null → 기본 테마.

--- a/apps/web/src/lib/server/plugins/index.ts
+++ b/apps/web/src/lib/server/plugins/index.ts
@@ -21,6 +21,7 @@ import { TieredCache } from '$lib/server/cache';
 import type { ExtensionManifest } from '@angple/types';
 import { runPluginMigrations, rollbackPluginMigrations } from './migration-runner';
 import { invalidateHandlerCache } from './route-dispatcher';
+import { publishPluginInvalidation } from './invalidation';
 
 /**
  * 설치된 플러그인의 전체 정보
@@ -113,7 +114,9 @@ export async function getPluginById(pluginId: string): Promise<InstalledPlugin |
 //
 // ⛔ 근본 해결은 아니다. 무효화 pub/sub 전파(TieredCache 전 소비자가 함께 이득)는
 //    별건으로 남긴다. 열어 둔 탭은 body-end 슬롯 특성상 하드 리로드가 필요한 것도 그대로다.
-const activePluginsTieredCache = new TieredCache<InstalledPlugin[]>(
+// export: pub/sub 구독자(invalidation-subscriber.ts)가 다른 파드의 변경 수신 시
+//         이 캐시의 L1 을 비운다(deleteL1).
+export const activePluginsTieredCache = new TieredCache<InstalledPlugin[]>(
     'plugins:active',
     3_000,
     300,
@@ -139,9 +142,16 @@ export async function getActivePlugins(): Promise<InstalledPlugin[]> {
     });
 }
 
-/** 플러그인 캐시 무효화 (활성화/비활성화 시 호출) */
+/**
+ * 플러그인 캐시 무효화 (활성화/비활성화/설정변경 시 호출).
+ *
+ * 1) 이 파드의 TieredCache(L1+L2) 를 지운다.
+ * 2) pub/sub 으로 전 파드에 방송 → 각 파드 구독자가 자기 L1/provider 로컬 캐시를 비운다.
+ *    (방송이 없으면 다른 파드는 L1 TTL 만큼 옛 값을 계속 쓴다 — 파드별 캐시 문제)
+ */
 export async function invalidateActivePluginsCache(): Promise<void> {
     await activePluginsTieredCache.delete('list');
+    await publishPluginInvalidation({ type: 'active' });
 }
 
 /**

--- a/apps/web/src/lib/server/plugins/invalidation-subscriber.ts
+++ b/apps/web/src/lib/server/plugins/invalidation-subscriber.ts
@@ -1,0 +1,91 @@
+/**
+ * 플러그인 캐시 무효화 pub/sub — 구독 측 (Option C 2단계)
+ *
+ * 각 파드에서 부팅 시 1회 구독을 시작한다(hooks.server.ts). 다른 파드가 플러그인을
+ * 토글/설정변경하면 invalidation.ts 가 방송하고, 여기서 받아 이 파드의 로컬 캐시를 비운다:
+ *   1) activePluginsTieredCache 의 L1 (deleteL1) — L2(Redis)는 발행 파드가 이미 지웠다.
+ *   2) pluginSettingsProvider.invalidateLocal() — DB provider 의 프로세스 로컬 캐시.
+ *   3) invalidateHandlerCache() — 라우트 디스패처 핸들러 캐시.
+ *
+ * ⛔ 구독 전용 커넥션(getRedis().duplicate())을 쓴다 — ioredis 는 subscribe 상태의
+ *    커넥션에서 일반 명령을 못 쓴다. 메인 커넥션을 구독에 쓰면 다른 캐시 get/set 이 막힌다.
+ * ⛔ 멱등 — 모듈 플래그로 중복 초기화를 막는다(HMR/중복 import 대비).
+ * ⛔ self-skip — 자기 파드가 방송한 이벤트는 무시한다(이미 로컬에서 무효화했다).
+ * best-effort — Redis 장애로 구독이 실패해도 앱은 계속 뜬다(파드 간 지연으로 열화될 뿐).
+ */
+
+import type Redis from 'ioredis';
+import { getRedis } from '$lib/server/redis';
+import { activePluginsTieredCache } from './index';
+import { invalidateHandlerCache } from './route-dispatcher';
+import { pluginSettingsProvider } from '$lib/server/settings/plugin-settings-provider';
+import {
+    PLUGIN_INVALIDATION_CHANNEL,
+    POD_ID,
+    type PluginInvalidationMessage
+} from './invalidation';
+
+let initialized = false;
+let subscriber: Redis | null = null;
+
+/** 방송을 받아 이 파드의 로컬 캐시를 비운다. */
+function applyInvalidation(msg: PluginInvalidationMessage): void {
+    // 자기 파드가 보낸 방송은 무시(이미 로컬 무효화 완료)
+    if (msg.origin === POD_ID) return;
+
+    // 활성 목록 L1 은 'list' 키에 담긴다(plugins/index.ts). L2 는 발행 파드가 이미 DEL.
+    activePluginsTieredCache.deleteL1('list');
+
+    // DB provider 의 프로세스 로컬 캐시 비우기(구현이 있을 때만)
+    pluginSettingsProvider.invalidateLocal?.();
+
+    // 라우트 핸들러 캐시(활성 플러그인 변화 → 라우트 매핑 변화 가능)
+    invalidateHandlerCache();
+}
+
+/**
+ * 플러그인 무효화 구독 시작. 부팅 시 1회 호출(멱등).
+ */
+export function initPluginInvalidationSubscriber(): void {
+    if (initialized) return;
+    initialized = true;
+
+    try {
+        // 구독 전용 커넥션 — 메인 커넥션은 일반 명령용으로 남겨둔다.
+        subscriber = getRedis().duplicate();
+
+        subscriber.on('error', (err: Error) => {
+            console.error('[PluginInvalidation] 구독 커넥션 오류:', err.message);
+        });
+
+        // reconnect(ready) 시마다 재구독 — 커넥션이 끊겼다 붙으면 구독이 풀린다.
+        subscriber.on('ready', () => {
+            subscriber?.subscribe(PLUGIN_INVALIDATION_CHANNEL).catch((err: Error) => {
+                console.error('[PluginInvalidation] subscribe 실패:', err.message);
+            });
+        });
+
+        subscriber.on('message', (channel: string, raw: string) => {
+            if (channel !== PLUGIN_INVALIDATION_CHANNEL) return;
+            try {
+                const msg = JSON.parse(raw) as PluginInvalidationMessage;
+                applyInvalidation(msg);
+            } catch (err) {
+                console.error('[PluginInvalidation] 메시지 파싱 실패:', err);
+            }
+        });
+
+        // lazyConnect 커넥션을 깨운다. 연결되면 'ready' 에서 subscribe 한다.
+        subscriber.connect().catch((err: Error) => {
+            // 이미 연결 중이면 무해한 에러가 날 수 있다.
+            if (!/already/i.test(err.message)) {
+                console.error('[PluginInvalidation] connect 실패:', err.message);
+            }
+        });
+
+        console.log('[PluginInvalidation] 구독자 초기화 완료:', PLUGIN_INVALIDATION_CHANNEL);
+    } catch (err) {
+        // 초기화 실패해도 앱은 계속 뜬다. 파드 간 무효화 전파만 열화.
+        console.error('[PluginInvalidation] 구독자 초기화 실패(무시):', err);
+    }
+}

--- a/apps/web/src/lib/server/plugins/invalidation.ts
+++ b/apps/web/src/lib/server/plugins/invalidation.ts
@@ -1,0 +1,59 @@
+/**
+ * 플러그인 캐시 무효화 pub/sub — 발행 측 (Option C 2단계)
+ *
+ * 문제: 활성 플러그인 캐시(plugins/index.ts 의 TieredCache L1 + 각 provider 의 로컬 캐시)는
+ *   **파드마다 따로** 존재한다. admin 이 한 파드에서 플러그인을 토글해도 나머지 파드는
+ *   자기 L1 TTL 만큼 옛 값을 계속 쓴다. Redis DEL 만으로는 다른 파드의 in-memory L1 을 지울 수 없다.
+ *
+ * 해법: Redis pub/sub 으로 "무효화" 이벤트를 전 파드에 방송한다. 각 파드의 구독자
+ *   (invalidation-subscriber.ts)가 이벤트를 받아 자기 로컬 캐시를 비운다.
+ *
+ * ⛔ best-effort — Redis 장애 시에도 throw 하지 않는다(토글 자체가 실패하면 안 된다).
+ *    자기 파드는 이미 로컬에서 무효화하므로, 방송 실패는 "다른 파드가 최대 L1 TTL 지연"에 그친다.
+ */
+
+import { getRedis } from '$lib/server/redis';
+
+/** 무효화 이벤트 타입. 지금은 활성 목록만이지만 확장 여지를 둔다. */
+export interface PluginInvalidationMessage {
+    /** 'active' = 활성 목록 변경, 'settings' = 특정 플러그인 설정 변경 */
+    type: 'active' | 'settings';
+    /** 대상 플러그인 ID (settings 타입에서 사용) */
+    pluginId?: string;
+    /** 발신 파드 식별자 — 구독자가 자기 방송을 무시(self-skip)하는 데 쓴다 */
+    origin: string;
+    /** 발행 시각(ms) */
+    ts: number;
+}
+
+/** CACHE_NAMESPACE 가 있으면 접두해 canary/prod 가 공유 Redis 를 써도 채널이 섞이지 않게 한다. */
+function channelName(): string {
+    const ns = process.env.CACHE_NAMESPACE;
+    return ns ? `${ns}:angple:plugin:invalidate` : 'angple:plugin:invalidate';
+}
+
+export const PLUGIN_INVALIDATION_CHANNEL = channelName();
+
+/** 이 프로세스(파드)의 식별자. self-skip 용. */
+export const POD_ID =
+    process.env.HOSTNAME || process.env.POD_NAME || `pid-${process.pid}-${Date.now()}`;
+
+/**
+ * 플러그인 무효화 이벤트를 전 파드에 방송한다.
+ * ⛔ best-effort — 실패해도 삼킨다.
+ */
+export async function publishPluginInvalidation(
+    payload: Pick<PluginInvalidationMessage, 'type' | 'pluginId'>
+): Promise<void> {
+    const message: PluginInvalidationMessage = {
+        type: payload.type,
+        pluginId: payload.pluginId,
+        origin: POD_ID,
+        ts: Date.now()
+    };
+    try {
+        await getRedis().publish(PLUGIN_INVALIDATION_CHANNEL, JSON.stringify(message));
+    } catch (err) {
+        console.error('[PluginInvalidation] publish 실패(무시):', err);
+    }
+}

--- a/apps/web/src/lib/server/settings/db-plugin-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/db-plugin-settings-provider.ts
@@ -1,0 +1,268 @@
+/**
+ * MySQL(전용 테이블) + Redis 기반 플러그인 설정 Provider — Option C
+ *
+ * ⭐ 왜 별도 테이블인가 (angple_settings 재사용판인 MySqlPluginSettingsProvider 와의 차이)
+ *   활성 목록을 `angple_settings` 의 JSON 배열 1행에 담으면 활성/비활성이
+ *   read-modify-write(목록 읽기 → 수정 → 통째로 UPSERT)가 되어, 읽기 순단 중
+ *   빈 목록에 하나만 얹어 나머지가 전부 꺼지는 사고에 노출된다.
+ *   여기서는 **플러그인당 1행**(angple_plugin_settings)으로 저장해 활성/비활성을
+ *   단일 원자적 UPSERT/UPDATE 로 처리한다 — RMW 경쟁이 원천적으로 없다.
+ *
+ * ⭐ 무효화 (pub/sub 와의 협업)
+ *   - MySQL = SoT(단일 진실 공급원, 파드 공유), Redis = L2 캐시(파드 공유), 프로세스 로컬 = L1.
+ *   - 쓰기 시 Redis 키를 DEL 하고 로컬 L1 을 비운다. angple_settings 재사용판이 캐시를
+ *     "갱신"했던 것과 달리 여기서는 DEL 이 안전하다 — SoT 가 파일(파드별)이 아니라 DB(공유)라
+ *     어느 파드가 재적재해도 같은 최신값을 읽기 때문이다. 파드 간 전파는
+ *     plugins/invalidation(pub/sub) 이 담당하며, 구독자가 각 파드에서 invalidateLocal() 로
+ *     L1 을 비운다.
+ *
+ * ⛔ 신규 설치(셀프호스팅)는 DB 스키마가 없을 수 있다 — ensureTable() 은 best-effort 이며
+ *    실패해도 throw 하지 않는다(mysql-plugin-settings-provider 선례). prod 는 006 DDL 을
+ *    수동 선행 적용한다(AutoMigrate 미실행).
+ */
+
+import type { PluginSettingsProvider } from './plugin-settings-provider';
+import { pool, readPool } from '$lib/server/db';
+import { getRedis } from '$lib/server/redis';
+import type { RowDataPacket, ResultSetHeader } from 'mysql2';
+
+const TABLE = 'angple_plugin_settings';
+
+/** Redis 캐시 키 */
+const KEY_ACTIVE = 'angple:plugin:active';
+const keyForSettings = (pluginId: string) => `angple:plugin:settings:${pluginId}`;
+
+/** 활성 목록 캐시 TTL(초). 변경 시 DEL + pub/sub 로 즉시 무효화되므로 넉넉히 잡는다. */
+const CACHE_TTL = 300;
+
+interface ActiveRow extends RowDataPacket {
+    plugin_id: string;
+}
+
+interface SettingsRow extends RowDataPacket {
+    settings: string | Record<string, unknown> | null;
+}
+
+interface L1Entry<T> {
+    value: T;
+    expiry: number;
+}
+
+/**
+ * MySQL 전용 테이블 + Redis 기반 플러그인 설정 Provider.
+ * PluginSettingsProvider 인터페이스의 drop-in 구현.
+ */
+export class DbPluginSettingsProvider implements PluginSettingsProvider {
+    private tableChecked = false;
+
+    /** 프로세스 로컬 L1 캐시. pub/sub 구독자가 invalidateLocal() 로 비운다. */
+    private local = new Map<string, L1Entry<unknown>>();
+    private static readonly L1_TTL_MS = CACHE_TTL * 1000;
+
+    // ========== 캐시 헬퍼 ==========
+
+    private getLocal<T>(key: string): T | null {
+        const e = this.local.get(key);
+        if (e && Date.now() < e.expiry) return e.value as T;
+        if (e) this.local.delete(key);
+        return null;
+    }
+
+    private setLocal<T>(key: string, value: T): void {
+        this.local.set(key, { value, expiry: Date.now() + DbPluginSettingsProvider.L1_TTL_MS });
+    }
+
+    private async getCache<T>(key: string): Promise<T | null> {
+        try {
+            const cached = await getRedis().get(key);
+            if (cached) return JSON.parse(cached) as T;
+        } catch (err) {
+            console.error('[PluginSettings/DB] Redis get 실패:', err);
+        }
+        return null;
+    }
+
+    private async setCache(key: string, value: unknown): Promise<void> {
+        try {
+            await getRedis().setex(key, CACHE_TTL, JSON.stringify(value));
+        } catch (err) {
+            console.error('[PluginSettings/DB] Redis set 실패:', err);
+        }
+    }
+
+    private async delCache(key: string): Promise<void> {
+        try {
+            await getRedis().del(key);
+        } catch (err) {
+            console.error('[PluginSettings/DB] Redis del 실패:', err);
+        }
+    }
+
+    /**
+     * 테이블 확인. prod 는 006 DDL 이 선행되므로 no-op 이지만, 신규 설치에서
+     * 플러그인을 먼저 건드릴 수 있어 남긴다. ⛔ 실패해도 throw 하지 않는다.
+     */
+    private async ensureTable(): Promise<void> {
+        if (this.tableChecked) return;
+        try {
+            await pool.query(`
+                CREATE TABLE IF NOT EXISTS ${TABLE} (
+                    plugin_id VARCHAR(100) PRIMARY KEY,
+                    is_active TINYINT(1) NOT NULL DEFAULT 0,
+                    settings JSON NULL,
+                    activated_at DATETIME NULL,
+                    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    INDEX idx_is_active (is_active)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            `);
+            this.tableChecked = true;
+        } catch (err) {
+            console.error('[PluginSettings/DB] 테이블 확인 실패(무시):', err);
+        }
+    }
+
+    /** JSON 컬럼은 드라이버 설정에 따라 문자열 또는 객체로 온다 — 양쪽 모두 안전 처리. */
+    private parseSettings(raw: SettingsRow['settings']): Record<string, unknown> {
+        if (raw == null) return {};
+        if (typeof raw === 'object') return raw as Record<string, unknown>;
+        try {
+            return JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+            return {};
+        }
+    }
+
+    // ========== PluginSettingsProvider 구현 ==========
+
+    async getActivePlugins(): Promise<string[]> {
+        const l1 = this.getLocal<string[]>(KEY_ACTIVE);
+        if (l1 !== null) return l1;
+
+        const cached = await this.getCache<string[]>(KEY_ACTIVE);
+        if (cached !== null) {
+            this.setLocal(KEY_ACTIVE, cached);
+            return cached;
+        }
+
+        try {
+            await this.ensureTable();
+            const [rows] = await readPool.query<ActiveRow[]>(
+                `SELECT plugin_id FROM ${TABLE} WHERE is_active = 1 ORDER BY activated_at, plugin_id`
+            );
+            const ids = rows.map((r) => r.plugin_id);
+            this.setLocal(KEY_ACTIVE, ids);
+            await this.setCache(KEY_ACTIVE, ids);
+            return ids;
+        } catch (err) {
+            // 읽기 전용 경로 — 실패 시 빈 목록으로 흡수(화면 전체가 죽지 않게).
+            console.error('[PluginSettings/DB] 활성 목록 조회 실패, 빈 목록 사용:', err);
+            return [];
+        }
+    }
+
+    async activatePlugin(pluginId: string): Promise<void> {
+        await this.ensureTable();
+        // 원자적 UPSERT — 목록 전체를 읽고 덮어쓰지 않는다(RMW 경쟁 없음).
+        await pool.query<ResultSetHeader>(
+            `INSERT INTO ${TABLE} (plugin_id, is_active, activated_at)
+             VALUES (?, 1, NOW())
+             ON DUPLICATE KEY UPDATE is_active = 1, activated_at = NOW()`,
+            [pluginId]
+        );
+        await this.delCache(KEY_ACTIVE);
+        this.invalidateLocal();
+    }
+
+    async deactivatePlugin(pluginId: string): Promise<void> {
+        await this.ensureTable();
+        await pool.query<ResultSetHeader>(`UPDATE ${TABLE} SET is_active = 0 WHERE plugin_id = ?`, [
+            pluginId
+        ]);
+        await this.delCache(KEY_ACTIVE);
+        this.invalidateLocal();
+    }
+
+    async getPluginSettings(pluginId: string): Promise<Record<string, unknown>> {
+        const cacheKey = keyForSettings(pluginId);
+
+        const l1 = this.getLocal<Record<string, unknown>>(cacheKey);
+        if (l1 !== null) return l1;
+
+        const cached = await this.getCache<Record<string, unknown>>(cacheKey);
+        if (cached !== null) {
+            this.setLocal(cacheKey, cached);
+            return cached;
+        }
+
+        try {
+            await this.ensureTable();
+            const [rows] = await readPool.query<SettingsRow[]>(
+                `SELECT settings FROM ${TABLE} WHERE plugin_id = ? LIMIT 1`,
+                [pluginId]
+            );
+            const settings = rows[0] ? this.parseSettings(rows[0].settings) : {};
+            this.setLocal(cacheKey, settings);
+            await this.setCache(cacheKey, settings);
+            return settings;
+        } catch (err) {
+            console.error(`[PluginSettings/DB] 설정 조회 실패 (id=${pluginId}):`, err);
+            return {};
+        }
+    }
+
+    async setPluginSettings(pluginId: string, settings: Record<string, unknown>): Promise<void> {
+        await this.ensureTable();
+        // 설정만 갱신 — is_active/activated_at 은 기존값 유지(신규 행이면 기본 0).
+        await pool.query<ResultSetHeader>(
+            `INSERT INTO ${TABLE} (plugin_id, settings)
+             VALUES (?, CAST(? AS JSON))
+             ON DUPLICATE KEY UPDATE settings = VALUES(settings)`,
+            [pluginId, JSON.stringify(settings)]
+        );
+        await this.delCache(keyForSettings(pluginId));
+        this.invalidateLocal();
+    }
+
+    /**
+     * 전체 설정 조회 (디버깅/백업용).
+     * 파일 구현과 같은 모양({activePlugins, plugins, version})으로 돌려준다.
+     */
+    async getAllPluginSettings(): Promise<Record<string, unknown>> {
+        await this.ensureTable();
+        const plugins: Record<string, { settings: Record<string, unknown>; activatedAt?: string }> =
+            {};
+        const activePlugins: string[] = [];
+        try {
+            const [rows] = await readPool.query<
+                (RowDataPacket & {
+                    plugin_id: string;
+                    is_active: number;
+                    settings: SettingsRow['settings'];
+                    activated_at: Date | string | null;
+                })[]
+            >(
+                `SELECT plugin_id, is_active, settings, activated_at FROM ${TABLE} ORDER BY activated_at, plugin_id`
+            );
+            for (const row of rows) {
+                plugins[row.plugin_id] = {
+                    settings: this.parseSettings(row.settings),
+                    activatedAt: row.activated_at
+                        ? new Date(row.activated_at).toISOString()
+                        : undefined
+                };
+                if (row.is_active) activePlugins.push(row.plugin_id);
+            }
+        } catch (err) {
+            console.error('[PluginSettings/DB] 전체 조회 실패:', err);
+        }
+        return { activePlugins, plugins, version: '1.0.0' };
+    }
+
+    /**
+     * 프로세스 로컬(L1) 캐시 전체 비우기.
+     * pub/sub 구독자가 다른 파드의 변경을 수신했을 때 호출한다(파드 간 전파).
+     */
+    invalidateLocal(): void {
+        this.local.clear();
+    }
+}

--- a/apps/web/src/lib/server/settings/plugin-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/plugin-settings-provider.ts
@@ -8,7 +8,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { env } from '$env/dynamic/private';
-import { MySqlPluginSettingsProvider } from './mysql-plugin-settings-provider';
+import { DbPluginSettingsProvider } from './db-plugin-settings-provider';
 
 /**
  * 플러그인 설정 Provider 인터페이스
@@ -50,6 +50,13 @@ export interface PluginSettingsProvider {
      * 전체 플러그인 설정 조회 (디버깅/백업용)
      */
     getAllPluginSettings(): Promise<Record<string, unknown>>;
+
+    /**
+     * 프로세스 로컬(in-memory) 캐시 무효화 (선택).
+     * pub/sub 구독자가 다른 파드의 변경을 수신했을 때 호출한다.
+     * 로컬 캐시가 없는 구현(JSON 파일 등)은 구현하지 않아도 된다.
+     */
+    invalidateLocal?(): void;
 }
 
 /**
@@ -228,24 +235,26 @@ class JsonPluginSettingsProvider implements PluginSettingsProvider {
 /**
  * 전역 플러그인 설정 Provider (Facade)
  *
- * 환경변수로 저장소 선택:
- *   - PLUGIN_SETTINGS_PROVIDER=json  (기본값) 파일. 단일 인스턴스·셀프호스팅용
- *   - PLUGIN_SETTINGS_PROVIDER=mysql  MySQL+Redis. **다중 파드 운영은 이쪽이어야 한다**
+ * 환경변수로 저장소 선택 (PLUGIN_SETTINGS_PROVIDER 우선, 없으면 SETTINGS_PROVIDER 재사용):
+ *   - json  (기본값) 파일. 단일 인스턴스·셀프호스팅용
+ *   - mysql  MySQL 전용 테이블(angple_plugin_settings) + Redis. **다중 파드 운영은 이쪽**
  *
  * ⛔ 기본값을 mysql 로 바꾸지 말 것 — 셀프호스팅 사용자는 DB 스키마 없이 설치한다.
+ *    운영 전환(006 DDL → 007 백필 → env=mysql → 롤링)은 배포 절차라 코드 범위 밖이다.
  * ⛔ json 구현을 지우지 말 것 — env 를 되돌리면 즉시 복귀하는 롤백 경로다.
  *
- * 파일 기반의 한계(2026-07-31 실측): prod web 파드 13개에 볼륨 마운트가 없어 파일이
+ * 파일 기반의 한계(2026-07-31 실측): prod web 파드 다수에 볼륨 마운트가 없어 파일이
  * 이미지에 구워진 채 파드별로 분리된다 → admin 토글이 파드 1개에만 적용되고 재배포 시
  * 소실되며, Redis L2 공유와 맞물려 변경이 스스로 되돌아가는 flapping 까지 발생했다.
- * 자세한 배경은 mysql-plugin-settings-provider.ts 상단 주석 참조.
+ * mysql 구현은 플러그인당 1행(원자적 UPSERT) + pub/sub 무효화로 이를 해소한다.
+ * 자세한 배경은 db-plugin-settings-provider.ts 상단 주석 참조.
  */
-const PROVIDER_TYPE = env.PLUGIN_SETTINGS_PROVIDER || 'json';
+const PROVIDER_TYPE = env.PLUGIN_SETTINGS_PROVIDER || env.SETTINGS_PROVIDER || 'json';
 
 function createProvider(): PluginSettingsProvider {
     if (PROVIDER_TYPE === 'mysql') {
-        console.log('[PluginSettings] Using MySQL + Redis provider');
-        return new MySqlPluginSettingsProvider();
+        console.log('[PluginSettings] Using MySQL + Redis provider (angple_plugin_settings)');
+        return new DbPluginSettingsProvider();
     }
     console.log('[PluginSettings] Using JSON file provider');
     return new JsonPluginSettingsProvider();

--- a/apps/web/src/lib/server/settings/plugin-settings-provider.ts
+++ b/apps/web/src/lib/server/settings/plugin-settings-provider.ts
@@ -240,8 +240,11 @@ class JsonPluginSettingsProvider implements PluginSettingsProvider {
  *   - mysql  MySQL 전용 테이블(angple_plugin_settings) + Redis. **다중 파드 운영은 이쪽**
  *
  * ⛔ 기본값을 mysql 로 바꾸지 말 것 — 셀프호스팅 사용자는 DB 스키마 없이 설치한다.
- *    운영 전환(006 DDL → 007 백필 → env=mysql → 롤링)은 배포 절차라 코드 범위 밖이다.
- * ⛔ json 구현을 지우지 말 것 — env 를 되돌리면 즉시 복귀하는 롤백 경로다.
+ *    운영 env 는 이미 mysql 이다. 이 코드는 mysql 매핑을 기존 MySqlPluginSettingsProvider
+ *    (공유 angple_settings)에서 DbPluginSettingsProvider(전용 angple_plugin_settings)로 바꾼다.
+ *    ⛔ 배포 전 반드시 006 DDL → 007 백필(angple_settings.active_plugins → 전용 테이블)을 선행할 것.
+ *       백필 없이 배포하면 빈 전용 테이블을 SoT 로 읽어 전 플러그인이 꺼진다.
+ * ⛔ json 구현을 지우지 말 것 — 셀프호스팅 롤백 경로다.
  *
  * 파일 기반의 한계(2026-07-31 실측): prod web 파드 다수에 볼륨 마운트가 없어 파일이
  * 이미지에 구워진 채 파드별로 분리된다 → admin 토글이 파드 1개에만 적용되고 재배포 시

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -679,13 +679,15 @@
                 });
         }
 
-        // 플러그인 hooks/components 지연 로드 (SSR에서는 빈 배열로 전달하여 __data.json 축소)
+        // 플러그인 hooks/components 지연 로드 (SSR에서는 hooks 빈 배열로 전달하여 __data.json 축소)
+        // Option C 3단계: activePlugins 는 CDN 캐시(layout/hooks·layout/init)에서 분리하고
+        // no-store 인 /api/plugins/active 에서 직접 가져온다 → admin 토글 즉시 반영.
         if ((data.activePlugins?.length ?? 0) > 0) {
-            fetch('/api/layout/hooks')
+            fetch('/api/plugins/active')
                 .then((res) => (res.ok ? res.json() : null))
-                .then((payload: { activePlugins?: typeof data.activePlugins } | null) => {
-                    if (!payload?.activePlugins?.length) return;
-                    pluginStore.initFromServer(payload.activePlugins);
+                .then((payload: { plugins?: typeof data.activePlugins } | null) => {
+                    if (!payload?.plugins?.length) return;
+                    pluginStore.initFromServer(payload.plugins);
                 })
                 .catch(() => {});
         }

--- a/apps/web/src/routes/api/layout/hooks/+server.ts
+++ b/apps/web/src/routes/api/layout/hooks/+server.ts
@@ -1,24 +1,22 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
+/**
+ * GET /api/layout/hooks (Option C 3단계 이후 deprecated)
+ *
+ * 이 엔드포인트는 원래 활성 플러그인(hooks/components)을 s-maxage=300 으로 CDN 캐시했다.
+ * 그러나 CDN 캐시는 admin 토글을 최대 5분간 stale 하게 만든다. 활성 플러그인 상태는
+ * 이제 no-store 인 /api/plugins/active 에서 별도로 fetch 한다(+layout.svelte).
+ *
+ * 소비자 회귀 방지를 위해 라우트와 응답 키(activePlugins)는 유지하되 빈 배열로 중립화한다.
+ * (클라이언트는 더 이상 이 라우트를 호출하지 않는다.)
+ */
 export const GET: RequestHandler = async () => {
-    const { getActivePlugins } = await import('$lib/server/plugins/index.js');
-    const plugins = await getActivePlugins();
-
-    const activePlugins = plugins.map((p) => ({
-        id: p.manifest.id,
-        name: p.manifest.name,
-        version: p.manifest.version,
-        hooks: p.manifest.hooks || [],
-        components: p.manifest.components || [],
-        settings: p.currentSettings || null
-    }));
-
     return json(
-        { activePlugins },
+        { activePlugins: [] },
         {
             headers: {
-                'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=1800, max-age=60'
+                'Cache-Control': 'no-store'
             }
         }
     );

--- a/apps/web/src/routes/api/layout/init/+server.ts
+++ b/apps/web/src/routes/api/layout/init/+server.ts
@@ -8,35 +8,26 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { getCachedCelebrations } from '$lib/server/celebration';
 import { getCachedBannersByPositions } from '$lib/server/ads/banners';
-import { getActivePlugins } from '$lib/server/plugins';
 import { env } from '$env/dynamic/private';
 
 export const GET: RequestHandler = async () => {
-    const [celebrationResult, bannersResult, pluginsResult] = await Promise.allSettled([
+    const [celebrationResult, bannersResult] = await Promise.allSettled([
         getCachedCelebrations(),
-        getCachedBannersByPositions(['index-top', 'board-head', 'sidebar']),
-        getActivePlugins()
+        getCachedBannersByPositions(['index-top', 'board-head', 'sidebar'])
     ]);
 
     const celebration = celebrationResult.status === 'fulfilled' ? celebrationResult.value : [];
     const banners = bannersResult.status === 'fulfilled' ? bannersResult.value : {};
-    const activePlugins =
-        pluginsResult.status === 'fulfilled'
-            ? pluginsResult.value.map((plugin) => ({
-                  id: plugin.manifest.id,
-                  name: plugin.manifest.name,
-                  version: plugin.manifest.version,
-                  hooks: plugin.manifest.hooks || [],
-                  components: plugin.manifest.components || [],
-                  settings: plugin.currentSettings || {}
-              }))
-            : [];
 
     return json(
         {
             celebration,
             banners,
-            activePlugins,
+            // ⛔ activePlugins 는 이 CDN 캐시(s-maxage=300) 응답에서 분리했다(Option C 3단계).
+            //    활성 플러그인은 no-store 인 /api/plugins/active 에서 클라이언트가 별도 fetch 한다.
+            //    소비자 회귀 방지를 위해 키 자체는 유지하되 빈 배열로 중립화한다
+            //    (applyLayoutInitPayload 는 length 가 있을 때만 initFromServer 하므로 no-op).
+            activePlugins: [],
             ga4MeasurementId: env.GA4_MEASUREMENT_ID || ''
         },
         {

--- a/apps/web/src/routes/api/plugins/active/+server.ts
+++ b/apps/web/src/routes/api/plugins/active/+server.ts
@@ -16,17 +16,27 @@ export const GET: RequestHandler = async () => {
     try {
         const activePlugins = await getActivePlugins();
 
-        return json({
-            plugins: activePlugins.map((plugin) => ({
-                id: plugin.manifest.id,
-                name: plugin.manifest.name,
-                version: plugin.manifest.version,
-                hooks: plugin.manifest.hooks || [],
-                components: plugin.manifest.components || [],
-                settings: plugin.currentSettings || {}
-            })),
-            total: activePlugins.length
-        });
+        return json(
+            {
+                plugins: activePlugins.map((plugin) => ({
+                    id: plugin.manifest.id,
+                    name: plugin.manifest.name,
+                    version: plugin.manifest.version,
+                    hooks: plugin.manifest.hooks || [],
+                    components: plugin.manifest.components || [],
+                    settings: plugin.currentSettings || {}
+                })),
+                total: activePlugins.length
+            },
+            {
+                // ⛔ CDN/edge 캐시 금지. 활성 플러그인 상태의 authoritative source 다 —
+                //    admin 토글이 즉시 반영되어야 한다(오리진 캐시는 pub/sub 로 무효화됨).
+                //    layout/init·layout/hooks 의 s-maxage(CDN) 와 분리된 이유가 이것이다.
+                headers: {
+                    'Cache-Control': 'no-store'
+                }
+            }
+        );
     } catch (error) {
         console.error('❌ [API /plugins/active] 활성 플러그인 조회 실패:', error);
 

--- a/migrations/006_angple_plugin_settings.sql
+++ b/migrations/006_angple_plugin_settings.sql
@@ -1,0 +1,20 @@
+-- 플러그인 활성상태 SoT(Source of Truth) 를 MySQL 로 이관 (Option C 1단계)
+-- 기존 파일 기반(data/plugin-settings.json)은 다중 파드에서 성립하지 않는다:
+--   prod web 파드 다수에 볼륨 마운트가 없어 파일이 이미지에 구워진 채 파드별로 분리된다
+--   → admin 토글이 파드 1개에만 적용되고 재배포 시 소실된다.
+--
+-- 테마 설정(angple_settings, LONGTEXT key-value)과 달리 플러그인은 **플러그인당 1행**으로
+-- 저장한다. 그래야 활성/비활성이 원자적 UPSERT(INSERT ... ON DUPLICATE KEY UPDATE) 로 처리되어
+-- read-modify-write 경쟁(빈 목록에 하나만 얹어 나머지가 전부 꺼지는 사고)이 원천 차단된다.
+--
+-- ⛔ prod 는 AutoMigrate 가 돌지 않는다 — 이 DDL 을 배포 전에 수동 선행 적용할 것.
+--    (배포 순서: 006 DDL → 007 백필 → env PLUGIN_SETTINGS_PROVIDER=mysql → 롤링 재배포)
+
+CREATE TABLE IF NOT EXISTS angple_plugin_settings (
+    plugin_id VARCHAR(100) PRIMARY KEY,
+    is_active TINYINT(1) NOT NULL DEFAULT 0,
+    settings JSON NULL,
+    activated_at DATETIME NULL,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_is_active (is_active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/migrations/007_backfill_plugin_settings.sql
+++ b/migrations/007_backfill_plugin_settings.sql
@@ -1,0 +1,21 @@
+-- 006 로 만든 angple_plugin_settings 에 현재 활성 플러그인 백필 (Option C 1단계)
+-- 정본: apps/web/data/plugin-settings.json 의 activePlugins (2026-08 기준 10개).
+--
+-- activated_at 은 JSON 의 실제 activatedAt 값을 그대로 넣는다(NOW() 아님).
+--   getActivePlugins() 가 `ORDER BY activated_at, plugin_id` 로 정렬하므로, 전부 NOW() 로
+--   찍으면 알파벳 순으로 재정렬되어 훅 실행 순서가 바뀔 수 있다. 원래 활성 순서를 보존한다.
+--
+-- 멱등: ON DUPLICATE KEY UPDATE is_active=1 — 이미 있으면 활성만 보장하고 설정/시각은 건드리지 않는다.
+
+INSERT INTO angple_plugin_settings (plugin_id, is_active, activated_at) VALUES
+    ('emoticon',               1, '2026-02-04 14:51:20'),
+    ('bracket-image',          1, '2026-02-07 12:00:00'),
+    ('auto-embed',             1, '2026-02-07 12:00:00'),
+    ('member-memo',            1, '2026-02-07 12:00:00'),
+    ('interaction-analysis',   1, '2026-02-09 12:00:00'),
+    ('da-reaction',            1, '2026-02-09 15:00:00'),
+    ('affiliate-link-private', 1, '2026-03-22 13:50:00'),
+    ('archive',                1, '2026-05-24 00:00:00'),
+    ('payment',                1, '2026-06-09 00:00:00'),
+    ('brickang',               1, '2026-06-09 00:00:00')
+ON DUPLICATE KEY UPDATE is_active = 1;

--- a/migrations/007_backfill_plugin_settings.sql
+++ b/migrations/007_backfill_plugin_settings.sql
@@ -1,21 +1,35 @@
--- 006 로 만든 angple_plugin_settings 에 현재 활성 플러그인 백필 (Option C 1단계)
--- 정본: apps/web/data/plugin-settings.json 의 activePlugins (2026-08 기준 10개).
+-- 006 으로 만든 angple_plugin_settings 에 현재 활성 플러그인 백필 (Option C 1단계)
 --
--- activated_at 은 JSON 의 실제 activatedAt 값을 그대로 넣는다(NOW() 아님).
---   getActivePlugins() 가 `ORDER BY activated_at, plugin_id` 로 정렬하므로, 전부 NOW() 로
---   찍으면 알파벳 순으로 재정렬되어 훅 실행 순서가 바뀔 수 있다. 원래 활성 순서를 보존한다.
+-- ⛔ 정본(SoT)은 파일이 아니라 **운영 DB 의 angple_settings.active_plugins** 다.
+--    운영 env 는 이미 PLUGIN_SETTINGS_PROVIDER=mysql 이고, 기존 MySqlPluginSettingsProvider 가
+--    공유 테이블 angple_settings 의 setting_key='active_plugins' 행(JSON 배열)을 SoT 로 쓴다.
+--    apps/web/data/plugin-settings.json(파일)은 stale 드리프트 상태다 — 백필에 쓰지 말 것.
+--    (2026-08 실측: 파일 10개 vs 운영 SoT 13개. 파일 기준으로 백필하면
+--     affiliate-link·angtt-review·poll 3개가 꺼진다.)
 --
--- 멱등: ON DUPLICATE KEY UPDATE is_active=1 — 이미 있으면 활성만 보장하고 설정/시각은 건드리지 않는다.
+-- 방식: angple_settings.active_plugins(JSON 배열)를 JSON_TABLE 로 펼쳐 그대로 전용 테이블로 옮긴다.
+--   하드코딩 목록이 아니라 운영 SoT 를 직접 읽으므로 향후 드리프트에도 안전하다.
+--   참고 — 이 백필 시점의 운영 SoT(13개):
+--     emoticon, bracket-image, auto-embed, member-memo, interaction-analysis, da-reaction,
+--     affiliate-link-private, archive, payment, brickang, affiliate-link, angtt-review, poll
+--
+-- activated_at: 배열의 순서가 곧 활성 순서다. getActivePlugins() 가 `ORDER BY activated_at, plugin_id`
+--   로 정렬하므로, 배열 인덱스(FOR ORDINALITY)만큼 NOW() 에 초를 더해 **원래 순서를 결정적으로 보존**한다.
+--   (전부 NOW() 로 찍으면 알파벳순으로 재정렬되어 훅 실행 순서가 바뀔 수 있다.)
+--
+-- 멱등: ON DUPLICATE KEY UPDATE is_active=1 — 이미 있으면 활성만 보장하고 activated_at 은 안 건드린다.
+--
+-- 요구사항: MySQL 8.0+ (JSON_TABLE). angple_settings 컬럼은 setting_key / setting_value (LONGTEXT, JSON 텍스트).
 
-INSERT INTO angple_plugin_settings (plugin_id, is_active, activated_at) VALUES
-    ('emoticon',               1, '2026-02-04 14:51:20'),
-    ('bracket-image',          1, '2026-02-07 12:00:00'),
-    ('auto-embed',             1, '2026-02-07 12:00:00'),
-    ('member-memo',            1, '2026-02-07 12:00:00'),
-    ('interaction-analysis',   1, '2026-02-09 12:00:00'),
-    ('da-reaction',            1, '2026-02-09 15:00:00'),
-    ('affiliate-link-private', 1, '2026-03-22 13:50:00'),
-    ('archive',                1, '2026-05-24 00:00:00'),
-    ('payment',                1, '2026-06-09 00:00:00'),
-    ('brickang',               1, '2026-06-09 00:00:00')
+INSERT INTO angple_plugin_settings (plugin_id, is_active, activated_at)
+SELECT jt.pid, 1, NOW() + INTERVAL jt.rn SECOND
+FROM angple_settings s,
+     JSON_TABLE(
+         s.setting_value,
+         '$[*]' COLUMNS (
+             rn  FOR ORDINALITY,
+             pid VARCHAR(100) PATH '$'
+         )
+     ) AS jt
+WHERE s.setting_key = 'active_plugins'
 ON DUPLICATE KEY UPDATE is_active = 1;


### PR DESCRIPTION
## 배경
플러그인 활성상태 SoT가 다중 파드에서 성립하지 않는 구조였다. Option C(DB 전용테이블 SoT + pub/sub 무효화 + CDN 분리) 전체 구현.

⚠️ **운영 env는 이미 `PLUGIN_SETTINGS_PROVIDER=mysql`** 이며, 기존 `MySqlPluginSettingsProvider`가 공유 테이블 `angple_settings`의 `active_plugins` 키(JSON 배열, 13개)를 SoT로 쓰고 있다. 이 PR은 그 매핑을 전용 테이블 기반 `DbPluginSettingsProvider`로 교체한다.

## 변경 사항

### 1단계 — 활성상태 SoT를 전용 테이블로
- `migrations/006_angple_plugin_settings.sql` — 전용 테이블(`plugin_id` PK, `is_active` 인덱스, `settings` JSON, `activated_at`). 005는 기존 `005_ui_settings.sql` 선점 → 006/007 사용.
- `migrations/007_backfill_plugin_settings.sql` — ⛔ **운영 SoT `angple_settings.active_plugins`(13개)에서 JSON_TABLE로 백필**(하드코딩 아님, 드리프트 안전). 배열 인덱스(`FOR ORDINALITY`)로 `activated_at` 오프셋 → 원래 활성 순서 보존. ⛔ 파일 `apps/web/data/plugin-settings.json`은 stale(10개)이라 백필 소스로 쓰지 않음.
- `db-plugin-settings-provider.ts` — 신규. 활성/비활성 **원자적 UPSERT/UPDATE**(RMW 경쟁 제거), Redis L2 + 프로세스 로컬 L1, public `invalidateLocal()`, `ensureTable()` best-effort.
- 팩토리: `PLUGIN_SETTINGS_PROVIDER || SETTINGS_PROVIDER || 'json'`, `mysql`→`DbPluginSettingsProvider`. 기본값 json(셀프호스팅 롤백 경로).

### 2단계 — pub/sub 파드 간 무효화
- `invalidation.ts` — `publishPluginInvalidation()`, 채널 `angple:plugin:invalidate`(CACHE_NAMESPACE 접두), origin(podId) self-skip. best-effort.
- `invalidation-subscriber.ts` — 구독 전용 커넥션(`getRedis().duplicate()`), 수신 시 `deleteL1('list')` + `invalidateLocal?.()` + `invalidateHandlerCache()`. 멱등, reconnect 재구독.
- `invalidateActivePluginsCache()`에 방송 추가. `hooks.server.ts`에서 부팅 시 구독 시작.

### 3단계 — CDN 분리
- `/api/plugins/active`: `Cache-Control: no-store`(활성상태 authoritative source).
- `/api/layout/init`·`/api/layout/hooks`: `activePlugins`를 CDN(s-maxage) 응답에서 분리, 키 유지·빈 배열 중립화(소비자 회귀 방지).
- `+layout.svelte`: 활성 플러그인을 `/api/plugins/active`에서 별도 fetch.

## ⛔ 배포 순서 (운영 env가 이미 mysql이라 특히 위험)
1. **006 DDL 수동 선행 적용**(prod는 AutoMigrate 미실행)
2. **007 백필** 적용 (`angple_settings.active_plugins` 13개 → 전용 테이블)
3. **배포** — 이 코드가 팩토리를 `DbPluginSettingsProvider`로 전환(env는 이미 mysql이라 별도 변경 없음)
4. 검증 (활성 플러그인 13개 노출 확인, admin 토글 즉시 반영 확인)

⛔ **백필(2번) 없이 배포하면 빈 전용 테이블을 SoT로 읽어 전 플러그인이 off 된다.**
롤백 = 이전 이미지(기존 `MySqlPluginSettingsProvider`가 `angple_settings`를 다시 읽음).

## 회귀 근거
- 소비자 심볼/시그니처 유지(`pluginSettingsProvider`, `getActivePlugins`, `invalidateActivePluginsCache`). `invalidateLocal?()`는 optional 추가.
- 응답 키(`activePlugins`) 삭제 없이 중립화. `applyLayoutInitPayload`는 length 가드라 빈 배열=no-op.
- `/api/layout/hooks` 유일 소비자였던 `+layout.svelte`를 전환, 다른 소비자 없음.
- 기존 `MySqlPluginSettingsProvider` 및 계약 테스트는 그대로 둠(팩토리에서만 분리) — 테스트 그린 유지.
- ⛔ 단, 운영 env가 이미 mysql이므로 **배포 시점에 SoT가 `angple_settings`→전용 테이블로 전환된다.** 배포 전 백필 필수(위 순서).