### PR TITLE
perf(memo): 메모가 없는 회원은 batch/memo 를 다시 부르지 않는다

### DIFF
--- a/apps/web/src/lib/components/features/board/recent-posts.svelte
+++ b/apps/web/src/lib/components/features/board/recent-posts.svelte
@@ -4,6 +4,7 @@
     import { apiClient } from '$lib/api/index.js';
     import type { FreePost, BoardDisplaySettings } from '$lib/api/types.js';
     import { readPostsStore } from '$lib/stores/read-posts.svelte.js';
+    import { memoPresence } from '$lib/stores/memo-presence.svelte.js';
     import { takeBoardList } from '$lib/stores/board-list-carryover.js';
     import { Button } from '$lib/components/ui/button/index.js';
     import Search from '@lucide/svelte/icons/search';
@@ -92,6 +93,13 @@
             memoByAuthorId = {};
             return;
         }
+        // ⛔ 메모가 하나도 없는 회원이면 응답은 언제나 빈 객체다. 부르지 않는다.
+        //    아직 모르는 상태(null)에서는 건너뛰지 않는다 — 모르면 부르는 쪽이 안전하다.
+        if (memoPresence.canSkip) {
+            memoByAuthorId = {};
+            return;
+        }
+
         const ids = [...new Set(posts.map((p) => p.author_id).filter(Boolean))];
         if (ids.length === 0) {
             memoByAuthorId = {};
@@ -107,6 +115,7 @@
             );
             if (!res.ok) return;
             const json = await res.json();
+            memoPresence.note(json?.has_any);
             const payload = (json?.data ?? {}) as Record<
                 string,
                 { content?: string; color?: string }

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -9,6 +9,7 @@
 
 import { apiClient } from '$lib/api';
 import type { DamoangUser } from '$lib/api/types.js';
+import { memoPresence } from './memo-presence.svelte.js';
 
 // 인증 상태
 let user = $state<DamoangUser | null>(null);
@@ -151,6 +152,9 @@ function resetAuth(): void {
     user = null;
     error = null;
     apiClient.setAccessToken(null);
+    // ⛔ 회원이 바뀌면 앞 회원의 「메모 없음」 판단을 물려주면 안 된다.
+    //    남겨두면 다음 회원에게 메모가 통째로 안 보인다.
+    memoPresence.reset();
 }
 
 /**

--- a/apps/web/src/lib/stores/memo-presence.svelte.ts
+++ b/apps/web/src/lib/stores/memo-presence.svelte.ts
@@ -1,0 +1,51 @@
+/**
+ * 회원 메모 보유 여부 store.
+ *
+ * `GET /api/v1/members/batch/memo` 는 "지금 로그인한 회원이 이 작성자들에게 남긴 메모"를
+ * 돌려준다. 메모를 한 번도 쓰지 않은 회원에게 이 응답은 **언제나** 빈 객체다.
+ * 그런데 목록을 넘길 때마다 다시 묻는다 — 결과를 미리 아는 질문이다.
+ *
+ * 백엔드가 응답에 `has_any` 를 함께 주므로, 한 번 `false` 를 받으면 그 뒤로는 부르지 않는다.
+ *
+ * ⛔ 모듈 상태다. 새로고침하면 다시 확인한다 — 일부러 그렇게 뒀다.
+ *    localStorage 에 담으면 다른 기기에서 메모를 지웠을 때 오래 어긋난다.
+ *
+ * ⛔ 호출부는 3곳이고 그중 하나는 premium 플러그인이다(member-memo). 셋 다 이 store 를 봐야
+ *    효과가 난다. 하나라도 빠지면 그 경로가 계속 호출한다.
+ */
+
+/** null = 아직 모름 · true = 가진 게 있다 · false = 하나도 없다 */
+let hasAnyMemo = $state<boolean | null>(null);
+
+export const memoPresence = {
+    /**
+     * 호출을 건너뛰어도 되는가.
+     *
+     * ⛔ `null`(아직 모름)일 때는 **반드시 false** 다. 모르면 부르는 쪽이 안전하다 —
+     *    잘못 건너뛰면 메모가 안 보인다.
+     */
+    get canSkip(): boolean {
+        return hasAnyMemo === false;
+    },
+
+    /**
+     * batch/memo 응답의 `has_any` 를 반영한다.
+     *
+     * ⛔ **엄격 비교**다. 키가 없는(구버전) 응답은 `undefined` 로 오는데, 그걸 `false` 로
+     *    해석하면 메모가 통째로 안 보인다. 불리언일 때만 받아들인다.
+     */
+    note(hasAny: unknown): void {
+        if (hasAny === true) hasAnyMemo = true;
+        else if (hasAny === false) hasAnyMemo = false;
+    },
+
+    /** 메모를 새로 저장했다 — 이제 확실히 가진 게 있다. */
+    markCreated(): void {
+        hasAnyMemo = true;
+    },
+
+    /** 로그인 주체가 바뀌면 앞 회원의 판단을 물려주면 안 된다. */
+    reset(): void {
+        hasAnyMemo = null;
+    }
+};

--- a/apps/web/src/routes/[boardId]/+page.svelte
+++ b/apps/web/src/routes/[boardId]/+page.svelte
@@ -18,6 +18,7 @@
     import type { PageData } from './$types.js';
     import type { FreePost } from '$lib/api/types.js';
     import { authStore } from '$lib/stores/auth.svelte.js';
+    import { memoPresence } from '$lib/stores/memo-presence.svelte.js';
     import {
         canUseCertifiedAction,
         getCertificationBlockedMessage,
@@ -451,6 +452,15 @@
             return;
         }
 
+        // ⛔ 메모가 하나도 없는 회원이면 응답은 언제나 빈 객체다. 부르지 않는다.
+        //    아직 모르는 상태(null)에서는 건너뛰지 않는다 — 모르면 부르는 쪽이 안전하다.
+        if (memoPresence.canSkip) {
+            clearMemoSchedule();
+            lastMemoRequestKey = '';
+            memoByAuthorId = {};
+            return;
+        }
+
         const uniqueAuthorIds = [...new Set(authorIds)].filter(Boolean);
         if (uniqueAuthorIds.length === 0) {
             clearMemoSchedule();
@@ -485,6 +495,7 @@
             }
 
             const json = await response.json();
+            memoPresence.note(json?.has_any);
             const payload = (json?.data ?? {}) as Record<
                 string,
                 { content?: string; color?: string }


### PR DESCRIPTION
## 무엇을

`GET /api/v1/members/batch/memo` 는 "지금 로그인한 회원이 이 작성자들에게 남긴 메모"를 돌려준다.
메모를 한 번도 쓰지 않은 회원에게 이 응답은 **언제나** 빈 객체다. 그런데 목록을 넘길 때마다 다시 물었다.

백엔드가 함께 주는 `has_any` 를 기억해, `false` 를 받으면 그 세션 동안 호출을 건너뛴다.

## 어떻게

새 store `lib/stores/memo-presence.svelte.ts` 하나를 두고 호출부가 함께 본다.

| 상태 | 의미 | 동작 |
|---|---|---|
| `null` | 아직 모름 | **부른다** |
| `true` | 가진 게 있다 | 부른다 |
| `false` | 하나도 없다 | 건너뛴다 |

## 안전 장치

- ⛔ **엄격 비교**(`has_any === false`)다. 키가 없는 응답은 `undefined` 로 오는데
  그걸 `false` 로 해석하면 메모가 통째로 안 보인다. 그래서 **백엔드를 먼저** 배포했다.
- ⛔ **로그아웃 시 초기화**한다. 앞 회원의 판단을 물려주면 다음 회원에게 메모가 안 보인다.
- 메모를 새로 저장하면 플래그를 푼다.
- 모듈 상태라 **새로고침하면 다시 확인**한다. `localStorage` 에 담으면 다른 기기에서
  메모를 지웠을 때 오래 어긋난다.

## 남은 한 곳

호출부는 셋이고 나머지 하나는 `member-memo` 플러그인(별도 저장소)이다. 그쪽도 같은 store 를 본다.

## 확인

- [ ] 메모 0건 계정으로 목록 3페이지 이동 → `batch/memo` 1회
- [ ] 메모 보유 계정 → 뱃지 그대로
- [ ] 메모 0건 계정이 메모 저장 → 즉시 뱃지 표시