### PR TITLE
fix(adfit): 같은 폴백 유닛이 한 페이지에 여러 번 들어가 애드핏이 거부했다

### DIFF
--- a/apps/web/src/lib/components/ui/adfit-slot/adfit-slot.svelte
+++ b/apps/web/src/lib/components/ui/adfit-slot/adfit-slot.svelte
@@ -24,7 +24,42 @@
     let destroyed = false;
     const containerId = `adfit-${id}`;
 
+    /**
+     * ⛔ **카카오 애드핏은 한 페이지에 같은 `data-ad-unit` 을 두 번 허용하지 않는다.**
+     *    콘솔에 `[ad-fit-web] 광고 data-ad-unit 은 유일한 값이어야 합니다.` 가
+     *    페이지마다 여러 번 찍혔다(2026-08-24 실사용자 로그).
+     *
+     *    원인은 설정이다. `ADFIT_FALLBACK_MAP` 은 12개 GAM 포지션을 **6개 유닛**에 매핑하는데,
+     *    `board-list-infeed`·`comment-infeed` 는 **한 페이지에 여러 번 반복**되는 슬롯이다.
+     *    GAM 이 비면 그것들이 전부 같은 애드핏 유닛으로 폴백해 중복이 된다.
+     *
+     *    ⚠️ 그냥 두면 애드핏이 예외를 던지고, 그 예외가 카카오 에러 수집기
+     *    (`aem-kakao-collector.onkakao.net`)를 **429 가 날 때까지** 두들긴다.
+     *
+     *    → **먼저 잡은 슬롯만 렌더한다.** 중복은 어차피 애드핏이 안 그리므로 잃는 수익이 없다.
+     */
+    const claimed: Set<string> = ((
+        globalThis as unknown as { __adfitClaimed?: Set<string> }
+    ).__adfitClaimed ??= new Set<string>());
+
+    /** 실제로 잡은 유닛. ⛔ 반납할 때 이 값을 써야 한다 — prop 이 바뀌어도 잡은 것을 놓는다. */
+    let claimedUnit: string | null = null;
+
     onMount(async () => {
+        // ⛔ 반드시 **await 이전**에 잡는다. await 뒤로 미루면 두 슬롯이 같이 통과한다.
+        //    onMount 콜백은 마운트 플러시에서 동기적으로 실행되므로 여기까지는 경합이 없다.
+        if (claimed.has(unit.unitId)) {
+            // 무엇이 얼마나 겹치는지 알아야 매핑을 고칠 수 있다.
+            trackAdEvent('ad_fallback_duplicate_unit', {
+                ad_unit: unit.unitId,
+                position: position ?? '',
+                reason: 'duplicate'
+            });
+            return;
+        }
+        claimed.add(unit.unitId);
+        claimedUnit = unit.unitId;
+
         const status = await loadAdfitSDK();
         if (destroyed) return;
 
@@ -54,6 +89,11 @@
 
     onDestroy(() => {
         destroyed = true;
+        // ⛔ 반납을 빼먹으면 SPA 이동 후 그 유닛이 영영 안 나온다.
+        if (claimedUnit) {
+            claimed.delete(claimedUnit);
+            claimedUnit = null;
+        }
         destroyAdfitAd(containerId);
     });
 </script>

--- a/apps/web/src/lib/services/ad-telemetry.ts
+++ b/apps/web/src/lib/services/ad-telemetry.ts
@@ -31,7 +31,14 @@ export type AdTelemetryEventName =
     | 'ad_fallback_failed'
     | 'ad_fallback_timeout'
     | 'ad_sdk_blocked'
-    | 'ad_blocked';
+    | 'ad_blocked'
+    /**
+     * 애드핏 폴백 유닛이 한 페이지에 중복돼 렌더를 건너뛴 경우.
+     * ⛔ 이건 "광고가 안 나갔다" 는 뜻이다 — ADFIT_FALLBACK_MAP 이 12개 포지션을
+     *    6개 유닛에 매핑하는데 infeed 계열은 한 페이지에 여러 번 반복되기 때문이다.
+     *    어느 포지션에서 얼마나 겹치는지 봐야 유닛을 추가 발급할 근거가 된다.
+     */
+    | 'ad_fallback_duplicate_unit';
 
 export interface AdTelemetryPayload {
     ad_unit?: string;
@@ -52,7 +59,11 @@ const sentKeys = new Set<string>();
  * 실패 신호(스파이크 감지가 중요)는 100% 유지.
  */
 const SAMPLE_RATE: Partial<Record<AdTelemetryEventName, number>> = {
-    ad_fallback_success: 100
+    ad_fallback_success: 100,
+    // 중복은 결함 신호라 전량이 원칙이지만, dedupe 후에도 페이지마다 몇 건씩 나온다.
+    // 하루 수십만 세션이면 기존 ad_telemetry 총량을 넘길 수 있어 1/10 로 줄인다.
+    // sample_rate 가 실려 나가므로 집계에서 총량은 복원된다.
+    ad_fallback_duplicate_unit: 10
 };
 
 export function trackAdEvent(name: AdTelemetryEventName, props: AdTelemetryPayload = {}): void {


### PR DESCRIPTION
## 증상 — 콘솔에 계속 쌓인다

```
[ad-fit-web] 광고 data-ad-unit 은 유일한 값이어야 합니다.
```

스택을 따라가면 연쇄가 보인다:

```
[ad-fit-web] 유닛 중복  ← 우리가 부름 (bundle:100 → ba.min.js)
   ↓
captureException @ ba.min.js
   ↓
POST aem-kakao-collector.onkakao.net → 429 (Too Many Requests)
```

**우리 중복 때문에 카카오 에러 수집기가 429 날 때까지 맞고 있다.**

## 원인은 매핑

`ADFIT_FALLBACK_MAP` 이 **12개 GAM 포지션 → 6개 애드핏 유닛**이다.

| 유닛 | 매핑된 포지션 수 |
|---|---|
| `desktop_banner` | 8 (desktop) |
| `mobile_banner` | 4 (mobile) |
| `medium_rect` | 3 |
| `skyscraper` | 2 (wing-left/right) |

여기에 더해 **`board-list-infeed`·`comment-infeed` 는 한 페이지에 여러 번 반복**되는 슬롯이다
(로그 실측: `board-list-infeed-6`, `recent-posts-infeed-11`, `comment-infeed-7116796` …).
GAM 이 비면 그 슬롯들이 **전부 같은 애드핏 유닛**으로 폴백한다.
카카오는 한 페이지에 같은 유닛을 **1회만** 허용한다.

## 수정

먼저 잡은 슬롯만 렌더한다. **중복은 어차피 애드핏이 안 그리므로 잃는 수익이 없다.**

### ⛔ 세 가지를 지켰다

1. **`await` 이전에 잡는다.** 뒤로 미루면 두 슬롯이 같이 통과한다.
   `onMount` 콜백은 마운트 플러시에서 동기 실행되므로 그 지점까지 경합이 없다.
2. **`onDestroy` 에서 반납한다.** 안 하면 SPA 이동 후 그 유닛이 영영 안 나온다.
3. **반납은 실제로 잡은 값으로 한다.** prop 이 바뀌어도 잡은 것을 놓아야 한다.

## 근본 해결은 따로다

이 PR 은 **증상을 멈추고 데이터를 모은다.** 중복이 어디서 얼마나 나는지
`ad_fallback_duplicate_unit` 텔레메트리로 수집한다.

진짜 해결은 **반복 슬롯(infeed)용 애드핏 유닛을 따로 발급**하는 것이고,
그건 카카오 콘솔 작업이라 사장님 판단이 필요하다.

## 검증

- [x] 단일 파일 컴파일 (client/server) — 경고 수 변화 없음(기존 `id` 1건)
- [x] prettier
- [ ] 배포 후 콘솔에서 `data-ad-unit` 경고 소멸
- [ ] `aem-kakao-collector` 429 소멸
- [ ] 애드핏 폴백이 **한 개는 정상 노출**되는지 (전부 사라지면 안 된다)