### PR TITLE
obs(cwv): 랜딩 경로를 함께 남긴다 — page= 만으로는 페이지별 비교가 성립하지 않는다

### DIFF
--- a/apps/web/src/lib/services/web-vitals-rum.ts
+++ b/apps/web/src/lib/services/web-vitals-rum.ts
@@ -86,6 +86,10 @@ function sendToDantry(
                 `page=${group}`,
                 `nav=${nav ?? '?'}`,
                 `vw=${window.innerWidth}`,
+                // ⛔ 이 필드 없이 page= 로 페이지별 비교를 하면 다른 페이지의 밀림을
+                //    이 페이지 탓으로 읽는다(위 landingPath 주석 참조).
+                //    분석은 `landing == page` 인 표본만 쓴다.
+                `landing=${landingPath}`,
                 // 광고 충전 신호: ads=<슬롯수>/<채워진수>/<자동광고 컨테이너수>
                 adFillSignature(),
                 // ⛔ 이 한 필드가 원인을 가른다:
@@ -114,6 +118,25 @@ function pathGroup(pathname: string): string {
         .replace(/\/\d+/g, '/:n')
         .slice(0, 60);
 }
+
+/**
+ * ⛔ **`page=` 는 이탈 시점 경로다 — 페이지별 비교의 기준이 될 수 없다.**
+ *
+ * CWV 는 `pagehide`/`visibilitychange(hidden)` 에서 **생애 최종값 1회**로 보고된다.
+ * 그때의 `location.pathname` 은 SPA 이동을 거친 뒤라면 **마지막에 있던 경로**다.
+ * 목록→글→뒤로 이동한 세션은 값이 세션 전체에 누적됐는데도 목록으로 태깅된다.
+ *
+ * 2026-08-24 실측: "모바일 `/free`(목록) CLS" 상위 타깃이 `#comments` ·
+ * `#economy-post-content` · `footer` — **전부 글 상세 요소**였다.
+ * 목록만 따로 열어 재면 CLS 0.0001 로 깨끗하다.
+ *
+ * → **랜딩 경로를 함께 싣는다.** 분석에서 `landing == page` 인 표본만 걸러야
+ *   페이지별 비교가 성립한다. 그 전에는 페이지별 개선의 효과를 판정할 수 없다.
+ *
+ * ⛔ 모듈 로드 시점에 한 번만 읽는다. 나중에 읽으면 이미 이동한 뒤라 의미가 없다.
+ * 비용: 초기화 시 `location.pathname` 읽기 1회 — 렌더 경로에 아무것도 추가하지 않는다.
+ */
+const landingPath = typeof window !== 'undefined' ? pathGroup(location.pathname) : '';
 
 let installed = false;
 


### PR DESCRIPTION
## 발단

"모바일 목록 CWV 를 개선하자" 는 판단을 하려다, **그 수치가 목록 것이 아니라는 것**을 발견했다.

## 문제

CWV 는 `pagehide`/`visibilitychange(hidden)` 에서 **생애 최종값 1회**로 보고된다.
그때 싣는 `page=` 는 그 순간의 `location.pathname` — 즉 **이탈 경로**다.

SPA 라 목록→글→뒤로 이동한 세션은 값이 세션 전체에 누적됐는데도 **마지막 경로로 태깅**된다.

### 증거

"모바일 `/free`(목록) CLS p75 **0.109**" 의 상위 타깃:

| 타깃 | 건수 | 합계 CLS |
|---|---|---|
| `#comments` | 174 | 141.9 |
| `#economy-post-content>div.prose` | 574 | 103.0 |
| `footer` | 60 | 44.8 |

**전부 글 상세 요소다.** 목록 페이지에 `#comments` 가 있을 리 없다.

목록만 따로 열어(모바일 뷰포트 + 1.6Mbps/CPU 4배 스로틀) 재면 **CLS 0.0001** 이다.

## 이미 알려져 있던 사실

이 파일 주석에 적혀 있었다:

> ⚠️ SPA soft-nav 는 미수집 … 사내 네비게이션은 hide 시점 경로로 오태깅하므로 **분석 시 랜딩 필터 전제**

그런데 **랜딩 경로를 안 실어서 그 필터를 걸 수가 없었다.** 그래서 전제가 지켜지지 않았다.

## 수정

모듈 로드 시점의 경로를 `landing=` 으로 함께 싣는다.

```
value=... target=... page=/free  landing=/free   ← 이동 없음, 페이지별 비교 가능
value=... target=... page=/free  landing=/free/:id ← 이동 섞임, 제외
```

- ⛔ 모듈 로드 시점에 **한 번만** 읽는다. 나중에 읽으면 이미 이동한 뒤다.
- ⛔ 새 필드를 만들지 않는다 — 수집기가 스키마 밖 필드를 버리므로 `stack` 에 싣는다.

## 프런트 비용

초기화 시 `location.pathname` 읽기 **1회**. 렌더 경로에 아무것도 추가하지 않는다.
전송은 기존 `sendBeacon` 페이로드에 문자열 한 줄이 늘 뿐이다.

## 검증

- [x] prettier
- [ ] 배포 후 `stack` 에 `landing=` 이 실리는지
- [ ] `landing == page` 표본 비율 확인 (너무 적으면 표본이 모자라 다른 접근이 필요)
- [ ] 랜딩 필터를 건 페이지별 CWV 가 기존과 얼마나 다른지