### PR TITLE
fix(ios): format-detection 끄기 — iOS Safari 자동 데이터 감지가 하이드레이션을 깨뜨린다

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -110,6 +110,19 @@
             })();
         </script>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <!-- ⛔ iOS Safari 자동 데이터 감지 끄기 — 하이드레이션 파손 방지.
+             iOS Safari 는 날짜·전화번호·주소를 스스로 감지해 <a> 로 감싼다.
+             그 DOM 변형이 SSR 마크업과 클라이언트 기대치를 어긋나게 만들어
+             하이드레이션이 통째로 폐기된다(문서 끝인 footer 에서 발각됨).
+        
+             실측(2026-08-19): iOS 사파리 하이드레이션 실패율 ~50~68%,
+             데스크톱 ~1.5% · 안드로이드 ~0.4% — 약 50배. 하루 3,302명.
+             Playwright WebKit(Linux)에서는 24회 전부 통과 — iOS 플랫폼 전용
+             기능이라 CI 에서는 재현되지 않는다. 글 상세 한 페이지에 날짜 패턴 116건.
+        
+             ⛔ 되돌리려면 아래 한 줄만 지운다. 지우기 전에
+                error_logs.js_errors 의 anchor_detached 추이를 먼저 볼 것. -->
+        <meta name="format-detection" content="telephone=no, date=no, address=no, email=no" />
         <!-- Critical CSS: FOUC 방지 (CSS 번들 로드 전 즉시 적용) -->
         <style>
             .mobile-meta,


### PR DESCRIPTION
## 관측 (2026-08-19)

하이드레이션 실패 **하루 3,302명**. 대조군(성공 로드 1% 표본)을 넣자 판별자가 갈렸다.

| 브라우저 | 환산 실패율 |
|---|---|
| **iOS 사파리** | **~50~68%** ← 다른 브라우저의 약 50배 |
| 데스크톱 | ~1.5% |
| 안드로이드 | ~0.4% |

그런데 **Playwright WebKit(Linux)으로 신선 로드·항해 24회를 돌려도 0.0%** 였다.
→ 브라우저 엔진이 아니라 **iOS 플랫폼 기능**이 관여한다.

## 가설

iOS Safari 는 **날짜·전화번호·주소를 스스로 감지해 `<a>` 로 감싼다.**
그 DOM 변형이 SSR 마크업과 클라이언트 기대치를 어긋나게 만들어 하이드레이션이 폐기된다.

| 관측 | 정합 |
|---|---|
| iOS 전용, Playwright 재현 불가 | ✅ iOS 플랫폼 기능 |
| SSR 출력(`tpre`)은 정상과 **완전 동일** | ✅ 감지는 그 뒤에 일어남 |
| `footer.svelte` 99.4% 에서 발각 | ✅ 문서 전반을 건드려 끝에서 누적 발각 |
| 광고·로그인·bfcache 무관 (전부 기각됨) | ✅ 무관 |
| 확률적 | ✅ 페이지별 패턴 수가 다름 |
| 글 상세 한 페이지에 **날짜 패턴 116건**, 메타는 **부재** | ✅ |

## 왜 지금 이 수정인가

**한 줄**이고, 되돌리기 쉽고, 지표가 시간당 수천 건이라 **배포 직후 판별된다.**

⛔ **단정하지 않는다 — 가설이다.** 승격 후 `anchor_detached` 추이로 검증하고,
효과가 없으면 되돌린다(해당 메타 한 줄만 제거).

## 사용자 영향

전화번호 탭-투-콜과 날짜 캘린더 링크가 사라진다.
커뮤니티 글에서 이 자동 링크의 효용은 낮고, 반대로 하이드레이션 폐기는
**글쓰기 버튼 안 먹힘 · 화면 깜빡임 · 로그인 상태 오표시**로 이어진다
(`classic.svelte:263` 의 2026-07-28 사고 기록).

## 검증 방법

승격 후 30분 내:
```sql
SELECT toStartOfMinute(timestamp), count()
FROM error_logs.js_errors
WHERE message LIKE '%anchor_detached%' AND userAgent LIKE '%iPhone%'
GROUP BY 1 ORDER BY 1
```