### PR TITLE
fix(comment): 앱 웹뷰에서 댓글 입력칸이 키보드에 가려지는 문제

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-editor.svelte
+++ b/apps/web/src/lib/components/features/board/comment-editor.svelte
@@ -44,6 +44,42 @@
     let isItalic = $state(false);
     let isSpoiler = $state(false);
 
+    // #13669 — 앱(웹뷰)에서 지연로딩된 에디터에 프로그래밍 방식으로 focus 가 넘어오면,
+    // 브라우저의 "포커스된 입력을 키보드 위로 스크롤" 휴리스틱이 발동하지 않아 입력창이
+    // 소프트 키보드 뒤에 잔류한다. focus 시 입력창을 키보드 위로 직접 스크롤해 보정한다.
+    // - browser(클라이언트)에서만 실행(onFocus 는 DOM 이벤트라 항상 클라이언트).
+    // - visualViewport 가 있으면(모바일/웹뷰) 가시영역 기준으로 판단, 없으면 innerHeight 폴백.
+    // - 이미 가시영역 안이면 스크롤하지 않는다 → 데스크톱·비키보드 환경에서 무해(불필요한 점프 없음).
+    // - 키보드가 뒤늦게 올라와 뷰포트가 줄어드는 웹뷰를 위해 resize 1회만 추가 보정(자기해제).
+    function scrollEditorAboveKeyboard(): void {
+        if (typeof window === 'undefined' || !editorElement) return;
+        const el = editorElement;
+        const vv = window.visualViewport;
+
+        const doScroll = () => {
+            const rect = el.getBoundingClientRect();
+            const visibleBottom = vv ? vv.height : window.innerHeight;
+            // 입력창 하단이 가시영역 안이고 상단이 위로 잘리지 않았으면 이미 보이는 것 → 스크롤 안 함.
+            if (rect.bottom <= visibleBottom && rect.top >= 0) return;
+            el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        };
+
+        // 포커스 직후 레이아웃 안정 후 1회 보정.
+        requestAnimationFrame(doScroll);
+
+        // 키보드가 늦게 올라와 visualViewport 가 줄어드는 순간 한 번 더 보정한다.
+        // 첫 resize 에서 스스로 해제하고, 키보드가 안 올라오는 환경(데스크톱)에서도
+        // 1초 뒤 반드시 해제해 리스너가 누적되지 않게 한다.
+        if (vv) {
+            const onResize = () => {
+                vv.removeEventListener('resize', onResize);
+                doScroll();
+            };
+            vv.addEventListener('resize', onResize);
+            setTimeout(() => vv.removeEventListener('resize', onResize), 1000);
+        }
+    }
+
     onMount(() => {
         if (!editorElement) return;
 
@@ -135,6 +171,8 @@
                 // #12939/#13045 — 작성 중 키보드가 내려가는 현상 진단.
                 // 포커스 중에만 관측하고, 이상 이탈일 때만 1회 전송한다(평상시 비용 0).
                 if (editorElement) watchCommentInput(editorElement);
+                // #13669 — 프로그래밍 focus 시 입력창을 소프트 키보드 위로 스크롤(작성·수정 폼 공통).
+                scrollEditorAboveKeyboard();
             },
             onTransaction: ({ editor: e }) => {
                 // ProseMirror 트랜잭션은 Svelte 렌더/effect 중 동기 호출될 수 있어, 여기서


### PR DESCRIPTION
## 버그 (bug/13669)
안드로이드 앱(웹뷰)에서 댓글 입력 시 **키보드가 올라오며 입력칸이 가려짐**. bug/13656(키보드 내려감) 수정으로 키보드가 계속 떠 있게 되면서 드러난 **선존 버그**(코드 부작용 아님).

## 원인
지연로딩(bug/13491)으로 탭 시 TipTap을 마운트하고 **프로그래밍 방식 `.focus()`**로 포커스 이전 → 브라우저의 '포커스된 입력을 키보드 위로 스크롤' 휴리스틱은 **유저 제스처 포커스에만** 걸려 발동 안 함 → 입력칸이 키보드 뒤 잔류. 코드 전역에 focus 시 scrollIntoView/visualViewport 보정 없음.

## 수정 (web 1파일)
`comment-editor.svelte` `onFocus`에 `scrollEditorAboveKeyboard()` 추가:
- **visualViewport 기반**(없으면 innerHeight 폴백)으로 가시하단 계산.
- **가려졌을 때만** 스크롤(`rect.bottom<=visibleBottom && rect.top>=0`이면 skip) → 데스크톱·비키보드 무해.
- `scrollIntoView({block:'center'})` + `requestAnimationFrame` 1회.
- 웹뷰 키보드 지연 대비 `visualViewport resize` 1회 리스너(self-remove + 1초 타임아웃 강제해제 = 누수 없음).
- `browser`/null 가드로 SSR 안전.
- ⭐ 작성 폼·수정 폼 **둘 다 같은 comment-editor를 마운트**하므로 한 곳으로 양쪽 커버.

## 검증 (독립 Evaluator SHIP)
- 보정 정확·데스크톱 무해·리스너 누수/무한루프 없음·작성+수정 커버·범위 무이탈·컴파일 0 warning 8/8 Pass. ⚠️앱 웹뷰 실동작은 온디바이스 확인 권장(코드 레벨까지 검증).