### PR TITLE
fix(admin): 대시보드 카드를 실제로 존재하는 지표로 바꾼다

### DIFF
--- a/apps/web/src/lib/api/admin-stats.ts
+++ b/apps/web/src/lib/api/admin-stats.ts
@@ -2,15 +2,29 @@
  * 관리자 대시보드 통계 API 클라이언트
  */
 
+/**
+ * 관리자 대시보드 통계.
+ *
+ * ⛔ 2026-08-18: 종전 타입에는 todayVisitors·postsChange·commentsChange·
+ * visitorsChange 가 있었으나 **백엔드가 그런 값을 준 적이 없다.**
+ * /api/v1/admin/stats 라우트 자체가 없었고, NoRoute 가 200 success:true 를
+ * 돌려주는 바람에 실패가 드러나지 않은 채 카드가 "-" 로만 떠 있었다.
+ *
+ * ⛔ 방문자 수는 넣지 않는다 — g5_visit 테이블이 **완전히 비어 있다**(PHP 시절 기능).
+ * 없는 지표를 0 으로 채우면 "방문자 0명"이라는 거짓을 화면이 말하게 된다.
+ */
 export interface DashboardStats {
-    totalPosts: number;
+    /** g5_member 전체 행 — 탈퇴 회원도 행이 남으므로 포함된다 */
     totalMembers: number;
-    todayComments: number;
-    todayVisitors: number;
-    postsChange: number;
+    /** 탈퇴하지 않은 회원 */
+    activeMembers: number;
+    leftMembers: number;
+    todayJoined: number;
+    todayLogin: number;
+    /** 최근 7일 가입 수 */
     membersChange: number;
-    commentsChange: number;
-    visitorsChange: number;
+    todayPosts: number;
+    todayComments: number;
 }
 
 export interface RecentActivity {

--- a/apps/web/src/routes/admin/dashboard/+page.svelte
+++ b/apps/web/src/routes/admin/dashboard/+page.svelte
@@ -30,39 +30,49 @@
     let dashboardStats = $state<DashboardStats | null>(null);
     let recentActivities = $state<RecentActivity[]>([]);
 
+    // ⛔ 카드는 **실제로 백엔드가 주는 값**만 쓴다.
+    // 종전에는 총 게시글·오늘 방문자 카드가 있었으나 백엔드에 그 값이 없다
+    // (방문자는 g5_visit 테이블이 비어 있다). 없는 값을 0 으로 채우면
+    // 화면이 "방문자 0명" 이라는 거짓을 말하게 되므로 카드를 뺐다.
+    // ⭐ 총 회원은 g5_member 전체(탈퇴 포함)다. 탈퇴는 행이 남으므로
+    //    활동 회원을 부제로 함께 보여 두 숫자가 어긋나 보이지 않게 한다.
     const stats = $derived(
         dashboardStats
             ? [
                   {
-                      label: '총 게시글',
-                      value: dashboardStats.totalPosts.toLocaleString(),
-                      icon: FileText,
-                      change: dashboardStats.postsChange
-                  },
-                  {
                       label: '총 회원',
                       value: dashboardStats.totalMembers.toLocaleString(),
+                      sub: `활동 ${dashboardStats.activeMembers.toLocaleString()} · 탈퇴 ${dashboardStats.leftMembers.toLocaleString()}`,
                       icon: Users,
                       change: dashboardStats.membersChange
                   },
                   {
-                      label: '오늘 댓글',
-                      value: dashboardStats.todayComments.toLocaleString(),
-                      icon: MessageSquare,
-                      change: dashboardStats.commentsChange
+                      label: '오늘 접속',
+                      value: dashboardStats.todayLogin.toLocaleString(),
+                      sub: `신규 가입 ${dashboardStats.todayJoined.toLocaleString()}`,
+                      icon: Eye,
+                      change: 0
                   },
                   {
-                      label: '오늘 방문자',
-                      value: dashboardStats.todayVisitors.toLocaleString(),
-                      icon: Eye,
-                      change: dashboardStats.visitorsChange
+                      label: '오늘 게시글',
+                      value: dashboardStats.todayPosts.toLocaleString(),
+                      sub: '',
+                      icon: FileText,
+                      change: 0
+                  },
+                  {
+                      label: '오늘 댓글',
+                      value: dashboardStats.todayComments.toLocaleString(),
+                      sub: '',
+                      icon: MessageSquare,
+                      change: 0
                   }
               ]
             : [
-                  { label: '총 게시글', value: '-', icon: FileText, change: 0 },
-                  { label: '총 회원', value: '-', icon: Users, change: 0 },
-                  { label: '오늘 댓글', value: '-', icon: MessageSquare, change: 0 },
-                  { label: '오늘 방문자', value: '-', icon: Eye, change: 0 }
+                  { label: '총 회원', value: '-', sub: '', icon: Users, change: 0 },
+                  { label: '오늘 접속', value: '-', sub: '', icon: Eye, change: 0 },
+                  { label: '오늘 게시글', value: '-', sub: '', icon: FileText, change: 0 },
+                  { label: '오늘 댓글', value: '-', sub: '', icon: MessageSquare, change: 0 }
               ]
     );
 
@@ -88,12 +98,6 @@
         } finally {
             loading = false;
         }
-    }
-
-    function formatChange(change: number): string {
-        if (change > 0) return `+${change}%`;
-        if (change < 0) return `${change}%`;
-        return '0%';
     }
 
     function getActivityIcon(type: RecentActivity['type']): string {
@@ -180,12 +184,16 @@
                 </CardHeader>
                 <CardContent>
                     <div class="text-2xl font-bold">{stat.value}</div>
-                    {#if dashboardStats}
+                    <!-- ⛔ 종전에는 모든 카드에 "지난 주 대비 N%" 를 붙였는데,
+                         백엔드가 증감률을 준 적이 없어 늘 "0%" 였다.
+                         지금은 실제 값이 있는 카드만, 그 값이 무엇인지 그대로 적는다. -->
+                    {#if dashboardStats && stat.sub}
+                        <p class="text-muted-foreground text-xs">{stat.sub}</p>
+                    {/if}
+                    {#if dashboardStats && stat.change > 0}
                         <p class="text-muted-foreground text-xs">
-                            <span class={stat.change >= 0 ? 'text-green-600' : 'text-red-600'}>
-                                {formatChange(stat.change)}
-                            </span>
-                            지난 주 대비
+                            <span class="text-green-600">+{stat.change.toLocaleString()}</span>
+                            최근 7일
                         </p>
                     {/if}
                 </CardContent>


### PR DESCRIPTION
백엔드 [`angple-backend#676`](https://github.com/damoang/angple-backend/pull/676) 과 함께 갑니다.

## 왜

`/api/v1/admin/stats` 라우트가 **없어서** 카드가 오래 `-` 로만 떠 있었습니다. 백엔드에서 라우트를 신설하면서, **백엔드가 준 적 없는 값**을 타입과 화면에서 걷어냈습니다.

## 걷어낸 것

| 항목 | 이유 |
|---|---|
| `todayVisitors` | ⛔ `g5_visit` 테이블이 **완전히 비어 있습니다**(PHP 시절 기능). 0 으로 채우면 화면이 **"방문자 0명"** 이라는 거짓을 말합니다 |
| `postsChange`·`commentsChange`·`visitorsChange` | 백엔드가 준 적이 없어 `formatChange` 가 늘 **`0%`** 를 찍고 있었습니다. 함수째 제거 |
| `totalPosts` | 누적 총계라 '오늘' 지표들과 성격이 섞였습니다 |

## 넣은 것

| 카드 | 값 |
|---|---|
| **총 회원** | 62,729 · 부제 `활동 60,467 · 탈퇴 2,262` |
| **오늘 접속** | 부제 `신규 가입 N` |
| **오늘 게시글** | |
| **오늘 댓글** | |

⭐ 총 회원에 활동·탈퇴를 부제로 함께 보여줍니다. **탈퇴 회원도 행이 남으므로**, 두 숫자를 따로 보면 어긋난 것처럼 보입니다.

⭐ 증감은 **실제 값이 있는 카드에만** 표시하고, `%` 가 아니라 **`+396 최근 7일`** 처럼 그 값이 무엇인지 그대로 적습니다.

## 검증

- svelte 단일파일 컴파일 OK — **대조군(HEAD 원본)과 경고 동일**
- prettier OK
- 아이콘 4종(`Users`·`Eye`·`FileText`·`MessageSquare`) 모두 계속 사용 중 — 미사용 import 없음
