### PR TITLE
나눔 당첨자 닉네임 클릭 → 프로필/쪽지 (규링 #13786)

### DIFF
--- a/apps/web/src/lib/features/giving/draw-result.svelte
+++ b/apps/web/src/lib/features/giving/draw-result.svelte
@@ -2,6 +2,7 @@
     import type { GivingDrawResult } from './api.js';
     import { methodLabel } from './methods.js';
     import { simulateLadder } from './pure/ladder.js';
+    import AuthorLink from '$lib/components/ui/author-link/author-link.svelte';
 
     let { draw }: { draw: GivingDrawResult } = $props();
 
@@ -54,7 +55,7 @@
         {#if draw.method === 'lowest_unique' && draw.winning_number != null}
             <p class="text-foreground text-sm">
                 당첨 번호 <strong class="text-primary">{draw.winning_number}</strong> —
-                <strong>{nick(winners[0])}</strong>
+                <strong><AuthorLink authorId={winners[0]} authorName={nick(winners[0])} /></strong>
             </p>
         {:else}
             <p class="text-foreground mb-1 text-sm">당첨자</p>
@@ -63,7 +64,7 @@
                     <li
                         class="rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
                     >
-                        {nick(w)}
+                        <AuthorLink authorId={w} authorName={nick(w)} />
                     </li>
                 {/each}
             </ul>


### PR DESCRIPTION
버그판 #13786(규링, 기능제안) 대응. 나눔 당첨자 닉이 plain text 라 당첨자가 글·댓글 이력 없으면 검색해 쪽지 보내기가 어려움. draw-result 의 당첨자(단일 lowest_unique·다수 목록)를 재사용 AuthorLink 로 감싸 '프로필 보기'·'쪽지 보내기' 드롭다운 제공. 비로그인은 기존 plain 표시로 degrade.