### PR TITLE
이용제한 기록 페이지 크래시 수정 (each_key_duplicate) — bug/13815

### DIFF
--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -80,8 +80,13 @@
     const grouped = $derived.by(() => {
         const acc: { date: string; items: DisciplineLogListItem[] }[] = [];
         for (const log of logs) {
-            const last = acc[acc.length - 1];
-            if (last && last.date === log.penalty_date_from) last.items.push(log);
+            // ⛔ 연속 병합만 하면 penalty_date_from 이 비연속으로 같은 날짜가 나올 때
+            //    (날짜 없는 기록이 사이에 끼는 등) 같은 date 그룹이 둘 생겨
+            //    {#each grouped (group.date)} 키가 중복 → svelte each_key_duplicate 로
+            //    페이지 전체가 크래시(빈 화면)한다. 날짜 전체 기준으로 묶어 각 날짜가
+            //    정확히 한 그룹이 되게 한다(Map 금지 규칙 → find 로 접는다).
+            const g = acc.find((x) => x.date === log.penalty_date_from);
+            if (g) g.items.push(log);
             else acc.push({ date: log.penalty_date_from, items: [log] });
         }
         return acc;


### PR DESCRIPTION
제보 #13815(취미생활자): /disciplinelog 빈 페이지. ClickHouse js_errors 로 원인 확인 = svelte each_key_duplicate(운영 sha-0cb9ec5, 다수 회원). 날짜 그룹핑이 연속 같은날짜만 병합→ penalty_date_from 빈값 기록(4551)이 08-30 사이에 껴서 08-30 그룹 2개 생성→ {#each grouped (group.date)} 키 중복→ 페이지 전체 크래시. 날짜 전체 기준 병합으로 수정(각 날짜 1그룹, Map 금지→find). node 검증: OLD 키 중복→NEW 중복 없음.