### PR TITLE
fix(scrap): 글 이동 시 '스크랩됨' 상태 누수 (bug/13722)

### DIFF
--- a/apps/web/src/lib/components/post/scrap-button.svelte
+++ b/apps/web/src/lib/components/post/scrap-button.svelte
@@ -28,10 +28,18 @@
     let scrapped = $state(initialScrapped);
     let loading = $state(false);
     let userInteracted = $state(false);
+    // bug/13722: userInteracted 가 글을 넘어가도 true 로 남아, 이전 글에서 스크랩한 상태(scrapped=true)가
+    // 다음 글(SPA 이동)로 누수돼 '스크랩됨'이 잘못 표시됐다("되돌아가면 정상"=새 인스턴스로 리셋되던 것).
+    // postId 가 바뀌면 조작 플래그를 리셋하고 새 글의 스크랩 상태로 동기화한다(인스턴스 재사용 대비).
+    let syncedPostId: string | number | undefined = undefined;
 
-    // SSR 스트리밍: initialScrapped prop이 변경되면 동기화 (사용자 조작 전만)
     $effect(() => {
-        if (!userInteracted) {
+        if (syncedPostId !== postId) {
+            syncedPostId = postId;
+            userInteracted = false;
+            scrapped = initialScrapped;
+        } else if (!userInteracted) {
+            // 같은 글에서 initialScrapped 가 늦게(SSR 스트리밍) 도착하면 동기화(사용자 조작 전만).
             scrapped = initialScrapped;
         }
     });


### PR DESCRIPTION
## 배경 (bug/13722, 비가오려나)
글 하나를 스크랩하면 다른 글을 읽을 때도 계속 '스크랩됨'으로 표시됨. 뒤로 가면 정상으로 돌아옴.

## 원인
`ScrapButton` 의 `userInteracted` 플래그가 `toggleScrap` 에서 true 로 세팅된 뒤 **글을 넘어가도 리셋되지 않아**, 동기화 $effect 가 `if (!userInteracted)` 에 걸려 새 글의 `initialScrapped` 로 갱신되지 못했다. 컴포넌트 인스턴스가 SPA 이동 시 재사용되면 이전 글의 `scrapped=true` 가 그대로 남는다. (뒤로가기=새 인스턴스라 리셋됨)

## 수정
`postId` 가 바뀌면 `userInteracted` 를 리셋하고 `scrapped=initialScrapped` 로 동기화. 같은 글에서 SSR 스트리밍으로 initialScrapped 가 늦게 도착하는 경우(사용자 조작 전)는 기존대로 동기화.

## 검증
svelte 컴파일 통과, prettier 준수.