### PR TITLE
fix(rum): 목록 오터치 직접 계측 + 텔레메트리 식별자 누출 차단

### DIFF
--- a/apps/web/src/lib/services/mistouch-probe.ts
+++ b/apps/web/src/lib/services/mistouch-probe.ts
@@ -1,0 +1,359 @@
+/**
+ * 오탭(mistouch) 직접 계측 — bug/13836.
+ *
+ * 증상: 모바일 목록에서 글을 터치하면 **아래 글**이 열린다. 석 달째, 두 번째 제보.
+ *
+ * ⛔ **CLS 로는 이 증상을 못 잰다** (2026-09-02 헤드리스 실측, `web-vitals-rum.ts` 주석 참조):
+ *   · 스크롤 앵커링이 밀림 엔트리를 통째로 지운다(scrollY=600/1500 에서 엔트리 0개).
+ *     실사용자는 **스크롤한 채로** 탭한다 — 즉 관측이 지워지는 바로 그 구간에서 탭한다.
+ *   · 모바일 스크롤은 포인터 입력이라, 스크롤 직후 500ms 안의 밀림은 `hadRecentInput`
+ *     으로 CLS 에서 **전부 빠진다**. 하필 오탭이 나는 구간이다.
+ *   · `layout-shift.sources` 는 **밀린** 요소만 담아 "민 주체" 를 못 준다.
+ *   → 대리 지표를 정교하게 만드는 방향이 틀렸다. **증상 자체**를 잰다.
+ *
+ * ⭐ 원리 — 크롬은 터치 탭의 호환 마우스 이벤트(click)를 **click 을 보내는 시점의
+ *   좌표 히트테스트**로 타겟팅한다. 그래서 손가락이 닿은 뒤 click 이 확정되기까지의
+ *   짧은 사이에 목록이 밀리면, 닿았던 글이 아니라 **그 자리에 새로 들어온 글**이 열린다.
+ *   그러니 **닿은 순간 그 좌표에 있던 링크**와 **실제로 열린 링크**를 비교하면
+ *   증상 발생 여부가 그 자리에서 확정된다. 밀림의 크기·부호를 유추할 필요가 없다.
+ *
+ * ⛔ 개인정보: **href·제목·회원 식별자를 절대 담지 않는다.** 두 링크가 "다른가" 와
+ *    "몇 행 차이인가" 만 보낸다. 봉투의 `url` 도 `pathGroup` 으로 익명화한다
+ *    (글 상세에서 오탭이 나면 `location.href` 에 글 번호가 실리기 때문).
+ */
+import { DANTRY_URL, adOverflowSignature, authSignature, pathGroup } from './web-vitals-rum';
+
+/**
+ * 오탭은 드물다 — 전수로 받는다. 대신 **한 페이지 로드당 최대 3건**으로 상한을 둔다
+ * (무한 루프성 오작동이 비콘 폭풍이 되는 것만 막으면 된다).
+ */
+const MISTOUCH_SAMPLE_RATE = 1.0;
+const MISTOUCH_MAX_PER_PAGE = 3;
+
+/**
+ * pointerdown → click 사이가 이보다 벌어지면 **같은 탭이 아니다**.
+ * 키보드 Enter 로 난 click(선행 pointerdown 없음)이나, 스크롤만 하고 한참 뒤에 누른
+ * 별개 동작이 짝지어지는 것을 막는다.
+ */
+const MAX_TAP_GAP_MS = 5000;
+
+/**
+ * pointerup → click 창. 포인터 탭의 click 은 pointerup 직후에 온다.
+ * ⛔ 이 창이 없으면, 스크롤이 끝난(=pointerup 까지 온) pointerdown 이 한참 뒤에 도착한
+ *    무관한 click 과 짝지어진다.
+ */
+const MAX_CLICK_AFTER_UP_MS = 1000;
+
+/**
+ * click 좌표가 pointerdown 좌표에서 이만큼 넘게 벗어나면 **오탭이 아니다**.
+ *
+ * ⭐ 이 증상의 정의가 "손가락은 그대로인데 **내용이** 밀려 다른 글이 열린다" 이므로,
+ *   진짜 오탭은 두 좌표가 사실상 같다. 좌표가 벌어졌다면 그건 드래그·별개 동작이다.
+ */
+const TAP_MOVE_TOLERANCE_PX = 16;
+
+/** 조상 사슬 탐색 상한 — 깊은 DOM 에서 비용이 튀지 않게. */
+const MAX_ANCESTOR_DEPTH = 40;
+
+let sentCount = 0;
+let installed = false;
+const sampled = typeof window !== 'undefined' && Math.random() < MISTOUCH_SAMPLE_RATE;
+
+/**
+ * 손가락이 닿은 순간의 스냅샷.
+ *
+ * ⭐ **왜 `elementFromPoint` 가 아니라 `event.target` 인가.**
+ *   `document.elementFromPoint()` 는 스타일·레이아웃 플러시를 강제한다. pointerdown 은
+ *   스크롤이 시작되는 순간이라 여기서 레이아웃을 강제하면 **첫 프레임을 늦춰 사용자
+ *   조작을 직접 망가뜨린다** — 관측이 증상을 만드는 최악의 경우다.
+ *   반면 `event.target` 은 브라우저가 이벤트를 디스패치하려고 **이미 수행한**
+ *   히트테스트 결과다. 즉 "닿은 순간 그 좌표에 있던 요소" 를 **추가 비용 0** 으로 준다.
+ *   우리가 필요한 것이 정확히 그것이므로 `elementFromPoint` 를 쓸 이유가 없다.
+ *   ⛔ 그래서 이 핸들러는 **프로퍼티 읽기와 대입만** 한다. `closest()` 조차 click 시점에
+ *      한다(레이아웃을 강제하진 않지만, 원칙을 흐리면 다음 사람이 무거운 걸 넣는다).
+ * ⛔ 노드 강참조는 **한 개만** 들고 다음 pointerdown 에서 덮어쓰며, click 처리 뒤 즉시
+ *    비운다. 누적되지 않는다.
+ * ⛔ `clientX/Y`·`pointerType` 도 **프로퍼티 읽기**라 레이아웃 강제가 아니다.
+ *    이 핸들러에는 이 이상 아무것도 넣지 않는다.
+ */
+interface TapDown {
+    target: EventTarget | null;
+    t: number;
+    x: number;
+    y: number;
+    /** 'touch' | 'mouse' | 'pen' — 분석에서 기기를 가른다. */
+    ptype: string;
+    /** 이 짝의 pointerup 이 온 시각. 아직 안 왔으면 null. */
+    upT: number | null;
+}
+let down: TapDown | null = null;
+
+/**
+ * 링크 식별자. **전송하지 않는다** — 오직 두 링크가 같은지 비교하는 데만 쓴다.
+ * `HTMLAnchorElement.href` 는 절대 URL 로 정규화되므로 상대/절대 표기 차이에 안 흔들린다.
+ */
+function linkKey(el: Element): string | null {
+    try {
+        if (el instanceof HTMLAnchorElement) return el.href;
+        return el.getAttribute('href');
+    } catch {
+        return null;
+    }
+}
+
+/** 이벤트 타겟에서 가장 가까운 `a[href]`. 레이아웃을 강제하지 않는다(트리 탐색만). */
+function closestLink(target: EventTarget | null): Element | null {
+    try {
+        if (!(target instanceof Element)) return null;
+        return target.closest('a[href]');
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * 두 링크의 **가장 가까운 공통 조상**.
+ * ⛔ 목록 컨테이너를 하드코딩하지 않는다 — 테마·프리미엄 위젯마다 마크업이 다르고,
+ *    하드코딩하면 그 표면에서만 조용히 `drow=?` 가 된다.
+ */
+function commonAncestor(a: Element, b: Element): Element | null {
+    let anc: Element | null = a.parentElement;
+    for (let d = 0; anc && d < MAX_ANCESTOR_DEPTH; d++) {
+        if (anc.contains(b)) return anc;
+        anc = anc.parentElement;
+    }
+    return null;
+}
+
+/**
+ * `ancestor` 의 자식들 중 `el` 을 품은 자식이 몇 번째인가. 못 구하면 -1.
+ * = "공통 조상 안에서 이 링크가 몇 번째 행인가".
+ */
+function rowIndexUnder(el: Element, ancestor: Element): number {
+    let node: Element | null = el;
+    for (let d = 0; node && d < MAX_ANCESTOR_DEPTH; d++) {
+        if (node.parentElement === ancestor) {
+            const kids = ancestor.children;
+            // ⛔ HTMLCollection 을 for..of 로 돌면 tsconfig(downlevelIteration)에 따라
+            //    CI 에서 막힌다 — 이 저장소의 기존 관례대로 인덱스 루프.
+            for (let i = 0; i < kids.length; i++) {
+                if (kids[i] === node) return i;
+            }
+            return -1;
+        }
+        node = node.parentElement;
+    }
+    return -1;
+}
+
+/**
+ * 행 차이(부호 포함). **+1 = 바로 아래 글이 열림 = 이번 제보 증상.**
+ *
+ * ⛔ **왜 `?` 인지를 구분해서 보낸다.** 닿은 링크가 DOM 에서 빠져버린 경우
+ *    (`drow=detached`)와, 붙어는 있는데 공통 조상·행 위치를 못 구한 경우(`drow=?`)는
+ *    처방이 다르다. 뭉뚱그리면 분석에서 "왜 모르는지" 를 되물을 수 없다.
+ *    ⚠️ 두 경우 모두 **비콘 자체는 나간다** — 오탭이 났다는 사실은 이미 확정된 표본이라
+ *       버리면 그만큼 과소집계된다.
+ */
+function rowDelta(intended: Element, opened: Element): string {
+    try {
+        if (!intended.isConnected || !opened.isConnected) return 'drow=detached';
+        const anc = commonAncestor(intended, opened);
+        if (!anc) return 'drow=?';
+        const a = rowIndexUnder(intended, anc);
+        const b = rowIndexUnder(opened, anc);
+        if (a < 0 || b < 0) return 'drow=?';
+        return `drow=${b - a}`;
+    } catch {
+        return 'drow=?';
+    }
+}
+
+/**
+ * 두 링크의 `getBoundingClientRect().top` 차이(px), `열린 것 − 닿은 것`.
+ * ⛔ 떨어져 나간(detached) 요소의 rect 는 전부 0 이라 그대로 재면 거짓값이 된다.
+ *    붙어 있는지부터 확인하고, 아니면 `?`.
+ * ⛔ 레이아웃을 강제하지만 **click 시점 1회**다(오탭이 확정된 표본에서만 부른다).
+ */
+function topDelta(intended: Element, opened: Element): string {
+    try {
+        // `drow` 와 같은 이유로 원인을 구분해서 보낸다(위 rowDelta 주석 참조).
+        if (!intended.isConnected || !opened.isConnected) return 'dy=detached';
+        const d = opened.getBoundingClientRect().top - intended.getBoundingClientRect().top;
+        return `dy=${Math.round(d)}`;
+    } catch {
+        return 'dy=?';
+    }
+}
+
+/**
+ * ⛔ 이 비콘은 **오탭이 확정된 순간에만** 나간다. 정상 탭에서는 한 줄도 안 나간다.
+ *    `web_vitals` 와 달리 pagehide 를 기다리지 않는다 — 오탭 직후 페이지가 이동하므로
+ *    그 자리에서 sendBeacon 으로 넘겨야 유실되지 않는다.
+ */
+function sendMistouch(lines: string[]): void {
+    try {
+        const payload = {
+            type: 'mistouch',
+            reason: 'mistouch',
+            channel: 'rum',
+            message: 'mistouch',
+            // ⛔ 수집기는 스키마에 없는 필드를 버린다(js_errors 컬럼 고정). stack 에 싣는다.
+            stack: lines.join('\n'),
+            // ⛔ `location.href` 를 그대로 쓰면 글 상세에서 글 번호가 실린다. 그룹화해서 익명화.
+            url: `${location.origin}${pathGroup(location.pathname)}`,
+            userAgent: navigator.userAgent
+        };
+        const body = JSON.stringify(payload);
+        if (typeof navigator.sendBeacon === 'function') {
+            navigator.sendBeacon(DANTRY_URL, new Blob([body], { type: 'application/json' }));
+        }
+    } catch {
+        // 관측 실패는 무시 — 사용자 조작에 영향이 있으면 안 된다
+    }
+}
+
+function onPointerDown(event: PointerEvent): void {
+    try {
+        // ⭐ 여기서는 프로퍼티 읽기와 대입만 한다. 위 TapDown 주석 참조.
+        down = {
+            target: event.target,
+            t: event.timeStamp,
+            x: event.clientX,
+            y: event.clientY,
+            ptype: event.pointerType,
+            upT: null
+        };
+    } catch {
+        down = null;
+    }
+}
+
+/**
+ * ⛔ **여기서 `down` 을 비우면 정상 탭이 통째로 죽는다** — 포인터 탭의 순서는
+ *    pointerdown → **pointerup** → click 이고, 판정에 필요한 `down` 은 click 시점에 쓴다.
+ *    그래서 소진은 "비우기" 가 아니라 **창 좁히기**로 한다: pointerup 이 왔다는 사실과
+ *    그 시각을 찍어두고, click 은 그 뒤 `MAX_CLICK_AFTER_UP_MS` 안에 온 것만 인정한다.
+ *    pointerup 이 아예 없었던 짝은 click 에서 거부한다(포인터에서 나온 click 이 아니다).
+ */
+function onPointerUp(event: PointerEvent): void {
+    try {
+        if (!down) return;
+        down.upT = event.timeStamp;
+    } catch {
+        down = null;
+    }
+}
+
+/**
+ * ⛔ pointercancel = **브라우저가 포인터를 스크롤·제스처에 가져갔다.** 이 pointerdown 에서
+ *    click 은 나오지 않는다. 여기서 즉시 비워야, 뒤에 도착한 무관한 click(합성 click·
+ *    키보드 Enter)이 이 짝을 주워가지 않는다. 정상 탭은 cancel 이 오지 않으므로 안 죽는다.
+ */
+function onPointerCancel(): void {
+    down = null;
+}
+
+function onClick(event: MouseEvent): void {
+    // ⛔ 짝은 무조건 한 번만 쓴다. 어디서 빠져나가든 다음 탭에 흘리면 안 되므로 즉시 비운다.
+    const d = down;
+    down = null;
+    try {
+        if (sentCount >= MISTOUCH_MAX_PER_PAGE) return;
+        if (!d) return; // 선행 pointerdown 없음(키보드 Enter 등) → 오탭 판정 대상이 아니다
+
+        /* ── 위양성 차단: 이 click 이 **그 탭에서 나온 것**인지 먼저 확정한다 ──────────
+         * 2026-09-02 독립 검증 실측 — 아래 셋이 전부 비콘을 냈다(drow=27/28/9):
+         *   · 스크롤(클릭 없이 끝남) → JS 합성 `el.click()`
+         *   · 스크롤(클릭 없이 끝남) → 키보드 Enter
+         *   · 데스크톱 마우스 드래그 → 키보드 Enter
+         * 원인은 `down` 이 최대 5초 살아 있어 **그 탭에서 나오지 않은 click** 과 짝지어진 것.
+         * 「선행 pointerdown 없으면 대상 아님」이라는 주석은 실제로 성립하지 않았다.
+         */
+        // ① 사용자 포인터 클릭만 인정: 합성 `click()`·키보드 Enter 는 `detail === 0` 이고
+        //    좌표도 (0,0) 이다. 진짜 탭은 `detail >= 1`.
+        if (!(event.detail > 0)) return;
+        // ② pointerup 이 선행해야 한다(위 onPointerUp 주석).
+        if (d.upT === null) return;
+        if (event.timeStamp - d.upT > MAX_CLICK_AFTER_UP_MS) return;
+        // ③ 좌표 일치: 오탭은 손가락이 그대로인 채 내용만 밀린 것이다. 드래그처럼 좌표가
+        //    벌어진 클릭은 "다른 글이 열렸다" 가 아니라 **다른 곳을 눌렀다** 이다.
+        if (Math.abs(event.clientX - d.x) > TAP_MOVE_TOLERANCE_PX) return;
+        if (Math.abs(event.clientY - d.y) > TAP_MOVE_TOLERANCE_PX) return;
+
+        const dt = event.timeStamp - d.t;
+        if (!(dt >= 0) || dt > MAX_TAP_GAP_MS) return;
+
+        const intended = closestLink(d.target);
+        const opened = closestLink(event.target);
+        // 둘 중 하나라도 링크가 아니면 "다른 글이 열렸다" 를 말할 수 없다.
+        // (닿은 곳이 링크가 아니었거나, 아무 데도 이동하지 않는 클릭)
+        if (!intended || !opened) return;
+        if (intended === opened) return;
+
+        const a = linkKey(intended);
+        const b = linkKey(opened);
+        // href 를 못 읽으면 판정 불가. ⛔ 값은 여기서만 쓰고 절대 전송하지 않는다.
+        if (!a || !b) return;
+        // ⭐ 같은 글이면 정상 탭이다. Svelte 가 목록을 다시 렌더해 노드 동일성이 깨져도
+        //   여기서 걸러진다 — 노드 비교만으로 판정하면 대량 오탐이 난다.
+        if (a === b) return;
+
+        sentCount++;
+        sendMistouch([
+            rowDelta(intended, opened),
+            topDelta(intended, opened),
+            `dt=${Math.round(dt)}`,
+            `sy=${Math.round(window.scrollY)}`,
+            `page=${pathGroup(location.pathname)}`,
+            `vw=${window.innerWidth}`,
+            // 기기 축. 이번 제보는 모바일(touch)이다 — mouse/pen 표본을 섞어 읽으면 안 된다.
+            `ptype=${(d.ptype || '?').slice(0, 8)}`,
+            adOverflowSignature(),
+            authSignature()
+        ]);
+    } catch {
+        // 관측 실패는 무시 — 사용자 조작에 영향이 있으면 안 된다
+    }
+}
+
+/**
+ * 오탭 프로브 설치.
+ *
+ * ⛔ SSR 안전: `window` 없으면 아무것도 하지 않는다.
+ * ⛔ `capture: true` — 앱 코드가 `stopPropagation()` 해도 먼저 본다.
+ * ⛔ `passive: true` — 우리가 `preventDefault()` 를 부를 수 없게 못박는다.
+ *    관측이 링크 이동을 막는 일은 절대 없어야 한다.
+ * 비용: 리스너 등록 4회. 렌더 경로에 아무것도 추가하지 않는다.
+ */
+export function initMistouchProbe(): void {
+    if (typeof window === 'undefined' || installed) return;
+    installed = true;
+    if (!sampled) return;
+    try {
+        const opts: AddEventListenerOptions = { capture: true, passive: true };
+        document.addEventListener('pointerdown', onPointerDown, opts);
+        document.addEventListener('pointerup', onPointerUp, opts);
+        document.addEventListener('pointercancel', onPointerCancel, opts);
+        document.addEventListener('click', onClick, opts);
+    } catch {
+        // 리스너 등록 실패는 무시 — 사용자 조작에 영향이 있으면 안 된다
+    }
+}
+
+/**
+ * 상한(`MISTOUCH_MAX_PER_PAGE`)을 **네비게이션마다** 되돌린다.
+ *
+ * ⛔ 모듈 스코프 카운터는 SPA soft-nav 로 리셋되지 않는다. 목록↔글상세를 오가는 실사용
+ *    패턴에서는 **초반 3건을 쓰고 나면 세션 내내 관측이 죽는다** — 상한이 사실상
+ *    "세션당 3건" 이 된다(2026-09-02 독립 검증 지적).
+ * ⭐ 그래서 `+layout.svelte` 의 **기존 `afterNavigate`** 에 태운다. 이 저장소는 이미 거기서
+ *    GA4 페이지뷰·Clarity 가드·광고 observer 를 재설정한다 — "한 페이지" 의 정의를 앱과
+ *    같게 맞추는 것이 맞다. 프로브가 따로 `popstate`/`pushState` 를 훔쳐보면 SvelteKit 의
+ *    이동 개념(리다이렉트·인터셉트 포함)과 어긋나고, 리스너가 하나 더 늘어난다.
+ * ⛔ 진행 중이던 짝도 같이 버린다. 네비게이션을 건너뛴 pointerdown 은 이미 남의 페이지 것이다.
+ */
+export function resetMistouchBudget(): void {
+    sentCount = 0;
+    down = null;
+}

--- a/apps/web/src/lib/services/web-vitals-rum.test.ts
+++ b/apps/web/src/lib/services/web-vitals-rum.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { pathGroup } from './web-vitals-rum';
+
+/**
+ * `pathGroup` 은 **기존 `web_vitals.page=` 와 공용**이다. 값이 한 글자라도 바뀌면
+ * 그 값으로 짜인 집계 쿼리가 전부 깨진다. 그래서 "안 바뀐다" 를 말로 두지 않고
+ * **바뀌기 전 구현을 그대로 박아** 대조한다(2026-09-02, bug/13836 3차).
+ */
+const legacyPathGroup = (pathname: string): string =>
+    pathname
+        .replace(/^\/([a-zA-Z0-9_-]+)\/\d+.*$/, '/$1/:id')
+        .replace(/\/\d+/g, '/:n')
+        .slice(0, 60);
+
+/** 식별자 누출과 무관한 경로들 — 여기 값은 **한 글자도** 달라지면 안 된다. */
+const UNCHANGED_PATHS = [
+    '/',
+    '',
+    '/free',
+    '/free/',
+    '/free/123',
+    '/free/123/edit',
+    '/notice/18300',
+    '/car',
+    '/wiki/damoang',
+    '/search',
+    '/admin/members',
+    '/my/posts',
+    '/messages/456',
+    '/point',
+    '/level',
+    '/shop/1/2',
+    // 대상 접두사이지만 **정적 라우트**인 것들 — 남아야 한다
+    '/member/settings',
+    '/member/settings/social',
+    '/member/settings/ui',
+    '/member/settings/verify-email',
+    '/member/orders',
+    '/member/leave',
+    '/member/leave/cancel',
+    '/member/leave/complete',
+    '/member/escrow',
+    '/checkout/complete',
+    // 대상 접두사 + **숫자** 식별자 — 기존 규칙이 이미 처리한다(값 보존)
+    '/member/12345',
+    '/member/orders/9876',
+    '/go/12',
+    '/checkout/4242',
+    // 프로토타입 키가 경로로 들어와도 예외 없이 그대로
+    '/toString/x',
+    '/constructor'
+];
+
+/** 회원 식별자가 그대로 실려 나가던 경로들 — `:id` 로 가려져야 한다. */
+const MASKED_PATHS: Array<[string, string]> = [
+    ['/member/naver_8e22080b', '/member/:id'],
+    ['/member/google_956d0909', '/member/:id'],
+    ['/member/kakao_1a2b3c4d', '/member/:id'],
+    ['/member/hong_gildong', '/member/:id'],
+    ['/member/naver_8e22080b/', '/member/:id/'],
+    ['/invite/AbC-token_1', '/invite/:id'],
+    ['/go/aBcD1234', '/go/:id'],
+    ['/checkout/ORD-2026-0902', '/checkout/:id'],
+    ['/member/orders/ORD-2026-0902', '/member/orders/:id']
+];
+
+describe('pathGroup — 기존 값 불변', () => {
+    it('식별자 누출과 무관한 경로는 변경 전 구현과 완전히 동일하다', () => {
+        for (const p of UNCHANGED_PATHS) {
+            expect(`${p} -> ${pathGroup(p)}`).toBe(`${p} -> ${legacyPathGroup(p)}`);
+        }
+    });
+
+    it('대표 값이 그대로다', () => {
+        expect(pathGroup('/')).toBe('/');
+        expect(pathGroup('/free')).toBe('/free');
+        expect(pathGroup('/free/123')).toBe('/free/:id');
+        expect(pathGroup('/member/settings')).toBe('/member/settings');
+        expect(pathGroup('/member/12345')).toBe('/member/:id');
+    });
+});
+
+describe('pathGroup — 회원 식별자 마스킹', () => {
+    it('member/invite/go/checkout 의 비숫자 식별자 세그먼트를 :id 로 가린다', () => {
+        for (const [input, expected] of MASKED_PATHS) {
+            expect(`${input} -> ${pathGroup(input)}`).toBe(`${input} -> ${expected}`);
+        }
+    });
+
+    it('가린 뒤에는 어떤 식별자 원문도 남지 않는다', () => {
+        for (const [input] of MASKED_PATHS) {
+            expect(pathGroup(input)).not.toMatch(/naver_|google_|kakao_|ORD-|token/);
+        }
+    });
+});

--- a/apps/web/src/lib/services/web-vitals-rum.ts
+++ b/apps/web/src/lib/services/web-vitals-rum.ts
@@ -28,7 +28,7 @@ import { trackEvent } from './ga4';
  *   - **표본은 페이지 단위로 한 번 결정한다.** 지표별로 따로 뽑으면 같은 페이지의
  *     CLS·LCP·INP 가 짝이 안 맞아 조인이 불가능해진다.
  */
-const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
+export const DANTRY_URL = 'https://aplog.damoang.net/api/v1/dantry';
 const RUM_SAMPLE_RATE = 0.1;
 /** 이 페이지 로드를 표본으로 삼을지 — 한 번 정하고 세 지표가 같은 결정을 공유한다 */
 const rumSampled = typeof window !== 'undefined' && Math.random() < RUM_SAMPLE_RATE;
@@ -62,12 +62,193 @@ function adFillSignature(): string {
     }
 }
 
+/* ------------------------------------------------------------------------- *
+ * CLS 밀림 방향·민 주체 계측 (2026-09-02, bug/13836)
+ *
+ * 증상: 모바일 목록에서 글을 터치하면 **아래 글**이 열린다. 석 달째, 두 번째 제보.
+ * 손가락이 닿는 순간과 탭이 확정되는 순간 사이에 목록이 **위로** 밀리면,
+ * 원래 누르려던 줄이 위로 빠지고 그 자리에 다음 줄이 들어온다.
+ *
+ * ⛔ **CLS 는 이 증상의 대리 지표로 못 쓴다** — 2026-09-02 헤드리스 실측 3건:
+ *   1) 스크롤 앵커링이 관측을 지운다. 같은 200px 축소를 scrollY=0/600/1500 에서 재니
+ *      600·1500 에서는 layout-shift 엔트리가 **0개**. 실사용자는 스크롤한 채로 탭한다.
+ *   2) `hadRecentInput` 제외가 하필 오탭 구간을 지운다. 모바일 스크롤은 포인터 입력이라
+ *      스크롤 직후 500ms 안의 밀림은 CLS 에서 **전부 빠진다**.
+ *   3) `sources` 는 **밀린** 요소만 담는다. 제자리에서 **높이만 바뀐** 민 주체는 절대
+ *      안 들어오고, rect 가 뷰포트로 클리핑돼 높이가 안 변한 요소가 `dH=-220` 으로 잡힌다.
+ *      → "민 주체(mover)" 를 이 API 로 뽑겠다는 접근 자체가 틀렸다. 제거했다.
+ *
+ * → **증상 자체를 직접 잰다**: `mistouch-probe.ts` 가 손가락이 닿은 좌표에 있던 글과
+ *   실제로 열린 글을 비교한다. 이 파일의 CLS 필드는 **보조 축**으로만 남긴다.
+ *
+ * 여기 남기는 것:
+ *   shift= / nsrc= → 가장 큰 단일 소스의 세로 이동량(부호 포함)과 소스 개수.
+ *                    ⛔ 예전엔 소스 dTop 을 **합산**해 `px` 를 붙였는데, 그건 밀린 요소
+ *                    **개수에 비례**하는 값이었다(5행 밀리면 실제 200px 인데 -1000px).
+ *   adh=          → 광고 축. 0보다 크면 "예약보다 크게 렌더" 경로가 열려 있다.
+ *   auth=         → 로그인 여부. 로그인 표면에만 있는 요소가 원인이면 여기서 갈린다.
+ *
+ * ⛔ 렌더 경로에 아무것도 추가하지 않는다. 별도 PerformanceObserver 도 없앴다 —
+ *    web-vitals 가 `attribution.largestShiftEntry` 로 같은 엔트리를 주므로 모듈 스코프에
+ *    엔트리 배열(DOM 강참조 누적)을 들고 있을 이유가 없다. 계산은 전송 시점 1회.
+ * ⛔ CLS 전송에만 붙인다. LCP/INP/TTFB 에는 의미가 없고 페이로드만 커진다.
+ * ------------------------------------------------------------------------- */
+
+/**
+ * ⛔ `LayoutShift` 는 표준 lib.dom 에 없다(크롬 계열 전용 확장).
+ *    전역 타입에 기대면 CI 가 깨지므로 필요한 필드만 로컬로 선언해 쓴다.
+ *    ⛔ `any` 로 받으면 ESLint 가 막고, 오필드를 조용히 숨겨 계측이 죽는다
+ *       (이 파일은 이미 `detail` 을 `string` 으로 받아 CI 가 2번 깨진 이력이 있다).
+ */
+interface LayoutShiftSourceLike {
+    readonly node: Node | null;
+    readonly previousRect: DOMRectReadOnly;
+    readonly currentRect: DOMRectReadOnly;
+}
+export interface LayoutShiftEntryLike extends PerformanceEntry {
+    readonly value: number;
+    readonly hadRecentInput: boolean;
+    readonly sources: ReadonlyArray<LayoutShiftSourceLike> | undefined;
+}
+
+/**
+ * 뷰포트 경계에 걸리지 않은 **온전한** rect 인가.
+ *
+ * ⛔ **layout-shift 의 rect 는 뷰포트로 클리핑된다.** 요소가 화면 밖으로 나가면
+ *    높이가 0 으로 잘리고 top 도 0 이 된다. 그 rect 로 dTop 을 재면 **부호가 뒤집힌다** —
+ *    2026-09-02 검증 실측: `#secA` 가 top 730 → 930 으로 **아래로 200px** 내려갔는데
+ *    `currentRect` 가 0 으로 클리핑돼 `dTop=-730`(위로 730)으로 보고됐다.
+ *    같은 클리핑 결함이 이미 `mover=`(민 주체) 를 죽였고, `shift=` 에도 그대로 남아 있었다.
+ * → 양쪽 rect 가 **둘 다 높이 0 초과이고 뷰포트 안에 온전히 들어와 있는** 소스만 쓴다.
+ *   경계에 닿은 rect 는 잘렸는지 아닌지를 rect 만으로 구분할 수 없으므로 **전부 버린다**
+ *   (거짓 부호 하나가 없느니만 못하다 — 위 실측이 정확히 그 사고였다).
+ * ⚠️ 뷰포트 높이는 **전송 시점**(pagehide)의 `innerHeight` 다. 밀림이 일어난 순간의
+ *    값이 아니다(모바일 주소창 접힘 등으로 수십 px 다를 수 있다). 이 판정은 그래서
+ *    "확실히 안전한 것만 통과" 쪽으로만 쓴다 — 통과 기준을 넓히면 안 된다.
+ */
+const VIEWPORT_EDGE_EPS_PX = 1;
+function isIntactRect(r: DOMRectReadOnly, viewportHeight: number): boolean {
+    if (!(r.height > 0)) return false;
+    if (r.top <= VIEWPORT_EDGE_EPS_PX) return false;
+    if (r.bottom >= viewportHeight - VIEWPORT_EDGE_EPS_PX) return false;
+    return true;
+}
+
+/**
+ * 가장 큰 밀림 엔트리에서 **가장 크게 밀린 단일 소스의 세로 이동량(부호 포함)** 과
+ * **소스 개수** 를 뽑는다.
+ *
+ * ⭐ 부호가 핵심이다. **음수 = 위로 밀림.**
+ * ⛔ 예전 구현은 소스들의 dTop 을 **합산**하고 단위에 `px` 를 붙였다. 그 값은 실제
+ *    이동거리가 아니라 **밀린 요소 개수에 비례**한다(5행이 200px 씩 밀리면 -1000px).
+ *    그래서 합이 아니라 **최대 절댓값 단일 소스**를 보내고 개수를 따로 싣는다.
+ * ⛔ 엔트리는 web-vitals 의 `attribution.largestShiftEntry` 를 그대로 받는다.
+ *    직접 PerformanceObserver 를 돌리면 (a) 모듈 스코프에 DOM 강참조가 쌓이고
+ *    (b) "가장 큰" 의 기준이 web-vitals 와 어긋나 `target=` 과 짝이 안 맞는다.
+ * ⛔ `sources` 는 **밀린** 요소만 담는다. 여기서 "민 주체" 를 유추하지 마라
+ *    (2026-09-02 실측: 클리핑된 rect 때문에 정반대 답이 나왔다).
+ *
+ * ⭐ **읽는 법**: `nsrc>0` 인데 `shift=?` = 소스는 있었지만 **전부 뷰포트 경계에 걸려**
+ *   부호를 신뢰할 수 없었다는 뜻이다. `nsrc=0`(소스 없음)·`nsrc=?`(엔트리 없음)와 다르다.
+ *   추정치를 채워 넣지 않는다.
+ */
+function shiftLines(entry: LayoutShiftEntryLike | undefined): string[] {
+    try {
+        // 엔트리 없음 = 판별 불가. 크롬 계열이 아니거나 밀림이 아예 없었다.
+        if (!entry) return ['shift=?', 'nsrc=?'];
+        const sources = entry.sources ?? [];
+        if (sources.length === 0) return ['shift=?', 'nsrc=0'];
+        const vh = window.innerHeight;
+        let best: number | null = null;
+        for (let i = 0; i < sources.length; i++) {
+            const s = sources[i];
+            // 양쪽 rect 가 모두 온전할 때만 dTop 이 실제 이동량이다.
+            if (!isIntactRect(s.previousRect, vh) || !isIntactRect(s.currentRect, vh)) continue;
+            const d = s.currentRect.top - s.previousRect.top;
+            if (best === null || Math.abs(d) > Math.abs(best)) best = d;
+        }
+        const shift = best === null ? 'shift=?' : `shift=${Math.round(best)}`;
+        return [shift, `nsrc=${sources.length}`];
+    } catch {
+        return ['shift=?', 'nsrc=?'];
+    }
+}
+
+/**
+ * 광고 프레임의 **실제 높이 − 예약 높이** 최댓값(px).
+ *
+ * ⭐ `min-height` 는 바닥값이라 예약보다 **큰** 광고는 막지 못한다. 그리고 광고는
+ *    30~45초마다 갱신되므로, 컸다가 작아지면 그만큼 아래 목록이 **위로** 올라간다.
+ *    이 값이 0보다 크면 그 경로가 열려 있다는 뜻이다.
+ *    ⛔ 지금 우리 관측에 이 축이 아예 없어서 "아마 광고" 를 확인도 배제도 못 했다.
+ *
+ * ⛔ 예약값은 ad-slot.svelte 가 인라인으로 주입하는 `--ad-slot-min-height`(= 모바일/base)다.
+ *    같은 요소에 `-tablet`·`-desktop` 변형도 있어 넓은 화면에서는 실제 적용값이 다르다 —
+ *    분석은 이 필드를 **모바일 표본에서** 읽어라(이번 증상이 모바일이다).
+ * ⛔ 비용은 pagehide 시점의 레이아웃 1회뿐. 렌더 경로에는 아무것도 안 넣는다.
+ *
+ * ⛔ **`.dm-display-floating`(사이드바·윙)은 건너뛴다.** 이 슬롯은 CSS 가
+ *    `min-height: 0` 으로 덮는데(ad-slot.svelte) 인라인 `--ad-slot-min-height` 에는
+ *    250/600px 이 그대로 남아 있어, 실제 예약이 0인데 `-250`/`-600` 이라는 **헛값**이
+ *    나온다. 2026-09-02 라이브 4개 뷰포트 측정에서 확인. in-flow 슬롯만 센다.
+ */
+export function adOverflowSignature(): string {
+    try {
+        const frames = document.querySelectorAll<HTMLElement>('.dm-display-frame');
+        if (frames.length === 0) return 'adh=none';
+        let max: number | null = null;
+        let inFlow = 0;
+        for (let i = 0; i < frames.length; i++) {
+            const el = frames[i];
+            // 예약값이 CSS 로 덮이는 floating 계열은 인라인 변수와 실제 적용값이 다르다
+            if (el.classList.contains('dm-display-floating')) continue;
+            inFlow++;
+            const raw = el.style.getPropertyValue('--ad-slot-min-height').trim();
+            if (!raw) continue; // 예약값을 못 읽은 요소는 건너뛴다
+            const reserved = parseFloat(raw);
+            if (!Number.isFinite(reserved)) continue;
+            const over = el.getBoundingClientRect().height - reserved;
+            if (max === null || over > max) max = over;
+        }
+        // in-flow 프레임이 하나도 없음(= 전부 floating) 은 `none`. "프레임은 있는데
+        // 예약값을 하나도 못 읽음" 은 판별 불가(`?`). 둘을 섞으면 안 된다.
+        if (inFlow === 0) return 'adh=none';
+        return max === null ? 'adh=?' : `adh=${Math.round(max)}`;
+    } catch {
+        return 'adh=?';
+    }
+}
+
+/**
+ * 로그인 여부만 1/0 으로.
+ *
+ * ⛔ **회원 식별자는 절대 담지 않는다.** 값도 파싱하지 않고 **쿠키 이름의 존재만** 본다.
+ * 판별 근거로 `user_basic` 쿠키를 고른 이유:
+ *   · 이 저장소가 이미 쓰는 client-side 로그인 신호다
+ *     (`httpOnly: false` 로 발급 — `lib/server/auth/user-basic.ts`, 로그아웃 시 삭제).
+ *   · `authStore` 를 여기서 import 하면 순환 참조·번들 증가가 생긴다. 이 파일은
+ *     `initWebVitalsRum()` 전에 아무것도 초기화하지 않는 게 원칙이다.
+ *   · `parseUserBasicBase64()`(utils/user-basic-client)를 부르면 atob+JSON 파싱까지
+ *     하게 되는데, 우리는 **있다/없다** 만 필요하다. 정규식 한 번이 가장 가볍고 부작용이 없다.
+ * ⛔ 쿠키가 없어도 세션이 살아 있을 수 있는 경계(만료 직후 등)에서는 0 으로 셀 수 있다.
+ *    이 필드는 **표면을 가르는 용도**지 인증 판정에 쓰면 안 된다.
+ */
+export function authSignature(): string {
+    try {
+        return /(?:^|;\s*)user_basic=/.test(document.cookie) ? 'auth=1' : 'auth=0';
+    } catch {
+        return 'auth=?';
+    }
+}
+
 function sendToDantry(
     name: string,
     value: number,
     target: string,
     group: string,
-    detail: string
+    detail: string,
+    /** CLS 전용. web-vitals 의 `attribution.largestShiftEntry` — 다른 지표에는 없다. */
+    clsEntry?: LayoutShiftEntryLike
 ): void {
     if (!rumSampled) return;
     try {
@@ -97,9 +278,21 @@ function sendToDantry(
                 //   dom-interactive = 파싱 후 밀림     → 하이드레이션·초기 스크립트 계열
                 //   complete        = 로드 완료 후 밀림 → 광고·지연 로드 계열
                 // 처방이 셋 다 다르다. 없으면 또 가설만 늘어난다(2026-08-20).
-                `detail=${detail}`
+                `detail=${detail}`,
+                // ⛔ 기존 8줄은 한 글자도 바꾸지 않는다 — 집계 쿼리가 전부 깨진다.
+                //    bug/13836 판별용 4줄은 **CLS 에만** 뒤에 덧붙인다
+                //    (LCP/INP/TTFB 에는 의미가 없고 페이로드만 커진다).
+                ...(name === 'CLS'
+                    ? [...shiftLines(clsEntry), adOverflowSignature(), authSignature()]
+                    : [])
             ].join('\n'),
-            url: location.href,
+            // ⛔ `location.href` 를 그대로 실으면 `page=` 를 가려도 **같은 행에서 샌다**
+            //    (운영 실측 7일 736행/152종에 소셜 mb_id 원문). 쿼리·프래그먼트도 떼어낸다.
+            // ⛔ 그렇다고 `pathGroup` 을 통째로 쓰면 안 된다 — `/free/123` 이 `/free/:id` 가 되어
+            //    `match(url,'damoang\\.net/[a-z]+/[0-9]+')` 로 글상세를 가르는 감시 두 개
+            //    (`adblock_regression_watch.py:148`, `hydration_deploy_verdict.py:49`)가
+            //    조용히 뒤집힌다. **숫자 아이디는 남기고 식별자 세그먼트만 가린다.**
+            url: location.origin + maskIdentifierSegments(location.pathname),
             userAgent: navigator.userAgent
         };
         const body = JSON.stringify(payload);
@@ -111,9 +304,78 @@ function sendToDantry(
     }
 }
 
+/**
+ * **경로 세그먼트가 숫자가 아닌 식별자**로 들어오는 라우트 → 그 세그먼트를 `:id` 로 가린다.
+ *
+ * ⛔ 이건 이번 변경이 만든 결함이 아니라 **원래 있던 누출**이다. 기존 `pathGroup` 은
+ *    **숫자만** 치환해서 `/member/naver_8e22080b` 가 원문 그대로 텔레메트리에 실렸다
+ *    (운영 DB 실측: 최근 3일 `web_vitals` 중 331건 — `/member/google_956d0909` 32건,
+ *     `/member/naver_8e22080b` 19건 …). 소셜 가입자의 `mb_id` 는 그 자체가 회원 식별자다.
+ *
+ * ⭐ **가르는 기준 = 실제 라우트 트리**(`apps/web/src/routes/`, 2026-09-02 직접 확인):
+ *      member/[id] · member/settings{,/social,/ui,/verify-email} · member/orders{,/[orderId]}
+ *      member/leave{,/cancel,/complete} · member/escrow
+ *      invite/[token] · go/[id] · checkout/[orderId] · checkout/complete
+ *    → 정적 자식 라우트 **이름 목록**을 그대로 적어두고, 그 목록에 없는 세그먼트만 가린다.
+ *    "형태로 추정"(소셜 아이디처럼 생겼나)하지 않는다 — 아이디 형식이 바뀌면 조용히 새는데
+ *    라우트 목록은 파일 트리로 검증되고, 새 정적 라우트가 생기면 값이 눈에 띄게 변한다.
+ * ⛔ **순수 숫자 세그먼트는 건드리지 않는다.** 기존 두 규칙이 이미 `:id`/`:n` 으로 바꾸고
+ *    있어서, 여기서 손대면 `/member/orders/:n` 같은 **기존 집계 값이 바뀐다**.
+ *    누출되는 것은 비숫자 식별자뿐이므로 그것만 가린다(값 불변은 테스트로 고정).
+ * ⛔ 평범한 객체로 만들면 `/toString/x` 같은 경로가 `Object.prototype` 을 주워
+ *    예외로 이어진다. Map 으로 둔다.
+ */
+const IDENTIFIER_ROUTES = new Map<string, ReadonlySet<string>>([
+    [
+        'member',
+        new Set([
+            'settings',
+            'orders',
+            'leave',
+            'escrow',
+            'social',
+            'ui',
+            'verify-email',
+            'cancel',
+            'complete'
+        ])
+    ],
+    // ⛔ `members`(복수형)도 실재한다 — `lib/server/url-compat.ts:74` 가 레거시
+    //    `/bbs/profile.php?mb_id=` 를 여기로 보낸다. 404 여도 루트 레이아웃이 떠서
+    //    RUM 이 발신된다(운영 실측 7일 95행/44종). 빠뜨리면 그대로 샌다.
+    ['members', new Set<string>()],
+    ['invite', new Set<string>()],
+    ['go', new Set<string>()],
+    ['checkout', new Set(['complete'])],
+    // ⛔ 재설정 토큰은 회원 식별자보다 민감하다. 로그에 원문이 남으면 안 된다.
+    ['password-reset', new Set<string>()],
+    // 2단계 접두사 — `/admin/members/<mbId>`. 아래 lookup 이 두 단계를 모두 본다.
+    ['admin/members', new Set<string>()]
+]);
+
+function maskIdentifierSegments(pathname: string): string {
+    const segs = pathname.split('/');
+    // 1단계(`/member/…`)와 2단계(`/admin/members/…`) 접두사를 모두 본다.
+    let known = IDENTIFIER_ROUTES.get(segs[1]);
+    let start = 2;
+    if (!known && segs[2]) {
+        known = IDENTIFIER_ROUTES.get(`${segs[1]}/${segs[2]}`);
+        start = 3;
+    }
+    if (!known) return pathname;
+    for (let i = start; i < segs.length; i++) {
+        const seg = segs[i];
+        if (!seg) continue; // 빈 세그먼트(끝 슬래시·중복 슬래시)
+        if (known.has(seg)) continue; // 실제 존재하는 정적 하위 라우트
+        if (/^\d+$/.test(seg)) continue; // 숫자는 아래 기존 규칙이 처리한다(값 불변)
+        segs[i] = ':id';
+    }
+    return segs.join('/');
+}
+
 /** URL 경로를 게시판 단위로 그룹화(고카디널리티 방지). /free/123 → /free/:id */
-function pathGroup(pathname: string): string {
-    return pathname
+export function pathGroup(pathname: string): string {
+    return maskIdentifierSegments(pathname)
         .replace(/^\/([a-zA-Z0-9_-]+)\/\d+.*$/, '/$1/:id')
         .replace(/\/\d+/g, '/:n')
         .slice(0, 60);
@@ -159,7 +421,8 @@ export function initWebVitalsRum(): void {
             name: string,
             value: number,
             target: string | undefined,
-            detail: string | undefined
+            detail: string | undefined,
+            clsEntry?: LayoutShiftEntryLike
         ) => {
             const v = name === 'CLS' ? Math.round(value * 1000) : Math.round(value);
             const t = (target ?? '').slice(0, 100);
@@ -171,7 +434,7 @@ export function initWebVitalsRum(): void {
                 page_group: g
             });
             // GA4 와 **같은 값**을 dantry 로도 보낸다(표본만). 두 곳이 어긋나면 안 된다.
-            sendToDantry(name, v, t, g, detail ?? '?');
+            sendToDantry(name, v, t, g, detail ?? '?', clsEntry);
         };
         // 각 메트릭은 페이지 생애 최종값을 pagehide/visibilitychange(hidden) 시 1회 보고한다.
         // gtag 는 sendBeacon 으로 hidden 시점 플러시 → 언로드 유실 없음.
@@ -179,8 +442,22 @@ export function initWebVitalsRum(): void {
         //    사내 네비게이션은 LCP 를 hide 시점 경로로 오태깅하므로 분석 시 랜딩 필터 전제.
         // ⛔ 메트릭마다 attribution 필드 이름이 다르다. 느슨한 unknown 으로 받으면
         //    오필드를 조용히 숨겨 계측이 죽는다(2026-07-31 Evaluator 정정 이력).
+        /**
+         * ⛔ `largestShiftEntry` 는 web-vitals v6 의 **공개 attribution 필드**다
+         *    (`node_modules/.pnpm/web-vitals@6.0.1/.../dist/modules/types/cls.d.ts:38`
+         *     `largestShiftEntry?: LayoutShift;`). 타입 `LayoutShift` 는 lib.dom 에 없는
+         *    전역이라 여기서는 이 파일이 직접 선언한 `LayoutShiftEntryLike` 로 좁혀 받는다.
+         *    ⛔ web-vitals 는 `hadRecentInput` 엔트리를 애초에 세지 않으므로 여기 오는
+         *       엔트리에는 그 계열이 없다 — 이게 CLS 를 오탭 대리지표로 못 쓰는 이유다.
+         */
         onCLS((m) =>
-            send('CLS', m.value, m.attribution.largestShiftTarget, m.attribution.loadState)
+            send(
+                'CLS',
+                m.value,
+                m.attribution.largestShiftTarget,
+                m.attribution.loadState,
+                m.attribution.largestShiftEntry as unknown as LayoutShiftEntryLike | undefined
+            )
         );
         onLCP((m) =>
             send(

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -43,6 +43,7 @@
     } from '$lib/services/ga4';
     import { detectAdblockOnce } from '$lib/services/ad-telemetry';
     import { initWebVitalsRum } from '$lib/services/web-vitals-rum';
+    import { initMistouchProbe, resetMistouchBudget } from '$lib/services/mistouch-probe';
     import { AdblockNotice } from '$lib/components/features/adblock-notice';
     import type { MenuItem } from '$lib/api/types';
     import { readUserBasicFromCookie } from '$lib/utils/user-basic-client';
@@ -476,6 +477,9 @@
 
     // afterNavigate 통합: GA4 페이지뷰 + 광고 observer 재설정
     afterNavigate(({ to }) => {
+        // 오탭 계측(bug/13836) 상한을 페이지 단위로 되돌린다. 모듈 스코프 카운터는
+        // soft-nav 로 리셋되지 않아, 안 하면 상한이 "세션당 3건" 이 된다.
+        resetMistouchBudget();
         // GA4 페이지뷰 추적
         if (to?.url) {
             // PIPA: 민감 페이지는 Clarity 리플레이 제외 (SPA 라우팅마다 재평가)
@@ -1014,6 +1018,10 @@
 
         // 실사용자 Core Web Vitals(CLS/LCP/INP + 범인 요소) → GA4. 유휴 후처리라 성능 영향 0.
         initWebVitalsRum();
+
+        // 오탭 계측(bug/13836): 닿은 좌표에 있던 글 vs 실제로 열린 글. 리스너 2개 등록뿐이라
+        // 렌더 경로에 아무것도 추가하지 않는다. 오탭이 확정된 순간에만 비콘이 나간다.
+        initMistouchProbe();
 
         // Built-in Hooks 초기화 (콘텐츠 임베딩, 게시판 필터 등)
         initBuiltinHooks();


### PR DESCRIPTION
## 왜

`bug/13836` — 모바일 목록에서 글을 터치하면 **아래 글**이 열린다. 석 달째, 두 번째 제보다.
`bug/12610`(6/05)이 같은 증상인데 **원인을 못 찾은 채 닫혔다.**

## CLS 로는 원리적으로 못 잡는다 (실측)

| 관측 | 뜻 |
|---|---|
| `scrollY=600·1500` 에서 layout-shift 엔트리 **0개** | 스크롤 앵커링이 흡수한다. 실사용자는 스크롤한 채로 탭한다 |
| 모바일에서 **스크롤도 포인터 입력** | 스크롤 직후 500ms 의 밀림은 `hadRecentInput` 으로 CLS 에서 전부 빠진다 |

오터치는 「손가락이 움직이는 그 순간의 밀림」인데 **CLS 규정이 정확히 그 구간을 버린다.**
그래서 대리 지표 대신 **증상 자체**를 잰다 — 닿은 링크 vs 실제로 열린 링크.

## 무엇

### `mistouch-probe.ts` (신규)
다를 때만 비콘. `drow`(**+1 = 바로 아래 글**) · `dy` · `dt` · `sy` · `ptype` · `adh` · `auth`.
⛔ URL·제목·회원 식별자는 담지 않는다.

- `pointerdown` 핸들러는 **대입만**. `elementFromPoint` 는 레이아웃을 강제하는데 `pointerdown` 은
  스크롤이 시작되는 프레임이라, 거기서 강제하면 **관측이 증상을 만든다.**
  `event.target` 은 브라우저가 이미 한 히트테스트 결과라 비용 0.
- 짝짓기 게이트 3단. 없으면 스크롤하다 만 뒤의 키보드 Enter 가 `drow=27` 로 기록된다.
- 허용 오차 **16px = 크롬 자체 컷오프**. 10px 이면 13~15px 의 진짜 오터치가 버려진다.

### `web-vitals-rum.ts`
- **`mover=` 제거** — `sources` 는 밀린 요소만 담아 「높이가 변한 요소」를 원리적으로 못 찾고,
  rect 가 뷰포트로 클리핑돼 **정반대 답**을 냈다.
- **`shift=`** — 소스 합이 아니라 **최대 단일 소스**의 `dTop`. 양쪽 rect 가 온전할 때만.
  클리핑된 값은 부호가 뒤집힌다(아래로 200px 을 「위로 730」으로 보고했다).
- **`adh=`** — 광고 실제높이 − 예약높이. `min-height` 는 바닥값이라 **예약보다 큰 광고를 못 막고**,
  광고는 **30~45초마다 갱신**된다.

### ⛔ 식별자 누출 (기존 결함, 이번 변경이 만든 것 아님)
`pathGroup` 이 **숫자만** 치환해 소셜 `mb_id` 가 원문 그대로 실려 있었다.

```
page= 에 3일 331건   /member/google_956d0909 32건 · /member/naver_8e22080b 19건
url  에 7일 736행 / 152종
/members/(복수형, 레거시 프로필 링크)  7일 95행
/password-reset/[token]  ← 재설정 토큰이 남을 경로
```

⛔ `url` 을 통째로 `pathGroup` 으로 바꾸지 **않았다.** `/free/123` → `/free/:id` 가 되면
글상세를 가르는 감시 두 개(`adblock_regression_watch.py:148`, `hydration_deploy_verdict.py:49`)의
정규식이 전부 안 맞아 **조용히 뒤집힌다.** 숫자 아이디는 남기고 **식별자만** 가린다.

## 검증

하네스 **5라운드**(구현자 ≠ 검증자). 매 라운드가 결함을 잡았다.

| 라운드 | 결과 |
|---|---|
| 1차 | ❌ **접근 자체가 틀림** — CLS 로는 못 잡음 |
| 2차 | ❌ 위양성 3종 · `shift=` 부호 반전 · 식별자 누출 |
| 3차 | ⚠️ 임계값 과잉(13~15px 손실) · 라우트 누락 3건 |
| 4차 | 통과 |

실측:
- 위양성 **9종 0건** (정상 탭·중첩 링크·같은 글 다른 부분·드래그·버튼·합성 click·키보드 Enter)
- 라이브 `/free` **23탭 비콘 0건**
- 진짜 오터치 `drow` **+1·+2·+3·−1**, `scrollY>0` 에서도 잡힘
- 성능 회귀 0 (CPU 4배 스로틀, 프레임 p95 32.30 → 32.23)
- `pathGroup` 값 불변 — 운영 실제 경로 **22,806종** 대조, **99.53% 무변경**, 변경분 전부 `/member/:id`
- 수집기 왕복 실증 — POST 200 → ClickHouse 적재 확인 (**버려지지 않는다**)
- `svelte-check` **0 errors** · 단위 테스트 **977 통과** · lint 증분 **0**

## ⛔ 배포 전 알아야 할 것

- **iOS 사파리 미검증** — 리그가 크로미움 전용이다. 제보는 크롬이지만 계측은 전 기기에 깔린다.
- **하루 실제 발생 건수는 배포 전엔 못 잰다** — observe-first 로 하루 재고 판단하는 게 맞다.
- 표본율 100%(오터치는 드물다). 페이지 로드당 3건 상한.
