### PR TITLE
fix(watermark): 댓글만 신고잠금이면 그 댓글만 워터마크 (정상 글 전체 덮임 수정)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -4,6 +4,7 @@
     import { DisciplinedContent } from '$lib/components/ui/discipline-related/index.js';
     import type { FreeComment, BoardPermissions } from '$lib/api/types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
+    import { disciplineRevealStore } from '$lib/stores/discipline-reveal.svelte.js';
     import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
     import { LevelBadge } from '$lib/components/ui/level-badge/index.js';
     import { memberLevelStore } from '$lib/stores/member-levels.svelte.js';
@@ -472,6 +473,26 @@
             expandedLockedComments.add(commentId);
         }
     }
+
+    // bug/13548(구현2): 신고 누적으로 잠긴 댓글을 [보기]로 펼쳤을 때 그 댓글 블록에만
+    // 겹치는 좁은 영역 캡처방지 워터마크 텍스트. #12920 disciplined-content.svelte 와 동일
+    // 방식(leading-4 로 한 줄 캡처에도 식별 텍스트가 교차)이되, 전체화면 오버레이
+    // (data.watermark)는 글 자체 잠금에서만 켜지므로 여기서는 disciplineRevealStore 를
+    // 건드리지 않는다(등록 시 #12920 전체화면 워터마크가 재발동해 정상 글이 통째로 덮인다).
+    // 열람자 식별정보(SSR viewer 우선, authStore 폴백)에 시각(타임스탬프)을 포함해 추적성 확보.
+    // 비로그인/미확정 열람자는 빈 문자열 → 오버레이 미렌더(익명 SSR 에 IP·식별정보 미노출).
+    const lockedCommentWatermark = $derived.by(() => {
+        const v = disciplineRevealStore.viewer;
+        const nickname = v?.nickname || authStore.user?.mb_name || '';
+        const userId = v?.userId || authStore.user?.mb_id || '';
+        const clientIp = v?.clientIp || '';
+        if (!nickname && !userId) return '';
+        const ts = new Date().toLocaleString('ko-KR', {
+            timeZone: 'Asia/Seoul',
+            hour12: false
+        });
+        return `@${nickname}(${userId}) ${clientIp} ${ts} `.repeat(120);
+    });
 
     // 작성자 확인
     function isCommentAuthor(comment: FreeComment): boolean {
@@ -1849,20 +1870,36 @@
                                 </div>
                             </DisciplinedContent>
                         {:else}
-                            <div
-                                class="comment-body text-foreground overflow-hidden whitespace-pre-wrap break-words {isFeed
-                                    ? 'leading-snug'
-                                    : commentLayout === 'bordered'
-                                      ? 'leading-snug'
-                                      : 'leading-normal'}"
-                                style="font-size: var(--comment-font-size, 1rem);"
-                            >
-                                <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                                {@html processedComments.get(comment.id) ??
-                                    ssrCommentHtml.get(comment.id) ??
-                                    ''}
-                                {#if comment.is_restricted}
-                                    <RestrictedBadge class="ml-1" />
+                            <!-- bug/13548(구현2): 잠긴 댓글(report_count==='lock')이면 이 댓글
+                                 블록에만 겹치는 좁은 영역 워터마크를 덮는다. 정상 댓글은 isLocked
+                                 =false 라 relative 래퍼만 남고 오버레이는 미렌더(회귀 없음). -->
+                            <div class="relative">
+                                <div
+                                    class="comment-body text-foreground overflow-hidden whitespace-pre-wrap break-words {isFeed
+                                        ? 'leading-snug'
+                                        : commentLayout === 'bordered'
+                                          ? 'leading-snug'
+                                          : 'leading-normal'}"
+                                    style="font-size: var(--comment-font-size, 1rem);"
+                                >
+                                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                                    {@html processedComments.get(comment.id) ??
+                                        ssrCommentHtml.get(comment.id) ??
+                                        ''}
+                                    {#if comment.is_restricted}
+                                        <RestrictedBadge class="ml-1" />
+                                    {/if}
+                                </div>
+                                {#if isLocked && lockedCommentWatermark}
+                                    <!-- #12920 방식 좁은 영역 캡처방지 워터마크. leading-4(1rem)가
+                                         댓글 한 줄 line-height 보다 작아 어떤 한 줄 캡처에도 식별
+                                         텍스트가 교차한다. 무회전(모서리 공백 방지). -->
+                                    <div
+                                        class="pointer-events-none absolute inset-0 select-none overflow-hidden break-all text-[10px] leading-4 text-red-500/10"
+                                        aria-hidden="true"
+                                    >
+                                        {lockedCommentWatermark}
+                                    </div>
                                 {/if}
                             </div>
                             {#if comment.link1 || comment.link2}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -743,18 +743,15 @@ export const load: PageServerLoad = async ({
         })();
 
         // 워터마크 대상: 열람자 정보 전달
-        // bug/13548: 진실의방 외에도 신고잠금(report-lock) 글/댓글을 [보기]로 열람할 때 캡처방지
+        // bug/13548: 진실의방 외에도 신고잠금(report-lock) "글"을 [보기]로 열람할 때 캡처방지
         // (Watermark 전체화면 오버레이)를 진실의방과 동일하게 적용한다. 기존엔 truthroom 만 채워
         // 일반 보드(free 등)의 신고잠금 글은 ContentBlur 로 열려도 캡처방지가 없었다.
         // - 글 잠금 신호: post.extra_7 === 'lock' (= wr_7. fetchPostReportCount 와 동일 컬럼이라
-        //   postReportCount === 'lock' 과 동치이며, 기존 line 749 도 이 신호를 신뢰한다)
-        // - 댓글 잠금 신호: SSR 스레드 댓글 중 report_count === 'lock' 존재 (line 635 필터와 동일 소스)
-        // 페이지의 단일 {#if data.watermark} 가 그대로 발동해 글·댓글을 한 오버레이로 커버하고,
-        // clientIp 는 SSR(getClientAddress)에서만 확정된다. always-on-when-locked.
-        const hasLockedComment =
-            commentsData?.comments?.items?.some(
-                (c: { report_count?: string | number }) => c.report_count === 'lock'
-            ) ?? false;
+        //   postReportCount === 'lock' 과 동치) 또는 postReportLock(신고 횟수 조회 결과).
+        // ⛔ bug/13548 후속(사장님 지시): 댓글만 잠긴 경우(글은 정상)는 더 이상 전체 오버레이를
+        //   켜지 않는다. 정상 인기글이 댓글 하나 때문에 통째로 덮이던 문제 → 잠긴 댓글만
+        //   좁게 처리한다(comment-list.svelte 가 자체 오버레이로 방어). clientIp 는
+        //   SSR(getClientAddress)에서만 확정된다.
         // 신고잠금(wr_7='lock') 동기 신호 — post.extra_7 은 백엔드 상세 응답에 없어 항상
         // undefined 이므로, 확실한 lock 신호인 신고 횟수 조회 결과를 워터마크 판정에 사용한다.
         const postReportLock = (await postReportCountPromise) === 'lock';
@@ -780,13 +777,7 @@ export const load: PageServerLoad = async ({
         let watermark: { nickname: string; userId: string; clientIp: string } | null = null;
         // ⛔ locals.user 가드 필수 — 익명 SSR 응답은 CDN 캐시라 워터마크에 요청자 IP 가
         //    박히면 첫 익명 방문자 IP 가 이후 모두에게 노출된다(#12920, 아래 disciplineViewer 와 동일 이유).
-        if (
-            (boardId === 'truthroom' ||
-                post.extra_7 === 'lock' ||
-                postReportLock ||
-                hasLockedComment) &&
-            locals.user
-        ) {
+        if ((boardId === 'truthroom' || post.extra_7 === 'lock' || postReportLock) && locals.user) {
             let clientIp = resolveClientIp(getClientAddress, request) ?? '';
             watermark = {
                 nickname: locals.user?.nickname || '',


### PR DESCRIPTION
## 문제
정상 글(신고 0·공감 다수)인데 **댓글 하나만 신고잠금**이면 `hasLockedComment`로 **글 전체가 워터마크로 덮이던** 부작용(예: free/7085876 공감594 인기글이 남의 댓글 1개로 통째 덮임).

## 수정
- `+page.server.ts`: 전체 워터마크 조건에서 **`hasLockedComment`만 제거**. truthroom·글자체잠김(extra_7='lock')·postReportLock·locals.user 가드는 유지(글이 문제면 전체 덮기 맞음).
- `comment-list.svelte`: 잠긴 댓글에만 **좁은 오버레이**(`absolute inset-0 text-[10px] leading-4 text-red-500/10` 무회전 + 닉/ID/IP/**시각**). ⭐leading-4가 댓글 한 줄 line-height보다 작아 한 줄 캡처에도 식별 텍스트 교차(#12920 방식).
- ⛔변조감지 미포함(일반글 오탐 방지), 익명 SSR엔 미렌더(IP 누수 차단), 전체화면 워터마크 재유발 없음.

독립 Evaluator 9/9 PASS. **신고잠금 게이트는 별도 PR**(CDN캐시·2형·SEO 판단 대기).