### PR TITLE
작성 시 경어체·비속어 넛지 (정규식·observe-first)

### DIFF
--- a/apps/web/src/lib/components/features/board/comment-form.svelte
+++ b/apps/web/src/lib/components/features/board/comment-form.svelte
@@ -15,6 +15,8 @@
     import type { BoardPermissions } from '$lib/api/types.js';
     import { apiClient } from '$lib/api/index.js';
     import { stripAdminMentions } from '$lib/utils/sanitize-mentions.js';
+    import { checkContent, NUDGE_ENFORCED } from '$lib/utils/politeness-filter.js';
+    import PolitenessNudgeDialog from './politeness-nudge-dialog.svelte';
     import Send from '@lucide/svelte/icons/send';
     import RefreshCw from '@lucide/svelte/icons/refresh-cw';
     import X from '@lucide/svelte/icons/x';
@@ -182,6 +184,38 @@
 
     let isSubmitting = $state(false);
 
+    // ── 작성 시점 경어체/비속어 넛지 (순수 정규식 · observe-first) ──────────────
+    let nudgeOpen = $state(false);
+    let nudgeResult = $state<{ politeness: boolean; profanity: boolean }>({
+        politeness: false,
+        profanity: false
+    });
+    let nudgeResolve: ((proceed: boolean) => void) | null = null;
+
+    /**
+     * 넛지 검사. 걸릴 게 없으면 즉시 통과.
+     * NUDGE_ENFORCED=false 면 모달을 띄우지 않고 관측만(콘솔) 하고 통과시킨다.
+     * true 면 모달을 띄우고 사용자의 [수정]/[무시하고 글쓰기] 선택을 기다린다.
+     */
+    function askNudge(text: string): Promise<boolean> {
+        const r = checkContent(text);
+        if (!r.politeness && !r.profanity) return Promise.resolve(true);
+        if (!NUDGE_ENFORCED) {
+            console.info('[politeness-nudge:observe]', { scope: 'comment', ...r });
+            return Promise.resolve(true);
+        }
+        nudgeResult = r;
+        nudgeOpen = true;
+        return new Promise<boolean>((resolve) => (nudgeResolve = resolve));
+    }
+
+    function decideNudge(proceed: boolean): void {
+        nudgeOpen = false;
+        const resolve = nudgeResolve;
+        nudgeResolve = null;
+        resolve?.(proceed);
+    }
+
     async function handleSubmit(e: Event): Promise<void> {
         e.preventDefault();
 
@@ -201,6 +235,8 @@
 
         try {
             const submitContent = await stripAdminMentions(convertEmoticonImages(content.trim()));
+            // 등록 직전 넛지 검사. [수정] 선택 시 여기서 멈춘다(finally 가 isSubmitting 해제).
+            if (!(await askNudge(submitContent))) return;
             // 별점은 원댓글(리뷰)에만 — 대댓글/비rating 보드는 undefined
             const reviewRating = showRating && !isReplyMode && rating > 0 ? rating : undefined;
             await onSubmit(submitContent, parentId, false, undefined, reviewRating);
@@ -473,6 +509,14 @@
             onchange={handleFileChange}
         />
     </form>
+
+    <PolitenessNudgeDialog
+        bind:open={nudgeOpen}
+        politeness={nudgeResult.politeness}
+        profanity={nudgeResult.profanity}
+        onEdit={() => decideNudge(false)}
+        onProceed={() => decideNudge(true)}
+    />
 {:else if authStore.isAuthenticated && !canUseCertifiedAction(authStore.user, boardId)}
     <div class="bg-muted/50 rounded-md p-4 text-center">
         <p class="text-muted-foreground">

--- a/apps/web/src/lib/components/features/board/politeness-nudge-dialog.svelte
+++ b/apps/web/src/lib/components/features/board/politeness-nudge-dialog.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+    /**
+     * 작성 시점 경어체/비속어 넛지 확인 모달.
+     *
+     * ⛔ 규제가 아니라 안내다. 막지 않고, 되돌리지 않는다. 회원이 [무시하고 글쓰기]를
+     *    누르면 그대로 등록된다. 톤은 manner-tip("경어체 사용해 주세앙 🙏")과 맞춘다.
+     * ⛔ "신고" 등 겁주는 문구 금지.
+     *
+     * 프로그램적으로 열고(handleSubmit 안에서), 사용자의 선택을 콜백으로 받는다.
+     *   - [수정]        → onEdit()   (에디터로 돌아가 고친다)
+     *   - [무시하고 글쓰기] → onProceed() (그대로 진행)
+     */
+    import {
+        Dialog,
+        DialogContent,
+        DialogFooter,
+        DialogHeader,
+        DialogTitle
+    } from '$lib/components/ui/dialog/index.js';
+    import { Button } from '$lib/components/ui/button/index.js';
+
+    /** 부드러운 앙 캐릭터 앙티콘. 상수로 빼 교체를 쉽게. */
+    const ANGTICON_SRC = 'https://damoang.net/emoticons/DINKIssTyle-3d-ang-031.webp';
+
+    interface Props {
+        open?: boolean;
+        /** 반말(경어체 아님) 감지됨 */
+        politeness?: boolean;
+        /** 비속어 감지됨 */
+        profanity?: boolean;
+        /** [수정] — 취소하고 에디터로 */
+        onEdit: () => void;
+        /** [무시하고 글쓰기] — 그대로 진행 */
+        onProceed: () => void;
+    }
+
+    let {
+        open = $bindable(false),
+        politeness = false,
+        profanity = false,
+        onEdit,
+        onProceed
+    }: Props = $props();
+
+    // 두 상황 모두 부드럽게. 둘 다면 두 줄.
+    const lines = $derived(
+        [
+            profanity ? '비속어가 포함된 것 같아앙.' : '',
+            politeness ? '경어체가 아닌 것 같아앙.' : ''
+        ].filter(Boolean)
+    );
+
+    // 오버레이 클릭/ESC 로 닫히면 [수정](취소)과 동일 취급 — 안전한 쪽.
+    // (버튼 클릭으로 닫힌 경우엔 이미 부모가 결정을 소비했으므로 중복 호출은 무시된다)
+    function handleOpenChange(next: boolean) {
+        if (!next && open) onEdit();
+    }
+</script>
+
+<Dialog bind:open onOpenChange={handleOpenChange}>
+    <DialogContent class="sm:max-w-sm" showCloseButton={false}>
+        <DialogHeader class="items-center text-center">
+            <img
+                src={ANGTICON_SRC}
+                alt="이모티콘"
+                width="72"
+                height="72"
+                class="h-18 w-18 mx-auto object-contain"
+                loading="lazy"
+            />
+            <DialogTitle class="mt-2 text-base font-semibold">잠깐, 확인해 주세앙 🙏</DialogTitle>
+        </DialogHeader>
+
+        <div class="text-muted-foreground space-y-1 text-center text-sm leading-relaxed">
+            {#each lines as line (line)}
+                <p>{line}</p>
+            {/each}
+            <p class="text-foreground pt-1 font-medium">그대로 등록할까요?</p>
+        </div>
+
+        <DialogFooter class="flex-row justify-center gap-2 sm:justify-center">
+            <Button variant="outline" onclick={onEdit}>수정</Button>
+            <Button variant="default" onclick={onProceed}>무시하고 글쓰기</Button>
+        </DialogFooter>
+    </DialogContent>
+</Dialog>

--- a/apps/web/src/lib/components/features/board/post-form.svelte
+++ b/apps/web/src/lib/components/features/board/post-form.svelte
@@ -15,6 +15,8 @@
     import { stripAdminMentions } from '$lib/utils/sanitize-mentions.js';
     import { findMapLink } from '$lib/utils/angmap-link.js';
     import { stripBlobMedia } from '$lib/utils/strip-blob-media.js';
+    import { checkContent, NUDGE_ENFORCED } from '$lib/utils/politeness-filter.js';
+    import PolitenessNudgeDialog from './politeness-nudge-dialog.svelte';
     import type {
         FreePost,
         CreatePostRequest,
@@ -574,6 +576,38 @@
     // 중복 제출 방지
     let isSubmitting = $state(false);
 
+    // ── 작성 시점 경어체/비속어 넛지 (순수 정규식 · observe-first) ──────────────
+    let nudgeOpen = $state(false);
+    let nudgeResult = $state<{ politeness: boolean; profanity: boolean }>({
+        politeness: false,
+        profanity: false
+    });
+    let nudgeResolve: ((proceed: boolean) => void) | null = null;
+
+    /**
+     * 넛지 검사. 걸릴 게 없으면 즉시 통과.
+     * NUDGE_ENFORCED=false 면 모달을 띄우지 않고 관측만(콘솔) 하고 통과시킨다.
+     * true 면 모달을 띄우고 사용자의 [수정]/[무시하고 글쓰기] 선택을 기다린다.
+     */
+    function askNudge(text: string): Promise<boolean> {
+        const r = checkContent(text);
+        if (!r.politeness && !r.profanity) return Promise.resolve(true);
+        if (!NUDGE_ENFORCED) {
+            console.info('[politeness-nudge:observe]', { scope: 'post', ...r });
+            return Promise.resolve(true);
+        }
+        nudgeResult = r;
+        nudgeOpen = true;
+        return new Promise<boolean>((resolve) => (nudgeResolve = resolve));
+    }
+
+    function decideNudge(proceed: boolean): void {
+        nudgeOpen = false;
+        const resolve = nudgeResolve;
+        nudgeResolve = null;
+        resolve?.(proceed);
+    }
+
     // bug/12839 후속: 에디터의 백그라운드 이미지 변환 진행 개수.
     // 제출 시 0 이 될 때까지 자동 대기 → "이미지가 떴는데 완료가 막힌다"는 마찰 제거.
     let uploadingCount = $state(0);
@@ -697,6 +731,8 @@
                   };
 
         try {
+            // 등록 직전 넛지 검사. [수정] 선택 시 여기서 멈춘다(finally 가 isSubmitting 해제).
+            if (!(await askNudge(`${sanitizedTitle}\n${finalContent}`))) return;
             await onSubmit(data);
 
             // 제출 성공 시 임시저장 삭제
@@ -1121,3 +1157,11 @@
         </form>
     </CardContent>
 </Card>
+
+<PolitenessNudgeDialog
+    bind:open={nudgeOpen}
+    politeness={nudgeResult.politeness}
+    profanity={nudgeResult.profanity}
+    onEdit={() => decideNudge(false)}
+    onProceed={() => decideNudge(true)}
+/>

--- a/apps/web/src/lib/utils/politeness-filter.test.ts
+++ b/apps/web/src/lib/utils/politeness-filter.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 작성 시점 경어체/비속어 넛지 필터 (#politeness-nudge).
+ *
+ * ⛔ 이 테스트는 **실제 구현을 import 한다.** 로직을 복제하면 구현이 바뀌어도
+ *    영원히 초록이 된다(계약이 아니라 계약의 사본을 고정하는 것).
+ *
+ * checkContent 는 순수함수다. 아래는 "잡아야 하는 것"과 "잡으면 안 되는 것"을
+ * 대칭으로 세운 대조군이다 — 한쪽만 통과하면 로직이 진짜로 재지지 않은 것.
+ */
+import { checkContent } from './politeness-filter';
+
+const politeness = (t: string) => checkContent(t).politeness;
+const profanity = (t: string) => checkContent(t).profanity;
+
+describe('C. 부적절한 표현(비속어/초성)', () => {
+    it('완성형 비속어를 잡는다', () => {
+        expect(profanity('이거 병신 같네')).toBe(true);
+        expect(profanity('씨발 진짜')).toBe(true);
+        expect(profanity('시발 뭐야')).toBe(true);
+        expect(profanity('지랄하네')).toBe(true);
+        expect(profanity('닥쳐')).toBe(true);
+        expect(profanity('개새끼야')).toBe(true);
+    });
+
+    it('존나/졸라(세기 표현)를 잡는다', () => {
+        expect(profanity('존나 별로임')).toBe(true);
+        expect(profanity('졸라 마음에 안 듦')).toBe(true);
+        expect(profanity('조낸 별로')).toBe(true);
+    });
+
+    it('초성 조합 비속어를 잡는다', () => {
+        expect(profanity('완전 ㅂㅅ 같음')).toBe(true);
+        expect(profanity('ㅅㅂ 뭐냐')).toBe(true);
+        expect(profanity('ㅈㄹ하고 있네')).toBe(true);
+        expect(profanity('ㅁㅊ 진짜')).toBe(true);
+        expect(profanity('ㄲㅈ')).toBe(true);
+        expect(profanity('ㅄ')).toBe(true);
+    });
+
+    it('초성 변형(ㅅ끼·ㅈ만)도 잡는다 — 필수 케이스', () => {
+        expect(profanity('ㅈ만한 ㅅ끼')).toBe(true);
+    });
+
+    it('⛔ "ㅈ" 단독은 잡지 않는다 (오탐 폭발 방지)', () => {
+        expect(profanity('ㅈ 이거 뭐지')).toBe(false);
+        expect(profanity('ㅋㅈㅋ')).toBe(false);
+    });
+
+    it('⛔ 함정: 졸라매/졸라서(끈)는 비속어가 아니다', () => {
+        expect(profanity('끈을 졸라맸어요')).toBe(false);
+        expect(profanity('신발끈을 졸라매고 뛰었다')).toBe(false);
+        expect(profanity('허리띠를 졸라서 고정했음')).toBe(false);
+    });
+});
+
+describe('A. 예의없음(반말) 검출', () => {
+    it('서술형 반말 종결을 잡는다', () => {
+        expect(politeness('이거 완전 좋다')).toBe(true);
+        expect(politeness('그건 아니다')).toBe(true);
+        expect(politeness('내가 볼때 걍 뭍힐듯 싶다')).toBe(true); // 필수 케이스
+        expect(politeness('밥 먹었다')).toBe(true);
+    });
+
+    it('의문형 반말을 잡는다', () => {
+        expect(politeness('이게 맞냐')).toBe(true);
+        expect(politeness('뭐 하니?')).toBe(true);
+        expect(politeness('너 밥 먹었어?')).toBe(true);
+    });
+
+    it('명령·청유 반말을 잡는다', () => {
+        expect(politeness('빨리 해라')).toBe(true);
+        expect(politeness('그만 좀 해')).toBe(true);
+        expect(politeness('우리 같이 가자')).toBe(true);
+    });
+
+    it('기타 반말 어미(네·군·더라·잖아·는데)를 잡는다', () => {
+        expect(politeness('생각보다 괜찮네')).toBe(true);
+        expect(politeness('완전 크구나')).toBe(true);
+        expect(politeness('전에도 그랬더라')).toBe(true);
+    });
+});
+
+describe('A. 존댓말 마커가 하나라도 있으면 통과', () => {
+    it('~요 로 끝나면 통과', () => {
+        expect(politeness('이거 정말 좋아요')).toBe(false);
+        expect(politeness('그렇게 하면 안 돼요')).toBe(false);
+        expect(politeness('감사해요')).toBe(false);
+        expect(politeness('맞나요?')).toBe(false);
+    });
+
+    it('~ㅂ니다/습니다 면 통과', () => {
+        expect(politeness('부탁드립니다')).toBe(false); // 필수 케이스
+        expect(politeness('감사합니다')).toBe(false);
+        expect(politeness('잘 모르겠습니다')).toBe(false);
+        expect(politeness('여기 있습니다')).toBe(false);
+    });
+
+    it('~세요/십시오 면 통과', () => {
+        expect(politeness('꼭 확인해 주세요')).toBe(false);
+        expect(politeness('여기 앉으십시오')).toBe(false);
+    });
+
+    it('반말과 존댓이 섞여도 존댓이 하나 있으면 통과', () => {
+        expect(politeness('이건 별로다. 그래도 감사합니다')).toBe(false);
+    });
+});
+
+describe('B. 음슴체/체언 종결 = 중립(flag 안 함)', () => {
+    it('~음/~슴/~ㅁ 은 반말로 잡지 않는다', () => {
+        expect(politeness('확인했음')).toBe(false); // 필수 케이스
+        expect(politeness('이거 좋음')).toBe(false);
+        expect(politeness('그냥 그런 것 같음')).toBe(false);
+        expect(politeness('다녀왔슴')).toBe(false);
+        expect(politeness('내 생각임')).toBe(false);
+    });
+
+    it('~듯/~것/~중/~예정/~완료 는 중립', () => {
+        expect(politeness('비가 올 듯')).toBe(false);
+        expect(politeness('먹고 있는 중')).toBe(false);
+        expect(politeness('내일 방문 예정')).toBe(false);
+        expect(politeness('업로드 완료')).toBe(false);
+    });
+
+    it('음슴체지만 비속어가 있으면 profanity 는 잡되 politeness 는 중립', () => {
+        const r = checkContent('존나 별로임');
+        expect(r.profanity).toBe(true);
+        expect(r.politeness).toBe(false);
+    });
+});
+
+describe('D. 예외(최우선)', () => {
+    it('① 이미지/앙티콘 단독 — 텍스트 없으면 skip (도메인 무관)', () => {
+        expect(
+            checkContent('<img src="https://damoang.net/emoticons/ang-1.webp" alt="이모티콘">')
+        ).toEqual({
+            politeness: false,
+            profanity: false
+        });
+        expect(
+            checkContent('<img src="https://r2.damoang.net/data/editor/2026/photo.jpg">')
+        ).toEqual({ politeness: false, profanity: false });
+        // 이미지 + 존댓 텍스트 → 통과(반말 아님)
+        expect(politeness('<img src="https://r2.damoang.net/data/editor/x.jpg"> 감사합니다')).toBe(
+            false
+        );
+    });
+
+    it('② 인용문(blockquote)은 검사에서 제외 — 남의 반말/욕은 넛지 대상 아님', () => {
+        // 필수 케이스: 인용은 제외, 뒤의 "감사합니다"만 본다
+        expect(checkContent('<blockquote>남의 반말 인용</blockquote> 감사합니다')).toEqual({
+            politeness: false,
+            profanity: false
+        });
+        // 인용 안의 욕은 내 표현이 아니다
+        expect(profanity('<blockquote>씨발 이라고 하더라</blockquote> 그렇군요')).toBe(false);
+        // 줄앞 > 인용 라인도 제외
+        expect(politeness('> 저건 병신같다\n좋은 지적이네요')).toBe(false);
+        expect(profanity('> 씨발\n감사합니다')).toBe(false);
+    });
+
+    it('③ 짧은 감탄사/자모 단독은 skip', () => {
+        expect(checkContent('ㅋㅋ')).toEqual({ politeness: false, profanity: false }); // 필수
+        expect(checkContent('ㅎㅎㅎ')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('ㄷㄷ')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('와')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('헐')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('ㅠㅠ')).toEqual({ politeness: false, profanity: false });
+    });
+
+    it('⑤ 링크/#태그/숫자만이면 skip', () => {
+        expect(checkContent('https://example.com/foo')).toEqual({
+            politeness: false,
+            profanity: false
+        });
+        expect(checkContent('#태그 #모음')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('12345')).toEqual({ politeness: false, profanity: false });
+    });
+});
+
+describe('종합 / 필수 대조군', () => {
+    it('잡아야 하는 것', () => {
+        expect(checkContent('ㅈ만한 ㅅ끼').profanity).toBe(true);
+        expect(checkContent('존나 별로임').profanity).toBe(true);
+        expect(checkContent('내가 볼때 걍 뭍힐듯 싶다').politeness).toBe(true);
+    });
+
+    it('잡으면 안 되는 것', () => {
+        expect(checkContent('부탁드립니다')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('확인했음')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('ㅋㅋ')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('끈을 졸라맸어요')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('<blockquote>남의 반말 인용</blockquote> 감사합니다')).toEqual({
+            politeness: false,
+            profanity: false
+        });
+    });
+
+    it('빈 입력/공백은 아무것도 잡지 않는다', () => {
+        expect(checkContent('')).toEqual({ politeness: false, profanity: false });
+        expect(checkContent('   \n  ')).toEqual({ politeness: false, profanity: false });
+    });
+
+    it('순수함수 — 같은 입력은 항상 같은 결과', () => {
+        const t = '내가 볼때 걍 뭍힐듯 싶다';
+        expect(checkContent(t)).toEqual(checkContent(t));
+    });
+});

--- a/apps/web/src/lib/utils/politeness-filter.ts
+++ b/apps/web/src/lib/utils/politeness-filter.ts
@@ -1,0 +1,322 @@
+/**
+ * 작성 시점 경어체/비속어 넛지 필터 (순수 정규식 · AI/LLM 호출 없음 · 토큰 0).
+ *
+ * 목적: 글/댓글을 등록하기 **직전**, 반말(예의없음)·비속어를 순수 규칙으로 감지해
+ *       부드럽게 되묻는(nudge) 데 쓴다. **차단이 아니라 확인**이다.
+ *
+ * ⛔ 이 필터는 판정만 한다. confirm/로깅/집행 여부는 호출부(폼)가 결정한다.
+ * ⛔ 리스트·패턴은 전부 아래 상수 배열로 뺐다 — 단어 추가/삭제가 "한 줄"이 되게.
+ *
+ * 판정 순서(스펙 그대로):
+ *   예외(D) 제거 → 부적절(C) 매칭 → 존댓마커(A) 있으면 통과
+ *                                 / 없고 반말종결(A)이고 음슴체(B) 아니면 flag
+ *
+ * checkContent 는 **순수함수**다(부수효과 없음). Evaluator 가 실제 신고 데이터로
+ * 정밀도를 재기 좋게, 입력 문자열만 보고 결정한다.
+ */
+
+/** 넛지 집행 스위치. false = confirm 안 띄우고 관측만(observe-first). 측정 후 켠다. */
+export const NUDGE_ENFORCED = false;
+
+/** checkContent 결과. 각 필드 true = 해당 넛지가 발동할 후보. */
+export interface ContentCheck {
+    /** 예의없음(반말)으로 감지됨 = 경어체 아님 */
+    politeness: boolean;
+    /** 부적절한 표현(비속어/초성)이 감지됨 */
+    profanity: boolean;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * A. 존댓말 마커 — 하나라도 있으면 통과(politeness=false).
+ *    (일부러 넉넉하게 잡는다: 잘못 '존댓'으로 봐도 결과는 '넛지 안 함'=안전한 쪽)
+ * ──────────────────────────────────────────────────────────────────────── */
+export const HONORIFIC_PATTERNS: RegExp[] = [
+    // ~ㅂ니다/습니다 (합니다·입니다·됩니다·있습니다 …). '아니다'(반말)는 제외.
+    /(?<!아)니다/,
+    // ~세요/십시오/시죠/셔요/시오
+    /세요/,
+    /셔요/,
+    /십시오/,
+    /시죠/,
+    /시오(?![가-힣])/,
+    // 존댓 상투어
+    /감사합니|고맙습니|죄송합니|미안합니|부탁드립|주십시오|주세요|해주세요/,
+    // ~요 로 끝나는 절 (해요·이에요·아요/어요·네요·지요·까요·데요·군요·는데요 …)
+    //   줄 끝(멀티라인)에서 '요' 뒤에 문장부호/따옴표만 오는 경우.
+    /요[)\]"'’”\s.!?~…,·]*$/m
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * A. 반말 종결 — 존댓 없이 이걸로 끝나면 flag. (긴 어미가 먼저 오도록 정렬)
+ * ──────────────────────────────────────────────────────────────────────── */
+export const BANMAL_ENDINGS: string[] = [
+    // 3자 이상
+    '구나',
+    '더라',
+    '잖아',
+    // 2자
+    '는데',
+    '해라',
+    '이다',
+    '있다',
+    '없다',
+    '된다',
+    '같다',
+    '좋다',
+    '한다',
+    // 1자 서술/의문/명령/청유
+    '다',
+    '냐',
+    '니',
+    '지',
+    '어',
+    '아',
+    '야',
+    '여',
+    '네',
+    '걸',
+    '군',
+    '해',
+    '라',
+    '게',
+    '자',
+    '봐',
+    '와',
+    '마'
+];
+
+/** 반말 종결 어미 정규식 (끝단 앵커). 상수 배열로부터 조립. */
+const BANMAL_END_RE = new RegExp('(' + BANMAL_ENDINGS.join('|') + ')$');
+
+/* ────────────────────────────────────────────────────────────────────────
+ * B. 음슴체/체언 종결 = 중립(flag 안 함). '~ㅁ' 받침은 종성 코드로 판별한다.
+ *    (했음·임·함·없음·좋음·슴 = 종성 ㅁ / 인 듯·한 듯 = 듯 / 것·중·예정·완료 …)
+ * ──────────────────────────────────────────────────────────────────────── */
+export const NEUTRAL_ENDING_WORDS: string[] = [
+    '듯',
+    '것',
+    '중',
+    '예정',
+    '완료',
+    '뿐',
+    '따름',
+    '터'
+];
+
+/** 한글 종성 인덱스: (code-0xAC00)%28. ㅁ = 16 → 음슴체. */
+const JONGSEONG_MIEUM = 16;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * C. 부적절한 표현.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** 완성형 비속어. (졸라/존나 계열은 함정 처리를 위해 아래 별도 패턴으로 뺐다) */
+export const PROFANITY_WORDS: string[] = [
+    '병신',
+    '씨발',
+    '시발',
+    '씨빨',
+    '시빨',
+    '씨바',
+    '시바',
+    '좆',
+    '좃',
+    '개새끼',
+    '새끼',
+    '지랄',
+    '닥쳐',
+    '꺼져',
+    '미친놈',
+    '미친년',
+    '조낸',
+    '존내',
+    '존나' // ← 존나 는 함정이 없어 완성형에 둔다
+];
+
+/** 초성 비속어 (조합만 — "ㅈ" 단독 금지: 오탐 폭발). */
+export const PROFANITY_INITIALS: string[] = [
+    'ㅂㅅ',
+    'ㅅㅂ',
+    'ㅈ같',
+    'ㅈㄴ',
+    'ㅈㄹ',
+    'ㅁㅊ',
+    'ㄷㅊ',
+    'ㄲㅈ',
+    'ㅄ',
+    'ㅅ끼', // 새끼 초성 변형 ("ㅅ끼")
+    'ㅈ만' // 좆만 초성 변형 ("ㅈ만한") — ㅈ 단독 아님(조합)
+];
+
+/** 정규식 메타문자 이스케이프. */
+function esc(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * 비속어 패턴 집합.
+ * - 완성형/초성: 상수 배열에서 조립.
+ * - 졸라/졸래: 비속어지만 "졸라매다/졸라서(끈)"는 예외 → 부정 선읽기로 제외.
+ */
+const PROFANITY_PATTERNS: RegExp[] = [
+    new RegExp(PROFANITY_WORDS.map(esc).join('|')),
+    new RegExp(PROFANITY_INITIALS.map(esc).join('|')),
+    // 졸라/졸래(=졸래) 세기 표현. 단, 졸라매·졸라서(끈 졸라매다)는 비속어 아님.
+    /졸(라|래)(?!매|맸|맬|맨|맵|맴|맴|서|맸|매다)/
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+ * D. 예외(최우선). 감탄사/자모 노이즈, 이모지, 링크/태그/코드/숫자.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** 웃음/노이즈 자모 (감탄·자모 단독 skip 용). 비속어 초성(ㅂㅅㅈ…)은 넣지 않는다. */
+const LAUGHTER_JAMO_RE = /[ㅋㅎㄷㅠㅜㅗㅡ]/g;
+
+/** 짧은 감탄사 단독 (와·헐·ㄷㄷ·ㅋㅋ 류). */
+export const INTERJECTION_WORDS: string[] = [
+    '와우',
+    '우와',
+    '와',
+    '헐',
+    '헉',
+    '흠',
+    '음',
+    '앗',
+    '악',
+    '오오',
+    '오',
+    '어머',
+    '휴',
+    '아이고',
+    '에이',
+    '대박',
+    '헐헐'
+];
+
+/** 이모지/기호 픽토그램 범위. */
+const EMOJI_RE =
+    /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}\u{200D}\u{24C2}\u{1F1E6}-\u{1F1FF}]/gu;
+
+/* ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * D. 예외 제거: 인용문(blockquote·줄앞 >)·이미지/앙티콘·코드·링크·태그·이모지 제거.
+ * 남는 것은 "글쓴이 자신의 평문"이어야 한다(남의 인용은 넛지 대상이 아니다).
+ */
+function sanitize(raw: string): string {
+    if (!raw) return '';
+    let t = raw;
+    // 인용(Tiptap = blockquote): 내용까지 통째로 제거
+    t = t.replace(/<blockquote[\s\S]*?<\/blockquote>/gi, ' ');
+    // 코드/이미지(앙티콘 포함)
+    t = t.replace(/<pre[\s\S]*?<\/pre>/gi, ' ');
+    t = t.replace(/<code[\s\S]*?<\/code>/gi, ' ');
+    t = t.replace(/<img[^>]*>/gi, ' ');
+    // 기타 태그
+    t = t.replace(/<[^>]+>/g, ' ');
+    // 엔티티
+    t = t
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&amp;/gi, '&')
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;/g, "'");
+    // 줄앞 인용(>) 라인은 통째로 제거 — 남의 말이라 넛지 대상 아님
+    t = t
+        .split('\n')
+        .filter((line) => !/^\s*>+/.test(line))
+        .join('\n');
+    // 코드스팬/블록
+    t = t.replace(/```[\s\S]*?```/g, ' ').replace(/`[^`]*`/g, ' ');
+    // 링크
+    t = t.replace(/https?:\/\/\S+/gi, ' ').replace(/www\.\S+/gi, ' ');
+    // 이모지
+    t = t.replace(EMOJI_RE, ' ');
+    return t;
+}
+
+/** D③⑤: 남는 게 감탄사/자모/링크/#태그/코드/숫자뿐이면 skip. */
+function isSkippable(clean: string): boolean {
+    let s = clean
+        .replace(/https?:\/\/\S+/gi, ' ')
+        .replace(/www\.\S+/gi, ' ')
+        .replace(/#[^\s#]+/g, ' ')
+        .replace(/`[^`]*`/g, ' ')
+        .replace(/[0-9]+/g, ' ');
+    for (const w of INTERJECTION_WORDS) s = s.split(w).join(' ');
+    s = s.replace(LAUGHTER_JAMO_RE, ' ');
+    // 한글 음절/자모/라틴 문자만 남긴다. (비속어 초성 ㅂㅅ 등은 자모라 남는다)
+    s = s.replace(/[^가-힣ㄱ-ㅣa-zA-Z]/g, '');
+    return s.length === 0;
+}
+
+/** 끝단 어미 분석용: 뒤쪽 문장부호/웃음/공백을 벗겨 마지막 의미 토막을 남긴다. */
+function tailToken(clean: string): string {
+    let t = clean.replace(/\s+$/u, '');
+    // 반복적으로 뒤쪽 노이즈 제거
+    for (let i = 0; i < 4; i++) {
+        t = t.replace(/[\s.,!?~…·「」『』"'`)\]\}*_\-]+$/u, '').replace(/[ㅋㅎㄷㅠㅜㅗㅡ]+$/u, '');
+    }
+    return t;
+}
+
+/** A. 존댓말 마커가 하나라도 있나. */
+function isHonorific(clean: string): boolean {
+    return HONORIFIC_PATTERNS.some((re) => re.test(clean));
+}
+
+/** B. 음슴체/체언 종결(중립)인가. */
+function isNeutralEnding(clean: string): boolean {
+    const tail = tailToken(clean);
+    if (!tail) return true; // 한글 없음 → 중립 취급
+    if (NEUTRAL_ENDING_WORDS.some((w) => tail.endsWith(w))) return true;
+    const last = tail.charCodeAt(tail.length - 1);
+    if (last >= 0xac00 && last <= 0xd7a3) {
+        const jong = (last - 0xac00) % 28;
+        if (jong === JONGSEONG_MIEUM) return true; // ~ㅁ 받침 = 음슴체
+    }
+    return false;
+}
+
+/** A. 반말 종결로 끝나나. */
+function hasBanmalEnding(clean: string): boolean {
+    const tail = tailToken(clean);
+    if (!tail) return false;
+    return BANMAL_END_RE.test(tail);
+}
+
+/** C. 비속어/초성이 있나. */
+function hasProfanity(clean: string): boolean {
+    return PROFANITY_PATTERNS.some((re) => re.test(clean));
+}
+
+/**
+ * 본문(글/댓글)을 검사한다. **순수함수** — 입력만 보고 결정, 부수효과 없음.
+ *
+ * @param text 원문(HTML 허용 — Tiptap 출력). 내부에서 예외(D) 제거 후 판정.
+ * @returns { politeness, profanity } — 각 true = 해당 넛지 발동 후보.
+ */
+export function checkContent(text: string): ContentCheck {
+    const clean = sanitize(text);
+    const trimmed = clean.replace(/\s+/g, ' ').trim();
+
+    // C. 부적절 매칭 (예외 제거된 평문에 대해서만 = 인용 속 욕은 안 잡는다)
+    const profanity = trimmed ? hasProfanity(trimmed) : false;
+
+    // D. 노이즈뿐이면 skip (단, 비속어가 잡혔으면 skip 하지 않는다)
+    if (!profanity && isSkippable(clean)) {
+        return { politeness: false, profanity: false };
+    }
+    if (!trimmed) {
+        return { politeness: false, profanity };
+    }
+
+    // A/B. 존댓 있으면 통과 / 없고 반말종결이며 음슴체 아니면 flag
+    let politeness = false;
+    if (!isHonorific(clean) && !isNeutralEnding(clean) && hasBanmalEnding(clean)) {
+        politeness = true;
+    }
+
+    return { politeness, profanity };
+}


### PR DESCRIPTION
## 요약
작성 시점에 반말/비속어를 감지해 부드러운 넛지를 띄우는 기능(글·댓글). **순수 정규식·AI 호출 0**. 예방으로 신고→판정→주의 체인을 줄이는 목적.

## 안전장치
- **observe-first**: `NUDGE_ENFORCED=false` — 지금은 **넛지 미표시·관측(console.info)만**. 켜는 건 별도 결정.
- **soft**: 켜져도 [무시하고 글쓰기]로 통과(차단 아님).
- 리스트·패턴은 상수 배열(단어 추가/삭제 한 줄).

## 검출 (A~D)
- 반말 종결어미(존댓말 마커 있으면 통과) · 초성비속어(ㅂㅅ·ㅈㄴ 등, ㅈ단독 제외) · **음슴체/체언 종결 예외** · 인용(blockquote)·이모티콘·감탄사 제외

## 검증
- 단위테스트 25/25
- **실데이터 600건**(Evaluator, 별도): 정상 댓글 오탐 3.3% / 신고 22·23 검출 31.5% — 잡힌 건 실제 반말/비속어, 못 잡은 다수는 존댓말 정치 파일온(안 잡는 게 맞음)
- observe-first라 카나리 사용자 영향 0. 오탐 튜닝은 관측 창에서.

## UI
- 앙티콘 모달(`ANGTICON_SRC` 상수) + [수정]/[무시하고 글쓰기]. '신고' 겁주는 문구 없음.