### PR TITLE
perf(ci): Playwright 브라우저 캐시 + chromium 만 설치 + 잡 타임아웃

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   html-comments:
     name: HTML Comment Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -65,6 +66,7 @@ jobs:
   nested-anchors:
     name: Nested Anchor Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -99,6 +101,7 @@ jobs:
     name: Lint (${{ matrix.app }})
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         app: [web]
@@ -135,6 +138,7 @@ jobs:
   build:
     name: Build (${{ matrix.app }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         app: [web]
@@ -177,6 +181,7 @@ jobs:
     name: Security Audit (${{ matrix.app }})
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         app: [web]
@@ -206,6 +211,10 @@ jobs:
   test:
     name: Test (${{ matrix.app }})
     runs-on: ubuntu-latest
+    # ⛔ 여기만 30분이다. DB·Redis·백엔드를 띄우고 브라우저를 깔고 앱을 빌드한 뒤
+    #    e2e 까지 돈다. 다른 잡 기준(15분)을 그대로 쓰면 **정상 실행을 죽인다**
+    #    (2026-08-19 실측: 25~35분). 캐시가 들으면 크게 줄겠지만, 상한은 여유 있게 둔다.
+    timeout-minutes: 30
     strategy:
       matrix:
         app: [web]
@@ -311,10 +320,37 @@ jobs:
           echo "Backend failed to start, skipping e2e tests"
           echo "BACKEND_READY=false" >> $GITHUB_OUTPUT
 
-      - name: Install Playwright browsers
+      # ⛔ 예전에는 `playwright install --with-deps` 로 **세 브라우저 전부**(chromium·
+      #    firefox·webkit)를 매번 새로 받았다. 그런데 apps/web/playwright.config.ts 에는
+      #    projects 가 없어 **chromium 하나만 쓴다** — 2/3 가 순수 낭비였다.
+      #    게다가 캐시가 없어 매 실행 20~35분이 걸렸고(2026-08-19 실측, 하루 4번 겪음),
+      #    그 시간이 모든 변경의 리드타임에 그대로 얹혔다. 긴급 수정일수록 손해가 컸다.
+      - name: Resolve Playwright version
         if: ${{ matrix.app != 'web' || steps.backend.outputs.BACKEND_READY != 'false' }}
+        id: pw
         working-directory: apps/${{ matrix.app }}
-        run: pnpm exec playwright install --with-deps
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # 캐시 키에 버전을 넣는다 — 버전이 오르면 자동으로 새로 받는다(수동 무효화 불필요).
+      - name: Cache Playwright browsers
+        if: ${{ matrix.app != 'web' || steps.backend.outputs.BACKEND_READY != 'false' }}
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: ${{ (matrix.app != 'web' || steps.backend.outputs.BACKEND_READY != 'false') && steps.pw-cache.outputs.cache-hit != 'true' }}
+        working-directory: apps/${{ matrix.app }}
+        run: pnpm exec playwright install --with-deps chromium
+
+      # ⛔ 캐시가 맞아도 시스템 의존 패키지(apt)는 캐시되지 않는다. 브라우저 바이너리만
+      #    복원되고 라이브러리가 없으면 실행 시점에 알 수 없는 에러로 죽는다 — deps 는 따로 깐다.
+      - name: Install Playwright system deps (cache hit)
+        if: ${{ (matrix.app != 'web' || steps.backend.outputs.BACKEND_READY != 'false') && steps.pw-cache.outputs.cache-hit == 'true' }}
+        working-directory: apps/${{ matrix.app }}
+        run: pnpm exec playwright install-deps chromium
 
       - name: Build app for E2E tests
         if: ${{ matrix.app != 'web' || steps.backend.outputs.BACKEND_READY != 'false' }}
@@ -364,6 +400,7 @@ jobs:
     name: Prettier Suggestions
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -415,6 +452,7 @@ jobs:
     name: ESLint Review (${{ matrix.app }})
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         app: [web]
@@ -481,6 +519,7 @@ jobs:
     name: TypeScript Review (${{ matrix.app }})
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         app: [web]
@@ -548,6 +587,7 @@ jobs:
     needs: [build, security, test]
     if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Determine status
         id: status

--- a/.github/workflows/safari-synthetic.yml
+++ b/.github/workflows/safari-synthetic.yml
@@ -39,9 +39,32 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright browsers
+      # ⛔ 이 워크플로는 **15분마다** 돈다(하루 96회). 캐시 없이 webkit 을 매번 받으면
+      #    그 다운로드만 하루 수 시간의 러너 시간을 태운다(실측: 회당 2~7분).
+      #    캐시 키에 버전을 넣어 버전이 오르면 자동으로 새로 받게 한다.
+      - name: Resolve Playwright version
+        id: pw
+        working-directory: apps/web
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-webkit-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         working-directory: apps/web
         run: pnpm exec playwright install --with-deps webkit
+
+      # ⛔ 브라우저 바이너리는 캐시돼도 apt 의존 패키지는 캐시되지 않는다.
+      #    빼먹으면 캐시 적중일 때만 알 수 없는 실행 오류로 죽는다 — 가장 찾기 어려운 종류다.
+      - name: Install Playwright system deps (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        working-directory: apps/web
+        run: pnpm exec playwright install-deps webkit
 
       - name: Run Mobile Safari synthetic monitor
         working-directory: apps/web
@@ -91,9 +114,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright browsers
+      - name: Resolve Playwright version
+        id: pw
+        working-directory: apps/web
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-webkit-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         working-directory: apps/web
         run: pnpm exec playwright install --with-deps webkit
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        working-directory: apps/web
+        run: pnpm exec playwright install-deps webkit
 
       - name: Measure hydration integrity
         working-directory: apps/web


### PR DESCRIPTION
## 왜

2026-08-19 하루에만 이 단계를 **네 번 20~35분씩** 기다렸다. 평소 CI 전체가 5~15분인데
**한 단계가 그보다 길다.** 그 시간이 모든 변경의 리드타임에 얹히고,
**긴급 수정일수록 손해가 크다** — 시간당 3.6만 건 500 을 고칠 때도 이걸 기다렸다.

## 무엇이 낭비였나

| | 실태 |
|---|---|
| 브라우저 | `--with-deps` 로 **3개 전부**(chromium·firefox·webkit) 설치. 그런데 `playwright.config.ts` 에 `projects` 가 없어 **chromium 하나만 쓴다** → 2/3 낭비 |
| 캐시 | **없음.** 매 실행 새로 받음 |
| synthetic | **15분마다(하루 96회)** webkit 재설치. 회당 2~7분 |

## 수정

- 버전을 키에 넣은 브라우저 캐시(`actions/cache@v4`) — 버전이 오르면 **자동으로** 새로 받는다(수동 무효화 불필요)
- CI 는 **chromium 만**, synthetic 은 **webkit 만**
- ⛔ **캐시가 맞아도 apt 의존 패키지는 캐시되지 않는다.** 바이너리만 복원되고 라이브러리가
  없으면 실행 시점에 알 수 없는 에러로 죽는다 — 가장 찾기 어려운 종류다.
  그래서 캐시 적중 시 `install-deps` 를 따로 돌린다.

## 타임아웃 — 한 곳도 없었다

`ci.yml` 에 `timeout-minutes` 가 **전무**했다. 멈춘 잡이 GitHub 기본값 **6시간**까지
PR 을 붙잡는다(오늘 35분째 매달린 잡을 직접 봤다).

- 대부분 **15분**
- ⛔ `test` 만 **30분** — DB·Redis·백엔드·브라우저·빌드·e2e 를 다 하는 잡이라
  15분을 주면 **정상 실행을 죽인다**(실측 25~35분).
  처음 일괄 15분으로 넣었다가 이 함정을 발견해 고쳤다.

## 검증

이 PR 자체의 CI 가 첫 검증이다(첫 실행은 캐시 미스 → 다음 실행부터 단축).