### PR TITLE
fix(auth): 닉네임 복붙 시 안 보이는 문자(제로폭·전각공백) 자동 제거 (#free-7070278)

### DIFF
--- a/apps/web/src/lib/server/auth/member-update.ts
+++ b/apps/web/src/lib/server/auth/member-update.ts
@@ -82,17 +82,19 @@ export async function updateNickname(
         }
     }
 
-    // 닉네임 유효성 검사 (중복 체크 포함)
+    // 닉네임 유효성 검사 (중복 체크 포함). 검증기가 안 보이는 문자(제로폭·전각공백 등)를
+    // 제거한 정규화 값을 돌려주므로, 저장·이력도 반드시 그 값(finalNick)을 써야 한다.
     const validation = await validateNickname(trimmed);
     if (!validation.valid) {
         return { success: false, error: validation.error };
     }
+    const finalNick = validation.normalized ?? trimmed;
 
     // UPDATE + 이력 저장
     try {
         const [result] = await pool.query<ResultSetHeader>(
             'UPDATE g5_member SET mb_nick = ?, mb_nick_date = CURDATE() WHERE mb_id = ?',
-            [trimmed, mbId]
+            [finalNick, mbId]
         );
         if (result.affectedRows === 0) {
             return { success: false, error: '회원 정보를 찾을 수 없습니다.' };
@@ -102,7 +104,7 @@ export async function updateNickname(
         try {
             await pool.query(
                 'INSERT INTO g5_member_nick_history (mb_id, old_nick, new_nick) VALUES (?, ?, ?)',
-                [mbId, profile.mb_nick, trimmed]
+                [mbId, profile.mb_nick, finalNick]
             );
         } catch (e) {
             console.error('[updateNickname] 이력 저장 실패:', e);

--- a/apps/web/src/lib/server/auth/register.test.ts
+++ b/apps/web/src/lib/server/auth/register.test.ts
@@ -1,7 +1,13 @@
 import { createHash } from 'crypto';
 import { describe, expect, it } from 'vitest';
 
-import { adler32, appendMbIdSuffix, generateSocialMbId, MB_ID_MAX_LENGTH } from './register';
+import {
+    adler32,
+    appendMbIdSuffix,
+    generateSocialMbId,
+    MB_ID_MAX_LENGTH,
+    stripInvisibleChars
+} from './register';
 
 describe('generateSocialMbId', () => {
     it('keeps the provider prefix and never emits a negative hash marker', () => {
@@ -65,5 +71,44 @@ describe('appendMbIdSuffix', () => {
         for (const provider of providers) {
             expect(generateSocialMbId(provider, 'x').length).toBeLessThanOrEqual(MB_ID_MAX_LENGTH);
         }
+    });
+});
+
+/**
+ * 복붙 닉네임 위생 회귀 방지.
+ *
+ * 외부 사이트에서 복사한 순수 한자 닉("山寂")이 앞뒤에 딸려온 안 보이는 문자
+ * (전각공백·제로폭·BOM·제어문자) 때문에 허용 문자 정규식을 통과하지 못해 거부됐다.
+ * (2026-08-19 실측: free/7070278 제보)
+ * stripInvisibleChars가 그 문자만 걷어내고 일반 공백(U+0020) 정책은 유지해야 한다.
+ *
+ * 코드포인트를 String.fromCharCode 로 만들어 테스트 소스에도 안 보이는 문자를 직접 넣지 않는다.
+ */
+describe('stripInvisibleChars', () => {
+    const ZWSP = String.fromCharCode(0x200b);
+    const ZWNJ = String.fromCharCode(0x200c);
+    const ZWJ = String.fromCharCode(0x200d);
+    const WJ = String.fromCharCode(0x2060);
+    const BOM = String.fromCharCode(0xfeff);
+    const FWSP = String.fromCharCode(0x3000); // 전각공백 — 눈에 보이지 않는 공백
+    const NUL = String.fromCharCode(0x0000); // C0 제어문자
+    const NEL = String.fromCharCode(0x0085); // C1 제어문자
+
+    it('전각공백을 제거해 복붙 한자 닉이 통과하도록 한다', () => {
+        expect(stripInvisibleChars(`山${FWSP}寂`)).toBe('山寂');
+    });
+
+    it('제로폭/BOM/WJ/제어문자를 모두 제거한다', () => {
+        expect(stripInvisibleChars(`${BOM}山${ZWSP}${ZWNJ}${ZWJ}${WJ}寂${NUL}${NEL}`)).toBe('山寂');
+    });
+
+    it('일반 공백(U+0020)은 제거하지 않는다 — 기존 정책 유지', () => {
+        expect(stripInvisibleChars('a b')).toBe('a b');
+    });
+
+    it('안 보이는 문자가 없는 정상 닉은 그대로 둔다', () => {
+        expect(stripInvisibleChars('홍길동')).toBe('홍길동');
+        expect(stripInvisibleChars('山寂')).toBe('山寂');
+        expect(stripInvisibleChars('a.b_c™')).toBe('a.b_c™');
     });
 });

--- a/apps/web/src/lib/server/auth/register.ts
+++ b/apps/web/src/lib/server/auth/register.ts
@@ -189,6 +189,49 @@ export async function findExistingTempAccount(baseMbId: string): Promise<{ mb_id
 }
 
 /**
+ * 닉네임 정규화에서 제거하는 "눈에 보이지 않는 문자"의 코드포인트 목록.
+ * 각 항목은 [시작, 끝] 코드포인트 범위(단일 문자는 시작=끝)다.
+ *
+ * ⚠️ 일반 공백(U+0020)은 목록에 없다 — 닉 중간 공백을 거부하는 기존 정책을 그대로 유지하기 위함.
+ *     여기 있는 것은 화면에 흔적이 없어 사용자가 의도하지 않은 문자들뿐이다.
+ */
+const INVISIBLE_CHAR_RANGES: ReadonlyArray<readonly [number, number]> = [
+    [0x0000, 0x001f], // C0 제어문자
+    [0x007f, 0x009f], // DEL · C1 제어문자
+    [0x200b, 0x200d], // ZWSP · ZWNJ · ZWJ (제로폭)
+    [0x2060, 0x2060], // Word joiner
+    [0xfeff, 0xfeff], // BOM / ZWNBSP
+    [0x3000, 0x3000] // 전각공백(눈에 보이지 않는 공백)
+];
+
+/**
+ * 위 코드포인트로 문자 클래스를 조립한다. String.fromCharCode 로 만들기 때문에
+ * 소스에는 눈에 안 보이는 문자가 직접 들어가지 않아 리뷰가 가능하다.
+ */
+const INVISIBLE_CHARS_RE = new RegExp(
+    '[' +
+        INVISIBLE_CHAR_RANGES.map(
+            ([start, end]) => String.fromCharCode(start) + '-' + String.fromCharCode(end)
+        ).join('') +
+        ']',
+    'g'
+);
+
+/**
+ * 닉네임에서 눈에 보이지 않는 문자를 제거한다.
+ *
+ * 외부 사이트에서 닉네임을 복사·붙여넣기 하면 눈에 안 보이는 문자가 딸려 오는 경우가 있다.
+ * 예를 들어 순수 한자 닉("山寂")을 붙여넣어도 앞뒤에 전각공백/제로폭 문자가 섞여
+ * 허용 문자 정규식(`^[가-힣a-zA-Z0-9._一-鿿™]+$`)을 통과하지 못해 거부됐다.
+ * (2026-08-19 실측: free/7070278 제보 — 딴지 등에서 복사한 한자 닉이 거부됨)
+ *
+ * 제거 대상은 INVISIBLE_CHAR_RANGES 참고. 일반 공백(U+0020)은 제거하지 않는다.
+ */
+export function stripInvisibleChars(value: string): string {
+    return value.replace(INVISIBLE_CHARS_RE, '');
+}
+
+/**
  * 닉네임 검증 (PHP register.lib.php 호환)
  * - 빈 값 불가
  * - 2~20자
@@ -196,15 +239,24 @@ export async function findExistingTempAccount(baseMbId: string): Promise<{ mb_id
  * - 연속 점 불가
  * - 금지어 불가
  * - 중복 불가
+ *
+ * 검증에 앞서 눈에 보이지 않는 문자(제로폭·전각공백·제어문자)를 제거하며,
+ * 길이·정규식·금지어·중복 검증과 최종 저장은 모두 정규화된 값(`normalized`) 기준으로 한다.
+ * 호출부는 검증 성공 시 `normalized` 값을 저장해야 한다.
  */
 export async function validateNickname(
     nickname: string
-): Promise<{ valid: boolean; error?: string }> {
+): Promise<{ valid: boolean; error?: string; normalized?: string }> {
     if (!nickname || !nickname.trim()) {
         return { valid: false, error: '닉네임을 입력해주세요.' };
     }
 
-    const trimmed = nickname.trim();
+    // 기존 trim → 안 보이는 문자 제거 순서. 이후 모든 검증·저장은 이 값 기준.
+    const trimmed = stripInvisibleChars(nickname.trim());
+
+    if (!trimmed) {
+        return { valid: false, error: '닉네임을 입력해주세요.' };
+    }
 
     if (trimmed.length < 2 || trimmed.length > 20) {
         return { valid: false, error: '닉네임은 2~20자로 입력해주세요.' };
@@ -234,7 +286,7 @@ export async function validateNickname(
         return { valid: false, error: '이미 사용 중인 닉네임입니다.' };
     }
 
-    return { valid: true };
+    return { valid: true, normalized: trimmed };
 }
 
 /**

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -251,6 +251,8 @@ export const actions: Actions = {
                     nickname
                 });
             }
+            // 검증기가 안 보이는 문자(제로폭·전각공백 등)를 제거한 정규화 값을 저장한다.
+            nickname = nicknameResult.normalized ?? nickname;
 
             // 같은 소셜 계정으로 만들어진 계정이 이미 있으면 새로 만들지 않는다.
             // mb_id는 소셜 sub에서 결정적으로 나오므로 충돌 = 동일인이 확실하다.


### PR DESCRIPTION
## 문제
외부 사이트(딴지 등)에서 순수 한자 닉네임을 복사·붙여넣기 하면 앞뒤에 딸려온 **안 보이는 문자** 때문에 허용 문자 정규식(\`^[가-힣a-zA-Z0-9._一-鿿™]+$\`)을 통과하지 못해 닉네임 등록/변경이 거부됐다. 제보자(free/7070278)가 복붙 → 오류 → "직접 쳐야 하나" 경험.

순수 한자(山寂·东宫·國) 자체는 정규식을 통과하지만, 복사 시 섞여 들어오는 다음 문자들이 거부를 유발:
- 전각공백 U+3000
- 제로폭 U+200B / U+200C / U+200D, Word joiner U+2060, BOM U+FEFF
- 제어문자 U+0000–U+001F, U+007F–U+009F

## 변경
- \`register.ts\`: \`stripInvisibleChars()\` 추가(제거 대상 코드포인트를 \`INVISIBLE_CHAR_RANGES\` 표로 문서화, \`String.fromCharCode\`로 문자 클래스 조립 — 소스에 안 보이는 문자를 직접 넣지 않아 리뷰 가능).
- \`validateNickname()\`: 기존 \`trim()\` 직후 정규화를 수행하고, **길이·정규식·금지어·중복 검증과 저장을 모두 정규화 값 기준**으로 처리. 정규화 값을 \`normalized\`로 반환.
- 호출부 배선: 등록(\`register/+page.server.ts\`)과 셀프 변경(\`member-update.ts\`, UPDATE + 이력 INSERT) 양쪽이 \`normalized\` 값을 저장.
- 단위 테스트(\`register.test.ts\`)에 \`stripInvisibleChars\` 케이스 추가.

## 정책 유지 (회귀 방지)
- **일반 공백(U+0020)은 제거 대상이 아님** — 닉 중간 공백을 거부하는 기존 정책 그대로. 안 보이는 문자만 걷어낸다.
- 안 보이는 문자가 없는 정상 닉(한글·한자·영문·숫자·\`._\`·™)은 무영향.
- 길이/금지어/중복 판정은 모두 정규화 후 값 기준.

## 검증
- \`stripInvisibleChars\`/정규식 조립 로직을 격리 재현: \`山␣寂\`(전각공백)→\`山寂\`, \`山​寂\`(ZWSP)→\`山寂\`, 제로폭+BOM+WJ+제어 혼합→\`山寂\` 통과. \`홍길동\`/\`山寂\`/\`a.b_c™\` 무회귀. \`a b\`는 여전히 거부(정책 유지).
- prettier --check 통과. 변경 4파일에 잔존 안 보이는 문자 0.
- ⛔ 노드 빌드/컴파일/svelte-check 미실행(정적 구현). 타입체크·유닛·lint는 CI에 위임.