### PR TITLE
이용제한열람 표기 변경 + 끌어올리기 버튼 비활성화

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.svelte
@@ -2433,38 +2433,41 @@
                         </Dialog.Footer>
                     </Dialog.Content>
                 </Dialog.Root>
-                <Dialog.Root bind:open={showBumpDialog}>
-                    <Dialog.Trigger>
-                        <Button variant="outline" size="sm" disabled={isBumping}>
-                            <ArrowUpCircle class="mr-1 h-4 w-4" />
-                            {isBumping ? '처리 중...' : '끌어올리기'}
-                        </Button>
-                    </Dialog.Trigger>
-                    <Dialog.Content>
-                        <Dialog.Header>
-                            <Dialog.Title>글 끌어올리기</Dialog.Title>
-                            <Dialog.Description>
-                                이 글을 목록 최상단으로 이동합니다.
-                            </Dialog.Description>
-                        </Dialog.Header>
-                        <div
-                            class="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
-                        >
-                            끌어올리기 시 <strong>1일 글쓰기 1회가 차감</strong>됩니다.<br />
-                            하루 2회, 1시간 간격으로 사용 가능합니다.
-                        </div>
-                        <Dialog.Footer>
-                            <Button
-                                variant="outline"
-                                onclick={() => (showBumpDialog = false)}
-                                disabled={isBumping}>취소</Button
-                            >
-                            <Button onclick={handleBump} disabled={isBumping}>
+                <!-- 끌어올리기 비활성화 (운영 요청 2026-09-01): 버튼/다이얼로그 숨김. 재활성화 시 {#if false} 제거 -->
+                {#if false}
+                    <Dialog.Root bind:open={showBumpDialog}>
+                        <Dialog.Trigger>
+                            <Button variant="outline" size="sm" disabled={isBumping}>
+                                <ArrowUpCircle class="mr-1 h-4 w-4" />
                                 {isBumping ? '처리 중...' : '끌어올리기'}
                             </Button>
-                        </Dialog.Footer>
-                    </Dialog.Content>
-                </Dialog.Root>
+                        </Dialog.Trigger>
+                        <Dialog.Content>
+                            <Dialog.Header>
+                                <Dialog.Title>글 끌어올리기</Dialog.Title>
+                                <Dialog.Description>
+                                    이 글을 목록 최상단으로 이동합니다.
+                                </Dialog.Description>
+                            </Dialog.Header>
+                            <div
+                                class="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
+                            >
+                                끌어올리기 시 <strong>1일 글쓰기 1회가 차감</strong>됩니다.<br />
+                                하루 2회, 1시간 간격으로 사용 가능합니다.
+                            </div>
+                            <Dialog.Footer>
+                                <Button
+                                    variant="outline"
+                                    onclick={() => (showBumpDialog = false)}
+                                    disabled={isBumping}>취소</Button
+                                >
+                                <Button onclick={handleBump} disabled={isBumping}>
+                                    {isBumping ? '처리 중...' : '끌어올리기'}
+                                </Button>
+                            </Dialog.Footer>
+                        </Dialog.Content>
+                    </Dialog.Root>
+                {/if}
             {/if}
         </div>
     </div>

--- a/apps/web/src/routes/disciplinelog/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/+page.svelte
@@ -100,7 +100,7 @@
 </script>
 
 <svelte:head>
-    <title>이용제한 기록</title>
+    <title>이용제한열람</title>
 </svelte:head>
 
 <div class="container mx-auto max-w-4xl px-4 py-6">
@@ -109,10 +109,10 @@
             <div class="flex items-center gap-2">
                 <Card.Title class="flex items-center gap-2">
                     <Shield class="text-muted-foreground h-5 w-5" />
-                    이용제한 기록
+                    이용제한열람
                 </Card.Title>
-                <BoardFavoriteButton boardId="disciplinelog" boardTitle="이용제한 기록" />
-                <BoardSubscribeButton boardId="disciplinelog" boardTitle="이용제한 기록" />
+                <BoardFavoriteButton boardId="disciplinelog" boardTitle="이용제한열람" />
+                <BoardSubscribeButton boardId="disciplinelog" boardTitle="이용제한열람" />
             </div>
             <Card.Description>규정을 위반한 회원에 대한 제재 기록입니다.</Card.Description>
         </Card.Header>

--- a/apps/web/src/routes/disciplinelog/[id]/+page.svelte
+++ b/apps/web/src/routes/disciplinelog/[id]/+page.svelte
@@ -109,7 +109,7 @@
 </script>
 
 <svelte:head>
-    <title>이용제한 기록 상세</title>
+    <title>이용제한열람 상세</title>
 </svelte:head>
 
 <div class="container mx-auto max-w-2xl px-4 py-6">


### PR DESCRIPTION
## 변경
- **disciplinelog**(이용제한열람): 목록/상세 페이지 제목·헤딩·즐겨찾기/구독 boardTitle 표기를 '이용제한 기록' → '이용제한열람'. 설명 산문은 '기록' 유지.
- **끌어올리기 버튼**: 홍보 게시판 글 상세의 date-bump '끌어올리기' 다이얼로그를 {#if false}로 비활성화.

## 참고
- 게시판 표시명(bug→버그제보, report→다모앙 리포트, disciplinelog→이용제한열람)은 DB(g5_board.bo_subject)에서 변경.