### PR TITLE
fix(auth): 닉네임에 ™(U+2122) 허용

### DIFF
--- a/apps/web/src/lib/server/auth/register.ts
+++ b/apps/web/src/lib/server/auth/register.ts
@@ -210,8 +210,8 @@ export async function validateNickname(
         return { valid: false, error: '닉네임은 2~20자로 입력해주세요.' };
     }
 
-    // 허용 문자: 한글, 한자(CJK 통합 U+4E00–U+9FFF), 영문, 숫자, 점, 밑줄
-    if (!/^[가-힣a-zA-Z0-9._一-鿿]+$/.test(trimmed)) {
+    // 허용 문자: 한글, 한자(CJK 통합 U+4E00–U+9FFF), 영문, 숫자, 점, 밑줄, ™(U+2122)
+    if (!/^[가-힣a-zA-Z0-9._一-鿿™]+$/.test(trimmed)) {
         return {
             valid: false,
             error: '닉네임은 한글, 한자, 영문, 숫자, 점, 밑줄만 사용 가능합니다.'


### PR DESCRIPTION
## 배경
™ 포함 닉네임 회원 약 50명이 닉네임 변경 시 검증에 걸려 저장 불가. ™만 구제(사장님 결정). 점자·이모지·장식문자는 계속 차단.

## 변경
`apps/web/src/lib/server/auth/register.ts` `validateNickname()` 정규식에 ™(U+2122)만 추가.
- 전: `/^[가-힣a-zA-Z0-9._一-鿿]+$/` (#2133 머지 상태)
- 후: `/^[가-힣a-zA-Z0-9._一-鿿™]+$/`

문자클래스 리터럴이라 이스케이프 불필요. ™ 하나만 추가.

## 문구 미변경
기존 50명 변경 구제 목적이라 오류 메시지·안내문은 유지(신규 유도 X).

## 회귀 범위
자모(ㄱ-ㅎ/ㅏ-ㅣ)·공백·이모지·점자·장식문자 계속 차단. 등록·셀프변경 양쪽 자동 반영(validateNickname 공유). 백엔드/DB 무변경.

## 검증 포인트
- 추가 코드포인트: ™=U+2122 (실측 확인)
- ™ 외 다른 기호 미추가

⚠️ 노드 빌드/svelte-check 미실행 (CI 위임).