### PR TITLE
fix(rss): 보드 피드 권한 게이트 fail-closed + 이용제한 마스킹

### DIFF
--- a/apps/web/src/routes/rss/+server.ts
+++ b/apps/web/src/routes/rss/+server.ts
@@ -17,7 +17,11 @@ export const GET: RequestHandler = async ({ url }) => {
     try {
         // 주요 게시판에서 최근 게시글 20개
         const [boards] = await pool.query<RowDataPacket[]>(
-            'SELECT bo_table, bo_subject FROM g5_board WHERE bo_use_search = 1 ORDER BY bo_order LIMIT 10'
+            // ⛔ `bo_use_search` 만 보면 회원/관리자 전용 보드가 섞인다.
+            //    gnuboard 규약상 비회원 = 레벨 1 이므로 `<= 1` 만 게스트 공개다.
+            `SELECT bo_table, bo_subject FROM g5_board
+              WHERE bo_use_search = 1 AND bo_list_level <= 1 AND bo_read_level <= 1
+              ORDER BY bo_order LIMIT 10`
         );
 
         const allPosts: Array<{

--- a/apps/web/src/routes/rss/[boardId]/+server.ts
+++ b/apps/web/src/routes/rss/[boardId]/+server.ts
@@ -1,6 +1,17 @@
 import type { RequestHandler } from './$types';
 import pool from '$lib/server/db.js';
 import type { RowDataPacket } from 'mysql2';
+import { findDisciplinedIds, DISCIPLINED_TITLE } from '$lib/server/discipline-mask.js';
+
+/**
+ * 게스트에게 공개된 보드의 경계.
+ *
+ * ⛔ gnuboard 규약에서 **비회원 = 레벨 1** 이다(v2 백엔드의 0 과 다르다).
+ *    그래서 `<= 1` 이 「게스트 공개」이고, 2 이상은 회원/관리자 전용이다.
+ *    실측(2026-08-31): 공개 121개 · 제한인데 피드가 열려 있던 것 2개
+ *    (`opsreport` 레벨 10 = 관리자 전용, `promotion_archive` 레벨 5 = 글 20건 실제 노출).
+ */
+const GUEST_LEVEL = 1;
 
 /**
  * 게시판별 RSS 피드
@@ -16,20 +27,40 @@ export const GET: RequestHandler = async ({ url, params }) => {
         return new Response('Invalid board ID', { status: 400 });
     }
 
-    // 게시판 정보 조회
+    // 게시판 정보 조회 + 공개 여부 판정
+    //
+    // ⛔ 예전에는 이 블록이 `catch { /* 무시 */ }` 였다. 조회가 던지면 게이트를 건너뛰고
+    //    그대로 피드를 내줬다 — **fail-open**. 이 게이트가 관리자·소명·이용제한 기록
+    //    게시판을 RSS 로부터 지키는 **유일한 장치**다. 실패하면 닫는다.
     let boardSubject = boardId;
     try {
         const [boards] = await pool.query<RowDataPacket[]>(
-            'SELECT bo_subject, bo_use_search FROM g5_board WHERE bo_table = ? LIMIT 1',
+            `SELECT bo_subject, bo_use_search, bo_list_level, bo_read_level
+             FROM g5_board WHERE bo_table = ? LIMIT 1`,
             [boardId]
         );
-        const row = (boards as Array<{ bo_subject: string; bo_use_search: number }>)[0];
-        if (!row || row.bo_use_search !== 1) {
+        const row = (
+            boards as Array<{
+                bo_subject: string;
+                bo_use_search: number;
+                bo_list_level: number;
+                bo_read_level: number;
+            }>
+        )[0];
+        // ⛔ `bo_use_search` 만으로는 부족하다. 검색에 노출되는 것과 비회원이 본문을
+        //    읽어도 되는 것은 다른 판단이다.
+        const guestVisible =
+            !!row &&
+            row.bo_use_search === 1 &&
+            Number(row.bo_list_level) <= GUEST_LEVEL &&
+            Number(row.bo_read_level) <= GUEST_LEVEL;
+        if (!guestVisible) {
             return new Response('Not Found', { status: 404 });
         }
         boardSubject = row.bo_subject;
-    } catch {
-        // 무시
+    } catch (err) {
+        console.error('[rss] 게시판 공개 여부 조회 실패 — 닫는다', boardId, err);
+        return new Response('Not Found', { status: 404 });
     }
 
     let items = '';
@@ -42,25 +73,34 @@ export const GET: RequestHandler = async ({ url, params }) => {
 			 ORDER BY wr_datetime DESC LIMIT 20`
         );
 
-        items = (
-            posts as Array<{
-                wr_id: number;
-                wr_subject: string;
-                wr_content: string;
-                wr_name: string;
-                wr_datetime: string;
-            }>
-        )
-            .map(
-                (post) => `    <item>
-      <title>${escapeXml(post.wr_subject)}</title>
+        const rows = posts as Array<{
+            wr_id: number;
+            wr_subject: string;
+            wr_content: string;
+            wr_name: string;
+            wr_datetime: string;
+        }>;
+
+        // ⛔ 인덱스 피드(`/rss`)는 이미 이 마스킹을 하는데 보드별 피드에는 없었다.
+        //    `discipline-mask.ts` 주석이 「무조건 마스킹이야말로 인증 무관 캐시의 근거」라고
+        //    적어둔 바로 그 전제를, 정작 보드별 피드가 안 지키고 있었다.
+        const disciplined = await findDisciplinedIds(
+            boardId,
+            rows.map((p) => p.wr_id)
+        );
+
+        items = rows
+            .map((post) => {
+                const masked = disciplined.has(post.wr_id);
+                return `    <item>
+      <title>${escapeXml(masked ? DISCIPLINED_TITLE : post.wr_subject)}</title>
       <link>${siteUrl}/${boardId}/${post.wr_id}</link>
-      <description>${escapeXml(stripHtmlTags(post.wr_content).slice(0, 200))}</description>
+      <description>${escapeXml(masked ? DISCIPLINED_TITLE : stripHtmlTags(post.wr_content).slice(0, 200))}</description>
       <author>${escapeXml(post.wr_name)}</author>
       <pubDate>${new Date(post.wr_datetime).toUTCString()}</pubDate>
       <guid isPermaLink="true">${siteUrl}/${boardId}/${post.wr_id}</guid>
-    </item>`
-            )
+    </item>`;
+            })
             .join('\n');
     } catch (err) {
         console.error('[RSS] %s 피드 생성 실패:', boardId, err);


### PR DESCRIPTION
캐시 작업(#2233) 중 Evaluator 가 찾은 결함입니다. **캐시보다 이게 먼저입니다** — 지금 `private, max-age=2` 가 이 결함들의 가림막 역할을 하고 있습니다.

## 1. 게이트가 fail-open 이었습니다

```ts
} catch {
    // 무시            ← 조회가 던지면 그대로 통과해 피드를 내줬습니다
}
```

이 게이트가 **관리자·소명·이용제한 기록 게시판을 RSS 로부터 지키는 유일한 장치**입니다(`bo_use_search<>1` 38개 — `disciplinelog`·`claim`·`adm`·`governance`·`truthroom` 포함). 실패하면 닫도록 바꾸고 사유를 로그로 남깁니다.

## 2. 레벨 검사가 없었습니다

`bo_use_search` 만 봤습니다. **검색 노출과 비회원 본문 열람은 다른 판단**입니다.

gnuboard 규약상 **비회원 = 레벨 1** 이므로 `bo_list_level <= 1 && bo_read_level <= 1` 만 게스트 공개입니다. (v2 백엔드의 0 과 다릅니다 — 이걸 혼동해 자유게시판이 회원전용으로 뒤집힌 사고 이력이 있습니다.)

**실측 (2026-08-31)**

| | |
|---|---|
| 공개 **121개** | 영향 없음 |
| **새로 차단 2개** | `opsreport` (레벨 **10** = 관리자 전용) |
| | `promotion_archive` (레벨 5) — ⛔ **비로그인에게 글 20건·16,990바이트 실제 노출 중** |

## 3. 보드 피드에만 이용제한 마스킹이 없었습니다

인덱스 피드(`/rss`)는 `findDisciplinedIds` 를 부르는데 **보드별은 안 불렀습니다.**

`discipline-mask.ts` 주석이 **「무조건 마스킹이야말로 인증 무관 캐시의 근거」**라고 적어둔 그 전제를, 정작 보드별 피드가 안 지키고 있었습니다.

인덱스 피드의 보드 선택에도 같은 레벨 필터를 넣었습니다.

## 검증

- **게이트 단위 9/9** — 공개 · level0 · 레벨5 · 레벨10 · read만높음 · list만높음 · use_search=0 · 보드없음 · 문자열레벨
- **회귀 없음 실측** — 통과 121개 유지, `free`/`qa`/`notice`/`economy`/`photo` 전부 통과
- TS 구문 3개 파일 (**대조군 포함** — 도구 신뢰성)

## 관련

- #2233 (RSS 캐시) 은 **이 PR 이 먼저 들어간 뒤**에 다시 봐야 합니다. 그 PR 은 보드 피드를 `public, s-maxage=1800` 으로 올리려 했는데, 위 결함들이 남은 채로는 **누수를 캐시하게 됩니다.**