### PR TITLE
feat(feed): /feed 를 게시판 리스트 레이아웃으로 재스킨 (재설계 2단계)

### DIFF
--- a/apps/web/src/routes/feed/+page.svelte
+++ b/apps/web/src/routes/feed/+page.svelte
@@ -7,10 +7,9 @@
     import { browser } from '$app/environment';
     import Newspaper from '@lucide/svelte/icons/newspaper';
     import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
-    import MessageSquare from '@lucide/svelte/icons/message-square';
-    import Eye from '@lucide/svelte/icons/eye';
     import FeedSkeleton from '$lib/components/features/feed/feed-skeleton.svelte';
-    import { formatCommentCountBadge } from '$lib/utils/comment-count.js';
+    import Classic from '$lib/components/features/board/layouts/list/classic.svelte';
+    import type { FreePost } from '$lib/api/types.js';
     import type { PageData } from './$types.js';
 
     let { data }: { data: PageData } = $props();
@@ -137,28 +136,39 @@
         goto(url.pathname + url.search);
     }
 
-    // 시간 포맷
-    function formatTime(dateString: string): string {
-        const date = new Date(dateString);
-        const now = new Date();
-        const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-        const targetDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-
-        if (targetDate.getTime() === today.getTime()) {
-            return date.toLocaleTimeString('ko-KR', {
-                timeZone: 'Asia/Seoul',
-                hour: '2-digit',
-                minute: '2-digit',
-                hour12: false
-            });
-        } else {
-            return date.toLocaleDateString('ko-KR', { month: '2-digit', day: '2-digit' });
-        }
-    }
-
     // 댓글인지 여부
     function isComment(item: { wr_id: number; wr_parent: number }): boolean {
         return item.wr_id !== item.wr_parent;
+    }
+
+    // 피드행(NewPostItem)을 게시판 리스트 레이아웃(classic)이 받는 FreePost 형태로 변환.
+    // ⛔ $lib/server 는 클라에서 import 못 하므로 param 은 구조적 타입으로 명시.
+    // 피드엔 없는 값(좋아요·카테고리·썸네일·아바타)은 비움 → classic 이 우아하게 degrade.
+    function mapFeedRowToPost(item: {
+        wr_id: number;
+        wr_parent: number;
+        wr_subject: string;
+        wr_content: string;
+        wr_name: string;
+        mb_id: string;
+        wr_hit: number;
+        wr_comment: number;
+        bn_datetime: string;
+        bo_table: string;
+    }): FreePost {
+        const comment = item.wr_id !== item.wr_parent;
+        return {
+            id: item.wr_id,
+            title: comment ? item.wr_content || item.wr_subject : item.wr_subject,
+            content: '',
+            author: item.wr_name,
+            author_id: item.mb_id,
+            views: item.wr_hit,
+            likes: 0,
+            comments_count: comment ? 0 : item.wr_comment,
+            created_at: item.bn_datetime,
+            board_id: item.bo_table
+        };
     }
 </script>
 
@@ -333,99 +343,17 @@
                 {:else}
                     <div class="divide-border divide-y">
                         {#each result.items as item (item.bn_id)}
-                            <a
+                            <!-- 재설계 2단계: 게시판 리스트 레이아웃(classic) 재사용 + 출처 게시판명 칩.
+                                 Classic 은 자체 <a> 를 렌더하므로 바깥 <a> 로 감싸지 않는다.
+                                 key 는 bn_id(전역 유일)로 유지 → 크로스보드 id 충돌 회피. -->
+                            <Classic
+                                post={mapFeedRowToPost(item)}
                                 href={isComment(item)
                                     ? `/${item.bo_table}/${item.wr_parent}#c_${item.wr_id}`
                                     : `/${item.bo_table}/${item.wr_id}`}
-                                class="hover:bg-muted/50 block px-4 py-2.5 no-underline transition-all duration-200"
-                            >
-                                <div class="flex items-center gap-2 md:gap-3">
-                                    <div class="hidden shrink-0 md:block">
-                                        <span
-                                            class="bg-muted text-muted-foreground inline-flex h-7 w-16 items-center justify-center rounded-lg text-xs font-medium"
-                                        >
-                                            {item.bo_subject}
-                                        </span>
-                                    </div>
-
-                                    <div class="min-w-0 flex-1">
-                                        <div
-                                            class="flex flex-col gap-1 md:flex-row md:items-center md:gap-3"
-                                        >
-                                            <div class="flex min-w-0 flex-1 items-center gap-1.5">
-                                                {#if isComment(item)}
-                                                    <span
-                                                        class="bg-muted flex h-5 w-5 shrink-0 items-center justify-center rounded"
-                                                    >
-                                                        <MessageSquare
-                                                            class="text-muted-foreground h-3 w-3"
-                                                        />
-                                                    </span>
-                                                    <span
-                                                        class="text-muted-foreground truncate text-[15px] leading-relaxed"
-                                                    >
-                                                        {item.wr_content || item.wr_subject}
-                                                    </span>
-                                                {:else}
-                                                    <span
-                                                        class="text-foreground truncate text-[15px] font-medium leading-relaxed"
-                                                    >
-                                                        {item.wr_subject}
-                                                    </span>
-                                                    {#if item.wr_comment > 0}
-                                                        <span
-                                                            class="shrink-0 rounded-full bg-blue-100 px-1.5 py-0.5 text-[11px] font-semibold text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
-                                                        >
-                                                            {formatCommentCountBadge(
-                                                                item.wr_comment
-                                                            )}
-                                                        </span>
-                                                    {/if}
-                                                {/if}
-                                            </div>
-
-                                            <div class="hidden shrink-0 items-center gap-2 md:flex">
-                                                <span
-                                                    class="text-muted-foreground w-[100px] truncate text-sm"
-                                                >
-                                                    {item.wr_name}
-                                                </span>
-                                                <span
-                                                    class="text-muted-foreground w-[65px] text-center text-sm"
-                                                >
-                                                    {formatTime(item.bn_datetime)}
-                                                </span>
-                                                <span
-                                                    class="text-muted-foreground flex w-[50px] items-center justify-end gap-1 text-sm"
-                                                >
-                                                    <Eye class="h-3.5 w-3.5" />
-                                                    {item.wr_hit.toLocaleString()}
-                                                </span>
-                                            </div>
-
-                                            <div
-                                                class="text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm md:hidden"
-                                            >
-                                                <span
-                                                    class="bg-muted rounded px-1.5 py-0.5 text-xs font-medium"
-                                                >
-                                                    {item.bo_subject}
-                                                </span>
-                                                <span>{item.wr_name}</span>
-                                                <span class="text-border">·</span>
-                                                <span>{formatTime(item.bn_datetime)}</span>
-                                                {#if !isComment(item) && item.wr_hit > 0}
-                                                    <span class="text-border">·</span>
-                                                    <span class="flex items-center gap-0.5">
-                                                        <Eye class="h-3 w-3" />
-                                                        {item.wr_hit.toLocaleString()}
-                                                    </span>
-                                                {/if}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </a>
+                                showBoardName
+                                boardName={item.bo_subject}
+                            />
                         {/each}
                     </div>
                 {/if}


### PR DESCRIPTION
재설계 2단계 — 사장님 '/feed 를 자유게시판 모양으로'.

## 변경 (feed/+page.svelte 1파일)
- 커스텀 Card 목록 → 공용 **classic 게시판 레이아웃** 재사용(1단계 #2195의 showBoardName 활용).
- `mapFeedRowToPost` 어댑터: NewPostItem→FreePost(필드 rename, 피드에 없는 값은 빈값→classic degrade).
- 각 줄 출처 게시판명 칩(`showBoardName`+`boardName=bo_subject`), key=`bn_id`(전역유일), 줄별 href(글/댓글).
- Classic 이 자체 `<a>` 렌더 → 바깥 `<a>` 제거(nested anchor 없음). unused import/함수 정리.

## 불변
- 서버·데이터(`new-posts.ts`, `feed/+page.server.ts`) 그대로. 스코프/종류/정렬 토글·페이지네이션 불변.
- ⛔ 게시판 목록(/free 등) **무영향**(1·2단계 모두 /free 안 건드림). 3단계(/free 토글)는 별도 보류.

## 검증
- [ ] /feed 가 classic 모양 + 줄별 보드명 칩
- [ ] 줄 클릭 → 원 게시판 글/댓글로 이동
- [ ] 중복/렌더death 없음(key=bn_id)·nested anchor 없음
- [ ] TS/prettier/build green · 게시판 목록 무영향