### PR TITLE
fix(cls): 리스트 글자크기 폴백을 스토어 기본값과 맞춘다 — 목록 5px 재배치 제거

### DIFF
--- a/apps/web/src/lib/components/features/daily-recommended/comment-card.svelte
+++ b/apps/web/src/lib/components/features/daily-recommended/comment-card.svelte
@@ -54,7 +54,7 @@
                 </p>
                 <p
                     class="mt-0.5 line-clamp-2 text-sm leading-relaxed"
-                    style="font-size: var(--recommend-font-size, 0.9rem)"
+                    style="font-size: var(--recommend-font-size, 1rem)"
                 >
                     {stripHtml(comment.content)}
                 </p>

--- a/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
+++ b/apps/web/src/lib/components/ui/promotion-inline-post/promotion-inline-post.svelte
@@ -66,7 +66,7 @@
                     >
                     <span
                         class="text-foreground truncate font-medium"
-                        style="font-size: var(--list-font-size, 0.9375rem);"
+                        style="font-size: var(--list-font-size, 1rem);"
                     >
                         {post.subject}
                     </span>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -1588,7 +1588,7 @@
                                             >
                                             <h3
                                                 class="text-foreground truncate font-medium"
-                                                style="font-size: var(--list-font-size, 0.9375rem);"
+                                                style="font-size: var(--list-font-size, 1rem);"
                                             >
                                                 {notice.title}
                                             </h3>
@@ -1627,7 +1627,7 @@
                                             >
                                             <h3
                                                 class="text-foreground truncate font-medium"
-                                                style="font-size: var(--list-font-size, 0.9375rem);"
+                                                style="font-size: var(--list-font-size, 1rem);"
                                             >
                                                 {notice.title}
                                             </h3>

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -411,7 +411,7 @@
                                             <!-- 댓글 내용 -->
                                             <p
                                                 class="mt-0.5 line-clamp-2 text-sm leading-relaxed"
-                                                style="font-size: var(--list-font-size, 0.9rem)"
+                                                style="font-size: var(--list-font-size, 1rem)"
                                             >
                                                 {stripHtml(comment.content)}
                                             </p>


### PR DESCRIPTION
## 증상

목록 페이지(`/free`)에서 **공지 행 3개가 하이드레이션 직후 각각 37.38 → 39.00px 로 자라며**
그 아래 목록 전체가 5px 밀린다. 데스크톱 CLS **0.0323** — 사이드바·Panel 수정 후 남은 밀림의 97%.

```
t= 611ms  [0]헤더=33.00  [1]공지=37.38  [2]공지=37.38  [3]공지=37.38  [4]일반=45.00
t=1379ms  [0]헤더=33.00  [1]공지=39.00  [2]공지=39.00  [3]공지=39.00  [4]일반=45.00
```

일반 행(45.00)은 고정인데 공지 행만 움직인다.

## 원인 — 폴백값과 스토어 기본값이 1px 어긋났다

행 안에서 바뀌는 것은 제목 `h3` 하나뿐이고, 클래스는 그대로다:

```
t= 650ms  h=24.38  font-size=15px  line-height=24.375px
t=1393ms  h=26.00  font-size=16px  line-height=26px
```

| | 값 |
|---|---|
| SSR | `--list-font-size` 미설정 → 폴백 **`0.9375rem` = 15px** |
| 클라이언트 | `uiSettingsStore` 가 `LIST_FONT_SIZES.base` = **16px** 설정 |

## ⚠️ 폰트 로딩이 아니다

처음엔 웹폰트 스왑을 의심했는데 **실측으로 기각**했다 — `document.fonts.ready` 는 **796ms**,
높이 변화는 **1451ms**(하이드레이션 시점)다. 폰트는 이미 로드가 끝나 있었다.

## 수정

저장소 전체에서 같은 어긋남을 찾았다. **이미 11곳이 `1rem`** 을 쓰고 있었고
`0.9375rem` 3곳 · `0.9rem` 2곳만 예외였다. 다섯 곳 모두 `1rem` 으로 통일한다.

- `[boardId]/+page.svelte` (공지 행 2곳)
- `promotion-inline-post.svelte`
- `daily-recommended/comment-card.svelte`
- `explore/+page.svelte`

`--recommend-font-size` 도 스토어가 `LIST_FONT_SIZES` 를 쓰므로 기본값은 16px 이다.

## 앞선 작업과의 관계

#2151 · #2152 · #2153 으로 글 상세 데스크톱 CLS 0.047 → **0.0047(-90%)**, 목록 0.075 → 0.033.
이 PR 은 목록에 남은 0.033 을 겨냥한다.

## 검증

- [x] 단일 파일 컴파일(client/server) · prettier
- [ ] 카나리: 공지 행 37.38→39.00 변동 소멸 · `/free` 데스크톱 CLS 재측정