### PR TITLE
feat(free): 자유게시판 "전체 새글" 제자리 토글 (재설계 3단계 B)

### DIFF
--- a/apps/web/src/lib/components/features/feed/feed-list-view.svelte
+++ b/apps/web/src/lib/components/features/feed/feed-list-view.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+    // 새글 피드(여러 게시판 합친 목록)를 게시판 리스트 레이아웃(classic)으로 렌더하는 공용 컴포넌트.
+    // /feed(독립 페이지)와 /free?all=1(제자리 토글)이 함께 쓴다.
+    // ⛔ authStore 로 렌더를 가르지 않는다(SSR null → 하이드레이션 미스매치). classic 도 authStore 무관.
+    import Classic from '$lib/components/features/board/layouts/list/classic.svelte';
+    import type { FreePost } from '$lib/api/types.js';
+
+    interface FeedRow {
+        bn_id: number;
+        wr_id: number;
+        wr_parent: number;
+        wr_subject: string;
+        wr_content: string;
+        wr_name: string;
+        mb_id: string;
+        wr_hit: number;
+        wr_comment: number;
+        bn_datetime: string;
+        bo_table: string;
+        bo_subject: string;
+    }
+
+    let { items = [], showBoardName = true }: { items?: FeedRow[]; showBoardName?: boolean } =
+        $props();
+
+    // 댓글행인지(피드엔 새 댓글도 섞임). wr_id != wr_parent 이면 댓글.
+    function isComment(item: { wr_id: number; wr_parent: number }): boolean {
+        return item.wr_id !== item.wr_parent;
+    }
+
+    // 피드행(NewPostItem)을 classic 이 받는 FreePost 형태로 변환. 피드에 없는 값(좋아요·아바타·
+    // 카테고리·썸네일)은 비움 → classic 이 우아하게 degrade. key 는 호출부가 bn_id 로 준다.
+    function mapFeedRowToPost(item: FeedRow): FreePost {
+        const comment = isComment(item);
+        return {
+            id: item.wr_id,
+            title: comment ? item.wr_content || item.wr_subject : item.wr_subject,
+            content: '',
+            author: item.wr_name,
+            author_id: item.mb_id,
+            views: item.wr_hit,
+            likes: 0,
+            comments_count: comment ? 0 : item.wr_comment,
+            created_at: item.bn_datetime,
+            board_id: item.bo_table
+        };
+    }
+</script>
+
+<div class="divide-border divide-y">
+    {#each items as item (item.bn_id)}
+        <Classic
+            post={mapFeedRowToPost(item)}
+            href={isComment(item)
+                ? `/${item.bo_table}/${item.wr_parent}#c_${item.wr_id}`
+                : `/${item.bo_table}/${item.wr_id}`}
+            {showBoardName}
+            boardName={item.bo_subject}
+        />
+    {/each}
+</div>

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -76,6 +76,8 @@
         DropdownMenuCheckboxItem
     } from '$lib/components/ui/dropdown-menu/index.js';
     import Settings2 from '@lucide/svelte/icons/settings-2';
+    import Newspaper from '@lucide/svelte/icons/newspaper';
+    import FeedListView from '$lib/components/features/feed/feed-list-view.svelte';
 
     // 특수 게시판 컴포넌트 (플러그인 레지스트리 기반)
     import { boardTypeRegistry } from '$lib/components/features/board/board-type-registry.js';
@@ -164,6 +166,44 @@
 
     // 현재 페이지 번호 (글 링크에 전달용)
     const listPage = $derived(Number($page.url.searchParams.get('page')) || 1);
+
+    // 재설계 3단계(B): 자유게시판에서 "전체 새글(피드)"로 제자리 토글. boardId==='free' + ?all=1.
+    // ⛔ authStore 로 가르지 않는다(SSR null 지뢰). URL 파라미터로만 판정 → SSR·클라 일치.
+    // 자유 포함 전체·글만(view=w). 기존 게시판 목록 파이프라인은 안 건드리고 렌더만 분기한다.
+    const allView = $derived(boardId === 'free' && $page.url.searchParams.get('all') === '1');
+    let feedItems = $state<
+        {
+            bn_id: number;
+            wr_id: number;
+            wr_parent: number;
+            wr_subject: string;
+            wr_content: string;
+            wr_name: string;
+            mb_id: string;
+            wr_hit: number;
+            wr_comment: number;
+            bn_datetime: string;
+            bo_table: string;
+            bo_subject: string;
+        }[]
+    >([]);
+    let feedLoading = $state(false);
+    // $effect 는 SSR 미실행(클라 전용). all=1 일 때만 /api/feed 로 전체 새글을 불러온다.
+    $effect(() => {
+        if (!allView) return;
+        feedLoading = true;
+        fetch('/api/feed?view=w')
+            .then((r) => (r.ok ? r.json() : { items: [] }))
+            .then((d) => {
+                feedItems = d.items ?? [];
+            })
+            .catch(() => {
+                feedItems = [];
+            })
+            .finally(() => {
+                feedLoading = false;
+            });
+    });
 
     // 목록 → 상세 재사용: 순수 목록 화면(쿼리가 page 뿐)일 때 현재 목록을 기억해 두면
     // 글 상세 하단 목록이 요청 없이 즉시 그려진다($effect 는 SSR 미실행 — 클라 전용).
@@ -1050,6 +1090,18 @@
                 </div>
 
                 <div class="flex items-center gap-2">
+                    <!-- 재설계 3단계(B): 자유게시판에서 전체 새글(피드) 제자리 토글. 톱니 왼쪽. -->
+                    {#if boardId === 'free'}
+                        <Button
+                            variant={allView ? 'default' : 'outline'}
+                            size="icon"
+                            class="relative h-9 w-9 shrink-0"
+                            title={allView ? '이 게시판만 보기' : '전체 새글 보기'}
+                            onclick={() => goto(allView ? '/free' : '/free?all=1')}
+                        >
+                            <Newspaper class="h-4 w-4" />
+                        </Button>
+                    {/if}
                     {#if listLayoutId === 'classic'}
                         <DropdownMenu>
                             <DropdownMenuTrigger>
@@ -1710,7 +1762,20 @@
                         {/each}
                     {/if}
                 {/if}
-                {#if !postsResult.error && displayPosts.length === 0 && !backfilling}
+                {#if allView}
+                    <!-- 재설계 3단계(B): 전체 새글(피드)를 게시판 자리에 렌더. 기존 목록 파이프라인 미사용. -->
+                    {#if feedLoading && feedItems.length === 0}
+                        <div class="text-muted-foreground py-10 text-center text-sm">
+                            전체 새글을 불러오는 중…
+                        </div>
+                    {:else if feedItems.length === 0}
+                        <div class="text-muted-foreground py-10 text-center text-sm">
+                            최근 7일 새 글이 없습니다.
+                        </div>
+                    {:else}
+                        <FeedListView items={feedItems} />
+                    {/if}
+                {:else if !postsResult.error && displayPosts.length === 0 && !backfilling}
                     <Card class="bg-background {listLayoutId === 'gallery' ? 'col-span-full' : ''}">
                         <CardContent class="py-12 text-center">
                             {#if isSearching}
@@ -1794,7 +1859,7 @@
             </div>
 
             <!-- 페이지네이션 -->
-            {#if shouldShowPagination && !dateMode}
+            {#if shouldShowPagination && !dateMode && !allView}
                 <div class="mt-8 flex items-center justify-center gap-1 sm:gap-2">
                     <!-- #11941: 첫페이지 단축 — 항상 노출 (1페이지일 때만 비활성) -->
                     <Button

--- a/apps/web/src/routes/api/feed/+server.ts
+++ b/apps/web/src/routes/api/feed/+server.ts
@@ -1,0 +1,41 @@
+/**
+ * 새글 피드 데이터 API (JSON).
+ * /free?all=1 (제자리 토글) 등에서 클라이언트가 피드를 불러올 때 사용.
+ * getNewPosts 는 서버 전용(new-posts.ts)이라 클라에서 직접 못 쓰므로 이 얇은 래퍼로 노출한다.
+ * 반환 데이터는 이미 /feed 에서 공개되는 것과 동일 → 새 노출 없음. 10초 캐시.
+ */
+import type { RequestHandler } from './$types.js';
+import { getNewPosts, type FeedSort } from '$lib/server/new-posts.js';
+
+const SCOPES = new Set(['', 'nofree']);
+const VIEWS = new Set(['', 'w', 'c']);
+const SORTS = new Set(['latest', 'comments', 'views']);
+
+export const GET: RequestHandler = async ({ url }) => {
+    const rawView = url.searchParams.get('view') || '';
+    const view = VIEWS.has(rawView) ? rawView : '';
+    const rawScope = url.searchParams.get('scope') || '';
+    const scope = SCOPES.has(rawScope) ? rawScope : '';
+    const rawSort = url.searchParams.get('sort') || 'latest';
+    const sort = (SORTS.has(rawSort) ? rawSort : 'latest') as FeedSort;
+    const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10));
+    const grId = url.searchParams.get('gr_id') || '';
+    const cursor = parseInt(url.searchParams.get('cursor') || '0', 10) || undefined;
+    const perPage = 30;
+
+    try {
+        const result = await getNewPosts(view, grId, page, perPage, cursor, sort, scope);
+        return new Response(JSON.stringify(result), {
+            headers: {
+                'Content-Type': 'application/json',
+                'Cache-Control': 'public, max-age=10'
+            }
+        });
+    } catch (error) {
+        console.error('피드 API 조회 실패:', error);
+        return new Response(JSON.stringify({ items: [], total: 0, nextCursor: null }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+};

--- a/apps/web/src/routes/feed/+page.svelte
+++ b/apps/web/src/routes/feed/+page.svelte
@@ -8,8 +8,7 @@
     import Newspaper from '@lucide/svelte/icons/newspaper';
     import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
     import FeedSkeleton from '$lib/components/features/feed/feed-skeleton.svelte';
-    import Classic from '$lib/components/features/board/layouts/list/classic.svelte';
-    import type { FreePost } from '$lib/api/types.js';
+    import FeedListView from '$lib/components/features/feed/feed-list-view.svelte';
     import type { PageData } from './$types.js';
 
     let { data }: { data: PageData } = $props();
@@ -134,41 +133,6 @@
             url.searchParams.delete('cursor');
         }
         goto(url.pathname + url.search);
-    }
-
-    // 댓글인지 여부
-    function isComment(item: { wr_id: number; wr_parent: number }): boolean {
-        return item.wr_id !== item.wr_parent;
-    }
-
-    // 피드행(NewPostItem)을 게시판 리스트 레이아웃(classic)이 받는 FreePost 형태로 변환.
-    // ⛔ $lib/server 는 클라에서 import 못 하므로 param 은 구조적 타입으로 명시.
-    // 피드엔 없는 값(좋아요·카테고리·썸네일·아바타)은 비움 → classic 이 우아하게 degrade.
-    function mapFeedRowToPost(item: {
-        wr_id: number;
-        wr_parent: number;
-        wr_subject: string;
-        wr_content: string;
-        wr_name: string;
-        mb_id: string;
-        wr_hit: number;
-        wr_comment: number;
-        bn_datetime: string;
-        bo_table: string;
-    }): FreePost {
-        const comment = item.wr_id !== item.wr_parent;
-        return {
-            id: item.wr_id,
-            title: comment ? item.wr_content || item.wr_subject : item.wr_subject,
-            content: '',
-            author: item.wr_name,
-            author_id: item.mb_id,
-            views: item.wr_hit,
-            likes: 0,
-            comments_count: comment ? 0 : item.wr_comment,
-            created_at: item.bn_datetime,
-            board_id: item.bo_table
-        };
     }
 </script>
 
@@ -341,21 +305,7 @@
                         {/if}
                     </div>
                 {:else}
-                    <div class="divide-border divide-y">
-                        {#each result.items as item (item.bn_id)}
-                            <!-- 재설계 2단계: 게시판 리스트 레이아웃(classic) 재사용 + 출처 게시판명 칩.
-                                 Classic 은 자체 <a> 를 렌더하므로 바깥 <a> 로 감싸지 않는다.
-                                 key 는 bn_id(전역 유일)로 유지 → 크로스보드 id 충돌 회피. -->
-                            <Classic
-                                post={mapFeedRowToPost(item)}
-                                href={isComment(item)
-                                    ? `/${item.bo_table}/${item.wr_parent}#c_${item.wr_id}`
-                                    : `/${item.bo_table}/${item.wr_id}`}
-                                showBoardName
-                                boardName={item.bo_subject}
-                            />
-                        {/each}
-                    </div>
+                    <FeedListView items={result.items} />
                 {/if}
             </CardContent>
         </Card>


### PR DESCRIPTION
재설계 3단계(B, /free 제자리 토글). 사장님 결정: ①자유 포함(기본 OFF) ②/free만 우선 ③아이콘 토글 · URL /free?all=1.

## 변경 (4파일)
- **FeedListView** 신규 공용 컴포넌트(classic 렌더+어댑터) — /feed·/free 공용. /feed 는 인라인(2단계)→이걸로 리팩터(동작 동일).
- **/api/feed** 신규 JSON 엔드포인트(getNewPosts 래퍼, /feed 와 동일 데이터·10초 캐시).
- **[boardId]/+page.svelte**: 톱니 왼쪽 토글(free만) + `?all=1` 이면 피드뷰를 게시판 자리에 렌더(글만 view=w·자유포함). 피드는 $effect 로 /api/feed 클라 fetch.

## 안전
- ⛔ /free **단일보드 렌더 파이프라인 미변경** — allView 를 **첫 branch로 추가**(기존 목록/dedup/backfill/읽음/bulk/페이지 그대로), allView 시 페이지네이션 숨김.
- ⛔ **board 서버 로드(42KB) 안 건드림** — 피드는 클라 fetch로 격리.
- ⛔ **authStore 미사용**(SSR null 하이드레이션 지뢰 회피) — URL 파라미터로만 판정, classic 도 authStore 무관.
- 다른 게시판·기존 /free(all 없음) 무영향.

## 검증
- [ ] /free?all=1 → 게시판 모양 전체 새글(글만) · 톱니 왼쪽 토글 on/off
- [ ] /free(기본) 기존 목록 완전 불변 · 다른 게시판 무영향
- [ ] 줄 클릭 → 원 게시판 · 보드칩 · 댓글 안 나옴 · 페이지네이션 숨김
- [ ] {#if allView} 분기 균형 · $effect 무한루프 없음 · TS/prettier/build green