### PR TITLE
탈퇴 화면 문구를 즉시 확정에 맞춰 정정

### DIFF
--- a/apps/web/src/routes/member/leave/+page.svelte
+++ b/apps/web/src/routes/member/leave/+page.svelte
@@ -36,27 +36,23 @@
             <CardDescription>탈퇴를 신청하시기 전에 아래 내용을 확인해주세요.</CardDescription>
         </CardHeader>
         <CardContent>
-            <!-- 탈퇴 숙려기간(30일) 고지문 -->
+            <!-- 탈퇴 고지문. 2026-08-25 숙려기간 폐지 — 신청 즉시 확정이다. -->
             <div
                 class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200"
             >
                 <ul class="space-y-2">
+                    <li class="font-semibold">- 탈퇴하시면 되돌릴 수 없습니다.</li>
                     <li>
-                        - 탈퇴를 신청하시면 계정이 즉시 비활성화되어, 게시글·댓글이 더 이상 표시되지
-                        않습니다.
+                        - 탈퇴하시면 계정이 즉시 비활성화되어 로그인할 수 없고, 게시글·댓글이 더
+                        이상 표시되지 않습니다.
                     </li>
                     <li>
-                        - 신청일로부터 30일 이내에 다시 로그인하시면 언제든 탈퇴를 취소하고 원래대로
-                        복구하실 수 있습니다.
+                        - 부정 이용 및 중복가입 방지를 위한 최소한의 식별정보는 관련
+                        법령·개인정보처리방침에 따라 일정 기간 보관 후 파기됩니다.
                     </li>
                     <li>
-                        - 30일이 지나면 탈퇴가 확정되며, 회원정보는 익명 처리됩니다. 단, 부정 이용
-                        및 중복가입 방지를 위한 최소한의 식별정보는 관련 법령·개인정보처리방침에
-                        따라 일정 기간 보관 후 파기됩니다.
-                    </li>
-                    <li>
-                        - 이용제한(제재)이 적용 중인 경우, 탈퇴하거나 취소하더라도 제재 이력은
-                        유지되며 탈퇴로 제재를 회피할 수 없습니다.
+                        - 이용제한(제재)이 적용 중인 경우, 탈퇴하더라도 제재 이력은 유지되며 탈퇴로
+                        제재를 회피할 수 없습니다.
                     </li>
                 </ul>
             </div>
@@ -84,7 +80,7 @@
                 <div class="flex items-start gap-2">
                     <Checkbox id="agree" name="agree" bind:checked={agreed} class="mt-0.5" />
                     <Label for="agree" class="cursor-pointer text-sm leading-relaxed">
-                        위 내용을 확인하였으며 탈퇴에 동의합니다.
+                        되돌릴 수 없음을 확인하였으며 탈퇴에 동의합니다.
                     </Label>
                 </div>
 
@@ -102,7 +98,7 @@
                         class="flex-1"
                         disabled={!agreed || submitting}
                     >
-                        {submitting ? '처리 중...' : '회원 탈퇴 신청'}
+                        {submitting ? '처리 중...' : '회원 탈퇴'}
                     </Button>
                 </div>
             </form>

--- a/apps/web/src/routes/member/leave/complete/+page.svelte
+++ b/apps/web/src/routes/member/leave/complete/+page.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-    import { page } from '$app/state';
     import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import CircleCheck from '@lucide/svelte/icons/circle-check';
 
-    const deadline = $derived(page.url.searchParams.get('deadline') || '');
+    // 2026-08-25 숙려기간 폐지 — 취소 기한(deadline)이 없어져 표시할 것이 없다.
 </script>
 
 <svelte:head>
-    <title>탈퇴 신청 완료 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
+    <title>탈퇴 완료 | {import.meta.env.VITE_SITE_NAME || 'Angple'}</title>
 </svelte:head>
 
 <div class="mx-auto max-w-lg px-4 py-8">
@@ -16,21 +15,12 @@
         <CardHeader>
             <CardTitle class="flex items-center gap-2">
                 <CircleCheck class="h-5 w-5 text-emerald-600" />
-                탈퇴가 신청되었습니다
+                탈퇴가 완료되었습니다
             </CardTitle>
         </CardHeader>
         <CardContent class="space-y-6">
             <p class="text-muted-foreground text-sm leading-relaxed">
-                {#if deadline}
-                    <strong class="text-foreground">{deadline}</strong>까지 다시 로그인하시면 탈퇴를
-                    취소할 수 있습니다.
-                {:else}
-                    신청일로부터 30일 이내에 다시 로그인하시면 탈퇴를 취소할 수 있습니다.
-                {/if}
-            </p>
-            <p class="text-muted-foreground text-xs leading-relaxed">
-                30일이 지나면 탈퇴가 확정되며 회원정보는 익명 처리됩니다. 그동안 이용해 주셔서
-                감사합니다.
+                계정이 비활성화되었습니다. 그동안 이용해 주셔서 감사합니다.
             </p>
             <div class="flex justify-end">
                 <Button href="/">홈으로</Button>


### PR DESCRIPTION
be#703 으로 숙려기간이 폐지됐다(`WithdrawalGraceDays = 0`). **신청 즉시 로그인이 거부되고 철회 경로가 없다.** 개인정보처리방침 제2조③도 오늘 같은 내용으로 교체했다.

화면만 옛 안내를 그대로 띄우고 있어 사실과 다르다.

## 탈퇴 신청 화면

```diff
+ - 탈퇴하시면 되돌릴 수 없습니다.                          (첫 줄, 강조)
  - 탈퇴하시면 계정이 즉시 비활성화되어 로그인할 수 없고 …
- - 신청일로부터 30일 이내에 다시 로그인하시면 … 복구하실 수 있습니다
- - 30일이 지나면 탈퇴가 확정되며, 회원정보는 익명 처리됩니다 …
+ - 부정 이용 및 중복가입 방지를 위한 최소한의 식별정보는 …   (보관 부분만 남김)
```

동의 체크 문구도 바꿨다 — ``위 내용을 확인하였으며`` → **``되돌릴 수 없음을 확인하였으며``**. 무엇에 동의하는지가 분명해야 한다. 버튼도 ``회원 탈퇴 신청`` → ``회원 탈퇴``.

### ``익명 처리됩니다`` 를 왜 뺐나

익명화 크론은 be#703 에서 제거했고, 익명화는 **정보주체가 요청했을 때만** 한다(2026-07-10 확정). 그대로 두면 **하지 않는 일을 하겠다고 적어 두는** 셈이다.

## 완료 화면

- 제목 ``탈퇴가 신청되었습니다`` → **``탈퇴가 완료되었습니다``**
- `deadline` 쿼리 파라미터 표시 제거 — 기한이 없어졌다

## ⛔ 남은 것 — 이 PR 밖

`/member/leave/cancel` 라우트는 그대로 뒀다. OAuth 콜백이 숙려 상태를 감지해야 도달하는데 그 상태가 더는 생기지 않아 **도달 불가**다. 로그인 경로를 건드리게 되므로 별도로 정리한다.

## 검증

- prettier `--check` 통과(repo `.prettierrc`)
- 문구·표시 변경만. 폼 제출·CSRF·서버 로직 미변경