### PR TITLE
obs(hydration): 대조군 1% + 앵커가 사는 곳(앱 div) 내부 서명 추가

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -404,8 +404,29 @@
                     if (kids.length > lim) out.push('+' + (kids.length - lim));
                     return out.join(',');
                 }
+                // 하이드레이션 타깃(앱 div) **내부** 서명. 앵커 주석이 사는 곳이 여기다.
+                // body 서명만으로는 정상 로드와 구분이 안 됐다(스크립트는 늘 붙는다).
+                // 주석 노드까지 담아야 SSR 마커가 그대로인지 보인다.
+                function targetSig(el) {
+                    if (!el) return '(no-target)';
+                    var out = [];
+                    var n = el.firstChild;
+                    var i = 0;
+                    for (; n && i < 12; n = n.nextSibling, i++) {
+                        if (n.nodeType === 8) out.push('#' + String(n.data).slice(0, 3));
+                        else if (n.nodeType === 3) out.push('t');
+                        else if (n.nodeType === 1) {
+                            var t = n.tagName.toLowerCase();
+                            if (n.id) t += '#' + n.id;
+                            out.push(t);
+                        }
+                    }
+                    if (n) out.push('+');
+                    return out.join(',');
+                }
                 try {
                     window.__angpleBodySig = bodySig();
+                    window.__angpleTargetSig = targetSig(document.body.firstElementChild);
                 } catch (e) {
                     /* 관측용 */
                 }

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -608,6 +608,74 @@
         return () => window.removeEventListener('auth:session-expired', handleSessionExpired);
     });
 
+    // 하이드레이션 앵커 관측용 서명 헬퍼 (2026-08-19).
+    // ⛔ 실패한 로드만 보면 아무것도 못 가른다 — 정상 로드에서도 스크립트는 붙고
+    //    광고도 붙는다. 실제로 첫 배포(#2129) 데이터에서 광고 인과 가설이
+    //    "광고 없이 실패 91건 / 있고 실패 102건" 으로 기각됐다.
+    //    그래서 **성공 로드도 1% 표본으로 같은 서명을 보낸다.** 분포를 비교해야
+    //    실패에 특이한 신호가 무엇인지 갈린다.
+    const ANCHOR_OK_SAMPLE_RATE = 0.01;
+
+    function bodySigNow(): string {
+        try {
+            const kids = Array.from(document.body.children).slice(0, 14);
+            const parts = kids.map((e) => {
+                let t = e.tagName.toLowerCase();
+                if (e.id) t += `#${e.id}`;
+                else if (typeof e.className === 'string' && e.className)
+                    t += `.${e.className.split(' ')[0]}`;
+                return t;
+            });
+            const extra = document.body.children.length - kids.length;
+            if (extra > 0) parts.push(`+${extra}`);
+            return parts.join(',');
+        } catch {
+            return '(sig-failed)';
+        }
+    }
+
+    function targetSigNow(): string {
+        try {
+            const el = document.body.firstElementChild;
+            if (!el) return '(no-target)';
+            const out: string[] = [];
+            let n = el.firstChild;
+            let i = 0;
+            for (; n && i < 12; n = n.nextSibling, i++) {
+                if (n.nodeType === 8) out.push(`#${String((n as Comment).data).slice(0, 3)}`);
+                else if (n.nodeType === 3) out.push('t');
+                else if (n.nodeType === 1) {
+                    const e = n as Element;
+                    out.push(e.id ? `${e.tagName.toLowerCase()}#${e.id}` : e.tagName.toLowerCase());
+                }
+            }
+            if (n) out.push('+');
+            return out.join(',');
+        } catch {
+            return '(sig-failed)';
+        }
+    }
+
+    function buildAnchorStack(
+        sigPre: string,
+        sigNow: string,
+        tgtPre: string,
+        tgtNow: string
+    ): string {
+        return [
+            `at=${Math.round(performance.now())}ms`,
+            '(anchor-context)',
+            `pre=${sigPre}`,
+            `post=${sigNow}`,
+            `same=${sigPre === sigNow}`,
+            `tpre=${tgtPre}`,
+            `tpost=${tgtNow}`,
+            `tsame=${tgtPre === tgtNow}`
+        ]
+            .join('\n')
+            .slice(0, 1500);
+    }
+
     onMount(() => {
         // 하이드레이션 앵커 판정 — 로그 없는 실패 경로 포착 (app.html 의 앵커 캡처와 한 쌍)
         //
@@ -638,33 +706,11 @@
                     //
                     //    ⛔ 수집기는 스키마에 없는 필드를 버린다(js_errors 컬럼 고정).
                     //       그래서 부가 정보는 새 필드가 아니라 stack 에 실어 보낸다.
-                    const sigNow = (() => {
-                        try {
-                            const kids = Array.from(document.body.children).slice(0, 14);
-                            const parts = kids.map((e) => {
-                                let t = e.tagName.toLowerCase();
-                                if (e.id) t += `#${e.id}`;
-                                else if (typeof e.className === 'string' && e.className)
-                                    t += `.${e.className.split(' ')[0]}`;
-                                return t;
-                            });
-                            const extra = document.body.children.length - kids.length;
-                            if (extra > 0) parts.push(`+${extra}`);
-                            return parts.join(',');
-                        } catch {
-                            return '(sig-failed)';
-                        }
-                    })();
+                    const sigNow = bodySigNow();
+                    const tgtNow = targetSigNow();
                     const sigPre = String(w.__angpleBodySig ?? '(none)');
-                    const stack = [
-                        `at=${Math.round(performance.now())}ms`,
-                        '(anchor-context)',
-                        `pre=${sigPre}`,
-                        `post=${sigNow}`,
-                        `same=${sigPre === sigNow}`
-                    ]
-                        .join('\n')
-                        .slice(0, 1500);
+                    const tgtPre = String(w.__angpleTargetSig ?? '(none)');
+                    const stack = buildAnchorStack(sigPre, sigNow, tgtPre, tgtNow);
                     fetch('https://aplog.damoang.net/api/v1/dantry', {
                         mode: 'cors',
                         credentials: 'include',
@@ -680,10 +726,31 @@
                             userAgent: navigator.userAgent
                         })
                     }).catch(() => {});
+                } else if (Math.random() < ANCHOR_OK_SAMPLE_RATE) {
+                    // 대조군 — 성공 로드 1% 표본. 실패 분포와 비교할 기준선이다.
+                    // ⛔ 이게 없으면 "실패 시 이렇더라"만 알 뿐 정상과 구분이 안 된다.
+                    const sigPre = String(w.__angpleBodySig ?? '(none)');
+                    const tgtPre = String(w.__angpleTargetSig ?? '(none)');
+                    fetch('https://aplog.damoang.net/api/v1/dantry', {
+                        mode: 'cors',
+                        credentials: 'include',
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            type: 'hydration_error',
+                            reason: 'anchor_ok',
+                            channel: 'anchor',
+                            message: 'hydration anchor anchor_ok',
+                            stack: buildAnchorStack(sigPre, bodySigNow(), tgtPre, targetSigNow()),
+                            url: window.location.href,
+                            userAgent: navigator.userAgent
+                        })
+                    }).catch(() => {});
                 }
                 delete w.__angpleHydrationAnchor;
                 // 서명도 함께 버린다 — 참조를 남기면 노드 누수와 같은 종류의 낭비다.
                 delete w.__angpleBodySig;
+                delete w.__angpleTargetSig;
             }
         } catch {
             // 관측용이라 실패해도 무시


### PR DESCRIPTION
#2129 의 첫 데이터가 **가설 하나를 죽였고**, 동시에 **왜 더 못 가르는지**도 드러냈다.

## 얻은 것 — 광고 인과 가설 기각

| | 건수 | 회원 |
|---|---|---|
| 광고 노드 있음 | 102 | 52 |
| **광고 노드 없음** | **91** | **37** |

절반 가까이가 광고 없이도 실패한다. **광고는 판별 조건이 아니다.**

## 못 얻은 것 — 비교 대상이 없다

`same=false` 가 **100%** 인데, 이게 실패에 특이한 신호인지 알 수 없다.
정상 로드에서도 스크립트는 붙는다. **실패만 보고 있어 기준선이 없다.**

## 그래서 둘을 더한다

**1) 대조군 (1% 표본)** — 성공 로드도 `reason='anchor_ok'` 로 같은 서명을 보낸다.
분포를 비교해야 "실패에서만 나타나는 것"이 갈린다.
실패가 시간당 3~4천 건이라 1% 표본이면 비슷한 규모가 몇 시간에 쌓인다.

**2) 타깃 서명** — `body` 자식이 아니라 **하이드레이션 타깃(앱 div) 내부**를 본다.
앵커 주석이 사는 곳이 거기다. 주석 노드까지 담아 SSR 마커가 그대로인지 확인한다.
body 서명은 스크립트 append 에 묻혀 정상/실패 구분이 되지 않았다.

## 제약 준수

- ⛔ `app.html` 은 계속 **ES5** (구형 브라우저에서도 돌아야 한다)
- ⛔ 서명은 12~14개까지, 초과는 `+` 로 축약 — 전송량을 늘리지 않는다
- ⛔ 전역 3개(anchor·bodySig·targetSig) 모두 판정 후 `delete`
- **관측 전용 — 사용자 동작 변화 없음**

## 기각된 가설 (재조사 금지)

| 가설 | 왜 아닌가 |
|---|---|
| 중첩 `<a>` | 2026-07-28 에 이미 수정됨(`classic.svelte:254`) |
| 광고 주입 | 광고 없이도 91건 실패 |
| 최근글 스켈레톤 | SSR 페이로드 `recentPosts.items` 가 비어 SSR/클라가 같은 분기 |

## 판정 기준 (배포 후)

`anchor_ok` 와 `anchor_detached` 의 `same` / `tsame` / `post` 분포를 비교해,
**실패에서만 유의하게 다른 항목**이 있으면 그게 원인 방향이다. 없으면 서명이
여전히 너무 거칠다는 뜻이니 더 깊은 지점을 잡아야 한다.