### PR TITLE
feat(member): 닉네임이 임시값인 회원에게 설정 안내

### DIFF
--- a/apps/web/src/lib/components/features/tmp-nickname-notice/index.ts
+++ b/apps/web/src/lib/components/features/tmp-nickname-notice/index.ts
@@ -1,0 +1,1 @@
+export { default as TmpNicknameNotice } from './tmp-nickname-notice.svelte';

--- a/apps/web/src/lib/components/features/tmp-nickname-notice/tmp-nickname-notice.svelte
+++ b/apps/web/src/lib/components/features/tmp-nickname-notice/tmp-nickname-notice.svelte
@@ -12,9 +12,16 @@
      *    닉네임을 정하는 단계를 안 만든 것이다.
      *
      * ⛔ 닉네임을 추천하거나 미리 채워주지 않는다 — 소셜 프로필 이름이 실명인 프로바이더가 있다.
+     *
+     * ⛔ 위치가 `bottom-32` 인 이유 — 모바일 글쓰기 버튼이 오른쪽 아래에 있다(`md:hidden`).
+     *    실측 높이: 글목록 100px(h-9 + gap-2 + h-10 + bottom-4),
+     *              글상세 104px(h-10 + gap-2 + h-10 + bottom-4).
+     *    `bottom-4` 로 두면 그 버튼을 통째로 덮는다. 128px 로 비켜 준다.
+     *    데스크톱(`md:`)은 그 버튼이 없으므로 원래 자리로 돌아온다.
      */
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { tmpNicknameNotice, isTempNickname } from '$lib/stores/tmp-nickname-notice.svelte.js';
+    import { adblockNotice } from '$lib/stores/adblock-notice.svelte';
     import { Button } from '$lib/components/ui/button';
     import X from '@lucide/svelte/icons/x';
 
@@ -29,8 +36,16 @@
     const currentNick = $derived(authStore.user?.mb_name);
 
     // ⛔ 로딩 중에는 띄우지 않는다. 인증이 확립되기 전에 판정하면 깜빡인다.
+    //
+    // ⛔ 광고차단 안내가 떠 있으면 양보한다. 두 안내가 **같은 자리**를 쓰기 때문이다
+    //    (`adblock-notice.svelte` 도 `fixed bottom-4 right-4 z-[100]`).
+    //    겹치면 나중에 그려지는 이쪽이 덮어 상대의 닫기 버튼까지 가린다.
+    //    ⭐ 잔소리는 한 번에 하나만. 광고차단 안내는 7일 뒤 사라지고 그때 이쪽이 뜬다.
     const show = $derived(
-        !authStore.isLoading && isTempNickname(currentNick) && tmpNicknameNotice.notDismissed
+        !authStore.isLoading &&
+            isTempNickname(currentNick) &&
+            tmpNicknameNotice.notDismissed &&
+            !adblockNotice.shouldShow
     );
 
     function handleDismiss() {
@@ -40,7 +55,7 @@
 
 {#if show}
     <div
-        class="tmp-nickname-notice fixed bottom-4 right-4 z-[100] max-w-sm rounded-xl border border-blue-200 bg-white p-4 shadow-2xl ring-1 ring-black/5 sm:bottom-6 sm:right-6 dark:border-blue-900/40 dark:bg-zinc-900 dark:ring-white/10"
+        class="tmp-nickname-notice fixed bottom-32 right-4 z-[100] max-w-sm rounded-xl border border-blue-200 bg-white p-4 shadow-2xl ring-1 ring-black/5 md:bottom-6 md:right-6 dark:border-blue-900/40 dark:bg-zinc-900 dark:ring-white/10"
         role="status"
         aria-live="polite"
         aria-label="닉네임 설정 안내"

--- a/apps/web/src/lib/components/features/tmp-nickname-notice/tmp-nickname-notice.svelte
+++ b/apps/web/src/lib/components/features/tmp-nickname-notice/tmp-nickname-notice.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+    /**
+     * 임시 닉네임(`tmp_…`) 회원에게 닉네임을 정하도록 알리는 우측 하단 토스트.
+     *
+     * ⛔ 왜 토스트인가 — `SSR_STRIP_USER` 환경이라 서버 렌더링 시점에 `data.user` 가 없다
+     *    (`routes/+layout.server.ts`). 그래서 이 안내는 **하이드레이션 뒤**에만 뜬다.
+     *    본문 흐름 안에 넣으면 그때 본문을 밀어 그대로 CLS 가 된다. 자리를 미리 비워두면
+     *    임시 닉네임이 아닌 대다수 회원에게 빈 칸이 생긴다.
+     *    ⭐ `fixed` 로 띄우면 레이아웃에 영향이 없다 — 그래서 높이 변동이 0px 다.
+     *
+     * ⛔ 문구에 「임시」·「tmp」·「미완료」를 쓰지 않는다. 회원 잘못이 아니라 우리 가입 흐름이
+     *    닉네임을 정하는 단계를 안 만든 것이다.
+     *
+     * ⛔ 닉네임을 추천하거나 미리 채워주지 않는다 — 소셜 프로필 이름이 실명인 프로바이더가 있다.
+     */
+    import { authStore } from '$lib/stores/auth.svelte.js';
+    import { tmpNicknameNotice, isTempNickname } from '$lib/stores/tmp-nickname-notice.svelte.js';
+    import { Button } from '$lib/components/ui/button';
+    import X from '@lucide/svelte/icons/x';
+
+    /**
+     * ⛔ 이름이 헷갈리는 자리다. **클라이언트의 `mb_name` 은 닉네임이다.**
+     *    `auth.svelte.ts:81` 이 `mb_name: ssrUser.nickname` 으로 채우고,
+     *    헤더도 `header.svelte:87` 에서 같은 값을 화면에 쓴다.
+     *    DB 의 `g5_member.mb_name`(실명)과는 다른 값이다 —
+     *    실명은 2026-08-08 개인정보 점검 때 응답에서 빠졌다(`api/types.ts:726` 주석).
+     *    `DamoangUser` 에는 `mb_nick` 필드가 아예 없다. 쓰면 항상 undefined 다.
+     */
+    const currentNick = $derived(authStore.user?.mb_name);
+
+    // ⛔ 로딩 중에는 띄우지 않는다. 인증이 확립되기 전에 판정하면 깜빡인다.
+    const show = $derived(
+        !authStore.isLoading && isTempNickname(currentNick) && tmpNicknameNotice.notDismissed
+    );
+
+    function handleDismiss() {
+        tmpNicknameNotice.dismiss();
+    }
+</script>
+
+{#if show}
+    <div
+        class="tmp-nickname-notice fixed bottom-4 right-4 z-[100] max-w-sm rounded-xl border border-blue-200 bg-white p-4 shadow-2xl ring-1 ring-black/5 sm:bottom-6 sm:right-6 dark:border-blue-900/40 dark:bg-zinc-900 dark:ring-white/10"
+        role="status"
+        aria-live="polite"
+        aria-label="닉네임 설정 안내"
+    >
+        <button
+            type="button"
+            class="text-muted-foreground hover:text-foreground absolute right-2 top-2 rounded p-1 transition"
+            aria-label="닫기 (7일간 안내 끄기)"
+            onclick={handleDismiss}
+        >
+            <X class="h-4 w-4" />
+        </button>
+        <div class="flex items-start gap-3 pr-6">
+            <div class="text-2xl" aria-hidden="true">✏️</div>
+            <div class="flex-1">
+                <p class="text-sm font-semibold">닉네임을 정해 주세요</p>
+                <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
+                    지금 닉네임이 <strong class="text-foreground break-all">{currentNick}</strong>
+                    으로 되어 있어요. 다른 분들께 보이는 이름이라, 원하시는 이름으로 바꾸실 수 있습니다.
+                </p>
+                <div class="mt-3 flex flex-wrap items-center gap-2">
+                    <Button size="sm" href="/member/settings" onclick={handleDismiss}>
+                        닉네임 정하기
+                    </Button>
+                    <Button size="sm" variant="ghost" onclick={handleDismiss}>나중에</Button>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/apps/web/src/lib/stores/tmp-nickname-notice.svelte.ts
+++ b/apps/web/src/lib/stores/tmp-nickname-notice.svelte.ts
@@ -1,0 +1,58 @@
+/**
+ * 임시 닉네임 안내 상태 store (2026-09-08).
+ *
+ * 배경
+ *   2026-07-10 부터 앱에서 소셜 로그인으로 가입하면 `tmp_<프로바이더>_<난수>` 형태의
+ *   임시 닉네임이 붙은 채 로그인이 끝난다. 그 뒤 닉네임을 정하게 하는 단계가 없어서
+ *   회원이 스스로 설정 화면을 찾아가지 않는 한 그대로 남는다.
+ *   실측(2026-09-08): 193명이 임시 닉네임 상태, 스스로 바꾼 사람은 29명(13%).
+ *
+ * ⭐ 바꿀 수는 이미 있다 — 가입 시 `skipNickLock:true` 로 30일 쿨다운이 면제돼 있다.
+ *    **알려주기만 하면 된다.** 그래서 이 안내는 막지 않고 알리기만 한다.
+ *
+ * ⛔ 닉네임을 대신 지어주지 않는다. 소셜 프로필의 displayName 은 naver·google·payco 에서
+ *    **실명으로 폴백**한다(`oauth/providers/*.ts`). 자동 채움은 실명 공개가 된다.
+ *
+ * ⛔ 강제 모달로 만들지 않는다. 닫을 수 없는 창이 앱 안에서 뜨면 되돌릴 방법이 없다.
+ *    읽기는 지금처럼 계속 되게 둔다.
+ */
+
+const DISMISS_KEY = 'damoang_tmp_nick_dismissed_until';
+const DISMISS_DAYS = 7;
+
+/** 임시 닉네임 접두사. 서버가 붙이는 값과 같아야 한다(`auth/register.ts`, 콜백 라우트). */
+const TMP_PREFIX = 'tmp_';
+
+function loadDismissedUntil(): number {
+    if (typeof localStorage === 'undefined') return 0;
+    try {
+        const raw = localStorage.getItem(DISMISS_KEY);
+        return raw ? Number(raw) || 0 : 0;
+    } catch {
+        // 저장소가 막힌 환경(사생활 보호 모드 등) — 안내는 뜨되 기억만 못 한다.
+        return 0;
+    }
+}
+
+let dismissedUntil = $state(loadDismissedUntil());
+
+/** 이 닉네임이 아직 임시값인가. ⛔ 빈 값·undefined 는 false 다(비로그인 포함). */
+export function isTempNickname(nick: string | null | undefined): boolean {
+    return typeof nick === 'string' && nick.startsWith(TMP_PREFIX);
+}
+
+export const tmpNicknameNotice = {
+    /** 안내를 띄워도 되는 시점인가. 대상 판정(닉네임)은 컴포넌트가 함께 본다. */
+    get notDismissed() {
+        return Date.now() >= dismissedUntil;
+    },
+    dismiss(days: number = DISMISS_DAYS): void {
+        const until = Date.now() + days * 24 * 60 * 60 * 1000;
+        dismissedUntil = until;
+        try {
+            localStorage.setItem(DISMISS_KEY, String(until));
+        } catch {
+            // 저장소가 막힌 환경 — 이번 세션 동안만 유지된다.
+        }
+    }
+};

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -46,6 +46,7 @@
     import { initMistouchProbe, resetMistouchBudget } from '$lib/services/mistouch-probe';
     import { initHistoryProbe, resetHistoryProbeBudget } from '$lib/services/history-probe';
     import { AdblockNotice } from '$lib/components/features/adblock-notice';
+    import { TmpNicknameNotice } from '$lib/components/features/tmp-nickname-notice';
     import type { MenuItem } from '$lib/api/types';
     import { readUserBasicFromCookie } from '$lib/utils/user-basic-client';
     import { env } from '$env/dynamic/public';
@@ -1228,6 +1229,11 @@
 <!-- AdBlock 감지 시 안내 토스트 (admin/install 제외) -->
 {#if !isAdminRoute && !isInstallRoute}
     <AdblockNotice />
+{/if}
+
+<!-- 임시 닉네임(tmp_…) 회원에게 닉네임 설정 안내 (admin/install 제외) -->
+{#if !isAdminRoute && !isInstallRoute}
+    <TmpNicknameNotice />
 {/if}
 
 <!-- 플러그인 슬롯: </body> 직전 (지연 로딩 컴포넌트, fallback 등) — Slot Catalog Sprint 2 -->


### PR DESCRIPTION
## 문제

소셜 로그인으로 가입하면 임시 닉네임이 붙은 채 로그인이 끝난다.
그 뒤 닉네임을 정하게 하는 단계가 없어서, 설정 화면을 스스로 찾아가지 않으면 그대로 남는다.
저장소 전체에 임시 닉네임을 보고 안내하는 코드가 하나도 없었다.

바꿀 수는 이미 있다 — 가입 시 `skipNickLock:true` 로 변경 쿨다운이 면제돼 있다. **알려주기만 하면 된다.**

## 변경

- `stores/tmp-nickname-notice.svelte.ts` — 판정(`isTempNickname`)과 7일 dismiss 상태
- `components/features/tmp-nickname-notice/` — 우측 하단 고정 토스트
- `+layout.svelte` — `AdblockNotice` 옆에 마운트 (admin·install 제외)

## 설계 근거

**왜 토스트인가** — `SSR_STRIP_USER` 환경이라 SSR 시점에 `data.user` 가 없다.
안내는 하이드레이션 뒤에만 뜬다. 본문 흐름에 넣으면 그때 본문을 밀어 CLS 가 되고,
자리를 미리 비워두면 대상이 아닌 대다수 회원에게 빈 칸이 생긴다.
`fixed` 로 띄우면 레이아웃에 영향이 없다.

**왜 강제 모달이 아닌가** — 닫을 수 없는 창은 앱 안에서 뜨면 되돌릴 방법이 없다. 읽기는 그대로 둔다.

**왜 닉네임을 추천하지 않는가** — 일부 제공자는 프로필 이름이 실명이다. 자동 적용하면 실명이 공개된다.

## ⛔ 필드 이름 함정

클라이언트의 `mb_name` 은 **닉네임**이다 (`auth.svelte.ts` 가 `nickname` 으로 채우고 헤더도 이 값을 쓴다).
`DamoangUser` 에는 `mb_nick` 필드가 **없다** — 쓰면 항상 undefined 다. 컴포넌트에 주석으로 남겼다.

## 검증

- svelte 단일 파일 컴파일 통과 (경고 0)
- prettier 4파일 unchanged
- 비대상·비로그인에서 렌더되지 않음 (`isLoading` 중 미표시, 접두사 불일치 시 미표시)
- SSR HTML 에 마크업이 나가지 않음 (하이드레이션 불일치 방지)
- 나머지는 CI

되돌리기는 마운트 조건 한 줄이면 된다. DB 변경·마이그레이션 없음.