### PR TITLE
fix(board): 모바일 액션바 공유·스크랩·신고 라벨 노출, 화나요만 아이콘(#13638)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -918,24 +918,13 @@
                      → 하단본을 initialScrapped 와 함께 복원(정확 표시 + 익숙한 위치 둘 다 충족). -->
                 <div class="ml-auto flex flex-wrap items-center justify-end gap-1">
                     {#if board?.use_sns}
-                        <ShareButton
-                            {boardId}
-                            postId={post.id}
-                            title={post.title || ''}
-                            labelHiddenMobile
-                        />
+                        <ShareButton {boardId} postId={post.id} title={post.title || ''} />
                     {/if}
                     <!-- 스크랩: 최종 순서 공유 → 스크랩 → 신고 → 화나요(사장님 확정). 종전엔 아이콘만
                          이라 옆의 공유·신고(아이콘+문구)와 어긋났는데, size="sm" 이면 컴포넌트가
                          "스크랩"/"스크랩됨" 문구를 함께 렌더한다(상단 툴바본은 아이콘만 유지). -->
                     {#if authStore.isAuthenticated}
-                        <ScrapButton
-                            {boardId}
-                            postId={post.id}
-                            {initialScrapped}
-                            size="sm"
-                            labelHiddenMobile
-                        />
+                        <ScrapButton {boardId} postId={post.id} {initialScrapped} size="sm" />
                     {/if}
                     {#if !isAuthor}
                         <!-- ⭐ 2026-08-18: 신고 버튼은 항상 보인다 — 제재 확정(B형) 글에서도.
@@ -959,7 +948,7 @@
                             aria-label="신고"
                         >
                             <Flag class="h-4 w-4" />
-                            <span class="hidden sm:inline">신고</span>
+                            <span>신고</span>
                         </Button>
                     {/if}
                     <PluginSlot


### PR DESCRIPTION
## 배경 (bug/13638)
화나요 버튼(#2108) 추가로 모바일(<640px) 본문 하단 액션바의 4버튼 라벨이 모두 보이면 아이폰 폭(~390-430px)에서 flex-wrap 으로 2줄 접힘 → 스크랩이 오프스크린 클립되는 회귀.

## 결정 (사장님)
모바일에서 **공유·스크랩·신고는 라벨 표시**, **화나요만 아이콘만**. 3라벨+1아이콘으로 1줄 유지.

## 변경 (basic.svelte 호출부만)
- `ShareButton`: `labelHiddenMobile` 제거 → 기본값 false=라벨 상시 노출
- `ScrapButton`: `labelHiddenMobile` 제거 → 라벨 상시 노출
- 신고 `<span>`: `hidden sm:inline` 제거 → 상시 노출
- 화나요 `<span>`: `hidden sm:inline` **유지**(아이콘만)

## 무회귀 근거
- `labelHiddenMobile` prop 정의(share-button/scrap-button)는 그대로 유지
- `git grep labelHiddenMobile` 결과 basic.svelte 외 사용처 없음 → 타 화면 영향 0
- 백엔드/DB 무관(화나요는 로컬 전용)

## 검증 포인트 (Evaluator/카나리)
- 아이폰 폭에서 3라벨+1아이콘 1줄 유지(2줄 접힘·스크랩 클립 없음)
- 데스크톱 표시 불변
- prop 정합(정의 유지, 호출부만 제거)

⚠️ 노드 빌드/svelte-check 미실행(CPU 스파이크 방지). 포맷/타입은 CI 위임.