### PR TITLE
fix(cls): Panel 위젯 3종의 SSR/하이드레이션 높이 불일치 제거

### DIFF
--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -4,6 +4,7 @@ import { loadMenus } from '$lib/server/menu-loader';
 import { getCachedLogoData } from '$lib/server/logo';
 import { resolveLogoRequestLocale } from '$lib/utils/logo-schedule';
 import { getWidgetLayout, getSidebarWidgetLayout } from '$lib/server/settings/index';
+import { getCachedCelebrations } from '$lib/server/celebration';
 import { DEFAULT_WIDGETS, DEFAULT_SIDEBAR_WIDGETS } from '$lib/constants/default-widgets';
 
 import { hooks } from '@angple/hook-system';
@@ -87,14 +88,20 @@ export const load: LayoutServerLoad = async ({
         logoResult,
         pluginsResult,
         widgetLayoutResult,
-        sidebarWidgetLayoutResult
+        sidebarWidgetLayoutResult,
+        celebrationResult
     ] = await Promise.allSettled([
         getActiveTheme(),
         isDataRequest ? Promise.resolve([]) : loadMenus(),
         getCachedLogoData(requestLocale),
         getActivePlugins(),
         getWidgetLayout(),
-        getSidebarWidgetLayout()
+        getSidebarWidgetLayout(),
+        // ⛔ 마음메시지를 여기서 같이 내린다. 지금까지 홈(+page.server.ts)에만 있어서
+        //    다른 페이지에서는 위젯이 SSR 에 **아무것도 못 그리고**(높이 0) 하이드레이션
+        //    후 81px 이 생기며 아래 위젯과 footer 를 밀었다(2026-08-20 실측).
+        //    getCachedCelebrations 는 KST 날짜 키 서버 캐시라 페이지마다 재조회하지 않는다.
+        isDataRequest ? Promise.resolve([]) : getCachedCelebrations(false)
     ]);
 
     const activeTheme = themeResult.status === 'fulfilled' ? themeResult.value : null;
@@ -140,7 +147,8 @@ export const load: LayoutServerLoad = async ({
         ['Logo', logoResult],
         ['Plugins', pluginsResult],
         ['WidgetLayout', widgetLayoutResult],
-        ['SidebarWidgetLayout', sidebarWidgetLayoutResult]
+        ['SidebarWidgetLayout', sidebarWidgetLayoutResult],
+        ['Celebration', celebrationResult]
     ] as const) {
         if (r.status === 'rejected') {
             console.error(`[Layout] ${name} load failed:`, r.reason);
@@ -164,6 +172,8 @@ export const load: LayoutServerLoad = async ({
         themeSettings: resolvedThemeSettings,
         activePlugins,
         menus,
+        // 마음메시지 위젯의 SSR 렌더용. 실패해도 빈 배열로 사이트는 정상 동작한다.
+        celebration: celebrationResult.status === 'fulfilled' ? celebrationResult.value : [],
         // SSR_STRIP_USER=true 시 user 제거 → SSR 캐시 가능 (클라이언트 /api/auth/me로 로드)
         // 단, CSRF 필요 경로(/member, /admin, /my)는 stripUser=false로 토큰 유지
         user: stripUser ? null : (locals.user ?? null),

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -527,7 +527,20 @@
         }
     });
 
-    // SSR 데이터로 celebration + banners 캐시 초기화 (CDN 요청 제거)
+    // ⛔ **초기 1회는 여기서 — $effect 는 서버에서 실행되지 않는다.**
+    //    이 시드가 $effect 안에만 있어서 SSR 시점의 스토어가 항상 비어 있었고,
+    //    마음메시지 위젯이 서버 HTML 에 아무것도 못 그렸다(높이 0). 하이드레이션 직후
+    //    81px 이 생기며 아래 위젯과 footer 를 밀었다 — 2026-08-20 실측.
+    //    같은 계열의 선례: 사이드바 아코디언(#2151)·메뉴 데이터(2026-08-12).
+    // ⚠️ 컴파일러가 state_referenced_locally 경고를 낸다 — **의도한 것이다.**
+    //    초기값만 읽고, 이후 변경은 아래 $effect 가 맡는다. (CI 는 --threshold error)
+    untrack(() => {
+        initAppData({ celebration: data.celebration || [], banners: data.banners || {} });
+        initCelebrationFromData(data.celebration || []);
+    });
+
+    // 이후 네비게이션에서 데이터가 바뀌면 갱신한다.
+    // 첫 렌더분은 위에서 이미 처리했으므로 여기서는 값이 바뀌지 않는다.
     $effect(() => {
         const celebration = data.celebration;
         const banners = data.banners;

--- a/widgets/giving/index.svelte
+++ b/widgets/giving/index.svelte
@@ -111,7 +111,18 @@
             진행중인 나눔이 없어요
         </div>
     {:else}
-        <ul class="text-muted-foreground space-y-2 text-xs">
+        <!--
+            ⛔ 실제 목록에도 스켈레톤과 **같은 최소 높이**를 준다.
+            스켈레톤은 항상 GIVING_WIDGET_LIMIT개인데 실제 데이터는 그보다 적을 수 있다.
+            2026-08-20 실측: 공지 스켈레톤 5개(112px) → 실제 4개(97px) 로 15px 줄며
+            아래 위젯과 footer 가 통째로 밀렸다. 빈 상태에는 이미 이 방어가 있었는데
+            **정작 목록에만 없었다.**
+        -->
+        <ul
+            class="text-muted-foreground space-y-2 text-xs"
+            style="min-height: calc({GIVING_WIDGET_LIMIT} * 1rem + {GIVING_WIDGET_LIMIT -
+                1} * 0.5rem)"
+        >
             {#each items as item (item.id)}
                 <li class="flex items-center gap-1.5">
                     <a

--- a/widgets/notice/index.svelte
+++ b/widgets/notice/index.svelte
@@ -108,7 +108,18 @@
             아직 공지사항이 없어요
         </div>
     {:else}
-        <ul class="text-muted-foreground space-y-2 text-xs">
+        <!--
+            ⛔ 실제 목록에도 스켈레톤과 **같은 최소 높이**를 준다.
+            스켈레톤은 항상 NOTICE_WIDGET_LIMIT개인데 실제 데이터는 그보다 적을 수 있다.
+            2026-08-20 실측: 공지 스켈레톤 5개(112px) → 실제 4개(97px) 로 15px 줄며
+            아래 위젯과 footer 가 통째로 밀렸다. 빈 상태에는 이미 이 방어가 있었는데
+            **정작 목록에만 없었다.**
+        -->
+        <ul
+            class="text-muted-foreground space-y-2 text-xs"
+            style="min-height: calc({NOTICE_WIDGET_LIMIT} * 1rem + {NOTICE_WIDGET_LIMIT -
+                1} * 0.5rem)"
+        >
             {#each notices as notice (notice.id)}
                 <li class="flex items-center gap-1">
                     <a


### PR DESCRIPTION
## 배경

#2151·#2152 로 사이드바 메뉴를 잡아 데스크톱 CLS 를 0.047 → 0.023 으로 줄였다.
**남은 0.023 은 전부 Panel(오른쪽 위젯 사이드바)** 이었다.

브라우저에서 위젯별 높이를 시간축으로 찍어 세 갈래로 분리했다.

```
t= 647ms  공지178  마음  0  나눔178   ← SSR
t=1462ms  공지178  마음  0  나눔130   ← 나눔이 48px 줄었다
t=1610ms  공지163  마음 81  나눔178   ← 공지 15px 줄고 마음 81px 생김
```

## 1. 마음메시지 — SSR 에서 아무것도 못 그렸다 (0 → 81px)

`+layout.svelte` 의 시드가 **`$effect` 안에만** 있었다. `$effect` 는 서버에서 실행되지 않으므로
SSR 시점 스토어가 항상 비었고, `{#if celebrations.length > 0}` 이 거짓이라 서버 HTML 에
위젯이 통째로 빠졌다.

게다가 `getCachedCelebrations` 는 **홈(`+page.server.ts`)에만** 있었다. 그래서 글 상세 SSR
페이로드에는 `celebration:` 키 자체가 없었다(`menus:` 는 있는데).

```
menus:        1회  →  menus:[{parent_id:null,title:"바로가기",...
celebration:  0회
```

⭐ `+layout.ts` 의 `STABLE_KEYS` 에는 `celebration` 이 **이미 들어 있다** — 원래 서버
레이아웃에서 내려오도록 설계돼 있었는데 빠져 있던 것이다. 이 PR 은 그 설계를 복원한다.

- `+layout.server.ts`: `Promise.allSettled` 에 `getCachedCelebrations(false)` 추가.
  KST 날짜 키 **서버 캐시**라 페이지마다 재조회하지 않는다. 실패해도 빈 배열로 정상 동작.
- `+layout.svelte`: 초기 1회를 `$effect` 밖에서 시드. `$effect` 는 이후 네비게이션용으로 유지.

## 2. 공지 — 스켈레톤 5개(112px) vs 실제 4개(97px)

```
t=1251ms  공지h=178  ul=112 항목5개 [16,16,16,16,16] 스켈레톤=true
t=2468ms  공지h=163  ul= 97 항목4개 [16,16,16,25]    스켈레톤=false
```

빈 상태에는 이미 `min-height` 방어가 있었는데 **정작 실제 목록에만 없었다.**
데이터 개수는 상수로 맞출 수 없으므로 목록에 같은 `min-height` 를 준다.

## 3. 나눔(코어) — 같은 방어를 예방적으로 적용

⚠️ 실제 왕복(178→130→178)의 주범은 **premium 포크의 스켈레톤 3개 하드코딩**이며
(`premium/widgets/giving/index.svelte:100` `Array(3)`, 같은 파일 `itemCount` 기본값은 5)
그쪽은 `damoang/angple-premium` 에 별도 PR 로 간다. 코어는 SSR 렌더러라 같은 위험이
있어 예방적으로 함께 방어한다.

## 검증

- [x] 단일 파일 컴파일(client/server) · prettier
- [ ] 카나리: 위젯별 높이 왕복 소멸 · 데스크톱 CLS 재측정
- [ ] SSR 페이로드에 `celebration:` 등장

⚠️ `+layout.svelte` 의 `state_referenced_locally` 경고는 **의도한 것**이다(초기값만 읽는다).
CI 는 `--threshold error` 라 통과한다.