### PR TITLE
fix(auth): 소셜 바인딩 관측에 요청 IP 를 남긴다

### DIFF
--- a/apps/web/src/lib/server/auth/oauth/observe-client-ip.test.ts
+++ b/apps/web/src/lib/server/auth/oauth/observe-client-ip.test.ts
@@ -1,0 +1,100 @@
+/**
+ * 소셜 바인딩 관측이 **IP 를 남기는지**.
+ *
+ * ⛔ 2026-08 사고에서 `identifier_mismatch_write_skipped` 80건이 전부 `client_ip=''` 이었다.
+ *    그 때문에 **11명의 피해 여부를 가리지 못했다.** 신원 지문만으로는
+ *    「누가 시도했는가」를 좁힐 수 없다. 그래서 회귀로 못 박는다.
+ *
+ * 이 테스트는 「관측이 발화하는가」가 아니라 **「발화할 때 IP 가 실려 있는가」**를 본다.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const query = vi.fn();
+const observeBinding = vi.fn();
+
+vi.mock('$lib/server/db.js', () => ({ default: { query: (...a: unknown[]) => query(...a) } }));
+vi.mock('./binding-observer.js', () => ({
+    observeBinding: (...a: unknown[]) => observeBinding(...a)
+}));
+
+const { upsertSocialProfile } = await import('./social-profile');
+
+const CLIENT_IP = '203.0.113.77';
+const profile = (identifier: string) => ({
+    provider: 'naver' as const,
+    identifier,
+    displayName: '',
+    email: '',
+    photoUrl: '',
+    profileUrl: ''
+});
+
+/**
+ * @param mine   이 회원+provider 에 저장된 identifier 목록
+ * @param others 이 회원의 **다른** provider 프로필 수
+ */
+function wire({ mine = [] as string[], others = 0, conflicting = null as string | null } = {}) {
+    query.mockReset();
+    observeBinding.mockReset();
+    query.mockImplementation(async (sql: string, params: unknown[]) => {
+        // findSocialProfile — 다른 회원이 이 신원을 쓰고 있나
+        if (sql.includes('WHERE provider = ? AND identifier = ?'))
+            return [conflicting ? [{ mb_id: conflicting }] : []];
+        // findSocialProfilesByMemberProvider
+        if (sql.includes('ORDER BY mp_register_day') && !sql.includes('provider <> ?'))
+            return [mine.map((identifier, i) => ({ mp_no: i + 1, identifier }))];
+        // 다른 provider 프로필 수
+        if (sql.includes('provider <> ?')) return [[{ cnt: others }]];
+        return [{ affectedRows: 1 }];
+    });
+}
+
+const observedWith = (kind: string) =>
+    observeBinding.mock.calls.find((c) => c[0] === kind)?.[1] as
+        | Record<string, unknown>
+        | undefined;
+
+describe('upsertSocialProfile — 관측에 IP 가 실린다', () => {
+    it('⛔ 신원 불일치 관측에 clientIp 가 들어간다 (80건이 비어 11명을 못 가렸다)', async () => {
+        wire({ mine: ['OTHER-ID'] });
+        await upsertSocialProfile('naver_v', 'naver', profile('INTRUDER-ID'), CLIENT_IP);
+
+        const d = observedWith('identifier_mismatch_write_skipped');
+        expect(d).toBeDefined();
+        expect(d?.clientIp).toBe(CLIENT_IP);
+        expect(d?.identifier).toBe('INTRUDER-ID'); // 지문 재료 — 원문은 observer 가 해시한다
+    });
+
+    it('기존 계정에 새 provider 가 붙는 관측에도 clientIp 가 들어간다', async () => {
+        wire({ mine: [], others: 1 });
+        await upsertSocialProfile('naver_v', 'naver', profile('NEW-ID'), CLIENT_IP);
+
+        const d = observedWith('new_provider_attached_to_existing_member');
+        expect(d).toBeDefined();
+        expect(d?.clientIp).toBe(CLIENT_IP);
+    });
+
+    it('다른 회원에게 묶인 신원 관측에도 clientIp 가 들어간다', async () => {
+        wire({ mine: ['MINE'], conflicting: 'naver_other' });
+        await upsertSocialProfile('naver_v', 'naver', profile('MINE'), CLIENT_IP);
+
+        const d = observedWith('identifier_bound_other_member_delete_skipped');
+        expect(d).toBeDefined();
+        expect(d?.clientIp).toBe(CLIENT_IP);
+        expect(d?.otherMbId).toBe('naver_other');
+    });
+
+    it('⚠️ clientIp 를 안 넘기면 undefined 다 — 호출부가 빠뜨린 것이 드러나야 한다', async () => {
+        wire({ mine: ['OTHER-ID'] });
+        await upsertSocialProfile('naver_v', 'naver', profile('INTRUDER-ID'));
+
+        expect(observedWith('identifier_mismatch_write_skipped')?.clientIp).toBeUndefined();
+    });
+
+    it('⛔ 정상 신규가입은 관측하지 않는다 — 하루 1,000건이 신호를 묻는다', async () => {
+        wire({ mine: [], others: 0 });
+        await upsertSocialProfile('naver_new', 'naver', profile('ID-1'), CLIENT_IP);
+
+        expect(observedWith('new_provider_attached_to_existing_member')).toBeUndefined();
+    });
+});

--- a/apps/web/src/lib/server/auth/oauth/social-profile.ts
+++ b/apps/web/src/lib/server/auth/oauth/social-profile.ts
@@ -229,7 +229,17 @@ export async function linkSocialProfile(
 export async function upsertSocialProfile(
     mbId: string,
     provider: string,
-    profile: OAuthUserProfile
+    profile: OAuthUserProfile,
+    /**
+     * 관측에 남길 요청 IP.
+     *
+     * ⛔ 2026-08-28 추가. 없으면 이 함수가 남기는 관측에 IP 가 비어 `identifier_mismatch`
+     *    80건 전부 `client_ip=''` 였고, 그 때문에 2026-08 사고에서 **11명의 피해 여부를
+     *    가리지 못했다.** 신원 지문만으로는 「누가 시도했는가」를 못 좁힌다.
+     *    선택 인자인 이유는 호출부가 4곳이고 전부 이미 clientIp 를 들고 있어서,
+     *    빠뜨린 곳이 조용히 컴파일되지 않도록 하는 것보다 점진 적용이 안전했기 때문이다.
+     */
+    clientIp?: string
 ): Promise<void> {
     const providerLower = provider.toLowerCase();
     const objectSha = createHash('sha1').update(JSON.stringify(profile)).digest('hex');
@@ -242,7 +252,9 @@ export async function upsertSocialProfile(
         await observeBinding('identifier_bound_other_member_delete_skipped', {
             mbId,
             provider: providerLower,
-            otherMbId: conflicting.mb_id
+            otherMbId: conflicting.mb_id,
+            identifier: profile.identifier,
+            clientIp
         });
     }
 
@@ -260,7 +272,8 @@ export async function upsertSocialProfile(
         await observeBinding('identifier_mismatch_write_skipped', {
             mbId,
             provider: providerLower,
-            identifier: profile.identifier
+            identifier: profile.identifier,
+            clientIp
         });
         return;
     }
@@ -300,7 +313,8 @@ export async function upsertSocialProfile(
             await observeBinding('new_provider_attached_to_existing_member', {
                 mbId,
                 provider: providerLower,
-                identifier: profile.identifier
+                identifier: profile.identifier,
+                clientIp
             });
         }
 

--- a/apps/web/src/routes/auth/callback/[provider]/+server.ts
+++ b/apps/web/src/routes/auth/callback/[provider]/+server.ts
@@ -227,6 +227,7 @@ async function handleCallback(
                     await observeBinding('email_match_into_bound_account', {
                         mbId: memberByEmail.mb_id,
                         provider: providerName,
+                        identifier: profile.identifier,
                         clientIp
                     });
                 }
@@ -398,7 +399,7 @@ async function handleCallback(
         }
 
         // 소셜 프로필 업데이트
-        await upsertSocialProfile(mbId, providerName, profile);
+        await upsertSocialProfile(mbId, providerName, profile, clientIp);
 
         await runSocialLoginPostProcess(mbId, clientIp, member.mb_leave_reason);
 

--- a/apps/web/src/routes/auth/native/apple/+server.ts
+++ b/apps/web/src/routes/auth/native/apple/+server.ts
@@ -95,6 +95,8 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         return json({ success: false, error: 'invalid_token' }, { status: 401 });
     }
 
+    const clientIp = resolveClientIp(getClientAddress, request) ?? '';
+
     const identifier = payload.sub;
     if (!identifier) {
         return json({ success: false, error: 'invalid_token' }, { status: 401 });
@@ -128,7 +130,9 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
                 if (bound.length > 0 && !bound.some((r) => r.identifier === identifier)) {
                     await observeBinding('email_match_into_bound_account', {
                         mbId: byEmail.mb_id,
-                        provider: 'apple'
+                        provider: 'apple',
+                        identifier,
+                        clientIp
                     });
                 }
                 mbId = byEmail.mb_id;
@@ -170,7 +174,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
                     mb_nick: nickname,
                     mb_email: verifiedEmail,
                     mb_name: nickname,
-                    mb_ip: resolveClientIp(getClientAddress, request) ?? '',
+                    mb_ip: clientIp,
                     skipNickLock: true
                 });
             }
@@ -183,7 +187,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         }
 
         // 5. 소셜 프로필 갱신 + app-login 코드 발급
-        await upsertSocialProfile(mbId, 'apple', profile);
+        await upsertSocialProfile(mbId, 'apple', profile, clientIp);
         const code = await generateAppLoginCode({
             mb_id: member.mb_id,
             mb_nick: member.mb_nick,

--- a/apps/web/src/routes/plugin/social/+server.ts
+++ b/apps/web/src/routes/plugin/social/+server.ts
@@ -114,6 +114,7 @@ async function handleCallback(
                     await observeBinding('email_match_into_bound_account', {
                         mbId: memberByEmail.mb_id,
                         provider: providerName,
+                        identifier: profile.identifier,
                         clientIp
                     });
                 }
@@ -160,7 +161,7 @@ async function handleCallback(
         }
 
         // 소셜 프로필 업데이트
-        await upsertSocialProfile(mbId, providerName, profile);
+        await upsertSocialProfile(mbId, providerName, profile, clientIp);
 
         await runSocialLoginPostProcess(mbId, clientIp, member.mb_leave_reason);
 

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -360,7 +360,7 @@ export const actions: Actions = {
                 photoUrl: socialProfile.photoUrl,
                 profileUrl: socialProfile.profileUrl
             };
-            await upsertSocialProfile(mbId, socialProfile.provider, oauthProfile);
+            await upsertSocialProfile(mbId, socialProfile.provider, oauthProfile, clientIp);
 
             // 로그인 시각 업데이트
             await updateLoginTimestamp(mbId, clientIp);


### PR DESCRIPTION
## 왜

2026-08 계정 탈취 조사에서 **45계정 중 11명의 피해 여부를 가리지 못했다.** 남은 것이 이것뿐이었다:

```
{"kind":"identifier_mismatch_write_skipped","otherMbId":null}   client_ip=''
```

액션별 실측 — **문제가 어디인지 정확히 갈린다**:

| 관측 | IP 있음 | 빈값 |
|---|---|---|
| `email_match_into_bound_account` | **11** | 0 |
| `identifier_mismatch_write_skipped` | 0 | **80** |
| `new_provider_attached_to_existing_member` | 0 | 1 |

⭐ `email_match` 는 **호출부가 `clientIp` 를 넘기기 때문에** 11/11 찍힌다. 나머지는 `upsertSocialProfile` 안에서 관측하는데 **그 함수가 request 컨텍스트를 안 받는다.** 신원 지문만으로는 「누가 시도했는가」를 좁힐 수 없다.

⛔ 안 고치면 **다음 사고 때도 똑같이 못 밝힌다.**

## 무엇을

`upsertSocialProfile` 에 선택 인자 `clientIp` 를 추가하고 내부 관측 3종에 전달. 호출부 4곳은 **이미 전부 `clientIp` 를 들고 있어서** 인자 하나만 흘리면 된다.

| 호출부 | 상태 |
|---|---|
| `auth/callback/[provider]:401` | `handleCallback(..., clientIp, ...)` 인자로 이미 있음 |
| `plugin/social:163` | 동일 |
| `auth/native/apple:186` | 지역 상수로 정리 |
| `register/+page.server.ts:363` | 액션의 `clientIp` 사용 |

**함께 정리한 것**
- `apple` 이 `resolveClientIp` 를 **두 번 계산**하던 것을 상수 하나로
- `apple` 의 `email_match` 관측에 빠져 있던 `clientIp`·`identifier` 추가
- `callback`·`plugin` 의 `email_match` 관측에 `identifier` 추가 (IP 는 이미 있었다)

→ 이제 **모든 소셜 바인딩 관측이 IP + 신원 지문을 남긴다.**

⛔ 원문 `identifier` 는 저장되지 않는다. `observeBinding` 이 sha256 앞 16자로 해싱해 `idFp` 로만 남긴다(#2224 에서 도입).

## 사용자 영향

**없다.** 판정·차단·리다이렉트 어느 것도 안 바뀐다. 기록만 늘어난다.

## 검증

회귀 테스트 5건 신규. ⭐ **대조군(현행 `origin/main`)에서 3건이 실패**하는 것을 확인했다 — 옛 코드에서도 통과하는 테스트였다면 아무것도 증명하지 못한다.

```
새 코드   18 passed   (oauth 디렉터리 전체, 기존 테스트 포함)
옛 코드    3 failed | 2 passed
```

통과한 2건은 「clientIp 를 안 넘기면 undefined」와 「정상 신규가입은 관측 안 함」이라 양쪽에서 같아야 맞다.

⛔ **배포 후 24h 실측 필요**: `identifier_mismatch_write_skipped` 에 실제로 IP 가 찍히는지. 파드 내부 프로브(`kubectl exec` → 127.0.0.1)는 X-Real-IP 가 없어 빈값이 나오므로 **실사용자 트래픽으로만 확인된다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaEkFsh9KCsFc4n79iV6bc