### PR TITLE
fix(emoticon): hover 확대 img가 인접 hover 가로채는 문제 — pointer-events-none(#13628)

### DIFF
--- a/apps/web/src/lib/components/features/board/emoticon-picker.svelte
+++ b/apps/web/src/lib/components/features/board/emoticon-picker.svelte
@@ -250,7 +250,7 @@
                                     <img
                                         src={stillThumbUrl(item)}
                                         alt={item.file}
-                                        class="emoticon-inline size-10 object-contain transition-transform [@media(hover:hover)]:group-hover/emo:z-50 [@media(hover:hover)]:group-hover/emo:scale-[3]"
+                                        class="emoticon-inline pointer-events-none size-10 object-contain transition-transform [@media(hover:hover)]:group-hover/emo:z-50 [@media(hover:hover)]:group-hover/emo:scale-[3]"
                                         loading="lazy"
                                     />
                                 </button>

--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -434,7 +434,7 @@
                                 alt={emo.reaction}
                                 loading="lazy"
                                 decoding="async"
-                                class="h-7 w-7 object-scale-down transition-transform group-hover/emo:z-50 group-hover/emo:scale-[4]"
+                                class="pointer-events-none h-7 w-7 object-scale-down transition-transform [@media(hover:hover)]:group-hover/emo:z-50 [@media(hover:hover)]:group-hover/emo:scale-[4]"
                             />
                         {:else}
                             <span class="text-xl leading-none">{emo.emoji}</span>


### PR DESCRIPTION
## 문제 (#13628)
데스크톱에서 댓글 이모티콘 hover가 "중간중간 반응 안 함".

## 원인 (확정)
hover 확대(`scale-[3]`/`scale-[4]`)된 이모티콘 `<img>`가 `pointer-events:auto` + `z-50`이라 확대되면서 인접 셀 위로 올라앉아 마우스오버를 가로챈다. 그래서 옆 이모티콘에 hover가 안 걸린다. #13614에서 hover 확대를 iOS(터치)만 껐고 데스크톱은 확대를 유지해 남은 버그.

## 수정
- `emoticon-picker.svelte` (img): `pointer-events-none` 추가 → 확대 img가 포인터를 가로채지 않음. hover 판정은 버튼에서만.
- `reaction-bar.svelte` (img): `pointer-events-none` 추가 + hover 확대(scale/z)에 `@media(hover:hover)` 가드 추가 → emoticon-picker와 동일 패턴으로 통일(터치 기기 확대 억제 겸).

## 무영향
- 클릭(버튼 발화)·hover 상태·playAnimation(currentTarget=버튼)은 모두 버튼에 배선되어 있어 img의 pointer-events 변경과 무관.
- #13614 iOS 가드(`@media(hover:hover)`) 유지·강화.
- premium 무접촉. 하단 선택창 무접촉.

## 검증
- ⚠️ 노드 빌드/컴파일 미수행(CI가 대행). 정적 검토만.
- ⚠️ 최종은 데스크톱 실환경에서 인접 이모티콘 hover 연속 반응 확인 필요.