### PR TITLE
obs(hydration): 내비게이션 유형 계측 — CI 재현이 막힌 뒤의 다음 판별자

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -673,6 +673,19 @@
         }
     }
 
+    // 내비게이션 유형(navigate/reload/back_forward)과 가시성.
+    // ⛔ 새 필드를 만들지 않는다 — 수집기가 스키마 밖 필드를 버린다. stack 에 싣는다.
+    function navType(): string {
+        try {
+            const nav = performance.getEntriesByType('navigation')[0] as
+                | PerformanceNavigationTiming
+                | undefined;
+            return `${nav?.type ?? '?'}/${document.visibilityState}`;
+        } catch {
+            return '?/?';
+        }
+    }
+
     function buildAnchorStack(
         sigPre: string,
         sigNow: string,
@@ -688,7 +701,13 @@
             `tpre=${tgtPre}`,
             `tpost=${tgtNow}`,
             `tsame=${tgtPre === tgtNow}`,
-            `ads=${adCounts()}`
+            `ads=${adCounts()}`,
+            // ⛔ 내비게이션 유형이 다음 판별자 후보다.
+            //    Playwright WebKit 으로 신선 로드·항해를 24회 돌려도 실패율 0% 였는데
+            //    운영 iOS 사파리는 ~50~68% 다(비로그인 포함). 차이가 뭔지 좁혀야 한다.
+            //    `back_forward` = bfcache 복원 — app.html 의 iOS 전용 reload 스크립트가
+            //    발화하는 바로 그 경로이고, Playwright 의 goBack 은 이걸 재현하지 못한다.
+            `nav=${navType()}`
         ]
             .join('\n')
             .slice(0, 1500);


### PR DESCRIPTION
## CI 재현은 막다른 길이었다

Playwright WebKit 으로 **신선 로드 15회 + 항해(목록→글→뒤로) 12회 = 24회 전부 통과(0.0%)**.

```
/free/5998999  0/4   /free  0/4   /  0/4
nav:list 0/4   nav:post 0/4   nav:back 0/4
전체 실패율 0.0% (0/24)
```

같은 시간대 운영 iOS 사파리는 **~50~68% 실패**한다. 로그인 여부는 원인이 아니다 —
비로그인도 iOS 에서 4,348 실패 / 정상표본 44(환산 ~4,400) ≈ **50%**.

→ Playwright 의 WebKit 빌드는 실제 iOS 사파리가 아니다.

## 다만 힌트가 하나 남았다

`nav:back` 이 0 인 것. **Playwright 의 `goBack` 은 진짜 bfcache 복원
(`pageshow.persisted`)을 만들지 않는다.** 그런데 `app.html` 의 **iOS 전용** 스크립트가
정확히 그 경로에서 `location.reload()` 를 건다(#303·#13022).

## 그래서 운영에서 직접 잰다

`nav=<navigate|reload|back_forward>/<visibility>` 를 `stack` 에 싣는다.

- 실패가 **`back_forward` 에 몰리면** → bfcache 경로가 원인. 제보의 "뒤로가기 위치 튐" 과도 한 줄로 이어진다
- **고르게 퍼져 있으면** → bfcache 는 아니다. 다른 축을 봐야 한다

⛔ 새 필드를 만들지 않는다(수집기가 스키마 밖 필드를 버린다) — `stack` 에 싣는다.
**관측 전용 — 사용자 동작 변화 없음.**