### PR TITLE
feat(board): 헤더에 "새글(자유 제외)" 진입 버튼 (실험, bug/13666)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -76,6 +76,8 @@
         DropdownMenuCheckboxItem
     } from '$lib/components/ui/dropdown-menu/index.js';
     import Settings2 from '@lucide/svelte/icons/settings-2';
+    import Newspaper from '@lucide/svelte/icons/newspaper';
+    import { trackEvent } from '$lib/services/ga4.js';
 
     // 특수 게시판 컴포넌트 (플러그인 레지스트리 기반)
     import { boardTypeRegistry } from '$lib/components/features/board/board-type-registry.js';
@@ -1050,6 +1052,25 @@
                 </div>
 
                 <div class="flex items-center gap-2">
+                    <!-- 실험(bug/13666·소모임): 자유 제외 전체 새글로 가는 진입점.
+                         /feed 는 읽기 전용이라 작성 유입을 유발하지 않고, scope=nofree 로
+                         자유(전체의 88%) 를 빼 다른 게시판(질문·소모임 등) 활동을 노출한다. -->
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        class="relative h-9 w-9 shrink-0"
+                        title="새글 (자유게시판 제외)"
+                        onclick={() => {
+                            trackEvent('feed_entry_click', {
+                                board_id: boardId,
+                                source: 'board_header',
+                                scope: 'nofree'
+                            });
+                            goto('/feed?scope=nofree');
+                        }}
+                    >
+                        <Newspaper class="h-4 w-4" />
+                    </Button>
                     {#if listLayoutId === 'classic'}
                         <DropdownMenu>
                             <DropdownMenuTrigger>


### PR DESCRIPTION
게시판 목록 헤더 우측(보기설정 톱니 왼쪽)에 Newspaper 아이콘 버튼 추가 → /feed?scope=nofree.

## 근거(하네스)
- A(링크버튼) 채택 / B(인라인병합) 기각(게시판 로드가 단일보드 하드스코프·고위험)
- /feed 읽기전용 → 작성 유입 없음(우려의 write-side 는 글쓰기 안내가 담당)
- 7일 새글 중 자유 88%(86,182) → scope=nofree 로 빼면 하루 ~1,678건(community·소모임·ecommerce 등) 노출
- 라벨 '새글'(⛔'모아보기'는 /explore 와 충돌)·아이콘 Newspaper·trackEvent('feed_entry_click') 계측

## 검증
- [ ] 톱니 왼쪽 항상 렌더 / 클릭→/feed?scope=nofree + GA 발화 / TS·prettier·build green