### PR TITLE
fix(emoticon): 이모티콘을 SSR에서도 렌더 (앱 웹뷰 원문코드 노출 수정)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-list.svelte
+++ b/apps/web/src/lib/components/features/board/comment-list.svelte
@@ -24,6 +24,7 @@
     import { widgetLayoutStore } from '$lib/stores/widget-layout.svelte';
     import { dompurify as DOMPurify } from '$lib/utils/dompurify.js';
     import { normalizeHtmlMediaUrls } from '$lib/utils/media-url';
+    import { transformEmoticons } from '$lib/utils/content-transform';
     import { applyFilter } from '$lib/hooks/registry';
     import { getHookVersion } from '$lib/hooks/hook-state.svelte';
     import { onMount, tick } from 'svelte';
@@ -851,7 +852,12 @@
                 map.set(comment.id, '');
                 continue;
             }
-            const withBr = comment.content.replace(/\n/g, '<br>');
+            // 이모티콘 {emo:...} → <img> 를 SSR 에서도 변환한다 (bug/13671).
+            // 종전엔 클라이언트 $effect(applyFilter 'comment_content')에서만 돌아,
+            // JS 하이드레이션 전(앱 웹뷰 등)에는 원문 코드가 그대로 노출됐다.
+            // 순수 함수라 SSR-safe. 멱등: 아래 processedComments $effect 는 원본
+            // comment.content 를 다시 필터하므로 이 SSR 결과를 재처리하지 않는다.
+            const withBr = transformEmoticons(comment.content.replace(/\n/g, '<br>'));
             map.set(
                 comment.id,
                 normalizeHtmlMediaUrls(

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -6,7 +6,7 @@
     import { getHookVersion } from '$lib/hooks/hook-state.svelte';
     import { browser } from '$app/environment';
     import { highlightAllCodeBlocks } from '$lib/utils/code-highlight';
-    import { transformEscapedMedia } from '$lib/utils/content-transform';
+    import { transformEscapedMedia, transformEmoticons } from '$lib/utils/content-transform';
     import { normalizeHtmlMediaUrls } from '$lib/utils/media-url';
     import { processContent as processEmbeds } from '$lib/plugins/auto-embed/embedder.js';
     import { attachLightbox } from '$lib/components/ui/image-lightbox/index.js';
@@ -301,6 +301,13 @@
         if (!content) return '';
         let rawHtml = marked.parse(content) as string;
         rawHtml = transformEscapedMedia(rawHtml);
+        // 이모티콘 {emo:...} → <img> 를 SSR 에서도 변환한다 (bug/13671).
+        // 종전엔 이 변환이 클라이언트 $effect(applyFilter 'post_content')에서만 돌아,
+        // JS 하이드레이션 전(앱 웹뷰 등)에는 원문 코드가 그대로 노출됐다.
+        // - transformEmoticons 는 순수 함수라 SSR-safe(DOM/window 미의존).
+        // - 멱등: 아래 클라 $effect 는 원본 content 를 다시 파싱하므로 이 SSR 결과를
+        //   재처리하지 않는다(이중 변환 없음). 라이브 렌더는 premium 파서가 최종 확정한다.
+        rawHtml = transformEmoticons(rawHtml);
         // processEmbeds는 클라이언트 $effect에서만 실행 (SSR 부하 방지)
         // 본문 이미지 src 더블슬래시 collapse + CDN 호스트 정규화 (#12697)
         return injectImageLoadingHints(


### PR DESCRIPTION
## 버그 (bug/13671)
안드로이드 앱(웹뷰)에서 이모티콘이 이미지로 안 뜨고 **원문 코드 `{emo:damoang-emo-004.gif}` 그대로** 노출(깨진 이미지·alt 아님 = 파싱 미실행).

## 원인
이모티콘 `{emo:...}`→`<img>` 변환이 **클라이언트 훅($effect)에만 등록** → SSR은 원문을 그대로 내보냄. 앱 웹뷰가 JS 하이드레이션을 안 하거나(또는 네이티브 렌더) SSR HTML의 원문 코드가 그대로 표시됨. (데스크톱 웹은 $effect 정상 실행이라 정상 = 앱 전용)

## 수정 (core-only, 2파일)
SSR 렌더 경로에서 순수 `transformEmoticons`를 직접 호출 → SSR HTML에 이미 `<img>`가 들어가 **JS가 0이어도 이모티콘 표시**:
- `markdown.svelte` `getInitialHtml()`: `transformEscapedMedia` 뒤·sanitize 전.
- `comment-list.svelte` `ssrCommentHtml`: `withBr`에 적용.

## 안전성 (독립 Evaluator SHIP 7/7)
- ⭐ **멱등**: 클라 경로가 원본 content를 재파싱(`marked.parse(content)`/원본 `comment.content`)해 SSR 결과를 재처리 안 함 → 이중래핑 0. SSR/클라가 같은 `transformEmoticons`라 src·width 일치(하이드레이션 mismatch 없음).
- **CLS 개선**: 고정 width img(텍스트→고정폭). **URL**: `/emoticons/` 루트상대경로 보존.
- **core-only**: premium/hook/에디터 무변경(premium-first 규칙 미트리거). 컴파일 clean.

⚠️ 앱 웹뷰 실동작(미하이드레이션 상태 img 표시)은 배포 후 온디바이스 확인 권장. 그래도 안 뜨면 네이티브 렌더 판정→앱팀.