### PR TITLE
fix: Multiplex 광고 래퍼를 SSR 에서 뺀다 + 2월부터 죽어 있던 예약 해제 규칙 복구

### DIFF
--- a/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
+++ b/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
@@ -63,16 +63,25 @@
     }
 </script>
 
-<!-- ⛔ 클래스 이름에 `adsense`/`ad` 를 넣지 마라. 이 래퍼는 **SSR 로 나가는 유일한
-     광고성 요소** 중 하나이고, `[class*="adsense"]` 같은 **일반 차단 규칙은 이름만으로**
-     매칭한다. 차단기가 하이드레이션 **전에** 이걸 지우면 Svelte 5 는 한 곳만 어긋나도
-     트리 전체를 버려 페이지가 통째로 CSR 재마운트된다(2026-08-25 실측: 같은 기전으로
-     글 상세 실패율 18.23%. 광고 칸을 SSR 에서 빼서 0.10% 로 내렸다 — PR #2218).
-     ⛔ 이건 **방어가 아니라 표면 축소**다. 사이트 지정 규칙이 붙으면 이름을 바꿔도 뚫린다
-        (`dm-` 접두로 이미 한 번 실패했다 — 커밋 22830eee). 그때 기댈 것은 감시다:
-        triage/tools/adblock_regression_watch.py -->
-<div class="dm-mplex-frame {className}" class:is-reserved={!suppressAds}>
-    {#if ready && !suppressAds}
+<!--
+  ⛔ 이 래퍼는 **마운트 후에만** 나간다. SSR 로 내보내면 차단기가 하이드레이션 **전에**
+     지워서 Svelte 5 가 트리 전체를 버린다 — 페이지가 통째로 CSR 재마운트되고 글쓰기 버튼
+     먹통·깜빡임·로그인 오표시가 난다(2026-08-25 실측: 같은 기전으로 글 상세 실패율
+     18.23% → 광고 칸을 SSR 에서 빼서 0.10%, PR #2218).
+
+  ⛔ **안쪽만 감싸면 안 된다.** 종전엔 이 div 가 SSR 에 **자식 없는 빈 껍데기**로 나갔고
+     (`<div class="adsense-multiplex … "></div>`, min-height 300px), 그게 정확히 #2189 가
+     저지른 실수의 모양이다 — `<ins>` 만 빼고 껍데기를 남겨 효과가 **0** 이었다.
+
+  ⛔ **이름 바꾸기로는 안 된다.** 사이트 지정 규칙은 이름을 안 본다(`dm-` 접두로 이미
+     실패했다). 8/25 실제로 지워진 것도 난독화된 `dm-clip-wrapper` 였다.
+     방향은 「차단을 뚫는다」가 아니라 **「지워져도 멀쩡하다」** 이다.
+
+  ⛔ 자리예약은 이 div 가 SSR 에 없으므로 **부모가 진다** —
+     `[postId]/+page.svelte` 의 `.dm-mplex-reserve`. 여기로 되돌리지 마라.
+-->
+{#if ready && !suppressAds}
+    <div class="dm-mplex-frame {className}">
         <ins
             bind:this={insEl}
             class="adsbygoogle"
@@ -81,31 +90,11 @@
             data-ad-client={ADSENSE_CLIENT}
             data-ad-slot={ADSENSE_SLOT}
         ></ins>
-    {/if}
-</div>
+    </div>
+{/if}
 
 <style>
     .dm-mplex-frame {
         overflow: hidden;
-    }
-
-    /*
-     * 높이 예약 — CLS 방지.
-     *
-     * 종전엔 스크립트 로드(`ready`) 전까지 래퍼 높이가 0 이었다가 autorelaxed
-     * 크리에이티브가 들어오면서 수백 px 로 뛰어, 이 아래의 "최근 글" 목록 전체를
-     * 밀어냈다(2026-08-11 감사: 글 상세 CLS 0.111 의 주요 기여분).
-     *
-     * 미충전 시 빈 공백이 남지 않도록 AdSense 가 부여하는
-     * `data-ad-status="unfilled"` 를 만나면 예약을 해제한다.
-     * 광고가 숨겨지는 글(성인/차단 작가)에는 애초에 예약하지 않는다.
-     */
-    .dm-mplex-frame.is-reserved {
-        min-height: 300px;
-        contain: layout;
-    }
-
-    .dm-mplex-frame.is-reserved:has(ins[data-ad-status='unfilled']) {
-        min-height: 0;
     }
 </style>

--- a/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
+++ b/apps/web/src/lib/components/ui/adsense-multiplex/adsense-multiplex.svelte
@@ -63,7 +63,15 @@
     }
 </script>
 
-<div class="adsense-multiplex {className}" class:is-reserved={!suppressAds}>
+<!-- ⛔ 클래스 이름에 `adsense`/`ad` 를 넣지 마라. 이 래퍼는 **SSR 로 나가는 유일한
+     광고성 요소** 중 하나이고, `[class*="adsense"]` 같은 **일반 차단 규칙은 이름만으로**
+     매칭한다. 차단기가 하이드레이션 **전에** 이걸 지우면 Svelte 5 는 한 곳만 어긋나도
+     트리 전체를 버려 페이지가 통째로 CSR 재마운트된다(2026-08-25 실측: 같은 기전으로
+     글 상세 실패율 18.23%. 광고 칸을 SSR 에서 빼서 0.10% 로 내렸다 — PR #2218).
+     ⛔ 이건 **방어가 아니라 표면 축소**다. 사이트 지정 규칙이 붙으면 이름을 바꿔도 뚫린다
+        (`dm-` 접두로 이미 한 번 실패했다 — 커밋 22830eee). 그때 기댈 것은 감시다:
+        triage/tools/adblock_regression_watch.py -->
+<div class="dm-mplex-frame {className}" class:is-reserved={!suppressAds}>
     {#if ready && !suppressAds}
         <ins
             bind:this={insEl}
@@ -77,7 +85,7 @@
 </div>
 
 <style>
-    .adsense-multiplex {
+    .dm-mplex-frame {
         overflow: hidden;
     }
 
@@ -92,12 +100,12 @@
      * `data-ad-status="unfilled"` 를 만나면 예약을 해제한다.
      * 광고가 숨겨지는 글(성인/차단 작가)에는 애초에 예약하지 않는다.
      */
-    .adsense-multiplex.is-reserved {
+    .dm-mplex-frame.is-reserved {
         min-height: 300px;
         contain: layout;
     }
 
-    .adsense-multiplex.is-reserved:has(ins[data-ad-status='unfilled']) {
+    .dm-mplex-frame.is-reserved:has(ins[data-ad-status='unfilled']) {
         min-height: 0;
     }
 </style>

--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2872,7 +2872,12 @@
                     slotKey="board-after-comments"
                 />
             </div>
-            <div class="mt-2 hidden md:block">
+            <!-- ⛔ 자리예약은 **여기(부모)** 가 진다. AdsenseMultiplex 의 래퍼는 마운트
+                 후에만 존재하므로(차단기가 하이드레이션 전에 지우면 트리 전체가 폐기된다)
+                 SSR 시점에 자리를 잡아 줄 것이 부모밖에 없다. 이걸 빼면 광고가 뜨는 순간
+                 아래 내용이 300px 밀린다 — 2026-08-11 감사에서 글 상세 CLS 0.111 의
+                 주요 기여분이었던 바로 그 밀림이다. -->
+            <div class="dm-mplex-reserve mt-2 hidden md:block">
                 <AdsenseMultiplex />
             </div>
         {/if}
@@ -3146,6 +3151,26 @@
 {/if}
 
 <style>
+    /*
+     * AdSense Multiplex 자리예약 — CLS 방지.
+     *
+     * 종전엔 컴포넌트 안의 래퍼가 `.is-reserved` 로 졌으나, 그 래퍼는 이제 마운트 후에만
+     * 존재한다(SSR 에 두면 차단기가 하이드레이션 전에 지워 트리 전체가 폐기된다).
+     * 그래서 예약을 부모인 여기로 올렸다.
+     *
+     * ⛔ 미충전 시 예약을 푸는 규칙은 반드시 `:global()` 이어야 한다. 종전 컴포넌트의
+     *    `:has(ins[data-ad-status='unfilled'])` 는 Svelte 가 **미사용 셀렉터로 판정해
+     *    산출 CSS 에서 잘라내 왔다**(#2040 이래 계속 죽어 있었고, 그래서 미충전 광고는
+     *    300px 빈칸이 영구히 남았다). `<ins>` 는 런타임에만 생기므로 정적으로 안 보인다.
+     */
+    .dm-mplex-reserve {
+        min-height: 300px;
+        contain: layout;
+    }
+
+    .dm-mplex-reserve:has(:global(ins[data-ad-status='unfilled'])) {
+        min-height: 0;
+    }
     .dm-welcome-line {
         animation: dm-welcome-pop 4.2s ease forwards;
     }


### PR DESCRIPTION
## 왜

차단기(AdGuard)가 하이드레이션 **전에** 광고성 요소를 지우면 Svelte 5 는 한 곳만 어긋나도 트리 전체를 버린다 → 페이지가 통째로 CSR 재마운트되고 **글쓰기 버튼 먹통·깜빡임·로그인 오표시**가 난다.

PR #2218 이 `author-activity-panel` 의 광고 칸을 SSR 에서 빼서 **18.23% → 0.10%** 로 내렸다. 이 PR 은 **남은 표면 하나**를 같은 방식으로 정리한다.

### 남아 있던 것

운영 SSR 실물:
```html
<div class="adsense-multiplex  svelte-1svrn3u is-reserved"></div>
```
**자식 없는 빈 껍데기**(min-height 300px). #2189 가 저지른 실수와 **똑같은 모양** — `<ins>` 만 빼고 껍데기를 남긴 것.

## 무엇을 했나

**① 래퍼 전체를 마운트 게이트 안으로**
`{#if ready && !suppressAds}` 가 `<div class="dm-mplex-frame">` 를 **바깥에서** 감싼다. `ready` 는 `onMount` 에서만 켜지므로 SSR 에는 빈 if-블록(주석 앵커)만 나간다 → 차단기가 지울 것이 없다.

**② 자리예약을 부모로 이관**
래퍼가 SSR 에 없으므로 자리를 잡아 줄 것이 부모밖에 없다. `[postId]/+page.svelte` 에 `.dm-mplex-reserve`(`min-height: 300px; contain: layout`).
⛔ 이걸 빼먹으면 광고가 뜨는 순간 아래가 **300px 밀린다** — 2026-08-11 감사에서 글 상세 CLS 0.111 의 주요 기여분이었던 그 밀림이다.

**③ 클래스 이름 중립화** (`adsense-multiplex` → `dm-mplex-frame`)
⛔ 이건 **방어가 아니라 표면 축소**다. 사이트 지정 규칙은 이름을 안 본다(8/25 실제로 지워진 것도 난독화된 `dm-clip-wrapper` 였다). ①이 본질이고 ③은 부차적이다.

## ⭐ 덤으로 고쳐진 것 — 2026-02 이래 죽어 있던 규칙

미충전 시 예약을 푸는 `:has(ins[data-ad-status='unfilled'])` 규칙을 **Svelte 가 미사용 셀렉터로 판정해 산출 CSS 에서 잘라내 왔다**(`b393dd60`/#2040 이래). `<ins>` 는 런타임에만 생겨 정적으로 안 보이기 때문이다.

즉 **미충전 광고는 300px 빈칸이 영구히 남아 있었다.** 부모로 옮기면서 `:global()` 로 살렸다.

검증 — 컴파일된 CSS 에 두 규칙 모두 존재:
```css
.dm-mplex-reserve { min-height: 300px; contain: layout; }
.dm-mplex-reserve:has(ins[data-ad-status='unfilled']) { min-height: 0; }
```
`css_unused_selector` 경고 **0**. 컴포넌트 경고 **2 → 1**(죽은 셀렉터 경고 소멸).

## 검증 — 독립 Evaluator 가 1차에 No-Go

**1차 시도는 클래스 이름만 바꿨고, 검증이 잡았다:**
- **F1** 대상 `<div>` 가 **여전히 SSR 로 나감** — rename 은 표면을 없애지 못한다
- **F2** 같은 날 문서화된 결론과 정면 충돌 — #2218 커밋 메시지와 감시 도구가 「이름 바꾸기로 대응하지 마라」를 명시하는데 그걸 했다
- **F3** 감시가 rename 후 **영구히 초록**이 되고 진짜 표면은 그대로
- **F9** 위의 죽은 CSS 규칙(선행 결함, 이번에 함께 해소)

이 PR 은 그 지적을 반영한 것이다.

## 함께 고친 감시 도구 (서버 로컬, 이 PR 밖)

`triage/tools/adblock_regression_watch.py` — 크론 `20 9 * * *`

| 결함 | 고침 |
|---|---|
| 이름 기반 패턴 → rename 하면 영구 초록 | **SSR 광고 래퍼 개수**를 이름 무관하게 센다 |
| `--quiet` + 표본 부족 = 완전 침묵 | 표본 부족이면 **경보** (「0건 ≠ 정상」) |
| 경보가 로그 파일에만 | **텔레그램 발송** (형제 감시기 4개와 동일) |
| 「어제 같은 시각」이 장식 | 어제 대비 5배도 경보 조건 |
| 글 하나만 검사(비결정적) | 여러 글의 최댓값 |

## ⬜ 손대지 않은 것 — 의도적

`div.dm-display-frame` **6~9개**는 SSR 에 그대로 둔다. 그게 **CLS 자리예약 본체**(`--ad-slot-min-height`)라 빼면 밀림이 회귀하고, 실측상 **현재 차단 표적이 아니다**(8/26 제거 0건). 안 아픈 곳을 째지 않는다.

⛔ 다만 **필터가 다음에 그걸 겨냥하면 재발한다.** 감시가 그때 잡는다 — 위 도구가 개수를 기준선(9)과 대조한다.
