### PR TITLE
fix(recommended): 공감·추천·탐색 목록에 차단 키워드/회원 필터 배선(#13598)

### DIFF
--- a/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
+++ b/apps/web/src/lib/components/features/daily-recommended/daily-recommended-page.svelte
@@ -15,6 +15,7 @@
     import ThresholdFilter from './threshold-filter.svelte';
     import SortSelector from './sort-selector.svelte';
     import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import DailyStatsBar from './daily-stats-bar.svelte';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card';
@@ -117,8 +118,10 @@
             posts = [...(sections[activeTab]?.posts ?? [])];
         }
 
-        // 차단된 사용자 글 필터
-        posts = posts.filter((p) => !blockedUsersStore.isBlocked(p.author));
+        // 차단된 사용자 글 + 차단 키워드(제목) 필터 (#13598)
+        posts = posts.filter(
+            (p) => !blockedUsersStore.isBlocked(p.author) && !uiSettingsStore.isMuted(p.title)
+        );
 
         // 최소 추천수 필터
         if (threshold > 0) {
@@ -168,8 +171,13 @@
             comments = [...(commentSections[activeTab]?.comments ?? [])];
         }
 
-        // 차단된 사용자 댓글 필터
-        comments = comments.filter((c) => !blockedUsersStore.isBlocked(c.author));
+        // 차단된 사용자 댓글 + 차단 키워드(원글 제목·댓글 본문) 필터 (#13598)
+        comments = comments.filter(
+            (c) =>
+                !blockedUsersStore.isBlocked(c.author) &&
+                !uiSettingsStore.isMuted(c.parent_title ?? '') &&
+                !uiSettingsStore.isMuted(c.content ?? '')
+        );
 
         if (threshold > 0) {
             comments = comments.filter((c) => c.recommend_count >= threshold);

--- a/apps/web/src/lib/components/features/explore/explore-preview.svelte
+++ b/apps/web/src/lib/components/features/explore/explore-preview.svelte
@@ -12,6 +12,7 @@
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { getReadPostClasses } from '$lib/stores/read-post-style.svelte.js';
     import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import type { ExploreData, ExploreMode, ExplorePost } from '$lib/api/types.js';
     import { TimedFetchError, timedFetch } from '$lib/utils/timed-fetch';
 
@@ -56,10 +57,11 @@
         } else {
             posts = modeData.posts ?? [];
         }
-        // 차단 사용자 제외 + 공감글 중복 제외 후 PREVIEW_COUNT 로 채운다
-        // (제외를 slice 앞에 둬야 빠진 만큼 다른 글로 채워져 목록이 빈약해지지 않음).
+        // 차단 사용자 + 차단 키워드(제목) 제외 + 공감글 중복 제외 후 PREVIEW_COUNT 로 채운다
+        // (제외를 slice 앞에 둬야 빠진 만큼 다른 글로 채워져 목록이 빈약해지지 않음). (#13598)
         return posts
             .filter((p) => !blockedUsersStore.isBlocked(p.author))
+            .filter((p) => !uiSettingsStore.isMuted(p.title))
             .filter((p) => !excludeIds || !excludeIds.has(p.id))
             .slice(0, PREVIEW_COUNT);
     });

--- a/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
@@ -6,6 +6,7 @@
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { getReadPostClasses } from '$lib/stores/read-post-style.svelte.js';
     import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     const PREVIEW_COUNT = 17;
 
@@ -38,6 +39,7 @@
             for (const post of section.posts ?? []) {
                 if (seen.has(post.id)) continue;
                 if (blockedUsersStore.isBlocked(post.author)) continue;
+                if (uiSettingsStore.isMuted(post.title)) continue; // 차단 키워드 필터 (#13598)
                 seen.add(post.id);
                 result.push({ ...post, uniqueKey: `${section.key}-${post.id}` });
             }

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -16,6 +16,8 @@
     } from '$lib/components/features/recommended/utils/index.js';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
     import { getReadPostClasses } from '$lib/stores/read-post-style.svelte.js';
+    import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import TagNav from '$lib/components/ui/tag-nav/tag-nav.svelte';
     import { formatCommentCountBadge } from '$lib/utils/comment-count.js';
     import type { PageData } from './$types';
@@ -107,13 +109,29 @@
     });
 
     const filteredPosts = $derived.by((): ExplorePost[] => {
-        if (selectedBoard === 'all') return currentPosts;
-        return currentPosts.filter((post) => post.board === selectedBoard);
+        const byBoard =
+            selectedBoard === 'all'
+                ? currentPosts
+                : currentPosts.filter((post) => post.board === selectedBoard);
+        // 차단 회원 + 차단 키워드(제목) 제외 (#13598)
+        return byBoard.filter(
+            (post) =>
+                !blockedUsersStore.isBlocked(post.author) && !uiSettingsStore.isMuted(post.title)
+        );
     });
 
     const filteredComments = $derived.by((): ExploreComment[] => {
-        if (selectedBoard === 'all') return currentComments;
-        return currentComments.filter((comment) => comment.board === selectedBoard);
+        const byBoard =
+            selectedBoard === 'all'
+                ? currentComments
+                : currentComments.filter((comment) => comment.board === selectedBoard);
+        // 차단 회원 + 차단 키워드(원글 제목·댓글 본문) 제외 (#13598)
+        return byBoard.filter(
+            (comment) =>
+                !blockedUsersStore.isBlocked(comment.author) &&
+                !uiSettingsStore.isMuted(comment.parent_title ?? '') &&
+                !uiSettingsStore.isMuted(comment.content ?? '')
+        );
     });
 
     $effect(() => {

--- a/widgets/hidden-gems/index.svelte
+++ b/widgets/hidden-gems/index.svelte
@@ -8,6 +8,8 @@
     import type { ExplorePost } from '$lib/api/types';
     import Gem from '@lucide/svelte/icons/gem';
     import { trackEvent } from '$lib/services/ga4.js';
+    import { blockedUsersStore } from '$lib/stores/blocked-users.svelte.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
 
     let { config, prefetchData }: WidgetProps = $props();
 
@@ -15,8 +17,13 @@
         Number((config?.settings as Record<string, unknown> | undefined)?.item_count ?? 4)
     );
 
+    // 셔플/slice(정원) 앞에서 차단 회원 + 차단 키워드(제목)를 제외한다 (#13598)
     const pool = $derived(
-        ((prefetchData as { posts?: ExplorePost[] })?.posts ?? []) as ExplorePost[]
+        (((prefetchData as { posts?: ExplorePost[] })?.posts ?? []) as ExplorePost[]).filter(
+            (post) =>
+                !blockedUsersStore.isBlocked(post.author) &&
+                !uiSettingsStore.isMuted(post.title ?? '')
+        )
     );
 
     // 방문(마운트)마다 다른 조합 — 서버 30초 캐시와 무관하게 클라에서 셔플


### PR DESCRIPTION
## 개요
차단 키워드(`uiSettingsStore.isMuted`)가 자유게시판 목록엔 적용되지만 공감/추천/탐색 목록엔 누락돼 차단어 포함 글이 노출되던 문제(#13598)를 6개 표면에 배선해 수정합니다.

대조군 패턴: `recent-posts.svelte`의 `posts.filter((p) => !uiSettingsStore.isMuted(p.title))`.

## 변경 표면 (6곳)
1. **공감 글** `daily-recommended-page.svelte` filteredPosts — 기존 회원 차단 필터에 `!isMuted(p.title)` 추가.
2. **공감 댓글** 같은 파일 filteredComments — `!isMuted(c.parent_title ?? '') && !isMuted(c.content ?? '')` 추가(원글 제목·본문 둘 중 하나라도 매칭 시 hide, null 안전).
3. **탐색 미리보기** `explore-preview.svelte` — filter 체인에 `!isMuted(p.title)` 추가. `.slice(0, PREVIEW_COUNT)` **앞**(정원 보존).
4. **추천글 위젯** `post-list.svelte` — 루프 내 `if (isMuted(post.title)) continue;` 추가. `slice` **앞**.
5. **숨은명작 위젯** `widgets/hidden-gems/index.svelte` — 회원+키워드 필터 **신설**. 셔플/`slice(0, itemCount)` **앞의 pool 단계**에서 제외(정원 보존).
6. **/explore 전체 페이지** `routes/explore/+page.svelte` — 글/댓글에 회원+키워드 필터 **신설**. (기존 `selectedBoard === 'all'` early-return을 재구성해 항상 필터가 적용되도록 함.)

## 검증
- 수정 6파일 단독 svelte 컴파일 OK, 신규 경고 0 (explore-preview의 `state_referenced_locally` 경고는 origin/main 대조군에도 동일하게 존재하는 기존 경고).
- prettier 스타일 통과.
- 백엔드/훅/공통 유틸 무변경. premium 오버라이드 없음.