### PR TITLE
fix(auth): 닉네임에 한자(漢字) 허용 (#free-7062815)

### DIFF
--- a/apps/web/src/lib/server/auth/register.ts
+++ b/apps/web/src/lib/server/auth/register.ts
@@ -192,7 +192,7 @@ export async function findExistingTempAccount(baseMbId: string): Promise<{ mb_id
  * 닉네임 검증 (PHP register.lib.php 호환)
  * - 빈 값 불가
  * - 2~20자
- * - 한글/영문/숫자/점/밑줄 허용
+ * - 한글/한자/영문/숫자/점/밑줄 허용
  * - 연속 점 불가
  * - 금지어 불가
  * - 중복 불가
@@ -210,9 +210,12 @@ export async function validateNickname(
         return { valid: false, error: '닉네임은 2~20자로 입력해주세요.' };
     }
 
-    // 허용 문자: 한글, 영문, 숫자, 점, 밑줄
-    if (!/^[가-힣a-zA-Z0-9._]+$/.test(trimmed)) {
-        return { valid: false, error: '닉네임은 한글, 영문, 숫자, 점, 밑줄만 사용 가능합니다.' };
+    // 허용 문자: 한글, 한자(CJK 통합 U+4E00–U+9FFF), 영문, 숫자, 점, 밑줄
+    if (!/^[가-힣a-zA-Z0-9._一-鿿]+$/.test(trimmed)) {
+        return {
+            valid: false,
+            error: '닉네임은 한글, 한자, 영문, 숫자, 점, 밑줄만 사용 가능합니다.'
+        };
     }
 
     // 연속 점 불가

--- a/apps/web/src/routes/register/+page.svelte
+++ b/apps/web/src/routes/register/+page.svelte
@@ -356,7 +356,7 @@
                             <p class="text-destructive text-xs font-medium">{form?.error}</p>
                         {/if}
                         <p class="text-muted-foreground text-xs">
-                            한글, 영문, 숫자, 점(.), 밑줄(_) 사용 가능 (2~20자)
+                            한글, 한자, 영문, 숫자, 점(.), 밑줄(_) 사용 가능 (2~20자)
                         </p>
                         <p class="text-muted-foreground text-xs">
                             ⚠️ 개인정보 보호를 위해 실명 닉네임 사용을 지양해 주세요.


### PR DESCRIPTION
## 배경
닉네임에 한자를 사용할 수 없다는 제보(#free-7062815). 기존 한자 닉네임 회원 71명이 활성 상태로, 셀프 닉네임 변경 시 검증에 걸려 저장 불가.

## 원인
web 단일 게이트 `apps/web/src/lib/server/auth/register.ts`의 `validateNickname()` 정규식이 한자를 배제.
등록(+page.server.ts)과 셀프 변경(member-update.ts)이 같은 `validateNickname()`을 공유하므로 이 한 곳만 고치면 양쪽 해결. Go 백엔드/DB 무변경.

## 변경
- 정규식에 CJK 통합 한자 범위(U+4E00–U+9FFF, `一-鿿`) 추가
- 오류 문구 및 함수 주석에 '한자' 추가
- 회원가입 안내문(+page.svelte)에 '한자' 표기 추가

## 회귀 범위
- 자모(ㄱ-ㅎ/ㅏ-ㅣ)·공백·이모지는 현행대로 계속 차단 (CJK 범위만 추가)
- 길이 2~20자·연속점·금지어·중복 로직 무변경 (한자는 BMP 1코드유닛이라 length 안전)

## 검증 포인트
- 정규식 CJK 범위: `一`=U+4E00, `鿿`=U+9FFF
- 자모/이모지/공백 계속 차단
- 등록·셀프변경 양쪽 자동 반영 (validateNickname 공유)

⚠️ 노드 빌드/컴파일 미실행 (CI 위임).