### PR TITLE
fix(hydration): AdSense ins 를 SSR 로 내보내지 않는다 — 글 상세 하이드레이션 폐기의 원인

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
+    import { onMount, tick } from 'svelte';
     import { browser } from '$app/environment';
     import type { FreePost } from '$lib/api/types.js';
     import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
@@ -58,6 +58,25 @@
     let loading = $state(!hasInitial);
     let recentPosts = $state<RecentPost[]>(hasInitial ? initialActivity!.recentPosts : []);
     let recentComments = $state<RecentComment[]>(hasInitial ? initialActivity!.recentComments : []);
+    /**
+     * ⛔ **AdSense `<ins>` 를 SSR HTML 에 내보내면 안 된다.**
+     *
+     * `adsbygoogle.js` 는 app.html 에서 `async` 로 먼저 로드되고, 문서에서 `ins.adsbygoogle` 를
+     * 찾아 **하이드레이션보다 먼저 채울 수 있다.** 그러면 Svelte 가 기대한 DOM 과 달라져
+     * 하이드레이션이 통째로 폐기된다(글쓰기 버튼 안 먹힘·깜빡임·로그인 오표시).
+     *
+     * 실측(2026-08-24, 봇 제외 12시간):
+     *   글 상세 4.08%  ·  홈 0.27%  ·  목록 0.06%    ← 글 상세만 68배
+     *   브라우저: 파이어폭스 22% · 엣지 6.6% · 데스크톱크롬 3.8% · 모바일 0.4~0.7%
+     *   실패는 888개 글에 **고르게** 퍼져 있다 — 특정 글의 콘텐츠 문제가 아니라 페이지 구조다.
+     *   이 패널은 **글 상세에만** 있고, 저장소에서 `<ins>` 를 SSR 로 내보내는 유일한 곳이다.
+     *
+     * 우리 `AdfitSlot` 은 이미 `{#if ready}` 로 마운트 후에만 그린다. 그 패턴에 맞춘다.
+     *
+     * ⛔ 레이아웃은 안 변한다 — `.dm-clip-wrapper` 가 CSS 로 높이를 고정(모바일 110px /
+     *    데스크톱 214px)하므로 `<ins>` 유무가 자리를 바꾸지 않는다. CLS 회귀 없음.
+     */
+    let adReady = $state(false);
     let adContainer = $state<HTMLElement | null>(null);
     let clipWrapper = $state<HTMLElement | null>(null);
     let panelEl = $state<HTMLElement | null>(null);
@@ -235,7 +254,10 @@
             // 프라이빗 모드 등 — 기본값(접힘) 유지
         }
 
-        loadAdSense();
+        // ⛔ 순서가 중요하다. `<ins>` 가 DOM 에 들어간 **뒤에** push 해야 AdSense 가 찾는다.
+        //    SSR 로 내보내지 않으므로 여기서 그리고, tick 으로 DOM 반영을 기다린다.
+        adReady = true;
+        void tick().then(() => loadAdSense());
 
         requestAnimationFrame(() => {
             if (!clipWrapper) return;
@@ -324,7 +346,7 @@
             >
                 <!-- AdSense가 이 div의 height를 !important로 바꿔도 외부 래퍼가 잘라냄 -->
                 <div bind:this={adContainer}>
-                    {#if ADSENSE_ACTIVITY_CLIENT && ADSENSE_ACTIVITY_SLOT}
+                    {#if adReady && ADSENSE_ACTIVITY_CLIENT && ADSENSE_ACTIVITY_SLOT}
                         <ins
                             class="adsbygoogle"
                             style="display:block;"


### PR DESCRIPTION
## 발단 — 경보가 가려져 있던 것을 드러냈다

오늘 오전 CF WAF 로 macOS Chrome/125 봇을 차단하자 하이드레이션 실패율이 1.16% → 3.58% 로
"급등"했다. 조사해보니 **급등이 아니었다.**

성공 비콘(`anchor_ok`)의 **73~74%가 그 봇**이었고, 봇은 `detached` 를 한 건도 내지 않는다.
분모만 부풀려 실패율을 5~6배 낮게 보이게 하고 있었던 것이다.
봇을 빼고 다시 재니 **30시간 내내 2.5~9.1% 로 평평**했다.

즉 메모리에 기록돼 있던 "데스크톱 정상치 1.58%" 는 **봇에 희석된 거짓값**이고,
실제로는 데스크톱 로드 **100건 중 4~5건이 하이드레이션에 실패**하고 있었다.
증상은 글쓰기 버튼 안 먹힘 · 화면 깜빡임 · 로그인 상태 오표시.

## 실측으로 좁힌 과정 (봇 제외, 12시간)

### ① 페이지 종류로 갈린다

| 페이지 | detached | ok | 실패율 |
|---|---|---|---|
| **글 상세** | 3,600 | 847 | **4.08%** |
| 홈 | 143 | 537 | 0.27% |
| 목록 | 26 | 431 | **0.06%** |

### ② 데스크톱만 나쁘다

| 브라우저 | 실패율 |
|---|---|
| 파이어폭스 | 22.2% |
| 엣지 | 6.6% |
| 데스크톱 크롬 | 3.8% |
| 안드로이드 / iOS / 삼성 | 0.44~0.67% |

### ③ 특정 글의 문제가 아니다

실패가 **888개 글에 고르게** 퍼져 있다(글당 1~3건이 662개, 31건 이상은 14개).
콘텐츠가 아니라 **페이지 구조** 문제다.

## 원인

`adsbygoogle.js` 는 `app.html` 에서 `async` 로 먼저 로드되고, 문서에서 `ins.adsbygoogle` 를
찾아 **하이드레이션보다 먼저 채울 수 있다.** 그러면 Svelte 가 기대한 DOM 과 달라져
하이드레이션이 통째로 폐기된다.

`author-activity-panel` 은 **글 상세에만** 렌더되고, 저장소에서
`<ins class="adsbygoogle">` 를 **SSR HTML 로 내보내는 유일한 곳**이다.
목록의 인피드 광고는 GPT 라 마운트 후에 그려지고, 그 페이지 실패율은 0.06% 다.

우리 `AdfitSlot` 은 이미 `{#if ready}` 로 마운트 후에만 그린다. **그 패턴에 맞춘다.**

## ⛔ 지킨 것

- `<ins>` 가 DOM 에 들어간 **뒤에** push 해야 AdSense 가 찾는다 → `tick()` 후 호출
- `adContainer` 바인딩은 `{#if}` 밖이라 그대로 — 클립 높이 보정 로직 무영향
- **레이아웃 불변** — `.dm-clip-wrapper` 가 CSS 로 높이 고정(모바일 110px / 데스크톱 214px)이라
  `<ins>` 유무가 자리를 바꾸지 않는다. CLS 회귀 없음

## ⚠️ 정직하게 — 이건 가설의 실험이다

`tpre`(하이드레이션 직전 DOM)는 성공·실패가 **동일**했다. 즉 텔레메트리만으로는
"광고가 원인"을 최종 확정하지 못한다. 다만 ①②③ 이 모두 이 패널을 가리키고,
우리 자신의 확립된 패턴과 어긋나는 유일한 지점이다.

**효과는 배포 후 같은 지표로 바로 측정된다.** 글 상세 실패율이 목록 수준(0.06%)에
가까워지면 확정이고, 안 변하면 다른 원인이므로 되돌리고 다시 판다.

## 검증

- [x] 단일 파일 컴파일 (client/server) — 경고 수 변화 없음(5 → 5)
- [x] prettier
- [ ] 배포 후 SSR HTML 에 `ins.adsbygoogle` 없음 확인
- [ ] 배포 후 글 상세 `anchor_detached` 실패율 하락
- [ ] 광고가 여전히 노출되는지 (마운트 후 채워짐)
- [ ] 패널 클립 높이 보정 정상 동작