### PR TITLE
feat(groups): 소모임 전체목록 페이지 상단 tag-nav 노출

### DIFF
--- a/apps/web/src/routes/groups/+page.svelte
+++ b/apps/web/src/routes/groups/+page.svelte
@@ -2,6 +2,7 @@
     // import { onMount } from 'svelte';
     import { SeoHead } from '$lib/seo/index.js';
     import AdSlot from '$lib/components/ui/ad-slot/ad-slot.svelte';
+    import TagNav from '$lib/components/ui/tag-nav/tag-nav.svelte';
     import Users from '@lucide/svelte/icons/users';
     import MessageSquare from '@lucide/svelte/icons/message-square';
     import FileText from '@lucide/svelte/icons/file-text';
@@ -128,6 +129,11 @@
 />
 
 <div class="mx-auto max-w-5xl px-4 py-8">
+    <!-- 상단 태그 네비 — 소모임 전체 목록 위에도 메뉴 노출 (bug/13921) -->
+    <div class="mb-4">
+        <TagNav />
+    </div>
+
     <Card class="gap-0">
         <CardHeader class="pb-0">
             <!-- 헤더 -->


### PR DESCRIPTION
## 요약
`/groups`(소모임 전체 목록) 페이지 상단에 태그 네비게이션(TagNav)을 추가합니다.

## 배경
tag-nav는 홈·/explore·게시판(/[boardId])에만 렌더돼 `/groups`에는 상단 메뉴가 없었습니다. 소모임 전체 목록 위에도 메뉴를 노출해 달라는 요청(bug/13921)에 대응합니다.

## 변경
- `routes/groups/+page.svelte` — `TagNav` import + 소모임 카드 위에 `<TagNav />` 렌더 (홈·/explore 동일 패턴)

## 확인
- 다른 페이지의 TagNav와 동일 컴포넌트/배치
- /groups 외 페이지 영향 없음