### PR TITLE
fix(emoticons): 같은 이모티콘 확장자 중복 제거 (bug/13683)

### DIFF
--- a/apps/web/src/routes/api/emoticons/list/+server.ts
+++ b/apps/web/src/routes/api/emoticons/list/+server.ts
@@ -128,15 +128,20 @@ async function scanEmoticons(): Promise<{ packs: EmoticonPack[] }> {
         }
     }
 
-    // 팩별 그룹핑
-    const packMap = new Map<string, EmoticonItem[]>();
+    // 같은 이모티콘이 여러 확장자로 존재하면(예: X.gif + 변환본 X.webp) baseName 당 하나만 남긴다.
+    // #13683: 확장자 중복이 걸러지지 않아 선택창에 같은 이모티콘이 2~3개씩 늘어섰다(실측 48쌍).
+    // 우선순위: 애니 webp(변환본·원본 대비 3~5배 작음) > gif(원본) > png > jpg.
+    // webp 가 없는 쌍(gif+jpg 등)은 gif 를 남겨 애니메이션을 보존한다.
+    const EXT_PRIORITY: Record<string, number> = { webp: 0, gif: 1, png: 2, jpeg: 3, jpg: 4 };
+    const extOf = (f: string) => f.split('.').pop()?.toLowerCase() || '';
+    const bestByBase = new Map<string, { file: string; prefix: string }>();
 
     for (const file of files) {
         // ⛔ _thumb 과 _still 은 이모티콘 자체가 아니라 부속 파일이다.
         //    거르지 않으면 선택창에 같은 이모티콘이 두세 개씩 늘어선다.
         if (file.includes('_thumb') || file.includes('_still') || SKIP_FILES.has(file)) continue;
 
-        const ext = file.split('.').pop()?.toLowerCase() || '';
+        const ext = extOf(file);
         if (!ALLOWED_EXTENSIONS.has(ext)) continue;
 
         // 로고 등 비이모티콘 제외
@@ -146,16 +151,22 @@ async function scanEmoticons(): Promise<{ packs: EmoticonPack[] }> {
         if (!prefix) continue;
         if (HIDDEN_PACKS.has(prefix)) continue;
 
-        if (!packMap.has(prefix)) {
-            packMap.set(prefix, []);
-        }
-
-        // thumb 찾기: "damoang-emo-001.gif" → baseName "damoang-emo-001"
+        // "damoang-emo-001.gif" → baseName "damoang-emo-001"
         const dotIdx = file.lastIndexOf('.');
         const baseName = dotIdx > 0 ? file.substring(0, dotIdx) : file;
+
+        const existing = bestByBase.get(baseName);
+        if (!existing || (EXT_PRIORITY[ext] ?? 99) < (EXT_PRIORITY[extOf(existing.file)] ?? 99)) {
+            bestByBase.set(baseName, { file, prefix });
+        }
+    }
+
+    // 팩별 그룹핑 (baseName 기준으로 중복 제거된 파일만)
+    const packMap = new Map<string, EmoticonItem[]>();
+    for (const [baseName, { file, prefix }] of bestByBase) {
+        if (!packMap.has(prefix)) packMap.set(prefix, []);
         const thumb = thumbMap.get(baseName) || null;
         const still = stillMap.get(baseName) || null;
-
         packMap.get(prefix)!.push({ file, thumb, still });
     }
 


### PR DESCRIPTION
## 문제 (bug/13683, 예지님 제보)
이모티콘 선택창에 **동일 이모티콘이 2~3개씩 중복** 표시.

## 원인
`api/emoticons/list/+server.ts` 의 scanEmoticons 가 확장자 dedup 없이 파일별로 아이템을 넣음.
같은 이모티콘의 원본 `X.gif` 와 변환본 `X.webp`(+일부 `X.jpg`)가 각각 아이템이 됨.
**실측: 48쌍 중복, 665→616 항목.**

## 수정
baseName 당 하나만 남기도록 dedup. 우선순위 **webp > gif > png > jpg**.
- webp = 애니메이션 변환본이며 원본 gif 대비 3~5배 작음(454KB→162KB 등, ANMF 확인) → 최적본.
- webp 없는 쌍(gif+jpg)은 **gif 유지**로 애니메이션 보존.
- 결과: 중복 47개는 webp, 1개(gif+jpg)는 gif 선택.

## 검증
- 실제 static/emoticons 파일로 시뮬레이션: 665→616, 중복 48 해소, webp 47/gif 1.
- ⛔서빙 dir 확인: 실제 이미지는 nginx가 `/home/damoang/legacy-data/emoticons` 에서 서빙 → 그 dir에 대상 webp 전부 실재(872개) 확인. 깨짐 없음.
- 기존 gif URL 은 파일 그대로라 옛 글 렌더 무영향(피커 신규 삽입만 webp).