### PR TITLE
feat(board): 신고잠금·이용제한 글/댓글 비로그인 게이트 (web)

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -97,6 +97,14 @@ export interface FreePost {
     } | null;
     is_left?: boolean; // 작성자 탈퇴 여부 (SSR enrichment)
     report_count?: number | string; // wr_7 값: 숫자(신고수) 또는 "lock"(잠김)
+    /** 신고잠금 글 (wr_7='lock'). be(#693)가 익명에게만 content='' 와 함께 내려준다. */
+    is_restricted?: boolean;
+    /**
+     * 게이트 종류(신고잠금/이용제한) — SSR load 가 서버 인증(locals.user)으로만 판정해 세팅한다.
+     * 비로그인 게이트 대상일 때만 'reportlock'|'discipline', 그 외(로그인·비게이트)엔 null.
+     * ⛔ 클라이언트에서 is_restricted 로 재계산 금지 — 로그인 사용자는 원문+is_restricted=true 라 오탐.
+     */
+    gated_kind?: 'reportlock' | 'discipline' | null;
     // 별점 집계 (features.rating 보드에서만 백엔드가 동봉 — 없으면 위젯 미표시)
     rating?: PostRating;
     // 레거시 평점 아카이브 (앙지도 전용, SSR enrichment, 읽기전용 — 신규 rating 과 별개로 나란히 표시)

--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -1216,7 +1216,9 @@
                     <EyeOff class="h-3.5 w-3.5" />
                     {isBlocked
                         ? '내가 차단한 회원의 댓글입니다'
-                        : '신고 누적으로 가려진 댓글입니다'}
+                        : authStore.isAuthenticated
+                          ? '신고 누적으로 가려진 댓글입니다'
+                          : '신고 누적으로 가려진 댓글입니다 · 로그인 후 확인'}
                 </button>
             </li>
         {:else}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -204,6 +204,16 @@ export const load: PageServerLoad = async ({
         const isGatedPost =
             !post.deleted_at &&
             (post.is_restricted === true || post.title?.trim() === '[이용제한 근거 글]');
+        // 게이트 화면 플래그 — be 는 "익명에게만" content 를 비우고 로그인엔 원문을 주므로,
+        // 인증의 유일 권위인 locals.user 로만 판정한다. content-빈 추론·is_restricted 단독 판정 금지
+        // (로그인 사용자는 원문+is_restricted=true 라 클라에서 재계산하면 원문을 안내로 덮어버린다).
+        // ⭐ 이미지 전용 제한글(원래 content 빈)도 로그인 사용자는 !locals.user 가 false 라 안 게이트된다.
+        post.gated_kind =
+            !locals.user && isGatedPost
+                ? post.title?.trim() === '[이용제한 근거 글]'
+                    ? 'discipline'
+                    : 'reportlock'
+                : null;
         if (isGatedPost) {
             // (3) SEO — free 한정 색인 차단(§6 ①안). 게이트 글은 색인돼도 비로그인이 못 보므로
             //     noindex + noarchive 로 검색 노출을 막는다. 다른 보드는 기존 정책 유지(free 만).

--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -197,6 +197,28 @@ export const load: PageServerLoad = async ({
             setHeaders({ 'X-Robots-Tag': 'noindex, noarchive' });
         }
 
+        // 신고잠금·이용제한 게이트 글 (비삭제) — be(#693)가 익명에게 content=''·is_restricted=true,
+        // 이용제한 근거글은 title='[이용제한 근거 글]' 로 내려준다. 게이트 판정은 그 두 신호로만 한다
+        // (허위 낙인 방지: 조회 실패 시 be 는 is_restricted 를 세우지 않으므로 여기서도 게이트로 보지 않음).
+        // ⛔ deleted 는 위에서 이미 처리·return 없이 이어지므로 !post.deleted_at 로 배타 처리한다.
+        const isGatedPost =
+            !post.deleted_at &&
+            (post.is_restricted === true || post.title?.trim() === '[이용제한 근거 글]');
+        if (isGatedPost) {
+            // (3) SEO — free 한정 색인 차단(§6 ①안). 게이트 글은 색인돼도 비로그인이 못 보므로
+            //     noindex + noarchive 로 검색 노출을 막는다. 다른 보드는 기존 정책 유지(free 만).
+            if (boardId === 'free') {
+                setHeaders({ 'X-Robots-Tag': 'noindex, noarchive' });
+            }
+            // (4) private 2차 자물쇠 — 로그인 사용자에겐 be 가 실본문을 내려주므로, 그 응답이
+            //     공유/엣지 캐시에 얹히지 않게 한다. CF 는 인증쿠키로 이미 익명과 분리하지만,
+            //     오리진이 다른 쿠키집합을 봐 우연히 캐시되는 것을 막는 두 번째 자물쇠다.
+            //     익명(마스킹) 응답은 캐시 가능하게 그대로 둔다.
+            if (locals.user) {
+                setHeaders({ 'Cache-Control': 'private, no-store' });
+            }
+        }
+
         // 앙지도 레거시 평점(아카이브): gnuboard 10점 시절 동결 집계를 읽기전용으로 별도 표시.
         // 신규 5점(post.rating)과 합치지 않는다 — 개인식별 매핑이 없어 합치면 날조가 된다.
         // 조회 실패는 헬퍼가 undefined 로 흡수 → 페이지 렌더에 영향 0.

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -262,9 +262,57 @@
         link2_affiliate?: boolean;
     }>({});
 
+    // ── 신고잠금·이용제한 게이트 안내 문구 (비로그인 유도) ─────────────────────────
+    // ⛔ A형(신고 자동잠금·미제재)과 이용제한 근거글은 상태가 달라 문구를 분리한다(묶지 말 것).
+    //    묶으면 미제재 회원 글에 제재 뉘앙스가 붙는다. 나중에 쉽게 바꾸도록 상수로 분리.
+    const DISCIPLINE_POST_TITLE = '[이용제한 근거 글]';
+    const GATE_NOTICE_REPORT_LOCK =
+        '이 글은 신고가 접수되어 확인 전까지 잠겨 있습니다. 로그인 후 확인하실 수 있습니다.';
+    const GATE_NOTICE_DISCIPLINE =
+        '이용제한 근거로 인용된 글입니다. 로그인 후 확인하실 수 있습니다.';
+
+    // 게이트 종류 판정 — 우선순위 deleted_at → 이용제한 근거글(title) → 신고잠금(is_restricted).
+    // ⛔ 삭제글은 별도 처리(빈 본문)라 여기서 제외. is_restricted 도 없고 근거글 제목도 아니면
+    //    게이트가 아니다 — 본문이 비어도(이미지/빈 글) 낙인 라벨을 붙이지 않는다(허위 낙인 금지).
+    function computePostGateKind(p: FreePost): 'reportlock' | 'discipline' | null {
+        if (p.deleted_at) return null;
+        if (p.title?.trim() === DISCIPLINE_POST_TITLE) return 'discipline';
+        if (p.is_restricted === true) return 'reportlock';
+        return null;
+    }
+    const postGateKind = $derived(computePostGateKind(data.post));
+
+    // 게이트 안내 본문 HTML — 본문 자리({@html postContent})에 렌더. 정적 문자열만 사용하고
+    // 로그인 링크의 redirect 만 encodeURIComponent 로 감싼다(외부 입력 없음).
+    function buildGateNoticeHtml(kind: 'reportlock' | 'discipline'): string {
+        const message = kind === 'discipline' ? GATE_NOTICE_DISCIPLINE : GATE_NOTICE_REPORT_LOCK;
+        const redirect = encodeURIComponent(`/${data.boardId}/${data.post.id}`);
+        const accent =
+            kind === 'discipline'
+                ? 'border-amber-500/40 bg-amber-500/5'
+                : 'border-border bg-muted/40';
+        return `<div class="report-lock-gate not-prose my-4 flex flex-col items-center gap-3 rounded-lg border ${accent} px-4 py-8 text-center">
+  <p class="text-muted-foreground text-sm">${message}</p>
+  <a href="/login?redirect=${redirect}" class="inline-flex items-center gap-1 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90">로그인</a>
+</div>`;
+    }
+
     // 제휴 변환 결과를 data.post 위에 덮은 derived — streamed linkAffiliate 가 도착하면 반영.
     // ViewComponent 와 link1Original 모두 이 값을 사용해 제휴 변환 후 링크 버튼 href 가 올바르게 갱신됨.
-    const displayPost = $derived({ ...data.post, ...linkAffiliate });
+    // 게이트 글이면 미디어/링크도 비워 안내 문구만 남긴다(이미지/첨부가 안내 옆에 뜨는 것 방지).
+    const displayPost = $derived.by(() => {
+        const merged = { ...data.post, ...linkAffiliate };
+        if (postGateKind) {
+            merged.images = [];
+            merged.videos = [];
+            merged.files = [];
+            merged.downloads = [];
+            merged.tags = [];
+            merged.link1 = '';
+            merged.link2 = '';
+        }
+        return merged;
+    });
 
     // link1이 동영상 URL이면 본문 앞에 삽입 (그누보드 wr_link1 호환)
     // link1_display: 제휴 변환 전 원본 URL (변환된 경우), 없으면 link1 자체가 원본
@@ -279,11 +327,14 @@
     const postContent = $derived(
         data.post.deleted_at
             ? ''
-            : link1Original && isEmbeddable(link1Original)
-              ? // YouTube 는 TipTap 형식으로 통일해 에디터 직접 삽입과 레이아웃 일치 (#12111).
-                // 그 외 플랫폼 (vimeo 등) 은 기존 auto-embed 경로 (plain URL → embed-container) 유지.
-                `${embedAsTiptapYoutube(link1Original) ?? link1Original}\n${renderedPostContent}`
-              : renderedPostContent
+            : postGateKind
+              ? // 신고잠금/이용제한 게이트: 본문 자리에 안내 문구 + 로그인 유도(be 가 익명엔 content='').
+                buildGateNoticeHtml(postGateKind)
+              : link1Original && isEmbeddable(link1Original)
+                ? // YouTube 는 TipTap 형식으로 통일해 에디터 직접 삽입과 레이아웃 일치 (#12111).
+                  // 그 외 플랫폼 (vimeo 등) 은 기존 auto-embed 경로 (plain URL → embed-container) 유지.
+                  `${embedAsTiptapYoutube(link1Original) ?? link1Original}\n${renderedPostContent}`
+                : renderedPostContent
     );
 
     // 소명글 ↔ 이용제한 연동: link1에서 disciplinelog ID 추출

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -265,20 +265,17 @@
     // ── 신고잠금·이용제한 게이트 안내 문구 (비로그인 유도) ─────────────────────────
     // ⛔ A형(신고 자동잠금·미제재)과 이용제한 근거글은 상태가 달라 문구를 분리한다(묶지 말 것).
     //    묶으면 미제재 회원 글에 제재 뉘앙스가 붙는다. 나중에 쉽게 바꾸도록 상수로 분리.
-    const DISCIPLINE_POST_TITLE = '[이용제한 근거 글]';
     const GATE_NOTICE_REPORT_LOCK =
         '이 글은 신고가 접수되어 확인 전까지 잠겨 있습니다. 로그인 후 확인하실 수 있습니다.';
     const GATE_NOTICE_DISCIPLINE =
         '이용제한 근거로 인용된 글입니다. 로그인 후 확인하실 수 있습니다.';
 
-    // 게이트 종류 판정 — 우선순위 deleted_at → 이용제한 근거글(title) → 신고잠금(is_restricted).
-    // ⛔ 삭제글은 별도 처리(빈 본문)라 여기서 제외. is_restricted 도 없고 근거글 제목도 아니면
-    //    게이트가 아니다 — 본문이 비어도(이미지/빈 글) 낙인 라벨을 붙이지 않는다(허위 낙인 금지).
+    // 게이트 종류 — 서버(+page.server.ts)가 인증(locals.user)으로만 판정해 내려준 플래그를 읽는다.
+    // ⛔ is_restricted 로 재계산 금지: 로그인 사용자는 원문+is_restricted=true 라 안내로 덮어버린다.
+    //    삭제글은 별도 처리(빈 본문)라 여기서 제외한다.
     function computePostGateKind(p: FreePost): 'reportlock' | 'discipline' | null {
         if (p.deleted_at) return null;
-        if (p.title?.trim() === DISCIPLINE_POST_TITLE) return 'discipline';
-        if (p.is_restricted === true) return 'reportlock';
-        return null;
+        return p.gated_kind ?? null;
     }
     const postGateKind = $derived(computePostGateKind(data.post));
 

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/+server.ts
@@ -377,6 +377,15 @@ export const GET: RequestHandler = async ({ params, url, locals, request, getCli
             const rowIsSecret = row.wr_option?.includes('secret') || false;
             const secretHidden = rowIsSecret && !canViewSecret(String(row.mb_id ?? ''));
 
+            // 비로그인 게이트(신고잠금·이용제한 근거 댓글): 삭제가 아닌 "잠긴(wr_7='lock')"
+            // 또는 "이용제한 근거(disciplineSet)" 댓글은 익명 요청에 한해 본문·링크를 중립화한다.
+            // ⛔ 행은 반드시 유지(빈 배열 금지) — 개수를 보존해 +page.svelte 의 count 불일치
+            //    자동복구 재당김 함정을 피한다. 로그인 사용자(isMember)는 원문 유지
+            //    (be #693 과 동일: "익명만 마스킹"). 삭제·비밀 마스킹이 우선한다.
+            const isLockRow = row.wr_7 === 'lock';
+            const gatedForAnon =
+                !isMember && !row.wr_deleted_at && (disciplineSet.has(row.wr_id) || isLockRow);
+
             return {
                 id: row.wr_id,
                 content: secretHidden
@@ -385,21 +394,27 @@ export const GET: RequestHandler = async ({ params, url, locals, request, getCli
                       ? isAdmin
                           ? row.wr_content
                           : ''
-                      : row.wr_content,
+                      : gatedForAnon
+                        ? ''
+                        : row.wr_content,
                 link1: secretHidden
                     ? ''
                     : row.wr_deleted_at
                       ? isAdmin
                           ? row.wr_link1 || ''
                           : ''
-                      : row.wr_link1 || '',
+                      : gatedForAnon
+                        ? ''
+                        : row.wr_link1 || '',
                 link2: secretHidden
                     ? ''
                     : row.wr_deleted_at
                       ? isAdmin
                           ? row.wr_link2 || ''
                           : ''
-                      : row.wr_link2 || '',
+                      : gatedForAnon
+                        ? ''
+                        : row.wr_link2 || '',
                 author: row.wr_deleted_at
                     ? isAdmin
                         ? nickMap.get(row.mb_id) || row.wr_name || row.mb_id
@@ -447,12 +462,17 @@ export const GET: RequestHandler = async ({ params, url, locals, request, getCli
                 ...(reviewRatingMap.has(row.wr_id)
                     ? { review_rating: reviewRatingMap.get(row.wr_id) }
                     : {}),
+                // admin 은 기존대로 신고수/lock 노출. 비로그인 잠긴 댓글은 'lock' 만 내려
+                // comment-list 가 "가려진 댓글" 접힘 플레이스홀더를 렌더하게 한다(본문은 위에서
+                // 이미 중립화됨). 로그인 일반 사용자는 기존 동작 유지(be 계약과 일관).
                 ...(isAdmin && row.wr_7
                     ? {
                           report_count:
                               row.wr_7 === 'lock' ? 'lock' : parseInt(row.wr_7, 10) || undefined
                       }
-                    : {})
+                    : gatedForAnon && isLockRow
+                      ? { report_count: 'lock' as const }
+                      : {})
             };
         });
 

--- a/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
+++ b/apps/web/src/routes/sitemap-posts-[page].xml/+server.ts
@@ -37,7 +37,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
                 //    인덱스가 없는 테이블(165개 중 4개)은 catch 에서 힌트 없이 재시도한다.
                 const sitemapQuery = (forceIndex: boolean) =>
                     pool.query<RowDataPacket[]>(
-                        `SELECT wr_id, wr_datetime, wr_last, LEFT(wr_content, 1000) AS content_head
+                        `SELECT wr_id, wr_datetime, wr_last, wr_7, LEFT(wr_content, 1000) AS content_head
                          FROM g5_write_${seg.board}${forceIndex ? ' FORCE INDEX (wr_is_comment)' : ''}
 					     WHERE wr_is_comment = 0
 					     ORDER BY wr_id DESC
@@ -59,8 +59,13 @@ export const GET: RequestHandler = async ({ params, url }) => {
                     wr_id: number;
                     wr_datetime: string;
                     wr_last: string;
+                    wr_7: string | null;
                     content_head: string;
                 }>) {
+                    // 신고잠금(A형) free 글은 sitemap 에서 제외한다 — 비로그인이 볼 수 없어
+                    // 색인 가치가 없다. 근거글·B형까지 포괄하는 최종 방어는 상세의 noindex 헤더이고
+                    // (+page.server.ts), 여기선 인덱스 스캔에 영향 없는 값싼 A형만 걸러낸다.
+                    if (seg.board === 'free' && post.wr_7 === 'lock') continue;
                     const lastmod = post.wr_last || post.wr_datetime;
                     const lastmodDate = new Date(lastmod).toISOString().split('T')[0];
                     const imageUrl = extractFirstImage(post.content_head);


### PR DESCRIPTION
## 신고잠금·이용제한 글/댓글 비로그인 게이트 (web)

신고 누적으로 자동잠금(A형)·이용제한 근거로 인용된 글/댓글을 **비로그인 사용자에게 가린다**. 백엔드(angple-backend #693, 카나리 검증 11 pass)가 익명에게 본문을 비우고 `is_restricted`를 내려주며, web은 아래를 담당한다.

제보: free/7091384

### 변경
- **댓글 프록시 마스킹** (`comments/+server.ts`): 익명(`!isMember`)이고 잠금(`wr_7='lock'`)/이용제한 근거 댓글의 `content`/`link`를 중립화. **행은 유지**(개수 보존 → 자동복구 재당김 함정 회피). 삭제·비밀 마스킹 우선. admin/로그인은 원문.
- **잠긴 글/댓글 안내 렌더** (`+page.svelte`, `comment-list.svelte`): 게이트 판정을 **서버 인증(`locals.user`) 권위**로만 수행(`+page.server.ts`가 `!locals.user && isGatedPost`일 때만 `gated_kind` 세팅). 로그인 사용자는 원문 + 기존 가림막/토글 정상 동작. 안내 문구는 A형/근거글 **2종 분리 상수**(미제재 뉘앙스 혼입 방지).
- **판별 순서**: `deleted_at`(삭제) → `is_restricted`(잠금) → 정상. 삭제 tombstone(`content=''`)에 잠김 라벨 오표기 방지.
- **SEO (free 한정)**: 게이트 글 && `boardId==='free'`에 `X-Robots-Tag: noindex, noarchive` + sitemap 제외. (truthroom·claim은 `bo_read_level=2`로 이미 비로그인 차단.)
- **private 2차 자물쇠**: 게이트 글 && 로그인 응답에 `Cache-Control: private, no-store`. 익명 마스킹 응답은 캐시 유지.
- **타입**: `FreePost`에 `is_restricted?`·`gated_kind?` 추가.

### 검증 (Evaluator SHIP)
- 로그인 사용자는 잠긴 글/댓글 **원문**(본문 원래 빈 26건 포함) — 서버 `!locals.user` 판정이라 content-추론 오게이트 없음.
- 비로그인은 게이트(안내 + 로그인 유도).
- 댓글 개수 보존(자동복구 미발동), 삭제 tombstone 오라벨 없음, 파일단위 svelte 컴파일 통과, 범위 이탈 없음.

### 배포 순서 (중요)
⛔ **be(#693) 먼저 → web 뒤.** web만 배포하면 봇 직격(댓글 API)이 안 막힌 채 "걸린 것처럼" 보인다. prod는 운영자 지시 대기.

### 잔여 (비차단)
- be fail-closed(판정 실패 시 `content=''` w/o `is_restricted`)의 중립 안내 문구는 미구현(현재 안전한 빈 본문 렌더). be 전용 신호 확보 후 별도 처리 권장.
- 안내 문구 표현은 운영자 확인 시 상수만 조정.
