### PR TITLE
fix(report): 제재 확정 글에서도 신고 버튼을 노출한다

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1690,8 +1690,11 @@
                                                     <Trash2 class="h-4 w-4" />
                                                 </Button>
                                             {/if}
-                                            {#if !isAuthor && authStore.isAuthenticated && !isLocked}
-                                                <!-- 신고 버튼 (본인이 아닌 경우에만, #12420: 잠긴 댓글은 추가 신고 불가) -->
+                                            {#if !isAuthor && authStore.isAuthenticated}
+                                                <!-- 신고 버튼 (본인이 아닌 경우에만).
+                                                     ⭐ 2026-08-18: 잠긴 댓글에서도 노출한다 — 백엔드가 409 를
+                                                     돌려주던 것을 제거했다(angple-backend). 게시글 쪽과 같은 규약.
+                                                     ⛔ canEditComment 의 잠금 차단(수정 금지)은 그대로 둔다. -->
                                                 <Button
                                                     variant="ghost"
                                                     size="sm"
@@ -2080,8 +2083,9 @@
                                 </Button>
                             {/if}
 
-                            <!-- 신고 버튼 (본인이 아닌 경우, #12420: 잠긴 댓글은 추가 신고 불가) -->
-                            {#if !isAuthor && authStore.isAuthenticated && !isLocked}
+                            <!-- 신고 버튼 (본인이 아닌 경우).
+                                 ⭐ 2026-08-18: 잠긴 댓글에서도 노출 — 위 분기와 같은 규약. -->
+                            {#if !isAuthor && authStore.isAuthenticated}
                                 <Button
                                     variant="ghost"
                                     size="sm"

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -122,7 +122,10 @@
         promotionExpired = false,
         postReactions,
         postReportCount,
-        isSanctioned = false,
+        // ⛔ 2026-08-18 이후 이 컴포넌트에서는 쓰지 않는다(신고 버튼을 항상 노출).
+        // 선언은 남긴다 — 부모(+page.svelte)가 계속 넘기고, 다른 레이아웃·테마가
+        // 같은 ViewLayoutProps 를 쓰기 때문에 지우면 그쪽이 조용히 깨진다.
+        isSanctioned: _isSanctioned = false,
         truthroomPostId,
         originalPostLink
     }: ViewLayoutProps = $props();
@@ -849,11 +852,14 @@
                     {#if board?.use_sns}
                         <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}
-                    {#if !isAuthor && !isSanctioned}
-                        <!-- #12420: 신고잠금 글의 추가 신고 게이트.
-                             제재 확정(B형)만 숨긴다 — 재신고 시 백엔드 409+트리거로 차단되기 때문.
-                             신고 누적 자동잠금(A형)은 다시 열어 추가 신고를 허용한다(백엔드가 계속 accept).
-                             ⛔ isLockedPost(가림/배지/워터마크)는 그대로 유지 — 게이트만 isSanctioned 로 분리. -->
+                    {#if !isAuthor}
+                        <!-- ⭐ 2026-08-18: 신고 버튼은 항상 보인다 — 제재 확정(B형) 글에서도.
+                             종전에 B형을 숨긴 근거는 "재신고 시 백엔드 409+트리거로 차단되기 때문"이었는데
+                             ⛔ 그 트리거는 존재하지 않았고, 409 도 같은 날 제거했다(angple-backend).
+                             접수는 열고 중복 처분은 세 곳이 나눠 막는다 —
+                             동일인 재신고 가드 · contentSanctioned(재잠금 금지) · ops inbox 제외.
+                             ⛔ isLockedPost(가림/배지/워터마크)는 그대로 유지 — 게이트만 없앤다.
+                             설계: ops-docs/2026-08-18-report-accept-always-inbox-exclude-design.html -->
                         <Button
                             variant="ghost"
                             size="sm"

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -741,12 +741,19 @@ export const load: PageServerLoad = async ({
         // undefined 이므로, 확실한 lock 신호인 신고 횟수 조회 결과를 워터마크 판정에 사용한다.
         const postReportLock = (await postReportCountPromise) === 'lock';
 
-        // 신고잠금(wr_7='lock') 2형 구분 — 신고 버튼 게이트 전용.
-        //  A형: 신고 누적 자동잠금(미제재). 백엔드가 신고를 계속 accept 하므로 추가 신고를 다시 연다.
-        //  B형: 관리자 제재 확정(g5_na_singo processed=1 AND admin_approved=1 AND discipline_log_id>0).
-        //       백엔드가 409(제재 확정)+DB 트리거로 재신고를 막으므로 버튼은 계속 숨긴다.
-        // B형은 정의상 wr_7='lock' 이므로 잠긴 글에서만 조회한다(비잠금 글엔 불필요한 DB 왕복 회피).
-        // isSanctionedPost 는 내부 try/catch 로 실패 시 false 수렴 — 판정 불가가 신고 차단이 되지 않는다.
+        // 신고잠금(wr_7='lock') 2형 구분 — 제재 확정(B형) 여부.
+        //  A형: 신고 누적 자동잠금(미제재)
+        //  B형: 관리자 제재 확정(g5_na_singo processed=1 AND admin_approved=1 AND discipline_log_id>0)
+        //
+        // ⛔ 2026-08-18: **더 이상 신고 버튼 게이트가 아니다.** 신고는 두 형 모두 받는다.
+        // 종전 주석에 "백엔드가 409+DB 트리거로 재신고를 막는다"고 적혀 있었으나
+        // 그 트리거는 애초에 존재하지 않았고, 409 도 제거했다(angple-backend).
+        // 중복 처분은 동일인 중복 가드 · contentSanctioned(재잠금 금지) ·
+        // ops inbox 의 processedExclusionSQL 이 나눠 막는다.
+        //
+        // 값은 계속 내려보낸다 — 레이아웃·테마가 같은 ViewLayoutProps 를 쓰고,
+        // 앞으로 다른 표시(배지 등)에 쓸 수 있다. 잠긴 글에서만 조회하므로 비용은 제한적이다.
+        // isSanctionedPost 는 내부 try/catch 로 실패 시 false 수렴한다.
         const isSanctioned =
             postReportLock || post.extra_7 === 'lock'
                 ? await isSanctionedPost(boardId, Number(postId))


### PR DESCRIPTION
## 왜

제재 확정(B형) 글에서 신고 버튼을 숨긴 근거가 코드 주석에 남아 있다 —
*"재신고 시 백엔드 409+트리거로 차단되기 때문"*.

⛔ **두 전제 모두 사실이 아니다.**

- 그 DB 트리거는 존재하지 않는다 (`g5_na_singo` 트리거는 `after_singo_insert` 하나뿐)
- 409 는 같은 날 `angple-backend#673` 에서 제거했다

버튼을 숨기면 회원은 **잠금 이후 새로 생긴 문제를 알릴 방법이 없다.**

## 무엇을

`{#if !isAuthor && !isSanctioned}` → `{#if !isAuthor}`

- ⛔ `isLockedPost`(가림·배지·워터마크)는 **그대로 유지** — 게이트만 없앴다
- `isSanctioned` prop 은 선언을 남긴다. 부모(`+page.svelte`)가 계속 넘기고
  다른 레이아웃·테마가 같은 `ViewLayoutProps` 를 쓰므로 지우면 그쪽이 조용히 깨진다

## 검증

- svelte 단일파일 컴파일 OK — **대조군(origin/main 원본)과 경고가 동일**
- prettier OK
- SvelteKit 프록시 `/api/v1/[...path]` 의 제재 게이트는 정규식이
  `.../comments` 와 본문 수정만 잡고 **`/report` 는 잡지 않는다** → 신고 경로 영향 없음
- premium 이 이 파일을 덮지 않는다

설계: `ops-docs/2026-08-18-report-accept-always-inbox-exclude-design.html`
