### PR TITLE
fix(obs): anchor_missing 은 거짓 양성이었다 — 앱 루트를 id 로 찾는다

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -377,7 +377,12 @@
         </script>
     </head>
     <body>
-        <div style="display: contents">%sveltekit.body%</div>
+        <!-- ⛔ id 를 지우지 말 것. 하이드레이션 앵커 탐지가 이 id 로 앱 루트를 찾는다.
+             예전엔 document.body.firstElementChild 로 찾았는데, AdSense 가 body 첫 요소로
+             div#aswift_0_host 를 끼워 넣으면 광고 컨테이너를 앱 루트로 오인했다.
+             그 결과 anchor_missing 이 하루 802명 규모로 찍혔는데 **전부 거짓 양성**이었다
+             (실측 2026-08-19: missing 432창 중 실제 하이드레이션 실패 동반은 1창). -->
+        <div id="app-root" style="display: contents">%sveltekit.body%</div>
         <script>
             // 하이드레이션 앵커 캡처 — 로그가 아예 없는 실패 경로를 잡기 위한 것.
             //
@@ -437,14 +442,20 @@
                     if (n) out.push('+');
                     return out.join(',');
                 }
+                // ⛔ firstElementChild 로 앱 루트를 찾지 마라. AdSense 가 body 첫 요소로
+                //    끼어들면 광고 컨테이너를 잡는다(실측: tpre=div#aswift_0_host 1,055건).
+                //    id 로 찾고, 없을 때만 예전 방식으로 물러선다.
+                function appRoot() {
+                    return document.getElementById('app-root') || document.body.firstElementChild;
+                }
                 try {
                     window.__angpleBodySig = bodySig();
-                    window.__angpleTargetSig = targetSig(document.body.firstElementChild);
+                    window.__angpleTargetSig = targetSig(appRoot());
                 } catch (e) {
                     /* 관측용 */
                 }
                 try {
-                    var target = document.body.firstElementChild;
+                    var target = appRoot();
                     if (!target) return;
                     for (var n = target.firstChild; n; n = n.nextSibling) {
                         // Comment 노드이면서 data 가 '[' 이면 HYDRATION_START

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -636,7 +636,9 @@
 
     function targetSigNow(): string {
         try {
-            const el = document.body.firstElementChild;
+            // ⛔ app.html 과 **같은 방식**으로 앱 루트를 찾아야 한다. 한쪽만 고치면
+            //    pre/post 서명이 서로 다른 요소를 보게 돼 tsame 이 무의미해진다.
+            const el = document.getElementById('app-root') ?? document.body.firstElementChild;
             if (!el) return '(no-target)';
             const out: string[] = [];
             let n = el.firstChild;
@@ -663,7 +665,7 @@
     function adCounts(): string {
         try {
             const all = document.querySelectorAll('ins.adsbygoogle, iframe[id^="aswift"]').length;
-            const root = document.body.firstElementChild;
+            const root = document.getElementById('app-root') ?? document.body.firstElementChild;
             const inRoot = root
                 ? root.querySelectorAll('ins.adsbygoogle, iframe[id^="aswift"]').length
                 : -1;


### PR DESCRIPTION
## 사용자 문제가 아니라 **계측 문제**였다

하이드레이션 앵커 탐지가 앱 루트를 `document.body.firstElementChild` 로 찾는데,
AdSense 가 body 첫 요소로 `div#aswift_0_host` 를 끼워 넣으면 **광고 컨테이너를
앱 루트로 오인**하고 SSR 마커를 못 찾아 `anchor_missing` 을 보낸다.

### 실측 (2026-08-19)

| | 창 |
|---|---|
| `missing` 발생 | 432 |
| 그중 `mismatch` 동반 | **0** |
| 그중 `detached` 동반 | **1** |
| **`missing` 단독** | **431 (99.8%)** |

`tsame=true` · `tpre=div#aswift_0_host` **1,055건**
→ 앱 div 내부가 그대로다 = **하이드레이션은 성공했다.**

**하루 802명으로 집계되던 `anchor_missing` 은 전부 유령이다.**

> ⛔ 확인하지 않고 "AdSense 가 하이드레이션을 깨뜨린다" 로 고쳤으면,
> 없는 문제를 고치느라 시간을 쓰고 지표는 그대로였을 것이다.

## 수정

- 앱 루트에 **`id="app-root"`** — SvelteKit 이 마운트하는 그 div 인데 id 도 class 도 없어
  위치로만 찾을 수밖에 없었다
- `app.html` 탐지기와 `+layout.svelte` 의 `targetSig`/`adCounts` 를 **같은 방식**으로 통일.
  한쪽만 고치면 pre/post 서명이 서로 다른 요소를 봐 `tsame` 이 무의미해진다
- 구형 대비 `|| document.body.firstElementChild` 폴백 유지

⛔ `app.html` 에는 prettier 를 돌리지 않았다 — 지난번 `--no-config` 로 돌렸다가
무관한 JS 에 후행쉼표가 붙어 CI 가 떨어졌다.

**관측 전용 — 사용자 동작 변화 없음.**

## 검증

배포 후 `anchor_missing` 이 802명/일 → 0 에 수렴하면 거짓 양성 판정이 맞은 것이다.
남아 있으면 다른 원인이 있다는 뜻이니 다시 본다.