### PR TITLE
feat(post): 신고잠금 글도 작성자 수정·삭제 허용 (#12420 해제)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1188,9 +1188,8 @@
 
     // 수정/삭제 권한 (작성자 또는 관리자)
     // 2026-08-23 사장님 결정: 신고 누적으로 잠긴 글도 작성자가 수정·삭제할 수 있게 허용(기존 #12420 차단 해제).
-    // 수정 이력은 g5_da_content_history 에 남아 추적 가능. isLockedPost 자체는 본문 blur 등에 계속 쓰이므로 유지하고, canModify 에서만 조건을 뺀다.
+    // 수정 이력은 g5_da_content_history 에 남아 추적 가능. (본문 blur 는 postReportCount·isSanctioned 로 별도 구동돼 이 변경과 무관)
     const isAdmin = $derived((authStore.user?.mb_level ?? 0) >= 10);
-    const isLockedPost = $derived(data.post.extra_7 === 'lock' || postReportCount === 'lock');
     const canModify = $derived(isAuthor || isAdmin);
 
     // 직접홍보 게시판 만료 여부

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -1187,10 +1187,11 @@
     );
 
     // 수정/삭제 권한 (작성자 또는 관리자)
-    // #12420: 신고 누적으로 잠긴 글은 작성자 수정 차단. admin 만 운영 도구로 수정 가능.
+    // 2026-08-23 사장님 결정: 신고 누적으로 잠긴 글도 작성자가 수정·삭제할 수 있게 허용(기존 #12420 차단 해제).
+    // 수정 이력은 g5_da_content_history 에 남아 추적 가능. isLockedPost 자체는 본문 blur 등에 계속 쓰이므로 유지하고, canModify 에서만 조건을 뺀다.
     const isAdmin = $derived((authStore.user?.mb_level ?? 0) >= 10);
     const isLockedPost = $derived(data.post.extra_7 === 'lock' || postReportCount === 'lock');
-    const canModify = $derived((isAuthor && !isLockedPost) || isAdmin);
+    const canModify = $derived(isAuthor || isAdmin);
 
     // 직접홍보 게시판 만료 여부
     const promotionExpired = $derived(data.promotionExpired === true && !isAuthor);


### PR DESCRIPTION
## 배경
사장님 결정(2026-08-23): 신고 누적으로 잠긴 글도 **작성자가 수정·삭제 가능**하게. 신고잠금은 본문 가림만 유지하고 작성자 잠금은 해제.

## 변경
- `canModify = (isAuthor && !isLockedPost) || isAdmin` → `isAuthor || isAdmin` (isLockedPost 조건 제거)
- `isLockedPost` 정의는 본문 ContentBlur('신고 누적으로 가려진 글') 등에 계속 쓰이므로 **유지**, canModify 에서만 제거.

## 함께 배포 필요 (be)
- ⚠️ **be#576**(신고잠금 글 댓글 작성 403 게이트) 제거와 **함께 배포**돼야 정합. angple-e3가 be 담당.
- 이거만 배포하면 작성자 수정은 열리는데 댓글은 여전히 막힘(FE/BE 불일치).

## 검증
- [ ] 신고잠금 글에서 작성자에게 수정·삭제 버튼 노출
- [ ] 일반 글은 기존과 동일(회귀 없음)
- [ ] 본문 blur(신고 누적으로 가려진 글)는 유지