### PR TITLE
feat(sidebar): 우측 위젯에 이용가이드 미니 카드 (마음메시지 아래)

### DIFF
--- a/apps/web/src/lib/components/layout/panel.svelte
+++ b/apps/web/src/lib/components/layout/panel.svelte
@@ -19,6 +19,20 @@
     <!-- 마음메시지 카드 위젯 (공지 아래, 사이드바 배너 위) -->
     <WidgetRenderer zone="sidebar" onlyIds={['celebration']} />
 
+    <!-- 이용가이드 미니 카드 (마음메시지 아래) -->
+    <a
+        href="/content/guide"
+        class="block rounded-xl border bg-teal-50 p-3.5 text-center no-underline transition-colors hover:border-teal-300 dark:bg-teal-950/30"
+    >
+        <div class="text-2xl">🙌</div>
+        <div class="text-foreground mt-0.5 text-sm font-bold">다모앙 이용가이드</div>
+        <div class="text-muted-foreground text-xs">처음이신가요? 3분이면 충분해요</div>
+        <span
+            class="mt-2 inline-block rounded-full bg-teal-500 px-3.5 py-1 text-xs font-bold text-white"
+            >가이드 보기 →</span
+        >
+    </a>
+
     <!-- 사이드바 배너 (슬롯 기반) -->
     <PluginSlot name="sidebar-banner" />
 


### PR DESCRIPTION
## 개요
우측 사이드바 위젯의 **마음메시지(celebration) 카드 아래**에 이용가이드(`/content/guide`) 진입 미니 카드를 추가.

## 배경
- 사장님 지시: 공지사항·마음메시지 아래에 이용가이드 진입점, **안 2(미니 카드, 아이콘 강조)** 채택.
- 딥다이브: `2026-08-22-guide-entrypoint-sidebar-design.html`

## 위치·노출
- `panel.svelte` L20(celebration) 바로 아래 삽입 → 배너슬롯 위.
- **코어 단일 파일**(라이브 테마 `custom-themes/damoang-default`·폴백 레이아웃이 공유) → 그대로 반영.
- 노출: **데스크톱 우측 사이드바 전 페이지**(`/admin`·`/install` 제외). 모바일은 우측 사이드바 없음 → 헤더 메뉴로 별도 커버 예정.

## 구현
- `<a href="/content/guide">` 미니 카드: 🙌 아이콘 + "다모앙 이용가이드" + "처음이신가요? 3분이면 충분해요" + "가이드 보기 →" 배지.
- shadcn 토큰 기반 다크모드 대응, **단색 파스텔**(⛔to-card 무효 그라데이션 회피).

## 검증
- [ ] 데스크톱 우측 사이드바에 공지·마음메시지 아래로 카드 노출
- [ ] 카드 클릭 → /content/guide 이동
- [ ] 라이트/다크 색 대비
- [ ] 모바일 미노출(우측 사이드바 없음) 정상