### PR TITLE
fix(mypage): 삭제글 항목 클릭 불가 명확화 (bug/13675 ②)

### DIFF
--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -347,15 +347,12 @@
                             <ul class="divide-border divide-y">
                                 {#each result.posts.items as post (post.id)}
                                     <li class="py-3 first:pt-0 last:pb-0">
-                                        <!-- 삭제한 글은 본문이 없어 열리지 않는다 — 링크 대신 기록만 -->
-                                        <svelte:element
-                                            this={post.deleted_at ? 'div' : 'a'}
-                                            href={post.deleted_at
-                                                ? undefined
-                                                : `/${post.board_id || 'free'}/${post.id}`}
+                                        <!-- 삭제한 글도 상세(tombstone)로 열린다(본인 삭제글 열람) — 링크 유지, 삭제는 opacity로만 표시 -->
+                                        <a
+                                            href={`/${post.board_id || 'free'}/${post.id}`}
                                             class="{post.deleted_at
                                                 ? 'opacity-70'
-                                                : 'hover:bg-accent'} -m-2 block w-full rounded-md p-2 no-underline transition-colors"
+                                                : ''} hover:bg-accent -m-2 block w-full rounded-md p-2 no-underline transition-colors"
                                         >
                                             <h3
                                                 class="text-foreground mb-1 line-clamp-1 font-medium"
@@ -379,7 +376,7 @@
                                                     >
                                                 {/if}
                                             </div>
-                                        </svelte:element>
+                                        </a>
                                     </li>
                                 {/each}
                             </ul>

--- a/apps/web/src/routes/my/+page.svelte
+++ b/apps/web/src/routes/my/+page.svelte
@@ -347,12 +347,15 @@
                             <ul class="divide-border divide-y">
                                 {#each result.posts.items as post (post.id)}
                                     <li class="py-3 first:pt-0 last:pb-0">
-                                        <!-- 삭제한 글도 상세(tombstone)로 열린다(본인 삭제글 열람) — 링크 유지, 삭제는 opacity로만 표시 -->
-                                        <a
-                                            href={`/${post.board_id || 'free'}/${post.id}`}
+                                        <!-- 삭제한 글은 열람 링크를 제공하지 않는다(정책 #2090: 대량삭제 유도 방지·삭제글 접근 링크 원복) — 기록으로만 표시하고 클릭 불가를 명확히(cursor-default) -->
+                                        <svelte:element
+                                            this={post.deleted_at ? 'div' : 'a'}
+                                            href={post.deleted_at
+                                                ? undefined
+                                                : `/${post.board_id || 'free'}/${post.id}`}
                                             class="{post.deleted_at
-                                                ? 'opacity-70'
-                                                : ''} hover:bg-accent -m-2 block w-full rounded-md p-2 no-underline transition-colors"
+                                                ? 'cursor-default opacity-70'
+                                                : 'hover:bg-accent'} -m-2 block w-full rounded-md p-2 no-underline transition-colors"
                                         >
                                             <h3
                                                 class="text-foreground mb-1 line-clamp-1 font-medium"
@@ -376,7 +379,7 @@
                                                     >
                                                 {/if}
                                             </div>
-                                        </a>
+                                        </svelte:element>
                                     </li>
                                 {/each}
                             </ul>


### PR DESCRIPTION
## 버그 (bug/13675 ②)
마이페이지 '삭제한 글'이 클릭되는 것처럼 보이는데 눌러도 반응 없어 제보자가 혼란.

## 정책 (중요)
삭제글 **열람 링크는 제공하지 않는다** — #2090(2026-08-14, 사장님)에서 '마이페이지 댓글 삭제버튼 + 삭제글 접근 링크'를 **대량삭제 유도 방지 원칙**으로 되돌린 정책 유지. (삭제는 글 페이지에서만.)

## 수정 (web 1파일)
삭제글 항목을 **기록으로만** 표시하고 **클릭 불가를 명확히**: 비링크(`<div>`) 유지 + `cursor-default`(포인터 커서 제거)·hover 미적용·`opacity-70`. 사용자가 클릭 가능한 줄 오인하지 않게. '삭제된 글입니다'·삭제일 표시 유지.
- 생존글은 기존대로 `<a href>` 링크.

## 참고
- 버그①(삭제 '댓글' 목록이 아예 비던 것)은 별개 = 순수 SQL 버그, be #696(angple-b3)에서 수정. 이건 유지된 '삭제한 댓글' 탭이 기록을 제대로 나열하게 하는 것으로 정책과 무관.