### PR TITLE
fix(board): 긴 메모 시 작성자 닉네임 세로 붕괴 수정(#13608, 13569 재수정)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -489,12 +489,18 @@
                              종전 items-center 조합에서 기준선이 3px 어긋났다 (bug/13536).
                              닉네임 크기는 줄이지 않는다 — 이 줄의 주 정보이고, 줄이면 메타 블록이
                              2px 더 좁아져 "답답하다"는 같은 제보의 다른 지적과 충돌한다. -->
-                        <p class="text-foreground flex items-baseline gap-1.5 font-medium">
+                        <!-- #13608: flex-wrap + min-w-0 로 긴 회원 메모 배지가 닉네임을
+                             min-content 까지 눌러 한글이 세로로 붕괴하는 것을 막는다.
+                             폭 부족 시 배지가 다음 줄로 내려가고 닉네임(nowrap)은 한 줄 유지. -->
+                        <p
+                            class="text-foreground flex min-w-0 flex-wrap items-baseline gap-1.5 font-medium"
+                        >
                             <LevelBadge level={memberLevelStore.getLevel(post.author_id)} />
                             <AuthorLink
                                 authorId={post.author_id}
                                 authorName={post.author}
                                 isWithdrawn={!!post.is_left}
+                                nowrap
                             />
                             {#if authStore.isAuthenticated && memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                                 <MemoBadge

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -548,13 +548,19 @@
                         {post.author.charAt(0).toUpperCase()}
                     </div>
                 {/if}
-                <div>
-                    <p class="text-foreground flex items-baseline gap-1.5 font-medium">
+                <div class="min-w-0">
+                    <!-- #13608: flex-wrap + min-w-0 로 긴 회원 메모 배지가 닉네임을
+                         min-content 까지 눌러 한글이 세로로 붕괴하는 것을 막는다.
+                         폭 부족 시 배지가 다음 줄로 내려가고 닉네임(nowrap)은 한 줄 유지. -->
+                    <p
+                        class="text-foreground flex min-w-0 flex-wrap items-baseline gap-1.5 font-medium"
+                    >
                         <LevelBadge level={memberLevelStore.getLevel(post.author_id)} />
                         <AuthorLink
                             authorId={post.author_id}
                             authorName={post.author}
                             isWithdrawn={!!post.is_left}
+                            nowrap
                         />
                         {#if authStore.isAuthenticated && memoPluginActive && MemoBadge && !uiSettingsStore.hideMemo}
                             <MemoBadge

--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -29,6 +29,13 @@
          * 댓글/상세처럼 인접 제목이 없는 곳은 true 로 짧은 닉네임 클릭을 보장.
          */
         expandTouchArea?: boolean;
+        /**
+         * 닉네임을 한 줄로 고정한다 (#13608).
+         * 글 상세 작성자 줄처럼 긴 메모 배지가 같은 flex 행에 붙는 곳에서, 닉네임이
+         * min-content(1음절)까지 눌려 한글이 세로로 쌓이는 붕괴를 막는다.
+         * 공용 컴포넌트라 기본은 false — 목록/댓글 등 flex-wrap 메타 행의 줄바꿈 동작을 보존한다.
+         */
+        nowrap?: boolean;
         children?: Snippet;
     }
 
@@ -38,8 +45,12 @@
         isWithdrawn = false,
         class: className = '',
         expandTouchArea = false,
+        nowrap = false,
         children
     }: Props = $props();
+
+    // 닉네임 세로 붕괴 차단용 클래스 (opt-in). 상세뷰에서만 적용.
+    const nowrapClass = $derived(nowrap ? 'whitespace-nowrap' : '');
 
     const isOwnProfile = $derived(authStore.user?.mb_id === authorId);
 
@@ -190,7 +201,7 @@
       뜨는 문제를 해소. 비회원에겐 프로필/팔로우/쪽지 같은 dropdown 메뉴가 무의미하므로
       클릭 영역 자체를 없애 부모 anchor (글 링크) 로 자연스럽게 propagate.
     -->
-    <span class="{className} {isWithdrawn ? 'line-through opacity-60' : ''}">
+    <span class="{className} {nowrapClass} {isWithdrawn ? 'line-through opacity-60' : ''}">
         {#if children}
             {@render children()}
         {:else}
@@ -224,7 +235,7 @@
               모바일은 기본 텍스트 너비만큼만 클릭 영역 — 제목 의도 터치 보호.
             -->
             <DropdownMenu.Trigger
-                class="inline-block cursor-pointer text-left hover:underline focus:outline-none {touchAreaClass} {className} {isWithdrawn
+                class="inline-block cursor-pointer text-left hover:underline focus:outline-none {touchAreaClass} {nowrapClass} {className} {isWithdrawn
                     ? 'line-through opacity-60'
                     : ''}"
             >


### PR DESCRIPTION
## 증상
글 상세(작성자 줄)에서 회원 메모가 길면 같은 flex 행의 **한글 닉네임이 한 글자씩 세로로 붕괴**.

## 원인
작성자 `<p>` 가 nowrap flex 행(flex-wrap 없음)이고 닉네임 요소에 nowrap/overflow 보호가 없어, 긴 메모 배지가 형제를 수축시켜 닉네임이 `min-content`(1음절)까지 눌려 세로 스택됨. 메모 배지(premium)는 nowrap+overflow+ellipsis 라 정상 → 무접촉.

## 수정
- **author-link.svelte**: opt-in `nowrap` prop 추가 → 닉네임 표시 요소(비회원 span·로그인 Trigger)에 `whitespace-nowrap`. 공용 컴포넌트라 기본 `false` 로 두어 목록/댓글 등 `flex-wrap` 메타 행의 줄바꿈 동작을 보존(회귀 0). 상세뷰에서만 opt-in.
- **basic.svelte / report.svelte**: 작성자 `<p>` 에 `flex-wrap` + `min-w-0`, `AuthorLink` 에 `nowrap`. report 는 부모 `div` 에도 `min-w-0`. → 폭 부족 시 메모 배지가 다음 줄로 내려가고 닉네임은 한 줄 유지.

## 무접촉
premium 메모 배지 / `memo-modal.svelte` / `memo-linked-text.svelte`(#159) 무변경.

## 검증
- 수정 3파일 단독 svelte 컴파일 OK. 신규 경고 0(basic 의 기존 경고 2건은 origin/main 대조군과 동일).
- prettier --check 통과.
- AuthorLink 사용처 전수(15+) 확인: 목록/댓글은 `flex flex-wrap` 메타 행 또는 truncate 컨테이너 → 기본 `nowrap=false` 이므로 무회귀.