### PR TITLE
feat(settings): 마이페이지 쪽지 수신 거부 토글 (bug/13664)

### DIFF
--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -72,6 +72,13 @@ export interface UiSettings {
     expandMemoInList: boolean;
     /** 메모 색상별 사용자 지정 이름표 (color→label). 빈 값은 기본 이름 사용 (#13013) */
     memoColorLabels: Record<string, string>;
+    // 쪽지(DM)
+    /**
+     * 쪽지 수신 전면 거부 (#13664). 켜면 다른 회원이 나에게 쪽지를 보낼 수 없다.
+     * ⛔ 발송 게이트는 백엔드가 별도로 구현한다. 여기서는 설정값만 서버(L2)에 저장한다.
+     * 운영 안내·이용제한 통보 등 시스템 쪽지는 이 설정과 무관하게 예외로 발송된다.
+     */
+    memoDeny: boolean;
 }
 
 const DEFAULTS: UiSettings = {
@@ -106,7 +113,8 @@ const DEFAULTS: UiSettings = {
     hideMemoInList: false,
     blurMemo: false,
     expandMemoInList: true,
-    memoColorLabels: {}
+    memoColorLabels: {},
+    memoDeny: false
 };
 
 // ⛔ normal 은 현재 라이브 하드코딩(markdown .prose p / tiptap p = 1.8)과 **같은 값**이어야 한다.
@@ -473,6 +481,10 @@ function createUiSettingsStore() {
         get memoColorLabels() {
             return settings.memoColorLabels;
         },
+        // 쪽지(DM)
+        get memoDeny() {
+            return settings.memoDeny;
+        },
 
         setTitleBold(v: boolean) {
             settings.titleBold = v;
@@ -542,6 +554,10 @@ function createUiSettingsStore() {
             if (trimmed) next[color] = trimmed;
             else delete next[color];
             settings.memoColorLabels = next;
+            save();
+        },
+        setMemoDeny(v: boolean) {
+            settings.memoDeny = v;
             save();
         },
 

--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -78,7 +78,7 @@ export interface UiSettings {
      * ⛔ 발송 게이트는 백엔드가 별도로 구현한다. 여기서는 설정값만 서버(L2)에 저장한다.
      * 운영 안내·이용제한 통보 등 시스템 쪽지는 이 설정과 무관하게 예외로 발송된다.
      */
-    memoDeny: boolean;
+    messageDeny: boolean;
 }
 
 const DEFAULTS: UiSettings = {
@@ -114,7 +114,7 @@ const DEFAULTS: UiSettings = {
     blurMemo: false,
     expandMemoInList: true,
     memoColorLabels: {},
-    memoDeny: false
+    messageDeny: false
 };
 
 // ⛔ normal 은 현재 라이브 하드코딩(markdown .prose p / tiptap p = 1.8)과 **같은 값**이어야 한다.
@@ -482,8 +482,8 @@ function createUiSettingsStore() {
             return settings.memoColorLabels;
         },
         // 쪽지(DM)
-        get memoDeny() {
-            return settings.memoDeny;
+        get messageDeny() {
+            return settings.messageDeny;
         },
 
         setTitleBold(v: boolean) {
@@ -556,8 +556,8 @@ function createUiSettingsStore() {
             settings.memoColorLabels = next;
             save();
         },
-        setMemoDeny(v: boolean) {
-            settings.memoDeny = v;
+        setMessageDeny(v: boolean) {
+            settings.messageDeny = v;
             save();
         },
 

--- a/apps/web/src/routes/api/my/ui-settings/+server.ts
+++ b/apps/web/src/routes/api/my/ui-settings/+server.ts
@@ -48,7 +48,8 @@ const ALLOWED_KEYS = new Set<string>([
     'hideMemoInList',
     'blurMemo',
     'expandMemoInList',
-    'memoColorLabels'
+    'memoColorLabels',
+    'memoDeny'
 ]);
 
 /** 남용 방어 상한 */

--- a/apps/web/src/routes/api/my/ui-settings/+server.ts
+++ b/apps/web/src/routes/api/my/ui-settings/+server.ts
@@ -49,7 +49,7 @@ const ALLOWED_KEYS = new Set<string>([
     'blurMemo',
     'expandMemoInList',
     'memoColorLabels',
-    'memoDeny'
+    'messageDeny'
 ]);
 
 /** 남용 방어 상한 */

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -25,6 +25,7 @@
     import LayoutList from '@lucide/svelte/icons/layout-list';
     import EyeOff from '@lucide/svelte/icons/eye-off';
     import MessageSquare from '@lucide/svelte/icons/message-square';
+    import Mail from '@lucide/svelte/icons/mail';
     import XIcon from '@lucide/svelte/icons/x';
     import Plus from '@lucide/svelte/icons/plus';
     import Search from '@lucide/svelte/icons/search';
@@ -1492,6 +1493,31 @@
                                 </div>
                             {/each}
                         </div>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle class="flex items-center gap-2">
+                        <Mail class="h-5 w-5" />
+                        쪽지 설정
+                    </CardTitle>
+                    <CardDescription>다른 회원의 쪽지 수신 여부를 설정합니다.</CardDescription>
+                </CardHeader>
+                <CardContent class="space-y-4">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <Label>쪽지 수신 거부</Label>
+                            <p class="text-muted-foreground text-xs">
+                                켜면 다른 회원이 나에게 쪽지를 보낼 수 없습니다. (운영 안내·이용제한
+                                통보 쪽지는 예외)
+                            </p>
+                        </div>
+                        <Switch
+                            checked={uiSettingsStore.memoDeny}
+                            onCheckedChange={(v) => uiSettingsStore.setMemoDeny(v)}
+                        />
                     </div>
                 </CardContent>
             </Card>

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -1515,8 +1515,8 @@
                             </p>
                         </div>
                         <Switch
-                            checked={uiSettingsStore.memoDeny}
-                            onCheckedChange={(v) => uiSettingsStore.setMemoDeny(v)}
+                            checked={uiSettingsStore.messageDeny}
+                            onCheckedChange={(v) => uiSettingsStore.setMessageDeny(v)}
                         />
                     </div>
                 </CardContent>


### PR DESCRIPTION
## 배경 (bug/13664)
설중매(google_8c3a08951) 기능제안 — 회원이 마이페이지에서 '쪽지 수신 거부'를 켜면 다른 회원이 쪽지를 못 보내게. 사장님 승인(발송자에게 '수신자가 쪽지 기능을 비활성화했습니다' 명시).

## 이 PR (web = 설정 저장 + 토글 UI)
설정 저장 테이블 `g5_da_member_ui_settings`(JSON, **web 소유**)에 `memoDeny` 키 추가. ⛔ DDL 없음, 신규 엔드포인트 없음.
- `ui-settings.svelte.ts`: `memoDeny: boolean`(기본 false) + getter/setter(기존 debounce write-through 재사용).
- `/api/my/ui-settings`: `ALLOWED_KEYS`에 `memoDeny` 등록(GET 반환·PUT 수용).
- `member/settings/ui` etc 탭: **전용 '쪽지 설정' 카드** 신설(메모 플러그인 설정과 별개 — 메모≠쪽지). 라벨 '쪽지 수신 거부', 설명 '켜면 다른 회원이 나에게 쪽지를 보낼 수 없습니다. (운영 안내·이용제한 통보 쪽지는 예외)'.

## 발송 차단 (백엔드, 별도)
실제 발송 차단은 백엔드가 `message_handler.go` 발송 게이트에서 이 `memoDeny`를 읽어 처리(angple-b3). ⭐ **제재·소명·처분 통보는 다른 경로(damoang-be SendMemo/크론 직접 INSERT)라 구조적으로 게이트와 분리 = 안 막힘**(소명 기간 미시작 위험 없음, 검증됨).

## 검증 (독립 Evaluator SHIP 7/7)
store/API 왕복/UI·메모≠쪽지 배치/하위호환(기존 유저 false·full write-through 키 유실 없음)/범위/컴파일 전부 Pass.