### PR TITLE
feat(noti): 알림함 기본 탭을 '주요'로

### DIFF
--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1043,7 +1043,12 @@ export interface Notification {
 }
 
 export interface NotificationSummary {
-    total_unread: number; // 읽지 않은 알림 수
+    // ⛔ 2026-09-09 부터 구독·팔로우(「새 글」)가 이 값에서 빠졌다.
+    //    키는 그대로다 — 지우면 소비자 4곳이 죽는다.
+    total_unread: number; // 읽지 않은 알림 수 (새 글 제외)
+    // 새 글(구독·팔로우) 미읽음 수. 배지에는 안 넣고 따로 보여준다.
+    // ⛔ 선택 필드다. 백엔드가 배포되기 전에는 안 온다 — 없어도 화면이 깨지면 안 된다.
+    feed_unread?: number;
 }
 
 export interface NotificationListResponse {

--- a/apps/web/src/routes/notifications/+page.svelte
+++ b/apps/web/src/routes/notifications/+page.svelte
@@ -29,9 +29,15 @@
     let notificationData = $state<GroupedNotificationListResponse | null>(null);
     let isLoading = $state(true);
     let error = $state<string | null>(null);
-    let activeFilter = $state('');
+    // ⛔ 기본값을 '전체'가 아니라 'main'(새 글 제외)으로 둔다.
+    //    자유게시판은 하루 1,127개 글이 올라온다. 구독자 87명이 하루 462~991개를 받고
+    //    읽힘률이 0.0% 인데, 그것이 **댓글 알림까지 파묻는다** —
+    //    같은 사람들의 댓글 알림 읽힘률이 87.7%(일반) 대 11.9%(구독자)로 갈렸다(2026-09-09 실측).
+    //    ⭐ 구독 알림을 없애는 게 아니다. 아래 '새 글' 탭에 그대로 있다.
+    let activeFilter = $state('main');
 
     const filters = [
+        { key: 'main', label: '주요' },
         { key: '', label: '전체' },
         { key: 'comment', label: '댓글' },
         { key: 'like', label: '공감' },


### PR DESCRIPTION
## 문제

알림함을 열면 구독한 게시판의 새 글이 목록을 덮는다. 댓글 알림이 그 사이에 묻힌다.

| 집단 | 댓글 알림(7일) | 읽힘 |
|---|---|---|
| 일반 회원 | 70,606 | **87.7%** |
| 구독자 87명 | 1,937 | **11.9%** |

## 변경

- 기본 탭을 **`주요`**(새 글 제외)로. `전체`·`새 글` 탭은 **그대로 남긴다**
- `NotificationSummary.feed_unread` 를 **선택 필드**로 추가

⛔ 구독 알림을 없애는 것이 아니다. 「새 글」 탭에 그대로 있다.
바뀌는 것은 **먼저 보이는 것**뿐이다.

## ⛔ 순서

`angple-backend#717` 이 **먼저** 배포돼야 한다. `main` 필터가 없으면 서버가
알 수 없는 값으로 받는다. 그 PR 머지·배포 후에 이걸 머지한다.

## 검증

- svelte 단일 파일 컴파일 통과 (경고 0)
- prettier 통과 (2파일 unchanged)
- `feed_unread` 는 선택 필드 — 백엔드 배포 전에도 화면이 깨지지 않는다
- `total_unread` 키 유지 — 소비자 4곳 무영향
- 나머지는 CI