### PR TITLE
fix(poll): SPA 이동 시 투표가 다른 글에 남는 문제 (onMount→$effect)

### DIFF
--- a/plugins/poll/components/poll-widget.svelte
+++ b/plugins/poll/components/poll-widget.svelte
@@ -90,10 +90,11 @@
         try {
             const res = await fetch(`/api/plugins/poll/by-post/${reqBoardId}/${reqPostId}`);
             // SPA 경합 가드: 응답 도착 시점에 다른 글로 이동했으면 폐기 (bug/13673 2차 방지)
-            if (reqPostId !== postId) return;
+            // wr_id 는 gnuboard 에서 보드별 시퀀스라 크로스보드 동일 wr_id 레이스가 가능 → board 도 대조
+            if (reqPostId !== postId || reqBoardId !== boardId) return;
             if (!res.ok) return;
             const body = await res.json();
-            if (reqPostId !== postId) return;
+            if (reqPostId !== postId || reqBoardId !== boardId) return;
             if (body?.success) {
                 poll = body.data as PollData;
                 multiPicks = new Set(poll?.my_choices ?? []);

--- a/plugins/poll/components/poll-widget.svelte
+++ b/plugins/poll/components/poll-widget.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
@@ -85,11 +84,16 @@
         return `${Math.max(1, Math.floor(diff / 60000))}분 남음`;
     }
 
-    async function load() {
+    // 요청 시점의 board/post 를 인자로 받아 조회한다. SPA 네비게이션에서 늦게 온 응답이
+    // 새 글에 잘못 적용되지 않도록, 응답 도착 시 현재 postId 와 캡처값을 대조해 stale 응답은 폐기.
+    async function load(reqBoardId: string, reqPostId: number) {
         try {
-            const res = await fetch(`/api/plugins/poll/by-post/${boardId}/${postId}`);
+            const res = await fetch(`/api/plugins/poll/by-post/${reqBoardId}/${reqPostId}`);
+            // SPA 경합 가드: 응답 도착 시점에 다른 글로 이동했으면 폐기 (bug/13673 2차 방지)
+            if (reqPostId !== postId) return;
             if (!res.ok) return;
             const body = await res.json();
+            if (reqPostId !== postId) return;
             if (body?.success) {
                 poll = body.data as PollData;
                 multiPicks = new Set(poll?.my_choices ?? []);
@@ -99,7 +103,19 @@
         }
     }
 
-    onMount(load);
+    // onMount 대신 $effect: SPA 네비게이션(글→글) 시 postId 변경에 반응해 재조회한다 (bug/13673).
+    // boardId/postId 를 읽어 의존성으로 추적하고, 값이 바뀌면 이전 글의 stale 상태를 즉시 리셋 후
+    // 재조회. 리셋 대상(poll·multiPicks 등)은 effect 안에서 읽지 않으므로 자기참조 재트리거 없음.
+    $effect(() => {
+        const reqBoardId = boardId;
+        const reqPostId = postId;
+        // 이전 글의 투표 상태가 새 글에 그대로 남지 않도록 즉시 초기화
+        poll = null;
+        multiPicks = new Set();
+        errorMsg = '';
+        showCreateForm = false;
+        load(reqBoardId, reqPostId);
+    });
 
     async function api(path: string, method: string, body?: unknown): Promise<boolean> {
         isSubmitting = true;


### PR DESCRIPTION
## 버그 (bug/13673)
게시판 투표를 만들면 작성자의 **다른/과거 글 전부에 그 투표 결과가 표시**됨. F5하면 정상.

## 원인 (DB·백엔드 정상)
- `angple_polls`에 `UNIQUE(bo_table, wr_id)`, 백엔드 조회도 wr_id 기준 — **데이터는 오염 안 됨**.
- `plugin-slot.svelte`가 위젯을 `{#key slot.id}`(플러그인 id)로 렌더 → SPA 글이동 시 위젯 인스턴스 유지, `postId` prop만 바뀜.
- `poll-widget.svelte`가 `onMount(load)`로 **1회만** 로드 → 첫 글의 투표 상태가 이후 모든 글에 잔류(표시만 stale).

## 수정 (web 1파일)
- `onMount(load)` → **`$effect`**: `boardId`/`postId` 추적, 변경 시 이전 상태(poll·multiPicks·errorMsg·showCreateForm) 리셋 후 재조회.
- **SPA 경합 가드**: 요청 시점 boardId/postId 캡처, 응답 도착 시 `reqPostId!==postId || reqBoardId!==boardId`면 폐기(늦게 온 응답이 새 글에 적용되는 2차 버그 + 크로스보드 동일 wr_id 레이스 방지).
- `{#key}`(공용 인프라)·POST 로직 무변경.

## 검증 (독립 Evaluator SHIP)
- $effect 재조회·리셋·경합가드·RMW 루프 없음·$state Set 재할당 안전·범위 무이탈 7/7 Pass. 파일단위 컴파일 0 warning. 백엔드·DB 무변경.