### PR TITLE
fix(home): 터치 기기에만 44px 적용 + 모아보기 개수 복구

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -444,6 +444,36 @@ html {
     }
 }
 
+/* 홈 위젯(공감글·모아보기·그룹·새글·경제) 목록 링크의 터치 타깃 — 2026-09-05.
+ *
+ * 2026-09-04 에 이 5개 위젯 링크에 min-height:44px 을 인라인 style 로 넣었다(오터치 하루 542건).
+ * 그런데 인라인 style 은 미디어쿼리를 못 써서 **마우스 환경에도 그대로 걸렸다** — 1440px 데스크톱
+ * 홈이 +592px 늘어났다. 터치 타깃은 손가락 문제지 마우스 문제가 아니다.
+ *
+ * ⭐ 그래서 4속성(min-height/display/flex-direction/justify-content)만 이 클래스로 옮기고
+ *    `(hover: none) and (pointer: coarse)` 안에서만 켠다. 위 :active 규칙과 같은 판정식이다.
+ * ⛔ padding 은 인라인에 그대로 둔다. `calc(0.125rem + var(--row-pad-extra))` 는 회원 UI 밀도
+ *    설정이고, 이미 인라인이라 class 의 py-* 를 이기고 있다. 여기로 옮기면 그 관계가 뒤집힌다.
+ * ⛔ Tailwind `block` 클래스를 같이 쓰지 않는다. `.block` 과 이 클래스는 특이성이 같아(0,1,0)
+ *    승자가 번들 순서로 갈린다 — 「클래스 넣음 ≠ 적용됨」. 기본값 display:block 을 이 클래스가
+ *    직접 들고, 같은 파일 뒤쪽 미디어쿼리에서 flex 로 덮는다(같은 특이성 + 뒤 = 확정적).
+ *    이 규칙들은 @layer 밖이라 Tailwind 유틸리티(@layer utilities)보다 항상 강하다.
+ * ⛔ 공용 클래스 하나로 둔 이유: 5개 파일이 같은 마크업·같은 수치다. 컴포넌트 <style> 은
+ *    스코프돼 있어 정의가 5벌로 갈라지고, 다음에 44 를 고칠 때 하나만 고쳐질 위험이 생긴다.
+ * ⛔ 44px 은 바닥만 보장한다(min-height). 밀도 relaxed 로 더 큰 회원 설정은 그대로 커진다. */
+.widget-post-row {
+    display: block;
+}
+
+@media (hover: none) and (pointer: coarse) {
+    .widget-post-row {
+        min-height: 44px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
+}
+
 /* 하이드레이션 중에는 읽음 표시 전환을 끈다 — 2026-08-19.
  *
  * 읽음 상태는 localStorage(L1) 기반이라 SSR 이 알 수 없다. 그래서 서버는 전부

--- a/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
+++ b/apps/web/src/lib/components/features/economy/components/post-list/economy-post-list.svelte
@@ -44,15 +44,21 @@
                     ⛔ padding 을 키워서 44px 을 만들지 말 것. --row-pad-extra 는 회원의 UI 밀도
                        설정(compact 0 / balanced 3 / relaxed 6px)이라 곱해지면 relaxed 가 56px 로
                        과해진다. min-height 는 바닥만 보장하므로 밀도를 크게 쓰는 회원 설정은 그대로다.
-                    ⛔ 인라인 style 이 Tailwind 클래스를 이긴다 — 아래 padding 계산식 때문에 class 의
-                       py-* 는 이미 무시되고 있다. 그래서 display 도 인라인에 두고 class 에서 block 을
-                       지웠다. 남겨두면 「class 는 block 인데 실제 동작은 flex」라는 거짓이 하나 더
-                       생긴다(py-* 가 이미 같은 방식으로 사람을 속였다).
+                    ⛔ 44px 은 **터치 기기에서만** 건다. 2026-09-04 에 인라인 style 로 넣었더니 인라인은
+                       미디어쿼리를 못 써 마우스에도 걸렸고, 1440px 데스크톱 홈이 +592px 늘어났다.
+                       지금은 app.css 의 `.widget-post-row` 가 `(hover:none) and (pointer:coarse)` 안에서만
+                       min-height/flex 를 켠다. 데스크톱은 그 클래스의 기본값 display:block 그대로다.
+                    ⛔ padding 만 인라인에 남긴다. 인라인이 Tailwind 를 이겨서 class 의 py-* 는 이미
+                       무시되고 있다 — 이 계산식을 클래스로 옮기면 그 관계가 뒤집힌다. 그대로 둔다.
+     * ⛔ 2026-09-07 정정 — 「특이성이 같아 번들 순서로 갈린다」는 **틀렸다**.
+     *    빌드된 CSS 실측: `.block` 은 `@layer utilities` **안**, `.widget-post-row` 는
+     *    **레이어 밖**이다. unlayered 가 레이어보다 **항상** 이기므로 순서와 무관하게 결정적이다.
+                       번들 순서로 승자가 갈린다. display 기본값은 `.widget-post-row` 가 직접 든다.
                 -->
                 <a
                     href={post.url}
-                    class="hover:bg-muted rounded px-0.5 py-2 transition-all duration-200 ease-out"
-                    style="min-height: 44px; display: flex; flex-direction: column; justify-content: center; padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
+                    class="hover:bg-muted widget-post-row rounded px-0.5 py-2 transition-all duration-200 ease-out"
+                    style="padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
                 >
                     <div class="flex items-center gap-1">
                         <!-- 추천수 배지 -->

--- a/apps/web/src/lib/components/features/explore/explore-preview.svelte
+++ b/apps/web/src/lib/components/features/explore/explore-preview.svelte
@@ -242,15 +242,21 @@
                                    밀도 설정(compact 0 / balanced 3 / relaxed 6px)이라 곱해지면 relaxed 가
                                    56px 로 과해진다. min-height 는 바닥만 보장하므로 밀도를 크게 쓰는
                                    회원 설정은 그대로다.
-                                ⛔ 인라인 style 이 Tailwind 클래스를 이긴다 — 아래 padding 계산식 때문에
-                                   class 의 py-* 는 이미 무시되고 있다. 그래서 display 도 인라인에 두고
-                                   class 에서 block 을 지웠다. 남겨두면 「class 는 block 인데 실제 동작은
-                                   flex」라는 거짓이 하나 더 생긴다(py-* 가 이미 같은 방식으로 속였다).
+                                ⛔ 44px 은 **터치 기기에서만** 건다. 2026-09-04 에 인라인 style 로 넣었더니 인라인은
+                                   미디어쿼리를 못 써 마우스에도 걸렸고, 1440px 데스크톱 홈이 +592px 늘어났다.
+                                   지금은 app.css 의 `.widget-post-row` 가 `(hover:none) and (pointer:coarse)` 안에서만
+                                   min-height/flex 를 켠다. 데스크톱은 그 클래스의 기본값 display:block 그대로다.
+                                ⛔ padding 만 인라인에 남긴다. 인라인이 Tailwind 를 이겨서 class 의 py-* 는 이미
+                                   무시되고 있다 — 이 계산식을 클래스로 옮기면 그 관계가 뒤집힌다. 그대로 둔다.
+     * ⛔ 2026-09-07 정정 — 「특이성이 같아 번들 순서로 갈린다」는 **틀렸다**.
+     *    빌드된 CSS 실측: `.block` 은 `@layer utilities` **안**, `.widget-post-row` 는
+     *    **레이어 밖**이다. unlayered 가 레이어보다 **항상** 이기므로 순서와 무관하게 결정적이다.
+                                   번들 순서로 승자가 갈린다. display 기본값은 `.widget-post-row` 가 직접 든다.
                             -->
                             <a
                                 href={post.url}
-                                class="hover:bg-muted rounded px-0.5 py-1.5 transition-all duration-200 ease-out"
-                                style="min-height: 44px; display: flex; flex-direction: column; justify-content: center; padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
+                                class="hover:bg-muted widget-post-row rounded px-0.5 py-1.5 transition-all duration-200 ease-out"
+                                style="padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
                             >
                                 <div class="flex items-center gap-1">
                                     <!-- 추천수 배지 -->

--- a/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
+++ b/apps/web/src/lib/components/features/group/components/post-list/group-post-list.svelte
@@ -44,15 +44,21 @@
                     ⛔ padding 을 키워서 44px 을 만들지 말 것. --row-pad-extra 는 회원의 UI 밀도
                        설정(compact 0 / balanced 3 / relaxed 6px)이라 곱해지면 relaxed 가 56px 로
                        과해진다. min-height 는 바닥만 보장하므로 밀도를 크게 쓰는 회원 설정은 그대로다.
-                    ⛔ 인라인 style 이 Tailwind 클래스를 이긴다 — 아래 padding 계산식 때문에 class 의
-                       py-* 는 이미 무시되고 있다. 그래서 display 도 인라인에 두고 class 에서 block 을
-                       지웠다. 남겨두면 「class 는 block 인데 실제 동작은 flex」라는 거짓이 하나 더
-                       생긴다(py-* 가 이미 같은 방식으로 사람을 속였다).
+                    ⛔ 44px 은 **터치 기기에서만** 건다. 2026-09-04 에 인라인 style 로 넣었더니 인라인은
+                       미디어쿼리를 못 써 마우스에도 걸렸고, 1440px 데스크톱 홈이 +592px 늘어났다.
+                       지금은 app.css 의 `.widget-post-row` 가 `(hover:none) and (pointer:coarse)` 안에서만
+                       min-height/flex 를 켠다. 데스크톱은 그 클래스의 기본값 display:block 그대로다.
+                    ⛔ padding 만 인라인에 남긴다. 인라인이 Tailwind 를 이겨서 class 의 py-* 는 이미
+                       무시되고 있다 — 이 계산식을 클래스로 옮기면 그 관계가 뒤집힌다. 그대로 둔다.
+     * ⛔ 2026-09-07 정정 — 「특이성이 같아 번들 순서로 갈린다」는 **틀렸다**.
+     *    빌드된 CSS 실측: `.block` 은 `@layer utilities` **안**, `.widget-post-row` 는
+     *    **레이어 밖**이다. unlayered 가 레이어보다 **항상** 이기므로 순서와 무관하게 결정적이다.
+                       번들 순서로 승자가 갈린다. display 기본값은 `.widget-post-row` 가 직접 든다.
                 -->
                 <a
                     href={post.url}
-                    class="hover:bg-muted rounded px-0.5 py-1.5 transition-all duration-200 ease-out"
-                    style="min-height: 44px; display: flex; flex-direction: column; justify-content: center; padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
+                    class="hover:bg-muted widget-post-row rounded px-0.5 py-1.5 transition-all duration-200 ease-out"
+                    style="padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
                 >
                     <div class="flex items-center gap-1">
                         <!-- 추천수 배지 -->

--- a/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
+++ b/apps/web/src/lib/components/features/new-board/components/post-list/simple-post-list.svelte
@@ -38,15 +38,21 @@
                     ⛔ padding 을 키워서 44px 을 만들지 말 것. --row-pad-extra 는 회원의 UI 밀도
                        설정(compact 0 / balanced 3 / relaxed 6px)이라 곱해지면 relaxed 가 56px 로
                        과해진다. min-height 는 바닥만 보장하므로 밀도를 크게 쓰는 회원 설정은 그대로다.
-                    ⛔ 인라인 style 이 Tailwind 클래스를 이긴다 — 아래 padding 계산식 때문에 class 의
-                       py-* 는 이미 무시되고 있다. 그래서 display 도 인라인에 두고 class 에서 block 을
-                       지웠다. 남겨두면 「class 는 block 인데 실제 동작은 flex」라는 거짓이 하나 더
-                       생긴다(py-* 가 이미 같은 방식으로 사람을 속였다).
+                    ⛔ 44px 은 **터치 기기에서만** 건다. 2026-09-04 에 인라인 style 로 넣었더니 인라인은
+                       미디어쿼리를 못 써 마우스에도 걸렸고, 1440px 데스크톱 홈이 +592px 늘어났다.
+                       지금은 app.css 의 `.widget-post-row` 가 `(hover:none) and (pointer:coarse)` 안에서만
+                       min-height/flex 를 켠다. 데스크톱은 그 클래스의 기본값 display:block 그대로다.
+                    ⛔ padding 만 인라인에 남긴다. 인라인이 Tailwind 를 이겨서 class 의 py-* 는 이미
+                       무시되고 있다 — 이 계산식을 클래스로 옮기면 그 관계가 뒤집힌다. 그대로 둔다.
+     * ⛔ 2026-09-07 정정 — 「특이성이 같아 번들 순서로 갈린다」는 **틀렸다**.
+     *    빌드된 CSS 실측: `.block` 은 `@layer utilities` **안**, `.widget-post-row` 는
+     *    **레이어 밖**이다. unlayered 가 레이어보다 **항상** 이기므로 순서와 무관하게 결정적이다.
+                       번들 순서로 승자가 갈린다. display 기본값은 `.widget-post-row` 가 직접 든다.
                 -->
                 <a
                     href={post.url}
-                    class="hover:bg-muted rounded px-0.5 py-1.5 transition-all duration-200 ease-out"
-                    style="min-height: 44px; display: flex; flex-direction: column; justify-content: center; padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
+                    class="hover:bg-muted widget-post-row rounded px-0.5 py-1.5 transition-all duration-200 ease-out"
+                    style="padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
                 >
                     <div class="flex items-center gap-1">
                         <!-- 추천수 배지 -->

--- a/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
+++ b/apps/web/src/lib/components/features/recommended/components/post-list/post-list.svelte
@@ -59,15 +59,21 @@
                     ⛔ padding 을 키워서 44px 을 만들지 말 것. --row-pad-extra 는 회원의 UI 밀도
                        설정(compact 0 / balanced 3 / relaxed 6px)이라 곱해지면 relaxed 가 56px 로
                        과해진다. min-height 는 바닥만 보장하므로 밀도를 크게 쓰는 회원 설정은 그대로다.
-                    ⛔ 인라인 style 이 Tailwind 클래스를 이긴다 — 아래 padding 계산식 때문에 class 의
-                       py-* 는 이미 무시되고 있다. 그래서 display 도 인라인에 두고 class 에서 block 을
-                       지웠다. 남겨두면 「class 는 block 인데 실제 동작은 flex」라는 거짓이 하나 더
-                       생긴다(py-* 가 이미 같은 방식으로 사람을 속였다).
+                    ⛔ 44px 은 **터치 기기에서만** 건다. 2026-09-04 에 인라인 style 로 넣었더니 인라인은
+                       미디어쿼리를 못 써 마우스에도 걸렸고, 1440px 데스크톱 홈이 +592px 늘어났다.
+                       지금은 app.css 의 `.widget-post-row` 가 `(hover:none) and (pointer:coarse)` 안에서만
+                       min-height/flex 를 켠다. 데스크톱은 그 클래스의 기본값 display:block 그대로다.
+                    ⛔ padding 만 인라인에 남긴다. 인라인이 Tailwind 를 이겨서 class 의 py-* 는 이미
+                       무시되고 있다 — 이 계산식을 클래스로 옮기면 그 관계가 뒤집힌다. 그대로 둔다.
+     * ⛔ 2026-09-07 정정 — 「특이성이 같아 번들 순서로 갈린다」는 **틀렸다**.
+     *    빌드된 CSS 실측: `.block` 은 `@layer utilities` **안**, `.widget-post-row` 는
+     *    **레이어 밖**이다. unlayered 가 레이어보다 **항상** 이기므로 순서와 무관하게 결정적이다.
+                       번들 순서로 승자가 갈린다. display 기본값은 `.widget-post-row` 가 직접 든다.
                 -->
                 <a
                     href={post.url}
-                    class="hover:bg-muted rounded px-0.5 py-2 transition-all duration-200 ease-out"
-                    style="min-height: 44px; display: flex; flex-direction: column; justify-content: center; padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
+                    class="hover:bg-muted widget-post-row rounded px-0.5 py-2 transition-all duration-200 ease-out"
+                    style="padding-top: calc(0.125rem + var(--row-pad-extra, 0px)); padding-bottom: calc(0.125rem + var(--row-pad-extra, 0px));"
                 >
                     <div class="flex items-center gap-1">
                         <!-- 추천수 배지 (Heart 아이콘 포함) -->

--- a/apps/web/src/lib/server/explore-loader.ts
+++ b/apps/web/src/lib/server/explore-loader.ts
@@ -19,7 +19,35 @@ const EXPLORE_FILE = 'explore.json';
 let cache: { data: ExploreData; timestamp: number } | null = null;
 const CACHE_TTL_MS = 60_000; // 60초
 
-const PREVIEW_POST_COUNT = 17;
+/**
+ * 서버가 미리보기로 내려주는 모드별 글 수.
+ *
+ * ⛔ 클라이언트가 화면에 그리는 개수는 17개다(explore-preview.svelte `PREVIEW_COUNT`).
+ *    이 상수는 **그 17개를 채우기 위한 후보 공급량**이지 표시 개수가 아니다.
+ *
+ * 왜 17 이면 안 됐나 — 클라이언트는 slice(0,17) **앞에서** 차단 회원·차단 키워드·
+ * 공감글 중복(#13598)을 걸러낸다. 「빠진 만큼 다른 글로 채운다」는 의도였지만
+ * 서버가 딱 17개만 줘서 채울 여분이 0 이었다. 새벽에는 새 글이 적어 공감글과
+ * 후보가 크게 겹쳐 실제로 **8개**까지 줄었다(공감글 23개 중 9개가 앞 17개와 중복).
+ *
+ * 왜 42 인가 — 17(표시) + 25(제외 상한). 공감글 id 집합은 홈 SSR prefetch 의
+ * 기본 기간(getDefaultPeriod: 0~6시 6h / 6~9시 3h / 그 외 1h)에서 만들어지고,
+ * 그 상한이 6h 스냅샷의 25개다(community 15 + group 7 + info 3). 즉 공감글 중복만으로는
+ * 42개 후보가 17개 아래로 깎이지 않는다. 실측 캐시로 「17개를 채우는 데 필요한 깊이」를
+ * 12개 조합(4모드 × 3기간)에서 재보니 최댓값이 32였고, 42는 그 위로 10개 여유다.
+ *
+ * ⛔ 공짜가 아니다. 이 응답은 홈에서 매번 부르고 s-maxage=120 으로 캐시된다.
+ *    실측(운영 응답 구조 동일): 17 → 23,504B / gzip 4,504B, 42 → 57,756B / gzip 9,865B.
+ *    즉 gzip +5,361B(+119%). 더 올릴 거면 이 숫자부터 다시 재라.
+ * ⛔ 50 을 넘기지 마라. 원본이 rising 50개 / top periods['24h'] 50개뿐이라 그 위는
+ *    바이트만 늘고 후보는 안 는다(hot/new 만 100개).
+ * ⛔ top 모드는 posts 가 아니라 periods['24h'] 를 쓴다 — 아래 slice 두 곳 모두에 걸린다.
+ */
+const PREVIEW_POST_COUNT = 42;
+// ⛔ 2026-09-07 추가 — 비용은 API 만이 아니다.
+//    이 페이로드는 **홈 SSR HTML 에도 그대로 실린다**(`+page.server.ts` → HomePageData.exploreData).
+//    실측: 홈 HTML 461,836B / gzip 69,505B 기준 **+34.3KB raw(+7.4%) · +5.6KB gzip(+8%)**.
+//    API 응답 자체는 gzip 4,186 → 9,812B (+134%).
 
 function trimExploreModeData(mode: ExploreModeData, topOnly = false): ExploreModeData {
     return {


### PR DESCRIPTION
사장님 지적 두 건입니다 — 「공감글 모아보기 높이가 너무 넓다」 · 「모아보기가 00시 이후 개수가 줄어든다」.

## ① ⛔ 데스크톱에도 44px 이 걸려 있었습니다 (제가 낸 문제)

9/04 에 홈 위젯 링크에 `min-height:44px` 을 넣었는데 **뷰포트 조건을 안 걸어** 마우스 사용자에게도 적용됐습니다. 터치 타깃은 **손가락 문제**인데 데스크톱까지 **+592px** 길어졌습니다.

`app.css` 에 `.widget-post-row` 를 두고 `(hover: none) and (pointer: coarse)` 안에서만 44px 을 줍니다. 같은 파일 441행의 **기존 관례**를 그대로 따랐습니다.

⛔ **인라인 style 은 미디어쿼리를 못 씁니다.** 그래서 9/04 에 인라인에 넣었던 4속성을 클래스로 옮겼습니다. **padding 인라인은 그대로** 둡니다 — 옮기면 인라인 > 클래스 관계가 뒤집힙니다.

⛔ **Tailwind `block` 을 되돌리지 않았습니다.** `.block` 은 `@layer utilities` 안이고 `.widget-post-row` 는 **레이어 밖**이라 unlayered 가 항상 이깁니다. 순서와 무관하게 결정적입니다.

**실측 (밀도 3종 × 기기 2종)**

| 기기 | compact | balanced | relaxed |
|---|---|---|---|
| **데스크톱** | **30** | **36** | **42** | ← 9/04 이전과 동일 복귀 |
| 터치 | **44** | **44** | **44** |

## ② 모아보기가 새벽에 8개로 줄었습니다

`explore.json` 원본에 hot **100개**가 있는데 서버가 **17개로 잘라** 보냅니다. 클라이언트는 거기서 차단·키워드·**공감글 중복**을 뺀 뒤 17개를 채우려 하는데 **여분이 0** 이라 그대로 깎입니다.

```
17개 − 공감글 겹침 9개 = 8개
```

⭐ 새 글이 적은 **새벽**에는 두 위젯의 후보가 더 많이 겹쳐 심해집니다.

`PREVIEW_POST_COUNT` 를 **17 → 42** 로 올립니다. 표시 17 + 공감글 제외 상한 25 = 42. 24조합 전수 측정에서 17개를 채우는 데 필요한 **최대 깊이는 32**(여유 10)였습니다.

**라이브 새벽 데이터 재현**

| 모드 | 현행 | 수정 후 |
|---|---|---|
| hot | **8** | **17** |
| rising | **7** | **17** |
| top | **13** | **17** |
| new | 17 | 17 |

⛔ 클라이언트 `PREVIEW_COUNT = 17` 은 **안 바꿨습니다.** 화면에 나오는 개수는 그대로입니다.

**비용**: API gzip 4,186 → 9,812B. ⛔ 이 데이터는 **홈 SSR HTML 에도 실려** 홈 gzip **+5.6KB(+8%)** 늘어납니다.

## 검증 — 구현자와 분리된 독립 검증

| 항목 | 결과 |
|---|---|
| 미디어 특성 | `matchMedia` 와 **CDP 강제 두 경로가 교차검증** |
| 기기 × 밀도 | 6조합 실측, **데스크톱은 base 와 전 항목 동일** |
| 자식 배치 | 데스크톱 전 항목 동일, 터치는 높이·`display`·세로중앙만 변경. **긴 제목 말줄임 정상** |
| 모아보기 | 라이브 캐시로 **24조합 전수**, 전부 17개 |
| check / lint / test | 0 errors · 증분 0 · **977/977** |

⛔ **첫 측정은 틀렸습니다.** `transition-all duration-200` 때문에 밀도 변경 직후 2 rAF 로 재면 **전이 중간값**(33.34px 등)이 나옵니다. 600ms 정착 후 재측정했습니다.

⛔ **판정 불가**: 프로덕션 빌드 CSS 번들은 확인 못 했습니다(호스트 빌드 금지). dev 산출물에서 `.widget-post-row` 가 레이어 밖에 정상 존재하고 손으로 쓴 CSS 라 purge 대상이 아니라 위험은 낮습니다.
