### PR TITLE
fix(member): 소셜 계정 추가 연결이 신규가입/바운스로 실패하던 문제 (#13862, #13860)

### DIFF
--- a/apps/web/src/routes/member/settings/+page.svelte
+++ b/apps/web/src/routes/member/settings/+page.svelte
@@ -145,6 +145,29 @@
         payco: 'bg-[#E42529] text-white'
     };
 
+    // 추가 연결 가능한 소셜 provider (login 페이지 mainProviders 와 동일 집합·순서)
+    const LINKABLE_PROVIDERS = [
+        'kakao',
+        'naver',
+        'google',
+        'apple',
+        'facebook',
+        'twitter',
+        'payco'
+    ] as const;
+
+    // 이미 연결된 provider 는 제외 — 남은 것만 "추가 연결" 버튼으로 노출.
+    let connectedProviders = $derived(new Set(profiles.map((p) => p.provider)));
+    let linkableProviders = $derived(LINKABLE_PROVIDERS.filter((p) => !connectedProviders.has(p)));
+
+    // #13862/#13860: 추가 연결은 로그인 세션을 유지한 채 link 모드로 시작해야 한다.
+    // 예전엔 /login 으로 보내 (a) 새 소셜이 신규가입으로 오판되거나(#13862)
+    // (b) 이미 로그인 상태라 login→settings 바운스 루프가 났다(#13860).
+    function socialLinkHref(provider: string): string {
+        const redirect = encodeURIComponent('/member/settings');
+        return `/auth/start?provider=${encodeURIComponent(provider)}&link=1&redirect=${redirect}`;
+    }
+
     async function disconnectSocial(mpNo: number): Promise<void> {
         if (disconnecting) return;
 
@@ -845,12 +868,22 @@
 
                 <div>
                     <p class="text-muted-foreground mb-3 text-sm">
-                        새 소셜 계정을 연결하려면 해당 서비스로 로그인하세요.
+                        새 소셜 계정을 현재 계정에 추가로 연결합니다. 연결할 서비스를 선택하세요.
                     </p>
-                    <Button variant="outline" href="/login?redirect=/member/settings">
-                        <Link class="mr-2 h-4 w-4" />
-                        소셜 계정 추가 연결
-                    </Button>
+                    {#if linkableProviders.length === 0}
+                        <p class="text-muted-foreground text-sm">
+                            연결 가능한 소셜 서비스를 모두 연결했습니다.
+                        </p>
+                    {:else}
+                        <div class="flex flex-wrap gap-2">
+                            {#each linkableProviders as provider (provider)}
+                                <Button variant="outline" size="sm" href={socialLinkHref(provider)}>
+                                    <Link class="mr-2 h-4 w-4" />
+                                    {providerNames[provider] || provider} 연결
+                                </Button>
+                            {/each}
+                        </div>
+                    {/if}
                 </div>
             </CardContent>
         </Card>


### PR DESCRIPTION
## 문제
설정 > 연결된 소셜 계정의 **'소셜 계정 추가 연결'** 버튼이 동작하지 않음.
- **#13862**: 기존 소셜을 해제하고 새 구글 계정을 연결하면 기존 계정에 붙지 않고 **'신규 가입' 안내**가 뜸(네이버로 로그인된 상태여도).
- **#13860**: 버튼을 누르면 설정↔로그인 사이를 3번 왕복 후 **'자동 이동이 반복되어 중단했습니다'** 오류. x.com 도 연결 불가.

## 원인
추가 연결 버튼이 `/login?redirect=/member/settings` 로 이동했다. 추가 연결은 **로그인 세션을 유지한 채** link 모드(`/auth/start?...&link=1`)로 시작해야 콜백에서 `linkTo` 분기를 타 기존 계정에 연결되는데, `/login` 을 거치면:
- 새 소셜 콜백에 `linkTo` 가 없어 → 신규 로그인/가입 분기 → `/register`(신규가입 안내) = #13862
- 이미 로그인 상태라 login 페이지가 settings 로 되돌려보내는 바운스 가드가 3회째 발동 = #13860

링크 모드 백엔드 경로(`auth/start` link=1 → 콜백 `linkTo` 분기 → `linkSocialProfile`)는 이미 존재하고 정상이었으나 **UI 가 호출하지 않았다**.

## 수정
추가 연결 섹션을 **아직 연결되지 않은 provider 별 버튼**으로 교체하고, 각 버튼이 `/auth/start?provider=<p>&link=1&redirect=/member/settings` 로 가도록 함. 이미 연결된 provider 는 노출하지 않고, 전부 연결 시 안내문 표시. 백엔드 무변경, 단일 파일.

## 검증
- [ ] 로그인 상태에서 미연결 provider 버튼 → 링크 모드로 이동, 기존 계정에 연결(신규가입/바운스 없음)
- [ ] 이미 연결된 provider 는 버튼 미노출
- [ ] x.com(twitter) 버튼도 링크 모드 (개발자포털 콜백 URL·키는 별도 점검 필요)

관련: 이후 bug/13834 답변 정정 예정(설정에서 재연동 가능하다고 안내했던 부분).