### PR TITLE
fix(list): 목록 읽음 표시가 하이드레이션 직후 여러 행에서 동시에 번지는 문제

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -443,3 +443,29 @@ html {
         background-color: var(--accent);
     }
 }
+
+/* 하이드레이션 중에는 읽음 표시 전환을 끈다 — 2026-08-19.
+ *
+ * 읽음 상태는 localStorage(L1) 기반이라 SSR 이 알 수 없다. 그래서 서버는 전부
+ * "안 읽음" 으로 그리고, 하이드레이션 직후 readPostsStore 가 localStorage 를 읽으며
+ * **이미 읽은 모든 행의 클래스가 한꺼번에** post-title → post-title-read-* 로 바뀐다.
+ *
+ * 여기에 `transition: color 0.8s` 가 걸려 있어, 여러 행의 색이 0.8초에 걸쳐
+ * **동시에 천천히 변한다.** 제보(free/7060456, Jei_): "글 목록 누르면 해당 글 말고
+ * 다른 글도 같이 하이라이트 되는 증상 (보안키보드 누르는 느낌)".
+ * 다크모드에서 foreground ↔ muted-foreground 대비가 커 훨씬 눈에 띈다.
+ *
+ * ⛔ 전환 자체를 지우지 않는다. 보는 중에 글을 읽어 상태가 바뀔 때의 부드러운 전환은
+ *    의도된 것이다. **최초 적용 순간에만** 끈다.
+ * ⛔ 전역 transition 을 통째로 끄지 않는다 — 다른 UI 전환까지 죽는다. 읽음 표시만 짚는다.
+ *
+ * `.hydrating` 은 app.html 인라인 스크립트가 붙이고, +layout.svelte 가 첫 페인트 뒤
+ * 제거한다. 스크립트가 실패해도 전환이 살아날 뿐 화면은 깨지지 않는다(안전한 실패).
+ *
+ * 특이성: `html.hydrating [class^=...]`(0,2,1) > Svelte 스코프 `.post-title.svelte-x`(0,2,0).
+ * 컴포넌트 스타일이 스코프돼 있어도 이 전역 규칙이 이긴다.
+ */
+html.hydrating .post-title,
+html.hydrating [class^='post-title-read-'] {
+    transition: none;
+}

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -37,6 +37,17 @@
             }
         </script>
         <script>
+            // 읽음 표시 전환을 하이드레이션 동안만 끈다 (app.css 의 html.hydrating 규칙).
+            //
+            // 읽음 상태는 localStorage 라 SSR 이 모른다 → 하이드레이션 직후 이미 읽은
+            // 행들의 클래스가 한꺼번에 바뀌고, transition: color 0.8s 때문에 여러 행의
+            // 색이 동시에 천천히 변한다("다른 글도 같이 하이라이트", 다크모드에서 특히).
+            //
+            // ⛔ 첫 페인트 **전**에 붙어야 의미가 있다. 제거는 +layout.svelte 가 첫 페인트 뒤에 한다.
+            //    이 스크립트가 실패해도 전환이 살아날 뿐 화면은 깨지지 않는다.
+            document.documentElement.classList.add('hydrating');
+        </script>
+        <script>
             (function () {
                 if (typeof history === 'undefined') return;
                 var op = history.pushState;

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -716,6 +716,16 @@
     }
 
     onMount(() => {
+        // 읽음 표시 전환 재개 — app.html 이 첫 페인트 전에 건 .hydrating 을 뗀다.
+        // ⛔ 프레임을 두 번 넘긴 뒤에 뗀다. 하이드레이션이 클래스를 바꾸는 그 프레임에
+        //    전환이 살아 있으면 0.8초짜리 색 변화가 그대로 보인다 — 끄는 의미가 없어진다.
+        //    (두 번인 이유: 첫 rAF 는 아직 그 프레임, 두 번째가 페인트 이후다)
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                document.documentElement.classList.remove('hydrating');
+            });
+        });
+
         // 하이드레이션 앵커 판정 — 로그 없는 실패 경로 포착 (app.html 의 앵커 캡처와 한 쌍)
         //
         // Svelte 가 HYDRATION_START 주석을 못 찾으면 throw HYDRATION_ERROR 로 빠지는데,


### PR DESCRIPTION
제보(`/free/7060456`, Jei_):
> 다크모드에서 글 목록 누르면 해당 글 말고 **다른 글도 같이 하이라이트** 되는 증상 (보안키보드 누르는 느낌)

## 원인

읽음 상태는 **localStorage 기반이라 SSR 이 알 수 없다.** 서버는 전부 "안 읽음"으로 그리고,
하이드레이션 직후 `readPostsStore` 가 localStorage 를 읽으며 이미 읽은 모든 행의 클래스가
한꺼번에 `post-title` → `post-title-read-*` 로 바뀐다.

```css
.post-title, [class^='post-title-read-'] {
    transition: color 0.8s ease-in-out;   /* ← 이것 */
}
```

**여러 행의 색이 0.8초에 걸쳐 동시에 천천히 변한다.** 다크모드는
`foreground ↔ muted-foreground` 대비가 커서 훨씬 눈에 띈다. 제보 표현 그대로다.

## 수정

`app.html` 이 첫 페인트 **전**에 `html.hydrating` 을 걸고,
`+layout.svelte` 가 첫 페인트 **뒤**(rAF 2회)에 뗀다. 그 사이에만 읽음 표시 전환을 끈다.

- ⛔ **전환 자체를 지우지 않았다** — 보는 중에 글을 읽어 상태가 바뀔 때의 부드러운 전환은 의도된 것이다. 최초 대량 적용 순간에만 끈다
- ⛔ **전역 transition 을 통째로 끄지 않았다** — 다른 UI 전환까지 죽는다. 읽음 표시만 짚는다
- ⛔ **rAF 를 두 번** 넘긴다. 한 번이면 아직 같은 프레임이라 전환이 살아 있어 의미가 없다

## 채택하지 않은 대안 — 서버 read-set 을 SSR 에 싣기

검토했으나 접었다. **localStorage 에만 있는 기록은 서버가 모르므로 어차피 남고**,
페이로드와 캐시 경로까지 건드려야 한다.
시각적 문제의 실체는 상태 차이가 아니라 **전환 애니메이션**이다.

## 안전한 실패

| 상황 | 결과 |
|---|---|
| 인라인 스크립트 실패 | `.hydrating` 미부착 → 전환이 살아날 뿐, 화면은 안 깨짐 |
| JS 없음 | 계속 붙어 있어 전환만 없음 |

특이성: `html.hydrating [class^=...]`(0,2,1) > Svelte 스코프 `.post-title.svelte-x`(0,2,0).
`classic.svelte` 와 `archive.svelte` 가 같은 클래스를 써서 **전역 규칙 하나로 함께 커버**된다.