### PR TITLE
관측: 하이드레이션 폐기의 원인 창을 연다 — 주석 마커 균형(hbal) + 외부 변형 수(b=)

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -609,11 +609,11 @@
                           d.ecnt +
                           '/' +
                           d.ccnt +
-                          '\nhbal=' +
-                          d.hbal +
-                          ',' +
-                          d.hmin +
-                          (d.trunc ? ',trunc' : '') +
+                          // ⛔ C1: 상한에서 끊기면 그 뒤의 닫는 마커를 못 세어 hbal 이 큰 양수로
+                          //    뜬다. 「hbal≠0 = 마커가 사라졌다」는 해석 규칙과 정면충돌하므로
+                          //    숫자를 내보내지 않는다. 실측 최대 7,798 노드(여유 35%)라
+                          //    댓글 많은 글은 넘길 수 있다.
+                          (d.trunc ? '\nhbal=na,na,trunc' : '\nhbal=' + d.hbal + ',' + d.hmin) +
                           '\ndsig=' +
                           d.sig +
                           '\ndpre=' +
@@ -627,6 +627,7 @@
                         var muts = [];
                         var tail = [];
                         var mutn = 0;
+                        var mutb = 0; // 하이드레이션 **전** 변형 수
                         var mo = new MutationObserver(function (recs) {
                             try {
                                 for (var i = 0; i < recs.length; i++) {
@@ -649,6 +650,12 @@
                         });
                         function push(s) {
                             mutn++;
+                            // ⭐ C2: 시각 비교가 아니라 **상태**로 가른다.
+                            //    __angpleHydrateAt 은 루트 컴포넌트가 하이드레이션되는 순간
+                            //    비로소 정의된다. 아직 없다 = 이 변형은 하이드레이션 **전**이다
+                            //    = 우리 코드가 아닌 **외부**가 건드린 것이다. 확정적이고 비용 0.
+                            //    (MO 의 타임스탬프는 전달 시각이라 이 판정에 못 쓴다)
+                            if (typeof window.__angpleHydrateAt === 'undefined') mutb++;
                             if (muts.length < 3) muts.push(s);
                             else {
                                 tail.push(s);
@@ -657,7 +664,7 @@
                         }
                         mo.observe(probeRoot, { childList: true, subtree: true });
                         window.__angpleMut = function () {
-                            return { n: mutn, list: muts.concat(tail) };
+                            return { n: mutn, b: mutb, list: muts.concat(tail) };
                         };
                         // ⛔ 반드시 해제된다 — 루트 onMount 가 어느 분기로 가든 호출한다.
                         window.__angpleMutStop = function () {

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -496,6 +496,104 @@
                 } catch (e) {
                     /* 관측용 */
                 }
+                // ── 하이드레이션 전 DOM 신호 2종 (2026-08-25)
+                //
+                // 왜 필요한가: 지금 계측은 **결과**만 본다(앵커가 떨어졌다).
+                // 원인은 "파싱 완료 ~ Svelte 하이드레이션" 사이 창에서 #app-root 안이
+                // 어떻게 달라졌는가다. 이 스크립트는 </body> 직전 인라인이고 번들은 그 뒤에
+                // 모듈로 로드돼 하이드레이션하므로, 그 창이 여기서 정확히 열린다.
+                //
+                // ⛔ 태그·id·class 앞부분만 담는다. 텍스트 내용·속성값·URL 은 담지 않는다.
+                //    사용자 작성 본문이 로그로 새면 안 된다.
+                function nodeSig(n) {
+                    try {
+                        if (!n) return '?';
+                        if (n.nodeType === 3) return 't';
+                        if (n.nodeType === 8) return '#';
+                        if (n.nodeType !== 1) return '?';
+                        var s = n.tagName.toLowerCase();
+                        if (n.id) s += '#' + String(n.id).slice(0, 12);
+                        var c = n.getAttribute && n.getAttribute('class');
+                        if (c) s += '.' + String(c).split(/\s+/)[0].slice(0, 14);
+                        return s;
+                    } catch (e) {
+                        return '?';
+                    }
+                }
+                // 서브트리 전체의 요소 수와 태그열 해시.
+                // ⭐ 판정법: **같은 글(URL)** 의 실패 로드와 성공 로드에서 이 둘이 다르면,
+                //    하이드레이션 전에 DOM 이 이미 달라졌다는 뜻이다(확장·스크립트·파서 교정).
+                //    같다면 SSR DOM 은 동일하고 원인은 클라이언트 쪽 타이밍이다.
+                //    tpre(최상위 12개)는 실패·성공이 전부 같은 값이라 판별력이 없었다.
+                function deepStats(el) {
+                    var cnt = 0;
+                    var h = 5381;
+                    var head = [];
+                    try {
+                        var walk = document.createTreeWalker(el, 1 /* SHOW_ELEMENT */);
+                        var n;
+                        while ((n = walk.nextNode())) {
+                            cnt++;
+                            if (cnt > 4000) break; // 폭주 방지
+                            var t = n.tagName;
+                            for (var i = 0; i < t.length; i++) {
+                                h = ((h << 5) + h + t.charCodeAt(i)) | 0;
+                            }
+                            if (head.length < 20) head.push(nodeSig(n));
+                        }
+                    } catch (e) {
+                        /* 관측용 */
+                    }
+                    return {
+                        cnt: cnt,
+                        sig: (h >>> 0).toString(36),
+                        head: head.join(',').slice(0, 200)
+                    };
+                }
+                try {
+                    var probeRoot = appRoot();
+                    if (probeRoot) {
+                        var d = deepStats(probeRoot);
+                        window.__angpleDeep =
+                            'dcnt=' + d.cnt + '\ndsig=' + d.sig + '\ndpre=' + d.head;
+                        // 파싱 후 ~ 하이드레이션 사이의 외부 변형을 잡는다.
+                        // ⛔ 파서 교정은 여기 안 잡힌다(파싱 중에 끝난다) — 그건 위 dcnt/dsig 몫이다.
+                        var muts = [];
+                        var mo = new MutationObserver(function (recs) {
+                            try {
+                                for (var i = 0; i < recs.length; i++) {
+                                    if (muts.length >= 5) return;
+                                    var r = recs[i];
+                                    var q;
+                                    // 시각을 함께 남긴다 — __angpleBundleAt 보다 앞이면 외부 요인이다.
+                                    var ts = Math.round(performance.now());
+                                    for (q = 0; q < r.removedNodes.length && muts.length < 5; q++) {
+                                        muts.push(ts + '-' + nodeSig(r.removedNodes[q]));
+                                    }
+                                    for (q = 0; q < r.addedNodes.length && muts.length < 5; q++) {
+                                        muts.push(ts + '+' + nodeSig(r.addedNodes[q]));
+                                    }
+                                }
+                            } catch (e) {
+                                /* 관측용 */
+                            }
+                        });
+                        mo.observe(probeRoot, { childList: true, subtree: true });
+                        window.__angpleMut = muts;
+                        // ⛔ 반드시 해제된다 — 루트 onMount 가 어느 분기로 가든 호출한다.
+                        window.__angpleMutStop = function () {
+                            try {
+                                mo.disconnect();
+                            } catch (e) {
+                                /* 관측용 */
+                            }
+                            window.__angpleMutStop = null;
+                        };
+                    }
+                } catch (e) {
+                    /* 관측용이라 실패해도 무시 — 아래 앵커 판정에 영향 없다 */
+                }
+
                 try {
                     var target = appRoot();
                     if (!target) return;

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -496,20 +496,19 @@
                 } catch (e) {
                     /* 관측용 */
                 }
-                // ── 하이드레이션 전 DOM 신호 2종 (2026-08-25)
+                // ── 하이드레이션 전 DOM 신호 (2026-08-25)
                 //
                 // 왜 필요한가: 지금 계측은 **결과**만 본다(앵커가 떨어졌다).
                 // 원인은 "파싱 완료 ~ Svelte 하이드레이션" 사이 창에서 #app-root 안이
                 // 어떻게 달라졌는가다. 이 스크립트는 </body> 직전 인라인이고 번들은 그 뒤에
                 // 모듈로 로드돼 하이드레이션하므로, 그 창이 여기서 정확히 열린다.
                 //
-                // ⛔ 태그·id·class 앞부분만 담는다. 텍스트 내용·속성값·URL 은 담지 않는다.
-                //    사용자 작성 본문이 로그로 새면 안 된다.
+                // ⛔ 태그·id·class 앞부분만 담는다. 텍스트 내용·주석 본문·속성값·URL 은 담지 않는다.
                 function nodeSig(n) {
                     try {
                         if (!n) return '?';
                         if (n.nodeType === 3) return 't';
-                        if (n.nodeType === 8) return '#';
+                        if (n.nodeType === 8) return '#' + markerKind(n);
                         if (n.nodeType !== 1) return '?';
                         var s = n.tagName.toLowerCase();
                         if (n.id) s += '#' + String(n.id).slice(0, 12);
@@ -520,66 +519,146 @@
                         return '?';
                     }
                 }
-                // 서브트리 전체의 요소 수와 태그열 해시.
-                // ⭐ 판정법: **같은 글(URL)** 의 실패 로드와 성공 로드에서 이 둘이 다르면,
-                //    하이드레이션 전에 DOM 이 이미 달라졌다는 뜻이다(확장·스크립트·파서 교정).
-                //    같다면 SSR DOM 은 동일하고 원인은 클라이언트 쪽 타이밍이다.
-                //    tpre(최상위 12개)는 실패·성공이 전부 같은 값이라 판별력이 없었다.
+                // 주석의 **종류만** 판별한다 — 본문은 절대 담지 않는다(사용자 HTML 주석 유출 방지).
+                //   '[' = Svelte 하이드레이션 여는 마커([, [!, [1 전부), ']' = 닫는 마커,
+                //   'e' = 빈 주석(앵커 placeholder), 'o' = 그 밖(사용자 작성 등)
+                function markerKind(n) {
+                    try {
+                        var d = n.data;
+                        if (d === '') return 'e';
+                        var c0 = d.charAt(0);
+                        if (c0 === '[') return '[';
+                        if (c0 === ']') return ']';
+                        return 'o';
+                    } catch (e) {
+                        return 'o';
+                    }
+                }
+                // 서브트리 통계.
+                //
+                // ⛔ **주석 노드를 반드시 센다.** 하이드레이션의 기전이 주석 마커이기 때문이다.
+                //    Svelte 는 여는 마커를 못 찾거나 짝이 안 맞으면 그 자리에서 전체를 폐기한다.
+                //    요소만 세면(SHOW_ELEMENT) 확장이 주석만 지웠을 때 실패·성공이 똑같이 나와
+                //    "SSR DOM 동일 → 원인은 타이밍"이라는 **틀린 결론**을 자신 있게 내게 된다.
+                //
+                // ⭐ hbal: 여는 마커와 닫는 마커의 수 차이. 운영 SSR HTML 실측(2026-08-25,
+                //    /free/7131800)에서 여는 것 1,648 · 닫는 것 1,648 로 **정확히 균형**이었다.
+                //    따라서 파싱된 DOM 에서 0 이 아니면 **그 로드에서 마커가 사라졌다는 뜻**이고,
+                //    이건 다른 로드와 짝지을 필요 없이 **한 건만으로** 판정된다.
+                // ⭐ hmin: 순회 중 깊이가 음수로 내려간 최솟값. 여는 것이 지워지면 여기서 잡힌다.
                 function deepStats(el) {
-                    var cnt = 0;
+                    var ecnt = 0;
+                    var ccnt = 0;
+                    var open = 0;
+                    var close = 0;
+                    var depth = 0;
+                    var hmin = 0;
+                    var trunc = 0;
                     var h = 5381;
                     var head = [];
                     try {
-                        var walk = document.createTreeWalker(el, 1 /* SHOW_ELEMENT */);
+                        // 129 = SHOW_ELEMENT(1) | SHOW_COMMENT(128)
+                        var walk = document.createTreeWalker(el, 129);
                         var n;
                         while ((n = walk.nextNode())) {
-                            cnt++;
-                            if (cnt > 4000) break; // 폭주 방지
-                            var t = n.tagName;
-                            for (var i = 0; i < t.length; i++) {
-                                h = ((h << 5) + h + t.charCodeAt(i)) | 0;
+                            if (ecnt + ccnt >= 12000) {
+                                trunc = 1;
+                                break;
+                            }
+                            var tok;
+                            if (n.nodeType === 8) {
+                                ccnt++;
+                                var k = markerKind(n);
+                                if (k === '[') {
+                                    open++;
+                                    depth++;
+                                } else if (k === ']') {
+                                    close++;
+                                    depth--;
+                                    if (depth < hmin) hmin = depth;
+                                }
+                                tok = '#' + k;
+                            } else {
+                                ecnt++;
+                                tok = n.tagName;
+                            }
+                            for (var i = 0; i < tok.length; i++) {
+                                h = ((h << 5) + h + tok.charCodeAt(i)) | 0;
                             }
                             if (head.length < 20) head.push(nodeSig(n));
                         }
                     } catch (e) {
-                        /* 관측용 */
+                        return null; // ⛔ 조용히 0 을 돌려주지 않는다 — "0건"과 "미작동"은 다르다
                     }
                     return {
-                        cnt: cnt,
+                        ecnt: ecnt,
+                        ccnt: ccnt,
+                        hbal: open - close,
+                        hmin: hmin,
+                        trunc: trunc,
                         sig: (h >>> 0).toString(36),
                         head: head.join(',').slice(0, 200)
                     };
                 }
                 try {
                     var probeRoot = appRoot();
+                    var d = probeRoot ? deepStats(probeRoot) : null;
+                    // ⛔ 계측이 안 돈 것과 "변화 0건"을 구분한다. 대조군까지 0 이면 장치를 의심해야 한다.
+                    window.__angpleDeep = d
+                        ? 'dcnt=' +
+                          d.ecnt +
+                          '/' +
+                          d.ccnt +
+                          '\nhbal=' +
+                          d.hbal +
+                          ',' +
+                          d.hmin +
+                          (d.trunc ? ',trunc' : '') +
+                          '\ndsig=' +
+                          d.sig +
+                          '\ndpre=' +
+                          d.head
+                        : 'dcnt=na';
                     if (probeRoot) {
-                        var d = deepStats(probeRoot);
-                        window.__angpleDeep =
-                            'dcnt=' + d.cnt + '\ndsig=' + d.sig + '\ndpre=' + d.head;
                         // 파싱 후 ~ 하이드레이션 사이의 외부 변형을 잡는다.
-                        // ⛔ 파서 교정은 여기 안 잡힌다(파싱 중에 끝난다) — 그건 위 dcnt/dsig 몫이다.
+                        // ⛔ 파서 교정은 여기 안 잡힌다(파싱 중에 끝난다) — 그건 위 hbal/dsig 몫이다.
+                        // ⛔ 5칸을 광고 주입(AdSense·adfit)이 선점할 수 있다. 그래서 **총 건수**를
+                        //    따로 세고, 앞 3 + 마지막 2 로 남겨 늦게 오는 것도 한 칸은 보이게 한다.
                         var muts = [];
+                        var tail = [];
+                        var mutn = 0;
                         var mo = new MutationObserver(function (recs) {
                             try {
                                 for (var i = 0; i < recs.length; i++) {
-                                    if (muts.length >= 5) return;
                                     var r = recs[i];
-                                    var q;
-                                    // 시각을 함께 남긴다 — __angpleBundleAt 보다 앞이면 외부 요인이다.
+                                    // ⛔ 시각은 **전달 시각**이지 발생 시각이 아니다(MO 는 마이크로태스크
+                                    //    배치 전달이라 per-record 타임스탬프가 없다). 판정 시
+                                    //    __angpleHydrateAt 보다 확실히 앞일 때만 "외부"로 확정한다.
                                     var ts = Math.round(performance.now());
-                                    for (q = 0; q < r.removedNodes.length && muts.length < 5; q++) {
-                                        muts.push(ts + '-' + nodeSig(r.removedNodes[q]));
+                                    var q;
+                                    for (q = 0; q < r.removedNodes.length; q++) {
+                                        push(ts + '-' + nodeSig(r.removedNodes[q]));
                                     }
-                                    for (q = 0; q < r.addedNodes.length && muts.length < 5; q++) {
-                                        muts.push(ts + '+' + nodeSig(r.addedNodes[q]));
+                                    for (q = 0; q < r.addedNodes.length; q++) {
+                                        push(ts + '+' + nodeSig(r.addedNodes[q]));
                                     }
                                 }
                             } catch (e) {
                                 /* 관측용 */
                             }
                         });
+                        function push(s) {
+                            mutn++;
+                            if (muts.length < 3) muts.push(s);
+                            else {
+                                tail.push(s);
+                                if (tail.length > 2) tail.shift();
+                            }
+                        }
                         mo.observe(probeRoot, { childList: true, subtree: true });
-                        window.__angpleMut = muts;
+                        window.__angpleMut = function () {
+                            return { n: mutn, list: muts.concat(tail) };
+                        };
                         // ⛔ 반드시 해제된다 — 루트 onMount 가 어느 분기로 가든 호출한다.
                         window.__angpleMutStop = function () {
                             try {

--- a/apps/web/src/hooks.client.ts
+++ b/apps/web/src/hooks.client.ts
@@ -5,6 +5,17 @@ import { loadAllPluginClientHooks } from '$lib/client/plugin-client-loader';
 // Fire-and-forget: 실패해도 앱 부팅에 영향 없음. 모듈 load 시점 1회 실행.
 void loadAllPluginClientHooks();
 
+// 하이드레이션 시작 경계 표식 (2026-08-25 계측).
+// 이 모듈 본문은 클라이언트 번들이 실행될 때 = **하이드레이션 직전**에 돌아간다.
+// app.html 의 MutationObserver 가 기록한 변형이 이 시각보다 **앞이면 외부 요인**
+// (확장·서드파티 스크립트), **뒤면 Svelte 자신의 하이드레이션/폐기 동작**이다.
+// 이 경계가 없으면 5칸짜리 기록이 Svelte 의 teardown 으로 채워져 범인을 가린다.
+try {
+    (window as unknown as Record<string, unknown>).__angpleBundleAt = Math.round(performance.now());
+} catch {
+    /* 관측용 */
+}
+
 const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
 
 // 외부 스크립트 소스 URL 필터 (광고, 애널리틱스, 브라우저 확장)

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -48,6 +48,22 @@
     import { readUserBasicFromCookie } from '$lib/utils/user-basic-client';
     import { env } from '$env/dynamic/public';
 
+    // ⭐ 진짜 하이드레이션 경계 (2026-08-25 계측).
+    //    이 줄은 **루트 컴포넌트가 하이드레이션되는 그 순간** 동기로 실행된다.
+    //    hooks.client.ts 의 __angpleBundleAt 은 모듈 평가 시각이라, 그 뒤 라우트 청크를
+    //    동적 import 해 평가하는 시간(느린 CPU 에서 수십 ms)만큼 **앞으로 헐겁다**.
+    //    그 창에서 일어난 외부 변형이 "Svelte 자신의 동작"으로 무죄 방면되는 걸 막는다.
+    //    ⛔ onMount 에 두면 안 된다 — 거기는 하이드레이션이 이미 끝난 뒤다.
+    if (browser) {
+        try {
+            (window as unknown as Record<string, unknown>).__angpleHydrateAt = Math.round(
+                performance.now()
+            );
+        } catch {
+            /* 관측용 */
+        }
+    }
+
     const LAYOUT_INIT_STORAGE_KEY = 'angple:layout-init:v1';
     const LAYOUT_INIT_STORAGE_TTL_MS = 5 * 60 * 1000;
     const MENU_STORAGE_KEY = 'angple:layout-menus:v1';
@@ -701,11 +717,17 @@
     function mutSig(): string {
         try {
             const w = window as unknown as Record<string, unknown>;
-            const m = w.__angpleMut;
-            // 경계 시각을 함께 싣는다 — 이게 없으면 변형이 하이드레이션 전인지 후인지 못 가른다.
-            const b = `@${String(w.__angpleBundleAt ?? '?')}`;
-            if (!Array.isArray(m) || m.length === 0) return b;
-            return `${b}|${m.join(',')}`.slice(0, 200);
+            const get = w.__angpleMut;
+            // ⛔ 관찰자가 아예 안 붙은 것과 "변형 0건"은 다르다. 섞으면 대조군이 거짓말한다.
+            if (typeof get !== 'function') return 'off';
+            const r = (get as () => { n: number; list: string[] })();
+            // 경계 두 개를 병기한다.
+            //   b = 번들 모듈 평가 시각(하이드레이션보다 앞이지만 청크 평가 시간만큼 헐겁다)
+            //   h = 루트 컴포넌트가 실제로 하이드레이션되는 시각 — 이쪽이 진짜 경계다
+            // 둘의 차이가 곧 "경계가 얼마나 헐거웠나"를 알려주는 자기 진단이 된다.
+            const b = `@${String(w.__angpleBundleAt ?? '?')}/${String(w.__angpleHydrateAt ?? '?')}`;
+            if (r.n === 0) return `${b}|n=0`;
+            return `${b}|n=${r.n}|${r.list.join(',')}`.slice(0, 200);
         } catch {
             return '?';
         }
@@ -753,19 +775,21 @@
             `tpost=${tgtNow}`,
             `tsame=${tgtPre === tgtNow}`,
             `ads=${adCounts()}`,
+            // ⛔ nav= 를 **신규 장문 필드보다 앞**에 둔다. stack 은 뒤에서 잘리는데,
+            //    가장 값싼 판별자가 제일 먼저 죽으면 안 된다.
+            `nav=${navType()}`,
             // 하이드레이션 전 DOM 신호 (app.html 이 파싱 직후 채운다).
             // dcnt/dsig: #app-root 서브트리의 요소 수와 태그열 해시.
             //   ⭐ **같은 글(URL)** 의 실패 로드와 성공 로드에서 이 둘이 다르면 하이드레이션
             //      전에 이미 DOM 이 달라진 것이다. 같으면 원인은 클라이언트 타이밍 쪽이다.
             // mut=: 파싱 후 ~ 하이드레이션 사이에 관찰된 childList 변형(최대 5건).
             String((window as unknown as Record<string, unknown>).__angpleDeep ?? 'dcnt=?'),
-            `mut=${mutSig()}`,
             // ⛔ 내비게이션 유형이 다음 판별자 후보다.
             //    Playwright WebKit 으로 신선 로드·항해를 24회 돌려도 실패율 0% 였는데
             //    운영 iOS 사파리는 ~50~68% 다(비로그인 포함). 차이가 뭔지 좁혀야 한다.
             //    `back_forward` = bfcache 복원 — app.html 의 iOS 전용 reload 스크립트가
             //    발화하는 바로 그 경로이고, Playwright 의 goBack 은 이걸 재현하지 못한다.
-            `nav=${navType()}`
+            `mut=${mutSig()}`
         ]
             .join('\n')
             .slice(0, 1500);
@@ -867,6 +891,8 @@
                 // 서명도 함께 버린다 — 참조를 남기면 노드 누수와 같은 종류의 낭비다.
                 delete w.__angpleBodySig;
                 delete w.__angpleTargetSig;
+                delete w.__angpleDeep;
+                delete w.__angpleMut;
             }
         } catch {
             // 관측용이라 실패해도 무시

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -697,6 +697,20 @@
     //    앱 div 안에 꽂히는 인피드 광고를 통째로 놓친다 — 실제로 그래서 2026-08-19 에
     //    "광고 없이도 실패 91건" 이라는 잘못된 기각 판정을 냈다.
     //    ok(대조군) 대비로 비교해야 의미가 있다.
+    /** app.html 이 모은 하이드레이션 전 DOM 변형 요약. 없으면 빈 값. */
+    function mutSig(): string {
+        try {
+            const w = window as unknown as Record<string, unknown>;
+            const m = w.__angpleMut;
+            // 경계 시각을 함께 싣는다 — 이게 없으면 변형이 하이드레이션 전인지 후인지 못 가른다.
+            const b = `@${String(w.__angpleBundleAt ?? '?')}`;
+            if (!Array.isArray(m) || m.length === 0) return b;
+            return `${b}|${m.join(',')}`.slice(0, 200);
+        } catch {
+            return '?';
+        }
+    }
+
     function adCounts(): string {
         try {
             const all = document.querySelectorAll('ins.adsbygoogle, iframe[id^="aswift"]').length;
@@ -739,6 +753,13 @@
             `tpost=${tgtNow}`,
             `tsame=${tgtPre === tgtNow}`,
             `ads=${adCounts()}`,
+            // 하이드레이션 전 DOM 신호 (app.html 이 파싱 직후 채운다).
+            // dcnt/dsig: #app-root 서브트리의 요소 수와 태그열 해시.
+            //   ⭐ **같은 글(URL)** 의 실패 로드와 성공 로드에서 이 둘이 다르면 하이드레이션
+            //      전에 이미 DOM 이 달라진 것이다. 같으면 원인은 클라이언트 타이밍 쪽이다.
+            // mut=: 파싱 후 ~ 하이드레이션 사이에 관찰된 childList 변형(최대 5건).
+            String((window as unknown as Record<string, unknown>).__angpleDeep ?? 'dcnt=?'),
+            `mut=${mutSig()}`,
             // ⛔ 내비게이션 유형이 다음 판별자 후보다.
             //    Playwright WebKit 으로 신선 로드·항해를 24회 돌려도 실패율 0% 였는데
             //    운영 iOS 사파리는 ~50~68% 다(비로그인 포함). 차이가 뭔지 좁혀야 한다.
@@ -751,6 +772,17 @@
     }
 
     onMount(() => {
+        // ⛔ 하이드레이션 전 DOM 관찰자를 **가장 먼저** 끊는다.
+        //    여기는 하이드레이션이 끝난 뒤다. 더 두면 앱이 정상적으로 만드는 변형까지
+        //    기록되어 5칸이 채워지고, 정작 원인인 초기 변형이 밀려난다.
+        //    ⭐ 아래 앵커 판정이 어느 분기로 가든(detached/missing/ok/무판정) 이미 해제된다.
+        try {
+            const stop = (window as unknown as Record<string, unknown>).__angpleMutStop;
+            if (typeof stop === 'function') (stop as () => void)();
+        } catch {
+            /* 관측용 */
+        }
+
         // 읽음 표시 전환 재개 — app.html 이 첫 페인트 전에 건 .hydrating 을 뗀다.
         // ⛔ 프레임을 두 번 넘긴 뒤에 뗀다. 하이드레이션이 클래스를 바꾸는 그 프레임에
         //    전환이 살아 있으면 0.8초짜리 색 변화가 그대로 보인다 — 끄는 의미가 없어진다.

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -720,14 +720,17 @@
             const get = w.__angpleMut;
             // ⛔ 관찰자가 아예 안 붙은 것과 "변형 0건"은 다르다. 섞으면 대조군이 거짓말한다.
             if (typeof get !== 'function') return 'off';
-            const r = (get as () => { n: number; list: string[] })();
+            const r = (get as () => { n: number; b: number; list: string[] })();
             // 경계 두 개를 병기한다.
             //   b = 번들 모듈 평가 시각(하이드레이션보다 앞이지만 청크 평가 시간만큼 헐겁다)
             //   h = 루트 컴포넌트가 실제로 하이드레이션되는 시각 — 이쪽이 진짜 경계다
             // 둘의 차이가 곧 "경계가 얼마나 헐거웠나"를 알려주는 자기 진단이 된다.
             const b = `@${String(w.__angpleBundleAt ?? '?')}/${String(w.__angpleHydrateAt ?? '?')}`;
-            if (r.n === 0) return `${b}|n=0`;
-            return `${b}|n=${r.n}|${r.list.join(',')}`.slice(0, 200);
+            // ⭐ b = 하이드레이션 **전** 변형 수 = 외부가 건드린 횟수.
+            //    이게 이 계측의 핵심 질문에 대한 답이다. n(총합)에는 실패 시 Svelte 자신의
+            //    폐기 동작이 섞이므로, n 만으로는 "외부가 몇 번 건드렸나"를 알 수 없다.
+            if (r.n === 0) return `${b}|n=0,b=0`;
+            return `${b}|n=${r.n},b=${r.b}|${r.list.join(',')}`.slice(0, 200);
         } catch {
             return '?';
         }


### PR DESCRIPTION
## 왜

글 상세에서 Svelte 하이드레이션이 폐기되는 비율이 **데스크톱 최대 31%** 다(모바일은 0.6~1.1%로 건강). 증상은 글쓰기 버튼 먹통 · 깜빡임 · 로그인 상태 오표시.

**후보 가설이 전부 데이터로 죽었다.**

| 가설 | 판정 | 근거 |
|---|---|---|
| 인증 분기가 SSR 과 어긋난다 | ⛔ | 운영·카나리 `SSR_STRIP_USER=true` → 글 상세는 로그인해도 `data.user` null. 인증은 루트 `onMount`(하이드레이션 뒤)에서 확립 |
| 광고 SSR 마크업을 차단기가 지운다 | ⛔ | 운영 글 상세 HTML 에 `<ins`·`adsbygoogle`·adfit **0개**. 지울 것이 없다 |
| #2189 (AdSense SSR 제거) | ⛔ | 이미 배포됨. 배포 전 15.24% → 후 18.28%, 시각을 정확히 잘라도 계단 없음 |
| SW 버전 스큐 | ⛔ | 에셋이 `/releases/sha-…/` 경로 서빙 — URL 에 sha 가 박혀 구버전 충돌 불가 |
| bfcache | ⛔ | `back_forward` 가 오히려 최저 |
| 로그인이 느려서 경합에 진다 | ⛔ | `at=` p50 로그인 1,241ms < 비로그인 1,708ms |

지금 계측은 **결과**만 본다(앵커가 떨어졌다). 원인은 "파싱 완료 ~ Svelte 하이드레이션" 사이 창에서 `#app-root` 안이 어떻게 달라졌는가다. **이 PR 은 고치지 않는다. 그 창을 연다.**

## 무엇을

### ⭐ `hbal` — 주석 마커 균형 (핵심)

하이드레이션의 기전은 **주석 마커**다. Svelte 는 여는 마커를 못 찾거나 짝이 안 맞으면 그 자리에서 전체를 폐기한다.

운영 SSR 실측(`/free/7131800`): 여는 마커(`[`·`[!`·`[1`) **1,648** : 닫는 마커(`]`) **1,648** — **정확히 균형**.

→ 파싱된 DOM 에서 0 이 아니면 **그 로드에서 마커가 사라진 것**이다. **다른 로드와 짝지을 필요가 없다.**

운영 HTML 로 시뮬레이션 검산:

| | ecnt | ccnt | hbal | hmin |
|---|---|---|---|---|
| 깨끗한 원본 | 1,961 | 5,843 | **0** | **0** |
| 여는 마커 1개 삭제 | 1,961 | 5,842 | **−1** | −1 |
| 여는 마커 10개 삭제 | 1,961 | 5,833 | **−10** | −10 |

### `mut` — 파싱 후~하이드레이션 사이 childList 변형

최대 5건(앞 3 + 마지막 2, 광고 주입이 선점하는 것 방지) + 총 건수 `n=`.

경계를 **두 개** 병기한다:
- `__angpleBundleAt` — `hooks.client.ts` 모듈 평가(라우트 청크 평가 시간만큼 헐겁다)
- `__angpleHydrateAt` — 루트 컴포넌트 script 본문 = **진짜 하이드레이션 순간**

두 값의 차이가 곧 "경계가 얼마나 헐거웠나"의 자기 진단이 된다.

⛔ `mut` 의 시각은 **전달 시각**이지 발생 시각이 아니다(MutationObserver 는 마이크로태스크 배치 전달이라 per-record 타임스탬프가 없다). 경계보다 확실히 앞일 때만 외부 요인으로 확정한다.

## 안전

- **렌더 경로 무변경.** 시각적 변화 0. 전 구간 `try/catch` — 계측이 실패해도 기존 앵커 판정·비콘·렌더에 영향 없음
- **개인정보**: 태그 · id(12자) · class 첫 토큰(14자)만. **텍스트 내용·주석 본문·속성값·URL 은 담지 않는다.** 주석은 종류(`[`/`]`/빈/기타)만 기록
- **대조군**: 실패(detached)와 성공(ok 1% 표본) **양쪽에 동일하게** 실린다
- **"0건"과 "미작동"을 구분**: `mut=off`(관찰자 미시작) / `n=0`(변형 없음) / `dcnt=na`(deepStats 실패)
- 새 ClickHouse 컬럼을 만들지 않는다 — 수집기가 스키마 밖 필드를 버리므로 `stack` 에 싣는다
- 관찰자는 루트 `onMount` **최상단**에서, 앵커 판정 어느 분기보다 먼저 해제
- stack 예산: 실측 평균 243자·최대 488자, 최악 +434자 → 922자 < 1500 상한. `nav=` 를 장문 필드 앞으로 옮겨 방어

## 판정 방법

`triage/tools/hydration_probe_verdict.py`

- `hbal≠0` 이 실패에 몰리면 → **하이드레이션 전에 마커가 지워졌다** 확정 → `mut` 의 삭제 항목에서 범인 특정
- 실패·성공 모두 `hbal=0` → 마커는 멀쩡. 원인은 다른 데
- 양쪽 다 `mut=off` → 계측이 안 붙은 것. 코드부터

## 검증

별도 Evaluator 2회. 1차에서 치명 결함 3건(주석 노드 미순회 / 교차 로드 비교 불성립 / 경계 헐거움)을 잡아 수정 후 재검증.

컴파일 client·server 통과, 경고 8개로 origin/main 대조군과 **동일**. prettier 통과.

## 남은 한계 (정직하게)

- **블록이 통째로 지워지는 경우**는 `hbal=0` 이라 못 잡는다. 서버가 SSR 서명을 내려보내 한 로드 안에서 대조하는 정공법은 별도 스프린트로 분리
- 파싱 **중**의 변형(파서 교정·`document.write`)은 관찰 시작 전이라 못 잡는다
- `deepStats` 가 첫 페인트 전 약 7,800 노드를 순회한다. Svelte 하이드레이션이 어차피 같은 트리를 걷으므로 상대 비용은 작다고 보지만, 카나리 CWV 로 대조 확인 예정
