### PR TITLE
obs(cwv): Web Vitals 를 GA4 와 함께 dantry 로도 보낸다 — 범인을 SQL 로 캐기 위해

### DIFF
--- a/apps/web/src/lib/services/web-vitals-rum.ts
+++ b/apps/web/src/lib/services/web-vitals-rum.ts
@@ -12,6 +12,58 @@
  */
 import { trackEvent } from './ga4';
 
+/**
+ * ⛔ GA4 로만 보내면 SQL 로 캘 수 없다 — 그래서 dantry(ClickHouse)로도 함께 보낸다.
+ *
+ * 2026-08-19 실측: 데스크톱 CLS 가 8/04 0.12~0.14 → 8/19 0.15~0.20 으로
+ * **보름 만에 43% 악화**됐다(목록 0.20 은 구글 "나쁨" 경계 0.25 에 근접).
+ * 모바일은 전부 FAST 인데 데스크톱만 AVERAGE 이고, 그 원인이 CLS 하나다.
+ *
+ * 범인 selector(largestShiftTarget)는 이미 수집되고 있었지만 **GA4 안에만 있어**
+ * "무엇이 미는가" 를 쿼리로 좁힐 수 없었다. 그 갭을 메운다.
+ *
+ * ⛔ 프런트를 늦추지 않는다:
+ *   - web-vitals 가 pagehide/visibilitychange(hidden) 시점에 최종값을 1회만 준다.
+ *     그 콜백 안에서 sendBeacon 한 번 — 렌더 경로에 아무것도 추가하지 않는다.
+ *   - **표본은 페이지 단위로 한 번 결정한다.** 지표별로 따로 뽑으면 같은 페이지의
+ *     CLS·LCP·INP 가 짝이 안 맞아 조인이 불가능해진다.
+ */
+const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
+const RUM_SAMPLE_RATE = 0.1;
+/** 이 페이지 로드를 표본으로 삼을지 — 한 번 정하고 세 지표가 같은 결정을 공유한다 */
+const rumSampled = typeof window !== 'undefined' && Math.random() < RUM_SAMPLE_RATE;
+
+function sendToDantry(name: string, value: number, target: string, group: string): void {
+    if (!rumSampled) return;
+    try {
+        const nav = (
+            performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined
+        )?.type;
+        const payload = {
+            type: 'web_vitals',
+            reason: name,
+            channel: 'rum',
+            message: `web_vitals ${name}`,
+            // ⛔ 수집기는 스키마에 없는 필드를 버린다(js_errors 컬럼 고정). stack 에 싣는다.
+            stack: [
+                `value=${value}`,
+                `target=${target}`,
+                `page=${group}`,
+                `nav=${nav ?? '?'}`,
+                `vw=${window.innerWidth}`
+            ].join('\n'),
+            url: location.href,
+            userAgent: navigator.userAgent
+        };
+        const body = JSON.stringify(payload);
+        if (typeof navigator.sendBeacon === 'function') {
+            navigator.sendBeacon(DANTRY_URL, new Blob([body], { type: 'application/json' }));
+        }
+    } catch {
+        // 관측 실패는 무시 — 사용자 영향이 없어야 한다
+    }
+}
+
 /** URL 경로를 게시판 단위로 그룹화(고카디널리티 방지). /free/123 → /free/:id */
 function pathGroup(pathname: string): string {
     return pathname
@@ -35,12 +87,17 @@ export function initWebVitalsRum(): void {
          *               web-vitals v6 에서 `.element` 가 아니라 `.target` — 2026-07-31 Evaluator 정정)
          */
         const send = (name: string, value: number, target: string | undefined) => {
+            const v = name === 'CLS' ? Math.round(value * 1000) : Math.round(value);
+            const t = (target ?? '').slice(0, 100);
+            const g = pathGroup(location.pathname);
             trackEvent('web_vitals', {
                 metric_name: name,
-                metric_value: name === 'CLS' ? Math.round(value * 1000) : Math.round(value),
-                metric_target: (target ?? '').slice(0, 100),
-                page_group: pathGroup(location.pathname)
+                metric_value: v,
+                metric_target: t,
+                page_group: g
             });
+            // GA4 와 **같은 값**을 dantry 로도 보낸다(표본만). 두 곳이 어긋나면 안 된다.
+            sendToDantry(name, v, t, g);
         };
         // 각 메트릭은 페이지 생애 최종값을 pagehide/visibilitychange(hidden) 시 1회 보고한다.
         // gtag 는 sendBeacon 으로 hidden 시점 플러시 → 언로드 유실 없음.


### PR DESCRIPTION
## 왜 — 데스크톱 CLS 가 보름 만에 43% 악화됐다

실사용자 CWV(`seo.cwv_daily`, CrUX)에서 **데스크톱만 나쁘고 원인은 CLS 하나**다.

| | LCP | INP | **CLS** | 판정 |
|---|---|---|---|---|
| 모바일 | 1.2~1.5s | 80~87ms | **0.08** | **FAST** ✅ |
| 데스크톱 | 1.6~2.5s | 55~62ms | **0.15~0.20** | **AVERAGE** ⚠️ |

그리고 **악화 중**이다:

| 날짜 | home | board_free | post |
|---|---|---|---|
| 8/04 | 0.12 | 0.14 | 0.14 |
| 8/11 | 0.14 | 0.18 | 0.16 |
| **8/19** | **0.15** | **0.20** | **0.17** |

`board_free 0.20` 은 구글 **"나쁨" 경계(0.25)** 에 근접한다. 넘으면 SEO 순위에 직접 영향이다.

급락이 아니라 **꾸준한 상승** — 아무도 안 보는 사이 서서히 나빠지는 유형이다.
오늘 하이드레이션(60일 평평하게 하루 3,302명)과 **같은 종류**다.

## 문제는 데이터가 없어서가 아니었다

`web-vitals-rum.ts` 는 CLS 와 함께 **`largestShiftTarget`(민 요소 selector)** 을 **이미 수집하고 있었다.**
그런데 **GA4 로만 보내서 SQL 로 캘 수 없었다.**
"무엇이 미는가" 를 selector 단위로 좁히려면 조회 가능한 곳에 있어야 한다.

## 무엇을 했나

GA4 로 보내던 **같은 값**을 dantry(ClickHouse)로도 보낸다 —
`value` / `target` / `page_group` / `nav` / viewport 폭.

⛔ **프런트를 늦추지 않는다**
- web-vitals 가 `pagehide` 시점에 최종값을 1회 준다. 그 콜백에서 `sendBeacon` 한 번뿐.
  **렌더 경로에 아무것도 추가하지 않는다**
- **표본은 페이지 단위로 한 번 결정**(10%). 지표별로 따로 뽑으면 같은 페이지의
  CLS·LCP·INP 가 **짝이 안 맞아 조인이 불가능**해진다

## ⛔ 범인을 고치는 것은 다음 단계다

데이터 없이 먼저 고치지 않는다 — 지난 감사에서 *"인피드 슬롯 예약 없음"* 지적이
**오진**이었던 전례가 있다(이미 예약돼 있었다).