### PR TITLE
위키 에디터 다크모드 흰배경+흰글씨 수정

### DIFF
--- a/apps/web/src/lib/components/wiki/markdown-editor.svelte
+++ b/apps/web/src/lib/components/wiki/markdown-editor.svelte
@@ -163,7 +163,8 @@
     }
     .md-tool {
         padding: 0.25rem 0.6rem;
-        background: white;
+        background: var(--background, white);
+        color: var(--foreground, #0f172a);
         border: 1px solid var(--border, #d1d5db);
         border-radius: 0.25rem;
         font-size: 0.8rem;
@@ -191,13 +192,14 @@
         font-size: 0.875rem;
         line-height: 1.6;
         border-right: 1px solid var(--border, #e5e7eb);
-        background: #fafbfc;
+        background: var(--background, #fafbfc);
         color: var(--foreground, #0f172a);
     }
     .md-preview {
         padding: 0.5rem 1rem;
         overflow-y: auto;
-        background: white;
+        background: var(--background, white);
+        color: var(--foreground, #0f172a);
     }
     .md-preview-empty {
         color: var(--muted-foreground, #6b7280);


### PR DESCRIPTION
markdown-editor 의 textarea/preview/toolbar 버튼 배경이 흰색 하드코딩이라 다크모드에서 글자(밝은색)와 겹쳐 안 보였습니다. 배경을 var(--background) 로 교체 → 다크모드에서 어두운 배경. 라이트모드는 fallback 동일.