### PR TITLE
perf(comments): 이용제한 근거 ID 캐시 — DB 5.0% 구간 제거

### DIFF
--- a/apps/web/src/lib/server/discipline-ids.ts
+++ b/apps/web/src/lib/server/discipline-ids.ts
@@ -1,0 +1,84 @@
+/**
+ * 이용제한 근거 글·댓글 ID 집합 (게시판 단위 캐시)
+ *
+ * `g5_na_singo.discipline_log_id IS NOT NULL` 인 대상은 화면에 "근거" 표시가 붙는다.
+ *
+ * ## ⛔ 왜 캐시하는가 — DB 실행시간의 5.0% 였다
+ *
+ * 댓글 목록을 그릴 때마다 그 글의 댓글 ID 를 통째로 넣어 조회하고 있었다.
+ * 2026-08-18 실측(performance_schema, 가동 490시간):
+ *
+ *   호출 205,449,448회 (초당 116회) · 누적 156,047초 · DB 전체의 5.0%
+ *   호출당 스캔 28행 · **반환 0.0행**
+ *
+ * 한 번이 느린 게 아니라(EXPLAIN `rows: 5`) **부르는 횟수가 문제**다.
+ * 그리고 거의 언제나 빈손으로 돌아온다.
+ *
+ * ⭐ 대상 전체가 작다 — 게시판 전부 합쳐 **3,407개(약 54KB)** 다.
+ *   free 3,171 · truthroom 120 · car 32 · hello 25 · …
+ *   그래서 게시판별로 **통째로 캐시**하고 메모리에서 판정한다. DB 왕복이 사라진다.
+ *
+ * ## ⛔ 갱신 쿼리가 비싸면 문제를 옮기는 것일 뿐이다
+ *
+ * 처음 재보니 갱신 쿼리가 153,626행을 훑고 **0.705초** 였다(그대로 캐시했으면 이득이 2배뿐).
+ * `g5_na_singo` 에 `discipline_log_id` 를 포함한 인덱스가 **하나도 없었다.**
+ * → `idx_table_disc_id(sg_table, discipline_log_id, sg_id)` 추가(4MB) 후 **0.072초**(10배).
+ *   커버링(`Using index`)으로 동작한다. ⛔ 이 인덱스를 지우면 갱신이 다시 비싸진다.
+ *
+ * ## TTL
+ *
+ * 제재는 하루 몇 건 수준이라 5분이면 충분하다. 갱신이 늦어도 "근거 표시"가
+ * 최대 5분 늦게 붙을 뿐, 글이 잘못 보이지는 않는다.
+ */
+import pool from '$lib/server/db';
+import { getRedis } from '$lib/server/redis';
+import type { RowDataPacket } from 'mysql2';
+
+const TTL_SEC = 300;
+
+interface IdRow extends RowDataPacket {
+    sg_id: number;
+}
+
+/**
+ * 게시판의 이용제한 근거 대상 ID 집합.
+ *
+ * ⛔ 실패해도 던지지 않는다. 이 값은 **표시용 부가 정보**라,
+ *    못 가져왔다고 댓글 목록 자체가 실패하면 안 된다(기존 동작과 동일하게 빈 집합).
+ */
+export async function getDisciplineIds(boardId: string): Promise<Set<number>> {
+    const key = `disc:ids:${boardId}`;
+
+    try {
+        const hit = await getRedis().get(key);
+        if (hit !== null) {
+            const arr = JSON.parse(hit) as number[];
+            return new Set(arr);
+        }
+    } catch {
+        // Redis 장애 → DB 로 간다
+    }
+
+    let ids: number[] = [];
+    try {
+        const [rows] = await pool.query<IdRow[]>(
+            `SELECT DISTINCT sg_id FROM g5_na_singo
+             WHERE sg_table = ? AND discipline_log_id IS NOT NULL`,
+            [boardId]
+        );
+        ids = rows.map((r) => r.sg_id);
+    } catch (e) {
+        console.warn('[discipline] id set 조회 실패:', e);
+        return new Set();
+    }
+
+    try {
+        // ⛔ 빈 결과도 캐시한다. 대부분의 게시판이 실제로 0개라, 캐시하지 않으면
+        //    그 게시판들은 매 요청마다 DB 를 쳐서 원래 문제가 그대로 남는다.
+        await getRedis().setex(key, TTL_SEC, JSON.stringify(ids));
+    } catch {
+        // Redis 장애 무시
+    }
+
+    return new Set(ids);
+}

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -9,6 +9,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
+import { getDisciplineIds } from '$lib/server/discipline-ids';
 import { isValidBoardId } from '$lib/utils/board-id.js';
 import {
     applyAffiliateField,
@@ -86,10 +87,6 @@ interface CommentResponseItem {
     from_board_name?: string;
     /** 리뷰 별점(리뷰=댓글+별점): 작성자가 이 댓글에 남긴 리뷰 점수(1~5). 별점 게시판만. */
     review_rating?: number;
-}
-
-interface DisciplineRow extends RowDataPacket {
-    sg_id: number;
 }
 
 function maskIp(ip: string): string {
@@ -257,20 +254,16 @@ export const GET: RequestHandler = async ({ params, url, locals, request }) => {
         const commentIds = rows.map((r) => r.wr_id);
 
         // 이용제한 근거 댓글 식별 (g5_na_singo.discipline_log_id IS NOT NULL)
-        // INDEX hit: (sg_table, sg_id) — idx_singo_table_id / idx_table_id_time.
-        // 실패 무시 (defensive, slow query 차단).
+        //
+        // ⛔ 예전에는 여기서 댓글 ID 목록을 넣어 **요청마다** DB 를 쳤다.
+        //    2026-08-18 실측: 2억 544만회 · 156,047초 = DB 실행시간의 5.0%.
+        //    한 번이 느린 게 아니라(EXPLAIN rows:5) 부르는 횟수가 문제였고,
+        //    반환은 평균 0.0행 — 거의 언제나 빈손이었다.
+        // → 게시판 단위 집합을 캐시하고 메모리에서 판정한다(전 게시판 합쳐 3,407개·54KB).
+        const boardDisciplineIds = await getDisciplineIds(safeBoardId);
         const disciplineSet = new Set<number>();
-        if (commentIds.length > 0) {
-            try {
-                const [dRows] = await pool.query<DisciplineRow[]>(
-                    `SELECT DISTINCT sg_id FROM g5_na_singo
-                     WHERE sg_table = ? AND sg_id IN (?) AND discipline_log_id IS NOT NULL`,
-                    [safeBoardId, commentIds]
-                );
-                for (const d of dRows) disciplineSet.add(d.sg_id);
-            } catch (e) {
-                console.warn('[discipline] enrich(comments) failed:', e);
-            }
+        for (const id of commentIds) {
+            if (boardDisciplineIds.has(id)) disciplineSet.add(id);
         }
 
         // 리뷰 별점(리뷰=댓글+별점): angple_post_ratings 에서 댓글 wr_id 별 평균(작성자 리뷰 점수).


### PR DESCRIPTION
## 발단
DB 슬로우쿼리 전수 점검에서 **3위**로 확인. 댓글 목록을 그릴 때마다 도는 쿼리입니다.

```sql
SELECT DISTINCT sg_id FROM g5_na_singo
 WHERE sg_table = ? AND sg_id IN (...) AND discipline_log_id IS NOT NULL
```

## 실측 (performance_schema, 가동 490시간)
| 항목 | 값 |
|---|---:|
| 호출 | **205,449,448회** (초당 116회) |
| 누적 실행시간 | **156,047초** |
| 호출당 스캔 | 28행 |
| 호출당 반환 | **0.0행** |
| DB 전체 대비 | **5.0%** |

`EXPLAIN` 은 `rows: 5` 로 **한 번은 이미 빠릅니다.** 문제는 부르는 횟수이고, 거의 언제나 빈손으로 돌아옵니다.

## 대상이 작습니다
```
전 게시판 합계 3,407개 (약 54KB)
free 3,171 · truthroom 120 · car 32 · hello 25 · stock 14 · claim 8
```
게시판별로 통째로 캐시하고 메모리에서 판정합니다. DB 왕복이 사라집니다.

## ⛔ 갱신 쿼리가 비싸면 문제를 옮기는 것뿐입니다
처음 재보니 갱신 쿼리가 **153,626행을 훑고 0.705초** 였습니다. 그대로 캐시했으면 이득이 2배에 그쳤습니다.

원인은 `g5_na_singo` 에 **`discipline_log_id` 를 포함한 인덱스가 하나도 없던 것**이었습니다.

```
idx_table_disc_id(sg_table, discipline_log_id, sg_id)  4MB

이전  type=index  rows=153,626  0.705초
이후  type=range  rows=38,478   0.072초   Using index (커버링)
```
이 인덱스는 **운영에 이미 반영**했습니다(온라인, `LOCK=NONE`).

## 설계에서 조심한 것
- **빈 결과도 캐시**합니다. 대부분의 게시판이 실제로 0개라, 캐시하지 않으면 그 게시판들은 매 요청마다 DB 를 쳐서 원래 문제가 그대로 남습니다.
- Redis 장애 시 DB fallback, DB 실패 시 빈 집합을 반환합니다. **표시용 부가 정보라 목록 자체를 막으면 안 됩니다**(기존 동작 유지).
- TTL 5분 — 제재는 하루 몇 건이라 충분하고, 늦어도 근거 표시가 5분 늦게 붙을 뿐입니다.
