### PR TITLE
fix: 광고 칸을 SSR 에서 빼 하이드레이션 폐기를 끊는다 (AdGuard, 실패의 73.6%)

### DIFF
--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -256,25 +256,29 @@
 
         // ⛔ 순서가 중요하다. `<ins>` 가 DOM 에 들어간 **뒤에** push 해야 AdSense 가 찾는다.
         //    SSR 로 내보내지 않으므로 여기서 그리고, tick 으로 DOM 반영을 기다린다.
+        // ⛔ clipWrapper·adContainer 는 이제 **SSR 에 없다**(위 {#if adReady}).
+        //    adReady 를 켠 뒤 tick 으로 DOM 반영을 기다려야 bind:this 가 채워진다.
+        //    rAF 를 tick 밖에 두면 참조가 비어 높이 방어가 통째로 죽는다.
         adReady = true;
-        void tick().then(() => loadAdSense());
+        void tick().then(() => {
+            loadAdSense();
+            requestAnimationFrame(() => {
+                if (!clipWrapper) return;
+                enforceClipHeight();
+                mutationObserver = new MutationObserver(() => enforceClipHeight());
+                mutationObserver.observe(clipWrapper, {
+                    attributes: true,
+                    attributeFilter: ['style']
+                });
 
-        requestAnimationFrame(() => {
-            if (!clipWrapper) return;
-            enforceClipHeight();
-            mutationObserver = new MutationObserver(() => enforceClipHeight());
-            mutationObserver.observe(clipWrapper, {
-                attributes: true,
-                attributeFilter: ['style']
+                if (typeof ResizeObserver !== 'undefined') {
+                    resizeObserver = new ResizeObserver(() => enforceClipHeight());
+                    resizeObserver.observe(clipWrapper);
+                    if (panelEl) resizeObserver.observe(panelEl);
+                } else {
+                    window.addEventListener('resize', handleResize);
+                }
             });
-
-            if (typeof ResizeObserver !== 'undefined') {
-                resizeObserver = new ResizeObserver(() => enforceClipHeight());
-                resizeObserver.observe(clipWrapper);
-                if (panelEl) resizeObserver.observe(panelEl);
-            } else {
-                window.addEventListener('resize', handleResize);
-            }
         });
 
         return () => {
@@ -334,31 +338,40 @@
 {/snippet}
 
 {#if post.author_id && !post.deleted_at}
-    <div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3" bind:this={panelEl}>
-        <!-- AdSense 광고 -->
-        <div class="flex flex-col">
-            <!-- 외부 클리핑 래퍼: MutationObserver로 AdSense의 height 덮어쓰기 방어 -->
-            <!-- 모바일: max-height 100px로 제한 / 데스크톱: 카드 높이에 맞춤 -->
-            <div
-                bind:this={clipWrapper}
-                class="dm-clip-wrapper overflow-hidden rounded-xl"
-                style="position: relative;"
-            >
-                <!-- AdSense가 이 div의 height를 !important로 바꿔도 외부 래퍼가 잘라냄 -->
-                <div bind:this={adContainer}>
-                    {#if adReady && ADSENSE_ACTIVITY_CLIENT && ADSENSE_ACTIVITY_SLOT}
-                        <ins
-                            class="adsbygoogle"
-                            style="display:block;"
-                            data-ad-client={ADSENSE_ACTIVITY_CLIENT}
-                            data-ad-slot={ADSENSE_ACTIVITY_SLOT}
-                            data-ad-format="auto"
-                            data-full-width-responsive="true"
-                        ></ins>
-                    {/if}
+    <div class="dm-ad-row mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3" bind:this={panelEl}>
+        <!-- ⛔ 광고 칸 전체를 마운트 후에만 그린다 — SSR 에 내보내면 차단기가 하이드레이션
+             **전에** 지워서 Svelte 가 트리 전체를 폐기한다(2026-08-25 실측: 실패의 73.6%에
+             하이드레이션 전 DOM 변형, 성공은 0%. 지워진 대상 `div.flex.flex-col` 121/121,
+             주체 `local.adguard.org` 95%).
+             ⛔ #2189 는 `<ins>` 만 뺐고 **이 껍데기를 남겨서 효과가 0** 이었다. 경계는
+                반드시 이 바깥이어야 한다 — Svelte 5 는 한 곳만 어긋나도 전체를 버린다.
+             ⛔ 되돌릴 때 SSR 로 다시 내보내지 마라. 같은 증상이 그대로 재발한다. -->
+        {#if adReady}
+            <!-- AdSense 광고 -->
+            <div class="flex flex-col">
+                <!-- 외부 클리핑 래퍼: MutationObserver로 AdSense의 height 덮어쓰기 방어 -->
+                <!-- 모바일: max-height 100px로 제한 / 데스크톱: 카드 높이에 맞춤 -->
+                <div
+                    bind:this={clipWrapper}
+                    class="dm-clip-wrapper overflow-hidden rounded-xl"
+                    style="position: relative;"
+                >
+                    <!-- AdSense가 이 div의 height를 !important로 바꿔도 외부 래퍼가 잘라냄 -->
+                    <div bind:this={adContainer}>
+                        {#if ADSENSE_ACTIVITY_CLIENT && ADSENSE_ACTIVITY_SLOT}
+                            <ins
+                                class="adsbygoogle"
+                                style="display:block;"
+                                data-ad-client={ADSENSE_ACTIVITY_CLIENT}
+                                data-ad-slot={ADSENSE_ACTIVITY_SLOT}
+                                data-ad-format="auto"
+                                data-full-width-responsive="true"
+                            ></ins>
+                        {/if}
+                    </div>
                 </div>
             </div>
-        </div>
+        {/if}
 
         <Card class="hidden gap-0 sm:col-span-2 sm:flex">
             <CardHeader class="pb-2 pt-2">
@@ -484,6 +497,21 @@
 {/if}
 
 <style>
+    /* ⛔ 광고 칸을 SSR 에서 빼면(위 {#if adReady}) 모바일에서 그리드가 **높이 0** 이 된다 —
+       옆 Card 가 `hidden sm:flex` 라 모바일에선 광고 칸이 그리드의 유일한 자식이기 때문이다.
+       마운트 후 110px 이 생기며 아래를 밀어 CLS 가 난다. 그래서 자리를 미리 잡는다.
+       값은 아래 .dm-clip-wrapper 와 **같아야** 한다(모바일 110 / sm+ 214). 함께 고쳐라.
+       ⚠️ 차단기가 광고 칸을 지운 사용자에게는 이만큼 빈 공간이 남는다 — 의도한 맞바꿈이다
+          (밀림은 전원에게, 빈 공간은 차단 사용자에게만). */
+    .dm-ad-row {
+        min-height: 110px;
+    }
+    @media (min-width: 640px) {
+        .dm-ad-row {
+            min-height: 214px;
+        }
+    }
+
     /* 모바일은 낮게, 데스크톱은 카드형 비율로 보이도록 높이를 제한합니다. */
     .dm-clip-wrapper {
         min-height: 110px;

--- a/apps/web/src/lib/components/features/board/author-activity-panel.svelte
+++ b/apps/web/src/lib/components/features/board/author-activity-panel.svelte
@@ -373,7 +373,11 @@
             </div>
         {/if}
 
-        <Card class="hidden gap-0 sm:col-span-2 sm:flex">
+        <!-- ⛔ `sm:col-start-2` 를 빼지 마라. 광고 칸이 SSR 에 없으므로, 이게 없으면
+             CSS 그리드 자동배치가 Card 를 **1-2열**에 놓았다가 마운트 후 광고가 1열을
+             차지하면서 **2-3열로 민다** — 데스크톱에서 ~300px 가로 밀림이다.
+             .dm-ad-row 의 min-height 가 세로를 잡듯, 이건 가로를 잡는다. -->
+        <Card class="hidden gap-0 sm:col-span-2 sm:col-start-2 sm:flex">
             <CardHeader class="pb-2 pt-2">
                 <button
                     type="button"
@@ -500,15 +504,18 @@
     /* ⛔ 광고 칸을 SSR 에서 빼면(위 {#if adReady}) 모바일에서 그리드가 **높이 0** 이 된다 —
        옆 Card 가 `hidden sm:flex` 라 모바일에선 광고 칸이 그리드의 유일한 자식이기 때문이다.
        마운트 후 110px 이 생기며 아래를 밀어 CLS 가 난다. 그래서 자리를 미리 잡는다.
-       값은 아래 .dm-clip-wrapper 와 **같아야** 한다(모바일 110 / sm+ 214). 함께 고쳐라.
+       ⛔ 값은 CSS 의 110/214 가 아니라 **JS 가 !important 로 강제하는 실제 높이**여야 한다
+          (MOBILE_AD_MAX_HEIGHT=88 / DESKTOP_AD_MAX_HEIGHT=190). CSS 값으로 잡으면
+          페이지가 영구히 22~24px 커진다 — 밀림은 없애고 높이를 늘리는 헛수고가 된다.
+          그 상수를 바꾸면 여기도 같이 바꿔라.
        ⚠️ 차단기가 광고 칸을 지운 사용자에게는 이만큼 빈 공간이 남는다 — 의도한 맞바꿈이다
           (밀림은 전원에게, 빈 공간은 차단 사용자에게만). */
     .dm-ad-row {
-        min-height: 110px;
+        min-height: 88px;
     }
     @media (min-width: 640px) {
         .dm-ad-row {
-            min-height: 214px;
+            min-height: 190px;
         }
     }
 


### PR DESCRIPTION
## 무엇을 고치는가

글 상세에서 Svelte 하이드레이션이 폐기된다(데스크톱 최대 31%, 모바일 0.6~1.1%).
증상은 **글쓰기 버튼 먹통 · 화면 깜빡임 · 로그인 상태 오표시**.

## 원인 — 계측(#2212·#2217)으로 확정

운영 실측, 표본 **829건**(봇 제외, 글 상세, `nav=navigate`):

| | 하이드레이션 **전** DOM 변형 |
|---|---|
| 실패(detached) | **73.6%** |
| 성공(ok) | **0%** (0/127) |

- **지워지는 대상**: `div.flex.flex-col` **121/121 단일**. 운영 글 상세 SSR HTML 에 `class="flex flex-col"` 은 **정확히 1개**이고 그게 이 광고 칸이다
- **주체**: `local.adguard.org` **95%** (115/121)
- 변형은 **전부 우리 번들 실행 전**(평균 839ms vs 번들 1517ms)
- `hbal` 전 표본 **0** — Svelte 주석 마커는 멀쩡. 원인은 **요소 제거**

Svelte 5 는 **한 곳만 어긋나도 트리 전체를 버린다.** 광고 칸 하나가 지워지면 페이지 전체가 CSR 로 재마운트된다.

### ⭐ #2189 가 왜 효과 0 이었는지

`<ins>` 만 SSR 에서 뺐고 **감싸는 껍데기를 남겼다.** 지워지는 건 그 껍데기다. 경계가 안쪽이면 아무 소용이 없다.

## ⛔ 하지 않은 것 — 차단 회피

클래스명 난독화는 **이미 한 번 실패**했다(`22830eee`, "ad block 우회"). `dm-` 접두로 바꿨는데도 지워진다 = **이름으로 매칭하는 게 아니다.** 회피에 성공해도 필터는 갱신되고 공유된다.

그리고 애초에 문제는 광고가 안 보이는 게 아니라 **사이트가 고장 나는 것**이다. 광고를 거부한 대가로 사이트가 깨지는 건 우리 잘못이다.

⭐ 목표는 「차단을 뚫는다」가 아니라 **「지워져도 멀쩡하다」**.

## 무엇을 했나

**① 광고 칸 전체를 `{#if adReady}` 로 감쌌다.**
SSR 에는 빈 if-블록(주석 앵커)만 나가므로 차단기가 지울 것이 없고, 하이드레이션 시점에 어긋날 것도 없다.
→ 검증: 서버 컴파일 산출물에서 광고 마크업 push **2건 전부 `if (adReady)` 안**. 밖은 주석뿐.

**② `onMount` 순서 교정.**
`clipWrapper`/`adContainer` 가 이제 SSR 에 없으므로 `tick()` 으로 DOM 반영을 기다린 뒤 `loadAdSense()` 와 rAF 를 돌린다.
⛔ rAF 를 tick 밖에 두면 `if (!clipWrapper) return` 으로 **AdSense 높이 덮어쓰기 방어가 통째로 죽는다.**

**③ `.dm-ad-row` 세로 자리예약 (88px / sm+ 190px).**
옆 Card 가 `hidden sm:flex` 라 **모바일에선 광고 칸이 그리드의 유일한 자식**이다. 예약이 없으면 그리드가 높이 0 이 됐다가 마운트 후 밀린다.
⛔ 값은 CSS 의 110/214 가 아니라 **JS 가 `!important` 로 강제하는 실제 높이**(`MOBILE_AD_MAX_HEIGHT=88` / `DESKTOP_AD_MAX_HEIGHT=190`)다. CSS 값으로 잡으면 페이지가 영구히 22~24px 커진다.

**④ Card 에 `sm:col-start-2` — 가로 자리예약.**
이게 없으면 CSS 그리드 **자동배치**가 SSR 에서 Card 를 1-2열에 놓았다가 마운트 후 광고가 1열을 차지하면서 **2-3열로 민다** — 데스크톱 **~300px 가로 밀림**. 세로 24px 을 없애려다 가로 300px 을 만드는 셈이었다.
→ twMerge 통과 확인(`sm:col-span-2 sm:col-start-2 sm:flex` 전부 생존).

## 검증 — 독립 Evaluator (1차 No-Go)

**1차가 잡은 블로커 2건**이 ③④ 다. 둘 다 내가 놓쳤다.

**검증에서 실측으로 통과한 것**:
- SSR 산출물에 광고 마크업 0개, `adReady` 는 SSR 에서 `false`(`onMount` 가 서버에선 `noop`)
- 높이 방어 3종(`enforceClipHeight`·style MutationObserver·ResizeObserver) **전부 발화** — `tick()` = `await Promise.resolve()` + `flushSync()` 라 `bind:this` 가 채워진 뒤 rAF 가 돈다
- **조기 언마운트 누수 없음** — `bind_this` teardown 이 microtask 로 참조를 비우고, microtask 는 다음 rAF 보다 먼저 배수된다
- **마운트 후 차단기가 지워도 `NotFoundError` 없음** — `adReady` 가 다시 false 가 되지 않고, `remove_effect_dom` 은 `node.remove()` 라 이미 떨어진 노드에 no-op
- 빈 if-블록의 주석 앵커는 표적이 아니다 — 코스메틱 필터는 요소를 매칭하고, `hbal` 이 전 표본 0 이었다
- 컴파일 client·server 통과, 경고 **5개로 대조군과 동일**

## ⬜ 카나리에서 반드시 확인할 것

**같은 페이지에 SSR 로 광고 껍데기를 내보내는 곳이 두 군데 더 있다:**
- `adsense-multiplex.svelte` → `div.adsense-multiplex` — **난독화 안 된 이름**이라 일반 필터의 표적이 되기 쉽다
- `ad-slot.svelte` → `div.dm-display-frame`

현재 제거 데이터(121/121)엔 안 나타나지만 **이 수정으로 표적이 그쪽으로 옮겨갈 수 있다.**
⛔ 판독 시 실패율만 보지 말고 **`rm=` 의 대상이 무엇으로 바뀌는지** 봐라.

그리고 **모바일에서 차단 사용자에게 남는 빈 공간**을 눈으로 확인한다 — 「작아서 못 느낀다」고 단정하지 않는다(8/17 정지썸네일 선례).

## 되돌릴 때

⛔ **광고 칸을 SSR 로 다시 내보내지 마라.** 같은 증상이 그대로 재발한다.

설계문서: `/home/damoang/docs/2026-08-25-adguard-hydration-fix-design.html`
