### PR TITLE
obs(cwv): TTFB 를 단계별 attribution 과 함께 수집 — 다음 병목 가르기

### DIFF
--- a/apps/web/src/lib/services/web-vitals-rum.ts
+++ b/apps/web/src/lib/services/web-vitals-rum.ts
@@ -1,6 +1,6 @@
 /**
  * 실사용자(RUM) Core Web Vitals 계측.
- * 설계: CLS/LCP/INP 를 attribution 과 함께 GA4 로 보내 "무엇이 CWV 를 악화시키는가" 를
+ * 설계: CLS/LCP/INP/TTFB 를 attribution 과 함께 GA4 로 보내 "무엇이 CWV 를 악화시키는가" 를
  * 실사용자 기준으로 확정한다. cwv_daily(PSI lab, 4개 URL 샘플)의 한계를 넘어
  * 전 페이지 실측 + 범인 요소(largestShiftTarget/LCP element/INP target) 확보.
  *
@@ -90,7 +90,7 @@ export function initWebVitalsRum(): void {
     if (typeof window === 'undefined' || installed) return;
     installed = true;
 
-    void import('web-vitals/attribution').then(({ onCLS, onLCP, onINP }) => {
+    void import('web-vitals/attribution').then(({ onCLS, onLCP, onINP, onTTFB }) => {
         /**
          * @param name  메트릭명
          * @param value CLS 는 소수(×1000 정수화), LCP/INP 는 ms(반올림)
@@ -139,5 +139,38 @@ export function initWebVitalsRum(): void {
         onINP((m) =>
             send('INP', m.value, m.attribution.interactionTarget, m.attribution.interactionType)
         );
+        /**
+         * TTFB — **사용자 체감의 시작점**이자 SSR 지연이 드러나는 유일한 실사용자 지표.
+         *
+         * 2026-08-20 에 DB 쿼리 CPU 를 실측했더니 12%(0.97코어/8vCPU)로 여유가 있었다.
+         * 즉 다음 병목은 DB 가 아니라 **요청이 실제로 기다리는 곳**이고, 그걸 가르는 게
+         * TTFB 의 단계별 attribution 이다.
+         *
+         * ⛔ target 자리에 **지배적인 단계 이름**을 넣는다. 다른 지표는 "범인 요소" 를
+         *    넣는데, TTFB 는 요소가 없고 대신 "어느 구간이 제일 길었나" 가 범인이다.
+         *    그래야 기존 target= 기준 집계 쿼리가 그대로 쓰인다.
+         *   · request  = 오리진 처리(SSR·백엔드) — 우리가 고칠 수 있는 구간
+         *   · waiting  = 요청 시작 전 대기(리다이렉트·워커·큐) — CDN/엣지 계열
+         *   · dns/connection/cache = 연결 계열
+         *
+         * detail 에는 전 구간을 함께 실어 나중에 합산·분해가 되게 한다.
+         */
+        onTTFB((m) => {
+            const a = m.attribution;
+            const phases: ReadonlyArray<readonly [string, number]> = [
+                ['waiting', a.waitingDuration],
+                ['cache', a.cacheDuration],
+                ['dns', a.dnsDuration],
+                ['connection', a.connectionDuration],
+                ['request', a.requestDuration]
+            ];
+            const dominant = phases.reduce((x, y) => (y[1] > x[1] ? y : x));
+            send(
+                'TTFB',
+                m.value,
+                dominant[0],
+                phases.map(([k, v]) => `${k}=${Math.round(v)}`).join(',')
+            );
+        });
     });
 }


### PR DESCRIPTION
## 왜

2026-08-20 DB 실측: 쿼리 CPU **0.97코어 / 8 vCPU = 12%**, 대기 행렬 없음
(`Threads_running` 중앙값 3). **DB 는 병목이 아니다.**

그러면 다음 병목은 "요청이 실제로 기다리는 곳" 인데, 지금 RUM 은 CLS/LCP/INP 만 보고 있어
그 구간이 보이지 않는다. TTFB 의 단계별 attribution 이 그걸 가른다.

| 구간 | 의미 |
|---|---|
| `request` | **오리진 처리(SSR·백엔드)** — 우리가 고칠 수 있는 구간 |
| `waiting` | 요청 시작 전 대기(리다이렉트·워커·큐) — CDN/엣지 계열 |
| `dns` / `connection` / `cache` | 연결 계열 |

## 어떻게

- `target` 자리에 **지배적인 구간 이름**을 넣는다. 다른 지표는 "범인 요소" 를 넣지만
  TTFB 는 요소가 없고 "어느 구간이 제일 길었나" 가 범인이다 — 기존 `target=` 기준 집계가
  그대로 쓰인다.
- `detail` 에 다섯 구간을 전부 실어 나중에 합산·분해가 되게 한다.

## 정확성

⛔ 필드명은 추측하지 않고 **web-vitals 원본 타입 정의**(`src/types/ttfb.ts`)로 확인했다:

```ts
export interface TTFBAttribution {
  waitingDuration: number;
  cacheDuration: number;
  dnsDuration: number;
  connectionDuration: number;
  requestDuration: number;
  navigationEntry?: PerformanceNavigationTiming | PerformanceSoftNavigation;
}
```

이 파일에는 LCP attribution 을 `.element` 로 잘못 썼다가 정정한 이력이 주석으로 남아 있다
(2026-07-31). 같은 실수를 반복하지 않기 위해 원본을 확인했다.

## 비용

**프런트 비용 0.** 표본율은 기존과 동일하고(페이지 단위 10% 결정을 네 지표가 공유 →
같은 로드의 CLS·LCP·INP·TTFB 가 조인된다), `pagehide` 시점에 `sendBeacon` 한 번이다.
렌더 경로에 아무것도 추가하지 않는다.

## 함께

`triage/tools/cwv_p75_watch.py` 에 TTFB 임계(좋음 800ms / 나쁨 1800ms)를 추가했다 —
**수집만 하고 아무도 안 보는 상태**를 만들지 않기 위해서다. 매일 09:40 크론이
등급이 바뀔 때만 알린다.

## 검증

- [x] prettier(TS 파서) 통과
- [ ] CI TypeScript — attribution 필드명이 틀리면 여기서 잡힌다
- [ ] 배포 후 `error_logs.js_errors` 에 `type='web_vitals'` + `TTFB` 수집 확인