### PR TITLE
fix(cert): 「고객센터」 대신 메일 주소를 직접 안내

### DIFF
--- a/apps/web/src/routes/cert/inicis/result/+server.ts
+++ b/apps/web/src/routes/cert/inicis/result/+server.ts
@@ -153,7 +153,8 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
         return certResultPage(
             false,
             '이전에 가입하신 계정이 있어 본인인증이 제한되었습니다. ' +
-                '기존 계정으로 로그인하시거나, 계정 복구가 필요하시면 고객센터로 문의해 주세요.'
+                '기존 계정으로 로그인해 주시고, 그 계정을 되살리고 싶으시면 ' +
+                'contact@damoang.net 으로 복원 요청 메일을 보내주세요.'
         );
     }
 
@@ -167,7 +168,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
         return certResultPage(
             false,
             '기존에 본인인증하신 명의와 일치하지 않습니다. 본인 명의로 진행해 주세요. ' +
-                '변경이 필요하시면 고객센터로 문의해 주세요.'
+                '변경이 필요하시면 contact@damoang.net 으로 메일을 보내주세요.'
         );
     }
 
@@ -183,14 +184,15 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
             return certResultPage(
                 false,
                 '기존에 본인인증하신 명의와 일치하지 않습니다. 본인 명의로 진행해 주세요. ' +
-                    '변경이 필요하시면 고객센터로 문의해 주세요.'
+                    '변경이 필요하시면 contact@damoang.net 으로 메일을 보내주세요.'
             );
         }
         if (reason === 'DI_COLLISION_BLOCKED') {
             return certResultPage(
                 false,
                 '이전에 가입하신 계정이 있어 본인인증이 제한되었습니다. ' +
-                    '기존 계정으로 로그인하시거나, 계정 복구가 필요하시면 고객센터로 문의해 주세요.'
+                    '기존 계정으로 로그인해 주시고, 그 계정을 되살리고 싶으시면 ' +
+                    'contact@damoang.net 으로 복원 요청 메일을 보내주세요.'
             );
         }
         return certResultPage(false, '인증 정보 저장에 실패했습니다.');

--- a/apps/web/src/routes/register/recover/+page.svelte
+++ b/apps/web/src/routes/register/recover/+page.svelte
@@ -62,7 +62,7 @@
                         </p>
                     </div>
                     <p class="text-muted-foreground text-sm leading-6">
-                        문의가 필요하시면 고객센터로 연락해 주세요.
+                        문의가 필요하시면 contact@damoang.net 으로 메일을 보내주세요.
                     </p>
                     <Button href="/" variant="outline" class="w-full">돌아가기</Button>
                 </div>


### PR DESCRIPTION
## 문제

본인인증 거부 화면이 **"고객센터로 문의해 주세요"** 라고만 안내한다.
그런데 다모앙에는 고객센터 창구가 따로 없고 **`contact@damoang.net`** 이 실제 창구다.

⛔ **회원이 고객센터를 한참 찾다가 못 찾았다**는 제보가 있었다.

## 왜 급한가

거부 화면에서 **다음 행동을 못 찾으면 그냥 떠난다.**

실제 사례 — 2026-08-22 `apple_875a084c`: 가입 10:42 → 인증 시도 → DI 충돌로 거부 → **당일 탈퇴, 작성 0건.**
⭐ 그 계정 계열은 **처분 이력이 하나도 없어** 규정상 복원 대상이었다.

## 변경

| 위치 | 전 | 후 |
|---|---|---|
| DI 충돌 (2곳) | 계정 복구가 필요하시면 **고객센터로** 문의해 주세요 | 그 계정을 되살리고 싶으시면 **`contact@damoang.net` 으로 복원 요청 메일**을 보내주세요 |
| 명의 불일치 (2곳) | 변경이 필요하시면 **고객센터로** | 변경이 필요하시면 **`contact@damoang.net` 으로 메일**을 |
| 계정 복구 페이지 | 문의가 필요하시면 **고객센터로** | 문의가 필요하시면 **`contact@damoang.net` 으로 메일**을 |

## ⛔ 일부러 안 고친 것

`login/+page.svelte` · `register/+page.server.ts` 의 **`account_blocked`** 안내 3곳.
그쪽은 **이용제한 상태**라 정본 경로가 **소명 게시판**이다. 메일로 안내하면 소명 절차를 우회한다.
**별도 판단이 필요하다.**

## 검증

- [x] `svelte compile` 통과 (대조군 함께)
- [x] `prettier --check` 통과
- [x] premium 에 동일 파일 없음 확인 — 코어가 라이브
- [ ] 배포 후 인증 거부 화면에서 메일 주소가 보이는지