### PR TITLE
refactor(reaction): 화나요 버튼을 우측 액션 그룹으로 이동(#2108)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -893,28 +893,6 @@
                             </Button>
                         </div>
                     {/if}
-
-                    <!-- 화나요 버튼 (#2108): 로컬 전용 이펙트. 서버 요청·DB·타인 노출 0,
-                         GA 익명 카운트만. 카운트·토글 상태 없음. claim 제외·비밀글 게이트는
-                         상위 boardId/canViewSecret 조건에서 자동 상속(새 게이트 추가 안 함). -->
-                    <div class="border-border relative flex items-center rounded-lg border">
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onclick={triggerAngry}
-                            class="gap-2"
-                            aria-label="화나요"
-                        >
-                            <span class="text-lg leading-none" aria-hidden="true">💢</span>
-                            <span class="font-semibold">화나요</span>
-                        </Button>
-                        {#if showAngryPop}
-                            <span
-                                class="da-angry-pop pointer-events-none absolute -top-2 left-1/2 text-xl"
-                                aria-hidden="true">💢</span
-                            >
-                        {/if}
-                    </div>
                 {/if}
 
                 <!-- 스크랩 + 공유 + 신고 (우측 정렬).
@@ -922,7 +900,7 @@
                      하단본이 initialScrapped 를 안 받아 표시가 부정확했다. bug/13468: 하단본을
                      통째로 제거했더니 사용자가 글 읽고 누르던 위치의 스크랩이 사라졌다는 제보.
                      → 하단본을 initialScrapped 와 함께 복원(정확 표시 + 익숙한 위치 둘 다 충족). -->
-                <div class="ml-auto flex items-center gap-1">
+                <div class="ml-auto flex flex-wrap items-center justify-end gap-1">
                     {#if board?.use_sns}
                         <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}
@@ -963,6 +941,30 @@
                         postId={post.id}
                         postAuthorId={post.author_id}
                     />
+                    <!-- 화나요 버튼 (#2108): 로컬 전용 이펙트. 서버 요청·DB·타인 노출 0,
+                         GA 익명 카운트만. 카운트·토글 상태 없음. 우측 액션 그룹 맨 끝으로 이동.
+                         비밀글 게이트는 상위 canViewSecret(CardFooter)에서 상속되지만, claim
+                         제외는 이 그룹이 boardId 게이트 밖이라 여기서 유지한다(동작 보존). -->
+                    {#if boardId !== 'claim'}
+                        <div class="relative flex items-center">
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onclick={triggerAngry}
+                                class="text-muted-foreground hover:text-destructive gap-2"
+                                aria-label="화나요"
+                            >
+                                <span class="text-base leading-none" aria-hidden="true">💢</span>
+                                <span>화나요</span>
+                            </Button>
+                            {#if showAngryPop}
+                                <span
+                                    class="da-angry-pop pointer-events-none absolute -top-2 left-1/2 text-xl"
+                                    aria-hidden="true">💢</span
+                                >
+                            {/if}
+                        </div>
+                    {/if}
                 </div>
             </div>
 

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -904,6 +904,12 @@
                     {#if board?.use_sns}
                         <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}
+                    <!-- 스크랩: 최종 순서 공유 → 스크랩 → 신고 → 화나요(사장님 확정). 종전엔 아이콘만
+                         이라 옆의 공유·신고(아이콘+문구)와 어긋났는데, size="sm" 이면 컴포넌트가
+                         "스크랩"/"스크랩됨" 문구를 함께 렌더한다(상단 툴바본은 아이콘만 유지). -->
+                    {#if authStore.isAuthenticated}
+                        <ScrapButton {boardId} postId={post.id} {initialScrapped} size="sm" />
+                    {/if}
                     {#if !isAuthor}
                         <!-- ⭐ 2026-08-18: 신고 버튼은 항상 보인다 — 제재 확정(B형) 글에서도.
                              종전에 B형을 숨긴 근거는 "재신고 시 백엔드 409+트리거로 차단되기 때문"이었는데
@@ -927,13 +933,6 @@
                             <Flag class="h-4 w-4" />
                             <span>신고</span>
                         </Button>
-                    {/if}
-                    <!-- 스크랩은 신고 오른쪽 끝에. 종전엔 이 줄 맨 왼쪽에 아이콘만 있어서
-                         옆의 공유·신고가 아이콘+문구인데 혼자 문구가 없었고, 북마크 아이콘만으로는
-                         무슨 버튼인지 알기 어려웠다. size="sm" 이면 컴포넌트가 "스크랩"/"스크랩됨"
-                         문구를 함께 렌더한다(상단 툴바본은 아이콘만 유지). -->
-                    {#if authStore.isAuthenticated}
-                        <ScrapButton {boardId} postId={post.id} {initialScrapped} size="sm" />
                     {/if}
                     <PluginSlot
                         name="post-detail-actions"


### PR DESCRIPTION
## 요약
사장님 요청으로 "화나요" 버튼을 리액션 바 왼쪽(공감/비추천 옆)에서 **우측 액션 그룹(ml-auto)** 맨 오른쪽 끝으로 이동합니다. 로직(핸들러·이펙트·GA·localStorage·CSS keyframe)은 무변경, 마크업 위치와 스타일만 조정.

## 변경
- `basic.svelte`: 화나요 버튼 블록을 좌측 리액션 클러스터에서 제거 → 우측 `ml-auto` 그룹의 PluginSlot 뒤(맨 끝)로 이동. 순서: 공유 → 신고 → 스크랩 → (플러그인) → **화나요**.
- 스타일 정합: 우측 그룹 버튼(공유/신고/스크랩)은 border 래퍼 없이 `ghost`/`sm`. 화나요도 border 래퍼 제거, 신고 버튼과 동일한 `text-muted-foreground hover:text-destructive gap-2` 적용. 라벨 "화나요"는 유지(사장님 확정), 이모지는 `text-base`로 그룹과 정렬.

## 회귀 수정 (canary 스크랩 버튼 소실)
- **원인**: 우측 그룹 `<div class="ml-auto flex items-center gap-1">`에 `flex-wrap`/shrink 제어가 없어 단일 줄 강제. 화나요 추가로 액션 바 폭이 커지자 폭 초과 시 rightmost 버튼(스크랩/PluginSlot)이 뷰포트 밖으로 밀려 페이지 `overflow-x` hidden에 잘려 스크랩이 사라져 보임.
- **수정**: 우측 그룹에 `flex-wrap justify-end` 추가 → 폭 초과 시 다음 줄로 wrap. 데스크톱/모바일 모두 공유·신고·스크랩·화나요 4개 노출.

## 게이트
- 우측 그룹은 `boardId !== "claim"` 게이트 **밖**이므로, 화나요에 `{#if boardId !== "claim"}` 재적용해 claim 게시판 제외 동작 보존. 비밀글 게이트는 상위 `canViewSecret`(CardFooter)에서 상속.

## 검증
- 수정 파일 단독 svelte 컴파일: 신규 경고 0 (control과 동일한 기존 경고 2건뿐).
- 로직 무변경: triggerAngry/playAngryEffect/isAngryShaking/showAngryPop/da-angry-shake/da-angry-pop 심볼 그대로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)