### PR TITLE
긴급: 계정 복구 경로 잠금 — 해시 충돌로 남의 계정이 열립니다

### DIFF
--- a/apps/web/src/lib/server/auth/account-recovery-lock.ts
+++ b/apps/web/src/lib/server/auth/account-recovery-lock.ts
@@ -1,0 +1,27 @@
+/**
+ * ⛔ 2026-08-27 긴급 잠금 — 계정 복구 경로를 닫는다.
+ *
+ * 왜: `inspectSocialMbIdOccupant` 가 `generateSocialMbId` **해시만** 보고
+ *     "당신의 이전 계정입니다"라고 안내한다. 그 계정이 정말 이 소셜 신원에
+ *     묶여 있는지(`g5_member_social_profiles`) 확인하지 않는다.
+ *
+ *     해시는 `adler32(md5(identifier))` 인데, md5 를 **hex 문자열 32자**로
+ *     받아 adler32 를 건다. 도달 가능한 값이 2^32 의 1/87 이하로 접혀
+ *     서로 다른 사람의 신원이 같은 mb_id 로 충돌한다(실측: 충돌 그룹 410개).
+ *
+ *     실사고 확인 — kakao 신원 5049479848 과 3427320197 이 둘 다
+ *     `kakao_8bf108d1` 로 해싱된다. 남이 그 계정으로 로그인했고, 다른 건에서는
+ *     침입자가 원 주인의 닉네임까지 바꿨다.
+ *
+ * ⛔ 이건 응급 지혈이지 수정이 아니다. 구멍은 register.ts 의
+ *    `inspectSocialMbIdOccupant` 에 그대로 있다. 소유 확인을 넣어 고친 뒤
+ *    이 잠금을 풀어야 한다.
+ *
+ * 대가: 정당한 복구 요청이 하루 0.8건(7/27~8/27 총 23건) 막힌다.
+ *       전부 contact@damoang.net 안내로 돌린다.
+ */
+export const ACCOUNT_RECOVERY_LOCKED = true;
+
+/** 잠금 중 회원에게 보여줄 문구. 원인을 노출하지 않는다. */
+export const ACCOUNT_RECOVERY_LOCKED_MESSAGE =
+    '이전 계정 복구 기능을 점검하고 있습니다. contact@damoang.net 으로 문의해 주시면 확인 후 도와드리겠습니다.';

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -18,6 +18,10 @@ import {
 } from '$lib/server/auth/register.js';
 import { upsertSocialProfile } from '$lib/server/auth/oauth/social-profile.js';
 import {
+    ACCOUNT_RECOVERY_LOCKED,
+    ACCOUNT_RECOVERY_LOCKED_MESSAGE
+} from '$lib/server/auth/account-recovery-lock.js';
+import {
     getMemberById,
     updateLoginTimestamp,
     findMemberByEmail
@@ -97,7 +101,13 @@ export const load: PageServerLoad = async ({ url, cookies }) => {
             socialProfile.provider,
             socialProfile.identifier
         );
-        if (occupant.kind !== 'none') {
+        // ⛔ 2026-08-27 잠금: 해시 충돌만으로 남의 계정을 "이전 계정"이라 안내하던
+        //    경로다(account-recovery-lock.ts 참고). 복구 화면으로 보내지 않는다.
+        //    이용제한 계정이 점유한 mb_id 는 계속 막는다 — 그건 별개 가드다.
+        if (occupant.kind === 'blocked') {
+            redirect(302, '/login?error=account_blocked');
+        }
+        if (!ACCOUNT_RECOVERY_LOCKED && occupant.kind !== 'none') {
             redirect(302, '/register/recover');
         }
     }
@@ -202,6 +212,11 @@ export const actions: Actions = {
         }
 
         let mbId: string;
+        if (isRecovery && ACCOUNT_RECOVERY_LOCKED) {
+            // ⛔ 화면 진입을 막아도 폼을 직접 POST 할 수 있다. 여기서 다시 막는다.
+            cookies.delete('pending_social_register', { path: '/' });
+            return fail(423, { error: ACCOUNT_RECOVERY_LOCKED_MESSAGE, nickname });
+        }
         if (isRecovery) {
             // 복구 경로: 닉네임·약관 절차 없이 옛 계정으로 이어붙인다.
             // 이 경로에 도달했다는 것 자체가 같은 소셜 sub 으로 로그인했다는 뜻이므로
@@ -267,7 +282,7 @@ export const actions: Actions = {
                     nickname
                 });
             }
-            if (occupant.kind === 'recoverable') {
+            if (!ACCOUNT_RECOVERY_LOCKED && occupant.kind === 'recoverable') {
                 return fail(409, {
                     error: '이전에 사용하시던 계정이 있습니다. 그 계정으로 이어서 이용하실 수 있습니다.',
                     nickname,
@@ -275,7 +290,12 @@ export const actions: Actions = {
                 });
             }
 
+            // ⛔ 잠금 중에는 점유 계정을 내주지 않고 새 mb_id 로 가입시킨다.
+            //    해시가 겹쳤다고 같은 사람이라는 보장이 없다.
             mbId = occupant.mbId;
+            if (ACCOUNT_RECOVERY_LOCKED && (await isMbIdTaken(mbId))) {
+                mbId = appendMbIdSuffix(mbId);
+            }
         }
 
         // 이메일 중복 체크: 같은 이메일로 가입된 계정이 있으면 가입 차단.

--- a/apps/web/src/routes/register/recover/+page.server.ts
+++ b/apps/web/src/routes/register/recover/+page.server.ts
@@ -1,6 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { inspectSocialMbIdOccupant } from '$lib/server/auth/register.js';
+import { ACCOUNT_RECOVERY_LOCKED } from '$lib/server/auth/account-recovery-lock.js';
 
 /**
  * 이전 계정 안내 화면.
@@ -27,6 +28,11 @@ export const load: PageServerLoad = async ({ cookies }) => {
 
     if (!socialProfile.identifier) {
         redirect(302, '/register');
+    }
+
+    // ⛔ 2026-08-27 잠금 — 직접 URL 접근도 막는다(account-recovery-lock.ts).
+    if (ACCOUNT_RECOVERY_LOCKED) {
+        redirect(302, '/register?recovery=locked');
     }
 
     const occupant = await inspectSocialMbIdOccupant(


### PR DESCRIPTION
## 무슨 일

`inspectSocialMbIdOccupant`(`register.ts:84-121`)가 `generateSocialMbId` **해시만** 보고 **「당신의 이전 계정입니다」**라고 안내합니다. 그 계정이 정말 이 소셜 신원에 묶여 있는지 `g5_member_social_profiles` 를 **한 번도 확인하지 않습니다.**

주석에 전제가 적혀 있는데, **그 전제가 거짓입니다:**
> `register.ts:64` — 「generateSocialMbId는 결정적이라 mb_id가 충돌한다는 것은 **같은 소셜 계정**이라는 뜻이다」

⭐ **결정적인 것과 충돌하지 않는 것은 다릅니다.**

## 해시가 무너져 있습니다

`adler32(md5(identifier))` 인데 md5 를 **hex 문자열 32자**로 받아 adler32 를 겁니다.

| | |
|---|---|
| `A = 1+Σbyte` | `[1537, 3265]` = 1,729개 |
| `B = 32+Σ(33-i)·byte` | `[25376, 53888]` = 28,513개 |
| 도달 가능 상한 | **≈ 4,930만 = 2³²의 1/87** |

저장된 신원 **68,272개를 직접 해싱**해 **충돌 그룹 410개(서로 다른 신원 823개)** 를 확인했습니다.

## 실사고 두 건

**①** `kakao 5049479848` 과 `kakao 3427320197` → **둘 다 `kakao_8bf108d1`** 로 해싱됩니다. 남이 그 계정으로 로그인했습니다(`identifier_mismatch` 3건, 08-21).

**②** `naver_989f08ee` — 08-20부터 다른 사람이 들어와 **원 주인의 닉네임을 바꿨고**, 두 사람이 **같은 계정으로 가입인사 게시판에서 대화**했습니다(`g5_write_hello` 38615 ↔ 38778, wr_ip 가 갈림).

## 막은 곳 셋

| 지점 | 변경 |
|---|---|
| `/register` load | 점유 계정 → 복구 화면으로 보내던 것 **중단**. ⭐ `blocked`(이용제한) 가드는 **그대로** |
| `intent=recover` 액션 | **423 거부.** 화면을 막아도 폼은 직접 POST 할 수 있습니다 |
| `/register/recover` | **직접 접근 차단** |

⭐ 잠금 중에는 점유 mb_id 를 내주지 않고 **`appendMbIdSuffix` 로 새 계정**을 만듭니다.

## ⛔ 이건 응급 지혈이지 수정이 아닙니다

구멍은 `inspectSocialMbIdOccupant` 에 그대로 있습니다. **소유 확인을 넣어 고친 뒤 `ACCOUNT_RECOVERY_LOCKED` 를 false 로 되돌려야 합니다.**

## 대가

정당한 복구가 **하루 0.8건**(07-27~08-27 총 **23건**) 막힙니다. `contact@damoang.net` 안내로 돌립니다.

## 검증

- [ ] 정상 신규 가입 회귀 없음
- [ ] 이용제한 계정 점유 시 계속 차단(`account_blocked`)
- [ ] `/register/recover` 직접 접근 차단
- [ ] `intent=recover` POST 거부
- prettier `--check` 통과. 로컬 빌드는 안 돌렸습니다(서버 빌드 금지) — CI 로 판정