### PR TITLE
feat(reaction): 화나요 계열 움직이는 이모지 추가 (🤬 😡)

### DIFF
--- a/apps/web/src/lib/config/reaction-config.ts
+++ b/apps/web/src/lib/config/reaction-config.ts
@@ -204,6 +204,18 @@ const NOTO_ANIMOJI: EmoticonDef[] = [
         category: 'noto-animoji',
         renderType: 'image',
         url: `${NOTO_BASE}/1f631/512.webp`
+    },
+    {
+        reaction: 'noto-animoji:1f92c',
+        category: 'noto-animoji',
+        renderType: 'image',
+        url: `${NOTO_BASE}/1f92c/512.webp`
+    },
+    {
+        reaction: 'noto-animoji:1f621',
+        category: 'noto-animoji',
+        renderType: 'image',
+        url: `${NOTO_BASE}/1f621/512.webp`
     }
 ];
 


### PR DESCRIPTION
리액션 피커 'Noto 움직이는 이모지' 탭에 화나요 계열 2종 추가.
- 🤬 (1f92c, 욕하는 얼굴) — 움직이는 버전 확인(webp 200)
- 😡 (1f621, 뿔난 빨간얼굴) — 💢(anger 기호)는 Noto 애니메이션이 없어 대체
config 항목 2줄 추가. 본문·댓글 리액션 공통 반영.