### PR TITLE
feat(board): 버그게시판 글쓰기 진입 안내 인터스티셜

### DIFF
--- a/apps/web/src/lib/components/features/board/bug-write-notice.svelte
+++ b/apps/web/src/lib/components/features/board/bug-write-notice.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+    /**
+     * 버그게시판 글쓰기 안내 인터스티셜.
+     * 신고는 신고 버튼으로, 질문은 질문게시판으로 유도하고, 버그 제보 양식을 안내한다.
+     * 특정 회원·사건을 언급하지 않는 중립 안내(게시판 용도 정리)로만 작성한다.
+     */
+    import { Button } from '$lib/components/ui/button/index.js';
+    import { setBugNoticeSkip } from './bug-write-notice.js';
+
+    let { onContinue }: { onContinue: () => void } = $props();
+
+    let skipToday = $state(false);
+
+    function handleContinue(): void {
+        if (skipToday) setBugNoticeSkip();
+        onContinue();
+    }
+</script>
+
+<div class="mx-auto max-w-xl">
+    <div class="border-border bg-background overflow-hidden rounded-xl border shadow-sm">
+        <div class="bg-slate-800 px-5 py-4 text-base font-semibold text-white dark:bg-slate-700">
+            🐛 버그·기능 제보 게시판이에요
+        </div>
+
+        <div class="text-muted-foreground space-y-4 px-5 py-4 text-sm">
+            <p>
+                이곳은 다모앙의 <strong class="text-foreground">버그 신고</strong>와
+                <strong class="text-foreground">기능 제안</strong>을 접수하는 창구예요. 더 나은
+                다모앙을 위한 제보 감사합니다.
+            </p>
+
+            <div class="border-border/60 border-t pt-3">
+                <p class="text-foreground font-medium">🚩 회원·게시물을 신고하시나요?</p>
+                <p class="mt-1">
+                    특정 회원이나 글·댓글에 대한 신고는 이 게시판이 아니라, 해당 글·댓글의
+                    <strong class="text-foreground">신고 버튼</strong>(글·댓글 ⋮ 메뉴 → 🚩 신고)을
+                    이용해 주세요. 접수된 신고는 운영팀이 별도 절차로 확인합니다.
+                </p>
+            </div>
+
+            <div class="border-border/60 border-t pt-3">
+                <p class="text-foreground font-medium">❓ 궁금한 점이 있으신가요?</p>
+                <p class="mt-1">
+                    사용법이나 질문은 <a href="/qa" class="text-primary hover:underline"
+                        >질문과 답변</a
+                    >
+                    게시판을 이용해 주시면 더 빠르게 도움받으실 수 있어요.
+                </p>
+            </div>
+
+            <div class="border-border/60 border-t pt-3">
+                <p class="text-foreground font-medium">
+                    🐛 버그 제보라면 — 아래 환경을 함께 적어주세요
+                </p>
+                <p class="mt-1">
+                    ㅇ 사용기기: 모바일 / PC / 맥 / 기타<br />
+                    ㅇ 브라우저: 크롬 / 사파리 / 엣지 / 기타<br />
+                    <span class="text-xs">(관련 없는 항목은 지우셔도 됩니다)</span>
+                </p>
+            </div>
+
+            <div class="border-border/60 border-t pt-3">
+                <p class="text-foreground font-medium">🚨 긴급 버그</p>
+                <p class="mt-1">
+                    로그인 불가·결제 오류·데이터 손실 등 긴급 건은 제목이나 본문에
+                    <strong class="text-foreground">[긴급]</strong>으로 표시해 주세요.
+                </p>
+            </div>
+        </div>
+
+        <div class="border-border/60 border-t px-5 py-4">
+            <Button class="w-full" onclick={handleContinue}>확인하고 제보 계속하기 →</Button>
+            <label
+                class="text-muted-foreground mt-3 flex select-none items-center justify-center gap-2 text-xs"
+            >
+                <input
+                    type="checkbox"
+                    bind:checked={skipToday}
+                    class="accent-primary h-3.5 w-3.5"
+                />
+                오늘 하루 이 안내 보지 않기
+            </label>
+        </div>
+    </div>
+</div>

--- a/apps/web/src/lib/components/features/board/bug-write-notice.test.ts
+++ b/apps/web/src/lib/components/features/board/bug-write-notice.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    isBugNoticeSkipped,
+    setBugNoticeSkip,
+    BUG_NOTICE_SKIP_KEY,
+    BUG_NOTICE_SKIP_WINDOW_MS,
+    BUG_TEMPLATE_CONTENT
+} from './bug-write-notice.js';
+
+/** 간단한 in-memory localStorage 목. */
+function mockStorage(initial: Record<string, string> = {}) {
+    const store = new Map<string, string>(Object.entries(initial));
+    return {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
+        clear: () => store.clear()
+    };
+}
+
+describe('bug-write-notice 스킵 헬퍼', () => {
+    beforeEach(() => {
+        vi.stubGlobal('localStorage', mockStorage());
+    });
+
+    it('저장값이 없으면 스킵하지 않는다(안내 표시)', () => {
+        expect(isBugNoticeSkipped()).toBe(false);
+    });
+
+    it('24시간 이내 저장이면 스킵한다', () => {
+        const now = 1_000_000_000_000;
+        setBugNoticeSkip(now);
+        // 23시간 59분 뒤: 아직 스킵 유효
+        expect(isBugNoticeSkipped(now + BUG_NOTICE_SKIP_WINDOW_MS - 60_000)).toBe(true);
+    });
+
+    it('24시간이 지나면 다시 안내를 표시한다', () => {
+        const now = 1_000_000_000_000;
+        setBugNoticeSkip(now);
+        expect(isBugNoticeSkipped(now + BUG_NOTICE_SKIP_WINDOW_MS + 1)).toBe(false);
+    });
+
+    it('저장값이 숫자가 아니면 안내를 표시한다', () => {
+        localStorage.setItem(BUG_NOTICE_SKIP_KEY, 'not-a-number');
+        expect(isBugNoticeSkipped()).toBe(false);
+    });
+
+    it('localStorage 접근이 실패해도 예외 없이 false를 반환한다', () => {
+        vi.stubGlobal('localStorage', {
+            getItem: () => {
+                throw new Error('access denied');
+            },
+            setItem: () => {
+                throw new Error('access denied');
+            }
+        });
+        expect(isBugNoticeSkipped()).toBe(false);
+        // 저장 실패도 조용히 무시되어야 한다
+        expect(() => setBugNoticeSkip()).not.toThrow();
+    });
+
+    it('본문 양식에는 사용기기·브라우저 항목이 포함된다', () => {
+        expect(BUG_TEMPLATE_CONTENT).toContain('사용기기');
+        expect(BUG_TEMPLATE_CONTENT).toContain('브라우저');
+    });
+});

--- a/apps/web/src/lib/components/features/board/bug-write-notice.ts
+++ b/apps/web/src/lib/components/features/board/bug-write-notice.ts
@@ -1,0 +1,49 @@
+/**
+ * 버그게시판 글쓰기 안내 인터스티셜 — 상수 및 localStorage 헬퍼.
+ *
+ * 버그게시판(board_id='bug')이 회원 신고 용도로 오용되는 것을 예방하기 위해,
+ * 글쓰기 진입 시 "신고는 신고 버튼 / 질문은 질문게시판 / 버그는 양식대로" 안내를 1회 보여준다.
+ * 안내는 "오늘 하루 보지 않기"로 24시간 동안 생략할 수 있다(버그게시판은 이용 빈도가 낮아
+ * 영구 스킵보다 하루 단위 재노출이 적절).
+ */
+
+/** "오늘 하루 보지 않기" 저장 키 (값 = 마지막으로 건너뛴 시각, ms 타임스탬프). */
+export const BUG_NOTICE_SKIP_KEY = 'angple_bug_write_notice_skip_ts';
+
+/** 안내 재노출 주기 — 24시간. */
+export const BUG_NOTICE_SKIP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 버그 제보 본문 기본 양식 (bug/3806 기준). create 진입 시 본문에 prefill 되며,
+ * 관련 없는 항목은 지우고 사용하면 된다.
+ */
+export const BUG_TEMPLATE_CONTENT =
+    '<p>ㅇ 사용기기: 모바일 / PC / 맥 / 기타</p>' +
+    '<p>ㅇ 브라우저: 크롬 / 사파리 / 엣지 / 기타</p>' +
+    '<p>(관련 없는 항목은 지우고 작성해 주세요)</p>' +
+    '<p><br></p>';
+
+/**
+ * 24시간 내에 "오늘 하루 보지 않기"가 저장돼 있으면 true.
+ * localStorage 접근 실패(프라이빗 모드 등) 시 false를 반환해 안내를 표시한다.
+ */
+export function isBugNoticeSkipped(now: number = Date.now()): boolean {
+    try {
+        const raw = localStorage.getItem(BUG_NOTICE_SKIP_KEY);
+        if (!raw) return false;
+        const ts = Number(raw);
+        if (!Number.isFinite(ts)) return false;
+        return now - ts < BUG_NOTICE_SKIP_WINDOW_MS;
+    } catch {
+        return false;
+    }
+}
+
+/** "오늘 하루 보지 않기" 선택 시 현재 시각을 저장한다. 실패는 조용히 무시. */
+export function setBugNoticeSkip(now: number = Date.now()): void {
+    try {
+        localStorage.setItem(BUG_NOTICE_SKIP_KEY, String(now));
+    } catch {
+        // 저장 실패는 무시 — 다음 진입에 안내가 다시 뜰 뿐이다
+    }
+}

--- a/apps/web/src/routes/[boardId]/write/+page.svelte
+++ b/apps/web/src/routes/[boardId]/write/+page.svelte
@@ -24,6 +24,11 @@
     import { Button } from '$lib/components/ui/button/index.js';
     import PluginSlot from '$lib/components/plugin/plugin-slot.svelte';
     import WriteEtiquetteSubtitle from '$lib/components/features/board/write-etiquette-subtitle.svelte';
+    import BugWriteNotice from '$lib/components/features/board/bug-write-notice.svelte';
+    import {
+        isBugNoticeSkipped,
+        BUG_TEMPLATE_CONTENT
+    } from '$lib/components/features/board/bug-write-notice.js';
 
     let { data }: { data: PageData } = $props();
 
@@ -69,6 +74,22 @@
 
     // claim 게시판 직접 접근 차단: disciplinelog_id 없이는 소명 작성 불가
     const isClaimWithoutDiscipline = $derived(boardId === 'claim' && !disciplinelogId);
+
+    // 버그게시판 글쓰기 안내 인터스티셜 (신고·질문 오용 예방)
+    const isBugBoard = $derived(boardId === 'bug');
+    let bugNoticeAcknowledged = $state(false);
+    // 버그게시판 진입 시 24시간 내 "오늘 하루 보지 않기"가 저장돼 있으면 안내 생략
+    $effect(() => {
+        if (browser && isBugBoard) {
+            bugNoticeAcknowledged = isBugNoticeSkipped();
+        }
+    });
+    function acknowledgeBugNotice(): void {
+        bugNoticeAcknowledged = true;
+    }
+    const showBugNotice = $derived(isBugBoard && !bugNoticeAcknowledged);
+    // 버그게시판 본문 양식 prefill (repost/소명 프리필이 없을 때만)
+    const bugInitialContent = $derived(isBugBoard ? BUG_TEMPLATE_CONTENT : '');
 
     // 글쓰기 권한 조회 결과
     const writePermission = $derived(data.writePermission as WritePermission | null);
@@ -270,6 +291,10 @@
                 <p class="text-muted-foreground mt-2 text-sm">{writePermissionMsg}</p>
             </div>
         </div>
+    {:else if showBugNotice}
+        <div class="pt-4">
+            <BugWriteNotice onContinue={acknowledgeBugNotice} />
+        </div>
     {:else}
         {#if error}
             <div class="bg-destructive/10 text-destructive mb-4 rounded-md p-4">
@@ -364,7 +389,7 @@
                     initialTitle={repostTitle || claimInitialTitle}
                     initialLink1={repostLink1 || claimInitialLink1}
                     initialLink2={repostLink2}
-                    initialContent={repostContent || claimInitialContent}
+                    initialContent={repostContent || claimInitialContent || bugInitialContent}
                     onSubmit={handleSubmit}
                     onCancel={handleCancel}
                     isLoading={isSubmitting}


### PR DESCRIPTION
## 요약
버그게시판(\`/bug\`) 글쓰기 진입 시 안내를 1회 표시해, 게시판을 **버그·기능 제보 용도**로 정리합니다.

## 배경
버그게시판에 회원·게시물 신고 성격의 글이 반복 유입되고, 버그 제보도 접속환경 누락이 잦습니다. 진입 안내로 창구를 정리합니다. (중립 안내 — 특정 대상 언급 없음)

## 변경
- \`bug-write-notice.svelte\` — 안내 인터스티셜(신고→신고 버튼, 질문→질문과 답변 게시판, 버그 양식·긴급 표시)
- \`bug-write-notice.ts\` — "오늘 하루 보지 않기"(24h) localStorage 헬퍼 + 본문 양식 상수
- \`[boardId]/write/+page.svelte\` — bug 보드일 때 canWrite 통과 후 분기 추가, 본문 양식 prefill
- \`bug-write-notice.test.ts\` — 단위 테스트

## 동작
- \`/bug/write\` 진입 → 안내 표시 → "확인하고 제보 계속하기" → 본문에 버그 양식 prefill된 폼
- "오늘 하루 보지 않기" 체크 → 24시간 생략, 이후 재표시
- 다른 게시판에는 영향 없음(bug 한정)

## 테스트
- 단위: 스킵 24h 경계 · localStorage 실패 fallback · 양식 내용
- 수동: /bug/write 안내 노출·스킵·prefill / /free/write 무영향