### PR TITLE
refactor(page-index): SSR 이 자기 자신을 HTTP 로 부르던 계층 제거

### DIFF
--- a/apps/web/src/lib/server/page-index.ts
+++ b/apps/web/src/lib/server/page-index.ts
@@ -1,0 +1,148 @@
+/**
+ * 글이 목록의 몇 페이지에 있는지 계산 (#12430)
+ *
+ * 글 상세 하단의 최근글 목록이 `?page` 없이 진입했을 때, 자기 글이 속한 페이지로
+ * 자동 이동하기 위해 쓴다.
+ *
+ *   prior = COUNT(wr_id > targetId, wr_is_comment=0, wr_deleted_at IS NULL)
+ *   page  = floor(prior / page_rows) + 1
+ *
+ * ## ⛔ 왜 라우트가 아니라 여기 있는가
+ *
+ * 이 계산의 **호출자는 100% SSR** 이다. 2026-08-18 실측:
+ * 운영 파드 nginx 사이드카 로그 3,000줄에서 브라우저 API 2,230건(좋아요 233·댓글 154) 중
+ * `page-index` 요청은 **0건**이었다. `[boardId]/[postId]/+page.server.ts` 가 부르는 게 전부다.
+ *
+ * 그런데 SSR 이 `svelteKitFetch('/api/.../page-index')` 로 **자기 자신을 HTTP 로** 부르고 있었다.
+ * 같은 프로세스라 네트워크는 없지만 Request/Response 생성과 JSON 직렬화·역직렬화가 매 요청 일어난다.
+ * 캐시 적중인데도 1~3ms 가 걸린 이유다(Redis GET 하나면 1ms 미만이어야 한다).
+ *
+ * → 로직을 여기로 빼고 **라우트와 SSR 이 같은 함수를 쓴다.** 결과는 완전히 동일하고 계층만 사라진다.
+ * ⭐ 요청당 객체 할당이 줄어드는 것은 **2026-08-07 web heap OOM** 이력이 있는 이 서비스에 부수 이득이다.
+ *
+ * ⛔ 공개 라우트(`/api/boards/.../page-index`)는 **지우지 마라.**
+ *    `recent-posts.svelte` 에 폴백 호출이 남아 있다(SSR 이 1페이지를 준 경우에만 발화).
+ *
+ * ## 캐시 설계 (2026-08-18, DB 실행시간 57.5% 구간)
+ *
+ * 캐시 전 실측: 호출 3,150만회 · 누적 1,812,104초 · 호출당 평균 99,305행 스캔.
+ * 인덱스로는 못 줄인다 — `idx_comment_deleted` + InnoDB 인덱스 확장으로 이미 커버링 범위 스캔이고
+ * `COUNT(wr_id > X)` 는 **스캔 행수 자체가 답의 크기**다.
+ *
+ * ⛔ `page` 가 아니라 **`prior` 를 캐시한다.** `page` 는 `bo_page_rows` 에 의존하므로
+ *    게시판 설정이 바뀌면 캐시된 page 가 틀린 값이 된다.
+ * ⛔ TTL 을 하나로 고정하지 마라. 최신 글은 쿼리도 싸고 페이지가 자주 바뀌므로 짧게,
+ *    아카이브 글은 비싸고 1페이지 오차가 무의미하므로 길게. **비싼 요청일수록 오래 캐시된다.**
+ */
+import pool from '$lib/server/db';
+import { getRedis } from '$lib/server/redis';
+import type { RowDataPacket } from 'mysql2';
+
+/** 게시판 설정(page_rows)은 거의 안 바뀐다. 길게 캐시해도 안전하다. */
+const PAGE_ROWS_TTL_SEC = 600;
+
+/** `bo_page_rows` 미설정 시 기본값. 라우트의 400 응답과도 같은 값을 쓴다. */
+export const DEFAULT_PAGE_ROWS = 25;
+
+export const BOARD_ID_RE = /^[a-zA-Z0-9_]{1,40}$/;
+
+/**
+ * prior 깊이별 TTL. 위 주석의 "비싼 쪽일수록 길게" 원칙을 표로 옮긴 것.
+ * 위에서부터 처음 걸리는 항목을 쓴다.
+ */
+const PRIOR_TTL_TIERS: ReadonlyArray<{ maxPrior: number; ttlSec: number }> = [
+    { maxPrior: 1_000, ttlSec: 60 }, // 1~40 페이지 — 사람이 실제로 오가는 구간
+    { maxPrior: 10_000, ttlSec: 600 }, // ~400 페이지
+    { maxPrior: Number.POSITIVE_INFINITY, ttlSec: 3_600 } // 그 이상 — 사실상 아카이브
+];
+
+function ttlForPrior(prior: number): number {
+    return PRIOR_TTL_TIERS.find((t) => prior < t.maxPrior)?.ttlSec ?? 3_600;
+}
+
+export interface PageIndexResult {
+    page: number;
+    page_rows: number;
+    prior: number;
+}
+
+/**
+ * 글의 페이지 번호.
+ *
+ * ⛔ 던지지 않는다. 이 값은 **하단 목록을 어느 페이지로 열지**를 정할 뿐이라,
+ *    실패했다고 글 상세 렌더가 막히면 안 된다. 실패 시 1페이지로 떨어진다(기존 동작).
+ */
+export async function getPageIndex(boardId: string, postId: number): Promise<PageIndexResult> {
+    if (!BOARD_ID_RE.test(boardId) || !Number.isFinite(postId) || postId <= 0) {
+        return { page: 1, page_rows: DEFAULT_PAGE_ROWS, prior: 0 };
+    }
+
+    try {
+        const pageRows = await getPageRows(boardId);
+        const prior = await getPrior(boardId, postId);
+        return { page: Math.floor(prior / pageRows) + 1, page_rows: pageRows, prior };
+    } catch (err) {
+        console.error('[page-index] 계산 실패:', err);
+        return { page: 1, page_rows: DEFAULT_PAGE_ROWS, prior: 0 };
+    }
+}
+
+/** 게시판 page_rows. Redis 실패는 무시하고 DB 로 간다. */
+async function getPageRows(boardId: string): Promise<number> {
+    const key = `pi:rows:${boardId}`;
+    try {
+        const hit = await getRedis().get(key);
+        if (hit !== null) return Math.max(1, parseInt(hit, 10) || DEFAULT_PAGE_ROWS);
+    } catch {
+        // Redis 장애 시 DB fallback
+    }
+
+    const [boardRows] = await pool.query<RowDataPacket[]>(
+        'SELECT bo_page_rows FROM g5_board WHERE bo_table = ? LIMIT 1',
+        [boardId]
+    );
+    const pageRows = Math.max(
+        1,
+        (boardRows[0]?.bo_page_rows as number | null) ?? DEFAULT_PAGE_ROWS
+    );
+
+    try {
+        await getRedis().setex(key, PAGE_ROWS_TTL_SEC, String(pageRows));
+    } catch {
+        // Redis 장애 무시
+    }
+    return pageRows;
+}
+
+/**
+ * 이 글보다 최신인 정상 글 개수.
+ * ⛔ 여기가 비용의 전부다. 캐시 miss 일 때만 DB 를 친다.
+ */
+async function getPrior(boardId: string, postId: number): Promise<number> {
+    const key = `pi:prior:${boardId}:${postId}`;
+    try {
+        const hit = await getRedis().get(key);
+        if (hit !== null) {
+            const cached = parseInt(hit, 10);
+            if (Number.isFinite(cached) && cached >= 0) return cached;
+        }
+    } catch {
+        // Redis 장애 시 DB fallback
+    }
+
+    // 해당 글보다 최신인 정상 글 개수 (1페이지에 최신 글이 옴)
+    const tableName = `g5_write_${boardId}`;
+    const [countRows] = await pool.query<RowDataPacket[]>(
+        `SELECT COUNT(*) AS c FROM \`${tableName}\`
+         WHERE wr_is_comment = 0 AND wr_id > ? AND wr_deleted_at IS NULL`,
+        [postId]
+    );
+    const prior = (countRows[0]?.c as number) ?? 0;
+
+    try {
+        await getRedis().setex(key, ttlForPrior(prior), String(prior));
+    } catch {
+        // Redis 장애 무시
+    }
+    return prior;
+}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -2,6 +2,7 @@ import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 import type { Board, FreePost } from '$lib/api/types.js';
 import { fetchPromotionPosts, fetchPromotionBoardPosts } from '$lib/server/ads/promotion.js';
+import { getPageIndex } from '$lib/server/page-index';
 import {
     applyAffiliateField,
     fetchPostAffiliateLinks,
@@ -827,18 +828,15 @@ export const load: PageServerLoad = async ({
         let recentPostsPage = urlPage > 0 ? urlPage : 1;
 
         if (urlPage === 0 && !post.deleted_at) {
-            try {
-                const piRes = await svelteKitFetch(
-                    `/api/boards/${boardId}/posts/${postId}/page-index`
-                );
-                if (piRes.ok) {
-                    const body = (await piRes.json()) as { page?: number };
-                    if (body.page && body.page > 1) {
-                        recentPostsPage = body.page;
-                    }
-                }
-            } catch {
-                // page-index 실패 시 1 유지 (사용자 흐름 방해 X)
+            // ⛔ 예전에는 여기서 `/api/.../page-index` 를 svelteKitFetch 로 불렀다.
+            //    같은 프로세스인데 Request/Response 생성과 JSON 왕복이 매 요청 일어나서,
+            //    캐시 적중인데도 1~3ms 가 걸렸다(Redis GET 하나면 1ms 미만이어야 한다).
+            //    실측상 이 계산의 호출자는 100% SSR 이라(브라우저 요청 0건) HTTP 계층이 순수 낭비였다.
+            // → 같은 로직을 함수로 직접 부른다. 결과·캐시 키·TTL 은 완전히 동일하다.
+            //    getPageIndex 는 던지지 않고 실패 시 page:1 을 돌려주므로 try 가 필요 없다.
+            const pi = await getPageIndex(boardId, Number(postId));
+            if (pi.page > 1) {
+                recentPostsPage = pi.page;
             }
         }
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/page-index/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/page-index/+server.ts
@@ -1,147 +1,31 @@
 /**
  * GET /api/boards/[boardId]/posts/[postId]/page-index
  *
- * 해당 글이 자유게시판 등에서 N페이지에 위치하는지 계산.
- * RecentPosts (글 상세 하단 목록) 가 URL `?page` 없이 진입했을 때
- * 자기 글이 속한 페이지로 자동 이동하기 위한 endpoint (#12430).
+ * 해당 글이 목록의 몇 페이지에 있는지 (#12430).
  *
- * 페이지 계산: 더 최신 (wr_id 가 더 큰) 정상 글 개수 / page_rows + 1.
- *   - prior = COUNT(wr_id > targetId, wr_is_comment=0, wr_deleted_at IS NULL)
- *   - page  = floor(prior / page_rows) + 1
+ * ⭐ 계산 로직은 `$lib/server/page-index.ts` 에 있다. SSR(`[boardId]/[postId]/+page.server.ts`)이
+ *    **같은 함수를 직접** 부르기 때문이다. 예전에는 SSR 이 이 라우트를 `svelteKitFetch` 로
+ *    호출해서, 같은 프로세스 안에서 Request/Response 생성과 JSON 왕복이 매 요청 일어났다.
  *
- * page_rows 는 g5_board.bo_page_rows (게시판 설정), 미설정 시 25 default.
- *
- * ## ⛔ 이 endpoint 는 DB 실행시간의 58% 를 쓰고 있었다 (2026-08-18 실측)
- *
- * `[boardId]/[postId]/+page.server.ts` 가 SSR 에서 **await 로 블로킹 호출**한다.
- * 즉 `?page` 없는 글 조회 **한 번마다 한 번씩** 불린다.
- *
- *   호출 3,150만회 · 누적 1,812,104초 · 호출당 평균 99,305행 스캔
- *   → DB 전체 누적 실행시간 3,149,562초의 **57.5%**
- *   (가동 시간보다 누적 실행시간이 커서 CPU 1코어 이상을 상시 점유)
- *
- * 비용의 정체는 `COUNT(wr_id > X)` 가 **X 가 오래된 글일수록 비싸다**는 것이다.
- * 인덱스는 이미 최적이다(`idx_comment_deleted` + InnoDB 인덱스 확장으로 wr_id 까지 커버,
- * `Using index`). 스캔하는 행 수 자체가 답의 크기라 인덱스로는 더 줄일 수 없다.
- *
- * ## 그래서 캐시한다 — 적중률이 실측으로 96% 다
- *
- * 같은 글 URL 이 반복 조회되기 때문이다(ClickHouse `aplog.ad_events`, 2일치):
- *
- *   글 상세 페이지뷰 3,545,380 / 고유 URL 138,775 = **URL 당 25.55회**
- *   → 이론 적중률 96.1%
- *
- * ⛔ 캐시하는 값은 `page` 가 아니라 **`prior`** 다. page 는 게시판 설정
- *    (`bo_page_rows`)에 의존하므로, 설정이 바뀌면 캐시된 page 는 틀린 값이 된다.
- *    prior 를 캐시하고 page 는 매번 현재 설정으로 계산한다.
- *
- * ⛔ TTL 을 하나로 고정하지 마라. 깊이에 따라 정확도 요구가 다르다.
- *    - 최신 글: prior 가 작아 **쿼리도 싸다**. 새 글 24개마다 페이지가 바뀌므로 짧게.
- *    - 오래된 글: 쿼리가 비싸고, 몇천 페이지 중 1페이지 어긋나는 것은 무의미하다. 길게.
- *    비싼 쪽일수록 오래 캐시된다 = 비용이 큰 요청일수록 캐시가 잘 듣는다.
+ * ⛔ **이 라우트를 지우지 마라.** `recent-posts.svelte` 에 폴백 호출이 남아 있다
+ *    (SSR 이 1페이지를 준 경우에만 발화). 공개 계약은 그대로 유지한다.
  */
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import pool from '$lib/server/db';
-import { getRedis } from '$lib/server/redis';
-import type { RowDataPacket } from 'mysql2';
-
-const BOARD_ID_RE = /^[a-zA-Z0-9_]{1,40}$/;
-
-/** 게시판 설정(page_rows)은 거의 안 바뀐다. 길게 캐시해도 안전하다. */
-const PAGE_ROWS_TTL_SEC = 600;
-
-/**
- * prior 깊이별 TTL. 위 주석의 "비싼 쪽일수록 길게" 원칙을 표로 옮긴 것.
- * 경계값은 `prior` 기준이며 위에서부터 처음 걸리는 항목을 쓴다.
- */
-const PRIOR_TTL_TIERS: ReadonlyArray<{ maxPrior: number; ttlSec: number }> = [
-    { maxPrior: 1_000, ttlSec: 60 }, // 1~40 페이지 — 사람이 실제로 오가는 구간
-    { maxPrior: 10_000, ttlSec: 600 }, // ~400 페이지
-    { maxPrior: Number.POSITIVE_INFINITY, ttlSec: 3_600 } // 그 이상 — 사실상 아카이브
-];
-
-function ttlForPrior(prior: number): number {
-    return PRIOR_TTL_TIERS.find((t) => prior < t.maxPrior)?.ttlSec ?? 3_600;
-}
+import { getPageIndex, BOARD_ID_RE, DEFAULT_PAGE_ROWS } from '$lib/server/page-index';
 
 export const GET: RequestHandler = async ({ params, setHeaders }) => {
     const boardId = params.boardId ?? '';
     const postId = parseInt(params.postId ?? '0', 10);
 
     if (!BOARD_ID_RE.test(boardId) || !Number.isFinite(postId) || postId <= 0) {
-        return json({ page: 1, page_rows: 25 }, { status: 400 });
+        return json({ page: 1, page_rows: DEFAULT_PAGE_ROWS }, { status: 400 });
     }
 
-    try {
-        const pageRows = await getPageRows(boardId);
-        const prior = await getPrior(boardId, postId);
-        const page = Math.floor(prior / pageRows) + 1;
+    const result = await getPageIndex(boardId, postId);
 
-        // 짧은 캐시 (1분) — 페이지 번호가 자주 바뀌지 않음
-        setHeaders({ 'Cache-Control': 'public, max-age=60' });
+    // 짧은 캐시 (1분) — 페이지 번호가 자주 바뀌지 않음
+    setHeaders({ 'Cache-Control': 'public, max-age=60' });
 
-        return json({ page, page_rows: pageRows, prior });
-    } catch (err) {
-        // DB 오류 시 1페이지 fallback (사용자 흐름 방해 X)
-        console.error('[page-index] DB error:', err);
-        return json({ page: 1, page_rows: 25 });
-    }
+    return json(result);
 };
-
-/** 게시판 page_rows. Redis 실패는 무시하고 DB 로 간다. */
-async function getPageRows(boardId: string): Promise<number> {
-    const key = `pi:rows:${boardId}`;
-    try {
-        const hit = await getRedis().get(key);
-        if (hit !== null) return Math.max(1, parseInt(hit, 10) || 25);
-    } catch {
-        // Redis 장애 시 DB fallback
-    }
-
-    const [boardRows] = await pool.query<RowDataPacket[]>(
-        'SELECT bo_page_rows FROM g5_board WHERE bo_table = ? LIMIT 1',
-        [boardId]
-    );
-    const pageRows = Math.max(1, (boardRows[0]?.bo_page_rows as number | null) ?? 25);
-
-    try {
-        await getRedis().setex(key, PAGE_ROWS_TTL_SEC, String(pageRows));
-    } catch {
-        // Redis 장애 무시
-    }
-    return pageRows;
-}
-
-/**
- * 이 글보다 최신인 정상 글 개수.
- * ⛔ 여기가 비용의 전부다. 캐시 miss 일 때만 DB 를 친다.
- */
-async function getPrior(boardId: string, postId: number): Promise<number> {
-    const key = `pi:prior:${boardId}:${postId}`;
-    try {
-        const hit = await getRedis().get(key);
-        if (hit !== null) {
-            const cached = parseInt(hit, 10);
-            if (Number.isFinite(cached) && cached >= 0) return cached;
-        }
-    } catch {
-        // Redis 장애 시 DB fallback
-    }
-
-    // 해당 글보다 최신인 정상 글 개수 (1페이지에 최신 글이 옴)
-    const tableName = `g5_write_${boardId}`;
-    const [countRows] = await pool.query<RowDataPacket[]>(
-        `SELECT COUNT(*) AS c FROM \`${tableName}\`
-         WHERE wr_is_comment = 0 AND wr_id > ? AND wr_deleted_at IS NULL`,
-        [postId]
-    );
-    const prior = (countRows[0]?.c as number) ?? 0;
-
-    try {
-        await getRedis().setex(key, ttlForPrior(prior), String(prior));
-    } catch {
-        // Redis 장애 무시
-    }
-    return prior;
-}


### PR DESCRIPTION
## 발단
`page-index` 캐시(#2118) 이후 **호출 구조**를 분석하다 발견했습니다.

SSR(`[boardId]/[postId]/+page.server.ts`)이 `svelteKitFetch` 로 **자기 자신의 API 라우트를 HTTP 로** 호출하고 있었습니다. 같은 프로세스라 네트워크는 없지만, Request/Response 생성과 JSON 직렬화·역직렬화가 **매 요청** 일어납니다.

## 실측 — 이 계산의 호출자는 100% SSR 입니다
운영 웹 파드의 nginx 사이드카 로그 3,000줄 표본:

```
브라우저 API 총합            2,230건
  ├ posts/{id}/like            233건
  ├ posts/{id}/comments        154건
  └ comments/likers-batch      109건
page-index                       0건   ← 브라우저는 부르지 않는다
```

즉 **HTTP 계층은 순수 낭비**였습니다. 캐시 적중인데도 요청당 1~3ms 가 걸린 이유입니다(Redis GET 하나면 1ms 미만이어야 합니다).

| | 20회 합 | 요청당 |
|---|---:|---:|
| 캐시 적중 | 0.161초 | 1~3ms |
| 캐시 미스 | 2.268초 | 약 105ms |

## 변경
- 계산 로직을 `$lib/server/page-index.ts` 로 추출
- 라우트는 **얇은 래퍼**로 축소 — 공개 계약·응답 스키마·`Cache-Control` 동일
- SSR 은 `getPageIndex()` 를 **직접 호출**

## 동일하게 유지한 것
- Redis 키 — `pi:prior:{board}:{postId}`, `pi:rows:{board}`
- 깊이별 TTL — 60s / 600s / 3600s, `page_rows` 600s
- 응답 스키마 — `{page, page_rows, prior}`
- 실패 시 `page:1` fallback (`getPageIndex` 는 던지지 않습니다)

## ⛔ 공개 라우트는 지우지 않았습니다
`recent-posts.svelte:229` 에 폴백 호출이 남아 있습니다(SSR 이 1페이지를 준 경우에만 발화). 실측상 거의 안 타지만 **계약을 깨지 않았습니다.**

## 부수 효과
요청당 객체 할당이 줄어듭니다. **2026-08-07 web heap OOM** 이력이 있는 서비스라 그냥 넘길 일이 아닙니다.

## 검증 계획
배포 전 실제 글 10건의 `{page, prior, page_rows}` 를 수집해뒀습니다. 배포 후 **같은 값이 나오는지 대조**합니다.
```
7050188: page=24 prior=718 rows=30
7049236: page=27 prior=808 rows=30
7050407: page=24 prior=697 rows=30
7056245: page=7  prior=202 rows=30
7041562: page=57 prior=1681 rows=30
```

설계서: `/home/damoang/docs/2026-08-18-page-index-call-structure.html`
