### PR TITLE
fix(list): 목록 2페이지부터 each_key_duplicate 로 렌더가 죽던 것

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -853,7 +853,32 @@
     const visibleBackfilled = $derived(
         backfilledPosts.filter((p) => !uiSettingsStore.isMuted(p.title))
     );
-    const displayPosts = $derived([...filteredPosts, ...visibleBackfilled]);
+    // ⛔ 여기서 id 중복을 반드시 걷어낸다. 아래 `{#each displayPosts as post (post.id)}` 가
+    //    키를 쓰므로 중복이 하나만 있어도 each_key_duplicate 로 렌더가 죽는다.
+    //
+    // 왜 중복이 생기나 — **$derived(동기)와 $effect(비동기)의 시차다.**
+    //    2 → 3 페이지 이동 시
+    //      ① posts 가 3페이지 것으로 바뀐다
+    //      ② displayPosts 는 $derived 라 **즉시** 재계산된다
+    //         = [새 filteredPosts, **아직 안 지워진 옛 backfill**]
+    //         옛 backfill 은 2페이지에서 3페이지를 당겨온 것이라 새 posts 와 겹친다
+    //      ③ $effect 가 나중에 backfilledPosts=[] 로 지우지만 그때는 이미 렌더가 죽었다
+    //
+    //    ⭐ 1페이지에는 이전 backfill 이 없어 **2페이지부터만** 났다.
+    //       2026-08-21 실측: 3일간 46명 (/free?page=2 가 20명으로 최다).
+    //
+    // ⛔ backfill 수집 루프의 `seen` 만으로는 못 막는다. 그건 **수집 시점**의 방어이고
+    //    여기 문제는 **렌더 시점**의 조합이다. 방어는 조합하는 자리에 있어야 한다.
+    const displayPosts = $derived.by(() => {
+        const seen = new Set(filteredPosts.map((p) => p.id));
+        const extra = [];
+        for (const p of visibleBackfilled) {
+            if (seen.has(p.id)) continue;
+            seen.add(p.id);
+            extra.push(p);
+        }
+        return [...filteredPosts, ...extra];
+    });
 
     // 다음 페이지 한 장을 현재 목록과 동일한 쿼리(카테고리·태그 포함)로 당겨온다.
     // SSR(+page.server.ts)이 쓰는 것과 같은 엔드포인트이며, 같은 오리진 fetch 라


### PR DESCRIPTION
## 증상

`/free?page=2` **이후에서만** `Uncaught Error: svelte.dev/e/each_key_duplicate`.
**1페이지에는 없다.**

```
2026-08-21 실측 (ClickHouse, 3일)
  /free?page=2   20명   ← 최다
  /free?page=3   12명
  /free?page=4   11명
  ...            합계 46명
```

⭐ **증상이 페이지에 의존한 것이 결정적 단서였다.**

## 원인 — `$derived`(동기)와 `$effect`(비동기)의 시차

```js
displayPosts = $derived([...filteredPosts, ...visibleBackfilled]);
```

2 → 3 페이지 이동 시:

1. `posts` 가 3페이지 것으로 바뀐다
2. `displayPosts` 는 `$derived` 라 **즉시** 재계산된다
   = `[새 filteredPosts, **아직 안 지워진 옛 backfill**]`
   옛 backfill 은 **2페이지에서 3페이지를 당겨온 것**이라 새 posts 와 겹친다
3. `$effect` 가 나중에 `backfilledPosts=[]` 로 지우지만 **그때는 이미 렌더가 죽었다**

1페이지에는 이전 backfill 이 없어 **2페이지부터만** 났다.

## ⛔ 이미 중복 제거가 있는데도 났다

backfill 수집 루프에 `const seen = new Set(posts.map(p => p.id))` 가 있다.
그런데도 났다 — 그건 **수집 시점**의 방어이고, 이 문제는 **렌더 시점의 조합**이다.

> **방어는 조합하는 자리에 있어야 한다.**

⚠️ backfill 도입 시 주석에 「경미한 페이지 간 중복은 감수한다」고 적혀 있었다.
감수할 수 있는 것은 **중복 노출**이지, 키가 있는 `{#each}` 의 **렌더 사망**이 아니다.
절충을 적을 때는 그 절충이 무엇을 깨뜨리는지까지 확인해야 한다.

## 수정

`displayPosts` 를 `$derived.by` 로 바꿔 **조합 시점에** id 중복을 걷어낸다.
타이밍과 무관하게 항상 유일하다.

## 검증

- [x] 파일 단위 컴파일 통과
- [x] **대조군**: 경고 7건으로 `origin/main` 과 **동일** — 새 경고 없음
- [x] prettier 통과
- [ ] CI

⛔ 전체 빌드는 서버에서 하지 않았다(CPU 100% + OOM 전례).

## 배포 후 확인

차단 키워드가 있는 계정으로 `/free?page=2` → `page=3` 이동. 콘솔에 `each_key_duplicate` 가 없어야 한다.
⚠️ **차단 키워드가 없으면 backfill 이 아예 안 돌아 재현되지 않는다** — 46명뿐인 이유도 이것이다.

```sql
SELECT extract(stack,'releases/(sha-[a-z0-9-]+)/') AS build, uniqExact(member_id)
FROM error_logs.js_errors
WHERE message LIKE '%each_key_duplicate%' AND timestamp >= now() - INTERVAL 1 DAY
GROUP BY build
```
