### PR TITLE
fix(cls): 본문 컬럼 폭을 미리 확정한다 — 데스크톱 CLS 의 99%

### DIFF
--- a/apps/web/src/lib/layouts/default-layout.svelte
+++ b/apps/web/src/lib/layouts/default-layout.svelte
@@ -62,7 +62,36 @@
                 </aside>
             {/if}
 
-            <div class="flex min-w-0 flex-1 flex-col">
+            <!--
+                ⛔ **본문 컬럼의 폭을 미리 확정한다.** `flex-1` 만 두면 브라우저가
+                   사이드바를 파싱하기 전에 본문을 **전체 폭으로 배치·페인트**하고,
+                   뒤늦게 사이드바를 만나 320px 좁힌다 — 그때 아래가 통째로 밀린다.
+
+                   2026-08-20 실측(CPU 4배 스로틀, 실사용자 조건):
+                     t= 731ms  aside 없음        main 1,162px
+                     t=1072ms  aside 320px 등장  main   842px   → CLS 0.107
+
+                   운영 HTML 에서 Panel 은 main 보다 **97KB 뒤**에 온다(main 165,382 /
+                   Panel 262,510). 그 간격이 느린 CPU 에서 밀림으로 드러난다.
+                   빠른 머신은 첫 페인트 전에 파싱이 끝나 안 보인다 — 프로브 0.0038 vs
+                   실사용자 p75 0.099 의 26배 간극이 이것이었다.
+
+                ⭐ 폭을 명시하면 사이드바가 아직 없어도 본문 폭이 안 바뀐다.
+                   DOM 순서·탭 순서·시각 배치는 그대로다(grid 리팩터나 order 뒤집기 불필요).
+                ⛔ fullWidth 페이지는 Panel 을 안 그리므로 폭을 빼면 안 된다 —
+                   조건을 Panel 렌더 조건과 **같은 식**으로 묶는다.
+                ⛔ `width` 가 아니라 **`max-width`** 다. 폭을 고정하면 사이드바 구성이
+                   다른 페이지에서 넘치거나 빈칸이 생긴다. 상한만 걸면 본문은 여전히
+                   줄어들 수 있고, **넓어지는 것만** 막는다 — 밀림의 원인은 그쪽이다.
+                   숫자: Panel 320px, 2xl 에서 Sidebar 230px 추가 → 550px.
+                   ⚠️ Sidebar 는 main **앞**에 있어 먼저 파싱되므로 밀림을 안 만든다.
+                      상한 계산에는 포함해야 넘치지 않는다.
+            -->
+            <div
+                class="flex min-w-0 flex-1 flex-col {fullWidth
+                    ? ''
+                    : 'lg:max-w-[calc(100%-320px)] 2xl:max-w-[calc(100%-550px)]'}"
+            >
                 {#if widgetLayoutStore.hasEnabledAds && $page.url.pathname !== '/'}
                     <div class="hidden w-full px-5 pt-4 md:px-0 lg:block">
                         <AdSlot position="header-after" height="90px" slotKey="header-after" />


### PR DESCRIPTION
## 근본 원인

본문이 `flex-1` 뿐이라, 브라우저가 사이드바를 파싱하기 전에 **전체 폭으로 배치·페인트**하고
뒤늦게 Panel 을 만나 320px 좁힌다. 그때 아래가 통째로 밀린다.

```
t= 731ms   aside 없음        main = 1,162px
t=1072ms   aside 320px 등장   main =   842px    → 단일 밀림 CLS 0.107
```

운영 HTML 의 DOM 위치:

```
aside(Sidebar)   97,472
main            165,382
aside(Panel)    262,510    ← main 보다 97KB 뒤
```

폭이 줄면 `aspect-[77/9]` 배너가 **132 → 94.7px** 로 따라 줄어 아래를 **37px 당긴다.**
측정된 총 CLS 0.1085 중 **0.1072 가 이 한 번**이다.

### 왜 지금까지 못 봤나

**빠른 머신은 첫 페인트 전에 파싱이 끝나 재현이 안 된다.**

| | CLS |
|---|---|
| 제 프로브 (빠른 CPU) | 0.0038 |
| CPU 4배 스로틀 | **0.1869** |
| 실사용자 데스크톱 p75 | 0.099 |

26배 간극의 정체가 이것이었다. **느린 기기 조건으로 안 재면 안 보인다.**

## 기각한 가설 — 다시 파지 말 것

| 가설 | 근거 |
|---|---|
| 광고 | 데스크톱은 **충전 시 오히려 낮다**(0.091 vs 미충전 0.098, n=1,001) |
| AdSense 자동광고 | `.google-auto-placed` 전 표본 **0건** |
| SPA 이동 누적 | 목록↔글 3회 왕복에도 **0.0018 그대로** |
| 본문 이미지 | 느린 3G + 즉시 스크롤에도 **0.0005** |

## 수정

본문 컬럼에 `max-width` 상한. 사이드바가 아직 없어도 폭이 안 바뀐다.
**DOM 순서·탭 순서·시각 배치 그대로** — grid 리팩터나 `order` 뒤집기가 필요 없다.

⛔ `width` 고정이 **아니라** `max-width` 다. 폭을 고정하면 사이드바 구성이 다른 페이지에서
넘치거나 빈칸이 생긴다. 상한만 걸면 본문은 여전히 줄어들 수 있고 **넓어지는 것만** 막는다 —
밀림의 원인이 그쪽이다.

⛔ **배너에 고정 높이를 주는 안은 버렸다** — 원본이 770×90 이라 유료 광고 크리에이티브가
잘린다. 스켈레톤만 고정하면 뷰포트별로 실제 배너와 어긋나 모바일이 나빠진다.

⛔ `fullWidth` 페이지는 Panel 을 안 그리므로 상한을 걸면 안 된다. 같은 조건으로 묶었다.

숫자: Panel 320px, 2xl 에서 Sidebar 230px 추가 → 550px.
⚠️ Sidebar 는 main **앞**에 있어 먼저 파싱되므로 밀림을 안 만든다. 다만 상한 계산에는
포함해야 넘치지 않는다.

## 검증

- [x] 단일 파일 컴파일(client/server) · prettier
- [ ] **카나리에서 CPU 4배 스로틀 재측정** — 0.1085 → 0.01 미만 목표
- [ ] 레이아웃 회귀: 목록·글상세·`/brickang`(fullWidth)·2xl 뷰포트