### PR TITLE
obs(cwv): 광고 충전 여부를 CLS 표본과 함께 받는다 — "아마 광고" 를 숫자로

### DIFF
--- a/apps/web/src/lib/services/web-vitals-rum.ts
+++ b/apps/web/src/lib/services/web-vitals-rum.ts
@@ -33,6 +33,35 @@ const RUM_SAMPLE_RATE = 0.1;
 /** 이 페이지 로드를 표본으로 삼을지 — 한 번 정하고 세 지표가 같은 결정을 공유한다 */
 const rumSampled = typeof window !== 'undefined' && Math.random() < RUM_SAMPLE_RATE;
 
+/**
+ * 이 페이지에서 광고가 **실제로 채워졌는가**.
+ *
+ * ⛔ 2026-08-20, 남은 데스크톱 CLS(실사용자 p75 0.093)의 원인을 "아마 광고" 라고
+ *    추측만 하고 있었다. 데이터센터 IP 의 헤드리스 브라우저에서는 AdSense 가 항상
+ *    `unfilled` 이라 재현이 안 된다 — 우리 코드 몫(프로브 0.0017~0.0038)만 확인될 뿐이다.
+ *    그래서 **실사용자 쪽에서 광고 충전 여부를 같이 받아** 갈라낸다.
+ *    이 한 필드가 "광고를 줄일지" 라는 제품 판단에 숫자를 준다.
+ *
+ * ⛔ 비용은 pagehide 시점 querySelectorAll 두 번뿐이다. 렌더 경로에 아무것도 안 넣는다.
+ * ⛔ 개수만 센다. 광고 내용·식별자는 담지 않는다.
+ */
+function adFillSignature(): string {
+    try {
+        const ins = document.querySelectorAll('ins.adsbygoogle');
+        let filled = 0;
+        // ⛔ NodeList 를 for..of 로 돌면 tsconfig(downlevelIteration)에 따라 CI 에서 막힌다.
+        for (let i = 0; i < ins.length; i++) {
+            if (ins[i].getAttribute('data-ad-status') === 'filled') filled++;
+        }
+        // google-auto-placed = AdSense 자동광고가 **우리 슬롯을 안 거치고** 꽂은 컨테이너.
+        // 우리 예약 로직 밖이라 따로 센다.
+        const auto = document.querySelectorAll('.google-auto-placed').length;
+        return `ads=${ins.length}/${filled}/${auto}`;
+    } catch {
+        return 'ads=?';
+    }
+}
+
 function sendToDantry(
     name: string,
     value: number,
@@ -57,6 +86,8 @@ function sendToDantry(
                 `page=${group}`,
                 `nav=${nav ?? '?'}`,
                 `vw=${window.innerWidth}`,
+                // 광고 충전 신호: ads=<슬롯수>/<채워진수>/<자동광고 컨테이너수>
+                adFillSignature(),
                 // ⛔ 이 한 필드가 원인을 가른다:
                 //   loading         = 초기 로딩 중 밀림 → 이미지·폰트·SSR 콘텐츠 계열
                 //   dom-interactive = 파싱 후 밀림     → 하이드레이션·초기 스크립트 계열


### PR DESCRIPTION
## 왜

2026-08-20 CLS 근본원인 5건을 제거해 **우리 코드 몫은 사실상 0** 이 됐다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 프로브(광고 미충전) | 0.047 | **0.0017 ~ 0.0038** |
| 실사용자 데스크톱 p75 | 0.119 | **0.093** (−22%) |

프로브는 −92%인데 실사용자는 −22%다. **차이는 광고**다. 데이터센터 IP 헤드리스
브라우저에서는 AdSense 가 항상 `unfilled` 이라 재현이 안 된다 — 우리 코드 몫만 확인되고
광고 몫은 영영 추측으로 남는다.

## 무엇을

`pagehide` 시점에 광고 충전 신호를 CLS 표본과 **같은 레코드**로 싣는다.

```
ads=<ins.adsbygoogle 수>/<data-ad-status=filled 수>/<.google-auto-placed 수>
```

⭐ 세 번째 값이 핵심이다. `.google-auto-placed` 는 AdSense **자동광고**가 우리 슬롯을
안 거치고 꽂은 컨테이너다. 우리 예약 로직 밖이라 따로 세야 **"우리가 못 고치는 몫"** 이
분리된다.

이 필드가 있으면 CLS 를 광고 충전 여부로 갈라 실측할 수 있고, 그래야
**"광고를 줄일지"** 라는 제품 판단에 숫자를 줄 수 있다. 지금은 그 판단을 근거 없이 하게 된다.

## 비용

- `pagehide` 시점 `querySelectorAll` 두 번. **렌더 경로에 아무것도 추가하지 않는다**
- 표본율 변화 없음(기존 10% 페이지 단위 결정 공유)
- 개수만 센다 — 광고 내용·식별자는 담지 않는다

## 함께 기각한 가설 — 본문 이미지 <span>(다시 파지 말 것)</span>

본문 이미지 **23개 전부 `width`/`height` 가 없어** CLS 주범으로 의심했다. 기각한다.

```
느린 3G 에뮬레이션 + 즉시 스크롤(대기 없음)  →  CLS 0.0005
```

`loading="lazy"` 와 브라우저 프리로드 여백 덕에 이미지가 **뷰포트에 들어오기 전에** 로드돼
확장이 화면 밖에서 일어난다. CLS 는 화면 안 밀림만 센다.

→ **치수 컬럼 DDL + 37.5만건 백필 + 렌더 재작성이 불필요**하다.
(`g5_da_editor_images` 는 filepath/filesize/filehash 만 있고 치수를 저장하지 않는다)

## 검증

- [x] prettier(TS 파서) 통과
- [ ] CI TypeScript
- [ ] 배포 후 `stack` 에 `ads=` 필드 수집 확인
- [ ] 광고 충전 여부별 CLS p75 분리 측정