### PR TITLE
obs(scroll): 뒤로가기 스크롤 복원에 계측 추가 — 두 경로 모두

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -548,9 +548,7 @@
                                         var payload = {
                                             type: 'scroll_restore',
                                             reason:
-                                                cause === 'done'
-                                                    ? 'restore_ok'
-                                                    : 'restore_timeout',
+                                                cause === 'done' ? 'restore_ok' : 'restore_timeout',
                                             channel: 'bfcache',
                                             message: 'scroll restore ' + cause,
                                             stack: [

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -531,10 +531,56 @@
                                 var done = false;
                                 var tries = 0;
                                 var maxTries = 180; // ~3s
+                                // 관측 — 이 경로에는 지금까지 텔레메트리가 **전혀 없었다.**
+                                // "뒤로가면 한참 위" 제보(free/7060456)를 받고도 몇 명이
+                                // 겪는지 알 방법이 없었고, Playwright 는 진짜 bfcache 복원을
+                                // 만들지 못해 재현도 안 된다. 그래서 여기서 직접 잰다.
+                                // ⛔ 루프 안에서는 플래그만 켠다. 전송은 끝에 1회뿐이다.
+                                var startedAt = Date.now();
+                                var heightReached = false;
+                                var reported = false;
+                                var report = function (cause) {
+                                    if (reported) return;
+                                    reported = true;
+                                    // 성공은 1% 표본만. 대부분의 뒤로가기에서는 전송이 없다.
+                                    if (cause === 'done' && Math.random() >= 0.01) return;
+                                    try {
+                                        var payload = {
+                                            type: 'scroll_restore',
+                                            reason:
+                                                cause === 'done'
+                                                    ? 'restore_ok'
+                                                    : 'restore_timeout',
+                                            channel: 'bfcache',
+                                            message: 'scroll restore ' + cause,
+                                            stack: [
+                                                'target=' + target,
+                                                'final=' + window.scrollY,
+                                                'maxScroll=' +
+                                                    (document.documentElement.scrollHeight -
+                                                        window.innerHeight),
+                                                'heightReached=' + heightReached,
+                                                'elapsed=' + (Date.now() - startedAt) + 'ms'
+                                            ].join('\n'),
+                                            url: location.href,
+                                            userAgent: navigator.userAgent
+                                        };
+                                        var body = JSON.stringify(payload);
+                                        if (typeof navigator.sendBeacon === 'function') {
+                                            navigator.sendBeacon(
+                                                'https://aplog.damoang.net/api/v1/dantry',
+                                                new Blob([body], { type: 'application/json' })
+                                            );
+                                        }
+                                    } catch (e) {
+                                        /* 관측 실패는 무시 */
+                                    }
+                                };
                                 var tryScroll = function () {
                                     var maxScroll =
                                         document.documentElement.scrollHeight - window.innerHeight;
                                     if (maxScroll >= target - 2) {
+                                        heightReached = true;
                                         window.scrollTo(0, target);
                                         if (Math.abs(window.scrollY - target) <= 2) done = true;
                                     }
@@ -542,20 +588,31 @@
                                 var attempt = function () {
                                     if (done) return;
                                     tryScroll();
-                                    if (!done && tries++ < maxTries) requestAnimationFrame(attempt);
+                                    if (done) {
+                                        report('done');
+                                        return;
+                                    }
+                                    if (tries++ < maxTries) requestAnimationFrame(attempt);
                                 };
                                 requestAnimationFrame(attempt);
                                 if (typeof ResizeObserver !== 'undefined') {
                                     var ro = new ResizeObserver(function () {
                                         if (done) {
                                             ro.disconnect();
+                                            report('done');
                                             return;
                                         }
                                         tryScroll();
-                                        if (done) ro.disconnect();
+                                        if (done) {
+                                            ro.disconnect();
+                                            report('done');
+                                        }
                                     });
                                     ro.observe(document.documentElement);
                                     setTimeout(function () {
+                                        // ⛔ 여기서 done=true 로 만들면 성공과 포기가 섞인다.
+                                        //    루프를 멈추되 결말은 timeout 으로 남긴다.
+                                        report(done ? 'done' : 'timeout');
                                         done = true;
                                         ro.disconnect();
                                     }, 5000);

--- a/apps/web/src/lib/utils/scroll-restore.ts
+++ b/apps/web/src/lib/utils/scroll-restore.ts
@@ -30,6 +30,93 @@ const MAX_FRAMES = 60;
 /** 늦게 로드되는 자산까지 기다리는 상한. 넘으면 포기한다 */
 const OBSERVE_TIMEOUT_MS = 3000;
 
+/**
+ * 관측 — 복원이 실제로 됐는지 데이터로 본다.
+ *
+ * ⛔ 왜 필요한가: 뒤로가기 스크롤 복원에는 **텔레메트리가 전혀 없었다.**
+ *    "한참 위로 간다"는 제보(free/7060456)를 받고도 몇 명이 겪는지, 어느 경로인지
+ *    알 방법이 없었다. Playwright 로는 3/3 정상 복원돼 재현도 안 된다
+ *    (goBack 이 진짜 bfcache 복원을 만들지 않아 iOS 전용 경로를 못 탄다).
+ *
+ * ⛔ 프런트를 늦추지 않는 것이 이 코드의 첫 번째 제약이다.
+ *    - 복원 루프(rAF/ResizeObserver) **안에서는 아무 일도 하지 않는다.** 종료 시점 1회뿐.
+ *    - `sendBeacon` 을 쓴다. fetch 와 달리 응답을 기다리지 않고 언로드도 막지 않는다.
+ *    - `requestIdleCallback` 으로 한가할 때 보낸다(없으면 setTimeout 0).
+ *    - **실패 전량 + 성공 1% 표본.** 대부분의 뒤로가기에서는 전송 자체가 없다.
+ *
+ * ⛔ 대조군(성공 표본)을 빼지 마라. 실패만 모으면 "실패 시 이렇더라"만 알 뿐
+ *    정상과 비교가 안 된다 — 2026-08-19 하이드레이션 조사에서 그 벽에 부딪혔다.
+ */
+const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
+const OK_SAMPLE_RATE = 0.01;
+
+type RestoreCause = 'done' | 'timeout' | 'cancelled';
+
+interface RestoreOutcome {
+    /** done=복원 성공 · timeout=3초 안에 못 함 · cancelled=사용자가 먼저 떠남 */
+    cause: RestoreCause;
+    target: number;
+    finalY: number;
+    maxScroll: number;
+    elapsedMs: number;
+    /** 높이가 목표에 한 번이라도 닿았는가 — 처방을 가르는 값 */
+    heightReached: boolean;
+}
+
+function reportRestore(o: RestoreOutcome): void {
+    // ⛔ cancelled 는 실패가 아니다. 사용자가 복원이 끝나기 전에 떠난 것뿐인데,
+    //    이걸 실패로 세면 실패율이 부풀려져 판단이 틀어진다. 아예 보내지 않는다.
+    if (o.cause === 'cancelled') return;
+    // 보낼 이유가 없으면 아무것도 하지 않는다(대부분의 경우).
+    if (o.cause === 'done' && Math.random() >= OK_SAMPLE_RATE) return;
+    const send = () => {
+        try {
+            const nav = (
+                performance.getEntriesByType('navigation')[0] as
+                    | PerformanceNavigationTiming
+                    | undefined
+            )?.type;
+            const payload = {
+                type: 'scroll_restore',
+                reason: o.cause === 'done' ? 'restore_ok' : 'restore_timeout',
+                channel: 'snapshot',
+                message: `scroll restore ${o.cause}`,
+                // ⛔ 수집기는 스키마에 없는 필드를 버린다(js_errors 컬럼 고정). stack 에 싣는다.
+                stack: [
+                    `target=${o.target}`,
+                    `final=${o.finalY}`,
+                    `maxScroll=${o.maxScroll}`,
+                    `heightReached=${o.heightReached}`,
+                    `elapsed=${o.elapsedMs}ms`,
+                    `nav=${nav ?? '?'}`
+                ].join('\n'),
+                url: location.href,
+                userAgent: navigator.userAgent
+            };
+            const body = JSON.stringify(payload);
+            if (typeof navigator.sendBeacon === 'function') {
+                const blob = new Blob([body], { type: 'application/json' });
+                if (navigator.sendBeacon(DANTRY_URL, blob)) return;
+            }
+            fetch(DANTRY_URL, {
+                mode: 'cors',
+                credentials: 'include',
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body,
+                keepalive: true
+            }).catch(() => {});
+        } catch {
+            // 관측 실패는 무시한다 — 사용자 영향이 없어야 한다
+        }
+    };
+    // 한가할 때 보낸다. 복원 직후는 렌더가 바쁜 구간이라 여기서 경쟁시키지 않는다.
+    const ric = (window as unknown as { requestIdleCallback?: (cb: () => void) => void })
+        .requestIdleCallback;
+    if (typeof ric === 'function') ric(send);
+    else setTimeout(send, 0);
+}
+
 export interface ScrollSnapshotValue {
     scrollY: number;
 }
@@ -71,9 +158,28 @@ export function createScrollSnapshot(): {
             let rafId = 0;
             let ro: ResizeObserver | null = null;
             let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            // 관측용. ⛔ 루프 안에서는 계산하지 않는다 — 플래그 하나만 켜고 끝낸다.
+            const startedAt = Date.now();
+            let heightReached = false;
+            let reported = false;
 
             /** rAF·ResizeObserver·timeout 을 모두 정리하고 활성 핸들을 비운다 */
-            const cleanup = () => {
+            const cleanup = (cause: RestoreCause = done ? 'done' : 'cancelled') => {
+                // 이 복원의 결말을 한 번만 보고한다.
+                // ⛔ cleanup 은 성공·타임아웃·이탈 세 경로에서 불린다. 셋을 구분해야
+                //    "실패율" 이 의미를 갖는다. 기본값은 done 여부로 추정하되,
+                //    타임아웃 경로는 명시적으로 넘긴다.
+                if (!reported) {
+                    reported = true;
+                    reportRestore({
+                        cause,
+                        target,
+                        finalY: window.scrollY,
+                        maxScroll: document.documentElement.scrollHeight - window.innerHeight,
+                        elapsedMs: Date.now() - startedAt,
+                        heightReached
+                    });
+                }
                 done = true;
                 if (rafId && typeof cancelAnimationFrame !== 'undefined')
                     cancelAnimationFrame(rafId);
@@ -91,6 +197,9 @@ export function createScrollSnapshot(): {
             const tryScroll = () => {
                 const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
                 if (maxScroll >= target - TOLERANCE_PX) {
+                    // 처방을 가르는 값: 높이는 됐는데 스크롤이 안 된 것인지,
+                    // 높이가 끝내 안 된 것인지. 대입 하나라 비용이 없다.
+                    heightReached = true;
                     window.scrollTo(0, target);
                     if (Math.abs(window.scrollY - target) <= TOLERANCE_PX) done = true;
                 }
@@ -121,7 +230,8 @@ export function createScrollSnapshot(): {
                 });
                 ro.observe(document.documentElement);
                 timeoutId = setTimeout(() => {
-                    cleanup();
+                    // 여기 도달 = 3초 안에 목표에 못 갔다. 진짜 실패다.
+                    cleanup('timeout');
                 }, OBSERVE_TIMEOUT_MS);
             }
         }


### PR DESCRIPTION
## 왜

*"글 보고 백버튼 누르면 **한참 위**로 간다"* (`/free/7060456`, Jei_) 제보를 받았는데
**스크롤 복원에는 텔레메트리가 전혀 없다.** 몇 명이 겪는지, 어느 경로인지 알 방법이 없다.

**Playwright 로는 재현되지 않는다.**

```
[1] 목표 1800px → 최종 1800px ✅   200ms:y=1800/h=2999 ...
[2] ✅   [3] ✅   복원 성공 3/3
```

SPA 스냅샷 경로는 정상이고, `goBack` 은 **진짜 bfcache 복원(`pageshow.persisted`)을
만들지 않아** `app.html` 의 iOS 전용 리로드 경로를 아예 못 탄다.
남은 용의자가 그쪽인데 **볼 수가 없다.** 그래서 계측을 넣는다.

## 무엇을 재나 — 처방이 갈리는 값

`target` / `final` / `maxScroll` / **`heightReached`** / `elapsed` / `nav`

| 관측 | 해석 |
|---|---|
| `heightReached=true` 인데 실패 | 복원 로직 문제 |
| `heightReached=false` | 문서가 목표만큼 안 길어짐(콘텐츠 문제) |

## ⛔ 프런트를 늦추지 않는 것이 첫 번째 제약

- 복원 루프(rAF/ResizeObserver) **안에서는 플래그 대입 1회뿐** — 계산·전송 없음
- **`sendBeacon`** — `fetch` 와 달리 응답을 안 기다리고 언로드도 막지 않는다
- **`requestIdleCallback`** 으로 한가할 때 전송(없으면 `setTimeout 0`)
- **성공 1% 표본 + `cancelled` 미전송** → 대부분의 뒤로가기에서 **전송 자체가 0**

## ⛔ 원인을 3분류로 나눈 이유

`done` / `timeout` / **`cancelled`**

`cleanup` 은 **사용자가 페이지를 떠날 때(`capture`)도 불린다.** 그걸 실패로 세면
**실패율이 부풀려져 판단이 틀어진다.** `cancelled` 는 아예 보내지 않는다.

그리고 `app.html` 쪽은 타임아웃에서도 `done = true` 로 만들어 **성공과 포기가 구분되지
않았다.** 루프는 그대로 멈추되 결말은 `timeout` 으로 남기게 고쳤다.

## ⛔ 대조군

성공 **1% 표본**을 함께 모은다. 실패만 보면 "실패 시 이렇더라"만 알 뿐 정상과 비교가 안 된다
— 오늘 하이드레이션 조사에서 그 벽에 부딪혔고, **대조군을 넣자 한 번에 갈렸다**(iOS 50배).

`app.html` 에는 prettier 를 돌리지 않았다(지난번 무관한 JS 에 후행쉼표가 붙어 CI 실패).