### PR TITLE
fix(web): 댓글 취소선(~~) GFM flanking 규칙 적용

### DIFF
--- a/apps/web/src/lib/utils/content-transform.test.ts
+++ b/apps/web/src/lib/utils/content-transform.test.ts
@@ -417,6 +417,31 @@ describe('transformInlineMarkdown', () => {
         expect(transformInlineMarkdown('~~취소선~~ 텍스트')).toBe('<del>취소선</del> 텍스트');
     });
 
+    // GFM flanking 규칙: 틸드 안쪽에 공백이 있으면 취소선이 아니라 리터럴
+    it('~~ 안쪽 공백 ~~ 은 취소선이 아니다 (부드러운 말투)', () => {
+        expect(transformInlineMarkdown('~~ 부드러운 ~~')).toBe('~~ 부드러운 ~~');
+    });
+
+    it('~~ 안쪽 공백 ~~ 은 취소선이 아니다 (꼬리)', () => {
+        expect(transformInlineMarkdown('~~ 꼬리 ~~')).toBe('~~ 꼬리 ~~');
+    });
+
+    it('딱 붙은 ~~꼬리~~ 는 취소선이다', () => {
+        expect(transformInlineMarkdown('~~꼬리~~')).toBe('<del>꼬리</del>');
+    });
+
+    it('닫는 틸드가 없으면 취소선이 아니다', () => {
+        expect(transformInlineMarkdown('그래요~~')).toBe('그래요~~');
+    });
+
+    it('단일 틸드는 취소선이 아니다', () => {
+        expect(transformInlineMarkdown('꼬리~')).toBe('꼬리~');
+    });
+
+    it('문장 중간 딱 붙은 ~~강조~~ 는 취소선이다', () => {
+        expect(transformInlineMarkdown('앞~~강조~~뒤')).toBe('앞<del>강조</del>뒤');
+    });
+
     it('혼합 사용', () => {
         const input = '**볼드** *이탤릭* ~~취소~~';
         const result = transformInlineMarkdown(input);

--- a/apps/web/src/lib/utils/content-transform.ts
+++ b/apps/web/src/lib/utils/content-transform.ts
@@ -321,8 +321,12 @@ export function transformInlineMarkdown(text: string): string {
     if (!text || (!text.includes('*') && !text.includes('~~'))) return text;
 
     // <pre>...</pre>, <code>...</code> 블록을 보호하면서 나머지만 변환
+    // 취소선(~~)은 GFM flanking 규칙 적용: 여는 ~~ 뒤·닫는 ~~ 앞이 모두 비공백일 때만 <del>.
+    // (예: "~~ 부드러운 ~~"처럼 안쪽에 공백이 있으면 취소선이 아닌 리터럴로 둔다)
+    // lookbehind 미사용 — 경계 문자를 캡처 그룹으로 강제해 구형 브라우저 호환.
+    // 개행/틸드를 넘지 않도록 . 대신 [^~\n] 사용(catastrophic backtracking 회피).
     return text.replace(
-        /(<pre[\s>][\s\S]*?<\/pre>|<code[\s>][\s\S]*?<\/code>)|(\*\*(.+?)\*\*|\*(.+?)\*|~~(.+?)~~)/g,
+        /(<pre[\s>][\s\S]*?<\/pre>|<code[\s>][\s\S]*?<\/code>)|(\*\*(.+?)\*\*|\*(.+?)\*|~~([^~\s](?:[^~\n]*[^~\s])?)~~)/g,
         (match, codeBlock, _md, bold, italic, strike) => {
             if (codeBlock) return codeBlock;
             if (bold) return `<strong>${bold}</strong>`;


### PR DESCRIPTION
## 버그
한국 사용자가 장식/어미로 쓰는 `~~ 부드러운 말투 ~~`(틸드 안쪽 공백)이 댓글에서 취소선으로 렌더됨. 본문(marked GFM)은 이미 정상 — **댓글 커스텀 정규식만** flanking 규칙이 없어서 발생.

## 수정
`content-transform.ts` `transformInlineMarkdown`의 취소선 정규식:
- Before: `~~(.+?)~~`
- After: `~~([^~\\s](?:[^~\\n]*[^~\\s])?)~~` — 여는/닫는 틸드 바로 옆이 비공백일 때만 `<del>`. 더블 틸드 전용 유지, lookbehind 미사용(구형 브라우저 호환), ReDoS 회피.

## 판정표 (테스트 고정)
| 입력 | 결과 |
|---|---|
| `~~ 부드러운 ~~` (공백) | 리터럴 |
| `~~꼬리~~` (딱붙음) | `<del>꼬리</del>` |
| `그래요~~` (닫힘없음) | 리터럴 |
| `꼬리~` (단일) | 리터럴 |
| `앞~~강조~~뒤` | `앞<del>강조</del>뒤` |

## 검증 (독립 Evaluator SHIP)
- content-transform.test.ts **80/80 pass**(6 회귀 케이스 추가). ReDoS 타이밍 0ms. 캡처그룹 정합(strike=group5). 범위: 취소선 정규식+테스트만(이탤릭·본문·sanitize 무변경).

⛔ 본문·에디터·sanitize 무관. 이탤릭 단일별표·본문 단일틸드는 별개 잠재이슈로 미포함.