### PR TITLE
fix(search): 검색 버튼 클릭이 빈 값으로 제출되던 것 (bug/13696)

### DIFF
--- a/apps/web/src/lib/components/features/search/search-autocomplete.svelte
+++ b/apps/web/src/lib/components/features/search/search-autocomplete.svelte
@@ -9,6 +9,8 @@
         placeholder?: string;
         initialQuery?: string;
         onSearch?: (query: string) => void;
+        /** 타이핑마다 부모에 값 전파(버튼 클릭 제출이 최신 값을 읽게, bug/13696) */
+        onQueryChange?: (query: string) => void;
         /** 네이티브 폼 제출용 input name (JS 죽어도 검색되게, bug/13503) */
         name?: string;
     }
@@ -17,6 +19,7 @@
         placeholder = '검색어를 입력하세요',
         initialQuery = '',
         onSearch,
+        onQueryChange,
         name
     }: Props = $props();
 
@@ -69,6 +72,9 @@
     function handleInput(e: Event): void {
         const target = e.target as HTMLInputElement;
         query = target.value;
+        // bug/13696: 검색 버튼(type=submit) 클릭 제출은 부모 상태를 읽으므로,
+        // 타이핑값을 부모에 전파해야 버튼 클릭도 최신 값으로 검색된다(엔터는 onSearch로 이미 전달됨).
+        onQueryChange?.(query);
     }
 
     // TEMP: 검색 서버 전용 인스턴스 생기면 드롭다운 네비게이션 복원

--- a/apps/web/src/routes/search/+page.svelte
+++ b/apps/web/src/routes/search/+page.svelte
@@ -219,6 +219,7 @@
                     name="q"
                     initialQuery={searchQuery}
                     placeholder="검색어를 입력하세요"
+                    onQueryChange={(q) => (searchQuery = q)}
                     onSearch={(q) => {
                         searchQuery = q;
                         handleSearch(new Event('submit'));


### PR DESCRIPTION
## 원인
`/search`의 검색 버튼(`type=submit`)은 부모 `handleSearch`가 부모 `searchQuery` 상태를 읽는데, **타이핑값은 SearchAutocomplete 내부 `query` 상태에만** 있음. 부모로는 `onSearch`(엔터/submitSearch 경로에서만 호출)로만 전달돼, **버튼 클릭 시엔 stale/빈 searchQuery로 제출**돼 결과가 안 나옴. 엔터·'이동'은 정상(제보와 일치).

## 수정
- `search-autocomplete.svelte`: `onQueryChange` 콜백 prop 추가, `handleInput`에서 타이핑마다 호출
- `search/+page.svelte`: `onQueryChange={(q) => (searchQuery = q)}` 연결 → 버튼·엔터 모두 최신 값 사용

## 검증
- [ ] 검색어 입력 후 **검색 버튼 클릭** → 결과 표시(회귀 수정)
- [ ] 엔터·모바일 '이동'도 여전히 정상
- [ ] 자동완성 드롭다운 동작 유지