### PR TITLE
fix(sidebar): 아코디언 자동 펼침을 SSR 로 내린다 — 데스크톱 CLS 최대 기여분 제거

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -60,19 +60,64 @@
     // Current path tracking for active menu highlighting
     const currentPath = $derived($page.url.pathname);
 
-    function isActive(url: string): boolean {
+    // 경로를 인자로 받는 순수 판정 — 아래 computeAutoExpand 가 SSR(반응성 밖)에서도
+    // 같은 규칙을 쓸 수 있어야 하므로 currentPath 를 캡처하지 않는다.
+    function isActiveFor(url: string, path: string): boolean {
         // url='/' 는 그룹/부모 메뉴(더보기·안내 등)의 placeholder 라 실제 목적지가 아니다.
-        // 홈(currentPath='/')에서 url='/' 메뉴가 전부 active 로 잡혀 "더보기"가 활성으로
+        // 홈(path='/')에서 url='/' 메뉴가 전부 active 로 잡혀 "더보기"가 활성으로
         // 보이던 문제 방지 — 홈에서는 어떤 메뉴도 활성으로 표시하지 않는다.
         if (!url || url === '/') return false;
-        return currentPath === url || currentPath.startsWith(url + '/');
+        return path === url || path.startsWith(url + '/');
     }
 
+    function isActive(url: string): boolean {
+        return isActiveFor(url, currentPath);
+    }
+
+    /**
+     * 현재 경로에 해당하는 1depth 아코디언 값과 2/3depth 펼침 그룹을 계산한다.
+     *
+     * ⛔ **이 계산이 $effect 안에만 있으면 안 된다.** $effect 는 서버에서 실행되지 않아
+     *    서버 HTML 이 전부 닫힌 채로 나간다(2026-08-20 실측: `data-state="open"` 0개 /
+     *    `closed` 49개). 하이드레이션 직후 활성 그룹이 열리며 사이드바 nav 가
+     *    **312 → 624px** 로 뛰고, 그 +312px 이 아래 전부와 footer 를 밀어낸다.
+     *    로컬 재현 데스크톱 CLS 0.0462(실사용자 p50 0.052)의 최대 단일 기여분이었다.
+     *    ⚠️ 모바일 p75 0.057 은 이미 통과 — 이 밀림은 사이드바가 있는 데스크톱/태블릿 전용이다.
+     *    같은 계열의 선례가 이 파일 위쪽 주석(메뉴 데이터 SSR 공백, 2026-08-12)에 있다.
+     */
+    function computeAutoExpand(
+        items: MenuItem[],
+        path: string
+    ): { value: string | undefined; groups: Set<number> } {
+        let value: string | undefined = undefined;
+        const groups = new Set<number>();
+        const traverse = (list: MenuItem[], depth: number) => {
+            for (const item of list) {
+                if (!item.children?.length) continue;
+                const childActive = item.children.some(
+                    (c) =>
+                        isActiveFor(c.url, path) ||
+                        c.children?.some((gc) => isActiveFor(gc.url, path))
+                );
+                if (depth === 0 && childActive) value = `item-${item.id}`;
+                if (depth >= 1 && childActive) groups.add(item.id);
+                traverse(item.children, depth + 1);
+            }
+        };
+        traverse(items, 0);
+        return { value, groups };
+    }
+
+    // ⛔ 초기값을 **여기서** 정해야 SSR HTML 이 이미 펼쳐진 채로 나간다.
+    //    아래 $effect 로 미루면 그 시점은 하이드레이션 이후라 이미 늦다.
+    //    untrack: 초기화용 1회 계산이라 의존성으로 잡히면 안 된다.
+    const initialExpand = untrack(() => computeAutoExpand(menuData, currentPath));
+
     // Writable state for accordion — allows both auto-open and manual interaction
-    let accordionValue = $state<string | undefined>(undefined);
+    let accordionValue = $state<string | undefined>(initialExpand.value);
 
     // 2/3depth 그룹 접기/펼치기 상태
-    let expandedGroups = $state<Set<number>>(new Set());
+    let expandedGroups = $state<Set<number>>(initialExpand.groups);
 
     function toggleSubGroup(id: number) {
         const next = new Set(expandedGroups);
@@ -81,29 +126,14 @@
         expandedGroups = next;
     }
 
-    // 단일 트리 순회로 1depth 아코디언 + 2/3depth 서브그룹 동시 처리
+    // 이후 네비게이션(게시판 이동)에서 자동 펼침을 갱신한다.
+    // 첫 렌더분은 위 initialExpand 가 이미 처리했으므로 여기서는 값이 바뀌지 않는다
+    // — 그래서 하이드레이션 시점에 레이아웃이 움직이지 않는다.
     $effect(() => {
-        let newAccordionValue: string | undefined = undefined;
-        const autoExpand = new Set<number>();
-
-        const traverse = (items: typeof menuData, depth: number) => {
-            for (const item of items) {
-                if (item.children?.length) {
-                    const childActive = item.children.some(
-                        (c) => isActive(c.url) || c.children?.some((gc) => isActive(gc.url))
-                    );
-                    if (depth === 0 && childActive) {
-                        newAccordionValue = `item-${item.id}`;
-                    }
-                    if (depth >= 1 && childActive) {
-                        autoExpand.add(item.id);
-                    }
-                    traverse(item.children, depth + 1);
-                }
-            }
-        };
-
-        traverse(menuData, 0);
+        const { value: newAccordionValue, groups: autoExpand } = computeAutoExpand(
+            menuData,
+            currentPath
+        );
         // accordionValue / expandedGroups 의 읽기·쓰기는 untrack 으로 격리한다.
         // 이 effect 의 의존성은 menuData + currentPath(isActive) 뿐이어야 한다.
         // 비교를 위해 accordionValue 를 그냥 읽으면 그것이 의존성이 되어, 사용자가


### PR DESCRIPTION
## 무엇을

사이드바 아코디언 자동 펼침 계산(`accordionValue`/`expandedGroups`)이 `$effect` 안에만 있었다.
`$effect` 는 **서버에서 실행되지 않는다** → 서버 HTML 이 전부 닫힌 채로 나가고, 하이드레이션
직후 활성 그룹이 열리며 사이드바가 커진다.

## 실측 (2026-08-20)

운영 페이지를 로컬 Chromium 으로 열어 `layout-shift` 의 `sources` 를 직접 수집했다.

| | 재현 CLS | 실사용자 p50 |
|---|---|---|
| 데스크톱 | **0.0462** | 0.052 |
| 모바일 | 0.0018 | 0.002 |

중앙값 사용자가 그대로 재현된다. 시간축:

```
t=1477ms   사이드바 nav 312px      (SSR 상태)
t=1604ms   사이드바 nav 624px      ← 하이드레이션 직후 정확히 2배
           사이드바 전체 4471 → 5615px (+1144)
```

SSR HTML 확인: \`data-state="open"\` **0개** / \`closed\` **49개**.

RUM 데스크톱 최빈 타깃(n=842)이 사이드바 내부였고 \`footer\` 중앙값이 0.43 이었던 것이
이걸로 설명된다.

### ⚠️ 모바일이 아니라 데스크톱 문제다

구글이 쓰는 p75 기준:

| 기기 | 표본 | p50 | **p75** | 등급 |
|---|---|---|---|---|
| 모바일 | 5,415 | 0.002 | **0.057** | ✅ 좋음 |
| 데스크톱 | 2,928 | 0.052 | **0.109** | ⚠️ 개선필요 |
| 태블릿 | 472 | 0.004 | **0.110** | ⚠️ 개선필요 |

모바일 심각(≥0.5) 구간은 5~6% 꼬리일 뿐 p75 를 못 넘긴다. 이 PR 은 사이드바가 있는
데스크톱/태블릿을 겨냥한다.

부수 확인: AdSense 자동광고(\`gutterAdHorizontal\`, body 직계 \`ins\`)가 켜져 있지만,
광고 미충전 상태에서도 데스크톱 0.046 이 나왔으므로 **광고는 데스크톱 주범이 아니다.**

## 어떻게

계산을 순수 함수 \`computeAutoExpand(items, path)\` 로 빼고 **컴포넌트 초기화 시점에 1회 평가**해
초기값으로 넣는다. 서버·클라이언트가 같은 값을 계산하므로 하이드레이션에서 움직이지 않는다.

\`$effect\` 는 **삭제하지 않는다** — 이후 게시판 이동 시 자동 펼침 갱신을 담당하고,
\`untrack\` 격리와 합집합 병합(#1589 펼치자마자 닫힘 / #12645 수동 상태 리셋 방지)이
그대로 유지된다. 첫 렌더분은 초기값이 이미 처리하므로 \`$effect\` 는 값을 바꾸지 않는다.

## 선례

이 파일 위쪽 주석에 같은 계열의 수정 이력이 있다(메뉴 **데이터** SSR 공백, 2026-08-12,
CLS 0.1045). 데이터는 그때 고쳤는데 **펼침 상태**는 남아 있었다.

## 검증

- [x] 단일 파일 컴파일 (client/server 양쪽) 통과
- [x] prettier 통과
- [ ] 배포 후 SSR HTML 에 \`data-state="open"\` ≥ 1
- [ ] 배포 후 로컬 프로브 데스크톱 CLS < 0.02
- [ ] 회귀: 아코디언 수동 펼침 유지 · 게시판 이동 시 자동 펼침 동작