### PR TITLE
fix(web): getClientAddress() 직접 호출을 전면 차단 — CI 가드 + 용도별 폴백

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Check admin API auth guard
         run: node scripts/check-admin-api-guard.mjs
 
+      # getClientAddress() 직접 호출 가드 — 2026-08-19.
+      # ADDRESS_HEADER=x-real-ip 환경에서 그 헤더가 없으면 이 함수는 throw 한다.
+      # SSR 이 event.fetch 로 자기 API 를 부르는 경로에는 x-real-ip 가 없어서,
+      # 댓글 API 가 시간당 약 3.6만 건의 500 을 냈고 댓글이 통째로 안 실렸다.
+      # ⛔ hooks.server.ts 에 이미 같은 함정을 막는 헬퍼와 주석이 있었는데도 재발했다.
+      #    파일 안에만 있고 강제 장치가 없어서다. 주석으로는 못 막아 기계가 막는다.
+      - name: Check direct getClientAddress() calls
+        run: node scripts/check-client-address.mjs
+
   # 하이드레이션 AST 가드 — 두 검사가 pnpm install 을 공유한다.
   #
   #  1) 중첩 <a>  (2026-07-28)

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -58,6 +58,7 @@ void siteResolver.resolve('').catch(() => {}); // warm-up: load() 강제 실행
 
 import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
 import { mapGnuboardUrl, mapRhymixUrl } from '$lib/server/url-compat.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 // --- 환경별 접근 제어 (hostname → 환경변수 매핑) ---
 // 각 환경변수가 설정된 경우에만 해당 호스트에서 접근 제어 활성화
@@ -385,11 +386,9 @@ const CSRF_EXEMPT_PATHS = [
  * 향후 getClientAddress() 호출 추가 시에도 같은 문제를 방지합니다.
  */
 function safeGetClientAddress(event: Parameters<Handle>[0]['event']): string | null {
-    try {
-        return event.getClientAddress();
-    } catch {
-        return null;
-    }
+    // ⛔ 로직을 여기 두지 않는다. 이 파일 안에만 있던 탓에 다른 라우트가 같은 함정을
+    //    그대로 밟았다(2026-08-19 댓글 SSR 500). 정본은 rate-limit.ts 의 resolveClientIp 하나다.
+    return resolveClientIp(() => event.getClientAddress(), event.request);
 }
 
 function getGlobalApiRateLimitKey(
@@ -943,6 +942,12 @@ const handleInner: Handle = async ({ event, resolve }) => {
     }
 
     // Rate limiting: 인증 관련 엔드포인트 보호 (SSR 내부 fetch는 IP 없으므로 건너뜀)
+    //
+    // ⛔ 여기서 건너뛰는 것은 의도적이다. 'unknown' 공용 버킷으로 바꾸지 마라 —
+    //    SSR 내부 fetch 가 인증 경로를 지날 때 자기 자신을 429 로 막게 된다.
+    //    IP 를 못 구했을 때의 인증 남용 방어는 **라우트 단**에서 한다
+    //    (api/auth/login · register · password-reset · login/review 가
+    //     resolvedIp ?? 'unknown' 으로 제한을 유지한다). 계층이 다르다.
     const rateLimitRule = RATE_LIMITED_PATHS.find((r) => pathname.startsWith(r.path));
     if (rateLimitRule) {
         const clientIp = safeGetClientAddress(event);

--- a/apps/web/src/routes/[boardId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/+page.server.ts
@@ -27,6 +27,7 @@ import { applyFilter } from '$lib/hooks/registry.js';
 import { buildHookContext } from '$lib/hooks/context.js';
 import { getBoardOwnerContext, getBoardIntro } from '$lib/server/board-owner';
 import { sanitizeIntroHtml } from '$lib/server/sanitize';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 // --- 인메모리 캐시: 비로그인 게시글 목록 (15초 TTL) ---
 interface PostsCacheData {
@@ -177,6 +178,7 @@ export const load: PageServerLoad = async ({
     url,
     params,
     locals,
+    request,
     getClientAddress,
     isDataRequest,
     setHeaders
@@ -868,12 +870,7 @@ export const load: PageServerLoad = async ({
     // 진실의방 워터마크 데이터 (목록 페이지)
     let watermark: { nickname: string; userId: string; clientIp: string } | null = null;
     if (boardId === 'truthroom') {
-        let clientIp = '';
-        try {
-            clientIp = getClientAddress();
-        } catch {
-            clientIp = '';
-        }
+        let clientIp = resolveClientIp(getClientAddress, request) ?? '';
         watermark = {
             nickname: locals.user?.nickname || '',
             userId: locals.user?.id || '',

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -41,6 +41,7 @@ import { getPostAspects, type AspectRating } from '$lib/server/rating-aspects.js
 import { getBoardAspectPreset } from '$plugins/angtt-review/lib/aspect-presets';
 import { fetchAngmapArchiveRating } from '$lib/server/angmap-archive-rating.js';
 import { getBoardOwnerContext } from '$lib/server/board-owner';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 /**
  * 게시글 상세 페이지 — Streaming SSR
@@ -94,6 +95,7 @@ export const load: PageServerLoad = async ({
     locals,
     url,
     cookies,
+    request,
     getClientAddress,
     setHeaders,
     isDataRequest
@@ -365,12 +367,7 @@ export const load: PageServerLoad = async ({
             const alreadyViewedByCookie = viewed.includes(vcKey);
 
             // 서버 사이드 IP 기반 중복 방지 (Redis — pod 간 공유)
-            let clientIp = '';
-            try {
-                clientIp = getClientAddress();
-            } catch {
-                clientIp = '';
-            }
+            let clientIp = resolveClientIp(getClientAddress, request) ?? '';
             const alreadyViewedByIp = clientIp
                 ? await hasRecentlyViewed(clientIp, boardId, Number(postId))
                 : false;
@@ -790,12 +787,7 @@ export const load: PageServerLoad = async ({
                 hasLockedComment) &&
             locals.user
         ) {
-            let clientIp = '';
-            try {
-                clientIp = getClientAddress();
-            } catch {
-                clientIp = '';
-            }
+            let clientIp = resolveClientIp(getClientAddress, request) ?? '';
             watermark = {
                 nickname: locals.user?.nickname || '',
                 userId: locals.user?.id || '',
@@ -807,12 +799,7 @@ export const load: PageServerLoad = async ({
         // 로그인 사용자에게만 발급 — 익명 SSR/데이터 캐시 응답에 IP 가 잔존하지 않게 한다.
         let disciplineViewer: { nickname: string; userId: string; clientIp: string } | null = null;
         if (locals.user) {
-            let clientIp = '';
-            try {
-                clientIp = getClientAddress();
-            } catch {
-                clientIp = '';
-            }
+            let clientIp = resolveClientIp(getClientAddress, request) ?? '';
             disciplineViewer = {
                 nickname: locals.user.nickname || '',
                 userId: locals.user.id || '',

--- a/apps/web/src/routes/api/auth/login/+server.ts
+++ b/apps/web/src/routes/api/auth/login/+server.ts
@@ -11,7 +11,12 @@ import {
 import { generateRefreshToken } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { getMemberById } from '$lib/server/auth/oauth/member.js';
-import { checkRateLimit, recordAttempt, resetAttempts } from '$lib/server/rate-limit.js';
+import {
+    checkRateLimit,
+    recordAttempt,
+    resetAttempts,
+    resolveClientIp
+} from '$lib/server/rate-limit.js';
 import { checkAndPromoteMember } from '$lib/server/auth/auto-promotion.js';
 import { grantLoginXP } from '$lib/server/auth/xp-grant.js';
 
@@ -28,10 +33,17 @@ const COOKIE_DOMAIN = env.COOKIE_DOMAIN || '.damoang.net';
  * 3. 세션 쿠키 + CSRF 쿠키 설정
  */
 export const POST: RequestHandler = async ({ request, cookies, getClientAddress }) => {
-    const clientIp = getClientAddress();
+    // [B 인증·남용 방지] IP 를 못 구해도 **제한을 건너뛰지 않는다.**
+    // ⛔ 건너뛰면 로그인·가입 무제한 시도가 조용히 열린다. 막히면 즉시 제보가 들어오지만
+    //    뚫리면 아무도 모른다 — fail-closed 를 택한다(2026-08-19).
+    // ⛔ 기록·캡차에는 공용 버킷 키를 쓰지 않는다. 'unknown' 이 mb_ip 에 저장되거나
+    //    Turnstile remoteip 로 나가면 데이터가 오염되고 검증이 깨진다.
+    const resolvedIp = resolveClientIp(getClientAddress, request);
+    const clientIp = resolvedIp ?? '';
+    const rateKey = resolvedIp ?? 'unknown';
 
     // Rate limiting
-    const rateCheck = checkRateLimit(clientIp, 'login', 10, 15 * 60 * 1000);
+    const rateCheck = checkRateLimit(rateKey, 'login', 10, 15 * 60 * 1000);
     if (!rateCheck.allowed) {
         return json(
             { success: false, message: '로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요.' },
@@ -41,7 +53,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
             }
         );
     }
-    recordAttempt(clientIp, 'login');
+    recordAttempt(rateKey, 'login');
 
     const body = await request.json();
     const { username, password } = body;
@@ -88,7 +100,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
         }
 
         // 로그인 성공 → Rate limit 초기화
-        resetAttempts(clientIp, 'login');
+        resetAttempts(rateKey, 'login');
 
         const mbId = userData.user.user_id;
 

--- a/apps/web/src/routes/api/boards/[boardId]/manage/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/manage/+server.ts
@@ -12,6 +12,7 @@ import pool from '$lib/server/db';
 import { getAuthUser } from '$lib/server/auth';
 import { getBoardOwnerContext, setBoardIntro } from '$lib/server/board-owner';
 import { sanitizeIntroHtml } from '$lib/server/sanitize';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 /** 소개글 상한 — 무제한이면 저장소·화면 모두 감당이 안 된다. */
 // HTML 커스텀 영역(구글 캘린더 iframe + 이미지)을 고려한 상한 — 2,000자로는 부족했다.
@@ -109,7 +110,7 @@ export const PATCH: RequestHandler = async ({ params, request, cookies, getClien
                 user!.mb_id,
                 boardId,
                 JSON.stringify({ changed, is_owner: ctx.isOwner, is_site_admin: ctx.isSiteAdmin }),
-                getClientAddress()
+                resolveClientIp(getClientAddress, request) ?? ''
             ]
         );
     } catch {

--- a/apps/web/src/routes/api/boards/[boardId]/posts/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/+server.ts
@@ -7,7 +7,7 @@ import type { RequestHandler } from './$types';
 import type { RowDataPacket } from 'mysql2';
 import pool from '$lib/server/db';
 import { isInternalAppRequest } from '$lib/server/internal-api.js';
-import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
+import { checkRateLimit, recordAttempt, resolveClientIp } from '$lib/server/rate-limit.js';
 
 interface Post {
     wr_id: number;
@@ -46,23 +46,27 @@ export const GET: RequestHandler = async ({ params, url, request, getClientAddre
 
     // 외부(브라우저) 요청 rate-limit — 정상 페이지네이션 허용, 대량 호출만 차단.
     if (!isInternalRequest) {
-        const ip = getClientAddress();
-        const rl = checkRateLimit(
-            ip,
-            'board-posts',
-            EXTERNAL_POSTS_RATE_LIMIT,
-            EXTERNAL_POSTS_RATE_WINDOW_MS
-        );
-        if (!rl.allowed) {
-            return json(
-                { success: false, error: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
-                {
-                    status: 429,
-                    headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
-                }
+        // [A 공개 읽기] IP 를 못 구하면 제한을 건너뛴다 — 키 없이는 제한을 걸 수 없고,
+        // 못 건다는 이유로 요청을 죽이면 SSR 이 통째로 깨진다(2026-08-19 댓글 사고).
+        const ip = resolveClientIp(getClientAddress, request);
+        if (ip) {
+            const rl = checkRateLimit(
+                ip,
+                'board-posts',
+                EXTERNAL_POSTS_RATE_LIMIT,
+                EXTERNAL_POSTS_RATE_WINDOW_MS
             );
+            if (!rl.allowed) {
+                return json(
+                    { success: false, error: '요청이 너무 잦습니다. 잠시 후 다시 시도해주세요.' },
+                    {
+                        status: 429,
+                        headers: rl.retryAfter ? { 'Retry-After': String(rl.retryAfter) } : {}
+                    }
+                );
+            }
+            recordAttempt(ip, 'board-posts');
         }
-        recordAttempt(ip, 'board-posts');
     }
 
     // boardId 유효성 검사 (영문, 숫자, 언더스코어만 허용)

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/[commentId]/like/+server.ts
@@ -19,6 +19,7 @@ import {
     invalidateReactionCaches,
     syncFeedReactionCounts
 } from '$lib/server/member-activity-cache.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 interface GoodRow extends RowDataPacket {
     bg_flag: string;
@@ -374,7 +375,10 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
         } else {
             // 추가
             // IP 보호: super admin/지정 멤버는 실제 IP 대신 치환 IP 기록 (Go 미들웨어와 동일 규칙)
-            const clientIp = protectClientIp(user, getClientAddress());
+            const clientIp = protectClientIp(
+                user,
+                resolveClientIp(getClientAddress, request) ?? ''
+            );
             await conn.query(
                 `INSERT INTO g5_board_good (bo_table, wr_id, mb_id, bg_flag, bg_datetime, bg_ip) VALUES (?, ?, ?, ?, CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?)`,
                 [safeBoardId, safeCommentId, user.mb_id, action, clientIp]

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/like/+server.ts
@@ -21,6 +21,7 @@ import {
     invalidateReactionCaches,
     syncFeedReactionCounts
 } from '$lib/server/member-activity-cache.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 interface GoodRow extends RowDataPacket {
     bg_flag: string;
@@ -419,7 +420,10 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
         } else {
             // 추가 (INSERT + 카운트 증가)
             // IP 보호: super admin/지정 멤버는 실제 IP 대신 치환 IP 기록 (Go 미들웨어와 동일 규칙)
-            const clientIp = protectClientIp(user, getClientAddress());
+            const clientIp = protectClientIp(
+                user,
+                resolveClientIp(getClientAddress, request) ?? ''
+            );
             await conn.query(
                 `INSERT INTO g5_board_good (bo_table, wr_id, mb_id, bg_flag, bg_datetime, bg_ip) VALUES (?, ?, ?, ?, CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '+09:00'), ?)`,
                 [safeBoardId, safePostId, user.mb_id, action, clientIp]

--- a/apps/web/src/routes/api/boards/[boardId]/support/actions/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/support/actions/+server.ts
@@ -31,6 +31,7 @@ import {
     countActiveSupportLocks,
     getLastSupportAction
 } from '$lib/server/board-support';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 const REASON_MAX = 200;
 /** 보드당 동시 잠금 상한 — 남용(무더기 잠금) 1차 방어선 */
@@ -149,7 +150,7 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
                     reason,
                     subject: summary.subject
                 }),
-                getClientAddress()
+                resolveClientIp(getClientAddress, request) ?? ''
             ]);
             await conn.commit();
         } catch (e) {
@@ -214,7 +215,7 @@ export const POST: RequestHandler = async ({ params, request, cookies, getClient
                 reason,
                 subject: summary.subject
             }),
-            getClientAddress()
+            resolveClientIp(getClientAddress, request) ?? ''
         ]);
         await conn.commit();
     } catch (e) {

--- a/apps/web/src/routes/api/reactions/+server.ts
+++ b/apps/web/src/routes/api/reactions/+server.ts
@@ -14,6 +14,7 @@ import { checkCertification } from '$lib/server/certification';
 import { protectClientIp } from '$lib/server/ip-protection';
 import { fetchReactionsByParentId } from '$lib/server/reactions';
 import { loadPluginServerLib } from '$lib/server/plugin-server-loader.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 const REACTION_LIMIT = 20;
 const VALID_REACTION_PATTERN = /^[a-zA-Z0-9:_-]+$/;
@@ -278,12 +279,7 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
 
         // 클라이언트 IP (PHP chosen_ip 호환)
         // IP 보호: super admin/지정 멤버는 실제 IP 대신 치환 IP 기록 (Go 미들웨어와 동일 규칙)
-        let clientIp = '';
-        try {
-            clientIp = protectClientIp(user, getClientAddress());
-        } catch {
-            // IP 가져오기 실패 시 빈 문자열
-        }
+        let clientIp = protectClientIp(user, resolveClientIp(getClientAddress, request) ?? '');
 
         if (!existing[0]) {
             // 리액션 추가

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -50,6 +50,7 @@ import {
     computeWithdrawalGrace,
     signWithdrawalGraceToken
 } from '$lib/server/auth/withdrawal.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 // 미설정 시 .damoang.net 으로 폴백 — host-only 쿠키가 되면 새 탭/PWA 에서 세션이 격리됨 (#12260, #12179).
 const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
@@ -534,7 +535,7 @@ export const GET: RequestHandler = async ({
         redirectError('missing_params', peekAppMode(cookies, stateParam));
     }
 
-    const clientIp = getClientAddress();
+    const clientIp = resolveClientIp(getClientAddress, request) ?? '';
     const origin = resolveOrigin(request);
     return handleCallback(params.provider!, cookies, locals, code, stateParam, clientIp, origin);
 };
@@ -560,7 +561,7 @@ export const POST: RequestHandler = async ({
         redirectError('missing_params', peekAppMode(cookies, stateParam));
     }
 
-    const clientIp = getClientAddress();
+    const clientIp = resolveClientIp(getClientAddress, request) ?? '';
     const origin = resolveOrigin(request);
     return handleCallback(params.provider!, cookies, locals, code, stateParam, clientIp, origin);
 };

--- a/apps/web/src/routes/auth/native/apple/+server.ts
+++ b/apps/web/src/routes/auth/native/apple/+server.ts
@@ -31,6 +31,7 @@ import {
 } from '$lib/server/auth/register.js';
 import { generateAppLoginCode } from '$lib/server/auth/jwt.js';
 import type { OAuthUserProfile } from '$lib/server/auth/oauth/types.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 const APPLE_ISSUER = 'https://appleid.apple.com';
 // Apple 공개키(JWKS)는 회전되므로 원격 세트로 검증(jose 가 캐시/회전 처리)
@@ -166,7 +167,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
                     mb_nick: nickname,
                     mb_email: verifiedEmail,
                     mb_name: nickname,
-                    mb_ip: getClientAddress(),
+                    mb_ip: resolveClientIp(getClientAddress, request) ?? '',
                     skipNickLock: true
                 });
             }

--- a/apps/web/src/routes/go/+server.ts
+++ b/apps/web/src/routes/go/+server.ts
@@ -9,6 +9,7 @@
 import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { logAffiliateClick } from '$lib/server/affiliate-click-log';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 /** 허용된 프로토콜 (open redirect 방지) */
 const ALLOWED_PROTOCOLS = ['https:', 'http:'];
@@ -44,12 +45,7 @@ export const GET: RequestHandler = async ({ url, locals, getClientAddress, reque
     }
 
     // 클릭 로깅 (fire-and-forget — 리다이렉트를 블로킹하지 않음)
-    let clientIp = '';
-    try {
-        clientIp = getClientAddress();
-    } catch {
-        clientIp = '';
-    }
+    let clientIp = resolveClientIp(getClientAddress, request) ?? '';
 
     void logAffiliateClick({
         userId: locals.user?.id,

--- a/apps/web/src/routes/go/[id]/+server.ts
+++ b/apps/web/src/routes/go/[id]/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { logAffiliateClick } from '$lib/server/affiliate-click-log';
 import { resolveAffiliateRedirectFromStorage } from '$lib/server/affiliate-links';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 const ALLOWED_PROTOCOLS = ['https:', 'http:'];
 
@@ -22,12 +23,7 @@ export const GET: RequestHandler = async ({ params, locals, getClientAddress, re
         throw redirect(302, '/');
     }
 
-    let clientIp = '';
-    try {
-        clientIp = getClientAddress();
-    } catch {
-        clientIp = '';
-    }
+    let clientIp = resolveClientIp(getClientAddress, request) ?? '';
 
     void logAffiliateClick({
         userId: locals.user?.id,

--- a/apps/web/src/routes/login/review/+page.server.ts
+++ b/apps/web/src/routes/login/review/+page.server.ts
@@ -26,7 +26,12 @@ import { generateRefreshToken } from '$lib/server/auth/jwt.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { getMemberById } from '$lib/server/auth/oauth/member.js';
 import { issueUserBasicCookie } from '$lib/server/auth/user-basic.js';
-import { checkRateLimit, recordAttempt, resetAttempts } from '$lib/server/rate-limit.js';
+import {
+    checkRateLimit,
+    recordAttempt,
+    resetAttempts,
+    resolveClientIp
+} from '$lib/server/rate-limit.js';
 
 // 미설정 시 .damoang.net 폴백 — host-only 쿠키 시 새 탭/PWA 세션 격리 (#12260, #12179).
 const COOKIE_DOMAIN = env.COOKIE_DOMAIN || '.damoang.net';
@@ -66,12 +71,19 @@ export const actions: Actions = {
         const cfg = reviewConfig();
         if (!cfg) throw error(404, 'Not Found');
 
-        const clientIp = getClientAddress();
-        const rate = checkRateLimit(clientIp, 'review-login', 10, 15 * 60 * 1000);
+        // [B 인증·남용 방지] IP 를 못 구해도 **제한을 건너뛰지 않는다.**
+        // ⛔ 건너뛰면 로그인·가입 무제한 시도가 조용히 열린다. 막히면 즉시 제보가 들어오지만
+        //    뚫리면 아무도 모른다 — fail-closed 를 택한다(2026-08-19).
+        // ⛔ 기록·캡차에는 공용 버킷 키를 쓰지 않는다. 'unknown' 이 mb_ip 에 저장되거나
+        //    Turnstile remoteip 로 나가면 데이터가 오염되고 검증이 깨진다.
+        const resolvedIp = resolveClientIp(getClientAddress, request);
+        const clientIp = resolvedIp ?? '';
+        const rateKey = resolvedIp ?? 'unknown';
+        const rate = checkRateLimit(rateKey, 'review-login', 10, 15 * 60 * 1000);
         if (!rate.allowed) {
             return fail(429, { message: '시도가 너무 많습니다. 잠시 후 다시 시도해주세요.' });
         }
-        recordAttempt(clientIp, 'review-login');
+        recordAttempt(rateKey, 'review-login');
 
         const data = await request.formData();
         const username = String(data.get('username') ?? '');
@@ -92,7 +104,7 @@ export const actions: Actions = {
             return fail(500, { message: '심사용 계정을 찾을 수 없습니다. 운영자에게 문의하세요.' });
         }
 
-        resetAttempts(clientIp, 'review-login');
+        resetAttempts(rateKey, 'review-login');
 
         // OAuth 콜백 / 일반 로그인과 동일한 세션·쿠키 스택 발급
         const session = await createSession(member.mb_id, {

--- a/apps/web/src/routes/member/leave/cancel/+page.server.ts
+++ b/apps/web/src/routes/member/leave/cancel/+page.server.ts
@@ -25,6 +25,7 @@ import {
     computeWithdrawalGrace,
     cancelMemberLeave
 } from '$lib/server/auth/withdrawal.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
 
@@ -74,7 +75,7 @@ export const actions: Actions = {
             return fail(403, { error: '이미 탈퇴가 확정되어 취소할 수 없습니다.' });
         }
 
-        const clientIp = getClientAddress();
+        const clientIp = resolveClientIp(getClientAddress, request) ?? '';
 
         // 백엔드 탈퇴 취소 (DELETE /api/v1/members/me/leave)
         try {

--- a/apps/web/src/routes/password-reset/+page.server.ts
+++ b/apps/web/src/routes/password-reset/+page.server.ts
@@ -9,23 +9,30 @@ import {
     sendPasswordResetEmail
 } from '$lib/server/auth/password-reset.js';
 import { verifyTurnstile } from '$lib/server/captcha.js';
-import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
+import { checkRateLimit, recordAttempt, resolveClientIp } from '$lib/server/rate-limit.js';
 
 export const actions: Actions = {
     default: async ({ request, getClientAddress }) => {
-        const clientIp = getClientAddress();
+        // [B 인증·남용 방지] IP 를 못 구해도 **제한을 건너뛰지 않는다.**
+        // ⛔ 건너뛰면 로그인·가입 무제한 시도가 조용히 열린다. 막히면 즉시 제보가 들어오지만
+        //    뚫리면 아무도 모른다 — fail-closed 를 택한다(2026-08-19).
+        // ⛔ 기록·캡차에는 공용 버킷 키를 쓰지 않는다. 'unknown' 이 mb_ip 에 저장되거나
+        //    Turnstile remoteip 로 나가면 데이터가 오염되고 검증이 깨진다.
+        const resolvedIp = resolveClientIp(getClientAddress, request);
+        const clientIp = resolvedIp ?? '';
+        const rateKey = resolvedIp ?? 'unknown';
         const formData = await request.formData();
         const email = (formData.get('email') as string)?.trim() || '';
 
         // Rate limit 체크 (5회/시간)
-        const rateCheck = checkRateLimit(clientIp, 'password-reset', 5, 60 * 60 * 1000);
+        const rateCheck = checkRateLimit(rateKey, 'password-reset', 5, 60 * 60 * 1000);
         if (!rateCheck.allowed) {
             return fail(429, {
                 error: `요청이 너무 많습니다. ${rateCheck.retryAfter}초 후 다시 시도해주세요.`,
                 email
             });
         }
-        recordAttempt(clientIp, 'password-reset');
+        recordAttempt(rateKey, 'password-reset');
 
         // Turnstile CAPTCHA 검증
         const turnstileToken = (formData.get('cf-turnstile-response') as string) || '';

--- a/apps/web/src/routes/plugin/social/+server.ts
+++ b/apps/web/src/routes/plugin/social/+server.ts
@@ -28,6 +28,7 @@ import { AppleProvider } from '$lib/server/auth/oauth/providers/apple.js';
 import { TwitterProvider } from '$lib/server/auth/oauth/providers/twitter.js';
 import type { OAuthUserProfile } from '$lib/server/auth/oauth/types.js';
 import { runSocialLoginPostProcess } from '$lib/server/auth/social-login-postprocess.js';
+import { resolveClientIp } from '$lib/server/rate-limit.js';
 
 // 미설정 시 prod 에서 .damoang.net 으로 폴백 — host-only 쿠키 시 새 탭/PWA 세션 격리 (#12260, #12179).
 const COOKIE_DOMAIN = env.COOKIE_DOMAIN || (dev ? undefined : '.damoang.net');
@@ -245,7 +246,7 @@ export const GET: RequestHandler = async ({ url, cookies, request, getClientAddr
         redirect(302, '/login?error=missing_params');
     }
 
-    const clientIp = getClientAddress();
+    const clientIp = resolveClientIp(getClientAddress, request) ?? '';
     const origin = resolveOrigin(request);
     return handleCallback(url, cookies, code, stateParam, clientIp, origin);
 };
@@ -265,7 +266,7 @@ export const POST: RequestHandler = async ({ url, cookies, request, getClientAdd
         redirect(302, '/login?error=missing_params');
     }
 
-    const clientIp = getClientAddress();
+    const clientIp = resolveClientIp(getClientAddress, request) ?? '';
     const origin = resolveOrigin(request);
     return handleCallback(url, cookies, code, stateParam, clientIp, origin);
 };

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -32,7 +32,7 @@ import {
 import type { OAuthUserProfile, SocialProvider } from '$lib/server/auth/oauth/types.js';
 import { setDamoangSSOCookie } from '$lib/server/auth/sso-cookie.js';
 import { verifyTurnstile } from '$lib/server/captcha.js';
-import { checkRateLimit, recordAttempt } from '$lib/server/rate-limit.js';
+import { checkRateLimit, recordAttempt, resolveClientIp } from '$lib/server/rate-limit.js';
 import { getCertConfig } from '$lib/server/auth/cert-inicis.js';
 import { getContent, getSiteTitle, replaceContentVariables } from '$lib/server/content.js';
 import { sanitizePostContent } from '$lib/server/sanitize.js';
@@ -136,7 +136,14 @@ export const load: PageServerLoad = async ({ url, cookies }) => {
 export const actions: Actions = {
     default: async ({ request, cookies, getClientAddress }) => {
         console.log('[Register] Action started');
-        const clientIp = getClientAddress();
+        // [B 인증·남용 방지] IP 를 못 구해도 **제한을 건너뛰지 않는다.**
+        // ⛔ 건너뛰면 로그인·가입 무제한 시도가 조용히 열린다. 막히면 즉시 제보가 들어오지만
+        //    뚫리면 아무도 모른다 — fail-closed 를 택한다(2026-08-19).
+        // ⛔ 기록·캡차에는 공용 버킷 키를 쓰지 않는다. 'unknown' 이 mb_ip 에 저장되거나
+        //    Turnstile remoteip 로 나가면 데이터가 오염되고 검증이 깨진다.
+        const resolvedIp = resolveClientIp(getClientAddress, request);
+        const clientIp = resolvedIp ?? '';
+        const rateKey = resolvedIp ?? 'unknown';
         const formData = await request.formData();
         const redirectUrl = safeRedirectUrl(formData.get('redirect') as string);
         const isInviteFlow = redirectUrl.includes('ads.damoang.net/invite/');
@@ -147,14 +154,14 @@ export const actions: Actions = {
         const isRecovery = formData.get('intent') === 'recover';
 
         // Rate limit 체크 (5회/시간)
-        const rateCheck = checkRateLimit(clientIp, 'register', 5, 60 * 60 * 1000);
+        const rateCheck = checkRateLimit(rateKey, 'register', 5, 60 * 60 * 1000);
         if (!rateCheck.allowed) {
             return fail(429, {
                 error: `요청이 너무 많습니다. ${rateCheck.retryAfter}초 후 다시 시도해주세요.`,
                 nickname
             });
         }
-        recordAttempt(clientIp, 'register');
+        recordAttempt(rateKey, 'register');
 
         // Turnstile CAPTCHA 검증 (초대·복구 플로우는 소셜 인증 완료 상태이므로 스킵)
         if (!isInviteFlow && !isRecovery) {

--- a/scripts/check-client-address.mjs
+++ b/scripts/check-client-address.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * `getClientAddress()` 직접 호출 금지 검사.
+ *
+ * adapter-node 에 `ADDRESS_HEADER=x-real-ip` 가 설정돼 있으면, 그 헤더가 없는 요청에서
+ * `getClientAddress()` 는 값을 돌려주지 않고 **throw** 한다. 핸들러 최상단에서 부르면
+ * try 밖이라 그대로 500 이 된다.
+ *
+ * 헤더가 없는 요청은 예외 상황이 아니라 **일상 경로**다. SvelteKit 의 `event.fetch` 로
+ * 서버가 자기 API 를 부를 때(SSR) 쿠키·인증 헤더만 승계되고 x-real-ip 는 실리지 않는다.
+ *
+ * 실제 사고: 2026-08-19. 글 상세 SSR 이 event.fetch 로 댓글 API 를 부르는데 이 throw 로
+ * 500 이 나면서 **댓글이 통째로 안 실렸다**. 운영 18파드 환산 시간당 약 3.6만 건.
+ * 화면에는 "리플 (4)" 인데 댓글이 0개로 보였고, 회원 제보로 알았다(free/7060456).
+ *
+ * ⛔ 이 사고가 특히 아픈 이유: `hooks.server.ts` 에 이미 같은 함정을 설명하는 헬퍼와
+ *    "이 헬퍼로 통일하면 향후 호출 추가 시에도 방지된다"는 주석이 **이미 있었다.**
+ *    그런데 그 헬퍼가 파일 안에만 있었고 강제하는 장치가 없어서, 새 라우트가 그대로 밟았다.
+ *    주석과 선의로는 못 막는다. 그래서 기계가 막는다.
+ *
+ * 규칙: `getClientAddress()` 호출은 `resolveClientIp()`(lib/server/rate-limit.ts) 안에서만.
+ *       라우트에서는 `resolveClientIp(getClientAddress, request)` 로 받아 쓴다.
+ *
+ * 값이 없을 때의 처리는 용도마다 다르다 — 하나로 통일하지 마라:
+ *   · 공개 읽기 API   → 속도제한을 **건너뛴다** (키 없이는 못 건다. 죽이는 건 더 나쁘다)
+ *   · 인증·남용 방지  → `?? 'unknown'` 공용 버킷으로 **제한을 유지한다** (fail-closed).
+ *                      ⛔ 기록·캡차에 이 값을 쓰지 마라. mb_ip 오염·Turnstile 실패로 이어진다
+ *   · IP 기록        → `?? ''` (키는 유지하고 값만 비운다)
+ *
+ * 검사 대상: apps/web/src/**\/*.ts (ALLOWLIST 제외)
+ * 종료코드: 위반 1건 이상이면 1
+ */
+import { readFileSync, globSync } from 'node:fs';
+
+// 정본 헬퍼가 사는 곳. 여기서만 직접 호출할 수 있다.
+const ALLOWLIST = new Set(['apps/web/src/lib/server/rate-limit.ts']);
+
+const CALL = /getClientAddress\s*\(\s*\)/;
+
+const files = globSync('apps/web/src/**/*.ts', {
+    exclude: (p) => p.includes('node_modules')
+});
+
+let violations = 0;
+
+for (const file of files) {
+    const rel = file.replaceAll('\\', '/');
+    if (ALLOWLIST.has(rel)) continue;
+
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+        if (!CALL.test(line)) return;
+
+        const trimmed = line.trim();
+        // 주석은 검사 대상이 아니다 — 이 규칙 자체를 설명하는 주석이 많다.
+        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
+        // 정본 헬퍼에 넘기는 형태는 허용한다.
+        //   resolveClientIp(getClientAddress, request)
+        //   resolveClientIp(() => event.getClientAddress(), event.request)
+        if (line.includes('resolveClientIp(')) return;
+
+        violations++;
+        console.error(
+            `${rel}:${i + 1}  getClientAddress() 직접 호출 — resolveClientIp(getClientAddress, request) 를 쓸 것\n` +
+                `    ${trimmed.slice(0, 100)}`
+        );
+    });
+}
+
+if (violations > 0) {
+    console.error(
+        `\n⛔ getClientAddress() 직접 호출 ${violations}건.\n` +
+            `   x-real-ip 가 없는 요청(SSR 의 event.fetch 등)에서 throw → 500 이 된다.\n` +
+            `   정본: apps/web/src/lib/server/rate-limit.ts 의 resolveClientIp()\n` +
+            `   값이 없을 때의 처리는 용도별로 다르다 — 이 파일 상단 주석을 읽을 것.\n`
+    );
+    process.exit(1);
+}
+
+console.log(`✅ getClientAddress() 직접 호출 없음 (${files.length}개 파일 검사)`);


### PR DESCRIPTION
어제 사고(#2125)는 개별 실수가 아니라 **구조 문제**였다.

`hooks.server.ts` 에 이미 같은 함정을 막는 헬퍼와, 이런 주석이 **있었는데도** 재발했다:

> *"SSR 내부 fetch(svelteKitFetch)로 호출된 요청에는 해당 헤더가 없어 getClientAddress()가 throw합니다. **이 헬퍼로 통일하면 향후 getClientAddress() 호출 추가 시에도 같은 문제를 방지합니다.**"*

헬퍼가 그 파일 안에만 있었고(export 안 됨) 강제하는 장치가 없었다. 새 라우트가 그대로 밟았다.
**주석과 선의로는 못 막는다. 기계가 막게 한다.**

## 정본화

- `resolveClientIp()`(`lib/server/rate-limit.ts`) 하나로 통일. `hooks.server.ts` 의 중복 헬퍼는 여기에 위임
- **`scripts/check-client-address.mjs` 신설** — 라우트에서 직접 호출하면 CI 실패.
  의존성이 필요 없어 기존 dependency-free 가드 잡(`HTML Comment Guard`)에 스텝으로 붙였다

## 값이 없을 때의 처리는 용도마다 다르다 — 하나로 통일하지 않았다

| 분류 | 대상 | 처리 | 근거 |
|---|---|---|---|
| **A** 공개 읽기 | posts 목록, 댓글 3종 | 제한 **건너뜀** | 키 없이는 못 건다. 죽이면 SSR 이 통째로 깨진다 |
| **B** 인증·남용 | login·register·password-reset·review | `?? 'unknown'` 버킷으로 **제한 유지** | 건너뛰면 무제한 시도가 조용히 열린다. 막히면 제보가 오지만 뚫리면 아무도 모른다 → fail-closed |
| **C** IP 기록 | like·reactions·support·social·callback·apple·go | `?? ''` | 키는 유지하고 값만 비운다(#604) |

⛔ **B 에서 기록·캡차에는 버킷 키를 쓰지 않는다.** `'unknown'` 이 `mb_ip` 에 저장되거나
Turnstile `remoteip` 로 나가면 데이터가 오염되고 검증이 깨진다.
그래서 `clientIp`(기록용 `?? ''`)와 `rateKey`(제한용)를 **분리**했다.

## 건드리지 않은 것

`hooks.server.ts` 의 전역 인증 rate-limit 은 IP 가 없으면 **계속 건너뛴다.**
`'unknown'` 으로 바꾸면 SSR 내부 fetch 가 인증 경로를 지날 때 자기 자신을 429 로 막는다.
그 층의 방어는 라우트 단(B)이 맡는다 — 근거를 코드 주석으로 남겼다.

## 검증

- 가드 스크립트 통과 (835개 파일)
- **대조군**: 일부러 위반을 주입하면 `exit 1` 로 검출, 복원 시 다시 통과 — 확인함
- 남은 직접 호출 2곳은 정본 헬퍼 자신과 hooks 위임뿐