### PR TITLE
fix(comments): 백필 실패를 미처리 거부로 두지 않는다 — 하루 1,000~2,400명 침묵 오류

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1476,6 +1476,65 @@
     // `/api/boards/undefined/posts/{id}/comments` 로 요청이 나갔다(운영 실측 시간당 42건).
     // → 진입 시점에 boardId 를 **고정**하고, 무효하면 아예 요청하지 않는다.
     // `cancel` 은 라우트 이탈 시 후속 시도를 멈추기 위한 신호다.
+    /**
+     * 댓글 백필 실패를 **잡되 삼키지 않는다.**
+     *
+     * ⛔ 지금까지 `void refetchComments(...)` 로 던져서 실패가 **미처리 거부**가 됐다.
+     *    2026-08-20 실측: `TimeoutError: signal timed out` 이 6시간에 1,131건 / 516명,
+     *    하루로 치면 1,000~2,400명이 8일 넘게 겪고 있었다. 아무도 몰랐다.
+     *
+     * ⛔ 그렇다고 그냥 삼키면 안 된다 — 8일간 못 본 이유가 바로 "보이지 않아서" 였다.
+     *    ⭐ 그리고 **어느 요청이 왜 끊겼는지**가 안 담겨서 원인을 못 좁혔다.
+     *       미니파이된 스택만 남아 엔드포인트조차 알 수 없었다. 그래서 URL 을 싣는다.
+     *
+     * 참고 — 서버는 범인이 아니다. 같은 6시간 동안 web 의 GET 스팬 221,973건 중
+     * 8초를 넘긴 것은 **1건**이었고 백엔드 댓글 API 는 p99 292ms 였다.
+     * `AbortSignal.timeout` 은 벽시계라 **브라우저 메인 스레드가 막히면**
+     * 서버가 5ms 에 답해도 8초가 지나간다(광고·하이드레이션 경합 의심).
+     * 그 가설을 확인하려면 URL 과 경과시간이 필요하다.
+     */
+    const BACKFILL_REPORT_URL = 'https://aplog.damoang.net/api/v1/dantry';
+    let backfillReported = false;
+
+    function reportBackfillFailure(err: unknown, startedAt: number): void {
+        // 라우트 이탈로 인한 취소는 정상이다 — 보고하지 않는다.
+        const name = err instanceof Error ? err.name : '';
+        if (name === 'AbortError') return;
+        // 페이지당 1회만 — 재시도 루프가 오류 수집을 채우지 않게 한다.
+        if (backfillReported) return;
+        backfillReported = true;
+        try {
+            const payload = {
+                type: 'comment_backfill_failed',
+                reason: name || 'unknown',
+                channel: 'client',
+                message: `comment backfill failed: ${name || 'unknown'}`,
+                // ⛔ 수집기는 스키마에 없는 필드를 버린다(js_errors 컬럼 고정). stack 에 싣는다.
+                stack: [
+                    `name=${name}`,
+                    `elapsed=${Math.round(performance.now() - startedAt)}`,
+                    `board=${boardId}`,
+                    `post=${data.post?.id ?? '?'}`,
+                    `comments=${comments.length}`,
+                    `vw=${window.innerWidth}`,
+                    // 메인 스레드 경합 가설 확인용 — 광고가 떠 있는가
+                    `ads=${document.querySelectorAll('ins.adsbygoogle').length}`
+                ].join('\n'),
+                url: location.href,
+                userAgent: navigator.userAgent
+            };
+            const body = JSON.stringify(payload);
+            if (typeof navigator.sendBeacon === 'function') {
+                navigator.sendBeacon(
+                    BACKFILL_REPORT_URL,
+                    new Blob([body], { type: 'application/json' })
+                );
+            }
+        } catch {
+            // 관측 실패는 무시 — 화면을 방해하면 안 된다
+        }
+    }
+
     async function refetchComments(cancel?: AbortSignal): Promise<void> {
         // 댓글 작성 / 수정 / 삭제 직후 호출되는 경로라 항상 fresh 응답이 필요.
         // 브라우저 HTTP 캐시 / SvelteKit data 캐시가 옛 응답을 반환하면 optimistic
@@ -1630,7 +1689,8 @@
         if (hash.startsWith('#c_')) {
             const anchorId = hash.slice(3);
             if (anchorId && !comments.some((c) => String(c.id) === anchorId)) {
-                void refetchComments(controller.signal);
+                const t0 = performance.now();
+                void refetchComments(controller.signal).catch((e) => reportBackfillFailure(e, t0));
                 return cancel;
             }
         }
@@ -1647,7 +1707,8 @@
                     scheduleBackfill(3000);
                     return;
                 }
-                void refetchComments(controller.signal);
+                const t0 = performance.now();
+                void refetchComments(controller.signal).catch((e) => reportBackfillFailure(e, t0));
             }, delay);
         };
         scheduleBackfill(1500);


### PR DESCRIPTION
## 증상

글 상세에서 1.5초 뒤 도는 댓글 백필이 `void refetchComments(...)` 로 던져져 실패가
**미처리 거부**가 된다. 잡는 곳이 없다.

```
TimeoutError: signal timed out    6시간 1,131건 / 516명
```

| 날짜 | 겪은 회원 |
|---|---|
| 8/13 | 2,115 |
| 8/14 | 2,156 |
| 8/15 | 1,706 |
| 8/16 | 1,541 |
| 8/17 | 1,834 |
| 8/18 | **2,429** |
| 8/19 | 1,196 |
| 8/20 | 843 (진행중) |

**하루 1,000~2,400명이 8일 넘게 겪고 있었고 아무도 몰랐다.** 경보가 없었고,
급등한 적이 없어 울릴 수도 없었다.

## 서버는 범인이 아니다 — 실측으로 배제

| | 값 |
|---|---|
| web `GET` 스팬 221,973건 중 8초 초과 | **1건** |
| 백엔드 댓글 API | p50 4ms · p95 6ms · p99 292ms · 8초 초과 **0건** |
| DB 댓글/알림 쿼리 | p50 7.9ms |
| web 파드 CPU | 한도의 15~20% |

`AbortSignal.timeout` 은 **벽시계**다. 브라우저 메인 스레드가 막히면 서버가 5ms 에
답해도 8초가 지나간다. 광고·하이드레이션 경합이 유력하지만 **지금 데이터로는 확정할 수 없다** —
오류에 "어느 요청이 왜 끊겼는지" 가 안 담겨 있어서다.

## 수정

- `void refetchComments(...)` **두 곳**(앵커 딥링크 · 스케줄 백필)에 `catch` 추가
- ⛔ **삼키지 않는다.** 8일간 못 본 이유가 정확히 "보이지 않아서" 였다.
  잡되 원인 판별에 필요한 것을 함께 보고한다:

  ```
  name · elapsed · board · post · 로드된 댓글 수 · vw · ads=<광고 개수>
  ```

  ⭐ 마지막 항목이 **메인 스레드 경합 가설을 가른다** — 광고가 떠 있는 로드에서만
  타임아웃이 난다면 원인이 확정된다.
- 라우트 이탈(`AbortError`)은 정상이므로 보고하지 않는다
- **페이지당 1회만** 보고 — 재시도 루프가 수집을 채우지 않게

## 부수 효과

`error_logs.js_errors` 잔삽입이 줄어든다(6시간 1,131건 감소). 이 테이블은 현재
**삽입당 1.3행**(광고 테이블은 68행)으로 파트가 과하게 생기고 있었다.

## 검증

- [x] 단일 파일 컴파일(client/server) · prettier
- [ ] 배포 후 `TimeoutError: signal timed out` 감소 확인
- [ ] `comment_backfill_failed` 수집 확인 → `ads=` 로 경합 가설 판정