### PR TITLE
feat(feed): 헤더 2버튼 + 전체 새글 토글에 인라인 옵션(글/댓글·정렬)

### DIFF
--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -77,7 +77,6 @@
     } from '$lib/components/ui/dropdown-menu/index.js';
     import Settings2 from '@lucide/svelte/icons/settings-2';
     import Newspaper from '@lucide/svelte/icons/newspaper';
-    import GalleryVerticalEnd from '@lucide/svelte/icons/gallery-vertical-end';
     import FeedListView from '$lib/components/features/feed/feed-list-view.svelte';
 
     // 특수 게시판 컴포넌트 (플러그인 레지스트리 기반)
@@ -1116,18 +1115,6 @@
                 </div>
 
                 <div class="flex items-center gap-2">
-                    <!-- 새글 모아보기(/feed) 전용 페이지 진입 — 전 게시판 노출, 신문 토글 왼쪽.
-                         옆 토글(제자리 훑기)과 구분되게 '모아보기(쌓인 목록)' 아이콘을 쓴다.
-                         /feed 는 글/댓글·정렬·그룹 필터가 있는 독립 페이지. -->
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        class="relative h-9 w-9 shrink-0"
-                        title="새글 모아보기"
-                        href="/feed"
-                    >
-                        <GalleryVerticalEnd class="h-4 w-4" />
-                    </Button>
                     <!-- 전체 새글(피드) 진입 유도 — 전 게시판 노출. 자유게시판(allView)=제자리 토글,
                          그 외 게시판=클릭 시 /free?all=1(전체 새글 피드)로 이동. 안 눌러 보는 분이 많아
                          비활성 상태엔 그라데이션이 연속으로 흐르게 해 눈에 띄게 한다(prefers-reduced-motion 존중). 톱니 왼쪽. -->

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -192,6 +192,29 @@
     let feedTotal = $state(0);
     // 페이지는 1 이상으로 클램프(음수/0/문자 방어). listPage 는 상세 링크용이라 그대로 둔다.
     const feedPage = $derived(Math.max(1, listPage));
+    // 전체 새글(allView) 인라인 옵션 — URL 파라미터로 유지(공유·새로고침 안전).
+    //   fv = 뷰('' 전체 | w 글만 | c 댓글만), fs = 정렬(latest 최신 | comments 댓글순 | views 조회순).
+    const FEED_VIEWS = ['', 'w', 'c'];
+    const FEED_SORTS = ['latest', 'comments', 'views'];
+    const feedView = $derived.by(() => {
+        const v = $page.url.searchParams.get('fv') ?? '';
+        return FEED_VIEWS.includes(v) ? v : '';
+    });
+    const feedSort = $derived.by(() => {
+        const s = $page.url.searchParams.get('fs') ?? 'latest';
+        return FEED_SORTS.includes(s) ? s : 'latest';
+    });
+    // 필터 변경: URL 갱신 + 1페이지로. goToPage 가 fv/fs 를 보존하므로 페이지 이동엔 유지된다.
+    function setFeedFilter(key: 'fv' | 'fs', value: string) {
+        const url = new URL(window.location.href);
+        if ((key === 'fv' && value) || (key === 'fs' && value !== 'latest')) {
+            url.searchParams.set(key, value);
+        } else {
+            url.searchParams.delete(key);
+        }
+        url.searchParams.delete('page');
+        goto(url.pathname + url.search, { keepFocus: true, noScroll: true });
+    }
     // fetch 순서 가드(비반응성 카운터). 페이지를 빠르게 넘길 때 늦게 온 이전 응답이
     // 최신 화면을 덮어쓰지 않게 한다(이 파일의 promotion/backfill effect 와 동일 패턴).
     let feedRunId = 0;
@@ -200,9 +223,11 @@
     $effect(() => {
         if (!allView) return;
         const p = feedPage;
+        const v = feedView; // 옵션 변경 시 재조회되도록 effect 안에서 읽는다
+        const s = feedSort;
         const myRun = ++feedRunId;
         feedLoading = true;
-        fetch(`/api/feed?view=w&page=${p}`)
+        fetch(`/api/feed?view=${v}&sort=${s}&page=${p}`)
             .then((r) => (r.ok ? r.json() : { items: [], total: 0 }))
             .then((d) => {
                 if (myRun !== feedRunId) return; // 더 새 요청이 떴으면 이 응답은 버린다
@@ -1791,6 +1816,33 @@
                 {/if}
                 {#if allView}
                     <!-- 재설계 3단계(B): 전체 새글(피드)를 게시판 자리에 렌더. 기존 목록 파이프라인 미사용. -->
+                    <!-- 인라인 옵션(글/댓글·정렬). 결과가 비어도 항상 보여 필터를 되돌릴 수 있게 한다. -->
+                    <div class="mb-3 flex flex-wrap items-center gap-2">
+                        <div class="bg-muted inline-flex rounded-lg p-0.5 text-sm">
+                            {#each [['', '전체'], ['w', '글'], ['c', '댓글']] as opt (opt[0])}
+                                <button
+                                    type="button"
+                                    class="rounded-md px-3 py-1 transition-colors {feedView ===
+                                    opt[0]
+                                        ? 'bg-background text-foreground shadow-sm'
+                                        : 'text-muted-foreground hover:text-foreground'}"
+                                    onclick={() => setFeedFilter('fv', opt[0])}>{opt[1]}</button
+                                >
+                            {/each}
+                        </div>
+                        <div class="bg-muted inline-flex rounded-lg p-0.5 text-sm">
+                            {#each [['latest', '최신순'], ['comments', '댓글순'], ['views', '조회순']] as opt (opt[0])}
+                                <button
+                                    type="button"
+                                    class="rounded-md px-3 py-1 transition-colors {feedSort ===
+                                    opt[0]
+                                        ? 'bg-background text-foreground shadow-sm'
+                                        : 'text-muted-foreground hover:text-foreground'}"
+                                    onclick={() => setFeedFilter('fs', opt[0])}>{opt[1]}</button
+                                >
+                            {/each}
+                        </div>
+                    </div>
                     {#if !feedLoaded || (feedLoading && feedItems.length === 0)}
                         <!-- 첫 조회 완료 전엔 '새 글 없음'을 띄우지 않는다(직접접속 가짜 빈화면 방지). -->
                         <div class="text-muted-foreground py-10 text-center text-sm">


### PR DESCRIPTION
## 배경
피드(모아보기)는 다른 페이지로 '이동'하는데 옆 전체 새글은 '토글'이라 어색 → 헤더는 **[전체 새글 토글][보기 설정] 2개**로. 대신 사용자가 원한 대로 **전체 새글을 켜면 그 자리에 옵션(글/댓글·정렬)** 이 뜨게 한다.

## 변경
1. 헤더 '새글 모아보기'(/feed) 버튼 제거 → **버튼 2개**.
2. 전체 새글(allView) 켜면 **인라인 옵션 바**:
   - 글/댓글: **전체 · 글 · 댓글**
   - 정렬: **최신순 · 댓글순 · 조회순**
   - URL 파라미터(`fv`/`fs`)로 유지 → 공유·새로고침·페이지 이동에 보존.
   - 결과가 비어도 옵션 바는 항상 표시(필터 되돌리기 가능).
3. 전체 새글 토글은 기존대로 **전 게시판** 노출.

## 후속
그룹 필터는 그룹목록 데이터가 별도로 필요해 다음에.

## 검증
svelte 컴파일 통과, prettier 준수, fetch 순서가드(feedRunId) 유지.