### PR TITLE
obs(hydration): anchor 실패에 DOM 서명 전후 비교를 실어 원인 특정 가능하게

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -381,6 +381,34 @@
             // 여기 해당한다. 앵커 노드를 붙잡아 두고 마운트 후 isConnected 를 보면
             // 폐기 여부를 확정할 수 있다. 비용은 노드 참조 1개 + boolean 1회.
             (function () {
+                // ⛔ 여기서 "왜" 는 알 수 없다. 폐기 판정은 마운트 후에나 가능한데,
+                //    그때 스택을 떠봐야 onMount 의 스택일 뿐 원인 지점이 아니다.
+                //    (2026-08-19: anchor_detached 3,302명/일인데 원인 미특정이었다)
+                //
+                //    대신 **하이드레이션 직전의 DOM 서명**을 남겨 둔다. 마운트 후 같은
+                //    서명을 다시 떠서 비교하면, SSR 과 하이드레이션 사이에 노드가
+                //    끼어들었는지(광고 스크립트·확장·번역기) 데이터로 갈린다.
+                //    ⛔ 이 스크립트는 구형 브라우저에서도 돌아야 한다 — ES5 로 쓴다.
+                function bodySig() {
+                    var kids = document.body.children;
+                    var out = [];
+                    var lim = kids.length < 14 ? kids.length : 14;
+                    for (var i = 0; i < lim; i++) {
+                        var e = kids[i];
+                        var t = e.tagName.toLowerCase();
+                        if (e.id) t += '#' + e.id;
+                        else if (typeof e.className === 'string' && e.className)
+                            t += '.' + e.className.split(' ')[0];
+                        out.push(t);
+                    }
+                    if (kids.length > lim) out.push('+' + (kids.length - lim));
+                    return out.join(',');
+                }
+                try {
+                    window.__angpleBodySig = bodySig();
+                } catch (e) {
+                    /* 관측용 */
+                }
                 try {
                     var target = document.body.firstElementChild;
                     if (!target) return;

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -627,6 +627,44 @@
                           ? 'anchor_detached' // 하이드레이션 폐기 후 CSR 재마운트됨
                           : null;
                 if (reason) {
+                    // ⛔ 여기서 Error 를 만들어 스택을 떠도 소용없다. 이 코드는 onMount,
+                    //    즉 하이드레이션이 이미 폐기된 **뒤**라 onMount 의 스택만 나온다.
+                    //    원인 지점은 그보다 앞에서 이미 지나갔다.
+                    //
+                    //    그래서 스택 대신 **DOM 서명 전후 비교**를 싣는다. app.html 이
+                    //    하이드레이션 직전에 body 자식 서명을 남겨두므로, 지금 다시 떠서
+                    //    비교하면 그 사이에 노드가 끼어들었는지 데이터로 갈린다
+                    //    (광고 스크립트·브라우저 확장·번역기 주입 가설의 직접 검증).
+                    //
+                    //    ⛔ 수집기는 스키마에 없는 필드를 버린다(js_errors 컬럼 고정).
+                    //       그래서 부가 정보는 새 필드가 아니라 stack 에 실어 보낸다.
+                    const sigNow = (() => {
+                        try {
+                            const kids = Array.from(document.body.children).slice(0, 14);
+                            const parts = kids.map((e) => {
+                                let t = e.tagName.toLowerCase();
+                                if (e.id) t += `#${e.id}`;
+                                else if (typeof e.className === 'string' && e.className)
+                                    t += `.${e.className.split(' ')[0]}`;
+                                return t;
+                            });
+                            const extra = document.body.children.length - kids.length;
+                            if (extra > 0) parts.push(`+${extra}`);
+                            return parts.join(',');
+                        } catch {
+                            return '(sig-failed)';
+                        }
+                    })();
+                    const sigPre = String(w.__angpleBodySig ?? '(none)');
+                    const stack = [
+                        `at=${Math.round(performance.now())}ms`,
+                        '(anchor-context)',
+                        `pre=${sigPre}`,
+                        `post=${sigNow}`,
+                        `same=${sigPre === sigNow}`
+                    ]
+                        .join('\n')
+                        .slice(0, 1500);
                     fetch('https://aplog.damoang.net/api/v1/dantry', {
                         mode: 'cors',
                         credentials: 'include',
@@ -637,13 +675,15 @@
                             reason,
                             channel: 'anchor',
                             message: `hydration anchor ${reason}`,
-                            stack: '(no stack)',
+                            stack,
                             url: window.location.href,
                             userAgent: navigator.userAgent
                         })
                     }).catch(() => {});
                 }
                 delete w.__angpleHydrationAnchor;
+                // 서명도 함께 버린다 — 참조를 남기면 노드 누수와 같은 종류의 낭비다.
+                delete w.__angpleBodySig;
             }
         } catch {
             // 관측용이라 실패해도 무시


### PR DESCRIPTION
## 왜

`anchor_detached`/`anchor_missing` 은 **하루 3,302명 / 31,261건**(24h 실측, 85% 모바일)으로
수집되는 최대 오류다. 그런데 `stack` 이 문자열 `'(no stack)'` 으로 하드코딩돼 있어
**원인을 특정할 수 없다.** `hydration_locate.py` 를 돌리면 표본 0 건이다.

이게 왜 중요하냐면 — `classic.svelte:263` 의 2026-07-28 사고 기록에
> "증상은 **화면 깜빡임, 글쓰기 버튼 안 보임, 로그인 상태 잘못 표시**"

라고 적혀 있고, 이번 제보(`/free/7060456`)의 증상이 그 목록과 같다.

## ⛔ 스택을 만들지 않은 이유

여기서 `Error` 를 만들어 스택을 떠도 **소용없다.** 판정 코드는 `onMount`,
즉 하이드레이션이 **이미 폐기된 뒤**에 돈다 — `onMount` 의 스택만 나오고
원인 지점은 그보다 앞에서 지나갔다.

> 참고: console 경로를 타는 `hydration_mismatch` 는 `buildStack` 으로 이미 **99.99%** 합성
> 스택이 붙는다(실측). 그쪽은 `footer.svelte` **99.4%** 로 특정됐다. 문제는 anchor 계열뿐이다.

## 대신 무엇을 싣나

하이드레이션 **직전/직후 DOM 서명**을 비교한다.

| 시점 | 어디서 | 무엇 |
|---|---|---|
| 하이드레이션 직전 | `app.html` 인라인 스크립트 (앵커 캡처와 한 쌍) | `body` 직계 자식 서명 |
| 폐기 판정 시 | `+layout.svelte` `onMount` | 같은 서명 다시 + `pre`/`post`/`same` 전송 |

이러면 **"SSR 과 하이드레이션 사이에 노드가 끼어들었는가"** 가 데이터로 갈린다
(광고 스크립트·브라우저 확장·번역기 주입). 지금은 가설일 뿐이다.

## 제약을 지킨 부분

- ⛔ 수집기는 스키마에 없는 필드를 버린다(`js_errors` 컬럼 고정) → 새 필드가 아니라 `stack` 에 싣는다
- ⛔ `app.html` 스크립트는 구형 브라우저에서도 돌아야 한다 → **ES5** 로 작성
- 서명은 `body` 직계 자식 **14개까지**, 초과분은 개수로 축약(전송량 억제)
- 앵커 참조와 함께 서명도 `delete` (누수 방지)

## 검증

- prettier(svelte 플러그인 포함) 파싱·포맷 통과
- **관측 전용 — 사용자 동작 변화 없음**
- 배포 24h 뒤 확인: `anchor_detached` 의 `stack` 에 `pre=`/`post=`/`same=` 이 실리는지,
  `same=false` 비율이 얼마인지 → 주입 가설의 직접 판정