### PR TITLE
fix(post): 이동/타인삭제 글에서 원본 댓글이 남아 본문과 어긋나던 문제 (#13754)

### DIFF
--- a/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
+++ b/apps/web/src/routes/[boardId]/[postId]/+page.server.ts
@@ -174,6 +174,10 @@ export const load: PageServerLoad = async ({
         }
 
         // 삭제된 게시글: 본문+메타데이터 숨김 + 검색엔진 색인 차단
+        // #13754: 타인삭제(이동/관리자)된 글은 본문이 tombstone 으로 가려지는데, 댓글은
+        // 웹 직접 SQL 경로(comments API)가 부모 삭제를 몰라 이동 전 원본 댓글을 그대로
+        // 채워 본문·댓글 소스가 어긋났다. 아래 댓글 fetch 를 이 플래그로 게이트한다.
+        let hideComments = false;
         if (post.deleted_at) {
             post.content = '';
             post.tags = [];
@@ -194,6 +198,7 @@ export const load: PageServerLoad = async ({
             if (!selfDeleted) {
                 // 헤더 카운트 라벨/SSR total/클라 backfill 게이트 일치를 위해 권위 카운트 0.
                 post.comments_count = 0;
+                hideComments = true;
             }
             setHeaders({ 'X-Robots-Tag': 'noindex, noarchive' });
         }
@@ -432,6 +437,24 @@ export const load: PageServerLoad = async ({
 
         // --- 2단계: 핵심/보조 데이터를 분리해 스트리밍 ---
         const commentsData = await (async () => {
+            // #13754: 타인삭제(이동/관리자)된 글은 원본 댓글도 노출하지 않는다.
+            // 본문 tombstone·comments_count=0 과 정합(웹 직접 SQL 이 부모 삭제를 몰라
+            // 이동 전 댓글을 채우던 문제 차단). 개별 "[삭제된 댓글]" 동작은 무영향.
+            if (hideComments) {
+                return {
+                    comments: {
+                        items: [],
+                        total: 0,
+                        page: 1,
+                        limit: initialCommentsLimit,
+                        total_pages: 0,
+                        loadState: 'complete' as 'complete' | 'partial' | 'failed',
+                        edit_policy: undefined as
+                            | { cost: number; grace_seconds: number }
+                            | undefined
+                    }
+                };
+            }
             if (isDataRequest && !locals.user?.id) {
                 // 비로그인 SPA 네비(__data.json): 댓글은 클라가 backfill 로 로드. total 은 권위값 보존.
                 // 비로그인 __data.json 은 nginx/SSR 캐시 대상이라 댓글을 비워 stale 캐시를 방지.


### PR DESCRIPTION
## 문제 (#13754)
글을 다른 게시판으로 **이동**한 뒤 원본을 삭제하면, 삭제된 원본을 조회할 때 **본문은 '삭제된 게시물입니다'(tombstone)** 인데 **댓글은 이동 전 원본 댓글이 그대로** 떠서 본문과 댓글이 어긋난다.

## 원인
글상세에서 본문과 댓글이 **다른 두 소스**에서 온다.
- **본문**: Go 백엔드(`/api/v1/boards/{board}/posts/{id}`) — 소프트삭제를 인지해 tombstone 마스킹.
- **댓글**: 웹 SvelteKit 라우트가 **MySQL 직접 조회**(`comments/+server.ts`) — `wr_deleted_at` 필터가 없어 이동 시 soft-delete된 원본 댓글을 그대로 계수·반환.

글상세(`[boardId]/[postId]/+page.server.ts`)는 타인삭제(self_deleted=false, 이동은 deleted_by=관리자≠작성자)일 때 `comments_count=0` 으로 헤더만 가릴 뿐, **댓글 fetch 는 무조건 실행**해 실제 스레드를 채웠다.

## 수정
타인삭제로 카운트를 0 으로 가리는 기존 분기에 `hideComments` 플래그를 세우고, 댓글 fetch IIFE 초입에서 그 플래그면 **빈 목록을 반환**한다(본문 tombstone·count 0 과 정합, #12711 의도 구현). 
- 자진삭제(작성자 본인) 글의 댓글 유지 — 무영향(#12965).
- 댓글 API 는 미변경 → 개별 '[삭제된 댓글]' 플레이스홀더 동작 회귀 없음.
- 웹 단일 파일.

## 검증
- [x] prettier
- [ ] 이동/관리자삭제된 글 조회 시 댓글 스레드 미표시(본문과 정합)
- [ ] 자진삭제·정상 글 회귀 없음