### PR TITLE
feat(board-layout): classic 리스트에 출처 게시판명 칩(showBoardName)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/list/classic.svelte
@@ -30,7 +30,9 @@
         href,
         isRead = false,
         memo = null,
-        searchQuery = ''
+        searchQuery = '',
+        showBoardName = false,
+        boardName = ''
     }: {
         post: FreePost;
         displaySettings?: BoardDisplaySettings;
@@ -38,6 +40,10 @@
         isRead?: boolean;
         memo?: { content: string; color: string } | null;
         searchQuery?: string;
+        // 여러 게시판을 합친 목록(예: 새글 피드)에서 각 줄이 어느 게시판 글인지 표시.
+        // 단일 게시판 목록은 넘기지 않아 default false → 기존과 동일 렌더(회귀 없음).
+        showBoardName?: boolean;
+        boardName?: string;
     } = $props();
 
     function highlightText(text: string): string {
@@ -192,6 +198,14 @@
             >
                 <!-- 제목 줄 (col 2) -->
                 <div class="flex min-w-0 items-center gap-1 md:flex-1">
+                    <!-- 합친 목록(피드)에서 출처 게시판 표시. 행 전체가 <a> 라 nested anchor 금지 → span. -->
+                    {#if showBoardName && boardName}
+                        <span
+                            class="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0 text-xs font-medium"
+                        >
+                            {boardName}
+                        </span>
+                    {/if}
                     {#if post.is_notice}
                         <span class="mobile-only" class:modern-view={isMobileView}
                             ><Pin class="text-liked h-3.5 w-3.5 shrink-0" /></span

--- a/apps/web/src/lib/components/features/board/layouts/types.ts
+++ b/apps/web/src/lib/components/features/board/layouts/types.ts
@@ -24,6 +24,10 @@ export interface ListLayoutProps {
     post: FreePost;
     displaySettings?: BoardDisplaySettings;
     href: string;
+    /** 여러 게시판을 합친 목록(새글 피드 등)에서 각 줄에 출처 게시판명을 표시할지. 단일 게시판은 미지정(false). */
+    showBoardName?: boolean;
+    /** showBoardName 이 true 일 때 표시할 게시판 이름. */
+    boardName?: string;
 }
 
 /**


### PR DESCRIPTION
재설계 1단계 — 공용 레이아웃 기반. classic 리스트 레이아웃에 optional prop `showBoardName`/`boardName` 추가해, 여러 게시판을 합친 목록(새글 피드)이 각 줄에 출처 게시판명을 표시할 수 있게 함.

- ⛔행 전체가 `<a>` 라 nested anchor 금지 → 칩은 `<span>`(Nested Anchor Guard 통과).
- 단일 게시판 목록은 prop 을 안 넘겨 **default false → 칩 미표시 = 기존과 픽셀 동일(회귀 0)**.
- 2단계(/feed 재스킨, 설계문서 먼저)의 기반. 이 PR 자체는 표시 변화 없음(capability 추가만).

## 검증
- [ ] 기존 게시판 목록 렌더 불변(showBoardName 미전달 default false)
- [ ] showBoardName+boardName 시 제목 앞 칩 표시·nested anchor 없음
- [ ] TS/prettier/build green