### PR TITLE
Revert "perf(nav): SvelteKit 링크 프리로드를 켠다" (#2186)

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -418,30 +418,7 @@
             })();
         </script>
     </head>
-    <!--
-        SvelteKit 링크 프리로드.
-
-        ⛔ **속성이 없으면 기본값이 `off` 다** — 켠 적이 없으면 프리로드가 아예 안 돈다.
-           `@sveltejs/kit` 소스 `runtime/client/utils.js`:
-               preload_data: levels[preload_data ?? 'off']
-               preload_code: levels[preload_code ?? 'off']
-           "SvelteKit 이 알아서 해 주겠지" 는 사실이 아니다(2026-08-24 확인).
-
-        왜 켜는가 — 실측(2026-08-24, 봇 제외):
-          · 모바일 INP p75 : 목록 224ms · 홈 200ms · 글상세 120ms
-            (목록·홈에서 상호작용의 25.9% / 25.1% 가 200ms 를 넘는다)
-          · 목록에서 글을 누르면 SPA 이동이 일어나고, 그때 받는 `__data.json` 이
-            **25~29KB · 중앙값 201ms** 다. INP 는 다음 페인트까지를 재므로 이게 그대로 잡힌다.
-          → `tap` 은 `touchstart`(=클릭보다 먼저)에 미리 시작한다. 그 시간만큼 앞당겨진다.
-
-        ⚠️ 대가: `tap` 은 **스크롤하려고 글을 짚기만 해도** 발동한다. 헛되이 받는 요청이 생긴다.
-           카나리/운영에서 원본 요청량을 반드시 대조할 것. 과하면 `preload-code` 만 남기고
-           `preload-data` 를 빼면 된다(데이터 요청 없이 JS 청크만 미리 받는다).
-
-        ⛔ `hover` 는 모바일에서 발동하지 않는다 — 데스크톱 INP 는 이미 64ms 로 문제없으므로
-           모바일을 겨냥한 이 변경에는 `tap` 이 맞다.
-    -->
-    <body data-sveltekit-preload-data="tap" data-sveltekit-preload-code="viewport">
+    <body>
         <!-- ⛔ id 를 지우지 말 것. 하이드레이션 앵커 탐지가 이 id 로 앱 루트를 찾는다.
              예전엔 document.body.firstElementChild 로 찾았는데, AdSense 가 body 첫 요소로
              div#aswift_0_host 를 끼워 넣으면 광고 컨테이너를 앱 루트로 오인했다.


### PR DESCRIPTION
## 왜 되돌리나

**이득을 실증하지 못했다.** 측정하겠다고 해놓고 못 했으므로 되돌린다.

### 측정 시도 (카나리 ON vs 운영 OFF, 각 3회)

| | 클릭→본문 표시 |
|---|---|
| 카나리(프리로드 ON) | 372 / 404 / **486**ms (중앙값 404) |
| 운영(OFF·대조군) | 406 / 413 / **511**ms (중앙값 413) |

**9ms 차이 — 측정 편차 안에 묻힌다.**

⛔ 원인은 측정 방법에 있다. Playwright 의 `click()` 은 `touchstart`→`click` 간격이
사실상 0이라 **프리로드가 앞설 시간이 없다.** 실제 사람 손가락은 100~200ms 걸리므로
실사용자에서는 효과가 있을 수 있다.

**즉 "효과 없음"이 증명된 게 아니라, 이 방법으로는 잴 수 없다.**

### 대가는 확인됐다

`tap` 은 `touchstart` 에 발동하므로 **스크롤하려고 글을 짚기만 해도** 데이터를 받는다.
CDP 로 진짜 스와이프를 8회 보내니 **헛요청 2건**(운영 대조군 0건). 25% 낭비다.

## 결론

이득 미실증 + 대가 확인 = 지금 상태로는 올릴 수 없다.
게다가 이 커밋이 main 에 얹혀 있어 **다른 사람의 수정 4건까지 함께 막고 있다**
(#2187 Clarity · #2188 adfit · #2189 하이드레이션 · #2190 hearts).

## 다시 하려면 — 의도된 실험으로

프리로드 자체는 여전히 후보다. 모바일 `/free` INP p75 224ms 는 실제 문제이고,
`data-sveltekit-preload-data` 가 **꺼져 있다는 사실**(SvelteKit 기본값 `off`)도 그대로다.

다만 다음에는 이렇게 해야 한다:

- 합성 프로브로 이득을 재려 하지 않는다 — **실사용자 INP p75 로 판정**한다
- 기준선을 미리 박아둔다: 모바일 `/free` **224ms**, 홈 200ms
- 원본 요청량 증가 상한을 미리 정하고, 넘으면 되돌린다
- `preload-code` 만 먼저 켜보는 단계적 접근도 선택지다(데이터 요청 없음)

## 검증

- [x] `<body>` 가 원래대로 (`sveltekit-preload` 흔적 0)
- [x] prettier