### PR TITLE
fix(reaction): import-image 리액션 액박 — 죽은 경로·틀린 확장자·없는 파일

### DIFF
--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -289,6 +289,32 @@
         document.addEventListener('click', handleClickOutside);
         return () => document.removeEventListener('click', handleClickOutside);
     });
+    /**
+     * 이모티콘 이미지가 404 일 때 대체 표시.
+     *
+     * ⛔ `import-image:` 리액션 76개 중 19개는 원본 파일이 **서버 어디에도 없다**
+     *    (2026-08-29 전수 확인). 지우면 리액션 수가 줄어 이상해지므로 남기되,
+     *    액박 대신 중립 아이콘을 보여준다.
+     * ⛔ 대체 이미지도 실패하면 무한 루프가 되므로 한 번만 바꾼다.
+     */
+    const BROKEN_ICON =
+        'data:image/svg+xml;utf8,' +
+        encodeURIComponent(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">' +
+                '<circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" ' +
+                'stroke-width="1.5" opacity=".45"/>' +
+                '<path d="M7 8.2a3 3 0 0 1 5.6 1.3c0 2-2.6 2.2-2.6 3.8" fill="none" ' +
+                'stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity=".45"/>' +
+                '<circle cx="10" cy="15.4" r=".9" fill="currentColor" opacity=".45"/>' +
+                '</svg>'
+        );
+
+    function handleIconError(event: Event) {
+        const img = event.currentTarget as HTMLImageElement | null;
+        if (!img || img.dataset.fallbackApplied === '1') return;
+        img.dataset.fallbackApplied = '1';
+        img.src = BROKEN_ICON;
+    }
 </script>
 
 <div class="reaction-bar-root relative inline-flex flex-wrap items-center gap-1.5">
@@ -320,7 +346,12 @@
                             media="(prefers-reduced-motion: reduce)"
                         />
                     {/if}
-                    <img src={display.url} alt={display.label} class="h-5 w-5 object-scale-down" />
+                    <img
+                        src={display.url}
+                        alt={display.label}
+                        class="h-5 w-5 object-scale-down"
+                        onerror={handleIconError}
+                    />
                 </picture>
             {:else}
                 <span class="text-base leading-none">{display.emoji}</span>

--- a/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
+++ b/apps/web/src/lib/components/features/reaction/reaction-bar.svelte
@@ -6,7 +6,8 @@
         getReactionDisplay,
         generateDocumentTargetId,
         generateCommentTargetId,
-        generateParentId
+        generateParentId,
+        BROKEN_REACTION_ICON
     } from '$lib/types/reaction.js';
     import {
         REACTION_CATEGORIES,
@@ -290,12 +291,15 @@
         return () => document.removeEventListener('click', handleClickOutside);
     });
     /**
-     * 이모티콘 이미지가 404 일 때 대체 표시.
+     * 이모티콘 이미지가 404 일 때의 **일반 안전망**.
      *
-     * ⛔ `import-image:` 리액션 76개 중 19개는 원본 파일이 **서버 어디에도 없다**
-     *    (2026-08-29 전수 확인). 지우면 리액션 수가 줄어 이상해지므로 남기되,
-     *    액박 대신 중립 아이콘을 보여준다.
+     * ⭐ `import-image:` 액박은 이걸로 막지 않는다 — `getReactionDisplay` 가
+     *    처음부터 올바른 URL(또는 data URI)을 주도록 고쳤다. 소비 지점이 셋이라
+     *    (리액션바·리액터 다이얼로그·emoji-awards 위젯) 근원에서 고치는 쪽이 맞다.
+     *    이 핸들러는 그 밖의 이미지가 깨졌을 때를 위한 여분이다.
      * ⛔ 대체 이미지도 실패하면 무한 루프가 되므로 한 번만 바꾼다.
+     * ⛔ `<picture>` 안에서 `<source media>` 가 매칭되면 `img.src` 교체가 무시된다.
+     *    (import-image 는 staticUrl 이 없어 source 가 안 생기므로 이번 건엔 무해)
      */
     const BROKEN_ICON =
         'data:image/svg+xml;utf8,' +
@@ -313,7 +317,7 @@
         const img = event.currentTarget as HTMLImageElement | null;
         if (!img || img.dataset.fallbackApplied === '1') return;
         img.dataset.fallbackApplied = '1';
-        img.src = BROKEN_ICON;
+        img.src = BROKEN_REACTION_ICON;
     }
 </script>
 

--- a/apps/web/src/lib/config/reaction-config.ts
+++ b/apps/web/src/lib/config/reaction-config.ts
@@ -219,10 +219,16 @@ const NOTO_ANIMOJI: EmoticonDef[] = [
     }
 ];
 
-// 리액션 교체 맵 (PHP와 동일: emoji:1f389 → import-image:ezgif-55990bc446328e)
-export const REACTION_REPLACE: Record<string, string> = {
-    'emoji:1f389': 'import-image:ezgif-55990bc446328e'
-};
+/**
+ * 리액션 교체 맵.
+ *
+ * ⛔ 2026-08-29 비움. 예전에는 `emoji:1f389` → `import-image:ezgif-55990bc446328e` 였는데,
+ *    그 이미지 파일이 **서버 어디에도 없다**(legacy-data·staging·아카이브 전부 확인).
+ *    그래서 회원이 🎉 를 누를 때마다 **액박이 새로 만들어지고 있었다** —
+ *    실측 25행 48회로 다른 import-image(1~4회)보다 압도적이었던 이유다.
+ *    파일을 되찾으면 그때 되살린다. 그 전까지는 🎉 를 그대로 쓴다.
+ */
+export const REACTION_REPLACE: Record<string, string> = {};
 
 /** 전체 이모티콘 목록 */
 export const REACTION_EMOTICONS: EmoticonDef[] = [...EMOJIS, ...ANGTICONS, ...NOTO_ANIMOJI];

--- a/apps/web/src/lib/types/reaction.ts
+++ b/apps/web/src/lib/types/reaction.ts
@@ -87,6 +87,90 @@ export function hexToEmoji(hex: string): string {
 }
 
 /** 리액션의 표시 정보를 동적으로 생성 */
+/**
+ * `import-image:` 리액션의 실제 확장자 표.
+ *
+ * ⭐ 이 집합은 **닫혀 있다.** `REACTION_REPLACE` 를 비운 뒤로 새 `import-image` 는
+ *    생기지 않고, 이모티콘 피커도 이 종류를 제공하지 않는다. 그래서 표가 정본이다.
+ * ⛔ 소비 코드가 `.webp` 를 하드코딩해 왔는데 실제로는 gif 40 · webp 9 · jpg 8 이다.
+ *    (2026-08-29 `g5_da_reaction` 76개 × legacy-data 전수 대조)
+ */
+const IMPORT_IMAGE_EXT: Record<string, string> = {
+    'damoang-air-001': 'webp',
+    'damoang-air-003': 'gif',
+    'damoang-air-004': 'gif',
+    'damoang-air-005': 'webp',
+    'damoang-air-006': 'gif',
+    'damoang-air-010': 'gif',
+    'damoang-air-011': 'gif',
+    'damoang-emo-000': 'gif',
+    'damoang-emo-004': 'gif',
+    'damoang-emo-005': 'gif',
+    'damoang-emo-006': 'gif',
+    'damoang-emo-007': 'gif',
+    'damoang-emo-008': 'gif',
+    'damoang-emo-011': 'gif',
+    'damoang-emo-012': 'gif',
+    'damoang-emo-014': 'gif',
+    'damoang-emo-015': 'gif',
+    'damoang-emo-016': 'gif',
+    'damoang-emo-017': 'gif',
+    'damoang-emo-023': 'gif',
+    'damoang-emo-025': 'gif',
+    'damoang-emo-026': 'gif',
+    'damoang-emo-028': 'gif',
+    'damoang-emo-029': 'gif',
+    'damoang-emo-030': 'gif',
+    'damoang-emo-031': 'gif',
+    'damoang-emo-033': 'webp',
+    'damoang-emo-036': 'webp',
+    'damoang-emo-037': 'webp',
+    'damoang-emo-038': 'gif',
+    'damoang-emo-040': 'gif',
+    'damoang-emo-041': 'gif',
+    'damoang-emo-042': 'gif',
+    'damoang-emo-043': 'gif',
+    'damoang-meme-002': 'gif',
+    'damoang-meme-007': 'webp',
+    'damoang-meme-016': 'webp',
+    'damoang-meme-023': 'webp',
+    'damoang-meme-030': 'gif',
+    'damoang-meme-037': 'gif',
+    'damoang-meme-63': 'webp',
+    'damoang-meme-69': 'jpg',
+    'logo-muzia': 'jpg',
+    'moon-emo-016': 'gif',
+    'onion-001': 'gif',
+    'onion-006': 'gif',
+    'onion-038': 'gif',
+    'onion-113': 'gif',
+    'onion-161': 'gif',
+    'onion-254': 'gif',
+    'onion-269': 'gif',
+    'president-003': 'jpg',
+    'president-006': 'jpg',
+    'welcome-001': 'jpg',
+    'welcome-002': 'jpg',
+    'welcome-003': 'jpg',
+    'welcome-004': 'jpg'
+};
+
+/**
+ * 원본이 서버에 남아 있지 않은 19개용 중립 아이콘.
+ *
+ * ⛔ 리액션 행을 지우면 반응 수가 줄어 이상해지므로 남긴다. 네트워크를 타지 않는
+ *    data URI 라 404 가 나지 않는다(`img-src 'self' data: blob: https:` 로 CSP 통과 확인).
+ */
+export const BROKEN_REACTION_ICON =
+    'data:image/svg+xml;utf8,' +
+    encodeURIComponent(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">' +
+            '<circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".45"/>' +
+            '<path d="M7 8.2a3 3 0 0 1 5.6 1.3c0 2-2.6 2.2-2.6 3.8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity=".45"/>' +
+            '<circle cx="10" cy="15.4" r=".9" fill="currentColor" opacity=".45"/>' +
+            '</svg>'
+    );
+
 export function getReactionDisplay(reaction: string): {
     renderType: ReactionRenderType;
     emoji?: string;
@@ -141,12 +225,18 @@ export function getReactionDisplay(reaction: string): {
                 label: `Noto ${reactionId}`
             };
         }
-        case 'import-image':
+        case 'import-image': {
+            const ext = IMPORT_IMAGE_EXT[reactionId];
             return {
                 renderType: 'image',
-                url: `/api/emoticons/da_reaction/${reactionId}.webp`,
+                // ⛔ da_reaction 경로를 쓰면 안 된다. 그 요청은 호스트 nginx 규칙에 없어
+                //    파드의 SvelteKit 라우트로 가는데, 파드에는 `/home/damoang/legacy-data`
+                //    가 마운트돼 있지 않아 **항상 404** 다(2026-08-29 파드 안에서 실측).
+                //    nariya 는 호스트 nginx 가 alias 로 직접 서빙해 200 이다 — 같은 파일이다.
+                url: ext ? `/api/emoticons/nariya/${reactionId}.${ext}` : BROKEN_REACTION_ICON,
                 label: `이미지 ${reactionId}`
             };
+        }
         default:
             return { renderType: 'emoji', emoji: reaction, label: reaction };
     }

--- a/apps/web/src/routes/api/emoticons/[...path]/+server.ts
+++ b/apps/web/src/routes/api/emoticons/[...path]/+server.ts
@@ -23,20 +23,8 @@ const MIME_TYPES: Record<string, string> = {
 
 const ALLOWED_DIRS: Record<string, string> = {
     nariya: '/home/damoang/legacy-data/emoticons',
-    // 2026-08-29: 원래 PHP 플러그인 경로(`/home/damoang/www/plugin/da_reaction/public/emoticon-images`)
-    // 를 가리켰는데 그 디렉터리는 서버에 **존재하지 않는다**. `import-image:` 리액션 139행이
-    // 전부 액박이었다(글 34개). 실제 파일은 legacy-data 에 살아 있으므로 같은 곳을 본다.
-    da_reaction: '/home/damoang/legacy-data/emoticons'
+    da_reaction: '/home/damoang/www/plugin/da_reaction/public/emoticon-images'
 };
-
-/**
- * 확장자 폴백 순서.
- *
- * ⛔ `import-image:` 리액션은 확장자 없이 이름만 저장한다(`import-image:damoang-emo-008`).
- *    소비 코드가 `.webp` 를 하드코딩해 왔는데 실제 파일은 `.gif` 49개 / `.jpg` 8개다.
- *    그래서 경로만 고쳐도 여전히 안 나온다 — 확장자를 찾아 줘야 한다.
- */
-const EXT_FALLBACK = ['webp', 'gif', 'png', 'jpg', 'jpeg'] as const;
 
 const CACHE_HEADERS = {
     'Cache-Control': 'public, max-age=31536000, immutable',
@@ -71,30 +59,16 @@ export const GET: RequestHandler = async ({ params }) => {
 
     // 로컬 파일에서 서빙
     const baseDir = ALLOWED_DIRS[dirKey];
-    // 요청된 확장자를 먼저 보고, 없으면 같은 이름의 다른 확장자를 찾는다.
-    // ⛔ 후보마다 baseDir 하위인지 다시 확인한다 — 확장자만 바꾼다고 안전이 보장되지 않는다.
-    const stem = filename.slice(0, filename.length - ext.length - 1);
-    const candidates = [
-        filename,
-        ...EXT_FALLBACK.filter((e) => e !== ext).map((e) => `${stem}.${e}`)
-    ];
+    const filePath = resolve(baseDir, filename); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
 
-    for (const candidate of candidates) {
-        const candidateExt = candidate.split('.').pop()?.toLowerCase() || '';
-        const candidateMime = MIME_TYPES[candidateExt];
-        if (!candidateMime) continue;
-
-        // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
-        const candidatePath = resolve(baseDir, candidate);
-        if (!candidatePath.startsWith(baseDir) || !existsSync(candidatePath)) continue;
-
+    if (filePath.startsWith(baseDir) && existsSync(filePath)) {
         try {
-            const data = await readFile(candidatePath);
+            const data = await readFile(filePath);
             return new Response(data, {
-                headers: { 'Content-Type': candidateMime, ...CACHE_HEADERS }
+                headers: { 'Content-Type': mimeType, ...CACHE_HEADERS }
             });
         } catch {
-            // 읽기 실패 — 다음 후보로
+            // 읽기 실패
         }
     }
 

--- a/apps/web/src/routes/api/emoticons/[...path]/+server.ts
+++ b/apps/web/src/routes/api/emoticons/[...path]/+server.ts
@@ -23,8 +23,20 @@ const MIME_TYPES: Record<string, string> = {
 
 const ALLOWED_DIRS: Record<string, string> = {
     nariya: '/home/damoang/legacy-data/emoticons',
-    da_reaction: '/home/damoang/www/plugin/da_reaction/public/emoticon-images'
+    // 2026-08-29: 원래 PHP 플러그인 경로(`/home/damoang/www/plugin/da_reaction/public/emoticon-images`)
+    // 를 가리켰는데 그 디렉터리는 서버에 **존재하지 않는다**. `import-image:` 리액션 139행이
+    // 전부 액박이었다(글 34개). 실제 파일은 legacy-data 에 살아 있으므로 같은 곳을 본다.
+    da_reaction: '/home/damoang/legacy-data/emoticons'
 };
+
+/**
+ * 확장자 폴백 순서.
+ *
+ * ⛔ `import-image:` 리액션은 확장자 없이 이름만 저장한다(`import-image:damoang-emo-008`).
+ *    소비 코드가 `.webp` 를 하드코딩해 왔는데 실제 파일은 `.gif` 49개 / `.jpg` 8개다.
+ *    그래서 경로만 고쳐도 여전히 안 나온다 — 확장자를 찾아 줘야 한다.
+ */
+const EXT_FALLBACK = ['webp', 'gif', 'png', 'jpg', 'jpeg'] as const;
 
 const CACHE_HEADERS = {
     'Cache-Control': 'public, max-age=31536000, immutable',
@@ -59,16 +71,30 @@ export const GET: RequestHandler = async ({ params }) => {
 
     // 로컬 파일에서 서빙
     const baseDir = ALLOWED_DIRS[dirKey];
-    const filePath = resolve(baseDir, filename); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+    // 요청된 확장자를 먼저 보고, 없으면 같은 이름의 다른 확장자를 찾는다.
+    // ⛔ 후보마다 baseDir 하위인지 다시 확인한다 — 확장자만 바꾼다고 안전이 보장되지 않는다.
+    const stem = filename.slice(0, filename.length - ext.length - 1);
+    const candidates = [
+        filename,
+        ...EXT_FALLBACK.filter((e) => e !== ext).map((e) => `${stem}.${e}`)
+    ];
 
-    if (filePath.startsWith(baseDir) && existsSync(filePath)) {
+    for (const candidate of candidates) {
+        const candidateExt = candidate.split('.').pop()?.toLowerCase() || '';
+        const candidateMime = MIME_TYPES[candidateExt];
+        if (!candidateMime) continue;
+
+        // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+        const candidatePath = resolve(baseDir, candidate);
+        if (!candidatePath.startsWith(baseDir) || !existsSync(candidatePath)) continue;
+
         try {
-            const data = await readFile(filePath);
+            const data = await readFile(candidatePath);
             return new Response(data, {
-                headers: { 'Content-Type': mimeType, ...CACHE_HEADERS }
+                headers: { 'Content-Type': candidateMime, ...CACHE_HEADERS }
             });
         } catch {
-            // 읽기 실패
+            // 읽기 실패 — 다음 후보로
         }
     }
 


### PR DESCRIPTION
`import-image:` 리액션 **139행 / 글 34개**가 전부 액박이었습니다.

⛔ **첫 시도는 운영에서 동작하지 않았습니다.** 독립 검증이 반증했고, 그 반증을 반영해 다시 짰습니다.

## 왜 첫 시도가 틀렸나

```
kubectl exec angple-web -c web -- ls /home/damoang/legacy-data/emoticons
→ No such file or directory
```

web 은 **k8s 파드**에서 돌고 그 디렉터리를 마운트하지 않습니다. 저는 **호스트에서 `ls` 해보고** 「파일이 살아 있다」고 결론지었습니다. 서버 라우트를 고쳐도 배포 후 **그대로 404** 였습니다.

## 실제 수정

**이미 200 으로 동작 중인 경로**를 씁니다. 호스트 nginx 가 `^~ /api/emoticons/nariya/` 를 alias 로 직접 서빙하고, 그 디렉터리가 곧 legacy-data 입니다 — **같은 파일**입니다.

| | |
|---|---|
| 확장자 | **gif 40 · webp 9 · jpg 8** = 57개 |
| 원본 없음 | 19개 → **요청조차 안 보내고** data URI 아이콘 |
| 신규 액박 생성 | **중단** (`REACTION_REPLACE` 비움) |

⭐ 이 집합은 **닫혀 있습니다.** 교체 맵을 비운 뒤로 새 `import-image` 는 생기지 않고 피커도 제공하지 않습니다. 그래서 정적 표가 취약하지 않고 **정본**입니다.

⭐ 소비 지점이 셋(리액션바 · 리액터 다이얼로그 · emoji-awards 위젯)인데 전부 `display.url` 을 씁니다. **근원에서 고치면 세 곳이 동시에 해결**됩니다. 첫 시도는 리액션바에만 폴백을 달아 나머지 둘이 남아 있었습니다.

## 검증

- **57개 URL 을 오리진에 직접 요청 → 57/57 HTTP 200**
- svelte 컴파일 OK (⛔ **대조군도 돌려** 도구 신뢰성 확인)
- TypeScript 구문 OK
- CSP `img-src 'self' data: blob: https:` → data URI 폴백 통과 확인
- SSR: 배지는 `$effect` 에서만 생성돼 SSR HTML 에 0개 → 하이드레이션 불일치 없음

## ⛔ 이 PR 이 고치지 않는 것

**이미 🎉 를 누른 50건**은 `import-image:ezgif-…` 로 남습니다. 폴백 아이콘으로 보일 뿐입니다.
그리고 `g5_da_reaction_choose` 의 유니크 키가 `reaction` 을 포함해, 같은 사람이 같은 글에서 🎉 를 다시 누르면 **칩이 2개**가 됩니다. 데이터 마이그레이션은 **별건**으로 다뤄야 합니다.

## 정정

첫 커밋 본문의 「gif 49 / jpg 8」은 **오류**였습니다. 우선순위 없이 첫 확장자를 집어 **webp 9개를 gif 로** 셌습니다.