### PR TITLE
feat(reaction): 화나요 버튼 — 로컬 전용 이펙트(#2108)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -74,7 +74,7 @@
     });
 
     import { toast } from 'svelte-sonner';
-    import { trackFileDownload } from '$lib/services/ga4.js';
+    import { trackFileDownload, trackEvent } from '$lib/services/ga4.js';
     import PinOff from '@lucide/svelte/icons/pin-off';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
     import { onMount } from 'svelte';
@@ -217,6 +217,54 @@
             togglingNotice = false;
         }
     }
+
+    // 화나요 버튼 (#2108): 로컬 전용 리액션. 서버 요청·다모앙 DB 기록·타인 노출 0.
+    // 누른 사람 화면에서만 이펙트 1회(카드 흔들림 + 💢 팝) + GA 익명 카운트(글당 1회).
+    // 카운트·토글 상태 없음 — fetch/authStore/리액션 store 미접근.
+    let isAngryShaking = $state(false);
+    let showAngryPop = $state(false);
+    let angryTimer: ReturnType<typeof setTimeout> | undefined;
+
+    // 이펙트 재생: 클래스를 뗐다가 다음 프레임에 다시 붙여 재클릭 시 재발화되게 한다.
+    function playAngryEffect(): void {
+        isAngryShaking = false;
+        showAngryPop = false;
+        clearTimeout(angryTimer);
+        requestAnimationFrame(() => {
+            isAngryShaking = true;
+            showAngryPop = true;
+            // CSS 1회 재생 후 클래스 제거(다음 클릭 재발화 가능). shake 0.5s / pop 0.7s 여유.
+            angryTimer = setTimeout(() => {
+                isAngryShaking = false;
+                showAngryPop = false;
+            }, 800);
+        });
+    }
+
+    function triggerAngry(): void {
+        // GA는 글당 1회만. localStorage 존재 여부로 게이트(없으면 게이트 없이 매번 발화 — 무해).
+        let shouldTrack = true;
+        try {
+            const key = `angple_angry_${post.id}`;
+            if (localStorage.getItem(key)) shouldTrack = false;
+            else localStorage.setItem(key, '1');
+        } catch {
+            /* localStorage 접근 불가 → 게이트 스킵 */
+        }
+        if (shouldTrack) {
+            trackEvent('angry_reaction', { board_id: boardId, post_id: String(post.id) });
+        }
+
+        // reduced-motion 이면 이펙트는 스킵(GA는 이미 발화됨).
+        if (
+            typeof window !== 'undefined' &&
+            window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+        ) {
+            return;
+        }
+
+        playAngryEffect();
+    }
 </script>
 
 <!-- 글자 크기 조절 — 종전에는 본문 바로 위에 전용 줄(34px)을 차지했다. 한 번 맞추면
@@ -296,7 +344,11 @@
 {/snippet}
 
 <!-- 게시글 카드 -->
-<Card class="bg-background mb-6 gap-3 rounded-xl px-3 pb-5 pt-3 md:px-3">
+<Card
+    class="bg-background mb-6 gap-3 rounded-xl px-3 pb-5 pt-3 md:px-3 {isAngryShaking
+        ? 'da-angry-shake'
+        : ''}"
+>
     <!-- gap-3: CardHeader 는 자체적으로 grid gap-1.5 를 갖는다. 종전 space-y-3 는
          그 gap 을 대체하지 못하고 margin 으로 얹혀 6+12=18px 이 됐다(의도는 12px).
          같은 축의 gap 으로 주면 tailwind-merge 가 gap-1.5 를 대체해 정확히 12px. -->
@@ -841,6 +893,28 @@
                             </Button>
                         </div>
                     {/if}
+
+                    <!-- 화나요 버튼 (#2108): 로컬 전용 이펙트. 서버 요청·DB·타인 노출 0,
+                         GA 익명 카운트만. 카운트·토글 상태 없음. claim 제외·비밀글 게이트는
+                         상위 boardId/canViewSecret 조건에서 자동 상속(새 게이트 추가 안 함). -->
+                    <div class="border-border relative flex items-center rounded-lg border">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onclick={triggerAngry}
+                            class="gap-2"
+                            aria-label="화나요"
+                        >
+                            <span class="text-lg leading-none" aria-hidden="true">💢</span>
+                            <span class="font-semibold">화나요</span>
+                        </Button>
+                        {#if showAngryPop}
+                            <span
+                                class="da-angry-pop pointer-events-none absolute -top-2 left-1/2 text-xl"
+                                aria-hidden="true">💢</span
+                            >
+                        {/if}
+                    </div>
                 {/if}
 
                 <!-- 스크랩 + 공유 + 신고 (우측 정렬).
@@ -924,5 +998,66 @@
 
     :global(.like-animation) {
         animation: da-thumbs-up 1s ease-in-out;
+    }
+
+    /* 화나요 버튼 (#2108): 글 카드 1회 흔들림. 클래스는 Card 자식 요소에 붙으므로 :global. */
+    @keyframes da-angry-shake {
+        0%,
+        100% {
+            transform: translateX(0);
+        }
+        15% {
+            transform: translateX(-6px) rotate(-1deg);
+        }
+        30% {
+            transform: translateX(6px) rotate(1deg);
+        }
+        45% {
+            transform: translateX(-5px) rotate(-1deg);
+        }
+        60% {
+            transform: translateX(5px) rotate(1deg);
+        }
+        75% {
+            transform: translateX(-3px);
+        }
+        90% {
+            transform: translateX(3px);
+        }
+    }
+
+    :global(.da-angry-shake) {
+        animation: da-angry-shake 0.5s ease-in-out;
+    }
+
+    /* 💢 팝 파티클: 위로 튀며 페이드아웃. 이 컴포넌트 템플릿 요소라 scoped 클래스. */
+    @keyframes da-angry-pop {
+        0% {
+            transform: translate(-50%, 0) scale(0.4);
+            opacity: 0;
+        }
+        30% {
+            transform: translate(-50%, -8px) scale(1.2);
+            opacity: 1;
+        }
+        100% {
+            transform: translate(-50%, -28px) scale(1);
+            opacity: 0;
+        }
+    }
+
+    .da-angry-pop {
+        animation: da-angry-pop 0.7s ease-out forwards;
+    }
+
+    /* reduced-motion: 이펙트 무력화(트리거 핸들러도 스킵하지만 CSS로 이중 보장). */
+    @media (prefers-reduced-motion: reduce) {
+        :global(.da-angry-shake) {
+            animation: none;
+        }
+        .da-angry-pop {
+            animation: none;
+            opacity: 0;
+        }
     }
 </style>


### PR DESCRIPTION
## 요약 (#2108)

글 상세 리액션 바에 **로컬 전용 "💢 화나요" 버튼**을 추가한다. 누른 사람 화면에서만 이펙트가 1회 재생된다 — **글 카드 흔들림 + 💢 팝 파티클**. 서버 요청·다모앙 DB 기록·타인 노출은 전부 0이고, GA 익명 카운트(`angry_reaction`)만 글당 1회 발화한다.

## 변경 파일

- `apps/web/src/lib/components/features/board/layouts/view/basic.svelte` (코어 basic 뷰, +137/-2)
  - `triggerAngry()` / `playAngryEffect()` 로컬 핸들러 + `$state` 2개(`isAngryShaking`, `showAngryPop`)
  - 비추천 버튼 직후에 화나요 버튼 마크업(카운트·토글 없음)
  - `da-angry-shake` / `da-angry-pop` keyframe 2개 + reduced-motion 무력화 CSS

## 동작

- **서버 무접근**: `fetch`·리액션 API·authStore·리액션/좋아요 store 미접근. 오직 로컬 `$state` + `trackEvent`(gtag 클라 전용) + `localStorage`.
- **GA 글당 1회**: `localStorage['angple_angry_<postId>']` 존재 시 GA skip, 이펙트는 매번 재생. 파라미터 `board_id`, `post_id`.
- **게이트 상속**: 상위 `{#if canViewSecret}`(비밀글) + `{#if boardId !== 'claim'}`(소명 제외) 안에 넣어 자동 상속. 새 게이트·플러그인 게이트 없음.
- **reduced-motion**: 이펙트 스킵, GA는 발화. CSS `@media (prefers-reduced-motion: reduce)`로 이중 보장.
- **재클릭 재발화**: rAF로 클래스 리셋 후 재부착, `setTimeout`(800ms)으로 해제.

## Evaluator 확인 포인트

1. 서버 요청 0 — DevTools Network에 화나요 클릭 시 요청 없음(GA gtag 비콘 제외). 코드상 `fetch`/store 호출 없음.
2. 이펙트 1회 — 클릭 시 카드 흔들림 + 💢 팝, 재클릭 시 재발화.
3. GA `angry_reaction` — 같은 글에서 첫 클릭만 발화(localStorage 게이트), `board_id`·`post_id` 포함.
4. reduced-motion(OS 설정 or DevTools rendering emulation) — 이펙트 없음, GA는 발화.
5. 회귀 — 공감/비추천/이모지 ReactionBar·신고·스크랩 정상. claim 게시판·비밀글 미열람 시 화나요 미노출.
6. Svelte 컴파일 — 단일 파일 compile OK(신규 경고 0, 기존 2개 동일). prettier clean.

## 주의/미결

- basic 코어 레이아웃에만 적용(정본). 다른 테마/레이아웃은 범위 밖.
- 이모지 폰트 렌더는 OS 의존(💢).
