### PR TITLE
fix(post): report 레이아웃 첨부 세로영상 오버플로 (bug/13894 잔존분)

### DIFF
--- a/apps/web/src/lib/components/features/board/layouts/view/report.svelte
+++ b/apps/web/src/lib/components/features/board/layouts/view/report.svelte
@@ -831,7 +831,15 @@
                         <div class="mt-6 space-y-4">
                             {#each post.videos as video, i (i)}
                                 <div class="overflow-hidden rounded-lg border">
-                                    <video controls preload="none" playsinline class="w-full">
+                                    <!-- bug/13894 잔존분: w-full 은 세로 첨부영상을 화면 밖으로 늘린다.
+                                         max-w-full + max-h-[80vh] 로 두 축을 캡해 비율 유지하며 화면 안에 맞춘다
+                                         (basic.svelte 와 동일 패턴). report 레이아웃 게시판에서도 오버플로 방지. -->
+                                    <video
+                                        controls
+                                        preload="none"
+                                        playsinline
+                                        class="mx-auto block max-h-[80vh] max-w-full"
+                                    >
                                         <source src={video.url} />
                                         동영상을 재생할 수 없습니다.
                                     </video>


### PR DESCRIPTION
## 배경
bug/13894(본문·첨부 세로영상이 화면을 넘침) 수정(#2256)이 `basic.svelte`·`markdown.svelte` 는 덮었으나, **`report` 레이아웃**(`view_layout='report'`)의 첨부 동영상 렌더는 누락됐다.

## 문제
`report.svelte` 의 첨부 `<video class="w-full">` 는 높이 상한이 없어, report 레이아웃을 쓰는 게시판에서 세로 첨부영상이 여전히 뷰포트를 넘어간다.

## 수정
`basic.svelte` 에 확립된 패턴 그대로: `w-full` → `mx-auto block max-h-[80vh] max-w-full`. 비율 유지하며 화면 안에 맞춤. 가로영상·이미지 무영향.

## 검증
- report 레이아웃 게시판에서 세로 첨부영상 → ≤80vh, 상하 잘림 없음
- 가로 16:9 영상 → 회귀 없음

---
_자동 트리아지 파이프라인(Phase 1 분석기)이 bug/13894 재분석 중 발견한 잔존 경로. **Draft — 사람 검토·시각 회귀 확인 후 머지.**_