### PR TITLE
fix(member): 닉네임 URL 프로필에서 통계·이용제한·팔로우 누락 수정 (#13780)

### DIFF
--- a/apps/web/src/routes/api/members/[id]/profile/+server.ts
+++ b/apps/web/src/routes/api/members/[id]/profile/+server.ts
@@ -164,7 +164,8 @@ export const GET: RequestHandler = async ({ params, locals }) => {
                         delete_post_by_admin, delete_comment_by_admin,
                         total_rcmd_count, total_singo_count
                  FROM g5_member_board_status WHERE mb_id = ?`,
-                [memberId]
+                // #13780: 슬러그가 닉네임일 수 있어 정본 mb_id 로 조회 (memberId=슬러그 금지)
+                [member.mb_id]
             );
             stats = statsRows[0] || defaultStats;
         } catch {
@@ -181,7 +182,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
             const counts = await calculateMemberCounts(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (sql: string, params?: unknown[]) => pool.query(sql, params) as any,
-                memberId
+                member.mb_id // #13780: 정본 mb_id (슬러그가 닉네임이면 재계산이 0건이 됨)
             );
             if (counts) {
                 stats = {
@@ -211,7 +212,8 @@ export const GET: RequestHandler = async ({ params, locals }) => {
                  WHERE (wr_subject = ? OR wr_subject LIKE CONCAT(?, '(%'))
                    AND wr_is_comment = 0
                  ORDER BY wr_datetime DESC LIMIT 10`,
-                [memberId, memberId]
+                // #13780: 정본 mb_id — wr_subject 는 `mb_id(닉네임)` 형식이라 슬러그(닉)로는 안 잡힘
+                [member.mb_id, member.mb_id]
             );
             for (const row of logRows) {
                 const entry = parseDisciplineLogContent(row);
@@ -237,11 +239,11 @@ export const GET: RequestHandler = async ({ params, locals }) => {
         try {
             [followerRows] = await pool.query<CountRow[]>(
                 'SELECT COUNT(*) AS count FROM g5_member_follow WHERE target_id = ?',
-                [memberId]
+                [member.mb_id]
             );
             [followingRows] = await pool.query<CountRow[]>(
                 'SELECT COUNT(*) AS count FROM g5_member_follow WHERE mb_id = ?',
-                [memberId]
+                [member.mb_id]
             );
         } catch {
             // 테이블 없으면 무시


### PR DESCRIPTION
## 문제 (#13780)
`/member/{mb_id}` 로 접근하면 프로필이 정상 출력되지만, `/member/{닉네임}` 으로 접근하면 팔로워/팔로잉·게시글/댓글·공감/신고 섹션이 0으로 비고, 이용제한 내역 섹션은 통째로 사라진다.

## 원인
프로필 API는 회원 row 를 `WHERE mb_id = ? OR mb_nick = ?` 로 찾아 헤더는 정상 표시되지만, 이후 이차 쿼리들이 **해석된 `member.mb_id` 가 아니라 URL 슬러그(=닉네임)** 를 그대로 조회 키로 사용한다. 해당 컬럼들은 mb_id 기준이라 닉네임으로는 0건/빈값이 되고, 이용제한 섹션은 `{#if length > 0}` 게이트에 걸려 사라진다. mb_id URL 일 때는 슬러그 == mb_id 라 우연히 맞아떨어졌다.

## 수정
슬러그가 닉네임일 수 있는 4개 이차 쿼리의 조회 키를 정본 `member.mb_id` 로 통일:
- 통계(`g5_member_board_status`)
- 글/댓글 실시간 재계산(`calculateMemberCounts`)
- 이용제한 내역(`g5_write_disciplinelog`, `wr_subject` 는 `mb_id(닉네임)` 형식이라 닉으로는 매칭 불가)
- 팔로워/팔로잉 카운트(`g5_member_follow`)

이미 같은 파일의 닉네임 변경 이력 쿼리가 `member.mb_id` 를 쓰고 있어(동일 사유 주석 존재) 그 패턴에 맞춘 것. 회원 조회 쿼리 자체는 raw 슬러그가 필요하므로 그대로 둠. 단일 파일 변경.

## 검증
- [ ] canary 에서 `/member/{닉네임}` 과 `/member/{mb_id}` 의 프로필 API 응답이 stats·팔로워/팔로잉·이용제한에서 동일한지 대조
- [ ] 닉네임에 한글 포함 케이스 정상
- [ ] mb_id URL 회귀 없음