### PR TITLE
style(reader): 글자크기 버튼 라벨 계단식 크기

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -300,7 +300,9 @@
             aria-label="글자 작게"
         >
             <span class="text-[11px] md:hidden">가</span>
-            <span class="hidden text-xs md:inline">작게</span>
+            <!-- 라벨 자체를 계단식 크기로: 작게(11)<보통(12=기존)<크게(14). 버튼은 h-[26px] 고정이라
+                 안쪽 글자가 커져도 작성자 줄 높이는 그대로다(모바일 '가' 15px 도 이 박스에 든다). -->
+            <span class="hidden text-[11px] md:inline">작게</span>
         </button>
         <!-- 기본값 복귀는 md 이상에서만. 모바일은 폭이 없어 작은가/큰가 로 오갈 수 있게만 둔다. -->
         <button
@@ -317,7 +319,7 @@
             aria-label="글자 크게"
         >
             <span class="text-[15px] md:hidden">가</span>
-            <span class="hidden text-xs md:inline">크게</span>
+            <span class="hidden text-[14px] md:inline">크게</span>
         </button>
     </span>
 {/snippet}


### PR DESCRIPTION
## 요약
글보기 상세의 글자크기 컨트롤(PC=md+)에서 '작게·보통·크게' 라벨이 셋 다 12px(text-xs)로 동일했던 것을, 버튼 자체가 효과 방향을 미리 보여주도록 **계단식 크기**로 바꾼다.

| 버튼 | 이전 | 이후 |
|---|---|---|
| 작게 | 12px | **11px** |
| 보통 | 12px | 12px(기존 유지) |
| 크게 | 12px | **14px** |

모바일(<md)은 이미 작은 '가'(11px)/큰 '가'(15px)로 크기 차이를 주고 있어 그대로 두고, 단어 라벨이 나오는 md+ 만 조정했다.

## 안전
- 버튼 높이 `h-[26px]` 고정 + `leading-none` → 안쪽 글자가 14px 로 커져도 작성자 줄(26px) 높이 불변(모바일 15px '가' 도 이 박스에 들어감).
- 기능 로직(changeContentFontSize/currentFontSize) 무변경, 순수 라벨 크기만.
- 보통 = 기존 baseline(12px) 유지.

## 검증
- 단일 파일 svelte 컴파일 통과(경고는 기존 무관 post/attachedImagesEl).
- prettier 준수.

카나리 확인(로그인 상태 글 상세) 후 prod 승격 예정.