### PR TITLE
fix(post): 인증 확립 후 하트 상태 재동기화 (bug/13729)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1255,6 +1255,23 @@ class ApiClient {
         return json.data;
     }
 
+    /**
+     * 글 전체 댓글의 현재 사용자 좋아요/비추천 상태 배치 조회 (bug/13729).
+     * 글상세는 SSR 시 user 가 stripped 되어 하트 상태가 비어 오므로, 클라이언트가
+     * 인증 확립 후 쿠키인증 라우트로 실제 상태를 다시 받는다.
+     */
+    async getCommentLikeStatuses(
+        boardId: string,
+        postId: string
+    ): Promise<{ likedIds: number[]; dislikedIds: number[] }> {
+        const res = await fetch(`/api/boards/${boardId}/posts/${postId}/comments/like-statuses`, {
+            credentials: 'include'
+        });
+        const json = await res.json();
+        if (!json.success) return { likedIds: [], dislikedIds: [] };
+        return json.data;
+    }
+
     // ========================================
     // 게시글 별점 (features.rating 보드 — 앙티티 Phase 0)
     // ========================================

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -689,6 +689,52 @@
     let isDisliking = $state(false);
     let isLikeAnimating = $state(false); // 좋아요 애니메이션
 
+    // bug/13729: 글상세는 SSR_STRIP_USER 로 서버에서 user=null → SSR/스트리밍 하트 상태가 항상 비어
+    // 있다(엣지캐시 설계). 인증은 하이드레이션 뒤 확립되므로, authStore.isAuthenticated 가 true 로
+    // 바뀌는 순간을 $effect 로 추적해 쿠키인증 엔드포인트로 실제 좋아요 상태를 다시 받아 하트를 채운다.
+    // ⛔ onMount 게이트로 걸면 그 시점엔 아직 false 라 영원히 안 돈다(과거 read-posts 0건 함정).
+    let likeStatusResyncedForPostId: number | null = null;
+    $effect(() => {
+        const postId = data.post.id;
+        const isAuth = authStore.isAuthenticated; // 추적 대상 — 인증 확립 시 발화
+        if (!browser || !isAuth) return;
+        if (likeStatusResyncedForPostId === postId) return;
+        likeStatusResyncedForPostId = postId;
+        untrack(() => {
+            void (async () => {
+                // 포스트 하트 — 내가 방금 누른 낙관적 값(postLikeStore)은 덮지 않는다.
+                if (!isLiking && !isDisliking) {
+                    try {
+                        const status = await apiClient.getPostLikeStatus(boardId, String(postId));
+                        if (data.post.id === postId && !isLiking && !isDisliking) {
+                            isLiked = status.user_liked;
+                            isDisliked = status.user_disliked ?? false;
+                            likeCount = status.likes;
+                            dislikeCount = status.dislikes ?? 0;
+                            const myLike = postLikeStore.get(boardId, postId);
+                            if (myLike) {
+                                isLiked = myLike.liked;
+                                isDisliked = myLike.disliked;
+                            }
+                        }
+                    } catch (e) {
+                        console.error('하트 상태 재조회 실패(post):', e);
+                    }
+                }
+                // 댓글 하트 — 글 전체(페이지네이션/backfill 절연).
+                try {
+                    const cs = await apiClient.getCommentLikeStatuses(boardId, String(postId));
+                    if (data.post.id === postId) {
+                        initialLikedCommentIds = cs.likedIds ?? [];
+                        initialDislikedCommentIds = cs.dislikedIds ?? [];
+                    }
+                } catch (e) {
+                    console.error('하트 상태 재조회 실패(comments):', e);
+                }
+            })();
+        });
+    });
+
     // 추천자 목록 다이얼로그 상태
     let showLikersDialog = $state(false);
     let likers = $state<LikerInfo[]>([]);

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -457,6 +457,9 @@
     let postReportCount = $state<number | string | null>(null);
     let syncedCommentsPostId: number | null = null;
     let syncedReactionStatePostId: number | null = null;
+    // bug/13729: 인증 확립 후 하트 재동기화가 이 글에 대해 이미 실값을 채웠는지 표시.
+    // 스트리밍(SSR strip 으로 빈값)과 재동기화의 순서 경쟁에서 재동기화가 이기게 한다.
+    let likeStatusResyncedForPostId: number | null = null;
     let trackedPostViewKey = '';
     let resetDetailUiPostId: number | null = null;
 
@@ -562,22 +565,26 @@
                     postReportCount = result.postReportCount;
                 }
 
-                if (result.postLikeStatus) {
-                    isLiked = result.postLikeStatus.userLiked;
-                    isDisliked = result.postLikeStatus.userDisliked;
-                }
+                // bug/13729: 인증 확립 후 재동기화($effect)가 이미 이 글의 실 하트값을 채웠으면,
+                // SSR strip 으로 비어 있는 스트리밍 값이 늦게 도착해도 덮어써 하트를 다시 비우지 않는다.
+                if (likeStatusResyncedForPostId !== data.post.id) {
+                    if (result.postLikeStatus) {
+                        isLiked = result.postLikeStatus.userLiked;
+                        isDisliked = result.postLikeStatus.userDisliked;
+                    }
 
-                // 낙관적 오버레이: 이 세션에서 직접 누른 공감/비공감이 있으면
-                // (SPA 재진입 시) 아직 반영 안 된 SSR 값보다 우선.
-                const myLike = postLikeStore.get(boardId, data.post.id);
-                if (myLike) {
-                    isLiked = myLike.liked;
-                    isDisliked = myLike.disliked;
-                }
+                    // 낙관적 오버레이: 이 세션에서 직접 누른 공감/비공감이 있으면
+                    // (SPA 재진입 시) 아직 반영 안 된 SSR 값보다 우선.
+                    const myLike = postLikeStore.get(boardId, data.post.id);
+                    if (myLike) {
+                        isLiked = myLike.liked;
+                        isDisliked = myLike.disliked;
+                    }
 
-                if (result.commentLikeStatuses) {
-                    initialLikedCommentIds = result.commentLikeStatuses.likedIds || [];
-                    initialDislikedCommentIds = result.commentLikeStatuses.dislikedIds || [];
+                    if (result.commentLikeStatuses) {
+                        initialLikedCommentIds = result.commentLikeStatuses.likedIds || [];
+                        initialDislikedCommentIds = result.commentLikeStatuses.dislikedIds || [];
+                    }
                 }
 
                 if (result.truthroomCommentMap) {
@@ -693,7 +700,6 @@
     // 있다(엣지캐시 설계). 인증은 하이드레이션 뒤 확립되므로, authStore.isAuthenticated 가 true 로
     // 바뀌는 순간을 $effect 로 추적해 쿠키인증 엔드포인트로 실제 좋아요 상태를 다시 받아 하트를 채운다.
     // ⛔ onMount 게이트로 걸면 그 시점엔 아직 false 라 영원히 안 돈다(과거 read-posts 0건 함정).
-    let likeStatusResyncedForPostId: number | null = null;
     $effect(() => {
         const postId = data.post.id;
         const isAuth = authStore.isAuthenticated; // 추적 대상 — 인증 확립 시 발화

--- a/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/like-statuses/+server.ts
+++ b/apps/web/src/routes/api/boards/[boardId]/posts/[postId]/comments/like-statuses/+server.ts
@@ -1,0 +1,35 @@
+/**
+ * 현재 사용자의 댓글 좋아요/비추천 상태 배치 조회 (클라이언트용) — bug/13729
+ * GET /api/boards/[boardId]/posts/[postId]/comments/like-statuses
+ *
+ * 글상세는 SSR_STRIP_USER 로 SSR 시 user=null 이라(엣지캐시 설계) 서버 렌더에 실은
+ * 하트 상태가 항상 비어 온다. 클라이언트가 인증 확립 후 이 라우트로 실제 상태를 다시 받아
+ * 하트를 채운다. 인증은 요청 쿠키에서 직접 확립하므로(getAuthUser) 페이지 로드 strip 과 무관.
+ * fetchCommentLikeStatuses 는 글 전체 댓글을 조회하므로 페이지네이션/backfill 과 절연된다.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getAuthUser } from '$lib/server/auth';
+import { fetchCommentLikeStatuses } from '$lib/server/comment-likes';
+
+export const GET: RequestHandler = async ({ params, cookies }) => {
+    const boardId = (params.boardId ?? '').replace(/[^a-zA-Z0-9_-]/g, '');
+    const postId = Number(params.postId);
+    if (!boardId || !Number.isFinite(postId) || postId <= 0) {
+        return json({ success: false, data: { likedIds: [], dislikedIds: [] } }, { status: 400 });
+    }
+
+    const user = await getAuthUser(cookies);
+    if (!user) {
+        // 비로그인은 빈 상태(성공). 하트는 비워 둔다.
+        return json({ success: true, data: { likedIds: [], dislikedIds: [] } });
+    }
+
+    try {
+        const data = await fetchCommentLikeStatuses(boardId, postId, user.mb_id);
+        return json({ success: true, data });
+    } catch (err) {
+        console.error('comment like-statuses 조회 실패:', err);
+        return json({ success: false, data: { likedIds: [], dislikedIds: [] } }, { status: 500 });
+    }
+};


### PR DESCRIPTION
## 배경 (bug/13729, 예지)
글상세에서 이미 좋아요한 글·댓글의 하트가 **빈 상태**로 뜨고, 클릭하면 좋아요가 **취소**되는 문제 재발(13688 회귀).

## 원인
운영·카나리는 `SSR_STRIP_USER=true`. 글상세는 `needsCsrf` 대상이 아니라 서버 load 에서 `user=null` → SSR/스트리밍으로 실은 `userLiked/likedIds` 가 항상 false/[]. 인증은 하이드레이션 뒤 root onMount 에서 확립되므로 그 이후 하트를 다시 채우는 코드가 없어 빈 채로 남고, like 엔드포인트가 토글이라 첫 클릭이 취소가 된다. (엣지캐시 60초를 위한 의도된 strip — SSR 에 사용자별 내용을 넣을 수 없음. angple-25 확인)

## 수정 (클라이언트 전용)
- `+page.svelte`: `authStore.isAuthenticated` 를 추적하는 `$effect` — true 로 바뀌는 순간 1회, 쿠키인증 엔드포인트로 **포스트+댓글 하트 상태를 다시 받아 반영**. onMount 게이트 함정(그 시점 false) 회피. 낙관적 오버레이(postLikeStore)·진행중 토글 가드 보존.
- 신규 라우트 `GET .../comments/like-statuses`: `getAuthUser(쿠키)` + `fetchCommentLikeStatuses(글 전체)` → `{likedIds,dislikedIds}`. 페이지네이션/backfill 절연.
- `client.getCommentLikeStatuses` 래퍼.

## 제약 준수
- ⛔ SSR 에서 authStore 채우지 않음(읽기만) · ⛔ page.data.user 미사용 · 클라 전용(browser 가드).

## 검증
svelte 컴파일 통과, prettier 준수. angple-25 #2212(계측만)와 파일 안 겹침.