### PR TITLE
feat(post): 이용제한·비밀글의 제3자 댓글 열람 노출

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -629,7 +629,7 @@
     }
 
     $effect(() => {
-        if (!browser || !canViewSecret) return;
+        if (!browser || !canViewComments) return;
         if (commentsLoaded || commentsError || commentsAutoRecoveryTriggered) return;
 
         const timer = window.setTimeout(() => {
@@ -1202,6 +1202,14 @@
         (!data.post.is_secret || isAuthor || isAdmin) && !promotionExpired
     );
 
+    // 이용제한/비밀글이라도 제3자가 쓴 댓글은 열람 노출한다(작성자 이용제한과 무관).
+    // 본문·사유는 canViewSecret 로 계속 가리고, 여기서는 댓글 목록 읽기만 연다.
+    // 봇의 대량 추출을 막기 위해 로그인 사용자에게만 노출한다(비로그인은 기존대로 게이트).
+    // 개별 제재 댓글(삭제·비밀·이용제한 근거)은 comment-list 가 각각 자동으로 계속 가린다.
+    const canViewComments = $derived(
+        canViewSecret || (!promotionExpired && !!authStore.user)
+    );
+
     // 댓글 레이아웃 (관리자 변경 시 즉시 반영용)
     // eslint-disable-next-line svelte/prefer-writable-derived -- layout must refresh from route data while remaining locally writable
     const commentLayout = $derived(data.board?.display_settings?.comment_layout || 'flat');
@@ -1712,7 +1720,7 @@
     // 댓글 backfill: SSR에서 일부만 로드된 경우 전체 댓글 가져오기
     // onMount 대신 $effect로 SPA 네비게이션에서도 동작하도록
     $effect(() => {
-        if (!browser || !canViewSecret) return;
+        if (!browser || !canViewComments) return;
         // loadState 신호 기반(총<=로드 산술의 0/0 함정 제거, #12663·#12668):
         // - complete: SSR 전량 로드(정상 0개 포함) → backfill 불필요.
         // - failed 또는 목록 0개: 즉시 재시도(backfillWithRetry, 백오프 3회).
@@ -2624,7 +2632,7 @@
         <div data-scroll-depth="75" aria-hidden="true"></div>
 
         <!-- 댓글 섹션 -->
-        {#if canViewSecret && commentsError}
+        {#if canViewComments && commentsError}
             <Card class="bg-background px-3 md:px-3">
                 <CardContent class="space-y-4 py-8 text-center">
                     <p class="text-destructive text-sm">댓글을 불러오지 못했습니다.</p>
@@ -2654,7 +2662,7 @@
                     {/if}
                 </CardContent>
             </Card>
-        {:else if canViewSecret}
+        {:else if canViewComments}
             <Card id="comments" class="bg-background rounded-xl px-3 md:px-3">
                 <CardHeader class="flex flex-row items-center justify-between">
                     <div class="flex items-center gap-2">
@@ -2780,6 +2788,10 @@
                         {:else if boardId === 'claim' && authStore.user?.mb_id !== data.post.author_id && (authStore.user?.mb_level ?? 0) < 10}
                             <p class="text-muted-foreground py-4 text-center text-sm">
                                 소명 게시판에서는 관리자와 글 작성자만 댓글을 작성할 수 있습니다.
+                            </p>
+                        {:else if !canViewSecret}
+                            <p class="text-muted-foreground py-4 text-center text-sm">
+                                비밀글에는 댓글을 작성할 수 없습니다.
                             </p>
                         {:else}
                             {#key data.post.id}

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1206,9 +1206,7 @@
     // 본문·사유는 canViewSecret 로 계속 가리고, 여기서는 댓글 목록 읽기만 연다.
     // 봇의 대량 추출을 막기 위해 로그인 사용자에게만 노출한다(비로그인은 기존대로 게이트).
     // 개별 제재 댓글(삭제·비밀·이용제한 근거)은 comment-list 가 각각 자동으로 계속 가린다.
-    const canViewComments = $derived(
-        canViewSecret || (!promotionExpired && !!authStore.user)
-    );
+    const canViewComments = $derived(canViewSecret || (!promotionExpired && !!authStore.user));
 
     // 댓글 레이아웃 (관리자 변경 시 즉시 반영용)
     // eslint-disable-next-line svelte/prefer-writable-derived -- layout must refresh from route data while remaining locally writable


### PR DESCRIPTION
## 개요
작성자가 이용제한되면 글이 secret으로 전환돼 **제3자가 쓴 댓글까지** 함께 가려지던 것을, 댓글 열람만 분리해 노출. (딥다이브: 2026-08-22-restricted-post-comments-visibility.html, 계기 free/7091054)

## 설계
- 댓글 데이터는 API·서버load가 이미 다 가져옴(secret 무시) — 프런트 게이트만 분리.
- `canViewComments = canViewSecret || (!promotionExpired && !!user)` 신설.
- **본문은 canViewSecret 유지** → 이용제한 사유·본문·링크는 계속 가림(basic.svelte).
- 댓글 열람(카드·로드 effect 4곳)만 canViewComments로 교체.
- **작성폼은 secret 글에서 차단**(`{:else if !canViewSecret}` → "비밀글에는 댓글을 작성할 수 없습니다") — 열람만, 작성 불가.

## 권한별 동작
| 뷰어 | 본문 | 댓글 열람 | 댓글 작성 |
|---|---|---|---|
| 비로그인 | 가림 | **가림(유지)** | - |
| 로그인 제3자 | 가림 | **열람 O(신규)** | 차단 |
| 작성자/관리자 | 열람 | 열람 | 작성 O |

## 안전
- 개별 제재 댓글(삭제/비밀/이용제한 근거)은 comment-list가 각각 자동 차단 → 정상 제3자 댓글만 보임.
- DB 변경 없음(순수 프런트, 되돌리기 파생값 한 줄).
- ⚠️ 비로그인 노출은 봇 추출 감안해 보류(A안). 원하면 `&& !!user` 제거로 확장.

## 검증
- [ ] secret 글 로그인 제3자: 댓글 목록 보임 + 작성폼 대신 안내
- [ ] 비로그인: 기존대로 전체 가림(누수 없음)
- [ ] 본문은 여전히 '비밀글입니다'
- [ ] 일반 글 회귀 없음