### PR TITLE
obs(hydration): 광고 노드를 문서 전체에서 센다 — 이전 기각 판정 철회

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -656,6 +656,23 @@
         }
     }
 
+    // ⛔ 광고 노드는 **문서 전체**에서 세야 한다. body 직계 자식만 보면
+    //    앱 div 안에 꽂히는 인피드 광고를 통째로 놓친다 — 실제로 그래서 2026-08-19 에
+    //    "광고 없이도 실패 91건" 이라는 잘못된 기각 판정을 냈다.
+    //    ok(대조군) 대비로 비교해야 의미가 있다.
+    function adCounts(): string {
+        try {
+            const all = document.querySelectorAll('ins.adsbygoogle, iframe[id^="aswift"]').length;
+            const root = document.body.firstElementChild;
+            const inRoot = root
+                ? root.querySelectorAll('ins.adsbygoogle, iframe[id^="aswift"]').length
+                : -1;
+            return `${all}/${inRoot}`;
+        } catch {
+            return '?/?';
+        }
+    }
+
     function buildAnchorStack(
         sigPre: string,
         sigNow: string,
@@ -670,7 +687,8 @@
             `same=${sigPre === sigNow}`,
             `tpre=${tgtPre}`,
             `tpost=${tgtNow}`,
-            `tsame=${tgtPre === tgtNow}`
+            `tsame=${tgtPre === tgtNow}`,
+            `ads=${adCounts()}`
         ]
             .join('\n')
             .slice(0, 1500);


### PR DESCRIPTION
## 정정 — 내가 낸 기각 판정이 틀렸다

#2130 직후 데이터로 **"광고 없이도 91건 실패 → 광고 인과 기각"** 이라 판정했는데,
그 근거가 **`body` 직계 자식 서명**이었다. 앱 div **안에** 꽂히는 인피드 광고는 거기 안 잡힌다.
"광고 없음" 이 아니라 **"안 보이는 곳에 있었을 수 있음"** 이다. 기각을 철회한다.

## 마침 반증이 나왔다

`anchor_missing` 의 `tpre` 가 **`div#aswift_0_host`** 다 (30분 34건 / 9명).
AdSense 가 **`body` 의 첫 요소로** 끼어들어 앱 div 가 `firstElementChild` 가 아니게 되고,
앵커 탐색이 실패한다. → `anchor_missing` 의 **원인 확정**이자, AdSense 가 공격적으로
삽입한다는 직접 증거다.

## 무엇을 더 세나

`ads=<문서전체>/<앱div내부>` 를 `stack` 에 싣는다
(`ins.adsbygoogle, iframe[id^="aswift"]`). 대조군(`anchor_ok`, 1%)이 이미 돌고 있어
**배포 즉시 비교 가능**하다.

## 함께 확정된 사실 두 가지

**1. `detached` 와 `hydration_mismatch` 는 같은 사건이다**

| | 창 수 |
|---|---|
| 동시 발생 | **861** |
| detached 만 | 107 |
| mismatch 만 | 20 |

→ mismatch 가 가리키는 **`footer.svelte` 가 곧 3,302명 문제의 단서**다. 별개가 아니다.

**2. 실패의 `tpre` 가 정상과 완전히 동일하다**

`detached` 와 `ok` 모두 `#[,#[,#[,#[!,#],#,t,#[1,#,#[,div,#],+`.
→ **하이드레이션 시작 시점 DOM 은 멀쩡**하다. SSR 출력 문제가 아니라 **실행 도중**의 문제다.

관측 전용 — 사용자 동작 변화 없음.