### PR TITLE
fix(api): 댓글 SSR 500 회귀 — getClientAddress() throw 로 댓글이 통째로 안 실림

### DIFF
--- a/apps/web/src/lib/server/rate-limit.ts
+++ b/apps/web/src/lib/server/rate-limit.ts
@@ -25,6 +25,37 @@ setInterval(() => {
 }, CLEANUP_INTERVAL);
 
 /**
+ * 요청의 클라이언트 IP 를 안전하게 얻는다. 못 구하면 null.
+ *
+ * ⛔ `getClientAddress()` 를 그대로 부르지 마라. `ADDRESS_HEADER=x-real-ip` 환경에서
+ *    그 헤더가 없으면 **throw** 하고, 그대로 500 이 된다.
+ *    SvelteKit 의 `event.fetch` 로 자기 API 를 호출하는 SSR 경로에는 x-real-ip 가
+ *    실리지 않는다(쿠키·인증 헤더만 승계된다).
+ *
+ *    2026-08-19 실측 사고: 글 상세 SSR 이 `event.fetch` 로 댓글 API 를 부르는데
+ *    이 throw 로 500 이 나면서 **시간당 약 3.6만 건**의 오류가 났고, SSR 이 댓글을
+ *    통째로 못 실었다. 화면에는 "리플 (4)" 인데 댓글이 0개로 보였다.
+ *
+ * IP 를 못 구했으면 **호출부는 속도제한을 건너뛴다.** 키가 없으면 애초에 제한을
+ * 걸 수 없고, 못 건다는 이유로 요청을 죽이는 건 더 나쁘다(제한은 남용 억제 수단이지
+ * 인증 수단이 아니다).
+ */
+export function resolveClientIp(getClientAddress: () => string, request: Request): string | null {
+    try {
+        const ip = getClientAddress();
+        if (ip) return ip;
+    } catch {
+        // ADDRESS_HEADER 부재 — 아래 헤더 폴백으로 넘어간다
+    }
+    const forwarded = request.headers.get('x-forwarded-for');
+    if (forwarded) {
+        const first = forwarded.split(',')[0]?.trim();
+        if (first) return first;
+    }
+    return request.headers.get('x-real-ip')?.trim() || null;
+}
+
+/**
  * Rate limit 체크
  * @returns allowed: true이면 요청 허용, false이면 차단
  */

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -462,7 +462,14 @@ export const load: PageServerLoad = async ({
             // 2.5s 상한. 초과/네트워크 오류는 .catch → failedMeta 로 일관 처리(무제한 대기 차단).
             const commentsResult = await svelteKitFetch(
                 `${url.origin}/api/boards/${boardId}/posts/${postId}/comments?page=1&limit=${initialCommentsLimit}`,
-                { signal: AbortSignal.timeout(2_500) }
+                {
+                    signal: AbortSignal.timeout(2_500),
+                    // ⛔ Referer 를 붙여야 이 호출이 **내부 요청**으로 분류된다.
+                    //    event.fetch 는 쿠키·인증 헤더만 승계할 뿐 Referer·x-real-ip 를 넘기지 않아,
+                    //    붙이지 않으면 외부 요청으로 오분류돼 IP 속도제한 경로를 탄다.
+                    //    (그 경로가 x-real-ip 부재로 500 을 냈다 — 2026-08-19 사고)
+                    headers: { referer: `${url.origin}/${boardId}/${postId}` }
+                }
             )
                 .then(async (res) => {
                     if (!res.ok) {

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -20,7 +20,7 @@ import {
 } from '$lib/server/affiliate-links';
 import { isLinkProcessingPluginEnabled } from '$lib/server/link-processing/runtime';
 import { isInternalAppRequest } from '$lib/server/internal-api.js';
-import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
+import { checkRateLimit, recordAttempt, resolveClientIp } from '$lib/server/rate-limit.js';
 import { fetchWithdrawnMemberIds } from '$lib/server/withdrawn-members.js';
 import { prefetchBlueskyDIDs } from '$lib/server/bluesky/transform.js';
 
@@ -155,23 +155,28 @@ export const GET: RequestHandler = async ({ params, url, locals, request, getCli
 
     // 외부 요청은 자르지 않고 rate-limit 으로 억제한다(위 주석 참조).
     if (!isInternalRequest) {
-        const ip = getClientAddress();
-        const rl = checkRateLimit(
-            ip,
-            'board-comments',
-            EXTERNAL_COMMENTS_RATE_LIMIT,
-            EXTERNAL_COMMENTS_RATE_WINDOW_MS
-        );
-        if (!rl.allowed) {
-            return json(
-                { success: false, message: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
-                {
-                    status: 429,
-                    headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
-                }
+        // ⛔ getClientAddress() 를 직접 부르면 안 된다 — x-real-ip 가 없으면 throw 하고
+        //    그대로 500 이 된다. SSR 이 event.fetch 로 이 API 를 부를 때가 정확히 그 경우다.
+        //    IP 를 못 구하면 제한을 **건너뛴다**(키 없이는 못 거는 게 정상이다).
+        const ip = resolveClientIp(getClientAddress, request);
+        if (ip) {
+            const rl = checkRateLimit(
+                ip,
+                'board-comments',
+                EXTERNAL_COMMENTS_RATE_LIMIT,
+                EXTERNAL_COMMENTS_RATE_WINDOW_MS
             );
+            if (!rl.allowed) {
+                return json(
+                    { success: false, message: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
+                    {
+                        status: 429,
+                        headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
+                    }
+                );
+            }
+            recordAttempt(ip, 'board-comments');
         }
-        recordAttempt(ip, 'board-comments');
     }
 
     const effectivePage = page;

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/likers/+server.ts
@@ -8,7 +8,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
-import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
+import { checkRateLimit, recordAttempt, resolveClientIp } from '$lib/server/rate-limit.js';
 import { getAuthUser } from '$lib/server/auth';
 import { getRedis } from '$lib/server/redis';
 import { isInternalAppRequest } from '$lib/server/internal-api.js';
@@ -83,23 +83,28 @@ export const GET: RequestHandler = async ({ params, url, cookies, request, getCl
 
     // 외부 요청은 페이지를 막지 않고 rate-limit 으로 억제한다(위 주석 참조).
     if (!isInternalRequest) {
-        const ip = getClientAddress();
-        const rl = checkRateLimit(
-            ip,
-            'comment-likers',
-            EXTERNAL_LIKERS_RATE_LIMIT,
-            EXTERNAL_LIKERS_RATE_WINDOW_MS
-        );
-        if (!rl.allowed) {
-            return json(
-                { success: false, message: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
-                {
-                    status: 429,
-                    headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
-                }
+        // ⛔ getClientAddress() 를 직접 부르면 안 된다 — x-real-ip 가 없으면 throw 하고
+        //    그대로 500 이 된다. SSR 이 event.fetch 로 이 API 를 부를 때가 정확히 그 경우다.
+        //    IP 를 못 구하면 제한을 **건너뛴다**(키 없이는 못 거는 게 정상이다).
+        const ip = resolveClientIp(getClientAddress, request);
+        if (ip) {
+            const rl = checkRateLimit(
+                ip,
+                'comment-likers',
+                EXTERNAL_LIKERS_RATE_LIMIT,
+                EXTERNAL_LIKERS_RATE_WINDOW_MS
             );
+            if (!rl.allowed) {
+                return json(
+                    { success: false, message: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
+                    {
+                        status: 429,
+                        headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
+                    }
+                );
+            }
+            recordAttempt(ip, 'comment-likers');
         }
-        recordAttempt(ip, 'comment-likers');
     }
 
     const effectivePage = page;

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/likers-batch/+server.ts
@@ -8,7 +8,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
-import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
+import { checkRateLimit, recordAttempt, resolveClientIp } from '$lib/server/rate-limit.js';
 import { getAuthUser } from '$lib/server/auth';
 import { getRedis } from '$lib/server/redis';
 import { isInternalAppRequest } from '$lib/server/internal-api.js';
@@ -82,23 +82,28 @@ export const GET: RequestHandler = async ({ params, url, cookies, request, getCl
 
     // 외부 요청은 자르지 않고 rate-limit 으로 억제한다(위 주석 참조).
     if (!isInternalRequest) {
-        const ip = getClientAddress();
-        const rl = checkRateLimit(
-            ip,
-            'comment-likers-batch',
-            EXTERNAL_LIKERS_BATCH_RATE_LIMIT,
-            EXTERNAL_LIKERS_BATCH_RATE_WINDOW_MS
-        );
-        if (!rl.allowed) {
-            return json(
-                { success: false, message: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
-                {
-                    status: 429,
-                    headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
-                }
+        // ⛔ getClientAddress() 를 직접 부르면 안 된다 — x-real-ip 가 없으면 throw 하고
+        //    그대로 500 이 된다. SSR 이 event.fetch 로 이 API 를 부를 때가 정확히 그 경우다.
+        //    IP 를 못 구하면 제한을 **건너뛴다**(키 없이는 못 거는 게 정상이다).
+        const ip = resolveClientIp(getClientAddress, request);
+        if (ip) {
+            const rl = checkRateLimit(
+                ip,
+                'comment-likers-batch',
+                EXTERNAL_LIKERS_BATCH_RATE_LIMIT,
+                EXTERNAL_LIKERS_BATCH_RATE_WINDOW_MS
             );
+            if (!rl.allowed) {
+                return json(
+                    { success: false, message: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
+                    {
+                        status: 429,
+                        headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
+                    }
+                );
+            }
+            recordAttempt(ip, 'comment-likers-batch');
         }
-        recordAttempt(ip, 'comment-likers-batch');
     }
 
     if (!boardId || !commentIdsParam) {


### PR DESCRIPTION
## 무슨 일이 있었나

#2124 가 넣은 IP 속도제한이 `getClientAddress()` 를 무방비로 호출했다.
`ADDRESS_HEADER=x-real-ip` 환경에서 그 헤더가 없으면 이 함수는 **throw** 하고,
핸들러 최상단이라 `try` 밖이어서 그대로 500 이 된다.

글 상세 SSR 은 `event.fetch` 로 자기 댓글 API 를 부르는데, `event.fetch` 는
쿠키·인증 헤더만 승계하고 `Referer`·`x-real-ip` 를 넘기지 않는다. 그래서:

1. `isInternalAppRequest` → **false** (Referer·Origin 없음) → 속도제한 경로 진입
2. `getClientAddress()` → **throw** → 500
3. SSR 은 `loadState:'failed'`, `items:[]` 로 렌더 → **댓글 0개**

## 실측 (2026-08-19 08시, 운영 18파드)

```
[Server Error] 500 /api/boards/{b}/posts/{id}/comments:
  Address header was specified with ADDRESS_HEADER=x-real-ip but is absent from request
```

- 표본 4파드 · 3시간 → **23,985건**. 18파드 환산 **시간당 약 3.6만 건**
- 엔드포인트별 집계에서 **댓글 API 단독**, 다른 500 사유 0건
- 사용자 제보(`/free/7060456`): *"지금도 리플 (4) 인데 리플 하나도 안보입니다"*

## 수정

- **`resolveClientIp()` 신설** — `getClientAddress()` 를 `try` 로 감싸고
  `x-forwarded-for` → `x-real-ip` 순으로 폴백, 그래도 없으면 `null`.
  IP 가 없으면 **속도제한을 건너뛴다**. 키 없이는 제한을 걸 수 없고,
  못 건다는 이유로 요청을 죽이는 건 더 나쁘다(제한은 남용 억제 수단이지 인증이 아니다).
- 같은 패턴을 쓰는 **3개 엔드포인트 전부** 적용 — `comments` · `comments/likers-batch` · `comments/{id}/likers`
- 글 상세 SSR 의 자체 호출에 `Referer` 를 붙여 내부 요청으로 올바르게 분류(이중 안전장치)

## 검증 계획

- 카나리에서 `/api/boards/free/posts/{id}/comments` 500 이 **0건**인지 로그로 확인
- 글 상세 HTML 에 댓글 본문이 실리는지 — 댓글 21개 이상인 글로 대조
- 429 정상 동작(공개 경로에서 IP 가 잡히는지) 확인