### PR TITLE
fix(board): 게시글 제목 긴 단어 강제 줄바꿈 폴백 — 구형 엔진 잘림 방지(#13516)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -398,7 +398,7 @@
                 <!-- bug/13388: 맨몸 텍스트는 익명 flex item 이 되어 min-width/줄바꿈을
                      제어할 수 없고, iOS WebKit 에서 줄바꿈 폭 오계산 → 1행 넘침이
                      조상 overflow-x:hidden 에 잘려 글자가 소실된다. 실요소로 감싼다. -->
-                <span class="min-w-0 [overflow-wrap:anywhere]">
+                <span class="min-w-0 [overflow-wrap:anywhere] [word-break:break-word]">
                     {#if post.is_discipline_related}
                         <DisciplinedContent
                             inline

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -493,7 +493,7 @@
                 class="text-foreground flex items-center gap-2 text-xl font-bold sm:text-2xl"
             >
                 <!-- bug/13388: basic.svelte 와 동일 — 익명 flex 텍스트를 실요소로 감싼다 -->
-                <span class="min-w-0 [overflow-wrap:anywhere]">
+                <span class="min-w-0 [overflow-wrap:anywhere] [word-break:break-word]">
                     {#if post.is_discipline_related}
                         <DisciplinedContent
                             inline


### PR DESCRIPTION
## 원인 (#13516)
게시글 상세 제목 h1이 조상 `overflow-x:hidden/clip` 안에 있어, 한 줄이 폭을 넘으면 잘려 글자가 소실됨. bug/13388(iOS WebKit) 수정(`overflow-wrap:anywhere`)이 안드로이드 스타곤 등 구형 Chromium/WebView 엔진에서 불충분. 순수 한글은 괜찮고 긴 라틴/URL/특수문자 런에서 발생.

## 수정 (저위험 폴백)
제목 텍스트 span에 `[word-break:break-word]` 를 `[overflow-wrap:anywhere]` 와 함께 부여해 구형 엔진에서도 강제 줄바꿈.

- `layouts/view/basic.svelte` 제목 span
- `layouts/view/report.svelte` 제목 span (일관성)

## 원칙 준수
- `break-all` 미사용 (한글/영문 가독성 유지)
- 클립 조상(`+page.svelte`의 `overflow-x:hidden/clip`)은 무변경 — 넓은 표·sticky 가로스크롤 방지 목적이라 제거 시 회귀 위험
- overflow-wrap:anywhere 유지
- 다른 레이아웃/목록 truncate 무변경

## 검증
- 수정 .svelte 단독 컴파일: 신규 경고 0 (대조군=origin/main 대비 동일)
- ⚠️ 스타곤 실기 재현 불가 — 이 폴백이 스타곤에서 실제 해소되는지는 배포 후 확인 필요