### PR TITLE
fix(clarity): 이동마다 start 를 다시 불러 태그가 중복됐다 (CL001)

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -425,15 +425,37 @@
         '/login' // 로그인(비밀번호 입력)
     ];
 
+    function isClarityExcluded(pathname: string) {
+        return CLARITY_EXCLUDED_PREFIXES.some(
+            (p) => pathname === p || pathname.startsWith(p + '/')
+        );
+    }
+
+    /**
+     * ⛔ **이미 돌고 있는데 또 `start` 하면 Clarity 가 태그를 다시 붙인다.**
+     *    콘솔에 `Error CL001: Multiple Clarity tags detected` 가 페이지 이동마다 찍혔다
+     *    (2026-08-24 실사용자 콘솔 로그에서 확인). 이전 코드는 afterNavigate 마다
+     *    조건 없이 `clarity('start')` 를 불렀다.
+     *    → **상태가 바뀔 때만** 부른다.
+     *
+     * ⛔ 초기값은 app.html 인라인 스크립트와 **정확히 같은 규칙**으로 정해야 한다.
+     *    거기서는 최초 경로가 제외 목록에 있으면 `clarity('stop')` 을 부른다.
+     *    초기값을 틀리면 두 방향 다 사고다 —
+     *      · 켜야 할 곳에서 꺼진 채 남으면 데이터 유실
+     *      · **꺼야 할 곳에서 켜진 채 남으면 PIPA 위반**(쪽지·결제 화면 녹화)
+     *    그래서 "모른다" 가 아니라 최초 경로로 계산해서 맞춘다.
+     */
+    let clarityStopped = browser ? isClarityExcluded(location.pathname) : false;
+
     function applyClarityPrivacyGuard(pathname: string) {
         if (!browser) return;
         const clarity = (window as unknown as { clarity?: (...args: unknown[]) => void }).clarity;
         if (typeof clarity !== 'function') return;
-        const excluded = CLARITY_EXCLUDED_PREFIXES.some(
-            (p) => pathname === p || pathname.startsWith(p + '/')
-        );
+        const excluded = isClarityExcluded(pathname);
+        if (excluded === clarityStopped) return; // 이미 그 상태다 — 중복 호출 금지
         // 스니펫 stub 이 큐잉하므로 실제 스크립트 로드 전 호출도 순서대로 반영된다.
         clarity(excluded ? 'stop' : 'start');
+        clarityStopped = excluded;
     }
 
     // afterNavigate 통합: GA4 페이지뷰 + 광고 observer 재설정


### PR DESCRIPTION
## 증상

실사용자 콘솔 로그에서 페이지 이동마다 반복:

```
Error CL001: Multiple Clarity tags detected.
```

## 원인

`applyClarityPrivacyGuard` 가 `afterNavigate` 마다 **조건 없이** `start` 를 불렀다.

```js
clarity(excluded ? 'stop' : 'start');   // ← 매 이동마다
```

이미 실행 중인데 다시 `start` 하면 Clarity 가 태그를 또 붙인다.

## 수정

상태가 바뀔 때만 호출한다.

## ⛔ 초기값이 핵심이다

`app.html` 인라인 스크립트는 **최초 경로가 제외 목록에 있으면** `clarity('stop')` 을 부른다.
그래서 `+layout.svelte` 의 초기 상태도 **같은 규칙**으로 계산해야 한다.

초기값을 틀리면 두 방향 다 사고다:
- 켜야 할 곳에서 꺼진 채 남으면 → 데이터 유실
- **꺼야 할 곳에서 켜진 채 남으면 → PIPA 위반** (쪽지·결제·본인인증 화면 녹화)

`isClarityExcluded(location.pathname)` 로 최초 경로를 그대로 계산해 맞췄다.

## 검증

- [x] 단일 파일 컴파일 (client/server) — 경고 수 변화 없음
- [x] prettier
- [ ] 배포 후 콘솔에 CL001 소멸 확인
- [ ] `/messages` 직접 진입 시 녹화 중단 유지 확인 (PIPA)
- [ ] `/free` → `/messages` → `/free` 왕복 시 상태가 정확히 전환되는지