### PR TITLE
fix(layout): 2xl 본문 폭 상한이 cascade 에서 지던 문제 수정

### DIFF
--- a/apps/web/src/lib/layouts/default-layout.svelte
+++ b/apps/web/src/lib/layouts/default-layout.svelte
@@ -86,11 +86,15 @@
                    숫자: Panel 320px, 2xl 에서 Sidebar 230px 추가 → 550px.
                    ⚠️ Sidebar 는 main **앞**에 있어 먼저 파싱되므로 밀림을 안 만든다.
                       상한 계산에는 포함해야 넘치지 않는다.
+                ⛔ **`2xl:` 의 `!` 를 지우지 마라 — cascade 순서에서 진다.**
+                   번들 CSS 에서 `lg` 규칙이 `2xl` 규칙보다 **뒤에** 놓인다(151,000 vs 143,350).
+                   특이도가 같으면 나중이 이기므로, `!` 없이는 1440px 이상에서도
+                   320px 상한이 걸려 밀림이 남는다. (2026-08-20 실측: -21% 에서 멈춤 → `!` 후 -89%)
             -->
             <div
                 class="flex min-w-0 flex-1 flex-col {fullWidth
                     ? ''
-                    : 'lg:max-w-[calc(100%-320px)] 2xl:max-w-[calc(100%-550px)]'}"
+                    : 'lg:max-w-[calc(100%-320px)] 2xl:!max-w-[calc(100%-550px)]'}"
             >
                 {#if widgetLayoutStore.hasEnabledAds && $page.url.pathname !== '/'}
                     <div class="hidden w-full px-5 pt-4 md:px-0 lg:block">


### PR DESCRIPTION
운영 테마(`premium` `damoang-default`)에 적용한 수정(damoang/angple-premium#162)을 코어 레이아웃에도 동일 반영한다.

## 문제

`lg:max-w-[calc(100%-320px)] 2xl:max-w-[calc(100%-550px)]` 인데 **1440px 이상에서 320px 가 적용**되고 있었다.

| 규칙 | 번들 CSS 위치 | @media |
|---|---|---|
| `2xl:max-w-[calc(100%-550px)]` | 143,350 | `min-width:1440px` |
| `lg:max-w-[calc(100%-320px)]` | **151,000** | `min-width:64rem` |

특이도가 같으면 나중이 이긴다.

## 실측 (CPU 4배 스로틀, 운영 페이지 A/B)

| 화면 | 현행 | 수정 후 | |
|---|---|---|---|
| 1512 목록 | 0.0877 | **0.0095** | -89% |
| 1512 글상세 | 0.0758 | **0.0109** | -86% |
| 1600 목록 | 0.0684 | **0.0083** | -88% |
| 1600 글상세 | 0.0677 | **0.0097** | -86% |

가로 넘침 없음, fullWidth 영향 없음.