### PR TITLE
fix(share): 공유 드롭다운 모바일 좌측 잘림 수정(#13644)

### DIFF
--- a/apps/web/src/lib/components/post/share-button.svelte
+++ b/apps/web/src/lib/components/post/share-button.svelte
@@ -115,8 +115,13 @@
     </button>
 
     {#if open}
+        <!-- bug/13644: 공유는 우측 액션 그룹(justify-end)의 최좌측 버튼이라, #2132 로
+             모바일 라벨이 복원돼 버튼 폭이 커지자 right-0(오른쪽 모서리 기준 왼쪽으로 176px
+             펼침)이 화면 좌측 밖으로 잘렸다. 모바일(<640px)에서만 left-0 으로 오른쪽 펼침
+             으로 바꾸고(우측엔 스크랩·신고 등 버튼이 있어 w-44 넘침 없음), 데스크톱은
+             sm:right-0 으로 종전 동작 그대로 유지한다. -->
         <div
-            class="bg-popover absolute bottom-full right-0 z-50 mb-1 w-44 rounded-md border p-1 shadow-md"
+            class="bg-popover absolute bottom-full left-0 z-50 mb-1 w-44 rounded-md border p-1 shadow-md sm:left-auto sm:right-0"
         >
             {#each platforms as platform}
                 <button


### PR DESCRIPTION
## 문제 (bug/13644)
게시글 상세 하단 액션의 **공유 드롭다운이 모바일에서 화면 좌측으로 잘림**.

## 원인
- `share-button.svelte` 드롭다운이 `right-0` (버튼 오른쪽 모서리 기준 왼쪽으로 w-44=176px 펼침).
- 공유 버튼은 우측 액션 그룹(`basic.svelte` L919 `ml-auto flex ... justify-end`)의 **최좌측**.
- #2132(8/19)가 모바일 라벨(`공유`)을 복원하며 버튼 폭이 커져 공유가 화면 좌측 끝으로 밀림 → 드롭다운이 좌측 화면 밖으로 잘림(가로 오버플로우).

## 수정 (최소·안전)
- 드롭다운 앵커를 **모바일(<640px)만 `left-0`**(오른쪽 펼침)으로, **데스크톱은 `sm:right-0 sm:left-auto`로 종전 동작 그대로 유지**.
- 공유 오른쪽에 스크랩·신고 등 버튼이 있어 176px 우측 펼침도 화면/카드 폭 내 → 우측 넘침 없음.
- 반응형 선택 근거: 잘림은 모바일 전용 문제이므로 데스크톱은 byte-identical(`right-0`) 유지 = 데스크톱 무회귀 보장.

## 무회귀
- `ShareButton` 사용처는 `basic.svelte` 1곳뿐(barrel export `post/index.ts` 외 grep 0). 타 사용처 영향 없음.
- #2132 되돌리지 않음(bug/13638 재발 방지).

## 변경 파일
- `apps/web/src/lib/components/post/share-button.svelte` — 드롭다운 위치 클래스 `right-0` → `left-0 sm:left-auto sm:right-0`