### PR TITLE
fix(settings): 뮤트 키워드 추가 유효성 검사·최대 개수 경고 (bug/13694)

### DIFF
--- a/apps/web/src/lib/stores/ui-settings.svelte.ts
+++ b/apps/web/src/lib/stores/ui-settings.svelte.ts
@@ -159,6 +159,10 @@ export const LIST_FONT_SIZES: Record<ListFontSize, string> = {
  * '혐오'는 담론성 표현('혐오 문화/표현/범죄' 등) 오탐이 심해 bare 매칭을 제거하고,
  * 이미지 지시 변형('혐짤/혐오짤/혐오 짤/혐오사진/혐오 사진/혐오 이미지')만 대상으로 한다.
  */
+/** 제목 필터링(뮤트) 키워드 최대 개수. isMuted 가 목록 항목마다 some(includes) 를
+ *  돌리므로 무한정 늘면 렌더 성능이 나빠진다. 초과 시 UI 가 경고를 띄운다(bug/13694). */
+export const MAX_MUTE_KEYWORDS = 200;
+
 export const BLUR_KEYWORDS = [
     '후방',
     '혐짤',
@@ -516,12 +520,15 @@ function createUiSettingsStore() {
             settings.muteKeywords = v;
             save();
         },
-        addMuteKeyword(keyword: string) {
+        // 추가 결과를 반환해 UI 가 상황별 피드백(중복/최대개수 초과)을 줄 수 있게 한다(bug/13694).
+        addMuteKeyword(keyword: string): 'added' | 'empty' | 'duplicate' | 'full' {
             const trimmed = keyword.trim();
-            if (trimmed && !settings.muteKeywords.includes(trimmed)) {
-                settings.muteKeywords = [...settings.muteKeywords, trimmed];
-                save();
-            }
+            if (!trimmed) return 'empty';
+            if (settings.muteKeywords.includes(trimmed)) return 'duplicate';
+            if (settings.muteKeywords.length >= MAX_MUTE_KEYWORDS) return 'full';
+            settings.muteKeywords = [...settings.muteKeywords, trimmed];
+            save();
+            return 'added';
         },
         removeMuteKeyword(keyword: string) {
             settings.muteKeywords = settings.muteKeywords.filter((k) => k !== keyword);

--- a/apps/web/src/routes/member/settings/ui/+page.svelte
+++ b/apps/web/src/routes/member/settings/ui/+page.svelte
@@ -42,6 +42,7 @@
         uiSettingsStore,
         BLUR_KEYWORDS,
         BLUR_SPOILER_KEYWORDS,
+        MAX_MUTE_KEYWORDS,
         type FontFamily,
         type LineHeight,
         type ContentFontSize,
@@ -49,6 +50,7 @@
         type ShortcutButtonSize
     } from '$lib/stores/ui-settings.svelte.js';
     import { densityStore } from '$lib/stores/density.svelte.js';
+    import { toast } from 'svelte-sonner';
     import {
         boardFavoritesStore,
         slotLabel,
@@ -205,10 +207,18 @@
 
     function addMuteKeyword() {
         const trimmed = muteInput.trim();
-        if (trimmed) {
-            uiSettingsStore.addMuteKeyword(trimmed);
-            muteInput = '';
+        if (!trimmed) return;
+        const result = uiSettingsStore.addMuteKeyword(trimmed);
+        if (result === 'full') {
+            // 최대 개수 초과 시 조용히 삼키지 않고 경고를 띄운다(bug/13694).
+            toast.warning(`뮤트 키워드는 최대 ${MAX_MUTE_KEYWORDS}개까지 등록할 수 있습니다.`);
+            return;
         }
+        if (result === 'duplicate') {
+            toast.info('이미 등록된 키워드입니다.');
+            return;
+        }
+        muteInput = '';
     }
 
     function handleMuteKeydown(e: KeyboardEvent) {
@@ -791,8 +801,15 @@
                         <Ban class="h-5 w-5" />
                         제목 필터링 (뮤트)
                     </CardTitle>
-                    <CardDescription>특정 단어가 포함된 게시글을 목록에서 숨깁니다.</CardDescription
-                    >
+                    <CardDescription>
+                        특정 단어가 포함된 게시글을 목록에서 숨깁니다.{#if hydrated}
+                            <span
+                                class:text-destructive={uiSettingsStore.muteKeywords.length >=
+                                    MAX_MUTE_KEYWORDS}
+                                >(현재 {uiSettingsStore.muteKeywords
+                                    .length}/{MAX_MUTE_KEYWORDS})</span
+                            >{/if}
+                    </CardDescription>
                 </CardHeader>
                 <CardContent class="space-y-3">
                     <div class="flex gap-2">
@@ -802,7 +819,13 @@
                             onkeydown={handleMuteKeydown}
                             class="flex-1"
                         />
-                        <Button variant="outline" size="sm" onclick={addMuteKeyword}>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={hydrated &&
+                                uiSettingsStore.muteKeywords.length >= MAX_MUTE_KEYWORDS}
+                            onclick={addMuteKeyword}
+                        >
                             <Plus class="mr-1 h-4 w-4" />
                             추가
                         </Button>


### PR DESCRIPTION
## 배경 (bug/13694, 취미생활자)
제목 필터링(뮤트) 키워드 [+ 추가]가 **개수 제한도 경고도 없이** 계속 추가됨. 제보자는 200개 초과 시 경고를 요청.

## 변경
- `MAX_MUTE_KEYWORDS = 200` 상한 도입. (`isMuted`가 목록 항목마다 `some(includes)` 를 돌려 무한정 늘면 렌더 성능 저하)
- `addMuteKeyword`가 결과 상태(`added|empty|duplicate|full`)를 반환.
- 상한 초과 시: 경고 토스트 + [+ 추가] 버튼 비활성 + 현재 개수 카운터 `(현재 N/200)`(초과 임박 시 붉게).
- 중복 키워드도 조용히 무시하던 것을 안내 토스트로 피드백.

## 참고
뮤트 키워드는 **localStorage 전용**(서버 저장 없음)이라 실제 하드 200 제한은 없었음 → 성능·UX 관점의 상한을 제품 결정으로 도입.

## 검증
- svelte 단일 파일 컴파일 0경고, prettier 준수.

카나리 확인 후 prod 승격 예정.