### PR TITLE
버그판 배치: 목록 긴 닉 오터치 완화 + 헤더 스크랩 바로가기

### DIFF
--- a/apps/web/src/lib/components/layout/header.svelte
+++ b/apps/web/src/lib/components/layout/header.svelte
@@ -4,6 +4,7 @@
     import Search from '@lucide/svelte/icons/search';
     import User from '@lucide/svelte/icons/user';
     import Bell from '@lucide/svelte/icons/bell';
+    import Bookmark from '@lucide/svelte/icons/bookmark';
     import X from '@lucide/svelte/icons/x';
     import Home from '@lucide/svelte/icons/home';
     import Sun from '@lucide/svelte/icons/sun';
@@ -488,6 +489,16 @@
             {/if}
 
             {#if !authResolving && isEffectivelyLoggedIn}
+                <!-- 스크랩 바로가기 (버그판 #13725: 스크랩 접근성) -->
+                <a
+                    href="/my/scraps"
+                    class="hover:bg-accent relative rounded-lg p-2 transition-all duration-200 ease-out"
+                    aria-label="내 스크랩"
+                >
+                    <span class="pointer-events-none absolute -inset-1"></span>
+                    <Bookmark class="text-muted-foreground h-5 w-5" />
+                </a>
+
                 <!-- 쪽지 아이콘 + 미읽음 배지 -->
                 <MessageIcon />
 

--- a/apps/web/src/lib/components/ui/author-link/author-link.svelte
+++ b/apps/web/src/lib/components/ui/author-link/author-link.svelte
@@ -235,7 +235,7 @@
               모바일은 기본 텍스트 너비만큼만 클릭 영역 — 제목 의도 터치 보호.
             -->
             <DropdownMenu.Trigger
-                class="inline-block cursor-pointer text-left hover:underline focus:outline-none {touchAreaClass} {nowrapClass} {className} {isWithdrawn
+                class="inline-block max-w-[11rem] cursor-pointer truncate text-left align-middle hover:underline focus:outline-none {touchAreaClass} {nowrapClass} {className} {isWithdrawn
                     ? 'line-through opacity-60'
                     : ''}"
             >


### PR DESCRIPTION
버그판 사용자 불편 2건. #13805 모바일 목록서 긴 닉네임이 글 탭을 가로챔 → AuthorLink 트리거 max-w-[11rem] truncate 바운드(긴 닉만 말줄임). #13725 스크랩 접근성(프로필>활동내역 깊이) → 헤더 쪽지·알림 옆 북마크 아이콘(→/my/scraps). ⚠️AuthorLink 변경은 닉 렌더 전반 영향(11rem 초과만 말줄임)이라 카나리 눈확인 권장.