### PR TITLE
fix(sidebar): SSR 로 열린 아코디언의 애니메이션을 끈다 — 두 번 재생되며 CLS 악화

### DIFF
--- a/apps/web/src/lib/components/layout/sidebar.svelte
+++ b/apps/web/src/lib/components/layout/sidebar.svelte
@@ -312,7 +312,9 @@
                                     >
                                 </div>
                             </AccordionTrigger>
-                            <AccordionContent class="pb-1">
+                            <!-- animated={false}: SSR 이 열린 채로 나가므로 애니메이션을 끈다.
+                                 켜두면 높이 변수(0px→실측)가 늦게 확정되며 두 번 재생돼 CLS 가 커진다. -->
+                            <AccordionContent class="pb-1" animated={false}>
                                 <div class="relative ms-2 overflow-hidden rounded-lg p-[1px]">
                                     <div
                                         class="from-border absolute inset-0 rounded-lg bg-gradient-to-r to-transparent to-[4%]"

--- a/apps/web/src/lib/components/ui/accordion/accordion-content.svelte
+++ b/apps/web/src/lib/components/ui/accordion/accordion-content.svelte
@@ -5,15 +5,30 @@
     let {
         ref = $bindable(null),
         class: className,
+        animated = true,
         children,
         ...restProps
-    }: WithoutChild<AccordionPrimitive.ContentProps> = $props();
+    }: WithoutChild<AccordionPrimitive.ContentProps> & { animated?: boolean } = $props();
 </script>
 
+<!--
+    animated={false} 로 열고닫기 애니메이션을 끌 수 있다.
+
+    ⛔ **서버에서 열린 채로 렌더되는 아코디언은 애니메이션을 끄는 편이 낫다.**
+    열림 애니메이션(accordion-down)은 height 0 → var(--bits-accordion-content-height) 로 가는데,
+    이 변수는 bits-ui 가 **마운트 후 실측해야** 정해진다. 서버 HTML 에는 항상 `0px` 로 나간다.
+    그래서 SSR 이 open 이면 (1) 0px 을 목표로 한 번 재생되고 (2) 마운트 후 변수가 실제 높이로
+    바뀌며 다시 재생된다 — 밀림이 한 번이 아니라 **두 번** 난다.
+    2026-08-20 카나리 실측: 데스크톱 CLS 0.045 → 0.111 로 오히려 악화.
+    닫힌 컨텐츠는 bits-ui 가 `hidden` 속성으로 숨기므로(SSR 에서도 10/10 확인)
+    애니메이션을 꺼도 닫힌 메뉴가 펼쳐지지 않는다.
+-->
 <AccordionPrimitive.Content
     bind:ref
     data-slot="accordion-content"
-    class="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+    class={animated
+        ? 'data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm'
+        : 'overflow-hidden text-sm'}
     {...restProps}
 >
     <div class={cn('pb-4 pt-0', className)}>


### PR DESCRIPTION
## 배경

#2151 로 사이드바 아코디언 펼침 상태를 SSR 로 내렸다. SSR HTML 은 의도대로
`data-state="open"` 8개로 나갔지만, **카나리 실측이 오히려 나빠졌다**: 데스크톱 CLS
0.045 → 0.111.

## 원인 — 상태가 아니라 애니메이션

브라우저에서 시간축으로 찍어보니 `data-state="open"` 은 **처음부터 끝까지 2개로 정확**했다.
바뀐 것은 `--bits-accordion-content-height` 하나였다.

```
t=1535ms  nav=312  open=2  --h=0px
t=1815ms  nav=682  open=2  --h=0px
t=2366ms  nav=312  open=2  --h=370px   ← 변수 확정되며 재생
t=2607ms  nav=682  open=2  --h=370px
```

열림 애니메이션 `accordion-down` 은 `height: 0 → var(--bits-accordion-content-height)` 인데,
이 변수는 bits-ui 가 **마운트 후 실측해야** 정해진다. 서버 HTML 에는 항상 `0px` 로 나간다
(SSR 응답의 accordion-content 12개 전부 `--bits-accordion-content-height: 0px`).

그래서 SSR 이 open 이면 **두 번** 재생된다 — 0px 을 목표로 한 번, 실측값이 들어온 뒤 또 한 번.

## 수정

`AccordionContent` 에 `animated` prop 추가(기본 `true` — 기존 동작 불변), 사이드바에서만 끈다.
사이드바 메뉴는 페이지마다 자동으로 열리므로 애니메이션의 사용자 가치보다 CLS 비용이 크다.

## 안전성

- ⛔ 닫힌 메뉴가 펼쳐지지 않는다 — bits-ui 가 `hidden` 속성으로 숨긴다.
  SSR HTML 에서 `closed` 10개 **전부** `hidden` 보유 확인.
- `AccordionContent` 사용처는 사이드바 **하나뿐**이라 영향 범위가 갇힌다.
- 수동으로 메뉴를 여닫을 때 애니메이션이 사라진다 (의도한 트레이드오프).

## 검증

- [x] 단일 파일 컴파일 (client/server) · prettier
- [ ] 카나리 재측정: 데스크톱 CLS < 0.02, nav 높이 왕복 소멸