### PR TITLE
fix(subscribe): 구독 시 board_subscribe 알림 플래그 보장 (bug/13715)

### DIFF
--- a/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
@@ -138,12 +138,17 @@ export const POST: RequestHandler = async ({ params, cookies, request }) => {
         // g5_noti_preference.noti_board_subscribe 가 0 이면 구독해도 모든 구독 알림이 막힌다
         // (write_after_worker 의 게이트). 과거 이 플래그가 0 인 채 구독만 한 스트랜딩 사례가
         // 다수 있어(bug/13715), 구독 시 이 플래그를 1 로 보장한다. 행이 없으면 기본값으로 생성.
-        await pool.query<ResultSetHeader>(
-            `INSERT INTO g5_noti_preference (mb_id, noti_board_subscribe)
-             VALUES (?, 1)
-             ON DUPLICATE KEY UPDATE noti_board_subscribe = 1`,
-            [user.mb_id]
-        );
+        // best-effort: 이 보장이 실패해도 이미 성공한 구독을 500 으로 되돌리지 않는다.
+        try {
+            await pool.query<ResultSetHeader>(
+                `INSERT INTO g5_noti_preference (mb_id, noti_board_subscribe)
+                 VALUES (?, 1)
+                 ON DUPLICATE KEY UPDATE noti_board_subscribe = 1`,
+                [user.mb_id]
+            );
+        } catch (prefErr) {
+            console.error('구독 알림 플래그 보장 실패(구독은 성공):', prefErr);
+        }
 
         const [countRows] = await pool.query<CountRow[]>(
             'SELECT COUNT(*) AS count FROM g5_board_subscribe WHERE bo_table = ?',

--- a/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/subscribe/+server.ts
@@ -134,6 +134,17 @@ export const POST: RequestHandler = async ({ params, cookies, request }) => {
             [level, user.mb_id, boardId]
         );
 
+        // 게시판을 구독한다는 것은 곧 '알림을 받겠다'는 의사표시다. 그런데 전역 마스터 토글
+        // g5_noti_preference.noti_board_subscribe 가 0 이면 구독해도 모든 구독 알림이 막힌다
+        // (write_after_worker 의 게이트). 과거 이 플래그가 0 인 채 구독만 한 스트랜딩 사례가
+        // 다수 있어(bug/13715), 구독 시 이 플래그를 1 로 보장한다. 행이 없으면 기본값으로 생성.
+        await pool.query<ResultSetHeader>(
+            `INSERT INTO g5_noti_preference (mb_id, noti_board_subscribe)
+             VALUES (?, 1)
+             ON DUPLICATE KEY UPDATE noti_board_subscribe = 1`,
+            [user.mb_id]
+        );
+
         const [countRows] = await pool.query<CountRow[]>(
             'SELECT COUNT(*) AS count FROM g5_board_subscribe WHERE bo_table = ?',
             [boardId]


### PR DESCRIPTION
## 배경 (bug/13715, metalkid)
소모임(그룹 게시판) 구독 후 새 글 알림이 안 온다는 제보. 근본 원인은 전역 마스터 플래그 `g5_noti_preference.noti_board_subscribe=0` 이 구독 알림 3경로(즉시/인기/다이제스트)를 전부 차단하는 것(`write_after_worker.go:460`). 소모임 특정 문제 아님.

## 이미 조치된 것
- **데이터**: metalkid + 스트랜딩 구독자 21명(구독중 ∧ bs=0 ∧ 나머지 알림 전부 ON) 플래그 1로 백필. (의도적으로 여러 알림을 끈 사용자는 제외)
- **UI**: 알림설정에 '게시판 구독 알림' 토글이 이미 분리 구현됨(main). 앞으로 사용자가 직접 켜고 끌 수 있음.

## 이 PR (재발 방지)
구독 POST 시 `noti_board_subscribe=1` 을 보장(`INSERT ... ON DUPLICATE KEY UPDATE`). 구독=알림 의사표시이므로, 마스터 플래그가 꺼진 채 구독만 해서 알림이 조용히 막히는 스트랜딩을 원천 차단.

## 안전
- 대상 컬럼 전부 NOT NULL + DEFAULT 1 → 부분 INSERT 안전.
- 순수 추가(구독 성공 경로에 1쿼리), 기존 동작 무변경.

카나리 확인 후 prod 승격 예정.