### PR TITLE
fix(rss): 조건부 요청(ETag) 지원 — 매 폴링마다 본문을 새로 만들던 것

### DIFF
--- a/apps/web/src/routes/rss/+server.ts
+++ b/apps/web/src/routes/rss/+server.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from './$types';
+import { rssEtag, etagMatches, rssHeaders } from './headers.js';
 import pool from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
@@ -7,7 +8,7 @@ import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-ma
  * 전체 RSS 피드 (최근 게시글)
  * RSS 2.0 규격
  */
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async ({ url, request }) => {
     const siteUrl = url.origin;
     const siteTitle = import.meta.env.VITE_SITE_NAME || 'Angple';
     const siteDescription = `${siteTitle} 커뮤니티 - 최근 게시글`;
@@ -109,12 +110,12 @@ ${items}
   </channel>
 </rss>`;
 
-    return new Response(xml, {
-        headers: {
-            'Content-Type': 'application/rss+xml; charset=utf-8',
-            'Cache-Control': 'max-age=1800'
-        }
-    });
+    // ⭐ 본문을 만든 뒤 해시로 판정한다. 삭제·수정·마스킹 무엇이든 여기 반영된다.
+    const etag = rssEtag(xml);
+    if (etagMatches(request, etag)) {
+        return new Response(null, { status: 304, headers: rssHeaders(etag) });
+    }
+    return new Response(xml, { headers: rssHeaders(etag) });
 };
 
 /** HTML 태그를 반복 제거 (중첩 태그 우회 방지) */

--- a/apps/web/src/routes/rss/[boardId]/+server.ts
+++ b/apps/web/src/routes/rss/[boardId]/+server.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from './$types';
+import { rssEtag, etagMatches, rssHeaders } from '../headers.js';
 import pool from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
 import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
@@ -17,7 +18,7 @@ const GUEST_LEVEL = 1;
  * 게시판별 RSS 피드
  * RSS 2.0 규격
  */
-export const GET: RequestHandler = async ({ url, params }) => {
+export const GET: RequestHandler = async ({ url, params, request }) => {
     const siteUrl = url.origin;
     const siteTitle = import.meta.env.VITE_SITE_NAME || 'Angple';
     const boardId = params.boardId;
@@ -119,12 +120,12 @@ ${items}
   </channel>
 </rss>`;
 
-    return new Response(xml, {
-        headers: {
-            'Content-Type': 'application/rss+xml; charset=utf-8',
-            'Cache-Control': 'max-age=1800'
-        }
-    });
+    // ⭐ 본문을 만든 뒤 해시로 판정한다. 삭제·수정·마스킹 무엇이든 여기 반영된다.
+    const etag = rssEtag(xml);
+    if (etagMatches(request, etag)) {
+        return new Response(null, { status: 304, headers: rssHeaders(etag) });
+    }
+    return new Response(xml, { headers: rssHeaders(etag) });
 };
 
 /** HTML 태그를 반복 제거 (중첩 태그 우회 방지) */

--- a/apps/web/src/routes/rss/headers.ts
+++ b/apps/web/src/routes/rss/headers.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'crypto';
+
+/**
+ * RSS 조건부 응답(ETag / 304).
+ *
+ * ⛔ `Cache-Control` 과 `Vary` 는 건드리지 않는다. 라우트가 `public, s-maxage=…` 를 줘 봐야
+ *    `/rss` 는 호스트 nginx 가 `proxy_hide_header Cache-Control` 로 벗기고,
+ *    두 피드 모두 Cloudflare 캐시 규칙이 없어 `s-maxage` 가 먹지 않는다(2026-08-31 실측).
+ *    엣지 캐시를 제대로 하려면 nginx·CF 까지 같은 변경 세트로 가야 하므로 별건으로 미룬다.
+ *
+ * ⭐ ETag 는 그 전부와 무관하게 동작한다. 훅이 주는 `max-age=2, must-revalidate` 때문에
+ *    피드 리더는 어차피 매번 재검증하는데, 지금은 그때마다 14.7KB 본문을 새로 만들어 보낸다.
+ *    ETag 가 있으면 내용이 안 바뀐 동안은 **본문 없이 304** 로 끝난다.
+ *
+ * ⛔ `Last-Modified`(최신 글 시각)를 쓰지 않는 이유: 글이 **삭제되거나 수정**되면 그 시각이
+ *    내려가거나 그대로여서, 독자가 자기 시각보다 더 새 글이 올라올 때까지 304 에 갇힌다.
+ *    글 간격이 긴 보드는 그 갇힘이 1~2.4일이다(실측: claim 56.6h · lecture 45.5h · angmap 41.2h).
+ *    본문 해시는 삭제·수정·이용제한 마스킹 무엇이든 반영하므로 그 고장 모드가 없다.
+ */
+export function rssEtag(xml: string): string {
+    return `"${createHash('sha1').update(xml).digest('base64url')}"`;
+}
+
+/** `If-None-Match` 가 현재 ETag 와 같으면 304 로 끝낸다. */
+export function etagMatches(request: Request, etag: string): boolean {
+    const inm = request.headers.get('if-none-match');
+    if (!inm) return false;
+    // 다중 값(`"a", "b"`)과 weak 접두사(`W/`)를 모두 받아준다.
+    return inm
+        .split(',')
+        .map((v) => v.trim().replace(/^W\//, ''))
+        .includes(etag);
+}
+
+/** 200·304 가 함께 쓰는 헤더. ⛔ Cache-Control 은 훅이 정한다 — 여기서 넣지 않는다. */
+export function rssHeaders(etag: string): HeadersInit {
+    return {
+        'Content-Type': 'application/rss+xml; charset=utf-8',
+        ETag: etag
+    };
+}


### PR DESCRIPTION
피드 리더는 5분 주기로 계속 긁어가는데 **304 응답이 0건**이었습니다. 조건부 요청 수단이 아예 없어 **매번 14.7KB 를 새로 만들어** 보냈습니다.

## ⛔ 범위를 줄였습니다

원래 이 PR 은 `Cache-Control` 과 훅 조건까지 바꾸려 했는데, 독립 검증에서 **이득이 없다**는 게 드러나 그 부분을 전부 뺐습니다.

| 뺀 것 | 왜 |
|---|---|
| 라우트 `public, s-maxage=1800` | `/rss` 는 호스트 nginx 가 `proxy_hide_header Cache-Control` 로 **벗깁니다** |
| | 두 피드 모두 **Cloudflare 캐시 규칙이 없어** `s-maxage` 가 무효입니다 |
| 훅 조건에 `/rss` 추가 | 위가 무효면 필요 없습니다. **`hooks.server.ts` 는 origin/main 과 diff 0** |
| `Vary` 변경 | 훅이 정하는 대로 둡니다 |

엣지 캐시는 **nginx·CF 까지 같은 변경 세트**로 가야 해서 별건으로 미룹니다.

⭐ **ETag 는 그 전부와 무관하게 동작합니다.** 훅이 주는 `max-age=2, must-revalidate` 때문에 리더는 어차피 매번 재검증하는데, 지금은 그때마다 본문을 새로 만듭니다.

## ⛔ `Last-Modified` 가 아니라 ETag 인 이유

최신 글 시각을 쓰면 글이 **삭제되거나 수정**될 때 그 시각이 내려가거나 그대로여서, 독자가 **자기 시각보다 더 새 글이 올라올 때까지 304 에 갇힙니다.**

글 간격이 긴 보드는 그 갇힘이 하루를 넘습니다 — 실측 `claim` **56.6시간** · `lecture` **45.5시간** · `angmap` **41.2시간**.

**본문 해시는 삭제·수정·이용제한 마스킹 무엇이든 반영**하므로 그 고장 모드가 없습니다.

## 검증

- **ETag 단위 8/8** — 동일내용 · **글삭제** · 헤더없음 · 일치 · **불일치** · weak접두사(`W/`) · 다중값 · `*`
- 특히 **「글 삭제 → 다른 ETag → 200」** 으로 고착이 없음을 확인
- TS 구문 3개 파일 + **대조군 1개**
- **`hooks.server.ts` diff 0** — 다른 경로에 영향 없음

## 관련

- #2234 (보드 피드 권한·마스킹) 머지 완료. 그 PR 이 먼저 들어가 **누수를 캐시할 위험은 해소**됐습니다.
- 엣지 캐시(nginx·CF)는 별건으로 다시 설계합니다.