### PR TITLE
우측 사이드바: 4분할 배너를 이용가이드 아래로 + 이용가이드 카드 콤팩트화

### DIFF
--- a/apps/web/src/lib/components/layout/panel.svelte
+++ b/apps/web/src/lib/components/layout/panel.svelte
@@ -19,28 +19,33 @@
     <!-- 마음메시지 카드 위젯 (공지 아래, 사이드바 배너 위) -->
     <WidgetRenderer zone="sidebar" onlyIds={['celebration']} />
 
-    <!-- 이용가이드 미니 카드 (마음메시지 아래) -->
+    <!-- 이용가이드 미니 카드 (마음메시지 아래) — 가로 1줄 콤팩트 -->
     <a
         href="/content/guide"
-        class="block rounded-xl border bg-teal-50 p-3.5 text-center no-underline transition-colors hover:border-teal-300 dark:bg-teal-950/30"
+        class="flex items-center gap-2.5 rounded-xl border bg-teal-50 px-3.5 py-2.5 no-underline transition-colors hover:border-teal-300 dark:bg-teal-950/30"
     >
-        <div class="text-2xl">🙌</div>
-        <div class="text-foreground mt-0.5 text-sm font-bold">다모앙 이용가이드</div>
-        <div class="text-muted-foreground text-xs">처음이신가요? 3분이면 충분해요</div>
+        <span class="text-xl leading-none">🙌</span>
+        <span class="text-foreground text-sm font-bold">다모앙 이용가이드</span>
         <span
-            class="mt-2 inline-block rounded-full bg-teal-500 px-3.5 py-1 text-xs font-bold text-white"
+            class="ml-auto whitespace-nowrap rounded-full bg-teal-500 px-3 py-1 text-xs font-bold text-white"
             >가이드 보기 →</span
         >
     </a>
 
-    <!-- 온라인 대전 현황 위젯 (이용가이드 아래) -->
+    <!-- 4분할 배너 (이용가이드 바로 아래로 승격) -->
+    <WidgetRenderer zone="sidebar" onlyIds={['sidebar-ad-2']} />
+
+    <!-- 온라인 대전 현황 위젯 (4분할 배너 아래) -->
     <WidgetRenderer zone="sidebar" onlyIds={['game-lobby']} />
 
     <!-- 사이드바 배너 (슬롯 기반) -->
     <PluginSlot name="sidebar-banner" />
 
-    <!-- 나머지 사이드바 위젯 -->
-    <WidgetRenderer zone="sidebar" excludeIds={['notice', 'celebration', 'game-lobby']} />
+    <!-- 나머지 사이드바 위젯 (4분할 배너는 위로 뺐으므로 제외) -->
+    <WidgetRenderer
+        zone="sidebar"
+        excludeIds={['notice', 'celebration', 'game-lobby', 'sidebar-ad-2']}
+    />
 
     <!-- Slot: sidebar-right-bottom -->
     {#each getComponentsForSlot('sidebar-right-bottom') as slotComp (slotComp.id)}


### PR DESCRIPTION
## 요약
우측 사이드바 위젯 배치를 사장님 요청대로 조정합니다.

### 변경
1. **4분할 배너(sidebar-ad-2, image-text grid) 를 이용가이드 미니카드 바로 아래로 승격**
   - 기존: 온라인대전·플러그인배너·b2b광고 아래(나머지 위젯 블록 내부)
   - 변경: 이용가이드 카드 직후로 이동 → 하단 `excludeIds` 에 추가해 이중 렌더 방지
2. **이용가이드 카드 가로 1줄 콤팩트화**
   - 세로 4단 중앙정렬 → `[🙌 다모앙 이용가이드 … 가이드 보기 →]` 가로 1줄
   - 부제('처음이신가요? 3분이면 충분해요') 제거로 높이 약 절반

### 배치 결과 (위→아래)
공지 → 마음메시지 → **이용가이드(축소)** → **4분할 배너** → 온라인대전 → 플러그인배너 → b2b → 나눔 → 정사각

### 검증
- svelte 단일 파일 컴파일 통과 (warnings 0)
- prettier 통과
- `sidebar-ad-2` 는 라이브 DB `sidebar_widget_layout` 의 4분할 배너 위젯 id (확인됨). 해당 id 부재 환경에선 onlyIds/excludeIds 모두 무해(no-op).