### PR TITLE
feat(blur): 작성자 부끄앙 통제 — 렌더 3-state + 게시 후 팝업(#13571 Phase3)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -65,6 +65,8 @@ export interface FreePost {
     /** 게시글 링크(wr_link1/2)와 클릭수. /files 라우트가 g5_write_{board} 에서 직접 읽어 채운다. */
     linkHits?: { n: number; url: string; hit: number }[];
     is_secret?: boolean; // 비밀글 여부
+    /** 작성자 부끄앙(가림) 통제 (#13571 Phase3). true=강제 흐림(리더 설정 무관), false=안 흐림, 생략=미지정(리더 shouldBlurContent 폴백). */
+    is_blur?: boolean;
     is_comments_disabled?: boolean; // 댓글 비활성화 (읽기 전용 공지)
     is_notice?: boolean; // 공지사항 여부
     notice_type?: 'normal' | 'important'; // 공지 타입 (일반/필수)
@@ -657,6 +659,7 @@ export interface UpdatePostRequest {
     content?: string; // 선택, 1자 이상
     category?: string; // 선택
     is_secret?: boolean; // 선택 (비밀글 설정/해제 — 생략 시 변경 없음) (#13161)
+    is_blur?: boolean; // 선택 (부끄앙/가림 설정/해제 — 생략 시 변경 없음) (#13571 Phase3)
     tags?: string[]; // 선택 (태그 목록)
     link1?: string; // 선택 (링크1)
     link2?: string; // 선택 (링크2)

--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -615,7 +615,11 @@
         {#if canViewSecret}
             <AdultBlur isAdult={post.is_adult ?? false}>
                 <ContentBlur
-                    shouldBlur={uiSettingsStore.shouldBlurContent(post.title) || isLockedPost}
+                    shouldBlur={(post.is_blur === true
+                        ? true
+                        : post.is_blur === false
+                          ? false
+                          : uiSettingsStore.shouldBlurContent(post.title)) || isLockedPost}
                     blurReason={isLockedPost
                         ? '신고 누적으로 가려진 글입니다 — 클릭하면 본인 책임 하에 표시'
                         : undefined}

--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -795,7 +795,13 @@
         <!-- 게시글 본문 -->
         {#if canViewSecret}
             <AdultBlur isAdult={post.is_adult ?? false}>
-                <ContentBlur shouldBlur={uiSettingsStore.shouldBlurContent(post.title)}>
+                <ContentBlur
+                    shouldBlur={post.is_blur === true
+                        ? true
+                        : post.is_blur === false
+                          ? false
+                          : uiSettingsStore.shouldBlurContent(post.title)}
+                >
                     <div id="economy-post-content" style="font-size: {FONT_SIZES[currentFontSize]}">
                         {#if post.is_discipline_related}
                             <DisciplinedContent

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -570,6 +570,15 @@ function createUiSettingsStore() {
         /** 제목에 블러 키워드가 포함되어 본문을 흐림 처리해야 하는지 */
         shouldBlurContent(title: string): boolean {
             if (!settings.contentBlur) return false;
+            return this.matchesBlurKeyword(title);
+        },
+
+        /**
+         * 제목이 블러 키워드셋에 매칭되는지 — 리더의 contentBlur 토글과 무관.
+         * 작성 후 부끄앙(가림) 팝업 감지용(#13571 Phase3). 작성자 개인 설정이
+         * 꺼져 있어도 제목에 키워드가 있으면 감지돼야 하므로 shouldBlurContent 와 분리한다.
+         */
+        matchesBlurKeyword(title: string): boolean {
             const lower = title.toLowerCase();
             // 이미지 지시성 키워드: 포함 매칭
             if (BLUR_KEYWORDS.some((k) => lower.includes(k.toLowerCase()))) return true;

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -17,6 +17,7 @@
     import { sendMentionNotifications } from '$lib/utils/mention-notify.js';
     import { checkPermission, getPermissionMessage } from '$lib/utils/board-permissions.js';
     import { trackEvent } from '$lib/services/ga4.js';
+    import { uiSettingsStore } from '$lib/stores/ui-settings.svelte.js';
     import type { FreePost } from '$lib/api/types.js';
     import FileText from '@lucide/svelte/icons/file-text';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
@@ -162,6 +163,22 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ boardId, wrId: newPost.id })
                 }).catch(() => {});
+            }
+
+            // 부끄앙(가림) 통제 — 게시 완료 후 팝업(#13571 Phase3).
+            // 작성 제출 흐름은 건드리지 않고, 제목에 블러 키워드가 있을 때만
+            // 확인 팝업으로 강제 흐림 여부를 작성자가 직접 고른다.
+            // matchesBlurKeyword 는 리더 contentBlur 토글과 무관하게 키워드만 본다.
+            if (browser && uiSettingsStore.matchesBlurKeyword(request.title || '')) {
+                const wantBlur = window.confirm(
+                    '제목에 가림 키워드가 있습니다. 이 글을 부끄앙(가림) 처리할까요?\n\n확인 = 가림 / 취소 = 안 가림'
+                );
+                try {
+                    await apiClient.updatePost(boardId, String(newPost.id), { is_blur: wantBlur });
+                } catch (blurErr) {
+                    // 가림 설정 실패는 글 작성 자체를 되돌리지 않는다 — 로그만 남기고 진행.
+                    console.error('Failed to set blur flag:', blurErr);
+                }
             }
 
             // 상세 페이지로 이동 (새 경로이므로 page load 자동 실행)


### PR DESCRIPTION
## 개요
작성자 부끄앙(가림) 통제 Phase 3 (web 단독). Phase 1(DDL)·Phase 2(backend `is_blur`, prod 라이브) 완료 전제.

## 변경
- **types** (`api/types.ts`): `FreePost`·`UpdatePostRequest` 에 `is_blur?: boolean` 추가. (`CreatePostRequest` 무변경 — 게시 후 팝업 방식)
- **렌더 3-state** (`view/basic.svelte`, `view/report.svelte`):
  - `is_blur === true` → 강제 흐림(리더 개인 '본문 흐림' 설정 무관, `shouldBlurContent` 우회)
  - `is_blur === false` → 안 흐림(키워드 무관)
  - 미지정(undefined) → 기존 `uiSettingsStore.shouldBlurContent(post.title)` 폴백(리더 게이트 포함)
  - basic 은 결과에 `|| isLockedPost` 유지(신고 누적 잠금 무회귀)
- **ui-settings** (`ui-settings.svelte.ts`): `matchesBlurKeyword()` 분리 — 리더 `contentBlur` 토글과 무관하게 제목 키워드만 감지(작성자 개인 설정 off 여도 팝업 뜨도록). `shouldBlurContent` 는 이를 게이트 뒤에서 재사용.
- **게시 후 팝업** (`[boardId]/write/+page.svelte`): `createPost` 성공 후 제목에 블러 키워드 감지 시 확인 팝업 → `updatePost(is_blur)`. 키워드 없으면 팝업 없음. **create 페이로드 무변경**, 작성 제출 흐름·`post-form.svelte` 무접촉. edit 경로는 범위 밖.

## 클릭 해제 관계
작성자 강제 흐림(`is_blur=true`)이어도 뷰어의 클릭 해제(`content-blur.svelte`)는 기존대로 동작 — 강제되는 것은 초기 흐림 상태뿐.

## 무접촉
`content-blur.svelte`(클릭 해제)·#13590 가드·premium·isLockedPost 로직.

🤖 Generated with [Claude Code](https://claude.com/claude-code)