### PR TITLE
fix(post): 본문·첨부 세로 영상이 화면 높이를 넘지 않도록

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/basic.svelte
@@ -661,12 +661,15 @@
                                 <div class="overflow-hidden rounded-lg border">
                                     <!-- poster = 관례 키(…_poster.jpg) 도출. 포스터 없는 옛 동영상은
                                          404 인데 <video poster> 는 로드 실패를 조용히 무시하므로 무해 -->
+                                    <!-- bug/13894: w-full 은 세로 첨부영상을 화면 밖으로 늘린다.
+                                         max-w-full + max-h-[80vh] 로 두 축을 캡하면 native <video> 가
+                                         비율을 유지한 채 화면 안에 맞춰지고, 가로영상은 종전대로 꽉 찬다. -->
                                     <video
                                         controls
                                         preload="none"
                                         playsinline
                                         poster={deriveVideoPoster(video.url)}
-                                        class="w-full"
+                                        class="mx-auto block max-h-[80vh] max-w-full"
                                     >
                                         <source src={video.url} />
                                         동영상을 재생할 수 없습니다.

--- a/apps/web/src/lib/components/ui/markdown/markdown.svelte
+++ b/apps/web/src/lib/components/ui/markdown/markdown.svelte
@@ -714,6 +714,15 @@
         height: auto !important;
     }
 
+    /* bug/13894: 본문 세로(portrait) 영상이 화면 높이를 넘지 않도록 높이 상한.
+       - embed-container(비율박스) 세로 임베드는 아래 컨테이너 폭 캡으로 처리되어 이 값은 무해(no-op).
+       - 직접 <video>({video:} 패턴·첨부)만 실제로 캡된다. 가로/이미지·iframe은 영향 없음. */
+    .prose :global(video) {
+        max-height: 80vh;
+        display: block;
+        margin-inline: auto;
+    }
+
     /* YouTube iframe은 16:9 비율 유지 */
     .prose :global(iframe[src*='youtube']),
     .prose :global(iframe[src*='youtu.be']),
@@ -763,9 +772,13 @@
     }
 
     /* 세로 영상 (Shorts, Reels, TikTok) */
+    /* bug/13894: 세로 비율(≈177.78%)이라 폭을 제한하면 높이도 함께 줄어든다.
+       45vh × 1.7778 ≈ 80vh 이므로, 폭을 min(작성자 지정폭, 45vh)로 캡하면
+       화면 높이의 80%를 넘지 않는다. 좁은 화면에선 --max-width(400px)가 그대로 유지된다. */
     .prose :global(.embed-container[data-platform='youtube-shorts']),
     .prose :global(.embed-container[data-platform='instagram-reel']),
     .prose :global(.embed-container[data-platform='tiktok']) {
+        max-width: min(var(--max-width, 400px), 45vh);
         margin-left: auto;
         margin-right: auto;
     }


### PR DESCRIPTION
## 문제
세로(portrait) 동영상이 게시글 본문에서 전체 너비로 렌더되며 높이 상한이 없어 화면(뷰포트)을 넘어간다.

## 원인
본문 미디어에 `max-height` / 뷰포트 높이 제약이 전혀 없었다. 세로 비율은 너비가 커질수록 높이가 그만큼 커진다.

## 수정 (CSS/클래스만)
- `markdown.svelte` — `.prose video` 에 `max-height: 80vh` + 중앙정렬
- `markdown.svelte` — 세로 임베드(Shorts/Reels/TikTok) 컨테이너 폭을 `min(지정폭, 45vh)` 로 캡 (비율박스 높이 ≈177% → 80vh 이내)
- `basic.svelte` — 첨부 동영상 `w-full` → `max-w-full max-h-[80vh]` 로 두 축 캡, 비율 유지·중앙정렬

## 영향 범위
가로(16:9) 영상·이미지·기타 iframe 임베드는 변화 없음. 세로 미디어만 화면 안으로 들어온다.