### PR TITLE
fix(editor): iOS 앙티콘 삽입 — hover 확대 hover기기 한정(#13614)

### DIFF
--- a/apps/web/src/lib/components/features/board/emoticon-picker.svelte
+++ b/apps/web/src/lib/components/features/board/emoticon-picker.svelte
@@ -239,10 +239,18 @@
                                         평소엔 정지 썸네일(~2KB), 확대할 때만 애니(~60KB).
                                         DINKIssTyle 팩 기준 6.22MB → 0.07MB.
                                     -->
+                                    <!--
+                                        확대(hover)는 hover 가능한 기기에만 건다.
+                                        iOS Safari 는 hover 로 모습이 바뀌는 요소의
+                                        첫 탭을 hover 에만 쓰고 click(삽입)은 두 번째
+                                        탭에서야 발화한다(#13614). @media(hover:hover)
+                                        가드로 터치 기기에선 확대를 끄면 첫 탭에 바로
+                                        삽입된다. transition-transform 은 그대로 둔다.
+                                    -->
                                     <img
                                         src={stillThumbUrl(item)}
                                         alt={item.file}
-                                        class="emoticon-inline size-10 object-contain transition-transform group-hover/emo:z-50 group-hover/emo:scale-[3]"
+                                        class="emoticon-inline size-10 object-contain transition-transform [@media(hover:hover)]:group-hover/emo:z-50 [@media(hover:hover)]:group-hover/emo:scale-[3]"
                                         loading="lazy"
                                     />
                                 </button>


### PR DESCRIPTION
## 문제 (#13614)
iOS Safari에서 앙티콘 피커의 아이템을 처음 탭하면 삽입되지 않고 확대만 됨. 이모지 탭은 정상.

## 원인 (확정)
iOS Safari의 "hover 2탭" 함정. 피커 아이템 `<img>`에 hover 시 3배 확대(`group-hover/emo:scale-[3]`) + `z-50` 변형이 걸려 있는데 `@media(hover:hover)` 가드가 없다. iOS Safari는 hover로 시각이 바뀌는 요소의 **첫 탭을 hover에만 소비**하고 click(=삽입)은 두 번째 탭에서야 발화한다. 이모지 탭은 hover 배경색만 바뀌어(레이아웃/변형 없음) 정상 동작.

## 수정
`emoticon-picker.svelte` 아이템 `<img>`의 확대·z 변형을 `@media(hover:hover)` 가드로 감쌈:
- `group-hover/emo:z-50 group-hover/emo:scale-[3]`
- → `[@media(hover:hover)]:group-hover/emo:z-50 [@media(hover:hover)]:group-hover/emo:scale-[3]`

터치 기기(iOS)에선 hover 확대가 걸리지 않아 첫 탭에 바로 click(삽입)이 발화. 데스크톱(hover 가능)에선 확대가 그대로 유지된다.

## 무회귀
- 이모지 탭, 툴바 열기, 데스크톱 hover 확대, 키보드 접근성(Enter=click) 무영향
- 삽입 경로(`onclick`→`selectEmoticon`→`onInsertEmoticon`) 및 `tiptap-editor` `handleInsertEmoticon`(#13590 composition 가드, `.focus()` 선행) 무접촉
- pointer 이벤트 도입은 키보드 회귀/이중삽입 위험으로 미채택(hover 가드만으로 근본 해결)

## 참고
- 동일 iOS hover 패턴이 `reaction-bar.svelte`(리액션 피커)에도 있으나 별개 컴포넌트라 본 PR 범위 밖
- ⚠️ **iOS 실기기 재현이 최종 확정** — 배포 후 iOS Safari 확인 필요
- 빌드/svelte-check 미실행(노드 CPU 스파이크 방지, 정적 검토만)