### PR TITLE
fix(disciplinelog): 초기 형식 기록을 원문으로 렌더 (500 → 표시)

### DIFF
--- a/apps/web/src/lib/api/discipline-log.ts
+++ b/apps/web/src/lib/api/discipline-log.ts
@@ -121,6 +121,14 @@ export interface DisciplineLogDetail {
      *    한 글에만 적용한 사유가 전건에 적용된 것처럼 읽힌다.
      */
     reasons_differ_by_item?: boolean;
+    /**
+     * 초기 형식(2024-05~08 등) 기록. 본문이 구조화 JSON 이 아니라 운영자 자유 서술이라
+     * 위 구조화 필드가 비어 있다. 이때는 legacy_content 를 그대로 보여준다.
+     * ⛔ 「기록 없음」이 아니다 — 실제 처분이다. 예전엔 이 글들이 500 이라
+     *    「불러오는데 실패했습니다」로 보였고, 이력 조회가 통째로 틀렸다.
+     */
+    is_legacy?: boolean;
+    legacy_content?: string;
 }
 
 export interface DisciplineLogListResponse {

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -131,6 +131,31 @@
                 <Button variant="outline" class="mt-4" href="/disciplinelog">목록으로</Button>
             </Card.Content>
         </Card.Root>
+    {:else if log.is_legacy}
+        <!--
+            초기 형식 기록(2024-05~08 등 25건). 본문이 구조화 JSON 이 아니라 운영자 자유 서술이라
+            구조화 카드를 못 그린다. 원문을 그대로 보여준다.
+            ⛔ 예전엔 이 글들이 500 이라 「불러오는데 실패했습니다」로 보였다. 기록은 멀쩡히 있는데
+               화면만 없다고 말하는 상태였고, 실제로 이력 조회 오판을 낳았다(2026-08-21).
+            ⛔ 본문은 백엔드에서 게시글 본문과 같은 정책으로 sanitize 된 값이다.
+        -->
+        <Card.Root class="mb-4">
+            <Card.Header>
+                <Card.Title class="flex items-center gap-2 text-base">
+                    <FileText class="h-5 w-5" />
+                    {log.member_nickname || '이용제한 기록'}
+                </Card.Title>
+                <p class="text-muted-foreground text-xs">
+                    {log.created_at} · 초기 형식으로 작성된 기록이라 원문 그대로 표시합니다
+                </p>
+            </Card.Header>
+            <Card.Content>
+                <div class="prose prose-sm dark:prose-invert max-w-none break-words">
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    {@html log.legacy_content}
+                </div>
+            </Card.Content>
+        </Card.Root>
     {:else}
         {@const penalty = getPenaltyDisplay(log.penalty_period, log.penalty_date_to)}
         {@const severity = penaltySeverity(log.penalty_period, penalty.released, !!log.revoked_at)}


### PR DESCRIPTION
백엔드 짝: damoang/angple-backend#692

## 문제

`/disciplinelog/6` 이 「이용제한 기록을 불러오는데 실패했습니다」로 뜬다는 제보(2026-08-21).
**3,909건 중 25건**이 같은 상태였다(2024-05-29~08-26 초기 21건 + 4건).

## ⛔ 이 500 이 낳은 실제 피해

2026-08-21 다중이 조사에서 한 회원을 「제재 이력 0」으로 판단해 처분 대상이 아니라고 보고했다.
그 회원은 **2024-06-01 에 30일 이용제한을 받고 그 기간 중 탈퇴한 사람**이었다.

기록은 멀쩡히 있는데 화면이 없다고 말한다 — 조회하는 사람에게는 구분이 안 된다.

## 변경

백엔드가 초기 형식 기록에 `is_legacy` + `legacy_content` 를 실어 200 으로 내린다.
그 분기를 렌더한다. 본문이 구조화 JSON 이 아니라 운영자 자유 서술이라 구조화 카드를 못 그리므로
**원문을 그대로 보여준다.**

- `legacy_content` 는 백엔드에서 게시글 본문과 같은 정책으로 sanitize 된 값
- 구조화 분기(`{:else}`)는 손대지 않았다 → **3,884건에 영향 없음**

## 검증

- [x] `svelte compile` 통과 (대조군도 함께)
- [x] `prettier --check` 통과
- [ ] `/disciplinelog/6` 에서 30일 정지 내용·근거글 링크가 보인다
- [ ] 레거시 25건 전부 표시
- [ ] **구조화 기록 회귀 없음** ← 대조군
- [ ] 비로그인 `/login` 리다이렉트 유지 (bug/13348)