### PR TITLE
feat(noti): 알림 전체/읽은것 삭제 버튼 (bug/13692)

### DIFF
--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2078,6 +2078,15 @@ class ApiClient {
     }
 
     /**
+     * 알림 전체 삭제 (bug/13692). onlyRead=true 면 읽은 알림만 삭제.
+     */
+    async deleteAllNotifications(onlyRead = false): Promise<void> {
+        await this.request<void>(`/notifications/all${onlyRead ? '?read_only=true' : ''}`, {
+            method: 'DELETE'
+        });
+    }
+
+    /**
      * 그룹화 알림 목록 조회
      */
     async getGroupedNotifications(

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -166,6 +166,21 @@
         }
     }
 
+    // bug/13692: 하나씩만 지울 수 있던 알림을 전체/읽은 것만 한번에 삭제.
+    async function handleDeleteAll(onlyRead: boolean): Promise<void> {
+        const msg = onlyRead
+            ? '읽은 알림을 모두 삭제하시겠습니까?'
+            : '모든 알림을 삭제하시겠습니까?';
+        if (!confirm(msg)) return;
+        try {
+            await apiClient.deleteAllNotifications(onlyRead);
+            await loadNotifications();
+        } catch (err) {
+            console.error('Failed to delete notifications:', err);
+            alert('알림 삭제에 실패했습니다.');
+        }
+    }
+
     async function handleDeleteGroup(
         notification: GroupedNotification,
         event: Event
@@ -244,11 +259,32 @@
                 {/if}
             </h1>
         </div>
-        {#if notificationData && notificationData.unread_count > 0}
-            <Button variant="ghost" size="sm" class="text-xs" onclick={handleMarkAllAsRead}>
-                <Check class="mr-1 h-3.5 w-3.5" />
-                모두 읽음
-            </Button>
+        {#if notificationData && notificationData.items.length > 0}
+            <div class="flex items-center gap-1">
+                {#if notificationData.unread_count > 0}
+                    <Button variant="ghost" size="sm" class="text-xs" onclick={handleMarkAllAsRead}>
+                        <Check class="mr-1 h-3.5 w-3.5" />
+                        모두 읽음
+                    </Button>
+                {/if}
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    class="text-muted-foreground text-xs"
+                    onclick={() => handleDeleteAll(true)}
+                >
+                    읽은 알림 삭제
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    class="text-destructive hover:text-destructive text-xs"
+                    onclick={() => handleDeleteAll(false)}
+                >
+                    <Trash2 class="mr-1 h-3.5 w-3.5" />
+                    전체 삭제
+                </Button>
+            </div>
         {/if}
     </div>
 


### PR DESCRIPTION
## 배경 (bug/13692, 너랑나랑)
알림이 쌓여도 각 알림 휴지통으로 **하나씩만** 지울 수 있어 불편.

## 변경
- 알림함(`/notifications`) 상단에 **'읽은 알림 삭제'**·**'전체 삭제'** 버튼 추가('모두 읽음' 옆).
- `apiClient.deleteAllNotifications(onlyRead)` → `DELETE /api/v1/notifications/all(?read_only=true)`.
- 삭제 후 `loadNotifications()` 재조회로 목록 갱신(그룹/부분삭제도 정확).
- 전체 삭제는 확인 다이얼로그.

## 의존
백엔드 엔드포인트 **damoang/angple-backend#704** 필요 — 그 배포 후 동작합니다.

## 검증
svelte 컴파일 0경고, prettier 준수.