### PR TITLE
fix(hearts): 세션 만료·JWT 생존 시 SSR 좋아요 하트가 빈 상태로 뜨던 것 (bug/13688)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -28,6 +28,7 @@ import { fetchMemberImagesWithTimestamp } from '$lib/server/member-images.js';
 import { fetchCommentLikeStatuses } from '$lib/server/comment-likes.js';
 
 import { fetchPostLikeStatus } from '$lib/server/post-like-status.js';
+import { getAuthUser } from '$lib/server/auth';
 import { fetchMemberActivity, type MemberActivity } from '$lib/server/member-activity.js';
 import { fetchWithdrawnMemberIds } from '$lib/server/withdrawn-members.js';
 import { fetchTruthroomPostId, fetchTruthroomCommentMap } from '$lib/server/truthroom.js';
@@ -622,6 +623,13 @@ export const load: PageServerLoad = async ({
                 }
             }
 
+            // #13688: SSR 좋아요 상태 인증을 좋아요 API(getAuthUser)와 일치시킨다.
+            // authenticateSSR 은 angple_sid 세션만 보므로, 세션이 만료됐지만 JWT(damoang_jwt 등)가
+            // 살아 있는 사용자(Safari ITP 로 세션 쿠키가 먼저 evict 된 경우)는 SSR 엔 익명이 되어
+            // 하트가 빈 상태로 렌더됐다(클릭은 API 로 인증돼 이미 누른 좋아요를 취소시킴).
+            // 세션이 있으면 locals.user.id 를 그대로 쓰고, 없을 때만 getAuthUser 로 폴백한다(둘 다 mb_id).
+            const likeUserId = locals.user?.id ?? (await getAuthUser(cookies))?.mb_id ?? null;
+
             const [
                 promotionResult,
                 reactionsResult,
@@ -660,8 +668,8 @@ export const load: PageServerLoad = async ({
                 // outer scope 에서 미리 시작한 공유 promise 재사용(워터마크 판정과 동일 조회).
                 postReportCountPromise,
                 // 게시글 추천/비추천 상태 (로그인 시만, DB 직접 조회)
-                locals.user?.id
-                    ? fetchPostLikeStatus(boardId, Number(postId), locals.user.id).catch(() => ({
+                likeUserId
+                    ? fetchPostLikeStatus(boardId, Number(postId), likeUserId).catch(() => ({
                           userLiked: false,
                           userDisliked: false
                       }))
@@ -678,13 +686,13 @@ export const load: PageServerLoad = async ({
                         : null
                 ),
                 (() => {
-                    if (!locals.user?.id) {
+                    if (!likeUserId) {
                         return Promise.resolve({ likedIds: [], dislikedIds: [] });
                     }
                     // 글 단위 조회 — SSR 1페이지(10개) 밖 backfill 댓글의 하트 토글 상태
                     // 누락 방지 (economy/77128 제보: 정렬 동률로 1페이지에서 밀린 댓글의
                     // 좋아요가 새로고침 후 미표시되던 문제)
-                    return fetchCommentLikeStatuses(boardId, Number(postId), locals.user.id).catch(
+                    return fetchCommentLikeStatuses(boardId, Number(postId), likeUserId).catch(
                         () => ({
                             likedIds: [],
                             dislikedIds: []


### PR DESCRIPTION
## 문제 (bug/13688, 예지님 · Mac Safari)
예전엔 좋아요 누른 글·댓글이 재접속해도 빨간 하트였는데, 요즘은 누를 때만 빨갛고 다시 열면 빈 하트 → 이미 좋아요한 글에 다시 누르면 **좋아요가 취소됨**.

## 원인 — SSR과 좋아요 API의 인증 불일치
- **SSR** 좋아요 상태(`postLikeStatus`·`commentLikeStatuses`)는 `locals.user`(=`authenticateSSR`, **`angple_sid` 세션만**, JWT 폴백 없음)로 판정.
- **좋아요 API**는 `getAuthUser` 4단계 폴백(세션→access→refresh→`damoang_jwt`)로 인증.
- Safari ITP가 `angple_sid`를 먼저 evict → 세션은 죽고 JWT·UI로그인은 생존하는 split 상태 → SSR엔 익명(빈 하트), 클릭은 API로 인증돼 기존 좋아요 행을 DELETE(취소). "요즘·Mac Safari"와 일치. 댓글 하트는 클라 폴백조차 없어 클릭 전까지 영구 빈 하트.

## 수정 (Option A — 좁은 범위)
`[boardId]/[postId]/+page.server.ts`의 좋아요상태 조회 유저를 `locals.user?.id ?? (await getAuthUser(cookies))?.mb_id`로 — **좋아요 API와 동일 인증**. 세션이 살아있으면 `getAuthUser`는 호출 안 됨(단락), 비용 증가 없음. 글·댓글 하트 둘 다 해소.
- `fetchPostLikeStatus`/`fetchCommentLikeStatuses`는 `userId=mb_id`로 `g5_board_good.mb_id` 조회, `getAuthUser().mb_id`와 동일 값 확인.

## 범위 밖(같은 근본원인, 후속)
스크랩(isScraped)·리액션(fetchReactionsByParentId)·SSR 로그인 플래시도 동일 원인 — 전역 `authenticateSSR`에 JWT 폴백을 넣는 Option B가 근본해결이나 전역 auth 영향이라 별도 신중검토.

## 검증 체크리스트
- [ ] 세션有 로그인: 기존과 동일(하트 정상, getAuthUser 미호출)
- [ ] 세션 만료+JWT 생존: 재접속 시 이미 누른 하트가 채워짐(글·댓글)
- [ ] 비로그인: 빈 하트(변화 없음)
- [ ] getAuthUser().mb_id == locals.user.id(mb_id) 동일 값
- [ ] reactionsResult가 하트 fill을 구동하지 않음(구동하면 확장 필요)
- [ ] TS/prettier/build green