### PR TITLE
fix(editor): IME 조합 가드 — iOS 새 글 입력 자모 깨짐(#13590)

### DIFF
--- a/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
+++ b/apps/web/src/lib/components/features/editor/tiptap-editor.svelte
@@ -455,8 +455,20 @@
         if (!editor) return;
         if (!c || c === lastLoadedContent) return;
 
-        // 에디터에 이미 사용자 입력이 있으면 덮어쓰지 않음
+        // IME 조합 중의 setContent 는 조합 세션을 파괴해 iOS Safari·서드파티
+        // 키보드에서 자모가 깨진다(#13590). 조합이 끝난 뒤 다시 판단한다.
+        if (editor.view.composing) return;
+
         const currentHtml = editor.getHTML();
+
+        // onUpdate 로 흘러나간 값이 부모를 거쳐 prop 으로 되돌아온 echo —
+        // 다시 주입하면 커서·조합이 깨진다(#13590 신규 글 첫 글자 트리거).
+        if (c === currentHtml) {
+            lastLoadedContent = c;
+            return;
+        }
+
+        // 에디터에 이미 사용자 입력이 있으면 덮어쓰지 않음
         const editorHasContent =
             currentHtml !== '' && currentHtml !== '<p></p>' && currentHtml !== lastLoadedContent;
         if (editorHasContent && lastLoadedContent !== '') {


### PR DESCRIPTION
## 증상
#13590 — iOS Safari(+서드파티 키보드)에서 새 글 첫 글자부터 한글 자모가 깨짐.

## 원인
tiptap content 되먹임 루프: onUpdate→부모 state→prop 재주입 $effect 가 **IME 조합 중 setContent()** 호출(조합 가드 전무). 신규 글은 lastLoadedContent='' 라 '사용자 입력 보호' 가드도 통과.

## 수정 (근본)
- `editor.view.composing` 이면 주입 보류
- prop == 현재 에디터 HTML 인 echo 는 주입 스킵

## 검증
iOS 실기기(Safari)에서 새 글 작성 — 첫 글자부터 정상 조합 확인 필요. 데스크톱/기존 수정 플로우는 setContent 경로 유지(비동기 로드·수정 진입 동작 불변).