### PR TITLE
fix(profile): '관리자 삭제' 라벨 정직화 (bug/13675 ④)

### DIFF
--- a/apps/web/src/routes/member/[id]/+page.svelte
+++ b/apps/web/src/routes/member/[id]/+page.svelte
@@ -839,9 +839,10 @@
                                 </div>
                             </div>
 
-                            <!-- 관리자 삭제 -->
+                            <!-- 관리자·글작성자 삭제: '댓글'은 관리자뿐 아니라 글 작성자가 자기 글에 달린
+                                 댓글을 지운 경우도 포함된다(내가 안 지웠는데 삭제된 것으로 보이던 오해 방지 — bug/13675). -->
                             <div>
-                                <div class="mb-1 text-sm font-medium">관리자 삭제</div>
+                                <div class="mb-1 text-sm font-medium">관리자·글작성자 삭제</div>
                                 <div class="bg-muted flex h-4 overflow-hidden rounded-full">
                                     <div
                                         class="flex flex-1 items-center justify-center bg-yellow-200 text-[10px] font-medium text-yellow-900 dark:bg-yellow-800 dark:text-yellow-100"
@@ -854,6 +855,9 @@
                                         댓글 {p.stats.delete_comment_by_admin.toLocaleString()}
                                     </div>
                                 </div>
+                                <p class="text-muted-foreground mt-1 text-[10px] leading-tight">
+                                    댓글은 글 작성자가 자기 글의 댓글을 삭제한 경우도 포함됩니다.
+                                </p>
                             </div>
 
                             <!-- 추천/신고 -->


### PR DESCRIPTION
## 배경 (bug/13675 ④)
프로필의 '관리자 삭제' 통계 중 **댓글** 수는 관리자뿐 아니라 **글 작성자가 자기 글에 달린 댓글을 삭제한 경우**도 포함(`wr_deleted_by ≠ 댓글작성자`)인데, 라벨이 '관리자 삭제'라 제보자가 '내가 안 지웠는데 관리자가 지웠나?'로 오해했다.

## 변경
- 헤더 '관리자 삭제' → **'관리자·글작성자 삭제'**.
- 하단에 설명: '댓글은 글 작성자가 자기 글의 댓글을 삭제한 경우도 포함됩니다.'

## 범위
3분할(본인/글작성자/관리자) 정밀 집계는 소스 통계 테이블(`g5_member_board_status`)이 stale·단일값이라 파이프라인 재작업이 필요 — 별건. 이 PR은 오해를 없애는 라벨 정직화.

## 검증
svelte 컴파일 통과(경고 기존 무관), prettier 준수.